### PR TITLE
feat(tools): codex tool — delegate subtasks to Codex CLI with Wisp skills/MCP access

### DIFF
--- a/src-tauri/src/codex_runtime.rs
+++ b/src-tauri/src/codex_runtime.rs
@@ -1,0 +1,299 @@
+//! Per-project Codex CLI runtime for the `codex` tool.
+//!
+//! Prepares `<project>/.wisp/codex-home`, seeded from the user's `~/.codex`
+//! (so auth and preferences carry over), and injects a marked `wisp_bridge`
+//! MCP block into the copied `config.toml` so Codex can reach Wisp's skills,
+//! bundled bio MCP, and custom MCP connections via the stdio bridge.
+//!
+//! Ported from the runner-as-provider work in #135 (experimental/local-runners,
+//! author jarxunlai), trimmed to the codex-as-tool scope.
+// ponytail: no WSL path translation here — the tool spawns codex on the host;
+// port runner_env_path/to_wsl_path from experimental/local-runners if WSL
+// codex setups show up.
+
+use std::collections::HashSet;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct McpBridgeLaunch {
+    pub command: String,
+    pub args: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunnerRuntime {
+    pub home_dir: PathBuf,
+    pub config_path: PathBuf,
+    pub env: Vec<(String, String)>,
+    pub diagnostics: Vec<String>,
+}
+
+pub fn prepare_codex_runtime(
+    project_root: &Path,
+    bridge: &McpBridgeLaunch,
+) -> Result<RunnerRuntime, String> {
+    let home_dir = project_root.join(".wisp").join("codex-home");
+    prepare_runtime_dir(&home_dir)?;
+    let source = user_home_dir().map(|h| h.join(".codex"));
+    let mut diagnostics = Vec::new();
+    match source.as_deref() {
+        Some(src) if src.is_dir() => sync_cli_home(src, &home_dir)?,
+        Some(src) => diagnostics.push(format!(
+            "Local Codex config directory not found: {}. Wisp generated a minimal CODEX_HOME.",
+            src.display()
+        )),
+        None => diagnostics
+            .push("Cannot locate user home directory; Wisp generated a minimal CODEX_HOME.".into()),
+    }
+    let config_path = home_dir.join("config.toml");
+    inject_codex_config_block(&config_path, bridge)?;
+    let env_home = home_dir.display().to_string();
+    Ok(RunnerRuntime {
+        home_dir,
+        config_path,
+        env: vec![("CODEX_HOME".into(), env_home)],
+        diagnostics,
+    })
+}
+
+fn prepare_runtime_dir(home_dir: &Path) -> Result<(), String> {
+    fs::create_dir_all(home_dir).map_err(|e| {
+        format!(
+            "Failed to create codex runtime '{}': {e}",
+            home_dir.display()
+        )
+    })
+}
+
+fn user_home_dir() -> Option<PathBuf> {
+    dirs::home_dir()
+        .or_else(|| std::env::var_os("USERPROFILE").map(PathBuf::from))
+        .or_else(|| {
+            let drive = std::env::var_os("HOMEDRIVE")?;
+            let path = std::env::var_os("HOMEPATH")?;
+            Some(PathBuf::from(format!(
+                "{}{}",
+                drive.to_string_lossy(),
+                path.to_string_lossy()
+            )))
+        })
+}
+
+/// Copy the user's CLI config into the per-project home, skipping caches,
+/// logs, and session state that must not leak between projects.
+fn sync_cli_home(source: &Path, target: &Path) -> Result<(), String> {
+    let skip = [
+        ".wisp", "cache", ".cache", "logs", "log", "tmp", "temp", "sessions", "history",
+    ]
+    .into_iter()
+    .collect::<HashSet<_>>();
+    let entries = fs::read_dir(source).map_err(|e| {
+        format!(
+            "Failed to read local CLI config directory '{}': {e}",
+            source.display()
+        )
+    })?;
+    for entry in entries {
+        let entry = entry.map_err(|e| format!("{e}"))?;
+        let path = entry.path();
+        let name = entry.file_name();
+        let name_s = name.to_string_lossy();
+        if skip.contains(name_s.as_ref()) || name_s.ends_with(".lock") || name_s.ends_with(".log") {
+            continue;
+        }
+        let dest = target.join(&name);
+        let meta = entry.metadata().map_err(|e| format!("{e}"))?;
+        if meta.is_dir() {
+            if dest.exists() {
+                fs::remove_dir_all(&dest).map_err(|e| {
+                    format!(
+                        "Failed to refresh inherited config dir '{}': {e}",
+                        dest.display()
+                    )
+                })?;
+            }
+            copy_dir_recursive(&path, &dest)?;
+        } else if meta.is_file() {
+            fs::copy(&path, &dest).map_err(|e| {
+                format!(
+                    "Failed to copy inherited config '{}' to '{}': {e}",
+                    path.display(),
+                    dest.display()
+                )
+            })?;
+        }
+    }
+    Ok(())
+}
+
+fn copy_dir_recursive(source: &Path, target: &Path) -> Result<(), String> {
+    fs::create_dir_all(target).map_err(|e| {
+        format!(
+            "Failed to create inherited config dir '{}': {e}",
+            target.display()
+        )
+    })?;
+    for entry in fs::read_dir(source).map_err(|e| format!("{e}"))? {
+        let entry = entry.map_err(|e| format!("{e}"))?;
+        let src = entry.path();
+        let dst = target.join(entry.file_name());
+        let meta = entry.metadata().map_err(|e| format!("{e}"))?;
+        if meta.is_dir() {
+            copy_dir_recursive(&src, &dst)?;
+        } else if meta.is_file() {
+            fs::copy(&src, &dst).map_err(|e| {
+                format!(
+                    "Failed to copy inherited config '{}' to '{}': {e}",
+                    src.display(),
+                    dst.display()
+                )
+            })?;
+        }
+    }
+    Ok(())
+}
+
+const WISP_BLOCK_BEGIN: &str = "# BEGIN WISP BUILTINS";
+const WISP_BLOCK_END: &str = "# END WISP BUILTINS";
+
+fn inject_codex_config_block(config_path: &Path, bridge: &McpBridgeLaunch) -> Result<(), String> {
+    let existing = fs::read_to_string(config_path).unwrap_or_default();
+    let block = codex_config_block(bridge);
+    let updated = replace_marked_block(&existing, &block);
+    if let Some(parent) = config_path.parent() {
+        fs::create_dir_all(parent).map_err(|e| format!("{e}"))?;
+    }
+    let mut f = fs::File::create(config_path).map_err(|e| {
+        format!(
+            "Failed to write Codex runtime config '{}': {e}",
+            config_path.display()
+        )
+    })?;
+    f.write_all(updated.as_bytes()).map_err(|e| format!("{e}"))
+}
+
+/// Replace (or append) the marked Wisp block, preserving user config around it.
+fn replace_marked_block(existing: &str, block: &str) -> String {
+    let Some(start) = existing.find(WISP_BLOCK_BEGIN) else {
+        let mut out = existing.trim_end().to_string();
+        if !out.is_empty() {
+            out.push_str("\n\n");
+        }
+        out.push_str(block);
+        out.push('\n');
+        return out;
+    };
+    let Some(rel_end) = existing[start..].find(WISP_BLOCK_END) else {
+        let mut out = existing[..start].trim_end().to_string();
+        if !out.is_empty() {
+            out.push_str("\n\n");
+        }
+        out.push_str(block);
+        out.push('\n');
+        return out;
+    };
+    let end = start + rel_end + WISP_BLOCK_END.len();
+    let mut out = String::new();
+    out.push_str(existing[..start].trim_end());
+    if !out.is_empty() {
+        out.push_str("\n\n");
+    }
+    out.push_str(block);
+    out.push_str(existing[end..].trim_start_matches(['\r', '\n']));
+    out
+}
+
+fn codex_config_block(bridge: &McpBridgeLaunch) -> String {
+    format!(
+        "{WISP_BLOCK_BEGIN}\n\
+[mcp_servers.wisp_bridge]\n\
+transport = \"stdio\"\n\
+command = {}\n\
+args = {}\n\
+startup_timeout_sec = 120\n\
+{WISP_BLOCK_END}",
+        toml_string(&bridge.command),
+        toml_string_array(&bridge.args)
+    )
+}
+
+fn toml_string_array(values: &[String]) -> String {
+    let inner = values
+        .iter()
+        .map(|s| toml_string(s))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("[{inner}]")
+}
+
+fn toml_string(value: &str) -> String {
+    let escaped = value
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r");
+    format!("\"{escaped}\"")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn codex_config_block_preserves_user_config_and_replaces_old_block() {
+        let bridge = McpBridgeLaunch {
+            command: r"C:\Wisp\wisp-tauri.exe".into(),
+            args: vec![
+                "--wisp-mcp-bridge".into(),
+                "--project-root".into(),
+                r"C:\repo".into(),
+            ],
+        };
+        let original = r#"model = "gpt-5"
+
+# BEGIN WISP BUILTINS
+[mcp_servers.wisp_bridge]
+command = "old"
+# END WISP BUILTINS
+
+[profiles.default]
+model = "local"
+"#;
+        let updated = replace_marked_block(original, &codex_config_block(&bridge));
+        assert!(updated.contains(r#"model = "gpt-5""#));
+        assert!(updated.contains("[profiles.default]"));
+        assert!(updated.contains("transport = \"stdio\""));
+        assert!(updated.contains("startup_timeout_sec = 120"));
+        assert!(!updated.contains("command = \"old\""));
+        assert!(updated.contains("wisp-tauri.exe"));
+    }
+
+    #[test]
+    fn sync_cli_home_skips_cache_and_copies_config_assets() {
+        let base = std::env::temp_dir().join(format!(
+            "wisp-codex-rt-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let src = base.join("src");
+        let dst = base.join("dst");
+        std::fs::create_dir_all(src.join("skills").join("s")).unwrap();
+        std::fs::create_dir_all(src.join("cache")).unwrap();
+        std::fs::write(src.join("config.toml"), "model = 'x'").unwrap();
+        std::fs::write(src.join("auth.json"), "{}").unwrap();
+        std::fs::write(src.join("skills").join("s").join("SKILL.md"), "body").unwrap();
+        std::fs::write(src.join("cache").join("stale"), "no").unwrap();
+        std::fs::create_dir_all(&dst).unwrap();
+        sync_cli_home(&src, &dst).unwrap();
+        assert!(dst.join("config.toml").is_file());
+        assert!(dst.join("auth.json").is_file());
+        assert!(dst.join("skills").join("s").join("SKILL.md").is_file());
+        assert!(!dst.join("cache").exists());
+        let _ = std::fs::remove_dir_all(base);
+    }
+}

--- a/src-tauri/src/codex_tool.rs
+++ b/src-tauri/src/codex_tool.rs
@@ -1,0 +1,378 @@
+//! `codex` — delegate a bounded subtask to the Codex CLI agent.
+//!
+//! Wisp's own agent stays in charge of the conversation; this tool hands one
+//! self-contained task to `codex exec` running in the project directory.
+//! Codex brings its own shell/file tools; Wisp's skills, bundled bio MCP, and
+//! custom MCP connections reach it through the `wisp_bridge` stdio MCP server
+//! configured in the per-project CODEX_HOME (see `codex_runtime`).
+
+use crate::codex_runtime::{self, McpBridgeLaunch};
+use async_trait::async_trait;
+use serde_json::{json, Value};
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::time::Duration;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::Command;
+use wisp_llm::ToolSchema;
+use wisp_tools::{Tool, ToolEnv, ToolEvent, ToolResult};
+
+const DEFAULT_TIMEOUT_SECS: u64 = 600;
+const MAX_TIMEOUT_SECS: u64 = 3600;
+const MAX_RESULT_BYTES: usize = 16 * 1024;
+
+pub struct CodexTool {
+    app_data: PathBuf,
+    project_id: String,
+    frame_id: String,
+}
+
+impl CodexTool {
+    pub fn new(app_data: PathBuf, project_id: String, frame_id: String) -> Self {
+        Self {
+            app_data,
+            project_id,
+            frame_id,
+        }
+    }
+
+    fn bridge_launch(&self, project_root: &std::path::Path) -> Result<McpBridgeLaunch, String> {
+        let exe = std::env::current_exe()
+            .map_err(|e| format!("Cannot locate Wisp executable for MCP bridge: {e}"))?
+            .display()
+            .to_string();
+        Ok(McpBridgeLaunch {
+            command: exe,
+            args: vec![
+                "--wisp-mcp-bridge".to_string(),
+                "--app-data".to_string(),
+                self.app_data.display().to_string(),
+                "--project-root".to_string(),
+                project_root.display().to_string(),
+                "--resource-root".to_string(),
+                wisp_paths::resource_root().display().to_string(),
+                "--project-id".to_string(),
+                self.project_id.clone(),
+                "--frame-id".to_string(),
+                self.frame_id.clone(),
+            ],
+        })
+    }
+}
+
+/// Whether the Codex CLI is installed — checked once per app run so the
+/// model never sees a phantom tool it can't actually use.
+pub async fn codex_cli_available() -> bool {
+    static AVAILABLE: tokio::sync::OnceCell<bool> = tokio::sync::OnceCell::const_new();
+    *AVAILABLE
+        .get_or_init(|| async {
+            let mut cmd = Command::new("codex");
+            cmd.arg("--version")
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null());
+            wisp_tools::process::hide_console_async(&mut cmd);
+            let Ok(mut child) = cmd.spawn() else {
+                return false;
+            };
+            match tokio::time::timeout(Duration::from_secs(5), child.wait()).await {
+                Ok(Ok(status)) => status.success(),
+                _ => {
+                    let _ = child.start_kill();
+                    false
+                }
+            }
+        })
+        .await
+}
+
+/// Resolves once the env's cancel flag is set (Stop button), polled at 100ms.
+async fn cancel_watch(env: &dyn ToolEnv) {
+    while !env.is_cancelled() {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+/// Pull the fields we surface out of one `codex exec --json` event line.
+/// Returns (agent_message_text, progress_note, error).
+fn parse_codex_event(line: &str) -> (Option<String>, Option<String>, Option<String>) {
+    let Ok(v) = serde_json::from_str::<Value>(line) else {
+        return (None, None, None);
+    };
+    let typ = v.get("type").and_then(|t| t.as_str()).unwrap_or("");
+    if typ == "error" || typ == "turn.failed" {
+        let msg = v
+            .get("message")
+            .or_else(|| v.get("error"))
+            .map(|m| {
+                m.as_str()
+                    .map(str::to_string)
+                    .unwrap_or_else(|| m.to_string())
+            })
+            .unwrap_or_else(|| "codex turn failed".into());
+        return (None, None, Some(msg));
+    }
+    let item = v.get("item").unwrap_or(&v);
+    let item_type = item.get("type").and_then(|t| t.as_str()).unwrap_or("");
+    let text = |keys: &[&str]| {
+        keys.iter()
+            .find_map(|k| item.get(*k).and_then(|t| t.as_str()))
+            .map(str::to_string)
+    };
+    match item_type {
+        "agent_message" | "message" => (text(&["text", "content"]), None, None),
+        "command_execution" => (
+            None,
+            text(&["command", "cmd"]).map(|c| format!("$ {c}")),
+            None,
+        ),
+        "mcp_tool_call" | "tool_call" => (
+            None,
+            text(&["tool", "name"]).map(|t| format!("[tool] {t}")),
+            None,
+        ),
+        _ => (None, None, None),
+    }
+}
+
+fn truncate_middle(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        return s.to_string();
+    }
+    let half = max / 2;
+    let head_end = (0..=half).rev().find(|i| s.is_char_boundary(*i)).unwrap_or(0);
+    let tail_start = (s.len() - half..s.len())
+        .find(|i| s.is_char_boundary(*i))
+        .unwrap_or(s.len());
+    format!(
+        "{}\n... [{} bytes truncated] ...\n{}",
+        &s[..head_end],
+        s.len() - head_end - (s.len() - tail_start),
+        &s[tail_start..]
+    )
+}
+
+#[async_trait]
+impl Tool for CodexTool {
+    fn name(&self) -> &str {
+        "codex"
+    }
+
+    fn schema(&self) -> ToolSchema {
+        ToolSchema::new(
+            "codex",
+            "Delegate one self-contained coding or analysis subtask to the Codex CLI agent, \
+             which works autonomously in the project directory with its own shell and file \
+             tools plus Wisp's skills and MCP tools (via the wisp_bridge MCP server). \
+             Codex cannot see this conversation, so the task must carry all needed context. \
+             Prefer it for large multi-file coding work; use Wisp's own tools for quick edits.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "task": { "type": "string", "description": "Complete, self-contained task description including relevant paths and acceptance criteria" },
+                    "timeout_secs": { "type": "integer", "description": "Max seconds to let codex run (default 600, max 3600)" }
+                },
+                "required": ["task"]
+            }),
+        )
+    }
+
+    fn preview(&self, args: &Value) -> String {
+        args.get("task")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .chars()
+            .take(150)
+            .collect()
+    }
+
+    async fn run(&self, args: &Value, env: &dyn ToolEnv) -> ToolResult {
+        let Some(task) = args.get("task").and_then(|v| v.as_str()).filter(|s| !s.trim().is_empty())
+        else {
+            return ToolResult::fail("codex error: missing required argument 'task'");
+        };
+        let timeout = args
+            .get("timeout_secs")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(DEFAULT_TIMEOUT_SECS)
+            .clamp(30, MAX_TIMEOUT_SECS);
+
+        let project_root = env.project_root().to_path_buf();
+        let bridge = match self.bridge_launch(&project_root) {
+            Ok(b) => b,
+            Err(e) => return ToolResult::fail(format!("codex error: {e}")),
+        };
+        // Runtime prep copies ~/.codex — keep it off the async runtime.
+        let runtime = {
+            let root = project_root.clone();
+            match tokio::task::spawn_blocking(move || {
+                codex_runtime::prepare_codex_runtime(&root, &bridge)
+            })
+            .await
+            {
+                Ok(Ok(rt)) => rt,
+                Ok(Err(e)) => return ToolResult::fail(format!("codex error: {e}")),
+                Err(e) => return ToolResult::fail(format!("codex error: {e}")),
+            }
+        };
+
+        // Non-interactive one-shot: task on stdin, JSONL events on stdout.
+        // workspace-write sandbox: codex may edit the project but not escape it;
+        // approval_policy=never because there is no interactive approver here.
+        let mut command = Command::new("codex");
+        command
+            .arg("exec")
+            .arg("--json")
+            .arg("--cd")
+            .arg(&project_root)
+            .arg("--skip-git-repo-check")
+            .arg("--sandbox")
+            .arg("workspace-write")
+            .arg("-c")
+            .arg("approval_policy=\"never\"")
+            .arg("-")
+            .current_dir(&project_root)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        for (k, v) in &runtime.env {
+            command.env(k, v);
+        }
+        wisp_tools::process::hide_console_async(&mut command);
+
+        let mut child = match command.spawn() {
+            Ok(c) => c,
+            Err(e) => {
+                return ToolResult::fail(format!(
+                    "codex error: failed to spawn `codex` (is Codex CLI installed and on PATH?): {e}"
+                ))
+            }
+        };
+
+        if let Some(mut stdin) = child.stdin.take() {
+            if let Err(e) = stdin.write_all(task.as_bytes()).await {
+                let _ = child.kill().await;
+                return ToolResult::fail(format!("codex error: failed to send task: {e}"));
+            }
+            drop(stdin);
+        }
+
+        let mut stdout_reader = child.stdout.take().map(|s| BufReader::new(s).lines());
+        let mut stderr_reader = child.stderr.take().map(|s| BufReader::new(s).lines());
+        let mut stdout_done = stdout_reader.is_none();
+        let mut stderr_done = stderr_reader.is_none();
+        let mut messages: Vec<String> = vec![];
+        let mut stderr_tail: Vec<String> = vec![];
+        let mut error: Option<String> = None;
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(timeout);
+        while !(stdout_done && stderr_done) {
+            tokio::select! {
+                _ = cancel_watch(env) => {
+                    let _ = child.kill().await;
+                    return ToolResult::fail("interrupted by user");
+                }
+                _ = tokio::time::sleep_until(deadline) => {
+                    let _ = child.kill().await;
+                    return ToolResult::fail(format!("codex timed out after {timeout}s"));
+                }
+                res = async { stdout_reader.as_mut().unwrap().next_line().await }, if !stdout_done => match res {
+                    Ok(Some(line)) => {
+                        let (msg, note, err) = parse_codex_event(&line);
+                        if let Some(msg) = msg {
+                            env.emit(ToolEvent::Stdout { chunk: format!("{msg}\n") }).await;
+                            messages.push(msg);
+                        }
+                        if let Some(note) = note {
+                            env.emit(ToolEvent::Stdout { chunk: format!("{note}\n") }).await;
+                        }
+                        if let Some(err) = err {
+                            error = Some(err);
+                        }
+                    }
+                    _ => stdout_done = true,
+                },
+                res = async { stderr_reader.as_mut().unwrap().next_line().await }, if !stderr_done => match res {
+                    Ok(Some(line)) => {
+                        stderr_tail.push(line);
+                        if stderr_tail.len() > 50 {
+                            stderr_tail.remove(0);
+                        }
+                    }
+                    _ => stderr_done = true,
+                },
+            }
+        }
+
+        let status = tokio::select! {
+            res = child.wait() => match res {
+                Ok(s) => s,
+                Err(e) => return ToolResult::fail(format!("codex error: {e}")),
+            },
+            _ = tokio::time::sleep_until(deadline) => {
+                let _ = child.kill().await;
+                return ToolResult::fail(format!("codex timed out after {timeout}s"));
+            }
+            _ = cancel_watch(env) => {
+                let _ = child.kill().await;
+                return ToolResult::fail("interrupted by user");
+            }
+        };
+
+        if let Some(err) = error {
+            return ToolResult::fail(truncate_middle(&format!("codex failed: {err}"), MAX_RESULT_BYTES));
+        }
+        if !status.success() {
+            let detail = if stderr_tail.is_empty() {
+                messages.join("\n\n")
+            } else {
+                stderr_tail.join("\n")
+            };
+            return ToolResult::fail(truncate_middle(
+                &format!("codex exit {}: {detail}", status.code().unwrap_or(-1)),
+                MAX_RESULT_BYTES,
+            ));
+        }
+        let body = match messages.last() {
+            Some(last) if messages.len() == 1 => last.clone(),
+            Some(_) => messages.join("\n\n"),
+            None => "(codex produced no final message)".into(),
+        };
+        let mut out = truncate_middle(&body, MAX_RESULT_BYTES);
+        if !runtime.diagnostics.is_empty() {
+            out.push_str("\n\n[runtime notes]\n");
+            out.push_str(&runtime.diagnostics.join("\n"));
+        }
+        ToolResult::ok(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_agent_message_command_and_error_events() {
+        let (msg, _, _) =
+            parse_codex_event(r#"{"type":"item.completed","item":{"type":"agent_message","text":"done"}}"#);
+        assert_eq!(msg.as_deref(), Some("done"));
+        let (_, note, _) = parse_codex_event(
+            r#"{"type":"item.started","item":{"type":"command_execution","command":"ls -la"}}"#,
+        );
+        assert_eq!(note.as_deref(), Some("$ ls -la"));
+        let (_, _, err) = parse_codex_event(r#"{"type":"turn.failed","error":"boom"}"#);
+        assert_eq!(err.as_deref(), Some("boom"));
+        let (msg, note, err) = parse_codex_event("not json");
+        assert!(msg.is_none() && note.is_none() && err.is_none());
+    }
+
+    #[test]
+    fn truncates_long_results_on_char_boundaries() {
+        let long = "中文内容".repeat(4096);
+        let out = truncate_middle(&long, MAX_RESULT_BYTES);
+        assert!(out.len() < long.len());
+        assert!(out.contains("truncated"));
+        // must not panic on boundaries; round-trip check
+        assert!(out.starts_with('中'));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,8 +14,11 @@ use wisp_llm::{Message, ProviderConfig};
 use wisp_skills::SkillIndex;
 use wisp_store::Store;
 
+mod codex_runtime;
+mod codex_tool;
 mod context_probe;
 mod harvest;
+mod mcp_bridge;
 mod models;
 mod review;
 mod run_context;
@@ -1666,6 +1669,13 @@ async fn send_message(
             ap.id.clone(),
             Some(frame_id.clone()),
         )));
+        if codex_tool::codex_cli_available().await {
+            agent.add_tool(Box::new(codex_tool::CodexTool::new(
+                state.app_data.clone(),
+                ap.id.clone(),
+                frame_id.clone(),
+            )));
+        }
         match state.store.load_messages(&frame_id).await {
             Ok(msgs) => agent.ctx.messages = msgs,
             Err(e) => tracing::warn!("load session from sqlite failed: {e}"),
@@ -4840,6 +4850,77 @@ pub fn run() {
         ])
         .run(tauri::generate_context!())
         .expect("error while running Wisp");
+}
+
+/// CLI args for the `--wisp-mcp-bridge` re-exec mode: the same wisp binary
+/// relaunches as a stdio MCP server inside the Codex runtime (see
+/// `codex_runtime::codex_config_block`).
+fn parse_mcp_bridge_cli_args() -> mcp_bridge::BridgeConfig {
+    let args = std::env::args().skip(1).collect::<Vec<_>>();
+    let mut app_data: Option<PathBuf> = None;
+    let mut project_root: Option<PathBuf> = None;
+    let mut resource_root: Option<PathBuf> = None;
+    let mut project_id = "default".to_string();
+    let mut frame_id: Option<String> = None;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--app-data" => {
+                i += 1;
+                app_data = args.get(i).map(PathBuf::from);
+            }
+            "--project-root" => {
+                i += 1;
+                project_root = args.get(i).map(PathBuf::from);
+            }
+            "--resource-root" => {
+                i += 1;
+                resource_root = args.get(i).map(PathBuf::from);
+            }
+            "--project-id" => {
+                i += 1;
+                if let Some(v) = args.get(i).filter(|s| !s.trim().is_empty()) {
+                    project_id = v.clone();
+                }
+            }
+            "--frame-id" => {
+                i += 1;
+                frame_id = args.get(i).filter(|s| !s.trim().is_empty()).cloned();
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    let app_data = app_data.unwrap_or_else(|| {
+        dirs::data_dir()
+            .unwrap_or_else(|| PathBuf::from(".wisp"))
+            .join("wisp-science")
+    });
+    let project_root = project_root.unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
+    let resource_root = resource_root.or_else(|| {
+        std::env::current_exe()
+            .ok()
+            .and_then(|p| p.parent().map(PathBuf::from))
+    });
+    mcp_bridge::BridgeConfig {
+        app_data,
+        project_root,
+        resource_root,
+        project_id,
+        frame_id,
+    }
+}
+
+pub fn run_mcp_bridge_cli() {
+    let cfg = parse_mcp_bridge_cli_args();
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("create Wisp MCP bridge runtime");
+    if let Err(e) = rt.block_on(mcp_bridge::run_stdio(cfg)) {
+        eprintln!("Wisp MCP bridge error: {e:?}");
+        std::process::exit(1);
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,5 +2,9 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
-    wisp_tauri::run();
+    if std::env::args().any(|a| a == "--wisp-mcp-bridge") {
+        wisp_tauri::run_mcp_bridge_cli();
+    } else {
+        wisp_tauri::run();
+    }
 }

--- a/src-tauri/src/mcp_bridge.rs
+++ b/src-tauri/src/mcp_bridge.rs
@@ -1,0 +1,486 @@
+//! Stdio MCP bridge exposed to local runners (Codex CLI / Claude Code).
+//!
+//! The bridge intentionally exposes Wisp's scientific capabilities (skills,
+//! bundled bio MCP, custom MCP, run contexts) without forwarding Wisp's generic
+//! shell/edit/read tools. Local runners already have their own filesystem tools;
+//! this process is only for Wisp-native capabilities and policy/config reuse.
+
+use crate::{
+    bio_domains, connect_mcp, load_disabled_connectors, load_disabled_skills,
+    load_enabled_skill_names, load_mcp_connections, run_context, skill_paths,
+};
+use anyhow::{anyhow, Context, Result};
+use serde::Deserialize;
+use serde_json::{json, Value};
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use wisp_skills::{list_resources, SkillIndex};
+use wisp_store::Store;
+use wisp_tools::{Approval, Tool, ToolEnv, ToolEvent, ToolResult};
+
+#[derive(Debug, Clone)]
+pub(crate) struct BridgeConfig {
+    pub(crate) app_data: PathBuf,
+    pub(crate) project_root: PathBuf,
+    pub(crate) resource_root: Option<PathBuf>,
+    pub(crate) project_id: String,
+    pub(crate) frame_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct JsonRpcIn {
+    id: Option<Value>,
+    method: String,
+    #[serde(default)]
+    params: Option<Value>,
+}
+
+#[derive(Clone)]
+enum Route {
+    Bio {
+        client: Arc<wisp_mcp::McpClient>,
+        remote_name: String,
+        description: String,
+        input_schema: Value,
+    },
+    Custom {
+        client: Arc<wisp_mcp::McpClient>,
+        remote_name: String,
+        description: String,
+        input_schema: Value,
+    },
+}
+
+struct BridgeServer {
+    cfg: BridgeConfig,
+    store: Store,
+    skills: Arc<SkillIndex>,
+    routes: HashMap<String, Route>,
+    remote_tools_loaded: bool,
+}
+
+impl BridgeServer {
+    async fn new(cfg: BridgeConfig) -> Result<Self> {
+        if let Some(root) = &cfg.resource_root {
+            wisp_paths::set_resource_root(root.clone());
+        }
+        std::fs::create_dir_all(&cfg.app_data).ok();
+        let store = Store::open(&cfg.app_data.join("wisp.sqlite"))
+            .await
+            .context("open Wisp store for MCP bridge")?;
+        let raw = SkillIndex::load(&skill_paths(&cfg.project_root));
+        let skills = Arc::new(filter_skills(&store, &cfg.project_id, raw).await);
+        Ok(Self {
+            cfg,
+            store,
+            skills,
+            routes: HashMap::new(),
+            remote_tools_loaded: false,
+        })
+    }
+
+    async fn handle(&mut self, req: JsonRpcIn) -> Option<Value> {
+        let id = req.id?;
+        let result = match req.method.as_str() {
+            "initialize" => Ok(json!({
+                "protocolVersion": "2024-11-05",
+                "capabilities": { "tools": {} },
+                "serverInfo": { "name": "wisp_bridge", "version": env!("CARGO_PKG_VERSION") }
+            })),
+            "tools/list" => self.tools_list().await,
+            "tools/call" => self.tools_call(req.params.unwrap_or_default()).await,
+            _ => Err(anyhow!("unknown MCP method '{}'", req.method)),
+        };
+        Some(match result {
+            Ok(result) => json!({ "jsonrpc": "2.0", "id": id, "result": result }),
+            Err(e) => json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "error": { "code": -32000, "message": e.to_string() }
+            }),
+        })
+    }
+
+    async fn tools_list(&mut self) -> Result<Value> {
+        let mut tools = vec![
+            json!({
+                "name": "wisp_list_skills",
+                "description": "List skills currently available from the active Wisp project/profile.",
+                "inputSchema": { "type": "object", "properties": {}, "additionalProperties": false }
+            }),
+            json!({
+                "name": "wisp_use_skill",
+                "description": "Load a Wisp skill's SKILL.md guidance plus script/reference file paths.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": { "name": { "type": "string", "description": "Wisp skill name" } },
+                    "required": ["name"]
+                }
+            }),
+            run_in_context_tool_schema(),
+        ];
+        let remote = self.ensure_remote_tools().await?;
+        tools.extend(remote);
+        Ok(json!({ "tools": tools }))
+    }
+
+    async fn tools_call(&mut self, params: Value) -> Result<Value> {
+        let name = params
+            .get("name")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("tools/call missing name"))?;
+        let args = params
+            .get("arguments")
+            .cloned()
+            .unwrap_or_else(|| json!({}));
+        let (text, is_error) = match name {
+            "wisp_list_skills" => (self.list_skills_text(), false),
+            "wisp_use_skill" => match self.use_skill_text(&args) {
+                Ok(s) => (s, false),
+                Err(e) => (e.to_string(), true),
+            },
+            "wisp_run_in_context" => {
+                let result = self.run_in_context(&args).await;
+                (result.content, !result.success)
+            }
+            other => {
+                self.ensure_remote_tools().await?;
+                let Some(route) = self.routes.get(other).cloned() else {
+                    return Err(anyhow!("unknown Wisp bridge tool '{other}'"));
+                };
+                match route {
+                    Route::Bio {
+                        client,
+                        remote_name,
+                        ..
+                    }
+                    | Route::Custom {
+                        client,
+                        remote_name,
+                        ..
+                    } => match client.tool_call(&remote_name, &args).await {
+                        Ok(s) => (s, false),
+                        Err(e) => (e.to_string(), true),
+                    },
+                }
+            }
+        };
+        Ok(json!({
+            "content": [{ "type": "text", "text": text }],
+            "isError": is_error
+        }))
+    }
+
+    async fn ensure_remote_tools(&mut self) -> Result<Vec<Value>> {
+        if self.remote_tools_loaded {
+            return Ok(self.route_tools());
+        }
+        self.remote_tools_loaded = true;
+
+        self.register_bundled_bio_tools().await;
+        self.register_custom_mcp_tools().await;
+        Ok(self.route_tools())
+    }
+
+    async fn register_bundled_bio_tools(&mut self) {
+        let disabled = load_disabled_connectors(&self.store).await;
+        let domains = bio_domains();
+        let all_off = !domains.is_empty() && domains.iter().all(|d| disabled.contains(&d.slug));
+        if all_off {
+            return;
+        }
+        let skip: HashSet<String> = domains
+            .iter()
+            .filter(|d| disabled.contains(&d.slug))
+            .flat_map(|d| d.tools.iter().cloned())
+            .collect();
+        let Ok(env) = wisp_python::PythonEnv::ensure(&self.cfg.app_data) else {
+            return;
+        };
+        let pkg = std::env::var("WISP_MCP_PKG").unwrap_or_else(|_| "mcp_bio".into());
+        let Ok(client) = wisp_mcp::McpClient::launch_bio_tools(
+            &env.python(),
+            &pkg,
+            &crate::models::service_env(),
+        )
+        .await
+        else {
+            return;
+        };
+        let client = Arc::new(client);
+        let Ok(tools) = client.tools_list().await else {
+            return;
+        };
+        for tool in tools {
+            if tool.name.is_empty() || skip.contains(&tool.name) || self.is_reserved(&tool.name) {
+                continue;
+            }
+            self.routes.insert(
+                tool.name.clone(),
+                Route::Bio {
+                    client: client.clone(),
+                    remote_name: tool.name.clone(),
+                    description: tool.description,
+                    input_schema: tool.input_schema,
+                },
+            );
+        }
+    }
+
+    async fn register_custom_mcp_tools(&mut self) {
+        let conns = load_mcp_connections(&self.store)
+            .await
+            .into_iter()
+            .filter(|c| c.enabled)
+            .collect::<Vec<_>>();
+        for conn in conns {
+            let Ok(client) = connect_mcp(&conn).await else {
+                continue;
+            };
+            let client = Arc::new(client);
+            let Ok(tools) = client.tools_list().await else {
+                continue;
+            };
+            let prefix = format!("wisp_custom_{}__", sanitize_tool_part(&conn.id));
+            for tool in tools {
+                if tool.name.is_empty() {
+                    continue;
+                }
+                let exposed = format!("{prefix}{}", sanitize_tool_part(&tool.name));
+                if self.is_reserved(&exposed) {
+                    continue;
+                }
+                self.routes.insert(
+                    exposed,
+                    Route::Custom {
+                        client: client.clone(),
+                        remote_name: tool.name,
+                        description: tool.description,
+                        input_schema: tool.input_schema,
+                    },
+                );
+            }
+        }
+    }
+
+    fn route_tools(&self) -> Vec<Value> {
+        self.routes
+            .iter()
+            .map(|(name, route)| {
+                let (desc, input_schema) = match route {
+                    Route::Bio {
+                        remote_name,
+                        description,
+                        input_schema,
+                        ..
+                    } => (
+                        if description.trim().is_empty() {
+                            format!("Bundled Wisp bio MCP tool `{remote_name}`.")
+                        } else {
+                            description.clone()
+                        },
+                        input_schema.clone(),
+                    ),
+                    Route::Custom {
+                        remote_name,
+                        description,
+                        input_schema,
+                        ..
+                    } => (
+                        if description.trim().is_empty() {
+                            format!("Custom Wisp MCP tool `{remote_name}`.")
+                        } else {
+                            description.clone()
+                        },
+                        input_schema.clone(),
+                    ),
+                };
+                json!({
+                    "name": name,
+                    "description": desc,
+                    "inputSchema": input_schema
+                })
+            })
+            .collect()
+    }
+
+    fn is_reserved(&self, name: &str) -> bool {
+        matches!(
+            name,
+            "wisp_list_skills" | "wisp_use_skill" | "wisp_run_in_context"
+        ) || self.routes.contains_key(name)
+    }
+
+    fn list_skills_text(&self) -> String {
+        if self.skills.is_empty() {
+            return "No Wisp skills are currently available. If this is a portable build, verify the skills/ resource directory is next to wisp-tauri.exe.".into();
+        }
+        self.skills
+            .all()
+            .iter()
+            .map(|s| format!("- {}: {}", s.name, s.description))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn use_skill_text(&self, args: &Value) -> Result<String> {
+        let name = args
+            .get("name")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("missing required argument 'name'"))?;
+        let Some(skill) = self.skills.get(name) else {
+            return Err(anyhow!("skill '{name}' not found"));
+        };
+        let mut out = format!("# Skill: {}\n{}\n", skill.name, skill.body);
+        let (scripts, refs) = list_resources(skill);
+        if !scripts.is_empty() {
+            out.push_str("\n## Scripts\n");
+            for p in &scripts {
+                out.push_str(p);
+                out.push('\n');
+            }
+        }
+        if !refs.is_empty() {
+            out.push_str("\n## References\n");
+            for p in &refs {
+                out.push_str(p);
+                out.push('\n');
+            }
+        }
+        Ok(out)
+    }
+
+    async fn run_in_context(&self, args: &Value) -> ToolResult {
+        let tool = run_context::RunInContextTool::new(
+            self.store.clone(),
+            self.cfg.project_id.clone(),
+            self.cfg.frame_id.clone(),
+        );
+        let env = BridgeToolEnv {
+            project_root: self.cfg.project_root.clone(),
+        };
+        tool.run(args, &env).await
+    }
+}
+
+async fn filter_skills(store: &Store, project_id: &str, raw: SkillIndex) -> SkillIndex {
+    if let Some(enabled) = load_enabled_skill_names(store, project_id).await {
+        return raw.filtered_by_names(Some(&enabled));
+    }
+    let disabled = load_disabled_skills(store).await;
+    if disabled.is_empty() {
+        raw
+    } else {
+        raw.filtered(&disabled)
+    }
+}
+
+fn run_in_context_tool_schema() -> Value {
+    json!({
+        "name": "wisp_run_in_context",
+        "description": "Create a persisted Wisp Run and execute a bounded command in an execution context (`local`, `ssh:<alias>`, or `wsl:<distro>`). Dangerous commands require approval and are rejected in this non-interactive bridge.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "context_id": { "type": "string", "description": "Execution context id, e.g. local, ssh:gpu, wsl:Ubuntu" },
+                "command": { "type": "string", "description": "Command to execute in that context" },
+                "title": { "type": "string", "description": "Short run title" },
+                "timeout_secs": { "type": "integer", "description": "Bounded timeout in seconds, clamped to 1..300" },
+                "output_specs": {
+                    "type": "array",
+                    "description": "Optional harvest specs for files produced by the run",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "glob": { "type": "string" },
+                            "kind": { "type": "string" },
+                            "residency": { "type": "string", "enum": ["local", "remote", "auto"] },
+                            "max_file_mb": { "type": "integer" },
+                            "max_total_mb": { "type": "integer" }
+                        },
+                        "required": ["glob", "kind", "residency"]
+                    }
+                }
+            },
+            "required": ["context_id", "command"]
+        }
+    })
+}
+
+struct BridgeToolEnv {
+    project_root: PathBuf,
+}
+
+#[async_trait::async_trait]
+impl ToolEnv for BridgeToolEnv {
+    fn project_root(&self) -> &Path {
+        &self.project_root
+    }
+    async fn confirm(&self, _message: &str) -> bool {
+        false
+    }
+    async fn approval_mode(&self, _tool: &str) -> Approval {
+        Approval::Allow
+    }
+    fn danger_auto_approve(&self) -> bool {
+        false
+    }
+    async fn emit(&self, _event: ToolEvent) {}
+}
+
+fn sanitize_tool_part(raw: &str) -> String {
+    let mut out = String::new();
+    for ch in raw.chars() {
+        if ch.is_ascii_alphanumeric() || ch == '_' || ch == '-' {
+            out.push(ch);
+        } else {
+            out.push('_');
+        }
+    }
+    if out.is_empty() {
+        "tool".into()
+    } else {
+        out
+    }
+}
+
+pub(crate) async fn run_stdio(cfg: BridgeConfig) -> Result<()> {
+    let mut server = BridgeServer::new(cfg).await?;
+    let stdin = tokio::io::stdin();
+    let mut reader = BufReader::new(stdin);
+    let mut stdout = tokio::io::stdout();
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let n = reader.read_line(&mut line).await?;
+        if n == 0 {
+            break;
+        }
+        let raw = line.trim();
+        if raw.is_empty() {
+            continue;
+        }
+        let Ok(req) = serde_json::from_str::<JsonRpcIn>(raw) else {
+            continue;
+        };
+        if let Some(resp) = server.handle(req).await {
+            stdout.write_all(resp.to_string().as_bytes()).await?;
+            stdout.write_all(b"\n").await?;
+            stdout.flush().await?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitizes_custom_tool_parts() {
+        assert_eq!(sanitize_tool_part("abc.Def/g"), "abc_Def_g");
+        assert_eq!(sanitize_tool_part(""), "tool");
+    }
+}


### PR DESCRIPTION
## Goal

**Codex as a tool, not a model.** Wisp's own `agent_loop` stays in charge of the conversation; this adds a `codex` tool it can call to hand one self-contained coding/analysis subtask to the Codex CLI agent. Codex works autonomously in the project directory with its own shell/file tools, **and can reach wisp-science's skills + MCP capabilities** through a bridge.

This is the direction from #134 (local runners removed from `main` as a provider path). #135 bundled the same bridge with a runner-as-model delegation flow; this PR takes only the reusable half and wires it as a tool.

## How Codex reaches Wisp's capabilities

`wisp-tauri` re-execs itself with `--wisp-mcp-bridge` as a stdio MCP server (`mcp_bridge.rs`). The per-project `<project>/.wisp/codex-home` (seeded from `~/.codex`) gets a marked `wisp_bridge` MCP block injected into its `config.toml`, so `codex exec` sees:

- `wisp_list_skills` / `wisp_use_skill` — the active project's Wisp skills
- `wisp_run_in_context` — persisted Runs in local/ssh/wsl execution contexts
- every bundled bio MCP tool + enabled custom MCP connection, routed through

It deliberately does **not** forward Wisp's generic shell/edit/read tools — Codex has its own.

## Tool behavior (`codex_tool.rs`)

- `{task, timeout_secs?}` → spawns `codex exec --json --sandbox workspace-write` with the task on stdin, streams agent messages / command notes to the UI as they arrive.
- Honors the env cancel flag (Stop button, ~100ms latency) and a bounded timeout (default 600s, max 3600s); kills the child on either.
- Output truncated on UTF-8 char boundaries (16KB cap).
- **Registered only when the Codex CLI is actually on PATH** (checked once per run), so the model never sees a phantom tool.
- Runs through the existing per-tool approval gate (`Registry::run`) — defaults can require approval before a delegation.

## Attribution

Bridge + runtime-prep code ported from #135 (author **jarxunlai**), trimmed to the codex-as-tool scope: dropped the provider/session-delegation path, runner settings/UI, and the duplicate paste-image implementation (main already has #133).

## Verification

- `cargo test --workspace` — all 20 suites pass (5 new tests: config-block injection, cli-home sync, event parsing, boundary-safe truncation)
- `cd ui && cargo check --target wasm32-unknown-unknown` — clean
- **Live end-to-end**: a real `codex exec` against the bridge returned **236 wisp tools** (3 `wisp_*` builtins + 233 bio MCP), confirming Codex can discover and reach Wisp's capabilities.

## Follow-ups (not in this PR)

- No WSL path translation in `codex_runtime` yet (host spawn only); port `to_wsl_path` from `experimental/local-runners` if WSL Codex setups appear — marked with a `ponytail:` note.
- UI affordance for the `codex` tool card is inherited from the generic tool renderer; a dedicated card could show live command notes better.

🤖 Generated with [Claude Code](https://claude.com/claude-code)