### PR TITLE
fix(ui): show image artifacts from png/pdf shorthand

### DIFF
--- a/docs/superpowers/specs/2026-07-07-session-export-design.md
+++ b/docs/superpowers/specs/2026-07-07-session-export-design.md
@@ -12,6 +12,8 @@ Users can right-click the current chat page and choose export. The app opens a n
 
 The frontend only owns the menu entry and the current artifact path list, because produced files are detected in the UI transcript. The backend owns zip generation, because it can read persisted messages, stored artifacts, provenance, and workspace files safely.
 
+Transcript artifact detection normalizes common assistant shorthand such as `figure.png/.pdf` to the previewable image path (`figure.png`) before display or export path collection.
+
 ## Zip Contents
 
 - `manifest.json`: export metadata, included files, missing artifacts.

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -229,6 +229,10 @@ export function tauriMock(): void {
           }
           case "read_file":
             return { path: arg("path") ?? "report.csv", mime: "text/csv", text: "a,b\n1,2", base64: null };
+          case "missing_files": {
+            const paths = Array.isArray(arg("paths")) ? arg("paths") : [];
+            return paths.filter((p) => String(p).includes("/.pdf") || String(p).includes("\\.pdf"));
+          }
           case "export_session":
             return "/mock/export.zip";
           case "get_artifact_provenance":
