### PR TITLE
fix(ui): don't send while IME is composing (#108)

### DIFF
--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -2614,6 +2614,12 @@ fn App() -> impl IntoView {
     };
 
     let on_send = move |ev: web_sys::KeyboardEvent| {
+        // While an IME is composing (e.g. Chinese pinyin), Enter confirms the
+        // candidate — its keydown reports isComposing — so let the IME handle
+        // every key and never send/navigate mid-composition (#108).
+        if ev.is_composing() {
+            return;
+        }
         if mention_show.get() {
             match ev.key().as_str() {
                 "ArrowDown" => {


### PR DESCRIPTION
Fixes #108

## Problem

On macOS with a Chinese IME, pressing **Enter to confirm a pinyin candidate** submitted the message mid-composition. The user then had to interrupt the run and retype. Reported on v0.5.2.

## Root cause

The composer keydown handler (`on_send` in `ui/src/main.rs`) sent on `Enter` without checking IME composition state. The `keydown` for the Enter that commits an IME candidate reports `isComposing === true`, but the handler treated it as a plain send.

## Fix

Add an `is_composing()` guard at the top of `on_send` — during composition the handler bails out entirely, so every key (Enter included) reaches the IME, and a message is only sent once composition has ended. This mirrors the `isComposing` guards already used elsewhere in the file (Escape handling, the global keydown listener), so it's the same root-cause pattern applied at the one spot that missed it. As a bonus it also stops the `@`-mention popup's Enter/Tab/Arrow keys from firing mid-composition.

```rust
let on_send = move |ev: web_sys::KeyboardEvent| {
    if ev.is_composing() { return; }   // #108
    ...
```

## Testing

- `cargo check --target wasm32-unknown-unknown` clean.
- No keyboard-event test harness exists in the UI crate; this is a one-line guard reusing an established pattern, so no test added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)