### PR TITLE
fix(llm): honor system proxy on Windows, surface reqwest error chain (#77)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1722,9 +1722,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -3868,6 +3870,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5255,6 +5278,17 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,9 @@ repository = "https://github.com/xuzhougeng/wisp-science"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls"] }
+# system-proxy: honor Windows/macOS system proxy settings (clash etc., #77);
+# socks: support socks5:// proxy URLs from env/system config.
+reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "rustls-tls", "system-proxy", "socks"] }
 futures-util = "0.3"
 anyhow = "1"
 thiserror = "2"

--- a/crates/wisp-llm/src/provider.rs
+++ b/crates/wisp-llm/src/provider.rs
@@ -3,9 +3,22 @@
 use crate::{Completion, Message, ToolSchema};
 use async_trait::async_trait;
 
+/// reqwest's Display hides the useful part ("connection refused", "proxy
+/// unreachable", dns errors) in `source()`; walk the chain so users see it (#77).
+fn error_chain(e: &reqwest::Error) -> String {
+    let mut s = e.to_string();
+    let mut src = std::error::Error::source(e);
+    while let Some(cause) = src {
+        s.push_str(": ");
+        s.push_str(&cause.to_string());
+        src = cause.source();
+    }
+    s
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum LlmError {
-    #[error("http: {0}")]
+    #[error("http: {}", error_chain(.0))]
     Http(#[from] reqwest::Error),
     #[error("decode: {0}")]
     Decode(#[from] serde_json::Error),


### PR DESCRIPTION
Fixes #77 — on Windows under clash's system-proxy mode, configuring a DeepSeek API key failed to validate the connection.

## Root cause

`reqwest` was declared with `default-features = false`, which silently drops the `system-proxy` feature that reqwest 0.12 enables by default. With it off, the app ignored the Windows registry / system proxy entirely, so requests went **direct** — under clash's system-proxy mode that means no route out, and validation failed to connect. The missing `socks` feature also made any `socks5://` proxy from the environment error out immediately.

## Changes

- **`Cargo.toml`** — add `"system-proxy"` and `"socks"` to the reqwest feature list. `Client::builder` inherits proxy settings automatically, so `openai.rs` needs no change.
- **`crates/wisp-llm/src/provider.rs`** — `LlmError::Http`'s `Display` now walks `source()`, so users see the real cause (`connection refused`, proxy unreachable, DNS failure) instead of reqwest's opaque `error sending request for url (…)` wrapper. Makes diagnosing proxy/network issues far easier.

## Verification

- `cargo build -p wisp-llm` ✅
- `cargo test -p wisp-llm` ✅ (8 passed)
- `cargo check -p wisp-mcp` ✅ (the other reqwest consumer)

Note: no automated test added — the error-chain change is plain string concatenation, and the proxy behavior can only be validated against a real Windows + clash environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)