### PR TITLE
perf: cut hot-path costs across ui, core, store, and tauri layers

### DIFF
--- a/crates/wisp-core/src/context.rs
+++ b/crates/wisp-core/src/context.rs
@@ -10,7 +10,7 @@
 
 use crate::output::Output;
 use std::path::Path;
-use wisp_llm::{Message, Provider, Role, ToolCall};
+use wisp_llm::{Content, Message, Part, Provider, Role, ToolCall};
 
 struct CompactRule {
     max_tokens: usize,
@@ -331,9 +331,29 @@ impl ContextManager {
         "executing".into()
     }
 
+    /// Rough token estimate (~JSON length / 4) from field lengths directly.
+    /// The old serialize-to-measure version dominated the compaction hot path:
+    /// it re-encoded every message to JSON on every `total_tokens()` call.
     pub fn estimated_tokens(msg: &Message) -> usize {
-        let s = serde_json::to_string(msg).unwrap_or_default();
-        s.len() / 4 + 4
+        let mut n = 32; // role + envelope punctuation
+        n += match &msg.content {
+            Content::Text(s) => s.len(),
+            Content::Parts(parts) => parts
+                .iter()
+                .map(|p| match p {
+                    Part::Text { text, .. } => text.len() + 24,
+                    Part::Image { image_url, .. } => image_url.url.len() + 40,
+                })
+                .sum(),
+        };
+        for tc in &msg.tool_calls {
+            n += tc.id.len() + tc.function.name.len() + tc.function.arguments.len() + 48;
+        }
+        n += msg.tool_call_id.as_deref().map_or(0, |s| s.len() + 20);
+        n += msg.tool_name.as_deref().map_or(0, |s| s.len() + 16);
+        n += msg.reasoning.as_deref().map_or(0, |s| s.len() + 16);
+        n += msg.model_name.as_deref().map_or(0, |s| s.len() + 18);
+        n / 4 + 4
     }
     pub fn total_tokens(&self) -> usize {
         self.messages.iter().map(Self::estimated_tokens).sum()
@@ -495,9 +515,8 @@ work in progress. Use this structure:
 7. Pending Tasks
 8. Current Work";
         self.append_user(PROMPT);
-        let messages = self.messages.clone();
         let comp = provider
-            .complete(&messages, &[])
+            .complete(&self.messages, &[])
             .await
             .map_err(|e| format!("full compact err: {e}"))?;
         let summary = comp.content;
@@ -540,12 +559,14 @@ work in progress. Use this structure:
     }
 
     /// micro-compact, then auto-compact if over threshold; return the messages
-    /// to send to the model (persisted + runtime injections).
+    /// to send to the model (persisted + runtime injections). Borrows the
+    /// history when there are no injections — the common case — instead of
+    /// deep-cloning every message on every loop iteration.
     pub async fn prepare_for_api(
         &mut self,
         provider: &dyn Provider,
         output: &dyn Output,
-    ) -> Vec<Message> {
+    ) -> std::borrow::Cow<'_, [Message]> {
         self.micro_compact();
         let before = self.total_tokens();
         self.auto_compact_if_needed(provider, output).await;
@@ -553,9 +574,13 @@ work in progress. Use this structure:
         if before > after {
             output.compaction(before, after, "auto");
         }
-        let mut out = self.messages.clone();
-        out.extend(self.runtime_injections.clone());
-        out
+        if self.runtime_injections.is_empty() {
+            std::borrow::Cow::Borrowed(&self.messages)
+        } else {
+            let mut out = self.messages.clone();
+            out.extend(self.runtime_injections.iter().cloned());
+            std::borrow::Cow::Owned(out)
+        }
     }
 }
 
@@ -602,5 +627,26 @@ mod tests {
     fn compact_text_keeps_short_multibyte_intact() {
         let s = "简短中文";
         assert_eq!(ContextManager::compact_text(s, 350, 350), s);
+    }
+
+    // The field-length token estimate replaced a serialize-to-measure version;
+    // compaction thresholds only need it to stay in the same ballpark.
+    #[test]
+    fn estimated_tokens_tracks_json_length() {
+        let mut m = Message::user("hello world, this is a normal chat message about data analysis");
+        m.tool_calls = vec![ToolCall {
+            id: "call_1".into(),
+            kind: "function".into(),
+            function: wisp_llm::FunctionCall {
+                name: "read".into(),
+                arguments: r#"{"path":"/tmp/some/file.csv","limit":200}"#.into(),
+            },
+        }];
+        let est = ContextManager::estimated_tokens(&m);
+        let json = serde_json::to_string(&m).unwrap().len() / 4 + 4;
+        assert!(
+            est >= json / 2 && est <= json * 2,
+            "estimate {est} should be within 2x of json-based {json}"
+        );
     }
 }

