### PR TITLE
fix(llm): cancellable token streaming — Stop works mid-generation (#58)

### DIFF
--- a/crates/wisp-core/src/agent.rs
+++ b/crates/wisp-core/src/agent.rs
@@ -38,10 +38,18 @@ pub async fn agent_loop(
         }
         iteration += 1;
         let messages = ctx.prepare_for_api(provider, output).await;
-        let mut sink = StreamSinkAdapter::new(output);
+        let mut sink = match cancel {
+            Some(c) => StreamSinkAdapter::with_cancel(output, c),
+            None => StreamSinkAdapter::new(output),
+        };
         let comp = provider
             .stream(&messages, &tools.schemas(), &mut sink)
             .await?;
+        // The streaming loop breaks on cancel and returns a partial completion;
+        // bail before processing it so Stop takes effect within one chunk.
+        if cancel.is_some_and(|c| c.load(Ordering::Relaxed)) {
+            anyhow::bail!("stopped by user");
+        }
 
         ctx.append_assistant(
             comp.content.clone(),

--- a/crates/wisp-core/src/output.rs
+++ b/crates/wisp-core/src/output.rs
@@ -105,10 +105,19 @@ impl<'a> wisp_tools::ToolEnv for ToolEnvAdapter<'a> {
 /// deltas only; usage/tool-call deltas are handled by the agent loop).
 pub struct StreamSinkAdapter<'a> {
     out: &'a dyn Output,
+    cancel: Option<&'a std::sync::atomic::AtomicBool>,
 }
 impl<'a> StreamSinkAdapter<'a> {
     pub fn new(out: &'a dyn Output) -> Self {
-        Self { out }
+        Self { out, cancel: None }
+    }
+    /// Like `new`, but the streaming loop can poll `is_cancelled()` to stop
+    /// token generation mid-stream when the user hits Stop.
+    pub fn with_cancel(out: &'a dyn Output, cancel: &'a std::sync::atomic::AtomicBool) -> Self {
+        Self {
+            out,
+            cancel: Some(cancel),
+        }
     }
 }
 impl<'a> wisp_llm::StreamSink for StreamSinkAdapter<'a> {
@@ -120,4 +129,30 @@ impl<'a> wisp_llm::StreamSink for StreamSinkAdapter<'a> {
     }
     fn on_tool_call(&mut self, _i: usize, _name: &str, _args: &str) {}
     fn on_usage(&mut self, _u: wisp_llm::Usage) {}
+    fn is_cancelled(&self) -> bool {
+        self.cancel
+            .is_some_and(|c| c.load(std::sync::atomic::Ordering::Relaxed))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use wisp_llm::StreamSink;
+
+    // The streaming loops break on `sink.is_cancelled()`; this proves the Stop
+    // flag is actually threaded through the sink and read (the wiring that was
+    // missing in #58, leaving Stop dead during token streaming).
+    #[test]
+    fn stream_sink_adapter_polls_cancel_flag() {
+        let out = NullOutput;
+        let flag = AtomicBool::new(false);
+        let sink = StreamSinkAdapter::with_cancel(&out, &flag);
+        assert!(!sink.is_cancelled(), "not cancelled before Stop");
+        flag.store(true, Ordering::Relaxed);
+        assert!(sink.is_cancelled(), "reflects the flag once Stop is pressed");
+        // A sink built without a cancel flag never reports cancelled.
+        assert!(!StreamSinkAdapter::new(&out).is_cancelled());
+    }
 }

--- a/crates/wisp-llm/src/anthropic.rs
+++ b/crates/wisp-llm/src/anthropic.rs
@@ -285,6 +285,11 @@ impl Provider for AnthropicProvider {
         let mut usage = Usage::default();
 
         while let Some(chunk) = stream.next().await {
+            // Stop mid-generation: drop the stream and return the partial result
+            // so the agent loop can bail (#58 — Stop was dead during streaming).
+            if sink.is_cancelled() {
+                break;
+            }
             let bytes = chunk?;
             buf.push_str(std::str::from_utf8(&bytes).unwrap_or(""));
             while let Some(idx) = buf.find("\n\n") {

--- a/crates/wisp-llm/src/openai.rs
+++ b/crates/wisp-llm/src/openai.rs
@@ -300,6 +300,11 @@ impl Provider for OpenAiProvider {
         let mut usage = Usage::default();
 
         while let Some(chunk) = stream.next().await {
+            // Stop mid-generation: drop the stream and return the partial result
+            // so the agent loop can bail (#58 — Stop was dead during streaming).
+            if sink.is_cancelled() {
+                break;
+            }
             let bytes = chunk?;
             buf.push_str(std::str::from_utf8(&bytes).unwrap_or(""));
             while let Some(idx) = buf.find("\n\n") {

--- a/crates/wisp-llm/src/provider.rs
+++ b/crates/wisp-llm/src/provider.rs
@@ -102,6 +102,12 @@ pub trait StreamSink: Send {
     /// as argument fragments arrive so the UI can render an in-progress call.
     fn on_tool_call(&mut self, index: usize, name: &str, arguments_so_far: &str);
     fn on_usage(&mut self, usage: crate::Usage);
+    /// Whether the user requested cancellation. Streaming loops poll this each
+    /// chunk so a Stop interrupts token generation mid-stream, not only between
+    /// whole model turns. Default `false` for sinks that don't support cancel.
+    fn is_cancelled(&self) -> bool {
+        false
+    }
 }
 
 /// A no-op sink for callers that only want the final `Completion`.


### PR DESCRIPTION
## Root cause (#58)
The three symptoms in #58 — **Stop button does nothing**, **can't send after stopping**, **streamed output only appears after restarting the app** — all trace to a single gap: **the LLM streaming loop was not cancellation-aware.**

`stop_agent` flips a per-session `cancel: AtomicBool`. That flag is polled between whole model turns (`agent.rs`) and inside tool execution (`shell.rs`/`kernel.rs`), but **never during `provider.stream()`**. The SSE consumption loops (`openai.rs` / `anthropic.rs`, `while let Some(chunk) = stream.next().await`) never checked it, and `StreamSinkAdapter` — unlike its sibling `ToolEnvAdapter` — carried no cancel flag.

So during a long GLM-5.2 generation, a Stop click only set the flag while the turn stayed blocked awaiting the stream. Consequences (all one cause):
- **Stop dead**: the flag is set but unread until the stream ends on its own (model finishes / connection drops / the 300s whole-request timeout).
- **Can't send after stop**: `agent.run().await` never returns → the per-session agent mutex stays locked → the next `send_message` queues forever behind `rt.agent.lock().await`; `running_turns` is never cleared and no `Done`/`Error` event fires.
- **Output appears only after restart**: token deltas render live while they arrive, but once frozen no terminal event flushes/clears; a restart reloads the transcript from SQLite (persisted incrementally), so the content "reappears."

This is **not** a context-window or compaction issue (`max_context` already defaults to 1,000,000).

## Fix (mirrors the existing tool-cancellation pattern)
- `StreamSink` gains a default `fn is_cancelled(&self) -> bool { false }`.
- `StreamSinkAdapter` gets a `cancel` field + `with_cancel(...)`; `agent.rs` threads the turn's cancel flag into the sink and bails right after `stream()` returns.
- Both SSE loops `break` on `sink.is_cancelled()`, dropping the stream (which aborts the HTTP request) and returning the partial completion.

Stop now interrupts **within one chunk**: the mutex releases, the terminal event fires, the UI clears. Everything downstream was already correct once `agent.run()` returns — no frontend change needed.

## Scope note
This fixes the whole Stop/resume/display-stall cluster. The separate max-output-tokens truncation cause (also in #58) is addressed in #84.

## Verification
- New unit test `stream_sink_adapter_polls_cancel_flag` (wisp-core) proves the cancel flag is threaded through the sink and read — the wiring that was missing.
- `cargo test --workspace` green (no regressions); `cargo check --workspace` clean.
- **Not runtime-verified**: interrupting a live GLM-5.2 stream needs the real app + provider. Please confirm in your environment: start a long GLM-5.2 turn → press Stop → it should now interrupt within a moment, and the composer should be usable again immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)