### PR TITLE
fix: 文件预览路径、GLM 进度截断、会话切换竞态 (#12 #15 #53 #55)

### DIFF
--- a/crates/wisp-core/src/agent.rs
+++ b/crates/wisp-core/src/agent.rs
@@ -49,6 +49,13 @@ pub async fn agent_loop(
         );
 
         if comp.tool_calls.is_empty() {
+            // A turn truncated at the model's token cap also arrives with no tool
+            // calls, looking identical to a clean finish — so the run would stop
+            // mid-task with no explanation (#55, seen with GLM-5.2 hitting
+            // max_tokens). Surface it instead of silently cutting progress off.
+            if is_truncated(comp.finish_reason.as_deref()) {
+                anyhow::bail!("模型输出在达到 max_tokens 上限时被截断，任务可能尚未完成——请在设置中调高该模型的 max_tokens，或直接继续对话让我接着做。(output truncated at max_tokens)");
+            }
             break;
         }
 
@@ -77,4 +84,30 @@ pub async fn agent_loop(
         }
     }
     Ok(())
+}
+
+/// A turn with no tool calls is normally a clean finish, but when the provider
+/// reports a token-cap stop the response was cut off mid-thought and the run
+/// should not be treated as complete. OpenAI-compatible APIs (incl. GLM) report
+/// `"length"`; Anthropic passes `"max_tokens"` through unmapped.
+fn is_truncated(finish_reason: Option<&str>) -> bool {
+    matches!(finish_reason, Some("length") | Some("max_tokens"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_truncated;
+
+    #[test]
+    fn truncation_detected_across_providers() {
+        // Both the OpenAI/GLM cap signal and the Anthropic cap signal count, so a
+        // capped turn is reported instead of silently ending mid-task (#55).
+        assert!(is_truncated(Some("length")));
+        assert!(is_truncated(Some("max_tokens")));
+        // Clean finishes and tool-call turns must NOT look like truncation, or
+        // every normal turn-end would raise a spurious error.
+        assert!(!is_truncated(Some("stop")));
+        assert!(!is_truncated(Some("tool_calls")));
+        assert!(!is_truncated(None));
+    }
 }

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -454,6 +454,20 @@ mod tauri_args_tests {
         assert_eq!(v["maxBytes"], 1024);
         assert!(v.get("max_bytes").is_none());
     }
+
+    // The agent is told to emit absolute paths, so a clicked file link must reach
+    // the backend intact. Stripping the leading slash turned `/Users/…/fig.png`
+    // into a bad root-relative path that 404'd on click (#12).
+    #[test]
+    fn normalize_path_keeps_absolute_paths() {
+        assert_eq!(normalize_path("/Users/x/proj/results/fig.png"), "/Users/x/proj/results/fig.png");
+        assert_eq!(normalize_path("C:\\proj\\out.csv"), "C:\\proj\\out.csv");
+        // Redundant current-dir prefixes are still trimmed; relative stays relative.
+        assert_eq!(normalize_path("./results/fig.png"), "results/fig.png");
+        assert_eq!(normalize_path(".\\results\\fig.png"), "results\\fig.png");
+        assert_eq!(normalize_path("results/fig.png"), "results/fig.png");
+        assert_eq!(normalize_path("  /a/b.txt  "), "/a/b.txt");
+    }
 }
 
 #[derive(Deserialize, Clone)]
@@ -910,11 +924,13 @@ fn art_chip(idx: usize, a: &Artifact) -> String {
 }
 
 fn normalize_path(path: &str) -> String {
+    // Only strip redundant `./` prefixes. Do NOT strip a leading `/` — the agent
+    // is told to emit absolute paths (system_prompt.rs), and the backend resolves
+    // absolute-under-root correctly; stripping the slash turned an absolute path
+    // into a bad root-relative one and 404'd on click (#12).
     path.trim()
         .trim_start_matches("./")
         .trim_start_matches(".\\")
-        .trim_start_matches('/')
-        .trim_start_matches('\\')
         .to_string()
 }
 
@@ -2629,8 +2645,14 @@ fn App() -> impl IntoView {
         right_tab.set(RightTab::Artifacts);
         spawn_local(async move {
             let v = invoke("new_session", JsValue::UNDEFINED).await;
-            let id = v.as_string();
-            active_session.set(id);
+            // Guard the malformed-response case: a `None` id would blank the active
+            // session and strand the user on an empty, unusable view (#15). The old
+            // transcript is already stashed above, so bailing keeps it reachable.
+            let Some(id) = v.as_string() else {
+                status.set(t(locale.get(), "status.send_failed").into());
+                return;
+            };
+            active_session.set(Some(id));
             items.set(vec![]);
             refresh_sessions(sessions);
         });
@@ -2715,8 +2737,13 @@ fn App() -> impl IntoView {
             if let Ok(list) = serde_wasm_bindgen::from_value::<Vec<LoadedItem>>(v) {
                 let chats: Vec<ChatItem> = list.into_iter().map(LoadedItem::into_chat).collect();
                 transcripts.update(|m| { m.insert(id.clone(), chats.clone()); });
-                items.set(chats);
-                force_chat_bottom();
+                // Only repaint the view if we're still on this session — a rapid
+                // switch could have moved on while the load was in flight, and an
+                // unguarded set would clobber the newer view with stale rows (#53).
+                if active_session.get().as_deref() == Some(&id) {
+                    items.set(chats);
+                    force_chat_bottom();
+                }
             }
         });
     });


