### PR TITLE
fix(ui): persist vision model assignment across save + reopen

### DIFF
--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -601,6 +601,40 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn save_then_reload_keeps_vision_assignment() {
+        // repro for "checkbox lost after save+reopen": full backend round-trip
+        // through save_raw + VISION_KEY + decorated.
+        let tmp = std::env::temp_dir().join(format!("wisp_vision_{}.sqlite", uuid::Uuid::new_v4()));
+        let store = wisp_store::Store::open(&tmp).await.unwrap();
+        let mut p = test_profile("m1", "claude", "claude-opus-4-8");
+        p.supports_vision = true;
+        save_raw(&store, &[test_profile("m0", "text", "deepseek"), p])
+            .await
+            .unwrap();
+        store.set_setting(VISION_KEY, "m1").await.unwrap();
+        let out = decorated(&store).await;
+        let m1 = out.iter().find(|p| p.id == "m1").unwrap();
+        assert!(m1.supports_vision, "capability lost in persistence");
+        assert!(m1.use_for_vision, "vision assignment lost after reload");
+        assert!(!out.iter().find(|p| p.id == "m0").unwrap().use_for_vision);
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    #[test]
+    fn use_for_vision_survives_deserialization() {
+        // repro for the "checkbox lost after save" report: does the incoming
+        // command payload keep use_for_vision despite skip_serializing?
+        let p: ModelProfile = serde_json::from_str(
+            r#"{"id":"m1","label":"l","provider":"anthropic","api_url":"u","model":"m",
+                "max_tokens":8192,"reasoning_effort":"medium",
+                "supports_vision":true,"use_for_vision":true}"#,
+        )
+        .unwrap();
+        assert!(p.supports_vision);
+        assert!(p.use_for_vision, "use_for_vision dropped on deserialize");
+    }
+
     #[test]
     fn fresh_id_skips_taken() {
         let existing = vec![test_profile("m1", "a", "x"), test_profile("m2", "b", "y")];

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -472,8 +472,13 @@ pub async fn save_model(
     state: State<'_, crate::AppState>,
     mut profile: ModelProfile,
     key: Option<String>,
+    use_for_vision: Option<bool>,
 ) -> Result<Vec<ModelProfile>, String> {
-    let assign_vision = profile.use_for_vision;
+    // Explicit top-level param: the flag nested inside `profile` was observed
+    // arriving as false through the webview IPC boundary, losing the
+    // assignment on save (#131 follow-up).
+    let assign_vision = use_for_vision.unwrap_or(profile.use_for_vision);
+    profile.use_for_vision = assign_vision;
     if profile.model.trim().is_empty() {
         return Err("Model is required.".into());
     }

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -41,7 +41,7 @@ export function tauriMock(): void {
   ];
   let memoryEnabled = true;
   let memoryFiles = [{ name: "2026-07-01.md", preview: "User prefers DeepSeek.", bytes: 128 }];
-  const mockModels = [
+  let mockModels = [
     {
       id: "default",
       label: "deepseek-v4-pro",
@@ -111,6 +111,12 @@ export function tauriMock(): void {
       invoke: async (cmd: string, args: any) => {
         ((window as any).__skillInvokeLog ??= []).push({ cmd, args });
         const arg = (key: string) => args instanceof Map ? args.get(key) : args?.[key];
+        const plain = (value: any): any => {
+          if (value instanceof Map) return Object.fromEntries([...value].map(([k, v]) => [k, plain(v)]));
+          if (Array.isArray(value)) return value.map(plain);
+          if (value && typeof value === "object") return Object.fromEntries(Object.entries(value).map(([k, v]) => [k, plain(v)]));
+          return value;
+        };
         switch (cmd) {
           case "list_demos":
             return demos;
@@ -172,7 +178,19 @@ export function tauriMock(): void {
             return executionContexts;
           case "list_runs":
             return runs;
-          case "save_model":
+          case "save_model": {
+            const profile = plain(arg("profile") ?? {});
+            const useForVision = Boolean(arg("useForVision") ?? profile.use_for_vision);
+            mockModels = mockModels.map((m) => m.id === profile.id ? {
+              ...m,
+              ...profile,
+              use_for_vision: useForVision,
+            } : {
+              ...m,
+              use_for_vision: useForVision ? false : m.use_for_vision,
+            });
+            return mockModels;
+          }
           case "remove_model":
           case "set_active_model":
             return mockModels;

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -204,12 +204,16 @@ test("vision assignment keeps model fields and stored key placeholder untouched"
     return args ? { ...args, key: args.key ?? null } : null;
   })).toMatchObject({
     key: null,
+    useForVision: true,
     profile: {
       provider: "openai",
       reasoning_effort: "",
       use_for_vision: true,
     },
   });
+
+  await page.locator(".settings-list-row").first().click();
+  await expect(page.getByLabel("Use for image analysis")).toBeChecked();
 });
 
 test("settings normalizes a blank stored provider to openai", async ({ page }) => {

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -3453,7 +3453,11 @@ fn App() -> impl IntoView {
         });
         let key_arg = if key.is_empty() { None } else { Some(key) };
         spawn_local(async move {
-            let arg = to_value(&serde_json::json!({ "profile": profile, "key": key_arg })).unwrap();
+            let arg = to_value(&serde_json::json!({
+                "profile": profile,
+                "key": key_arg,
+                "useForVision": form.use_for_vision,
+            })).unwrap();
             match invoke_checked("save_model", arg).await {
                 Ok(v) => {
                     if let Ok(list) = serde_wasm_bindgen::from_value::<Vec<ModelProfile>>(v) {


### PR DESCRIPTION
## Bug

Checking **Use for image analysis**, saving, and reopening the model form showed the checkbox cleared again (and the provider/effort edits reverted with it).

## Diagnosis

Verified layer by layer with new regression tests:

- serde deserialization of `ModelProfile` keeps `use_for_vision` (despite `skip_serializing`) ✓
- backend round-trip `save_raw` → `VISION_KEY` → `decorated()` restores the assignment ✓
- ✗ the flag nested inside the `profile` payload arrives as `false` across the webview IPC boundary — the assignment was never written.

## Fix

Lands the dangling commit from `fix/model-form-vision-key` (cdaeaf8, written on top of #131 but never merged): pass `useForVision` as an **explicit top-level command arg**, with `unwrap_or(profile.use_for_vision)` fallback. Rebased onto current main — dropped the `is_local_runner` line (removed by #134).

Adds on top:
- two backend regression tests pinning the deserialization + persistence round-trip
- (from cdaeaf8) stateful `save_model` mock + a save-then-reopen assertion in the Playwright suite

## Verification

- `cargo test -p wisp-tauri models` — 7 pass
- Playwright: full suite 30/30, including the new reopen assertion
- `cargo check --target wasm32-unknown-unknown` clean

After merge, the remote branch `fix/model-form-vision-key` is fully landed and can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)