### PR TITLE
feat(ui): top-nav project switcher dropdown + Project Settings modal

### DIFF
--- a/crates/wisp-store/src/lib.rs
+++ b/crates/wisp-store/src/lib.rs
@@ -114,12 +114,31 @@ impl Store {
         Ok(row)
     }
 
+    /// Full editable metadata for the Project Settings modal: (name, description, workspace_dir).
+    pub async fn get_project_meta(&self, id: &str) -> Result<Option<(String, String, String)>> {
+        let row: Option<(String, String, String)> = sqlx::query_as(
+            "SELECT COALESCE(name,''), COALESCE(description,''), COALESCE(workspace_dir,'') FROM projects WHERE id=?",
+        )
+        .bind(id).fetch_optional(&self.pool).await?;
+        Ok(row)
+    }
+
+    /// Update a project's user-visible name and description (touches updated_at).
+    pub async fn update_project(&self, id: &str, name: &str, description: &str) -> Result<()> {
+        let now = chrono::Utc::now().timestamp();
+        sqlx::query("UPDATE projects SET name=?, description=?, updated_at=? WHERE id=?")
+            .bind(name).bind(description).bind(now).bind(id)
+            .execute(&self.pool).await?;
+        Ok(())
+    }
+
     /// All projects, newest-updated first, each with its session count
     /// (root frames that have at least one user turn — matches `list_sessions`).
