### PR TITLE
Fix model vision edits and stored key display

### DIFF
--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -149,6 +149,49 @@ test("settings modal shows the saved provider", async ({ page }) => {
   await page.getByRole("button", { name: "Cancel" }).click();
 });
 
+test("vision assignment keeps model fields and stored key placeholder untouched", async ({ page }) => {
+  await enterApp(page);
+  await openModelsSettings(page);
+
+  const effort = page.getByLabel("Reasoning effort");
+  const key = page.getByLabel("API key (stored in OS keyring)");
+  const useForVision = page.getByLabel("Use for image analysis");
+
+  await expect(providerSelect(page)).toHaveValue("openai");
+  await expect(effort).toHaveValue("default");
+  await expect(key).toHaveValue("");
+  await expect(key).toHaveAttribute("placeholder", "(stored — leave blank to keep)");
+
+  if (await useForVision.isChecked()) {
+    await useForVision.uncheck();
+  }
+  await useForVision.check();
+
+  await expect(providerSelect(page)).toHaveValue("openai");
+  await expect(effort).toHaveValue("default");
+  await expect(key).toHaveValue("");
+
+  await page.getByRole("button", { name: "Save" }).click();
+  await expect.poll(async () => page.evaluate(() => {
+    const plain = (value: any): any => {
+      if (value instanceof Map) return Object.fromEntries([...value].map(([k, v]) => [k, plain(v)]));
+      if (Array.isArray(value)) return value.map(plain);
+      if (value && typeof value === "object") return Object.fromEntries(Object.entries(value).map(([k, v]) => [k, plain(v)]));
+      return value;
+    };
+    const calls = ((window as any).__skillInvokeLog ?? []).filter((c: any) => c.cmd === "save_model");
+    const args = plain(calls.at(-1)?.args ?? null);
+    return args ? { ...args, key: args.key ?? null } : null;
+  })).toMatchObject({
+    key: null,
+    profile: {
+      provider: "openai",
+      reasoning_effort: "",
+      use_for_vision: true,
+    },
+  });
+});
+
 test("settings normalizes a blank stored provider to openai", async ({ page }) => {
   await enterApp(page);
   await openModelsSettings(page);

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -375,17 +375,11 @@ fn settings_required_error_key(cfg: &Settings, key: &str) -> Option<&'static str
     if cfg.model.trim().is_empty() {
         return Some("err.model_required");
     }
-    let stored = t(Locale::En, "settings.stored_key");
-    let has_new_key = !key.trim().is_empty() && !key.starts_with(&stored) && !key.starts_with("(stored");
+    let has_new_key = !key.trim().is_empty();
     if !is_runner && !cfg.has_api_key && !has_new_key {
         return Some("err.api_key_required");
     }
     None
-}
-
-fn is_stored_key_placeholder(key: &str, locale: Locale) -> bool {
-    let stored = t(locale, "settings.stored_key");
-    key.starts_with(&stored) || key.starts_with("(stored")
 }
 
 fn should_close_right_pane_on_escape(ev: &web_sys::KeyboardEvent) -> bool {
@@ -3352,8 +3346,7 @@ fn App() -> impl IntoView {
         if settings_busy.get() { return; }
         let Some(form) = model_form.get() else { return; };
         let loc = locale.get();
-        let key_raw = model_form_key.get();
-        let key = if is_stored_key_placeholder(&key_raw, loc) { String::new() } else { key_raw };
+        let key = model_form_key.get();
         let has_key = form.id.as_ref()
             .and_then(|id| models.get().iter().find(|m| &m.id == id).map(|m| m.has_api_key))
             .unwrap_or(false);
@@ -3411,8 +3404,7 @@ fn App() -> impl IntoView {
         if settings_busy.get() { return; }
         let Some(form) = model_form.get() else { return; };
         let loc = locale.get();
-        let key_raw = model_form_key.get();
-        let key = if is_stored_key_placeholder(&key_raw, loc) { String::new() } else { key_raw };
+        let key = model_form_key.get();
         let has_key = models.get().iter().find(|m| Some(m.id.as_str()) == form.id.as_deref()).map(|m| m.has_api_key).unwrap_or(false);
         let cfg = model_form_to_settings(&form, has_key);
         if let Some(err_key) = settings_required_error_key(&cfg, &key) {
@@ -5719,6 +5711,15 @@ fn App() -> impl IntoView {
                                                 {move || (model_form.get().map(|f| !provider_is_local_runner(&f.provider)).unwrap_or(true)).then(|| view! {
                                                     <label class="span-2">{move || t(locale.get(), "settings.api_key")}
                                                         <input type="password" prop:value=move || model_form_key.get()
+                                                            placeholder=move || {
+                                                                let Some(id) = model_form.get().and_then(|f| f.id) else { return String::new(); };
+                                                                if models.get().iter().any(|m| m.id == id && m.has_api_key) {
+                                                                    t(locale.get(), "settings.stored_key").to_string()
+                                                                } else {
+                                                                    String::new()
+                                                                }
+                                                            }
+                                                            autocomplete="new-password"
                                                             on:input=move |ev| model_form_key.set(event_target_input(&ev).value()) /></label>
                                                 })}
                                             </div>
@@ -5762,11 +5763,7 @@ fn App() -> impl IntoView {
                                                         class:settings-list-row-active=is_active
                                                         on:click=move |_| {
                                                             model_form.set(Some(profile_to_form(&edit)));
-                                                            model_form_key.set(if edit.has_api_key {
-                                                                t(locale.get(), "settings.stored_key").into()
-                                                            } else {
-                                                                String::new()
-                                                            });
+                                                            model_form_key.set(String::new());
                                                             model_form_msg.set(None);
                                                         }>
                                                         <div class="settings-list-main">


### PR DESCRIPTION
## Problem

Editing a model could make the form look unstable around vision assignment and saved API keys:

- Toggling **Use for image analysis** should not mutate unrelated model fields such as provider or reasoning effort.
- Existing API keys were represented as text inside the password input, so reopening the form showed misleading masked dots with a fake length.

## Changes

- Keep the API key input empty for profiles that already have a stored key.
- Show the stored-key message as a placeholder instead of a password value.
- Simplify model save/validate key handling so only real user input is treated as a new key.
- Add a Playwright regression test for the vision assignment flow and stored-key placeholder.

## Tests

- `cargo fmt --all -- --check`
- `cd ui && cargo test`
- `cd ui && cargo check --target wasm32-unknown-unknown`
- `cd ui-tests && UI_TEST_PORT=1422 npx playwright test`
- `git diff --check`

## Known limitations

- This does not add key reveal or key deletion UI; it only fixes the edit form so stored keys are not shown as fake password values.