@@ -434,6 +438,7 @@ export function parallelMock(): void {
           case "list_dir": return [];
           case "search_files": return [];
           case "read_file": return { path: "x", mime: "text/plain", text: "", base64: null };
+          case "missing_files": return [];
           case "export_session": return "/mock/export.zip";
           case "upload_file": return { id: "a", name: "x", kind: "text/csv", path: "x", ts: 1 };
           case "new_session": return `s-${Math.random().toString(36).slice(2)}`;

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -125,6 +125,21 @@ test("clicking a figure opens the artifact modal with provenance", async ({ page
   await expect(page.locator(".am-env")).toContainText("matplotlib");
 });
 
+test("artifact panel normalizes png/pdf shorthand to the previewable image", async ({ page }) => {
+  await enterApp(page);
+  await page
+    .getByPlaceholder(/Ask wisp-science/i)
+    .fill("show `figures/panel_I_heatmap_4genes_median.png/.pdf`");
+  await page.getByRole("button", { name: "Send" }).click();
+  await expect(page.getByText("Hello from mock wisp-science.")).toBeVisible({ timeout: 10_000 });
+  await page.getByRole("button", { name: "Toggle panel" }).click();
+
+  const tile = page.locator('.rp-tile[data-artifact-name="panel_I_heatmap_4genes_median.png"]');
+  await expect(tile).toBeVisible();
+  await expect(tile.locator(".rp-badge")).toHaveText("image");
+  await expect(page.locator('.rp-tile[data-artifact-name="panel_I_heatmap_4genes_median.png/.pdf"]')).toHaveCount(0);
+});
+
 test("settings modal shows the saved provider", async ({ page }) => {
   await enterApp(page);
   await openModelsSettings(page);

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -505,6 +505,30 @@ mod tauri_args_tests {
         assert_eq!(normalize_path(".\\results\\fig.png"), "results\\fig.png");
         assert_eq!(normalize_path("results/fig.png"), "results/fig.png");
         assert_eq!(normalize_path("  /a/b.txt  "), "/a/b.txt");
+        assert_eq!(
+            normalize_path("figures/panel_I_heatmap_4genes_median.png/.pdf"),
+            "figures/panel_I_heatmap_4genes_median.png"
+        );
+        assert_eq!(normalize_path("./figures/plot.JPG/.PDF"), "figures/plot.JPG");
+        assert_eq!(normalize_path("C:\\proj\\fig.png\\.pdf"), "C:\\proj\\fig.png");
+    }
+
+    #[test]
+    fn collect_artifacts_normalizes_image_pdf_shorthand() {
+        let items = vec![ChatItem::Assistant {
+            text: "`figures/panel_I_heatmap_4genes_median.png/.pdf`".into(),
+            model: None,
+        }];
+        let arts = collect_artifacts(&items, Locale::En);
+        let a = arts.iter().find(|a| a.name == "panel_I_heatmap_4genes_median.png").unwrap();
+        assert_eq!(a.kind, "image");
+        match &a.data {
+            PreviewData::File { path, kind } => {
+                assert_eq!(path, "figures/panel_I_heatmap_4genes_median.png");
+                assert_eq!(kind, "image");
+            }
+            _ => panic!("expected file artifact"),
+        }
     }
 }
 
@@ -1262,13 +1286,13 @@ fn split_segments(text: &str) -> Vec<Seg> {
 }
 
 fn push_file_artifact(out: &mut Vec<Artifact>, seen: &mut std::collections::HashSet<String>, path: &str) {
-    let p = path.trim().trim_matches('`').trim_matches('"').trim_matches('\'');
-    if p.is_empty() || seen.contains(p) { return; }
-    let Some(kind) = file_kind(p) else { return; };
-    seen.insert(p.to_string());
-    let name = p.rsplit(['/', '\\']).next().unwrap_or(p).to_string();
+    let p = normalize_path(path.trim().trim_matches('`').trim_matches('"').trim_matches('\''));
+    if p.is_empty() || seen.contains(&p) { return; }
+    let Some(kind) = file_kind(&p) else { return; };
+    seen.insert(p.clone());
+    let name = p.rsplit(['/', '\\']).next().unwrap_or(&p).to_string();
     let id = next_artifact_id(out.len());
-    out.push(Artifact { id, name, kind, data: PreviewData::File { path: p.to_string(), kind: kind.to_string() } });
+    out.push(Artifact { id, name, kind, data: PreviewData::File { path: p, kind: kind.to_string() } });
 }
 
 struct ArtifactScan {

--- a/ui/src/text.rs
+++ b/ui/src/text.rs
@@ -176,10 +176,26 @@ pub(crate) fn normalize_path(path: &str) -> String {
     // is told to emit absolute paths (system_prompt.rs), and the backend resolves
     // absolute-under-root correctly; stripping the slash turned an absolute path
     // into a bad root-relative one and 404'd on click (#12).
-    path.trim()
+    let path = path.trim()
         .trim_start_matches("./")
-        .trim_start_matches(".\\")
-        .to_string()
+        .trim_start_matches(".\\");
+    strip_image_pdf_shorthand(path).to_string()
+}
+
+fn strip_image_pdf_shorthand(path: &str) -> &str {
+    const IMAGE_EXTS: [&str; 6] = ["png", "jpg", "jpeg", "gif", "webp", "svg"];
+    let lower = path.to_ascii_lowercase();
+    for ext in IMAGE_EXTS {
+        let slash = format!(".{ext}/.pdf");
+        if let Some(start) = lower.find(&slash) {
+            return &path[..start + ext.len() + 1];
+        }
+        let backslash = format!(".{ext}\\.pdf");
+        if let Some(start) = lower.find(&backslash) {
+            return &path[..start + ext.len() + 1];
+        }
+    }
+    path
 }
 
 pub(crate) fn is_external_href(href: &str) -> bool {


### PR DESCRIPTION
## User-facing problem

Analysis transcripts can mention generated figures as shorthand paths like `figures/panel_I_heatmap_4genes_median.png/.pdf`. The UI treated that as a literal PDF-ish path, `missing_files` filtered it out, and the actual PNG artifact was not shown in the artifacts panel or exported path list.

## Changes

- Normalize common image/PDF shorthand (`*.png/.pdf`, `*.jpg/.pdf`, etc.) to the previewable image path in `normalize_path`.
- Apply path normalization before artifact kind detection/deduping, so transcript-scraped artifacts store the real image path.
- Add a Playwright regression for the exact `panel_I_heatmap_4genes_median.png/.pdf` case and make the Tauri mock cover `missing_files`.
- Document the artifact path normalization behavior in the session export design note.

## Tests

- `cargo fmt --all -- --check`
- `cd ui && cargo test`
- `cargo test --workspace`
- `cd ui && cargo check --target wasm32-unknown-unknown`
- `cd ui-tests && UI_TEST_PORT=1421 npx playwright test`

Note: `cd ui && cargo fmt -- --check` still reports broad pre-existing formatting drift across UI files, so this PR avoids bulk formatting unrelated code.

## Manual smoke

- Used the exported session zip to confirm the real artifact exists at `artifacts/045-panel_I_heatmap_4genes_median.png` while transcript text contains `figures/panel_I_heatmap_4genes_median.png/.pdf`.
- Playwright fresh-port run verifies the normalized artifact appears as `panel_I_heatmap_4genes_median.png` with image kind.

## Known limitations

- This intentionally chooses the image side of `image/.pdf` shorthand. If a future transcript only produces a PDF and no image sibling, that should be handled by a separate existence-aware fallback rather than broadening this UI-only normalization.