-    pub async fn list_projects(&self) -> Result<Vec<(String, String, String, i64, i64, i64)>> {
+    pub async fn list_projects(&self) -> Result<Vec<(String, String, String, i64, i64, i64, String)>> {
         let rows = sqlx::query(
             "SELECT p.id AS id, COALESCE(p.name,'') AS name, COALESCE(p.workspace_dir,'') AS ws, \
                     p.created_at AS created_at, p.updated_at AS updated_at, \
+                    COALESCE(p.description,'') AS description, \
                     (SELECT COUNT(*) FROM frames f WHERE f.project_id = p.id AND f.parent_frame_id = f.id \
                        AND EXISTS (SELECT 1 FROM messages m WHERE m.frame_id = f.id AND m.role='user')) AS sessions \
              FROM projects p ORDER BY p.updated_at DESC, p.rowid DESC",
@@ -130,6 +149,7 @@ impl Store {
             out.push((
                 r.try_get("id")?, r.try_get("name")?, r.try_get("ws")?,
                 r.try_get("created_at")?, r.try_get("updated_at")?, r.try_get("sessions")?,
+                r.try_get("description")?,
             ));
         }
         Ok(out)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -78,6 +78,7 @@ struct ArtifactInfo {
 
 #[derive(Serialize, Clone)]
 struct ProjectInfo {
+    id: String,
     name: String,
     root: String,
     skill_count: usize,
@@ -143,6 +144,7 @@ struct SessionInfo {
 struct ProjectSummary {
     id: String,
     name: String,
+    description: String,
     workspace_dir: String,
     session_count: i64,
     updated_at: i64,
@@ -152,16 +154,16 @@ struct ProjectSummary {
 
 async fn build_project_summary(state: &AppState, id: &str) -> ProjectSummary {
     let running = state.running_turns.lock().await.clone();
-    let Some((id, name, ws, _c, upd, cnt)) = state.store.list_projects().await.ok()
+    let Some((id, name, ws, _c, upd, cnt, desc)) = state.store.list_projects().await.ok()
         .and_then(|v| v.into_iter().find(|r| r.0 == id))
     else {
         return ProjectSummary {
-            id: id.into(), name: String::new(), workspace_dir: String::new(),
+            id: id.into(), name: String::new(), description: String::new(), workspace_dir: String::new(),
             session_count: 0, updated_at: 0, running_count: 0, needs_you_count: 0,
         };
     };
     let (running_count, needs_you_count) = project_status_counts(&state.store, &id, &running).await;
-    ProjectSummary { id, name, workspace_dir: ws, session_count: cnt, updated_at: upd, running_count, needs_you_count }
+    ProjectSummary { id, name, description: desc, workspace_dir: ws, session_count: cnt, updated_at: upd, running_count, needs_you_count }
 }
 
 fn session_runtime_status(id: &str, last_role: Option<&str>, running: &HashSet<String>) -> &'static str {
@@ -1018,9 +1020,9 @@ async fn list_projects(state: State<'_, AppState>) -> Result<Vec<ProjectSummary>
     let running = state.running_turns.lock().await.clone();
     let rows = state.store.list_projects().await.map_err(|e| format!("{e}"))?;
     let mut out = vec![];
-    for (id, name, ws, _c, upd, cnt) in rows {
+    for (id, name, ws, _c, upd, cnt, desc) in rows {
         let (running_count, needs_you_count) = project_status_counts(&state.store, &id, &running).await;
-        out.push(ProjectSummary { id, name, workspace_dir: ws, session_count: cnt, updated_at: upd, running_count, needs_you_count });
+        out.push(ProjectSummary { id, name, description: desc, workspace_dir: ws, session_count: cnt, updated_at: upd, running_count, needs_you_count });
     }
     Ok(out)
 }
@@ -1085,6 +1087,46 @@ async fn delete_project(state: State<'_, AppState>, id: String) -> Result<(), St
     }
     state.store.delete_project(&id).await.map_err(|e| format!("{e}"))?;
     Ok(())
+}
+
+#[derive(Serialize, Clone)]
+struct ProjectSettings {
+    id: String,
+    name: String,
+    description: String,
+    agent_context: String,
+}
+
+/// Read the active project's editable settings for the Project Settings modal.
+/// Agent Context is `.wisp/WISP.md`, injected into every seeded system prompt.
+#[tauri::command]
+async fn get_project_settings(state: State<'_, AppState>) -> Result<ProjectSettings, String> {
+    let ap = state.active();
+    let (name, description, _ws) = state.store.get_project_meta(&ap.id).await
+        .map_err(|e| format!("{e}"))?
+        .unwrap_or_default();
+    let agent_context = std::fs::read_to_string(ap.root.join(".wisp").join("WISP.md")).unwrap_or_default();
+    Ok(ProjectSettings { id: ap.id.clone(), name, description, agent_context })
+}
+
+/// Save the active project's name/description (DB) and Agent Context (.wisp/WISP.md).
+/// An empty Agent Context removes WISP.md so the prompt falls back to "no rules".
+/// Takes effect on the next seeded session; already-running agents keep their prompt.
+#[tauri::command]
+async fn update_project(state: State<'_, AppState>, name: String, description: String, agent_context: String) -> Result<ProjectSummary, String> {
+    if name.trim().is_empty() { return Err("Project name is required".into()); }
+    let ap = state.active();
+    state.store.update_project(&ap.id, name.trim(), description.trim()).await.map_err(|e| format!("{e}"))?;
+    let wisp_dir = ap.root.join(".wisp");
+    let wisp_md = wisp_dir.join("WISP.md");
+    let ctx = agent_context.trim();
+    if ctx.is_empty() {
+        let _ = std::fs::remove_file(&wisp_md);
+    } else {
+        std::fs::create_dir_all(&wisp_dir).map_err(|e| format!("Failed to write Agent Context: {e}"))?;
+        std::fs::write(&wisp_md, ctx).map_err(|e| format!("Failed to write Agent Context: {e}"))?;
+    }
+    Ok(build_project_summary(&state, &ap.id).await)
 }
 
 /// Switch the active session to `id`, load its transcript, and return the
@@ -1619,8 +1661,14 @@ async fn build_project_info(state: &AppState) -> ProjectInfo {
     let ap = state.active();
     let (_, _, _, api_key) = load_settings(&state.store).await;
     let mcp = list_mcp_servers(&ap.root);
-    let name = ap.root.file_name().and_then(|n| n.to_str()).unwrap_or("Workspace").to_string();
+    // Prefer the user-set project name (Project Settings) over the folder name.
+    let db_name = state.store.get_project(&ap.id).await.ok().flatten()
+        .map(|(n, _)| n).unwrap_or_default();
+    let name = if db_name.trim().is_empty() {
+        ap.root.file_name().and_then(|n| n.to_str()).unwrap_or("Workspace").to_string()
+    } else { db_name };
     ProjectInfo {
+        id: ap.id.clone(),
         name,
         root: ap.root.to_string_lossy().into_owned(),
         skill_count: ap.skills.all().len(),
@@ -1993,6 +2041,8 @@ pub fn run() {
             create_project,
             open_project,
             delete_project,
+            get_project_settings,
+            update_project,
             load_session,
             rewind_session,
             list_skills,

--- a/ui/preview.html
+++ b/ui/preview.html
@@ -78,15 +78,39 @@
 </div>
 <div class="app">
   <aside class="sidebar">
-    <div class="brand">
-      <span class="brand-name">Wisp Science</span>
-      <span class="brand-beta">Beta</span>
+    <div class="sidebar-head">
+      <button class="side-back" title="Back to projects">&larr;</button>
+      <button class="proj-switch active">
+        <span class="proj-name">Cross-species scRNA-seq</span>
+        <span class="caret">&#9662;</span>
+      </button>
       <button class="icon-btn" title="Collapse">&lsaquo;</button>
     </div>
-    <button class="proj-switch">
-      <span class="proj-name">wisp-science</span>
-      <span class="caret">&#9662;</span>
-    </button>
+    <div class="proj-menu">
+      <button class="proj-menu-item"><span class="gi gear"></span>Project settings</button>
+      <div class="proj-menu-sep"></div>
+      <div class="proj-menu-list">
+        <button class="proj-menu-row active">
+          <span class="pm-text">
+            <span class="pm-name">Cross-species scRNA-seq</span>
+            <span class="pm-desc">Integration methods benchmark &amp; review</span>
+          </span>
+          <span class="pm-check">&check;</span>
+        </button>
+        <button class="proj-menu-row">
+          <span class="pm-text">
+            <span class="pm-name">Run a first-pass analysis</span>
+            <span class="pm-desc">Your first project, created during onboarding.</span>
+          </span>
+        </button>
+        <button class="proj-menu-row">
+          <span class="pm-text">
+            <span class="pm-name">Example project</span>
+            <span class="pm-desc">New to Wisp? These analyses show what's possible.</span>
+          </span>
+        </button>
+      </div>
+    </div>
     <nav class="nav">
       <button class="side-btn primary"><span class="gi plus"></span>New session</button>
       <button class="side-btn"><span class="gi grid"></span>Open demo</button>

--- a/ui/src/dto.rs
+++ b/ui/src/dto.rs
@@ -216,6 +216,7 @@ pub(crate) struct DirEntry {
 #[derive(Deserialize, Clone)]
 #[allow(dead_code)]
 pub(crate) struct ProjectInfo {
+    #[serde(default)] pub(crate) id: String,
     pub(crate) name: String,
     pub(crate) root: String,
     pub(crate) skill_count: usize,
@@ -228,11 +229,22 @@ pub(crate) struct ProjectInfo {
 pub(crate) struct ProjectSummary {
     pub(crate) id: String,
     pub(crate) name: String,
+    #[serde(default)] pub(crate) description: String,
     #[allow(dead_code)] #[serde(default)] pub(crate) workspace_dir: String,
     #[serde(default)] pub(crate) session_count: i64,
     #[serde(default)] pub(crate) updated_at: i64,
     #[serde(default)] pub(crate) running_count: i64,
     #[serde(default)] pub(crate) needs_you_count: i64,
+}
+
+/// Editable project settings (Project Settings modal). `agent_context` is the
+/// project's `.wisp/WISP.md`, injected into every seeded system prompt.
+#[derive(Clone, Deserialize, Default)]
+pub(crate) struct ProjectSettings {
+    #[allow(dead_code)] #[serde(default)] pub(crate) id: String,
+    #[serde(default)] pub(crate) name: String,
+    #[serde(default)] pub(crate) description: String,
+    #[serde(default)] pub(crate) agent_context: String,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]

--- a/ui/src/i18n.rs
+++ b/ui/src/i18n.rs
@@ -301,6 +301,14 @@ fn lookup(locale: Locale, key: &str) -> Option<&'static str> {
         (Locale::En, "projects.delete_confirm") => Some("Remove this project from Wisp? Your files on disk are kept."),
         (Locale::En, "projects.back") => Some("Projects"),
 
+        (Locale::En, "proj_menu.settings") => Some("Project settings"),
+        (Locale::En, "proj_settings.title") => Some("Project Settings"),
+        (Locale::En, "proj_settings.name") => Some("Name"),
+        (Locale::En, "proj_settings.description") => Some("Description"),
+        (Locale::En, "proj_settings.description_hint") => Some("Shown in the project switcher for your reference — not included in the agent's prompt."),
+        (Locale::En, "proj_settings.agent_context") => Some("Agent Context"),
+        (Locale::En, "proj_settings.agent_context_hint") => Some("Included in every agent's system prompt for this project. Use it for background, conventions, or instructions all agents should follow. Takes effect on the next new session."),
+
         (Locale::En, "sess_status.running") => Some("Running"),
         (Locale::En, "sess_status.needs_you") => Some("Needs you"),
         (Locale::En, "sess_status.complete") => Some("Complete"),
@@ -564,6 +572,14 @@ fn lookup(locale: Locale, key: &str) -> Option<&'static str> {
         (Locale::Zh, "projects.delete") => Some("删除"),
         (Locale::Zh, "projects.delete_confirm") => Some("从 Wisp 移除该项目？磁盘上的文件会保留。"),
         (Locale::Zh, "projects.back") => Some("项目"),
+
+        (Locale::Zh, "proj_menu.settings") => Some("项目设置"),
+        (Locale::Zh, "proj_settings.title") => Some("项目设置"),
+        (Locale::Zh, "proj_settings.name") => Some("名称"),
+        (Locale::Zh, "proj_settings.description") => Some("描述"),
+        (Locale::Zh, "proj_settings.description_hint") => Some("显示在项目切换器中供你参考 —— 不会包含在 Agent 的提示词里。"),
+        (Locale::Zh, "proj_settings.agent_context") => Some("Agent 上下文"),
+        (Locale::Zh, "proj_settings.agent_context_hint") => Some("会包含在本项目每个 Agent 的系统提示词中。可用于填写背景信息、约定或所有 Agent 都应遵循的指令。下次新建会话时生效。"),
 
         (Locale::Zh, "sess_status.running") => Some("运行中"),
         (Locale::Zh, "sess_status.needs_you") => Some("需要你"),

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -1425,6 +1425,12 @@ fn App() -> impl IntoView {
     let demos = create_rw_signal::<Vec<DemoInfo>>(vec![]);
     let show_projects = create_rw_signal(true); // app lands on the Projects screen
     let demo_mode = create_rw_signal(false); // true = the synthetic "Example project" is open
+    // Top-nav project switcher dropdown + Project Settings modal.
+    let show_proj_menu = create_rw_signal(false);
+    let proj_list = create_rw_signal::<Vec<ProjectSummary>>(vec![]);
+    let show_proj_settings = create_rw_signal(false);
+    let proj_settings = create_rw_signal(ProjectSettings::default());
+    let proj_settings_busy = create_rw_signal(false);
 
     // Session history (left sidebar).
     let sessions = create_rw_signal::<Vec<SessionInfo>>(vec![]);
@@ -2379,6 +2385,61 @@ fn App() -> impl IntoView {
         }
     });
 
+    // --- Top-nav project switcher + Project Settings ---
+    // Switch the active project inline (same flow as the Projects screen).
+    let switch_project = Callback::new(move |id: String| {
+        show_proj_menu.set(false);
+        show_projects.set(false);
+        demo_mode.set(false);
+        spawn_local(async move {
+            let arg = to_value(&serde_json::json!({ "id": id })).unwrap();
+            let _ = invoke("open_project", arg).await;
+            items.set(vec![]);
+            active_session.set(None);
+            refresh_sessions(sessions);
+            let v = invoke("get_project_info", JsValue::UNDEFINED).await;
+            if let Ok(p) = serde_wasm_bindgen::from_value::<ProjectInfo>(v) { project_info.set(Some(p)); }
+        });
+    });
+    let toggle_proj_menu = move |_| {
+        let opening = !show_proj_menu.get();
+        show_proj_menu.set(opening);
+        if opening {
+            spawn_local(async move {
+                let v = invoke("list_projects", JsValue::UNDEFINED).await;
+                if let Ok(list) = serde_wasm_bindgen::from_value::<Vec<ProjectSummary>>(v) { proj_list.set(list); }
+            });
+        }
+    };
+    let open_proj_settings = move |_| {
+        show_proj_menu.set(false);
+        spawn_local(async move {
+            let v = invoke("get_project_settings", JsValue::UNDEFINED).await;
+            if let Ok(s) = serde_wasm_bindgen::from_value::<ProjectSettings>(v) {
+                proj_settings.set(s);
+                show_proj_settings.set(true);
+            }
+        });
+    };
+    let save_proj_settings = move |_| {
+        if proj_settings_busy.get() { return; }
+        let form = proj_settings.get();
+        if form.name.trim().is_empty() { return; }
+        proj_settings_busy.set(true);
+        spawn_local(async move {
+            let arg = to_value(&serde_json::json!({
+                "name": form.name, "description": form.description, "agentContext": form.agent_context,
+            })).unwrap();
+            let res = invoke_checked("update_project", arg).await;
+            proj_settings_busy.set(false);
+            if res.is_ok() {
+                show_proj_settings.set(false);
+                let v = invoke("get_project_info", JsValue::UNDEFINED).await;
+                if let Ok(p) = serde_wasm_bindgen::from_value::<ProjectInfo>(v) { project_info.set(Some(p)); }
+            }
+        });
+    };
+
     view! {
         {move || show_projects.get().then(|| {
             let open = Callback::new(move |id: String| {
@@ -2430,18 +2491,46 @@ fn App() -> impl IntoView {
         })}
         <div class="app" class:app-hidden=move || show_projects.get() on:contextmenu=on_context_menu>
         <aside class="sidebar" class:collapsed=move || !show_sidebar.get()>
-            <div class="brand">
-                <span class="brand-name" title=move || t(locale.get(), "sidebar.back_projects")
-                    on:click=move |_| { demo_mode.set(false); show_projects.set(true); }>"Wisp Science"</span>
-                <span class="brand-beta">"Beta"</span>
-                <span class="spacer"></span>
-                <button class="icon-btn" title=move || t(locale.get(), "sidebar.back_projects")
-                    on:click=move |_| { demo_mode.set(false); show_projects.set(true); }><span class="gi grid"></span></button>
+            <div class="sidebar-head">
+                <button class="side-back" title=move || t(locale.get(), "sidebar.back_projects")
+                    on:click=move |_| { show_proj_menu.set(false); demo_mode.set(false); show_projects.set(true); }>"←"</button>
+                <button class="proj-switch" class:active=move || show_proj_menu.get() on:click=toggle_proj_menu>
+                    <span class="proj-name">{move || if demo_mode.get() { t(locale.get(), "projects.example").to_string() } else { project_info.get().map(|p| p.name.clone()).unwrap_or_else(|| "wisp-science".into()) }}</span>
+                    <span class="caret">"▾"</span>
+                </button>
                 <button class="icon-btn" title=move || t(locale.get(), "sidebar.collapse") on:click=move |_| show_sidebar.set(false)>"‹"</button>
             </div>
-            <button class="proj-switch" on:click=move |_| { demo_mode.set(false); show_projects.set(true); }>
-                <span class="proj-name">{move || if demo_mode.get() { t(locale.get(), "projects.example").to_string() } else { project_info.get().map(|p| p.name.clone()).unwrap_or_else(|| "wisp-science".into()) }}</span>
-            </button>
+            {move || show_proj_menu.get().then(|| view! {
+                <div class="proj-menu-backdrop" on:click=move |_| show_proj_menu.set(false)></div>
+                <div class="proj-menu">
+                    <button type="button" class="proj-menu-item" on:click=open_proj_settings>
+                        <span class="gi gear"></span>
+                        {move || t(locale.get(), "proj_menu.settings")}
+                    </button>
+                    <div class="proj-menu-sep"></div>
+                    <div class="proj-menu-list">
+                        {move || {
+                            let active_id = project_info.get().map(|p| p.id.clone()).unwrap_or_default();
+                            let dm = demo_mode.get();
+                            proj_list.get().into_iter().map(|p| {
+                                let is_active = !dm && p.id == active_id;
+                                let pid = p.id.clone();
+                                let desc = p.description.clone();
+                                view! {
+                                    <button type="button" class="proj-menu-row" class:active=is_active
+                                        on:click=move |_| switch_project.call(pid.clone())>
+                                        <span class="pm-text">
+                                            <span class="pm-name">{p.name.clone()}</span>
+                                            {(!desc.trim().is_empty()).then(|| view! { <span class="pm-desc">{desc.clone()}</span> })}
+                                        </span>
+                                        {is_active.then(|| view! { <span class="pm-check">"✓"</span> })}
+                                    </button>
+                                }
+                            }).collect_view()
+                        }}
+                    </div>
+                </div>
+            })}
             <nav class="nav">
                 <button class="side-btn primary" on:click=new_session><span class="gi plus"></span>{move || t(locale.get(), "sidebar.new_session")}</button>
                 <button class="side-btn" on:click=open_files><span class="gi doc"></span>{move || t(locale.get(), "sidebar.files")}</button>
@@ -3149,6 +3238,44 @@ fn App() -> impl IntoView {
         }.into_view()
         })}
 
+        {move || show_proj_settings.get().then(|| view! {
+            <div class="overlay">
+                <div class="modal proj-settings-modal">
+                    <div class="ps-head">
+                        <h2>{move || t(locale.get(), "proj_settings.title")}</h2>
+                        <button type="button" class="ps-close"
+                            title=move || t(locale.get(), "settings.cancel")
+                            on:click=move |_| show_proj_settings.set(false)>"×"</button>
+                    </div>
+                    <label>
+                        {move || t(locale.get(), "proj_settings.name")}
+                        <input prop:value=move || proj_settings.get().name
+                            on:input=move |ev| { let v = event_target_value(&ev); proj_settings.update(|s| s.name = v); } />
+                    </label>
+                    <label>
+                        {move || t(locale.get(), "proj_settings.description")}
+                        <span class="ps-hint">{move || t(locale.get(), "proj_settings.description_hint")}</span>
+                        <textarea class="ps-textarea" rows="2"
+                            prop:value=move || proj_settings.get().description
+                            on:input=move |ev| { let v = event_target_value(&ev); proj_settings.update(|s| s.description = v); }></textarea>
+                    </label>
+                    <label>
+                        {move || t(locale.get(), "proj_settings.agent_context")}
+                        <span class="ps-hint">{move || t(locale.get(), "proj_settings.agent_context_hint")}</span>
+                        <textarea class="ps-textarea ps-ctx" rows="8"
+                            prop:value=move || proj_settings.get().agent_context
+                            on:input=move |ev| { let v = event_target_value(&ev); proj_settings.update(|s| s.agent_context = v); }></textarea>
+                    </label>
+                    <div class="row">
+                        <button type="button" disabled=move || proj_settings_busy.get()
+                            on:click=move |_| show_proj_settings.set(false)>{move || t(locale.get(), "settings.cancel")}</button>
+                        <button type="button" class="primary"
+                            disabled=move || proj_settings_busy.get() || proj_settings.get().name.trim().is_empty()
+                            on:click=save_proj_settings>{move || t(locale.get(), "settings.save")}</button>
+                    </div>
+                </div>
+            </div>
+        })}
         {move || show_settings.get().then(|| view! {
             <div class="overlay">
                 <div class="modal settings-modal">

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -79,6 +79,7 @@ html, body {
 
 /* ---------- Left sidebar ---------- */
 .sidebar {
+  position: relative;
   flex: 0 0 248px; width: 248px;
   background: var(--bg-sunken);
   border-right: 1px solid var(--border);
@@ -1418,26 +1419,75 @@ textarea.host-input { min-height:64px; resize:vertical; }
    step summary, finding cards. Reuses existing tokens.
    ================================================================ */
 
-/* --- Sidebar brand wordmark + Beta tag --- */
-.brand { display: flex; align-items: baseline; gap: 8px; padding: 6px 6px 8px; }
-.brand-name { font-family: var(--font-serif); font-size: 19px; font-weight: 500; letter-spacing: -0.02em; color: var(--text); line-height: 1; cursor: pointer; }
-.brand-name:hover { color: var(--clay); }
-.brand-beta { font-size: 10.5px; font-weight: 500; letter-spacing: .01em; color: var(--text-faint); }
-.brand .spacer { flex: 1; }
-.brand .icon-btn { align-self: center; }
-
-/* --- Project switcher row (back arrow + name + caret) --- */
-.proj-switch {
-  display: flex; align-items: center; gap: 7px; width: 100%;
-  text-align: left; background: transparent; border: 1px solid transparent;
-  border-radius: var(--radius-sm); padding: 6px 8px; margin-bottom: 2px;
-  font: inherit; cursor: pointer; color: var(--text);
-  transition: background .12s ease;
+/* --- Sidebar header: back arrow + project switcher + collapse --- */
+.sidebar-head { position: relative; display: flex; align-items: center; gap: 4px; padding: 4px 4px 6px; }
+.side-back {
+  flex: 0 0 auto; display: inline-flex; align-items: center; justify-content: center;
+  width: 28px; height: 28px; padding: 0; border: 1px solid transparent; border-radius: 7px;
+  background: transparent; color: var(--text-faint); font-size: 16px; line-height: 1; cursor: pointer;
+  transition: background .12s ease, color .12s ease;
 }
-.proj-switch:hover { background: var(--bg-elev); }
-.proj-switch .proj-back { color: var(--text-faint); font-size: 15px; line-height: 1; flex: 0 0 auto; }
+.side-back:hover { background: var(--bg-elev); color: var(--text); }
+
+/* --- Project switcher pill (name + caret, opens dropdown) --- */
+.proj-switch {
+  flex: 1 1 auto; min-width: 0; display: flex; align-items: center; gap: 6px;
+  text-align: left; background: transparent; border: 1px solid transparent;
+  border-radius: var(--radius-sm); padding: 5px 8px;
+  font: inherit; cursor: pointer; color: var(--text);
+  transition: background .12s ease, border-color .12s ease;
+}
+.proj-switch:hover, .proj-switch.active { background: var(--bg-elev); }
 .proj-switch .proj-name { font-weight: 600; font-size: 14px; letter-spacing: -0.015em; flex: 1 1 auto; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
 .proj-switch .caret { color: var(--text-faint); font-size: 10px; flex: 0 0 auto; }
+
+/* --- Project switcher dropdown --- */
+.proj-menu-backdrop { position: fixed; inset: 0; z-index: 40; }
+.proj-menu {
+  position: absolute; z-index: 41; top: 42px; left: 6px; right: 6px;
+  background: var(--bg-elev); border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm); box-shadow: 0 8px 28px rgba(0,0,0,.14);
+  padding: 6px; max-height: 60vh; overflow-y: auto;
+}
+.proj-menu-item {
+  width: 100%; display: flex; align-items: center; gap: 8px;
+  background: transparent; border: none; border-radius: 8px;
+  padding: 8px 10px; font: inherit; font-size: 13px; color: var(--text);
+  cursor: pointer; text-align: left;
+}
+.proj-menu-item:hover { background: var(--bg-sunken); }
+.proj-menu-item .gi { width: 15px; height: 15px; flex: 0 0 auto; opacity: .8; }
+.proj-menu-sep { height: 1px; background: var(--border); margin: 6px 4px; }
+.proj-menu-list { display: flex; flex-direction: column; gap: 1px; }
+.proj-menu-row {
+  display: flex; align-items: center; gap: 8px; width: 100%;
+  background: transparent; border: none; border-radius: 8px;
+  padding: 7px 10px; font: inherit; color: var(--text); cursor: pointer; text-align: left;
+}
+.proj-menu-row:hover { background: var(--bg-sunken); }
+.proj-menu-row.active { background: var(--clay-soft); }
+.pm-text { display: flex; flex-direction: column; gap: 1px; min-width: 0; flex: 1 1 auto; }
+.pm-name { font-size: 13px; font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.pm-desc { font-size: 11px; color: var(--text-faint); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.pm-check { flex: 0 0 auto; color: var(--clay-strong); font-weight: 700; }
+
+/* --- Project Settings modal --- */
+.proj-settings-modal { width: min(560px, 92vw); max-width: 560px; }
+.proj-settings-modal .ps-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.proj-settings-modal .ps-close {
+  flex: 0 0 auto; background: transparent; border: none; color: var(--text-faint);
+  font-size: 20px; line-height: 1; padding: 2px 6px; border-radius: 7px; cursor: pointer;
+}
+.proj-settings-modal .ps-close:hover { color: var(--text); background: var(--bg-sunken); }
+.proj-settings-modal .ps-hint { font-size: 11.5px; line-height: 1.4; font-weight: 400; color: var(--text-faint); }
+.proj-settings-modal .ps-textarea {
+  width: 100%; box-sizing: border-box; background: var(--bg-input); color: var(--text);
+  border: 1px solid var(--border-strong); border-radius: var(--radius-sm); padding: 9px 11px;
+  font-family: var(--font-mono); font-size: 12px; line-height: 1.5; resize: vertical; outline: none;
+  transition: border-color .12s ease, box-shadow .12s ease;
+}
+.proj-settings-modal .ps-textarea:focus { border-color: var(--clay); box-shadow: 0 0 0 3px rgba(13, 148, 136, 0.14); }
+.proj-settings-modal .ps-ctx { min-height: 150px; }
 
 /* --- Session group headers inside the list (Today / Earlier) --- */
 .side-group-title { font-size: 11px; font-weight: 600; letter-spacing: .02em; color: var(--text-faint); padding: 12px 10px 4px; }


### PR DESCRIPTION
Aligns the top navigation with the Claude Science reference and adds a Project Settings modal (scope chosen by the user: ① nav restructure + ② settings modal; ③ Download-artifacts / session context-menu were intentionally out of scope).

## What changed

**Top-nav (cleaner header + switcher)**
- Sidebar header collapses from two rows (`Wisp Science / Beta` brand block + separate project button) to one compact row: `← back` · project-switcher pill (`Name ▾`) · `‹ collapse`.
- The pill opens a dropdown: **Project settings** + project list (name + description subtitle, active project highlighted with ✓, click to switch inline).
- The sidebar now shows the **DB project name** instead of the folder name, so it stays consistent with what the settings modal edits.

**Project Settings modal (Name / Description / Agent Context)**
- **Name / Description** → `projects` table (`description` column already existed).
- **Agent Context** → `<workspace>/.wisp/WISP.md`, the file the system prompt already injects as *User Rules*. This deliberately avoids a new DB column and any agent-seed threading. Empty context removes the file; takes effect on the next seeded session (already-running agents keep their prompt).

## Implementation notes for reviewers
- `wisp-store`: `list_projects` now returns `description` (7-tuple; both callers updated, existing test reads `.0`/`.5` so stays valid); new `get_project_meta` / `update_project`.
- `src-tauri`: `ProjectInfo`/`ProjectSummary` gain `id`/`description`; `build_project_info` reads the DB name; new commands `get_project_settings` + `update_project` (operate on the active project) registered in the handler.
- Frontend (`ui/`): new switcher/menu/modal in `main.rs`, `ProjectSettings` DTO, En/Zh strings, CSS, and `preview.html` mock updated. Modal reuses the base `.modal` styles.

## Verification
- `cargo check -p wisp-tauri` ✅ and `cargo check --target wasm32-unknown-unknown` (wisp-ui) ✅ — both clean.
- `cargo test -p wisp-store` ✅ 6/6.
- Visual check in the preview mock: header + dropdown + modal match the reference screenshots.

## Known limitation
Agent Context applies to **new** sessions only (consistent with how `.wisp/WISP.md` already behaved); noted in a code comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)