### PR TITLE
Fix uploaded files not showing in artifacts panel and session bleed

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,8 +1,8 @@
 name: macOS Build
 
+# Manual diagnostic/packaging build (unsigned app + dmg). Not tied to push —
+# release packages only come from release-macos.yml on a version tag.
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -3,8 +3,6 @@ name: macOS Build
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,8 +1,8 @@
 name: Windows Build
 
+# Manual diagnostic/packaging build (msi/nsis). Not tied to push — release
+# packages only come from release-windows.yml on a version tag.
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -3,8 +3,6 @@ name: Windows Build
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,13 @@ jobs:
             ui -> target
           cache-on-failure: true
 
+      # src-tauri (workspace member) pulls in webkit2gtk/gtk3 on Linux; these
+      # aren't preinstalled on ubuntu-latest. See tauri.app/start/prerequisites.
+      - name: Install Tauri Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev libxdo-dev
+
       - name: cargo test --workspace
         run: cargo test --workspace
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,70 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  rust:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - uses: swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            . -> target
+            ui -> target
+          cache-on-failure: true
+
+      - name: cargo test --workspace
+        run: cargo test --workspace
+
+      - name: cargo check (wasm UI crate)
+        run: cargo check --target wasm32-unknown-unknown
+        working-directory: ui
+
+  ui-e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - uses: swatinem/rust-cache@v2
+        with:
+          workspaces: ui -> target
+          cache-on-failure: true
+
+      - name: Cache Trunk
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin
+          key: trunk-${{ runner.os }}-v1
+
+      - name: Install Trunk
+        run: command -v trunk >/dev/null 2>&1 || cargo install trunk --locked
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install Playwright deps
+        working-directory: ui-tests
+        run: npm ci
+
+      - name: Install Chromium
+        working-directory: ui-tests
+        run: npx playwright install --with-deps chromium
+
+      - name: Playwright E2E
+        working-directory: ui-tests
+        run: npx playwright test

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -514,11 +514,13 @@ fn stop_agent(state: State<'_, AppState>) {
 #[tauri::command]
 async fn new_session(state: State<'_, AppState>) -> Result<(), String> {
     let mut guard = state.agent.lock().await;
+    // Reset even when the agent hasn't been created yet (lazy init in
+    // send_message), otherwise the next message lands in the old frame.
+    let mut sess = state.session.lock().await;
+    sess.frame_id = None;
+    sess.last_seq = 0;
     if let Some(agent) = guard.as_mut() {
         agent.ctx.clear();
-        let mut sess = state.session.lock().await;
-        sess.frame_id = None;
-        sess.last_seq = 0;
         let frame_id = ensure_frame(&state.store, &state.project_id, &mut sess).await.map_err(|e| format!("{e}"))?;
         agent.ctx.messages = state.store.load_messages(&frame_id).await.unwrap_or_default();
         sess.last_seq = agent.ctx.messages.len() as i64;

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -32,6 +32,20 @@ test("send streams a mocked assistant reply", async ({ page }) => {
   await expect(page.getByText("Hello from mock wisp-science.")).toBeVisible({ timeout: 10_000 });
 });
 
+test("uploaded file shows up in the artifacts panel after send", async ({ page }) => {
+  await page.goto("/");
+  await page.setInputFiles("#composer-file-input", {
+    name: "counts.csv",
+    mimeType: "text/csv",
+    buffer: Buffer.from("a,b\n1,2"),
+  });
+  await expect(page.locator(".composer-attachment.ready")).toHaveText("counts.csv");
+  await page.getByRole("button", { name: "Send" }).click();
+  await expect(page.getByText("Hello from mock wisp-science.")).toBeVisible({ timeout: 10_000 });
+  // The upload path lives in the user turn; the panel must pick it up from there.
+  await expect(page.locator('.rp-tile[data-artifact-name="counts.csv"]')).toBeVisible();
+});
+
 test("settings modal shows the saved provider", async ({ page }) => {
   await page.goto("/");
   await page.getByRole("button", { name: "Settings" }).click();

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -830,6 +830,7 @@ fn file_kind(path: &str) -> Option<&'static str> {
         "fasta" | "fa" | "fas" | "fna" | "faa" | "ffn" | "frn" => "fasta",
         "md" => "markdown",
         "nwk" | "newick" | "treefile" | "tre" => "text",
+        "txt" | "log" | "json" => "text",
         _ => return None,
     })
 }
@@ -953,6 +954,12 @@ fn collect_artifacts(items: &[ChatItem], locale: Locale) -> Vec<Artifact> {
 
     for it in items {
         match it {
+            // Uploaded files live only in the user turn ("Uploaded files: a, b").
+            ChatItem::User(s) => {
+                for word in s.split(|c: char| c.is_whitespace() || c == ',' || c == '"' || c == '\'') {
+                    push_file_artifact(&mut out, &mut seen, word);
+                }
+            }
             ChatItem::Assistant(s) => collect_markdown_artifacts(&mut out, &mut seen, s, locale, &mut scan),
             ChatItem::Tool { name, input, output, .. } => {
                 if name == "attempt_completion" && !output.is_empty() {
@@ -1742,6 +1749,9 @@ fn App() -> impl IntoView {
 
     let new_session = move |_| {
         items.set(vec![]);
+        // ponytail: mid-upload switch can still re-add chips when the upload
+        // finishes; add a generation guard if that ever bites.
+        attachments.set(vec![]);
         active_session.set(None);
         sel_artifact.set(0);
         open_file.set(None);
@@ -1766,6 +1776,7 @@ fn App() -> impl IntoView {
         move |_| {
             if busy.get() { return; }
             show_capabilities.set(false);
+            attachments.set(vec![]);
             active_session.set(None);
             sel_artifact.set(0);
             open_file.set(None);
@@ -1790,6 +1801,7 @@ fn App() -> impl IntoView {
     };
 
     let load_session = Callback::new(move |id: String| {
+        attachments.set(vec![]);
         active_session.set(Some(id.clone()));
         sel_artifact.set(0);
         open_file.set(None);
@@ -1823,6 +1835,7 @@ fn App() -> impl IntoView {
         let busy = busy;
         show.set(false);
         busy.set(true);
+        attachments.set(vec![]);
         sel_artifact.set(0);
         open_file.set(None);
         right_tab.set(RightTab::Artifacts);


### PR DESCRIPTION
## Summary
- Uploaded files never appeared in the right-hand artifacts panel — the panel scanner (`collect_artifacts`) only walked assistant/tool transcript rows, but the upload path is only ever written into the *user* message ("Uploaded files: ..."). Added a `User` branch to the scanner and widened `file_kind` to cover `txt`/`log`/`json`.
- `new_session` reset `frame_id` only inside `if let Some(agent)`, but the agent is lazily created on first `send_message`. Launch app → open a saved session → "New session" → send a message would silently reuse the old session's frame and mix conversations together. The reset now runs unconditionally.
- Composer attachments staged (but not yet sent) in one session survived switching to `new_session`/`load_session`/`load_demo`/env-setup, so they could get attached to a message sent in a different session. Cleared on all four entry points.
- Added a Playwright regression test: upload a csv → send → assert it shows up as a tile in the artifacts panel.

## Test plan
- [x] `cargo check -p wisp-tauri`
- [x] `cargo check` (ui crate, wasm32-unknown-unknown target)
- [x] `npx playwright test` in `ui-tests/` — 9/9 passed (including the new upload test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)