### PR TITLE
fix(ui): add export session to sidebar session context menu

### DIFF
--- a/ui/src/context_menu.rs
+++ b/ui/src/context_menu.rs
@@ -194,6 +194,11 @@ pub fn build(ev: &web_sys::MouseEvent, locale: Locale, can_export: bool) -> Opti
             ));
             items.extend(session_move_items(&id, locale));
             items.push(item(
+                "exportSession",
+                i18n::t(locale, "ctx.export_session"),
+                id.clone(),
+            ));
+            items.push(item(
                 "deleteSession",
                 i18n::t(locale, "ctx.delete_session"),
                 id,

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -3397,15 +3397,25 @@ fn App() -> impl IntoView {
         let artifacts = artifacts;
         Callback::new(move |(action, payload): (String, String)| {
             if action == "exportSession" {
-                let Some(session_id) = active_session.get() else { return };
-                let artifact_paths = artifacts
-                    .get()
-                    .into_iter()
-                    .filter_map(|a| match a.data {
-                        PreviewData::File { path, .. } => Some(path),
-                        _ => None,
-                    })
-                    .collect::<Vec<_>>();
+                let session_id = if payload.is_empty() {
+                    let Some(id) = active_session.get() else { return };
+                    id
+                } else {
+                    payload.clone()
+                };
+                let is_active = active_session.get().as_deref() == Some(session_id.as_str());
+                let artifact_paths = if is_active {
+                    artifacts
+                        .get()
+                        .into_iter()
+                        .filter_map(|a| match a.data {
+                            PreviewData::File { path, .. } => Some(path),
+                            _ => None,
+                        })
+                        .collect::<Vec<_>>()
+                } else {
+                    Vec::new()
+                };
                 spawn_local(async move {
                     let arg = to_value(&serde_json::json!({
                         "sessionId": session_id,


### PR DESCRIPTION
## Summary
- The sidebar session right-click menu (Copy title / Open / Rename / Move to / Delete) never included "Export session" — only the message/code/artifact fallback menus had it, and those always export whatever session is currently active.
- Matches the Claude Science reference, where export lives in the same per-session actions menu, bound to that card's own session id rather than a global "active session".
- `exportSession` now uses the session id carried in the context-menu payload (falling back to the active session when there is no payload, e.g. from the message/code fallback menus).
- Locally-loaded artifact paths are only attached when exporting the currently active session, since they belong to whichever session's chat is loaded and would be wrong for an arbitrary right-clicked session.

## Test plan
- [x] `cargo check --target wasm32-unknown-unknown` passes in `ui/`
- [x] Manually verify in the desktop app: right-click a non-active session in the sidebar, confirm "Export session" appears and exports that session's own content