--- a/crates/wisp-store/src/lib.rs
+++ b/crates/wisp-store/src/lib.rs
@@ -1163,12 +1163,22 @@ impl Store {
         frame_id: &str,
         path: &str,
     ) -> Result<Option<ExecLog>> {
+        // Substring prefilter pushed into SQL so we don't fetch and JSON-parse
+        // every row in the frame. The needle is the path's JSON encoding
+        // (quotes included) because that's the byte form stored in the column —
+        // matching the raw path would miss e.g. backslashes stored as `\\`.
+        // The exact match below drops false positives (`a.csv` in `data.csv`,
+        // LIKE's ASCII case folding), so the prefilter only ever over-selects.
+        let needle = serde_json::to_string(path).unwrap_or_default();
+        let escaped = needle.replace('\\', "\\\\").replace('%', "\\%").replace('_', "\\_");
         let rows = sqlx::query(
             "SELECT id,frame_id,cell_index,tool,language,source,stdout,stderr,exit_status,\
              wall_s,files_written,files_read,env_hash FROM execution_log \
-             WHERE frame_id=? ORDER BY created_at DESC, cell_index DESC",
+             WHERE frame_id=? AND files_written LIKE '%' || ? || '%' ESCAPE '\\' \
+             ORDER BY created_at DESC, cell_index DESC",
         )
         .bind(frame_id)
+        .bind(&escaped)
         .fetch_all(&self.pool)
         .await?;
         for r in rows {
@@ -2428,6 +2438,27 @@ mod tests {
         assert_eq!(got.files_read, vec!["data.csv".to_string()]);
         assert!(store
             .find_provenance_by_path("f1", "missing.png")
+            .await
+            .unwrap()
+            .is_none());
+        // LIKE-prefilter regressions: `_`/`%` must be escaped as literals, a
+        // backslash path must match its JSON-encoded stored form, and a
+        // suffix of a written path must not match (exact check, not substring).
+        let e2 = ExecLog {
+            id: "e2".into(),
+            cell_index: 1,
+            files_written: vec!["out/my_fig 100%.png".into(), r"C:\data\x.csv".into()],
+            ..e.clone()
+        };
+        store.insert_execution_log(&e2).await.unwrap();
+        for p in ["out/my_fig 100%.png", r"C:\data\x.csv"] {
+            assert!(
+                store.find_provenance_by_path("f1", p).await.unwrap().is_some(),
+                "should find {p}"
+            );
+        }
+        assert!(store
+            .find_provenance_by_path("f1", "fig.png")
             .await
             .unwrap()
             .is_none());

--- a/crates/wisp-tools/src/grep.rs
+++ b/crates/wisp-tools/src/grep.rs
@@ -54,6 +54,11 @@ impl Tool for GrepTool {
             if !entry.file_type().is_file() {
                 continue;
             }
+            // ponytail: flat 10MB skip like code-search tools; no override knob
+            // until someone actually greps huge files.
+            if entry.metadata().is_ok_and(|m| m.len() > 10 * 1024 * 1024) {
+                continue;
+            }
             let path = entry.path();
             let Ok(text) = std::fs::read_to_string(path) else {
                 continue;

--- a/crates/wisp-tools/src/read.rs
+++ b/crates/wisp-tools/src/read.rs
@@ -50,6 +50,17 @@ impl Tool for ReadTool {
         {
             return crate::image::view_image(&path);
         }
+        // Cap checked before the read: a multi-GB log slurped whole can hang
+        // or OOM the process.
+        const MAX_READ_BYTES: u64 = 50 * 1024 * 1024;
+        if let Ok(m) = std::fs::metadata(&path) {
+            if m.len() > MAX_READ_BYTES {
+                return ToolResult::fail(format!(
+                    "read {path} error: file is {} bytes (limit {MAX_READ_BYTES}); use shell tools like head/tail/rg to sample it",
+                    m.len()
+                ));
+            }
+        }
         let bytes = match std::fs::read(&path) {
             Ok(b) => b,
             Err(e) => return ToolResult::fail(format!("read {path} error: {e}")),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2642,7 +2642,9 @@ async fn download_file(
         return Ok(None); // user cancelled
     };
     let dest_path = std::path::PathBuf::from(dest.to_string());
-    std::fs::copy(&real, &dest_path).map_err(|e| format!("copy failed: {e}"))?;
+    tokio::fs::copy(&real, &dest_path)
+        .await
+        .map_err(|e| format!("copy failed: {e}"))?;
     Ok(Some(dest_path.to_string_lossy().into_owned()))
 }
 
@@ -3412,8 +3414,17 @@ async fn install_skill(
     if dest.exists() {
         return Err(format!("a skill named '{}' already exists", skill.name));
     }
-    std::fs::create_dir_all(dest.parent().unwrap()).map_err(|e| format!("{e}"))?;
-    copy_dir_recursive(&skill_dir, &dest).map_err(|e| format!("{e}"))?;
+    {
+        // Recursive copy off the async runtime: a skill folder can be large.
+        let (skill_dir, dest) = (skill_dir.clone(), dest.clone());
+        tokio::task::spawn_blocking(move || {
+            std::fs::create_dir_all(dest.parent().unwrap())?;
+            copy_dir_recursive(&skill_dir, &dest)
+        })
+        .await
+        .map_err(|e| format!("{e}"))?
+        .map_err(|e| format!("{e}"))?;
+    }
     reload_skills(&state, window.label());
     let ap = state.active(window.label());
     if let Some(mut enabled) = load_enabled_skill_names(&state.store, &ap.id).await {
@@ -3435,7 +3446,9 @@ async fn remove_skill(
     if !dir.is_dir() {
         return Err("only user-added skills can be removed".into());
     }
-    std::fs::remove_dir_all(&dir).map_err(|e| format!("{e}"))?;
+    tokio::fs::remove_dir_all(&dir)
+        .await
+        .map_err(|e| format!("{e}"))?;
     let ap = state.active(window.label());
     if let Some(mut enabled) = load_enabled_skill_names(&state.store, &ap.id).await {
         enabled.remove(&name);
@@ -3936,19 +3949,20 @@ fn list_dir(
 }
 
 fn read_file_at(
-    state: &AppState,
-    label: &str,
+    root: &Path,
     path: String,
     max_bytes: Option<u64>,
 ) -> Result<FileContent, String> {
-    let ap = state.active(label);
-    let real = wisp_tools::safety::validate_file_path(&ap.root, &path)?;
+    let real = wisp_tools::safety::validate_file_path(root, &path)?;
     let mime = mime_for_path(&real);
     let cap = max_bytes.unwrap_or(8 * 1024 * 1024).min(32 * 1024 * 1024);
-    let bytes = std::fs::read(&real).map_err(|e| format!("{e}"))?;
-    if bytes.len() as u64 > cap {
+    // Size check before the read: the old order slurped a file of any size
+    // into memory just to reject it.
+    let len = std::fs::metadata(&real).map_err(|e| format!("{e}"))?.len();
+    if len > cap {
         return Err(format!("file exceeds {cap} byte limit"));
     }
+    let bytes = std::fs::read(&real).map_err(|e| format!("{e}"))?;
     let path_str = real.to_string_lossy().into_owned();
     if is_text_mime(mime)
         || mime == "text/csv"
@@ -3983,7 +3997,7 @@ fn read_file(
     path: String,
     max_bytes: Option<u64>,
 ) -> Result<FileContent, String> {
-    read_file_at(&state, window.label(), path, max_bytes)
+    read_file_at(&state.active(window.label()).root, path, max_bytes)
 }
 
 #[tauri::command]
@@ -4050,7 +4064,10 @@ async fn read_artifact(
         .map_err(|e| format!("{e}"))?
         .ok_or_else(|| format!("artifact '{id}' not found"))?;
     let (_name, _ct, storage_path, _frame) = row;
-    read_file_at(&state, window.label(), storage_path, None)
+    let root = state.active(window.label()).root;
+    tokio::task::spawn_blocking(move || read_file_at(&root, storage_path, None))
+        .await
+        .map_err(|e| format!("{e}"))?
 }
 
 fn mcp_lib_dir(_root: &std::path::Path) -> Option<PathBuf> {
@@ -4787,9 +4804,13 @@ async fn upload_file(
     }
     let ap = state.active(window.label());
     let upload_dir = ap.root.join("uploads");
-    std::fs::create_dir_all(&upload_dir).map_err(|e| format!("{e}"))?;
+    tokio::fs::create_dir_all(&upload_dir)
+        .await
+        .map_err(|e| format!("{e}"))?;
     let dest = unique_upload_path(&ap.root, "uploads", &name);
-    std::fs::write(&dest, &bytes).map_err(|e| format!("{e}"))?;
+    tokio::fs::write(&dest, &bytes)
+        .await
+        .map_err(|e| format!("{e}"))?;
     let rel = dest
         .strip_prefix(&ap.root)
         .map(|p| p.to_string_lossy().replace('\\', "/"))
@@ -4917,8 +4938,15 @@ async fn export_session(
         .list_artifacts(&session_id)
         .await
         .unwrap_or_default();
-    let (files, missing_artifacts) =
-        collect_export_artifacts(&ap.root, artifact_paths, stored_artifacts);
+    let (files, missing_artifacts) = {
+        // Reads every exported artifact into memory — off the async runtime.
+        let root = ap.root.clone();
+        tokio::task::spawn_blocking(move || {
+            collect_export_artifacts(&root, artifact_paths, stored_artifacts)
+        })
+        .await
+        .map_err(|e| format!("{e}"))?
+    };
     let tool_calls = export_tool_calls(&messages);
 
     let mut artifact_manifest = Vec::<ExportArtifactManifest>::new();
@@ -4975,24 +5003,32 @@ async fn export_session(
         return Ok(None);
     };
     let dest_path = std::path::PathBuf::from(dest.to_string());
-    let out = std::fs::File::create(&dest_path).map_err(|e| format!("{e}"))?;
-    let mut zip = zip::ZipWriter::new(out);
+    // Compression is CPU-bound and the archive can carry many MB of
+    // artifacts — keep it off the async runtime.
+    let out_path = dest_path.clone();
+    tokio::task::spawn_blocking(move || -> Result<(), String> {
+        let out = std::fs::File::create(&out_path).map_err(|e| format!("{e}"))?;
+        let mut zip = zip::ZipWriter::new(out);
 
-    zip_json(&mut zip, "manifest.json", &manifest)?;
-    zip_text(
-        &mut zip,
-        "transcript.md",
-        &render_export_transcript(&messages),
-    )?;
-    zip_json(&mut zip, "messages.json", &messages)?;
-    zip_json(&mut zip, "tool-calls.json", &tool_calls)?;
-    for file in &files {
-        zip_bytes(&mut zip, &file.zip_path, &file.bytes)?;
-    }
-    for (path, provenance) in &provenance_files {
-        zip_json(&mut zip, path, provenance)?;
-    }
-    zip.finish().map_err(|e| format!("{e}"))?;
+        zip_json(&mut zip, "manifest.json", &manifest)?;
+        zip_text(
+            &mut zip,
+            "transcript.md",
+            &render_export_transcript(&messages),
+        )?;
+        zip_json(&mut zip, "messages.json", &messages)?;
+        zip_json(&mut zip, "tool-calls.json", &tool_calls)?;
+        for file in &files {
+            zip_bytes(&mut zip, &file.zip_path, &file.bytes)?;
+        }
+        for (path, provenance) in &provenance_files {
+            zip_json(&mut zip, path, provenance)?;
+        }
+        zip.finish().map_err(|e| format!("{e}"))?;
+        Ok(())
+    })
+    .await
+    .map_err(|e| format!("{e}"))??;
 
     Ok(Some(dest_path.to_string_lossy().into_owned()))
 }

--- a/ui/src/highlight.js
+++ b/ui/src/highlight.js
@@ -22,8 +22,11 @@ function ensure() {
 /** @param {ParentNode} root */
 async function highlight_root(root) {
   const hljs = await ensure();
-  root.querySelectorAll("pre code").forEach((node) => {
+  // Re-rendered blocks are fresh DOM nodes without the marker, so content
+  // changes still re-highlight; untouched siblings are skipped.
+  root.querySelectorAll("pre code:not([data-hl])").forEach((node) => {
     hljs.highlightElement(node);
+    node.dataset.hl = "1";
   });
 }
 

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -513,7 +513,7 @@ mod tauri_args_tests {
             text: "`figures/panel_I_heatmap_4genes_median.png/.pdf`".into(),
             model: None,
         }];
-        let arts = collect_artifacts(&items, Locale::En);
+        let arts = collect_artifacts(&items, Locale::En, &mut ProtoCache::new());
         let a = arts.iter().find(|a| a.name == "panel_I_heatmap_4genes_median.png").unwrap();
         assert_eq!(a.kind, "image");
         match &a.data {
@@ -1284,14 +1284,24 @@ fn split_segments(text: &str) -> Vec<Seg> {
     segs
 }
 
-fn push_file_artifact(out: &mut Vec<Artifact>, seen: &mut std::collections::HashSet<String>, path: &str) {
-    let p = normalize_path(path.trim().trim_matches('`').trim_matches('"').trim_matches('\''));
-    if p.is_empty() || seen.contains(&p) { return; }
-    let Some(kind) = file_kind(&p) else { return; };
-    seen.insert(p.clone());
-    let name = p.rsplit(['/', '\\']).next().unwrap_or(&p).to_string();
-    let id = next_artifact_id(out.len());
-    out.push(Artifact { id, name, kind, data: PreviewData::File { path: p, kind: kind.to_string() } });
+/// Locale-free artifact material extracted from one chat item. Ids, localized
+/// names, per-kind numbering, and cross-item file dedup are assigned later in
+/// `assemble_artifacts`, so this half is cacheable per item and streaming only
+/// re-extracts the tail message instead of rescanning the whole transcript.
+enum ProtoArtifact {
+    Table(TableData),
+    Csv(TableData),
+    Fasta(String),
+    Code { lang: String, body: String },
+    Latex(String),
+    File { path: String, kind: &'static str },
+}
+
+fn file_proto(word: &str) -> Option<ProtoArtifact> {
+    let p = normalize_path(word.trim().trim_matches('`').trim_matches('"').trim_matches('\''));
+    if p.is_empty() { return None; }
+    let kind = file_kind(&p)?;
+    Some(ProtoArtifact::File { path: p, kind })
 }
 
 struct ArtifactScan {
@@ -1301,23 +1311,10 @@ struct ArtifactScan {
     tex_n: usize,
 }
 
-fn collect_markdown_artifacts(
-    out: &mut Vec<Artifact>,
-    seen: &mut std::collections::HashSet<String>,
-    s: &str,
-    locale: Locale,
-    scan: &mut ArtifactScan,
-) {
+fn extract_markdown_protos(out: &mut Vec<ProtoArtifact>, s: &str) {
     for seg in split_segments(s) {
         if let Seg::Table(t) = seg {
-            scan.tbl_n += 1;
-            let id = next_artifact_id(out.len());
-            out.push(Artifact {
-                id,
-                name: tf(locale, "artifact.table", &[("n", &scan.tbl_n.to_string())]),
-                kind: "table",
-                data: PreviewData::Table(t),
-            });
+            out.push(ProtoArtifact::Table(t));
         }
     }
     let lines: Vec<&str> = s.lines().collect();
@@ -1333,21 +1330,11 @@ fn collect_markdown_artifacts(
                 if lang == "csv" || lang == "tsv" {
                     let headers = parse_csv_line(body[0]);
                     let rows: Vec<Vec<String>> = body[1..].iter().map(|l| parse_csv_line(l)).collect();
-                    scan.csv_n += 1;
-                    let id = next_artifact_id(out.len());
-                    out.push(Artifact { id, name: format!("data-{}.csv", scan.csv_n), kind: "csv", data: PreviewData::Table(TableData { headers, rows }) });
+                    out.push(ProtoArtifact::Csv(TableData { headers, rows }));
                 } else if lang == "fasta" || lang == "fa" {
-                    let id = next_artifact_id(out.len());
-                    out.push(Artifact { id, name: format!("alignment-{}.fasta", scan.csv_n), kind: "fasta", data: PreviewData::Fasta(body.join("\n")) });
+                    out.push(ProtoArtifact::Fasta(body.join("\n")));
                 } else {
-                    scan.code_n += 1;
-                    let id = next_artifact_id(out.len());
-                    out.push(Artifact {
-                        id,
-                        name: tf(locale, "artifact.code", &[("n", &scan.code_n.to_string())]),
-                        kind: "code",
-                        data: PreviewData::Code { lang, body: body.join("\n") },
-                    });
+                    out.push(ProtoArtifact::Code { lang, body: body.join("\n") });
                 }
             }
             i = j + 1;
@@ -1358,22 +1345,102 @@ fn collect_markdown_artifacts(
             let mut j = i + 1;
             while j < lines.len() && !lines[j].trim().ends_with("$") { body.push(lines[j]); j += 1; }
             if j < lines.len() { body.push(lines[j].trim().trim_end_matches("$")); }
-            scan.tex_n += 1;
-            let id = next_artifact_id(out.len());
-            out.push(Artifact {
-                id,
-                name: tf(locale, "artifact.equation", &[("n", &scan.tex_n.to_string())]),
-                kind: "latex",
-                data: PreviewData::Latex { tex: body.join("\n"), display: true },
-            });
+            out.push(ProtoArtifact::Latex(body.join("\n")));
             i = j + 1;
             continue;
         }
         i += 1;
     }
     for word in s.split(|c: char| c.is_whitespace() || c == '(' || c == ')' || c == '[' || c == ']') {
-        push_file_artifact(out, seen, word);
+        if let Some(p) = file_proto(word) { out.push(p); }
     }
+}
+
+/// Extraction half of the artifact scan: pure function of one item's content.
+fn extract_protos(it: &ChatItem) -> Vec<ProtoArtifact> {
+    let mut out = vec![];
+    match it {
+        // Uploaded files live only in the user turn ("Uploaded files: a, b").
+        ChatItem::User(s) => {
+            for word in s.split(|c: char| c.is_whitespace() || c == ',' || c == '"' || c == '\'') {
+                if let Some(p) = file_proto(word) { out.push(p); }
+            }
+        }
+        ChatItem::Assistant { text: s, .. } => extract_markdown_protos(&mut out, s),
+        ChatItem::Tool { name, input, output, .. } => {
+            if name == "attempt_completion" && !output.is_empty() {
+                extract_markdown_protos(&mut out, output);
+            } else {
+                let text = if output.is_empty() { input.as_str() } else { output.as_str() };
+                for word in text.split(|c: char| c.is_whitespace() || c == '\n' || c == '"' || c == '\'') {
+                    if let Some(p) = file_proto(word) { out.push(p); }
+                }
+            }
+        }
+        _ => {}
+    }
+    out
+}
+
+/// Numbering half: assign ids, localized names, and cross-item file dedup.
+/// O(artifact count) per run — cheap next to re-scanning message text.
+fn assemble_artifacts(per_item: &[Rc<Vec<ProtoArtifact>>], locale: Locale) -> Vec<Artifact> {
+    let mut out: Vec<Artifact> = vec![];
+    let mut seen = std::collections::HashSet::<String>::new();
+    let mut scan = ArtifactScan { tbl_n: 0, csv_n: 0, code_n: 0, tex_n: 0 };
+    for protos in per_item {
+        for p in protos.iter() {
+            match p {
+                ProtoArtifact::Table(t) => {
+                    scan.tbl_n += 1;
+                    let id = next_artifact_id(out.len());
+                    out.push(Artifact {
+                        id,
+                        name: tf(locale, "artifact.table", &[("n", &scan.tbl_n.to_string())]),
+                        kind: "table",
+                        data: PreviewData::Table(t.clone()),
+                    });
+                }
+                ProtoArtifact::Csv(t) => {
+                    scan.csv_n += 1;
+                    let id = next_artifact_id(out.len());
+                    out.push(Artifact { id, name: format!("data-{}.csv", scan.csv_n), kind: "csv", data: PreviewData::Table(t.clone()) });
+                }
+                ProtoArtifact::Fasta(body) => {
+                    let id = next_artifact_id(out.len());
+                    out.push(Artifact { id, name: format!("alignment-{}.fasta", scan.csv_n), kind: "fasta", data: PreviewData::Fasta(body.clone()) });
+                }
+                ProtoArtifact::Code { lang, body } => {
+                    scan.code_n += 1;
+                    let id = next_artifact_id(out.len());
+                    out.push(Artifact {
+                        id,
+                        name: tf(locale, "artifact.code", &[("n", &scan.code_n.to_string())]),
+                        kind: "code",
+                        data: PreviewData::Code { lang: lang.clone(), body: body.clone() },
+                    });
+                }
+                ProtoArtifact::Latex(tex) => {
+                    scan.tex_n += 1;
+                    let id = next_artifact_id(out.len());
+                    out.push(Artifact {
+                        id,
+                        name: tf(locale, "artifact.equation", &[("n", &scan.tex_n.to_string())]),
+                        kind: "latex",
+                        data: PreviewData::Latex { tex: tex.clone(), display: true },
+                    });
+                }
+                ProtoArtifact::File { path, kind } => {
+                    if seen.contains(path.as_str()) { continue; }
+                    seen.insert(path.clone());
+                    let name = path.rsplit(['/', '\\']).next().unwrap_or(path).to_string();
+                    let id = next_artifact_id(out.len());
+                    out.push(Artifact { id, name, kind, data: PreviewData::File { path: path.clone(), kind: kind.to_string() } });
+                }
+            }
+        }
+    }
+    out
 }
 
 /// Promote `attempt_completion` output into the assistant bubble (web-dist renders
@@ -1403,35 +1470,59 @@ fn artifacts_fingerprint(arts: &[Artifact]) -> u64 {
     h.finish()
 }
 
-/// Collect tables, code, latex, and file-path artifacts from the transcript.
-fn collect_artifacts(items: &[ChatItem], locale: Locale) -> Vec<Artifact> {
-    let mut out: Vec<Artifact> = vec![];
-    let mut seen = std::collections::HashSet::<String>::new();
-    let mut scan = ArtifactScan { tbl_n: 0, csv_n: 0, code_n: 0, tex_n: 0 };
+type ProtoCache = HashMap<(usize, u64), Rc<Vec<ProtoArtifact>>>;
 
-    for it in items {
-        match it {
-            // Uploaded files live only in the user turn ("Uploaded files: a, b").
-            ChatItem::User(s) => {
-                for word in s.split(|c: char| c.is_whitespace() || c == ',' || c == '"' || c == '\'') {
-                    push_file_artifact(&mut out, &mut seen, word);
-                }
-            }
-            ChatItem::Assistant { text: s, .. } => collect_markdown_artifacts(&mut out, &mut seen, s, locale, &mut scan),
-            ChatItem::Tool { name, input, output, .. } => {
-                if name == "attempt_completion" && !output.is_empty() {
-                    collect_markdown_artifacts(&mut out, &mut seen, output, locale, &mut scan);
-                } else {
-                    let text = if output.is_empty() { input.as_str() } else { output.as_str() };
-                    for word in text.split(|c: char| c.is_whitespace() || c == '\n' || c == '"' || c == '\'') {
-                        push_file_artifact(&mut out, &mut seen, word);
-                    }
-                }
-            }
-            _ => {}
-        }
+/// Collect tables, code, latex, and file-path artifacts from the transcript.
+/// Extraction is cached per (index, content hash): a streaming flush only
+/// re-extracts the message it touched, then renumbering runs over the cached
+/// protos — instead of rescanning every message on every signal write.
+fn collect_artifacts(items: &[ChatItem], locale: Locale, cache: &mut ProtoCache) -> Vec<Artifact> {
+    let mut next: ProtoCache = HashMap::with_capacity(items.len());
+    let mut per_item: Vec<Rc<Vec<ProtoArtifact>>> = Vec::with_capacity(items.len());
+    for (i, it) in items.iter().enumerate() {
+        let key = (i, it.fingerprint());
+        let protos = cache.remove(&key).unwrap_or_else(|| Rc::new(extract_protos(it)));
+        next.insert(key, protos.clone());
+        per_item.push(protos);
     }
-    out
+    *cache = next;
+    assemble_artifacts(&per_item, locale)
+}
+
+#[cfg(test)]
+mod artifact_scan_tests {
+    use super::*;
+
+    fn fresh(items: &[ChatItem], locale: Locale) -> Vec<Artifact> {
+        collect_artifacts(items, locale, &mut ProtoCache::new())
+    }
+
+    /// Streaming reuses cached extractions for untouched messages; the result
+    /// must be identical to a from-scratch scan (ids, names, order, dedup).
+    #[test]
+    fn cached_scan_matches_fresh_scan() {
+        let mut cache = ProtoCache::new();
+        let mut items = vec![
+            ChatItem::User("check data.csv and data.csv".into()),
+            ChatItem::Assistant { text: "| a | b |\n|---|---|\n| 1 | 2 |\n\n```csv\nx,y\n1,2\n```".into(), model: None },
+        ];
+        let a1 = collect_artifacts(&items, Locale::En, &mut cache);
+        assert!(a1 == fresh(&items, Locale::En));
+        // csv file (deduped once) + table + fenced csv
+        assert_eq!(a1.len(), 3);
+
+        // Simulate a streaming flush: the tail message grows a code fence.
+        if let ChatItem::Assistant { text, .. } = &mut items[1] {
+            text.push_str("\n```py\nprint(1)\n```");
+        }
+        items.push(ChatItem::Tool {
+            name: "write".into(), ok: Some(true), input: String::new(),
+            output: "wrote out/result.csv".into(), started_at_ms: None, duration_ms: Some(1),
+        });
+        let a2 = collect_artifacts(&items, Locale::En, &mut cache);
+        assert!(a2 == fresh(&items, Locale::En));
+        assert_eq!(a2.len(), 5); // + code block, + result.csv file
+    }
 }
 
 fn table_view(t: &TableData, locale: Locale) -> impl IntoView {
@@ -2549,7 +2640,10 @@ fn App() -> impl IntoView {
     let composer_drag_start_h = create_rw_signal(0.0_f64);
 
     // Artifacts (right pane): tables + CSV detected in the transcript.
-    let artifacts_all = create_memo(move |_| collect_artifacts(&items.get(), locale.get()));
+    let proto_cache = Rc::new(RefCell::new(ProtoCache::new()));
+    let artifacts_all = create_memo(move |_| {
+        items.with(|list| collect_artifacts(list, locale.get(), &mut proto_cache.borrow_mut()))
+    });
     // File-backed artifacts are scraped from chat text, so a file that was
     // renamed or overwritten still lingers and 404s on click (#41). Ask the
     // backend which referenced files are gone and drop them from the list.
@@ -4343,7 +4437,7 @@ fn App() -> impl IntoView {
 
             <div class="chat" id=CHAT_SCROLLER_ID>
                 <div class="thread" id=CHAT_THREAD_ID>
-                    {move || items.get().is_empty().then(|| view! {
+                    {move || items.with(|l| l.is_empty()).then(|| view! {
                         <div class="empty">
                             <span class="empty-logo"></span>
                             <h1>{move || empty_title(locale.get(), empty_title_idx.get())}</h1>
@@ -4358,7 +4452,9 @@ fn App() -> impl IntoView {
                             use std::hash::{Hash, Hasher};
                             let arts_fp = artifacts.with(|a| artifacts_fingerprint(a));
                             let busy_now = busy.get();
-                            let list = items.get();
+                            // `with` avoids deep-cloning every message per flush;
+                            // only rows being built clone their item below.
+                            items.with(|list| {
                             let last = list.len().saturating_sub(1);
                             // Coalesce consecutive thinking + tool items into one
                             // foldable steps panel; render everything else as a
@@ -4406,6 +4502,7 @@ fn App() -> impl IntoView {
                                 }
                             }
                             rows
+                            })
                         }
                         key=|(start, fp, _)| (*start, *fp)
                         children=move |(_, _, row)| {


### PR DESCRIPTION
## What & why

A performance pass over the four layers, ordered by user-visible impact. The headline fix: long conversations no longer freeze during streaming.

### UI — streaming render path
- **Incremental artifact scan.** `collect_artifacts` previously rescanned every message (tables, fences, latex, file paths) on every 50ms flush — O(transcript) work per token batch. Extraction is now split from numbering: extraction is cached per `(index, content-hash)` so a flush only re-extracts the tail message; the numbering pass is O(artifact count) and produces byte-identical ids/names/order (guarded by an equivalence test: cached scan == fresh scan across streaming growth).
- **No more full-Vec deep clones per flush.** The thread `For each` closure, the artifact memo, and the empty check now use `items.with()` instead of `items.get()`, which was deep-cloning every message twice per flush.
- **highlight.js marker.** Only highlights `pre code:not([data-hl])`, so old code blocks aren't re-highlighted every time a new message renders. Re-rendered blocks are fresh DOM nodes without the marker, so content changes still highlight.

### wisp-core — agent loop
- `prepare_for_api` returns `Cow<[Message]>`: borrows the history when there are no runtime injections (the common case) instead of deep-cloning the entire conversation every loop iteration.
- `estimated_tokens` estimates from field lengths instead of `serde_json::to_string`-ing every message on each `total_tokens()` call (which runs twice per iteration plus repeatedly inside compaction loops). Ballpark-equivalence test included.

### wisp-store
- `find_provenance_by_path` pushes a `LIKE` prefilter into SQL instead of fetching and JSON-parsing every `execution_log` row in the frame. The needle is the path's **JSON encoding** (quotes included) — matching the raw path would miss Windows paths whose `\` is stored as `\\`. `%`/`_` are LIKE-escaped; the in-memory exact match stays to drop substring false positives. Regression tests cover `%`, `_`, backslash paths, and suffix non-matches.

### src-tauri
- Blocking IO in async commands moved to `tokio::fs` / `spawn_blocking`: download copy, skill dir recursive copy/remove, upload write, export artifact reads, and zip compression.
- `read_file_at` checks file size before reading (previously slurped a file of any size into memory just to reject it) and `read_artifact` no longer blocks the async runtime.

### wisp-tools
- `read` refuses files over 50MB with a hint to sample via head/tail/rg; `grep` skips files over 10MB (hit cap of 500 already existed).

## Verification

- `cargo test --workspace` and `cargo test` in `ui/` all pass (includes 4 new tests); `cargo check --target wasm32-unknown-unknown` clean.
- Verified in the browser via `trunk serve` + mock session: table/code/csv artifacts, chips, right-pane numbering, and syntax highlighting all render correctly through the new pipeline.
- Rebased onto the artifacts-panel rework (#127) and path-shorthand normalization (#129): `normalize_path` is folded into `file_proto`, and the upstream shorthand test passes through the new scan.

## Notes for review

- Two subagent-reported findings were checked and rejected as non-issues: composer drag already saves to localStorage only on mouseup, and the thread view was already fingerprint-keyed (#65) — the real cost was the full rescan + clones above.
- Compaction paths in `context.rs` still clone turns while rebuilding; left as-is since compaction is rare and the cheap token estimator removed the dominant cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)