### PR TITLE
fix(skills,mcp): parse YAML block-scalar descriptions; cap stdio MCP calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5684,7 +5684,7 @@ checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wisp-cli"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5703,7 +5703,7 @@ dependencies = [
 
 [[package]]
 name = "wisp-core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5722,7 +5722,7 @@ dependencies = [
 
 [[package]]
 name = "wisp-llm"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5738,7 +5738,7 @@ dependencies = [
 
 [[package]]
 name = "wisp-mcp"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5754,11 +5754,11 @@ dependencies = [
 
 [[package]]
 name = "wisp-paths"
-version = "0.6.0"
+version = "0.7.0"
 
 [[package]]
 name = "wisp-python"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5775,7 +5775,7 @@ dependencies = [
 
 [[package]]
 name = "wisp-skills"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -5790,7 +5790,7 @@ dependencies = [
 
 [[package]]
 name = "wisp-store"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5806,7 +5806,7 @@ dependencies = [
 
 [[package]]
 name = "wisp-tauri"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5841,7 +5841,7 @@ dependencies = [
 
 [[package]]
 name = "wisp-tools"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/wisp-mcp/src/client.rs
+++ b/crates/wisp-mcp/src/client.rs
@@ -16,6 +16,10 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{ChildStdin, ChildStdout};
 use tokio::sync::Mutex;
 
+/// Hard cap on a single stdio JSON-RPC exchange, matching the HTTP transport's
+/// request timeout. Without it a hung server blocks the agent turn forever.
+const STDIO_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+
 /// Path to the vendored bio-tools MCP servers bundled with the app.
 pub fn bundled_bio_tools_dir() -> Option<PathBuf> {
     wisp_paths::bio_tools_dir()
@@ -232,33 +236,42 @@ impl McpClient {
                     params,
                 };
                 let val = serde_json::to_value(&req)?;
-                // send
-                {
-                    let mut w = stdin.lock().await;
-                    w.write_all(val.to_string().as_bytes()).await?;
-                    w.write_all(b"\n").await?;
-                    w.flush().await?;
-                }
-                // read matching id
-                loop {
-                    let mut line = String::new();
-                    let mut r = stdout.lock().await;
-                    let n = r.read_line(&mut line).await?;
-                    drop(r);
-                    if n == 0 {
-                        return Err(anyhow!("MCP server closed stdout"));
+                let exchange = async {
+                    // send
+                    {
+                        let mut w = stdin.lock().await;
+                        w.write_all(val.to_string().as_bytes()).await?;
+                        w.write_all(b"\n").await?;
+                        w.flush().await?;
                     }
-                    let trimmed = line.trim();
-                    if trimmed.is_empty() {
-                        continue;
-                    }
-                    let resp: JsonRpcResp = serde_json::from_str(trimmed)?;
-                    if resp.id == Some(id) {
-                        if let Some(e) = resp.error {
-                            return Err(anyhow!("MCP error: {}", e.message));
+                    // read matching id
+                    loop {
+                        let mut line = String::new();
+                        let mut r = stdout.lock().await;
+                        let n = r.read_line(&mut line).await?;
+                        drop(r);
+                        if n == 0 {
+                            return Err(anyhow!("MCP server closed stdout"));
                         }
-                        return Ok(resp.result.unwrap_or(Value::Null));
+                        let trimmed = line.trim();
+                        if trimmed.is_empty() {
+                            continue;
+                        }
+                        let resp: JsonRpcResp = serde_json::from_str(trimmed)?;
+                        if resp.id == Some(id) {
+                            if let Some(e) = resp.error {
+                                return Err(anyhow!("MCP error: {}", e.message));
+                            }
+                            return Ok(resp.result.unwrap_or(Value::Null));
+                        }
                     }
+                };
+                match tokio::time::timeout(STDIO_REQUEST_TIMEOUT, exchange).await {
+                    Ok(res) => res,
+                    Err(_) => Err(anyhow!(
+                        "MCP stdio request '{method}' timed out after {}s",
+                        STDIO_REQUEST_TIMEOUT.as_secs()
+                    )),
                 }
             }
             Transport::Http(h) => {

--- a/crates/wisp-skills/src/index.rs
+++ b/crates/wisp-skills/src/index.rs
@@ -125,6 +125,13 @@ pub fn parse_skill_file(md: &Path) -> Result<Skill, String> {
     parse_skill(md, dir)
 }
 
+/// A YAML block-scalar header: `>` or `|`, optionally with a chomping/indent
+/// indicator (`>-`, `|+`, `>2`, …). Everything else is a plain scalar.
+fn is_block_scalar(val: &str) -> bool {
+    let indicator = val.trim_end_matches(|c: char| c == '-' || c == '+' || c.is_ascii_digit());
+    indicator == ">" || indicator == "|"
+}
+
 fn parse_skill(path: &Path, dir: PathBuf) -> Result<Skill, String> {
     let text =
         std::fs::read_to_string(path).map_err(|e| format!("could not read SKILL.md: {e}"))?;
@@ -145,13 +152,17 @@ fn parse_skill(path: &Path, dir: PathBuf) -> Result<Skill, String> {
     let mut description = String::new();
     let mut tags: Vec<String> = vec![];
 
-    for line in yaml.lines() {
-        let line = line.trim();
+    let lines: Vec<&str> = yaml.lines().collect();
+    let mut i = 0;
+    while i < lines.len() {
+        let raw = lines[i];
+        i += 1;
+        let line = raw.trim();
         if line.is_empty() || line.starts_with('#') {
             continue;
         }
         // Skip nested mapping/list lines (indented under a parent key).
-        if line.starts_with('-') || line.starts_with(' ') {
+        if raw.starts_with(char::is_whitespace) || line.starts_with('-') {
             continue;
         }
         let (key, val) = match line.split_once(':') {
@@ -159,10 +170,30 @@ fn parse_skill(path: &Path, dir: PathBuf) -> Result<Skill, String> {
             None => continue,
         };
         let key = key.trim();
-        let val = val
+        let mut val = val
             .trim()
             .trim_matches(|c: char| c == '"' || c == '\'')
             .to_string();
+        // YAML block scalar (`description: >` / `|`): fold the following
+        // more-indented lines into the value. ponytail: folds every
+        // continuation line with spaces — enough for one-line skill
+        // descriptions, not full literal/fold chomping semantics.
+        if is_block_scalar(&val) {
+            let mut parts: Vec<String> = vec![];
+            while i < lines.len() {
+                let cont = lines[i];
+                if cont.trim().is_empty() {
+                    i += 1;
+                    continue;
+                }
+                if !cont.starts_with(char::is_whitespace) {
+                    break;
+                }
+                parts.push(cont.trim().to_string());
+                i += 1;
+            }
+            val = parts.join(" ");
+        }
         match key {
             "name" => {
                 if !val.is_empty() {
@@ -248,6 +279,43 @@ mod tests {
         assert_eq!(names, vec!["a", "c"]);
         assert!(out.get("b").is_none());
         assert!(out.get("a").is_some());
+    }
+
+    #[test]
+    fn parses_yaml_block_scalar_description() {
+        // Regression: the bundled bear-*/bio-model skills use `description: >`,
+        // which the old parser collapsed to just ">", leaving them undescribed
+        // in the system prompt.
+        let dir = std::env::temp_dir().join(format!(
+            "wisp-skill-blockscalar-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let md = dir.join("SKILL.md");
+        std::fs::write(
+            &md,
+            "---\nname: bear-support\ndescription: >\n 找出真实学术文献来支持它。\n\n 不适用于：找反对文献。\ntags: lit, search\n---\n# body\ncontent",
+        )
+        .unwrap();
+        let skill = parse_skill_file(&md).unwrap();
+        assert_eq!(skill.name, "bear-support");
+        assert!(
+            skill.description.contains("找出真实学术文献"),
+            "block scalar not folded: {:?}",
+            skill.description
+        );
+        assert!(
+            skill.description.contains("不适用于"),
+            "second paragraph lost: {:?}",
+            skill.description
+        );
+        assert!(
+            !skill.description.contains('\n'),
+            "description must stay single-line for the prompt list: {:?}",
+            skill.description
+        );
+        assert_eq!(skill.tags, vec!["lit", "search"]);
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]


### PR DESCRIPTION
## 背景

审查 skill / MCP 调度链路时发现两个 dispatch-layer 问题，一个是把大半个技能库悄悄废掉的真 bug，一个是健壮性缺口。

## 改动

### 1. 修复 skill 块标量描述解析（真 bug）

`crates/wisp-skills/src/index.rs` 的手写 frontmatter 解析器不支持 YAML 块标量（`description: >` / `|`），把整段描述压成了 `>`。结果 **39 个内置 skill 中有 23 个**（全部 `bear-*` 研究技能、全部生信模型技能 alphafold2/boltz/chai1/esmfold2/proteinmpnn…）注入 system prompt 时**没有描述**，模型无从判断何时触发，`use_skill` 的自动选择对大半个 catalog 形同虚设。

- 解析器现在把块标量的后续缩进行折叠成单行值（保持 prompt 里"一行一个 skill"的清单格式不被换行破坏）。
- 顺手修正了原来用 `line.starts_with(' ')`（`trim()` 之后恒为 false）判断缩进的失效逻辑，改用原始行判断。
- 折叠语义为简化版（续行用空格拼接，不实现完整 literal/fold chomping），对"一行 skill 描述"足够，已用 `// ponytail:` 注释标明天花板。

**验证**：对真实 catalog 复现新解析逻辑，全部 39 个 skill 都解析出完整描述，**此前 `>` 的 23 个降到 0 个**；`bear-support`（331 字）、`alphafold2`（414 字）正确折叠为单行、无换行。新增回归测试 `parses_yaml_block_scalar_description`。

### 2. 给 stdio MCP 调用加超时

`crates/wisp-mcp/src/client.rs` 的 stdio JSON-RPC 交换没有超时（只有 HTTP 通道有），卡住的 MCP server 会把整个 agent 回合永久挂死。现在包一层 `tokio::time::timeout`，上限 120s，与 HTTP 对齐。未引入新依赖（`tokio` 已带 `time`）。

## 测试

- `cargo test -p wisp-skills`：4 passed（含新回归测试）
- `cargo test -p wisp-mcp`：2 passed
- 两个 crate 均编译通过

## Reviewer notes

- 超时这条**未写独立测试**：它是对 `tokio::time::timeout` 的薄包装，逻辑由编译期类型检查覆盖；构造"永不回复的子进程"来测得搭 fixture，代价与收益不成比例。
- `Cargo.lock` 的改动仅为 workspace 版本从 0.6.0 同步到 0.7.0（`Cargo.toml` 已在此版本），构建时自动修正的陈旧 lockfile。

🤖 Generated with [Claude Code](https://claude.com/claude-code)