### PR TITLE
fix: 新建项目名称框每次输入都 panic，导致无法创建项目

### DIFF
--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -49,11 +49,12 @@ export function tauriMock(): void {
             return [{ id: "default", name: project.name, workspace_dir: project.root, session_count: 0, updated_at: 1 }];
           case "list_recent_sessions":
             return [];
+          case "pick_directory":
+            return "/mock/root/new-project";
           case "open_project":
           case "create_project":
             return { id: "default", name: project.name, workspace_dir: project.root, session_count: 0, updated_at: 1 };
           case "delete_project":
-          case "pick_directory":
             return null;
           case "get_settings":
             return { provider: "", api_url: "https://api.deepseek.com", model: "deepseek-v4-pro", has_api_key: true, locale: "en" };

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -102,3 +102,18 @@ test("provider switch fills current API defaults", async ({ page }) => {
   await expect(page.getByLabel("API URL")).toHaveValue("https://api.anthropic.com");
   await expect(page.getByLabel("Model")).toHaveValue("claude-sonnet-5");
 });
+
+test("new project form enables Create after name and folder are set", async ({ page }) => {
+  // Stay on the Projects landing screen (don't enter a project).
+  await page.goto("/");
+  await page.getByRole("button", { name: "New project" }).click();
+  const create = page.locator(".proj-new .btn-primary");
+  await expect(create).toBeDisabled();
+  // Typing the name must register in the signal — a wrong event-target cast
+  // used to panic in the input handler, leaving the name empty and Create
+  // permanently disabled.
+  await page.locator(".proj-new input").pressSequentially("My Project");
+  await page.locator(".pn-dir .btn-ghost").click(); // Choose folder → mock path
+  await expect(page.locator(".pn-dir .path")).toHaveText("/mock/root/new-project");
+  await expect(create).toBeEnabled();
+});

--- a/ui/mock-bridge.js
+++ b/ui/mock-bridge.js
@@ -36,8 +36,9 @@
           case "create_project":
             return { id: "default", name: project.name, workspace_dir: project.root, session_count: sessions.length, updated_at: 1 };
           case "delete_project":
-          case "pick_directory":
             return null;
+          case "pick_directory":
+            return "/Users/mock/Desktop/demo-project";
           case "load_session":
             return [
               { role: "user", text: "查找文献 FX-cell", tool_name: null, ok: null },

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -533,7 +533,13 @@ fn refresh_dir(cwd: RwSignal<String>, entries: RwSignal<Vec<DirEntry>>) {
 
 fn event_target_value(ev: &web_sys::Event) -> String {
     use wasm_bindgen::JsCast;
-    ev.target().unwrap().dyn_into::<web_sys::HtmlTextAreaElement>().unwrap().value()
+    // Works for both <input> and <textarea>. Casting the wrong one used to
+    // panic in the event handler (input never registered) — see the project
+    // name field.
+    let target = ev.target().unwrap();
+    if let Some(i) = target.dyn_ref::<web_sys::HtmlInputElement>() { return i.value(); }
+    if let Some(a) = target.dyn_ref::<web_sys::HtmlTextAreaElement>() { return a.value(); }
+    String::new()
 }
 fn event_target_input(ev: &web_sys::Event) -> web_sys::HtmlInputElement {
     use wasm_bindgen::JsCast;


### PR DESCRIPTION
## 问题
新建项目时，**Create 按钮永远灰着、无法创建项目**。用户在真机上发现（多屏 computer-use 调试受阻后由用户手动定位）。

## 根因
名称框的每次按键都 panic，`new_name` 信号从未更新，于是 `disabled = name空 || dir空` 恒为 true。

`event_target_value`（`ui/src/main.rs`）把事件目标强转 `HtmlTextAreaElement` 再 `.unwrap()`。名称框是 `<input>`，转换返回 `Err` → `.unwrap()` panic（`main.rs:536`），`on:input` 在 `new_name.set(...)` 之前就崩了。
- composer 是 `<textarea>` → 转换成功，不受影响；
- settings 的 `<input>` 用的是 `event_target_input` → 不受影响。

## 修复
在共享函数一处修复：`event_target_value` 现在对 `<input>` 和 `<textarea>` 都能读 `.value()`，永不 panic。call site 无需改动，未来任意 input 也安全。

## 验证
- 在浏览器里用 trunk serve + mock 复现：console 显示 `panicked at main.rs:536`，临时信号读数显示 `NAME=[]`（打字后名字信号仍空）。
- 修复后新增 e2e 回归测试（输入名称 + 选目录 → 断言 Create 启用），**全部 10 个 e2e 通过**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)