### PR DESCRIPTION
本次修复 4 个 issue,均为定位到根因的最小改动,并为两处纯逻辑核心补了防回归单测。

## 修复内容

### #12 点击产物文件"未找到"
`normalize_path` 把绝对路径的前导 `/` 削掉,而系统提示词明确要求 agent 输出**绝对路径**(`crates/wisp-core/src/system_prompt.rs`)。削掉后 `/Users/…/fig.png` 变成坏的相对路径,被后端按 `root.join(...)` 解析到错误位置 → 404。改为只去 `./` 前缀,保留绝对路径;后端 `validate_file_path` 本就能正确处理"绝对且在 root 内"。

### #55 GLM-5.2 进度自动截止
模型命中 `max_tokens` 时返回 `finish_reason: "length"` 且没有 tool call,而 agent 循环把"无 tool call"一律当作正常结束(`agent.rs`),导致任务中途被**静默中断**。现在识别截断(`length`/`max_tokens`)并报出清晰提示——提示用户调大该模型的 max_tokens 或直接继续对话——而不是无声停下。截断前的部分输出已增量落盘,可直接"继续"。

### #53 会话切换滞后 / 视图被覆盖
切换本身是可用的(运行中的会话从缓存实时渲染)。真正的竞态在 `load_session` 的 DB 回填:异步加载返回时无条件 `items.set(...)`,若用户在加载途中已切到别的会话,旧数据会盖掉新视图。加了 `active_session == id` 守卫(复用发送完成路径已上线的同一模式)。
> 注:"跨项目切换会取消运行中的会话"是**有意设计**(单活动项目,`lib.rs` open_project),不在本次改动范围。

### #15 分析中新建会话丢对话(加固)
主体已被 v0.3 多会话缓存重构解决(旧对话进 `transcripts` 缓存并保留在侧边栏)。本次补齐 `new_session` 对**异常返回(None id)**的守卫,避免把 `active_session` 清成 `None` 让用户搁浅在空白视图。

## 测试
- 新增 `normalize_path_keeps_absolute_paths`(ui)
- 新增 `truncation_detected_across_providers`(wisp-core)
- 全量:`wisp-core` 6 passed,`ui` 3 passed,无回归

#15/#53 为异步 + Leptos 信号闭包内的防御守卫,本仓库现有测试仅覆盖纯函数,为两行守卫搭响应式 mock harness 属过度工程,故未单测。

🤖 Generated with [Claude Code](https://claude.com/claude-code)