### PR TITLE
fix: render user messages immediately

### DIFF
--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -446,6 +446,7 @@ export function tauriMock(): void {
             return null;
           case "send_message": {
             const fid = (args && (args.sessionId ?? args.session_id)) || "t1";
+            const msg = (args && args.message) || "";
             if (String(arg("message") ?? "").includes("PLANOTHER")) {
               const planPreview = "Plan (2 steps · 0 done · 0 in progress · 2 pending):\n[ ] Inspect confirmation protocol\n[ ] Add plan feedback UI";
               setTimeout(
@@ -492,9 +493,16 @@ export function tauriMock(): void {
               setTimeout(tick, 20);
               return fid;
             }
+            if (String(arg("message") ?? "").includes("DELAYUSER")) {
+              setTimeout(() => {
+                emit("agent", { kind: "User", frame_id: fid, text: msg });
+                emit("agent", { kind: "Text", frame_id: fid, delta: "delayed reply" });
+                emit("agent", { kind: "Done", frame_id: fid });
+              }, 1200);
+              return fid;
+            }
             // Multi-tool path (#82): a thinking + tool-call run that must fold
             // into one collapsible "steps" panel instead of a wall of cards.
-            const msg = (args && args.message) || "";
             if (String(arg("message") ?? "").includes("STEPSDEMO")) {
               setTimeout(() => {
                 emit("agent", { kind: "User", frame_id: fid, text: msg });

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -69,6 +69,16 @@ test("send streams a mocked assistant reply", async ({ page }) => {
   await expect(page.getByText("Hello from mock wisp-science.")).toBeVisible({ timeout: 10_000 });
 });
 
+test("user message renders before a delayed backend User event", async ({ page }) => {
+  await enterApp(page);
+  await page.getByPlaceholder(/Ask wisp-science/i).fill("DELAYUSER");
+  await page.getByRole("button", { name: "Send" }).click();
+
+  await expect(page.locator(".user-bubble .body", { hasText: /^DELAYUSER$/ })).toBeVisible({ timeout: 500 });
+  await expect(page.getByText("delayed reply")).toBeVisible({ timeout: 3_000 });
+  await expect(page.locator(".user-bubble .body", { hasText: /^DELAYUSER$/ })).toHaveCount(1);
+});
+
 test("send menu supports plan first", async ({ page }) => {
   await enterApp(page);
   await page.getByPlaceholder(/Ask wisp-science/i).fill("draft the analysis");

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -725,6 +725,12 @@ fn start_user_turn(items: &mut Vec<ChatItem>, text: String, model: Option<String
                 },
             ],
         );
+    } else if items.windows(2).any(|pair| {
+        matches!(&pair[0], ChatItem::User(s) if s == &text)
+            && matches!(&pair[1], ChatItem::Assistant { text: assistant, .. } if assistant.is_empty())
+    }) {
+        // Normal sends are rendered optimistically. The backend User event is
+        // only an acknowledgement in that case, so do not append a duplicate.
     } else {
         items.push(ChatItem::User(text));
         items.push(ChatItem::Assistant {
@@ -3485,6 +3491,13 @@ fn App() -> impl IntoView {
         let branch_items = items.get();
         if !branch && active.as_ref().is_some_and(|id| running.get().contains(id)) {
             items.update(|v| v.push(ChatItem::QueuedUser(message.clone())));
+            force_chat_bottom();
+        } else if !branch {
+            let model = active_model_label(&models.get());
+            items.update(|v| {
+                v.push(ChatItem::User(message.clone()));
+                v.push(ChatItem::Assistant { text: String::new(), model });
+            });
             force_chat_bottom();
         }
         needs_api_key.set(false);


### PR DESCRIPTION
## What changed

Render normal user messages optimistically as soon as Send is pressed. Treat the delayed backend `User` event as an acknowledgement so it cannot duplicate the message.

## Why

The previous flow waited for backend agent initialization (including cold Python/MCP setup) before the frontend inserted the user bubble, exposing a 1–2 second delay. Running-session queued messages already rendered immediately, but normal sends did not.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cd ui && cargo check --target wasm32-unknown-unknown`
- `cd ui-tests && NO_COLOR=true TRUNK_NO_COLOR=true npx playwright test` (46 passed)

Added a delayed-backend UI regression test that verifies the user bubble appears within 500ms and remains a single message.