### PR TITLE
fix(ui): skills tags input overlapping next skill's name

### DIFF
--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -458,6 +458,10 @@
   padding: 13px 2px;
   border-bottom: 1px solid var(--border);
   min-height: 48px;
+  /* `.settings-list` is a column flex scroll container; without this, rows
+     flex-shrink below their content and multi-line skill rows (name + desc +
+     tags input) collapse to min-height, overflowing into the next row. */
+  flex-shrink: 0;
 }
 .settings-list-row.settings-list-row-link {
   align-items: center;


### PR DESCRIPTION
## Bug
In Settings → Skills, each skill's **tags input** rendered on top of the *next* skill's name — the rows overlapped (see screenshot in the report).

## Root cause
`.settings-list` is a `display: flex; flex-direction: column` scroll container, so its rows are flex items with the default `flex-shrink: 1`. A skill row is multi-line (name + description + a full-width tags input, laid out with a 3-row grid). When the list had more content than fit, flex **compressed each row down to its `min-height: 48px`**, and the tags input (grid row 3) overflowed the shrunken row box into the next row — landing on top of the following skill's name.

It only reproduced for rows with a **description** present (name + tags alone fit within 48px), which is why it looked intermittent.

## Fix
`flex-shrink: 0` on `.settings-list-row` — rows keep their content height instead of being squeezed to `min-height`; the container still scrolls via its own `overflow: auto`.

## Verification (trunk preview, measured on the live DOM)
| | before | after |
|---|---|---|
| row height (name+desc+tags) | 48px (clipped) | 115px (fits) |
| tags input overflows into next row | **yes** | **no** |

Visually confirmed: name (with the toggle inline on the right), description, then the tags input stacked full-width below — no overlap. CSS-only change; no Rust rebuild affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)