### PR TITLE
fix(models): raise default max output tokens 4096 → 8192

### DIFF
--- a/crates/wisp-llm/src/provider.rs
+++ b/crates/wisp-llm/src/provider.rs
@@ -58,7 +58,7 @@ impl ProviderConfig {
             api_key: api_key.into(),
             model: model.into(),
             anthropic_version: "2023-06-01".into(),
-            max_tokens: 4096,
+            max_tokens: 8192,
             reasoning_effort: None,
         }
     }
@@ -73,7 +73,7 @@ impl ProviderConfig {
             api_key: api_key.into(),
             model: model.into(),
             anthropic_version: "2023-06-01".into(),
-            max_tokens: 4096,
+            max_tokens: 8192,
             reasoning_effort: None,
         }
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -847,7 +847,7 @@ async fn load_locale(store: &Store) -> String {
 fn default_max_tokens(provider: &str) -> u64 {
     match normalized_provider(provider).as_str() {
         "anthropic" => 8192,
-        _ => 4096,
+        _ => 8192,
     }
 }
 

--- a/ui/src/dto.rs
+++ b/ui/src/dto.rs
@@ -129,7 +129,7 @@ impl Default for Settings {
             has_api_key: false,
             locale: Locale::En.code().into(),
             workspace_dir: String::new(),
-            max_tokens: 4096,
+            max_tokens: 8192,
             reasoning_effort: String::new(),
         }
     }

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -601,7 +601,7 @@ fn profile_to_form(m: &ModelProfile) -> ModelForm {
         provider: m.provider.clone(),
         api_url: m.api_url.clone(),
         model: m.model.clone(),
-        max_tokens: if m.max_tokens >= 16 { m.max_tokens } else { 4096 },
+        max_tokens: if m.max_tokens >= 16 { m.max_tokens } else { 8192 },
         reasoning_effort: m.reasoning_effort.clone(),
     }
 }
@@ -612,7 +612,7 @@ fn new_model_form() -> ModelForm {
         provider: "openai".into(),
         api_url: api_url.into(),
         model: model.into(),
-        max_tokens: 4096,
+        max_tokens: 8192,
         ..Default::default()
     }
 }
@@ -4423,7 +4423,7 @@ fn App() -> impl IntoView {
                                                         on:input=move|ev| model_form.update(|o| if let Some(o)=o {
                                                             o.max_tokens = dom_value(&ev).parse().unwrap_or(0);
                                                         })
-                                                        prop:value=move || model_form.get().map(|f| f.max_tokens.to_string()).unwrap_or_else(|| "4096".into()) />
+                                                        prop:value=move || model_form.get().map(|f| f.max_tokens.to_string()).unwrap_or_else(|| "8192".into()) />
                                                 </label>
                                                 <label>{move || t(locale.get(), "settings.reasoning_effort")}
                                                     <select


### PR DESCRIPTION
## What
Raises the default **max output tokens** from `4096` to `8192` everywhere the default lives.

## Why (refs #58)
The 4096 output cap is a primary cause of the "auto-termination / 卡壳" reported in #58. On a long response (GLM-5.2's reasoning + final report), the model hits the 4096 output cap → the completion arrives with `finish_reason=length` → `is_truncated` trips the `bail!` added in #55 → the turn stops and reads like a hang.

This is **not** a context-window problem: `max_context` already defaults to `1_000_000` and the context compacts. The knob that matters is the *per-response output quota*, which was too conservative.

**Why 8192 and not higher:** 8192 matches the existing anthropic default and is DeepSeek's max output (the bundled default model), so it won't `400` on mainstream models — `16k+` would. Users who need more raise it per-model in Settings → Max output tokens.

## Where
- `default_max_tokens` (non-anthropic branch) — `src-tauri/src/lib.rs`
- `ProviderConfig::openai` / `openai_responses` constructors (the CLI path) — `crates/wisp-llm/src/provider.rs` (`anthropic()` was already 8192)
- UI new/edit model form default + input placeholder — `ui/src/main.rs`
- `ModelForm::default` — `ui/src/dto.rs`

## Verification
`cargo check --workspace` clean (incl. wisp-cli); `cd ui && cargo check --target wasm32-unknown-unknown` clean.

## Not addressed here (separate bug in #58)
The stop-button-unresponsive / can't-resume-after-stop / output-only-appears-after-reopen symptoms are a distinct frontend streaming + turn-state-cleanup bug — raising max_tokens doesn't touch those. Worth its own issue/fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)