### PR TITLE
fix(ui): 添加技能失败时显示错误而非静默吞掉 (#117)

### DIFF
--- a/crates/wisp-skills/src/index.rs
+++ b/crates/wisp-skills/src/index.rs
@@ -47,7 +47,7 @@ impl SkillIndex {
                     continue;
                 }
                 let dir = entry.path().parent().map(PathBuf::from).unwrap_or_default();
-                if let Some(skill) = parse_skill(entry.path(), dir.clone()) {
+                if let Ok(skill) = parse_skill(entry.path(), dir.clone()) {
                     skills.push(skill);
                 }
             }
@@ -120,16 +120,21 @@ impl SkillIndex {
 /// Parse a single `SKILL.md` file (its parent dir is the skill's `dir`).
 /// Public wrapper around `parse_skill` for callers outside this crate (e.g.
 /// the Tauri `install_skill` command validating a picked file/folder).
-pub fn parse_skill_file(md: &Path) -> Option<Skill> {
+pub fn parse_skill_file(md: &Path) -> Result<Skill, String> {
     let dir = md.parent().map(PathBuf::from).unwrap_or_default();
     parse_skill(md, dir)
 }
 
-fn parse_skill(path: &Path, dir: PathBuf) -> Option<Skill> {
-    let text = std::fs::read_to_string(path).ok()?;
-    let body_start = text.find("---")?;
+fn parse_skill(path: &Path, dir: PathBuf) -> Result<Skill, String> {
+    let text =
+        std::fs::read_to_string(path).map_err(|e| format!("could not read SKILL.md: {e}"))?;
+    let body_start = text
+        .find("---")
+        .ok_or_else(|| "SKILL.md has no frontmatter (--- block)".to_string())?;
     let rest = &text[body_start + 3..];
-    let end = rest.find("---")?;
+    let end = rest
+        .find("---")
+        .ok_or_else(|| "SKILL.md frontmatter is not closed with ---".to_string())?;
     let yaml = &rest[..end];
     let body = rest[end + 3..].trim().to_string();
 
@@ -177,7 +182,7 @@ fn parse_skill(path: &Path, dir: PathBuf) -> Option<Skill> {
         }
     }
 
-    Some(Skill {
+    Ok(Skill {
         name,
         description,
         tags,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2883,8 +2883,7 @@ async fn install_skill(
         return Err("select a skill folder or a SKILL.md file".into());
     };
     // Parse name from frontmatter (fall back to dir name), validate description.
-    let skill = wisp_skills::parse_skill_file(&skill_md)
-        .ok_or_else(|| "could not parse SKILL.md frontmatter".to_string())?;
+    let skill = wisp_skills::parse_skill_file(&skill_md)?;
     if skill.description.trim().is_empty() {
         return Err("SKILL.md is missing a description".into());
     }

--- a/ui/src/i18n.rs
+++ b/ui/src/i18n.rs
@@ -295,6 +295,12 @@ fn lookup(locale: Locale, key: &str) -> Option<&'static str> {
         (Locale::En, "err.api_key_required") => Some("API key is required."),
         (Locale::En, "err.unknown") => Some("Unknown error"),
         (Locale::En, "err.validation_timeout") => Some("Validation timed out after 30s"),
+        (Locale::En, "err.skill_no_md") => Some("The selected folder has no SKILL.md."),
+        (Locale::En, "err.skill_pick") => Some("Select a skill folder or a SKILL.md file."),
+        (Locale::En, "err.skill_no_frontmatter") => Some("SKILL.md has no frontmatter (--- block)."),
+        (Locale::En, "err.skill_frontmatter_unclosed") => Some("SKILL.md frontmatter is not closed with ---."),
+        (Locale::En, "err.skill_no_description") => Some("SKILL.md is missing a description."),
+        (Locale::En, "err.skill_exists") => Some("A skill named '{name}' already exists."),
         (Locale::En, "err.file_not_found") => Some("File not found: {path}"),
         (Locale::En, "chat.you") => Some("You"),
         (Locale::En, "chat.assistant") => Some("wisp-science"),
@@ -648,6 +654,12 @@ fn lookup(locale: Locale, key: &str) -> Option<&'static str> {
         (Locale::Zh, "status.compact") => Some("压缩 {before} → {after}"),
         (Locale::Zh, "status.demo") => Some("示例：{title}"),
         (Locale::Zh, "err.api_url_required") => Some("API 地址不能为空。"),
+        (Locale::Zh, "err.skill_no_md") => Some("所选文件夹中没有 SKILL.md。"),
+        (Locale::Zh, "err.skill_pick") => Some("请选择技能文件夹或 SKILL.md 文件。"),
+        (Locale::Zh, "err.skill_no_frontmatter") => Some("SKILL.md 缺少 frontmatter（--- 块）。"),
+        (Locale::Zh, "err.skill_frontmatter_unclosed") => Some("SKILL.md 的 frontmatter 没有以 --- 结束。"),
+        (Locale::Zh, "err.skill_no_description") => Some("SKILL.md 缺少 description。"),
+        (Locale::Zh, "err.skill_exists") => Some("已存在名为 '{name}' 的技能。"),
         (Locale::Zh, "err.model_required") => Some("模型不能为空。"),
         (Locale::Zh, "err.api_key_required") => Some("API 密钥不能为空。"),
         (Locale::Zh, "err.unknown") => Some("未知错误"),
@@ -800,6 +812,15 @@ pub fn localize_backend(locale: Locale, msg: &str) -> String {
         "No API key set. Open Settings and paste your provider API key." => t(locale, "err.no_api_key"),
         "Validation timed out after 30s" => t(locale, "err.validation_timeout"),
         "Validation succeeded" => t(locale, "status.validation_succeeded"),
+        "selected folder has no SKILL.md" => t(locale, "err.skill_no_md"),
+        "select a skill folder or a SKILL.md file" => t(locale, "err.skill_pick"),
+        "SKILL.md has no frontmatter (--- block)" => t(locale, "err.skill_no_frontmatter"),
+        "SKILL.md frontmatter is not closed with ---" => t(locale, "err.skill_frontmatter_unclosed"),
+        "SKILL.md is missing a description" => t(locale, "err.skill_no_description"),
+        m if m.starts_with("a skill named '") && m.ends_with("' already exists") => {
+            let name = &m["a skill named '".len()..m.len() - "' already exists".len()];
+            tf(locale, "err.skill_exists", &[("name", name)])
+        }
         m if m.starts_with("Validated ") => {
             if let Some(rest) = m.strip_prefix("Validated ") {
                 if let Some((provider, model)) = rest.split_once(" with ") {

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -2186,6 +2186,7 @@ fn App() -> impl IntoView {
     let settings_section = create_rw_signal(String::from("general"));
     let skills_list = create_rw_signal(Vec::<SkillRow>::new());
     let skills_search = create_rw_signal(String::new());
+    let skills_msg = create_rw_signal(None::<(bool, String)>);
     let model_form = create_rw_signal(None::<ModelForm>);
     let model_form_key = create_rw_signal(String::new());
     let model_form_msg = create_rw_signal(None::<(bool, String)>);
@@ -2911,6 +2912,21 @@ fn App() -> impl IntoView {
         });
     };
 
+    let install_skill_from = move |path: String| {
+        spawn_local(async move {
+            let arg = to_value(&serde_json::json!({ "srcPath": path })).unwrap();
+            match invoke_checked("install_skill", arg).await {
+                Ok(_) => {
+                    skills_msg.set(None);
+                    refresh_skills();
+                }
+                Err(err) => {
+                    skills_msg.set(Some((false, localize_backend(locale.get(), &js_error_text(err)))));
+                }
+            }
+        });
+    };
+
     let refresh_conns = move || {
         spawn_local(async move {
             let v = invoke("list_mcp_connections", JsValue::UNDEFINED).await;
@@ -2949,6 +2965,7 @@ fn App() -> impl IntoView {
         memory_selected.set(None);
         memory_editor.set(String::new());
         memory_msg.set(None);
+        skills_msg.set(None);
     };
 
     let go_settings_section = move |sec: &str| {
@@ -5421,9 +5438,7 @@ fn App() -> impl IntoView {
                                             spawn_local(async move {
                                                 let picked = invoke("pick_skill_source", JsValue::UNDEFINED).await;
                                                 if let Some(path) = picked.as_string() {
-                                                    let arg = to_value(&serde_json::json!({ "srcPath": path })).unwrap();
-                                                    let _ = invoke_checked("install_skill", arg).await;
-                                                    refresh_skills();
+                                                    install_skill_from(path);
                                                 }
                                             });
                                         }>{move || t(locale.get(), "skills.add_file")}</button>
@@ -5431,9 +5446,7 @@ fn App() -> impl IntoView {
                                             spawn_local(async move {
                                                 let picked = invoke("pick_directory", JsValue::UNDEFINED).await;
                                                 if let Some(path) = picked.as_string() {
-                                                    let arg = to_value(&serde_json::json!({ "srcPath": path })).unwrap();
-                                                    let _ = invoke_checked("install_skill", arg).await;
-                                                    refresh_skills();
+                                                    install_skill_from(path);
                                                 }
                                             });
                                         }>{move || t(locale.get(), "skills.add_folder")}</button>
@@ -5467,6 +5480,9 @@ fn App() -> impl IntoView {
                                     }}
                                 </div>
                                 <p class="settings-note">{move || t(locale.get(), "settings.applies_new_session")}</p>
+                                {move || skills_msg.get().map(|(ok, text)| view! {
+                                    <div class="settings-status" class:ok=ok class:fail=move || !ok>{text}</div>
+                                })}
                                 <div class="settings-list">
                                     <For each=move || {
                                         let q = skills_search.get().trim().to_lowercase();


### PR DESCRIPTION
## 问题

Issue #117：添加技能失败且无任何提示。用户选择技能后"没反应"，无法得知失败原因。

## 根因

`ui/src/main.rs` 里两个"添加技能"按钮用 `let _ = invoke_checked("install_skill", arg).await;` 直接丢弃了返回的 `Result`。于是 SKILL.md 缺失、frontmatter 解析失败、缺 description、重名等所有错误都被静默吞掉，之后无条件 `refresh_skills()`，用户只看到列表没变。

## 改动

- **ui/src/main.rs**：新增 `skills_msg` signal 和共享的 `install_skill_from` 闭包（文件/文件夹两个入口共用）。失败时把 localize 后的错误显示在 skills 面板的 `settings-status` 条上（参照 `model_form_msg` 模式），成功才清空消息并 `refresh_skills()`；切换设置分区时清空该消息。
- **crates/wisp-skills/src/index.rs**：`parse_skill` / `parse_skill_file` 从 `Option<Skill>` 改为 `Result<Skill, String>`，区分"读取失败（含 IO 原因）""缺少 frontmatter""frontmatter 未以 `---` 闭合"三种情况；扫描目录处改用 `if let Ok`，行为不变。
- **src-tauri/src/lib.rs**：`install_skill` 直接 `?` 透传具体 parse 错误，替换原来笼统的 "could not parse SKILL.md frontmatter"。
- **ui/src/i18n.rs**：`localize_backend` 新增 6 条技能安装错误映射（无 SKILL.md、选择提示、缺 frontmatter、frontmatter 未闭合、缺 description、重名——重名用前缀匹配提取技能名），补齐 En/Zh 词条。

## 验证

- `cargo check`：`wisp-skills`、`wisp-ui`（wasm32 target）、`wisp-tauri` 均编译通过
- `cargo test -p wisp-skills`：2 passed

## 备注

`could not read SKILL.md: {io}` 的动态 IO 错误未做本地化（罕见路径，直接显示原文）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)