### PR TITLE
fix(macos): inherit login-shell PATH so tool detection sees installed tools

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3536,8 +3536,50 @@ fn set_dev_flag(app: &tauri::AppHandle) {
     let _ = window.eval(&format!("window.__WISP_DEV__ = {};", dev));
 }
 
+/// A macOS/Linux `.app` launched from Finder/Dock/Launchpad inherits a bare
+/// `PATH` (`/usr/bin:/bin:/usr/sbin:/sbin`), not the login-shell `PATH`. So
+/// Homebrew tools (`/opt/homebrew/bin` on Apple Silicon), `~/.local/bin`,
+/// `~/.cargo/bin`, nvm, etc. are invisible to `which::which` (capability
+/// detection) *and* to the `sh -c` / uv / node / pixi child spawns — the
+/// tools are installed and work in a terminal, but the app reports them
+/// missing. Resolve the user's real login-shell `PATH` once, up front, and set
+/// it on the process so every downstream consumer sees the same `PATH` the
+/// terminal does. Runs before any threads spawn children (env mutation is safe
+/// here). No-op on Windows.
+#[cfg(not(target_os = "windows"))]
+fn inherit_login_shell_path() {
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".into());
+    // Markers survive noisy rc files that print to stdout (p10k instant prompt,
+    // MOTD, a stray `echo` in .zshrc). `-ilc` sources both login (.zprofile,
+    // where `brew shellenv` usually lives) and interactive (.zshrc) profiles.
+    // ponytail: assumes a colon-PATH shell (zsh/bash/sh); fish joins list vars
+    // with spaces and would parse wrong — fish users set UV_PATH/PIXI_PATH or
+    // launch from a terminal. Widen to fish only if someone reports it.
+    let script = r#"printf '__WISP_PATH__%s__WISP_END__' "$PATH""#;
+    let Ok(out) = std::process::Command::new(&shell)
+        .args(["-ilc", script])
+        .stdin(std::process::Stdio::null())
+        .output()
+    else {
+        return;
+    };
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    if let Some(path) = stdout
+        .split_once("__WISP_PATH__")
+        .and_then(|(_, rest)| rest.split_once("__WISP_END__"))
+        .map(|(p, _)| p.trim())
+        .filter(|p| !p.is_empty())
+    {
+        std::env::set_var("PATH", path);
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn inherit_login_shell_path() {}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    inherit_login_shell_path();
     let filter = tracing_subscriber::EnvFilter::from_default_env()
         .add_directive("wisp=info".parse().unwrap());
     let subscriber = tracing_subscriber::fmt().with_env_filter(filter);


### PR DESCRIPTION
Closes #94

## 问题

macOS（尤其 M1）从访达 / Dock / 启动台打开 `.app` 时，进程只继承精简的 `PATH`（`/usr/bin:/bin:/usr/sbin:/sbin`），**不继承**登录 shell 的 `PATH`。因此 Homebrew（Apple Silicon 的 `/opt/homebrew/bin`）、`~/.local/bin`、`~/.cargo/bin`、nvm 等目录里的工具，对 `which::which`（能力检测）和 `sh -c` / uv / node / pixi 子进程都不可见——终端里明明装了也能跑，App 却报"缺失"。

## 修复

在 `run()` 第一行（任何线程 / 子进程创建之前）用 `$SHELL -ilc` 解析一次真实的登录 shell `PATH`，写回进程环境。一处修复同时覆盖能力检测与所有下游子进程，让 App 看到和终端一致的 `PATH`。Windows 上为 no-op。

- 用带标记的 `printf '__WISP_PATH__%s__WISP_END__' "$PATH"`，避免被 rc 文件里打到 stdout 的内容（p10k instant prompt、MOTD、`.zshrc` 里的 `echo`）污染。
- `-ilc` 同时加载 login（`.zprofile`，`brew shellenv` 通常在此）与 interactive（`.zshrc`）配置。

## 验证

在复现机器（与报告者同款 M1）上用探针脚本模拟同一解析逻辑：登录 shell `PATH` 能定位到 `uv`（`~/.local/bin`）、`node`/`npm`/`sci`（`/opt/homebrew/bin`）——这些在精简 PATH 下都会被漏判；`pixi` 是真未安装（正确的"缺失"）。`cargo check -p wisp-tauri` 通过。

## 已知边界

fish 的 `$PATH` 是空格分隔的 list，会解析错——已在代码里加 `ponytail:` 注释说明；fish 用户可设 `UV_PATH` / `PIXI_PATH` 或从终端启动。若有人反馈再扩展。

🤖 Generated with [Claude Code](https://claude.com/claude-code)