### PR TITLE
fix: firm wisp-science self-identity (#42) + readable CSV tables

### DIFF
--- a/crates/wisp-core/src/system_prompt.rs
+++ b/crates/wisp-core/src/system_prompt.rs
@@ -20,7 +20,15 @@ impl<'a> SystemPrompt<'a> {
     }
 
     fn base_intro() -> String {
-        "You are an interactive agent that helps users with software engineering and scientific computing tasks. \
+        "You are **wisp-science**, an interactive AI agent for software engineering and scientific computing tasks. \
+\"wisp-science\" is your name and identity — always refer to yourself as wisp-science. You are NOT \"Claude Science\", \
+\"Claude\", \"ChatGPT\", \"Gemini\", or any other assistant or product, and you must never call yourself by those names, \
+even though you are built on top of a large language model.\n\n\
+About the model that powers you: your provider and model are configured by the host (the wisp-science app) and chosen \
+by the user — the backend may be an Anthropic, OpenAI-compatible (e.g. GLM, DeepSeek, Qwen), or other model, and it can \
+change between sessions. Do NOT assume or claim a specific vendor or model name. If the user asks which model you use, \
+tell them the underlying model is whatever is set in wisp-science's Settings (provider + model), that you can't reliably \
+read the exact version from inside a turn, and point them to Settings — never guess \"Claude\" or any other name.\n\n\
 Use the instructions below and the tools available to you to assist the user.\n\
 IMPORTANT: Never generate or guess URLs unless you are confident they help the user with their work. \
 For file paths, prefer absolute paths when possible. If you need to read a directory, use the `shell` tool \
@@ -104,5 +112,16 @@ mod tests {
         let skills = SkillIndex::default();
         let sp = SystemPrompt::new(std::path::Path::new("/tmp"), &skills, None);
         assert!(!sp.assemble().contains("## Compute hosts"));
+    }
+
+    #[test]
+    fn identity_names_wisp_science_and_stays_model_agnostic() {
+        let skills = SkillIndex::default();
+        let out = SystemPrompt::new(std::path::Path::new("/tmp"), &skills, None).assemble();
+        // #42: the agent confused itself with the upstream "Claude Science" and
+        // claimed an Anthropic model while actually running GLM. Lock in that the
+        // prompt fixes its name and keeps it from asserting a specific model.
+        assert!(out.contains("You are **wisp-science**"), "identity anchor missing:\n{out}");
+        assert!(out.contains("wisp-science's Settings"), "model-agnostic guidance missing:\n{out}");
     }
 }

--- a/skills/compute-env-setup/SKILL.md
+++ b/skills/compute-env-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: compute-env-setup
-description: Set up a compute environment on a remote provider so Claude Science jobs can run there. Covers direct SSH/conda hosts, Slurm clusters, container-via-bridge runners, and managed-API providers (Modal, GCP, RunPod). Use when standing up a new provider, porting an env to a different backend, adding a tool that needs its own software stack, or wiring weight caches. Triggers on "new compute provider", "set up env on", "port env to", "build GPU image", "weight cache", "compute_details", "conda env on the box", "apptainer on slurm".
+description: Set up a compute environment on a remote provider so wisp-science jobs can run there. Covers direct SSH/conda hosts, Slurm clusters, container-via-bridge runners, and managed-API providers (Modal, GCP, RunPod). Use when standing up a new provider, porting an env to a different backend, adding a tool that needs its own software stack, or wiring weight caches. Triggers on "new compute provider", "set up env on", "port env to", "build GPU image", "weight cache", "compute_details", "conda env on the box", "apptainer on slurm".
 license: Apache-2.0
 ---
 

--- a/skills/customize/SKILL.md
+++ b/skills/customize/SKILL.md
@@ -12,7 +12,7 @@ Build and maintain **agent profiles** and **skills** programmatically via the
 A **profile** is a named bundle that shapes how an agent behaves:
 
 - **`system_prompt`** — the profile's **identity**. This is the opening of the
-  agent's system prompt; it REPLACES the generic "You are Claude Science" base identity.
+  agent's system prompt; it REPLACES the generic "You are wisp-science" base identity.
   Write it in second person, lead with `You are {display_name}, ...`, state what
   the agent specializes in and what it does NOT do. Everything else (tool-usage
   rules, working-style bullets, scope guardrail) is inherited automatically —

--- a/skills/self-awareness/SKILL.md
+++ b/skills/self-awareness/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: self-awareness
-description: Claude Science's own session database schema and SDK surface for introspection via host.query(). Load this when you need to query your own conversation history, token usage, cost accounting, execution log, or artifact metadata beyond what host.frames()/host.artifacts() provide — e.g. "how many tokens has this session used", "what was my last tool call", "list every file I've written", "where are messages stored", "what tables can I query", "inspect frames.context_data", or any time you're about to PRAGMA-probe the Claude Science metadata DB to discover its schema.
+description: wisp-science's own session database schema and SDK surface for introspection via host.query(). Load this when you need to query your own conversation history, token usage, cost accounting, execution log, or artifact metadata beyond what host.frames()/host.artifacts() provide — e.g. "how many tokens has this session used", "what was my last tool call", "list every file I've written", "where are messages stored", "what tables can I query", "inspect frames.context_data", or any time you're about to PRAGMA-probe the wisp-science metadata DB to discover its schema.
 license: Apache-2.0
 ---
 
