### PR TITLE
fix(ui): tighten chat markdown spacing and white-space

### DIFF
--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -240,6 +240,23 @@ export function tauriMock(): void {
               }, 30);
               return fid;
             }
+            if (String(arg("message") ?? "").includes("MDLIST")) {
+              const md = [
+                "FX细胞（FX cell）是一种常用于病毒学研究的人源细胞系，具有以下特点：",
+                "",
+                "- **来源**：从人胚肾细胞（HEK293）衍生",
+                "- **应用**：广泛用于慢病毒载体包装和生产",
+                "- **优势**：转染效率高，适合大规模病毒生产",
+                "",
+                "有什么我可以帮你的吗？",
+              ].join("\n");
+              setTimeout(() => {
+                emit("agent", { kind: "User", frame_id: fid, text: msg });
+                emit("agent", { kind: "Text", frame_id: fid, delta: md });
+                emit("agent", { kind: "Done", frame_id: fid });
+              }, 30);
+              return fid;
+            }
             setTimeout(() => {
               emit("agent", { kind: "User", frame_id: fid, text: msg });
               emit("agent", { kind: "Text", frame_id: fid, delta: "Hello " });

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -322,6 +322,17 @@ test("external links open in the system browser, not the app webview (#97)", asy
   await expect(page.getByRole("button", { name: "New session" })).toBeVisible();
 });
 
+test("assistant markdown uses normal whitespace (no phantom blank lines)", async ({ page }) => {
+  await enterApp(page);
+  await page.getByPlaceholder(/Ask wisp-science/i).fill("MDLIST");
+  await page.getByRole("button", { name: "Send" }).click();
+  await expect(page.getByText("FX细胞")).toBeVisible({ timeout: 10_000 });
+  const whiteSpace = await page.locator(".msg.assistant .body.md").first().evaluate(
+    (el) => getComputedStyle(el).whiteSpace,
+  );
+  expect(whiteSpace).toBe("normal");
+});
+
 test("a thinking + tool run folds into one collapsible steps panel (#82)", async ({ page }) => {
   // Instead of a wall of separate tool cards, consecutive thinking/tool activity
   // collapses into a single foldable "Ran N steps" panel, collapsed by default.

--- a/ui/mock-bridge.js
+++ b/ui/mock-bridge.js
@@ -168,6 +168,24 @@
             return "User prefers DeepSeek.\n";
           case "send_message": {
             const fid = (args && args.session_id) || "mock-frame";
+            const msg = (args && args.message) || "";
+            if (String(msg).includes("MDLIST")) {
+              const md = [
+                "FX细胞（FX cell）是一种常用于病毒学研究的人源细胞系，具有以下特点：",
+                "",
+                "- **来源**：从人胚肾细胞（HEK293）衍生",
+                "- **应用**：广泛用于慢病毒载体包装和生产",
+                "- **优势**：转染效率高，适合大规模病毒生产",
+                "",
+                "有什么我可以帮你的吗？",
+              ].join("\n");
+              setTimeout(() => {
+                emit("agent", { kind: "User", frame_id: fid, text: msg });
+                emit("agent", { kind: "Text", frame_id: fid, delta: md });
+                emit("agent", { kind: "Done", frame_id: fid });
+              }, 80);
+              return fid;
+            }
             setTimeout(() => {
               emit("agent", { kind: "Reasoning", frame_id: fid, delta: "Searching literature…" });
               emit("agent", { kind: "ToolCall", frame_id: fid, name: "python", preview: "scimaster-cli search FX-cell" });

--- a/ui/src/styles/chat.css
+++ b/ui/src/styles/chat.css
@@ -39,7 +39,7 @@
 
 .msg { width: 100%; }
 .msg .role { font-size: 11px; color: var(--text-faint); margin-bottom: 6px; text-transform: uppercase; letter-spacing: .06em; font-weight: 600; }
-.msg .body { white-space: pre-wrap; line-height: 1.62; font-size: 14.5px; font-family: var(--font-ui); }
+.msg .body { white-space: pre-wrap; line-height: 1.55; font-size: 14.5px; font-family: var(--font-ui); }
 .msg.user { align-self: flex-end; max-width: 82%; }
 .msg.user .user-bubble { display: flex; flex-direction: column; align-items: flex-end; }
 .msg.user .body { background: var(--bg-panel); border: 1px solid var(--border-strong); padding: 10px 16px; border-radius: 16px; }
@@ -65,7 +65,7 @@ button.msg-icon-btn .gi { width: 14px; height: 14px; }
 .msg.assistant .role-model { font-size: 10.5px; font-weight: 500; font-family: var(--font-mono); color: var(--text-faint); letter-spacing: 0; text-transform: none; padding: 1px 7px; border-radius: 999px; border: 1px solid var(--border); background: var(--bg-elev); }
 .msg.assistant .role::before { content: ""; width: 15px; height: 15px; border-radius: 5px; background: center / contain no-repeat url("logo.svg"); }
 .msg.assistant .body { color: var(--text); font-family: var(--font-response); }
-.msg.assistant .body.md { display: block; font-size: 15px; line-height: 1.58; letter-spacing: -0.004em; }
+.msg.assistant .body.md { display: block; font-size: 15px; line-height: 1.55; letter-spacing: -0.004em; white-space: normal; }
 .msg.assistant .body.md:empty { display: none; }
 .msg.reasoning .body { color: var(--text-faint); font-style: italic; font-size: 13.5px; border-left: 2px solid var(--border-strong); padding-left: 12px; font-family: var(--font-ui); }
 
@@ -153,7 +153,7 @@ details.rz .body { margin-top: 6px; }
 .md {
   font-family: var(--font-response);
   font-size: 15px;
-  line-height: 1.58;
+  line-height: 1.55;
   letter-spacing: -0.004em;
   white-space: normal;
   text-wrap: pretty;
@@ -231,7 +231,7 @@ details.rz .body { margin-top: 6px; }
 details.tool:not([open]) > summary.head .run-dot { animation: tool-pulse 1.1s ease-in-out infinite; }
 
 .md ul, .md ol {
-  margin: 0.15em 0 0.35em;
+  margin: 0.1em 0 0.25em;
   padding-left: 0;
   list-style: none;
 }
@@ -246,7 +246,7 @@ details.tool:not([open]) > summary.head .run-dot { animation: tool-pulse 1.1s ea
   line-height: 1.5;
 }
 .md ul > li + li,
-.md ol > li + li { margin-top: 0.4em; }
+.md ol > li + li { margin-top: 0.25em; }
 .md ul > li::before {
   content: "";
   position: static;


### PR DESCRIPTION
## Summary
- Fix oversized gaps in assistant markdown by setting `white-space: normal` on `.msg.assistant .body.md`, overriding inherited `pre-wrap` that rendered phantom blank lines between block elements.
- Tighten list and line-height spacing conservatively (li+li margin, ul/ol margin, 1.58 to 1.55 line-height).
- Add an `MDLIST` mock scenario (Chinese bullet list) for visual comparison in dev/Playwright.
- Add a regression test asserting assistant markdown uses `white-space: normal`.

## Test plan
- [x] Send `MDLIST` in dev mock — list items should be compact, no large phantom gaps between paragraphs/lists.
- [x] User bubbles still preserve newlines (pre-wrap unchanged for non-markdown bodies).
- [x] Playwright: `assistant markdown uses normal whitespace` passes.