-# Self-awareness — Claude Science's own database and SDK
+# Self-awareness — wisp-science's own database and SDK
 
 `host.query(sql, params=[], limit=None, df=False)` runs read-only SQLite
-against Claude Science's own metadata DB. It is only available via the **`repl`
+against wisp-science's own metadata DB. It is only available via the **`repl`
 tool** (not `python`/`r`). Results are automatically scoped to the current
 project, so `SELECT * FROM frames` returns only frames in this project. The
 `repl` tool is stdlib-only — `df=True` returns the raw dict there (use

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -467,7 +467,10 @@ button.stop:hover { background: hsl(0 70% 50% / 0.08); border-color: hsl(0 70% 5
 .tbl-wrap { overflow: auto; border: 1px solid var(--border); border-radius: var(--radius-sm); white-space: normal; }
 .tbl-note { font-size: 11px; color: var(--text-faint); padding: 6px 11px; border-bottom: 1px solid var(--border); background: var(--bg-sunken); }
 .tbl { border-collapse: collapse; width: 100%; font-size: 12.5px; table-layout: auto; }
-.tbl th, .tbl td { padding: 7px 11px; text-align: left; border-bottom: 1px solid var(--border); border-right: 1px solid var(--border); white-space: normal; word-break: break-word; vertical-align: top; line-height: 1.45; }
+/* Data cells stay on one line — a wide CSV scrolls horizontally in .tbl-wrap
+   instead of shattering numbers/headers character-by-character (matches the
+   Claude Science CsvPreview approach: nowrap + tabular-nums + scroll). */
+.tbl th, .tbl td { padding: 7px 11px; text-align: left; border-bottom: 1px solid var(--border); border-right: 1px solid var(--border); white-space: nowrap; vertical-align: middle; line-height: 1.45; font-variant-numeric: tabular-nums; }
 .tbl td strong, .tbl th strong { font-weight: 650; }
 .tbl td code, .tbl th code { font-family: var(--font-mono); font-size: 11.5px; background: var(--bg-sunken); border: 1px solid var(--border); border-radius: 4px; padding: 0 4px; }
 .tbl th:last-child, .tbl td:last-child { border-right: none; }


### PR DESCRIPTION
Two independent fixes, one commit each.

## 1. Self-cognition — Closes #42
The agent confused itself with the upstream "Claude Science" in the same reply and, asked which model it uses, claimed an Anthropic model **while actually running GLM-5.2** via an OpenAI-compatible endpoint.

Root cause: the system prompt never named the agent (`base_intro` just said "You are an interactive agent"), so the model improvised an identity — reinforced by a few bundled skill **descriptions** (which are injected into every prompt) that mention "Claude Science".

- `base_intro` now opens with **"You are wisp-science"**, explicitly forbids self-identifying as Claude Science / Claude / ChatGPT / Gemini, and stays **model-agnostic**: provider + model are host-configured (Settings) and may be Anthropic, OpenAI-compatible (GLM/DeepSeek/Qwen), etc. — never guess a vendor.
- Scrubbed "Claude Science" from the always-injected skill descriptions (`self-awareness`, `compute-env-setup`) and the `customize` skill's stated base identity.
- Added a regression test asserting the wisp-science identity anchor.

Deferred: operational "Claude Science" references inside on-demand skill **bodies** (Modal daemon/sandbox mechanics, skill publishing) — they mix in host-runtime specifics that don't map 1:1 to wisp's Tauri architecture, so they want a separate careful sweep rather than a blind replace.

## 2. CSV tables shatter numbers into vertical strips
`.tbl` cells used `white-space: normal` + `word-break: break-word`, so a wide CSV crammed its columns into the panel and broke every header and number character-by-character (`12 .1 90 02 9`).

Following the Claude Science `CsvPreview` approach: cells are now `white-space: nowrap` with `tabular-nums`, so values stay intact on one line and a wide table scrolls horizontally in `.tbl-wrap` (which already has `overflow: auto`). Sticky header still works. Only affects data tables (CSV preview + table artifacts); chat prose tables use a separate `.md table` selector.

## Verification
- `cargo test -p wisp-core system_prompt` — 3 pass (incl. the new identity test).
- CSV table verified against the real `styles.css` at a 640px panel width: `.tbl-wrap` scrollWidth 860 > clientWidth 612 (scrolls), headers/numbers single-line, `tabular-nums` applied.

Independent of #44 (settings/artifacts/search), which is still open on its own branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)