### PR TITLE
Fix UI focus, palette layout, and artifact group polish

### DIFF
--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -114,6 +114,14 @@ test("Ctrl+K opens the unified command palette and Shift+Enter attaches", async 
   await expect(search).toBeVisible();
   const paletteRows = page.locator(".project-search-overlay .project-search-row");
   await expect(paletteRows.first()).toBeVisible();
+  // Session glyphs use `.gi.bubble` — `.gi.chat` collides with the main `.chat` scroller
+  // (`flex: 1 1 auto`) and stretches the icon, shoving labels to the right.
+  await expect(page.locator(".project-search-overlay .gi.chat")).toHaveCount(0);
+  const sessionIcon = page.locator(".project-search-overlay .gi.bubble").first();
+  if (await sessionIcon.count()) {
+    const box = await sessionIcon.boundingBox();
+    expect(box?.width ?? 0).toBeLessThanOrEqual(24);
+  }
   await search.press("ArrowDown");
   await expect(paletteRows.nth(1)).toHaveClass(/active/);
   await search.fill("counts");
@@ -132,9 +140,27 @@ test("Ctrl+P command palette runs commands and switches themes", async ({ page }
   await expect(input).toBeFocused();
   await expect(palette).toContainText("New session");
 
+  // Typing must keep focus in the input; otherwise arrow keys hit the page behind.
+  await input.pressSequentially("d");
+  await expect(input).toBeFocused();
+  await expect(input).toHaveValue("d");
+  await page.keyboard.press("ArrowDown");
+  await expect(input).toBeFocused();
+  await expect(palette.locator(".project-search-row.active")).toBeVisible();
+  await input.fill("");
+
   await input.press("ArrowDown");
   await input.press("Enter");
   await expect(page.getByPlaceholder("Search this project…")).toBeVisible();
+  await page.keyboard.press("Escape");
+
+  await page.keyboard.press("Control+k");
+  const search = commandPalette(page);
+  await expect(search).toBeVisible();
+  await search.pressSequentially("c");
+  await expect(search).toBeFocused();
+  await page.keyboard.press("ArrowDown");
+  await expect(search).toBeFocused();
   await page.keyboard.press("Escape");
 
   await page.keyboard.press("Control+p");
@@ -167,6 +193,32 @@ test("new session focuses the composer", async ({ page }) => {
   await enterApp(page);
   await page.getByRole("button", { name: "New session" }).click();
   await expect(composer(page)).toBeFocused();
+});
+
+test("rename session modal autofocuses so Ctrl+A selects the title", async ({ page }) => {
+  await page.addInitScript(parallelMock);
+  await page.goto("/");
+  await page.locator(".proj-card-main").first().click();
+  await expect(page.getByRole("button", { name: "New session" })).toBeVisible();
+
+  await composer(page).fill("rename-me");
+  await page.getByRole("button", { name: "Send" }).click();
+  await expect(page.getByText("echo:rename-me")).toBeVisible({ timeout: 10_000 });
+
+  await page.locator(".side-item.ses", { hasText: "rename-me" }).dblclick();
+  const input = page.locator("#rename-session-input");
+  await expect(input).toBeVisible();
+  await expect(input).toBeFocused();
+  await expect.poll(async () => input.evaluate((el: HTMLInputElement) =>
+    el.selectionStart === 0 && el.selectionEnd === el.value.length && el.value.length > 0
+  )).toBe(true);
+
+  // Even after clearing selection, Ctrl+A must stay inside the field.
+  await input.evaluate((el: HTMLInputElement) => el.setSelectionRange(0, 0));
+  await page.keyboard.press("Control+a");
+  await expect.poll(async () => input.evaluate((el: HTMLInputElement) =>
+    el.selectionStart === 0 && el.selectionEnd === el.value.length
+  )).toBe(true);
 });
 
 test("user message renders before a delayed backend User event", async ({ page }) => {
@@ -310,6 +362,30 @@ test("uploaded file shows up in the artifacts panel after send", async ({ page }
   await tile.click({ button: "right" });
   await page.locator(".ctx-menu").getByRole("button", { name: "Download" }).click();
   await expect.poll(() => lastInvokeArgs(page, "download_file")).toMatchObject({ path: "uploads/counts.csv" });
+});
+
+test("artifact category headers collapse and expand their tiles", async ({ page }) => {
+  await enterApp(page);
+  await composer(page).fill("make a volcano plot volcano.png");
+  await page.getByRole("button", { name: "Send" }).click();
+  await expect(page.getByText("Hello from mock wisp-science.")).toBeVisible({ timeout: 10_000 });
+  await page.getByRole("button", { name: "Toggle panel" }).click();
+
+  const tile = page.locator('.rp-tile[data-artifact-name="volcano.png"]');
+  await expect(tile).toBeVisible();
+  const group = page.locator(".rp-art-group").filter({ has: tile });
+  const header = group.locator(".rp-art-group-label");
+  await expect(header).toHaveAttribute("aria-expanded", "true");
+
+  await header.click();
+  await expect(group).toHaveClass(/collapsed/);
+  await expect(header).toHaveAttribute("aria-expanded", "false");
+  await expect(tile).toBeHidden();
+
+  await header.click();
+  await expect(group).not.toHaveClass(/collapsed/);
+  await expect(header).toHaveAttribute("aria-expanded", "true");
+  await expect(tile).toBeVisible();
 });
 
 test("dropped local file uploads and attaches to the composer", async ({ page }) => {

--- a/ui/src/app_support.rs
+++ b/ui/src/app_support.rs
@@ -1420,6 +1420,43 @@ pub(super) fn replace_artifact_tokens(mut html: String, arts: &[Artifact]) -> St
     html
 }
 
+/// Drop stray list markers left in front of artifact chips.
+/// Models often write `- \`file\`` inside table cells; after chip promotion the
+/// leading `- ` remains as a dash beside the pill.
+pub(super) fn strip_list_markers_before_art_refs(html: &str) -> String {
+    const CHIPS: &[&str] = &[
+        r#"<button type="button" class="art-ref""#,
+        r#"<span class="art-ref"#,
+    ];
+    let mut out = String::with_capacity(html.len());
+    let mut rest = html;
+    while let Some((idx, needle)) = CHIPS
+        .iter()
+        .filter_map(|n| rest.find(n).map(|i| (i, *n)))
+        .min_by_key(|(i, _)| *i)
+    {
+        let (before, after) = rest.split_at(idx);
+        out.push_str(strip_trailing_list_marker(before));
+        out.push_str(needle);
+        rest = &after[needle.len()..];
+    }
+    out.push_str(rest);
+    out
+}
+
+fn strip_trailing_list_marker(before: &str) -> &str {
+    let trimmed = before.trim_end_matches([' ', '\t']);
+    let Some(without) = trimmed.strip_suffix(['-', '*', '•', '–', '—']) else {
+        return before;
+    };
+    let boundary = without.trim_end_matches([' ', '\t']);
+    if boundary.is_empty() || boundary.ends_with('>') || boundary.ends_with('\n') {
+        boundary
+    } else {
+        before
+    }
+}
+
 /// Post-process rendered Markdown: artifact chips, code wrappers, filename links.
 pub(super) fn enrich_md_html(mut html: String, arts: &[Artifact]) -> String {
     html = replace_artifact_tokens(html, arts);
@@ -1434,8 +1471,30 @@ pub(super) fn enrich_md_html(mut html: String, arts: &[Artifact]) -> String {
             &format!(r#"<button type="button" class="art-ref" data-art-idx="{i}" title="{fname}"><code>{fname}</code></button>"#),
         );
     }
+    html = strip_list_markers_before_art_refs(&html);
     html = html.replace("<pre><code", "<pre class=\"md-code\"><code");
     html
+}
+
+#[cfg(test)]
+mod art_ref_marker_tests {
+    use super::*;
+
+    #[test]
+    fn strips_list_dashes_before_chips_in_table_cells() {
+        let html = r#"<td> - <button type="button" class="art-ref" data-art-idx="0">a.fasta</button> - <button type="button" class="art-ref" data-art-idx="1">b.fasta</button></td>"#;
+        let out = strip_list_markers_before_art_refs(html);
+        assert_eq!(
+            out,
+            r#"<td><button type="button" class="art-ref" data-art-idx="0">a.fasta</button><button type="button" class="art-ref" data-art-idx="1">b.fasta</button></td>"#
+        );
+    }
+
+    #[test]
+    fn keeps_dashes_that_are_part_of_prose() {
+        let html = r#"see range 1 - <button type="button" class="art-ref" data-art-idx="0">x.csv</button>"#;
+        assert_eq!(strip_list_markers_before_art_refs(html), html);
+    }
 }
 
 pub(super) fn handle_md_click(
@@ -2212,14 +2271,45 @@ pub(super) fn focus_composer() {
 }
 
 pub(super) fn focus_element(id: &str) {
+    focus_element_inner(id, false);
+}
+
+pub(super) fn focus_and_select_element(id: &str) {
+    focus_element_inner(id, true);
+}
+
+fn focus_element_inner(id: &str, select_all: bool) {
     let Some(doc) = web_sys::window().and_then(|w| w.document()) else { return; };
-    if let Some(el) = doc.get_element_by_id(id) {
-        let _ = el.dyn_ref::<web_sys::HtmlElement>().map(|e| e.focus());
+    let Some(el) = doc.get_element_by_id(id) else { return; };
+    let _ = el.dyn_ref::<web_sys::HtmlElement>().map(|e| e.focus());
+    if !select_all {
+        return;
+    }
+    if let Some(input) = el.dyn_ref::<web_sys::HtmlInputElement>() {
+        input.select();
+    } else if let Some(ta) = el.dyn_ref::<web_sys::HtmlTextAreaElement>() {
+        ta.select();
     }
 }
 
 pub(super) fn focus_element_soon(id: &'static str) {
-    let focus = Closure::once(move || focus_element(id));
+    schedule_focus(id, false);
+}
+
+/// Focus a text field after the next paint and select its contents.
+/// Used by rename/create modals so Ctrl/⌘A and typing work immediately.
+pub(super) fn focus_and_select_soon(id: &'static str) {
+    schedule_focus(id, true);
+}
+
+fn schedule_focus(id: &'static str, select_all: bool) {
+    let focus = Closure::once(move || {
+        if select_all {
+            focus_and_select_element(id);
+        } else {
+            focus_element(id);
+        }
+    });
     if let Some(window) = web_sys::window() {
         let _ = window.set_timeout_with_callback_and_timeout_and_arguments_0(focus.as_ref().unchecked_ref(), 0);
     }
@@ -2435,6 +2525,11 @@ pub(super) fn ApprovalCard(
     let feedback = create_rw_signal(String::new());
     let approval_scope = create_rw_signal(String::from("once"));
     let feedback_ready = move || !feedback.get().trim().is_empty();
+    create_effect(move |_| {
+        if show_feedback.get() {
+            focus_element_soon("plan-feedback-input");
+        }
+    });
     let lang = tool_lang(&tool).to_string();
     // For the plan card, `preview` is the rendered checklist; parse it into rows.
     let plan_steps: Vec<(&'static str, String)> = if is_plan {
@@ -2551,6 +2646,7 @@ pub(super) fn ApprovalCard(
                                     }
                                 }>
                                 <textarea
+                                    id="plan-feedback-input"
                                     class="plan-feedback-input"
                                     rows="3"
                                     prop:value=move || feedback.get()
@@ -2643,6 +2739,13 @@ pub(super) fn ProjectsScreen(
         if search_open.get() {
             search_query.get();
             refresh_artifact_search(search_query, artifact_hits);
+            focus_element_soon("project-search-input");
+        }
+    });
+
+    create_effect(move |_| {
+        if creating.get() {
+            focus_and_select_soon("new-project-name");
         }
     });
 
@@ -2805,163 +2908,164 @@ pub(super) fn ProjectsScreen(
                     </button>
                 </div>
             </div>
-            {move || search_open.get().then(|| {
-                let loc = locale.get();
-                let q = search_query.get().trim().to_lowercase();
-                let active = search_active.get();
-                let mut idx = 0usize;
-
-                let project_start = idx;
-                let project_rows = projects
-                    .get()
-                    .into_iter()
-                    .filter(|p| contains_search(&q, &[&p.name, &p.description]))
-                    .take(HOME_SEARCH_PROJECT_LIMIT)
-                    .map(|p| {
-                        let row_idx = idx;
-                        idx += 1;
-                        let open = run_search_action;
-                        let sessions = tf(loc, "projects.sessions_n", &[("n", &p.session_count.to_string())]);
-                        let when = format_relative_time(p.updated_at, loc);
-                        view! {
-                            <button type="button" class="project-search-row" class:active=active == row_idx
-                                on:click=move |_| open.call(row_idx)>
-                                <span class="gi folder"></span>
-                                <span class="project-search-main">
-                                    <span class="project-search-title">{p.name.clone()}</span>
-                                    <span class="project-search-sub">
-                                        {sessions}{(!when.is_empty()).then(|| format!(" · {when}")).unwrap_or_default()}
-                                    </span>
-                                </span>
-                            </button>
-                        }
-                    })
-                    .collect_view();
-                let has_project_rows = idx > project_start;
-                let artifact_start = idx;
-                let artifact_rows = artifact_hits
-                    .get()
-                    .into_iter()
-                    .take(HOME_SEARCH_ARTIFACT_LIMIT)
-                    .map(|a| {
-                        let row_idx = idx;
-                        idx += 1;
-                        let open = run_search_action;
-                        let badge = artifact_badge(&a.kind, &a.name);
-                        let when = format_relative_time(a.ts, loc);
-                        view! {
-                            <button type="button" class="project-search-row" class:active=active == row_idx
-                                on:click=move |_| open.call(row_idx)>
-                                <span class="gi doc"></span>
-                                <span class="project-search-main">
-                                    <span class="project-search-title">{a.name.clone()}</span>
-                                    <span class="project-search-sub">
-                                        {a.path.clone()}{(!when.is_empty()).then(|| format!(" · {when}")).unwrap_or_default()}
-                                    </span>
-                                </span>
-                                <span class="project-search-badge">{badge}</span>
-                            </button>
-                        }
-                    })
-                    .collect_view();
-                let has_artifact_rows = idx > artifact_start;
-                let session_start = idx;
-                let session_rows = recent
-                    .get()
-                    .into_iter()
-                    .filter(|s| contains_search(&q, &[&s.title]))
-                    .take(HOME_SEARCH_SESSION_LIMIT)
-                    .map(|s| {
-                        let row_idx = idx;
-                        idx += 1;
-                        let open = run_search_action;
-                        let status = SessionStatusKind::from_str(&s.status);
-                        view! {
-                            <button type="button" class="project-search-row" class:active=active == row_idx
-                                on:click=move |_| open.call(row_idx)>
-                                <span class="gi chat"></span>
-                                <span class="project-search-main">
-                                    <span class="project-search-title">{s.title.clone()}</span>
-                                    <span class="project-search-sub">{format_relative_time(s.ts, loc)}</span>
-                                </span>
-                                <SessionStatusBadge status=status locale=locale />
-                            </button>
-                        }
-                    })
-                    .collect_view();
-                let has_session_rows = idx > session_start;
-                let new_project_idx = idx;
-                view! {
-                    <div class="project-search-overlay" on:click=move |_| search_open.set(false)>
-                        <div class="project-search-dialog" role="dialog" aria-label=move || t(locale.get(), "projects.search")
-                            on:click=|ev| ev.stop_propagation()>
-                            <div class="project-search-input">
-                                <span class="gi search"></span>
-                                <input type="search" autofocus=true
-                                    placeholder=move || t(locale.get(), "projects.search_ph")
-                                    prop:value=move || search_query.get()
-                                    on:input=move |ev| search_query.set(event_target_value(&ev))
-                                    on:keydown=move |ev: web_sys::KeyboardEvent| {
-                                        if ev.is_composing() { return; }
-                                        let key = ev.key();
-                                        let last = search_count().saturating_sub(1);
-                                        match key.as_str() {
-                                            "Escape" => {
-                                                ev.prevent_default();
-                                                search_open.set(false);
-                                            }
-                                            "ArrowDown" => {
-                                                ev.prevent_default();
-                                                search_active.update(|i| *i = (*i + 1).min(last));
-                                            }
-                                            "ArrowUp" => {
-                                                ev.prevent_default();
-                                                search_active.update(|i| *i = i.saturating_sub(1));
-                                            }
-                                            "Enter" => {
-                                                ev.prevent_default();
-                                                run_search_action.call(search_active.get().min(last));
-                                            }
-                                            _ => {}
+            {move || search_open.get().then(|| view! {
+                <div class="project-search-overlay" on:click=move |_| search_open.set(false)>
+                    <div class="project-search-dialog" role="dialog" aria-label=move || t(locale.get(), "projects.search")
+                        on:click=|ev| ev.stop_propagation()>
+                        <div class="project-search-input">
+                            <span class="gi search"></span>
+                            <input id="project-search-input" type="search" autofocus=true
+                                placeholder=move || t(locale.get(), "projects.search_ph")
+                                prop:value=move || search_query.get()
+                                on:input=move |ev| search_query.set(event_target_value(&ev))
+                                on:keydown=move |ev: web_sys::KeyboardEvent| {
+                                    if ev.is_composing() { return; }
+                                    let key = ev.key();
+                                    let last = search_count().saturating_sub(1);
+                                    match key.as_str() {
+                                        "Escape" => {
+                                            ev.prevent_default();
+                                            search_open.set(false);
                                         }
-                                    } />
-                            </div>
-                            <div class="project-search-results">
-                                {has_project_rows.then(|| view! {
-                                    <div class="project-search-section">
-                                        <div class="project-search-label">{move || t(locale.get(), "projects.title")}</div>
-                                        {project_rows}
-                                    </div>
-                                })}
-                                {has_artifact_rows.then(|| view! {
-                                    <div class="project-search-section">
-                                        <div class="project-search-label">{move || t(locale.get(), "projects.search_artifacts")}</div>
-                                        {artifact_rows}
-                                    </div>
-                                })}
-                                {has_session_rows.then(|| view! {
-                                    <div class="project-search-section">
-                                        <div class="project-search-label">{move || t(locale.get(), "projects.recent")}</div>
-                                        {session_rows}
-                                    </div>
-                                })}
-                            </div>
-                            <button type="button" class="project-search-new" class:active=active == new_project_idx
-                                on:click=move |_| {
-                                    search_open.set(false);
-                                    creating.set(true);
-                                }>
-                                <span class="gi plus"></span>
-                                <span>{move || t(locale.get(), "projects.new")}</span>
-                            </button>
-                            <div class="project-search-foot">
-                                <span><kbd>"↑↓"</kbd>{move || t(locale.get(), "projects.search_nav")}</span>
-                                <span><kbd>"↵"</kbd>{move || t(locale.get(), "projects.search_open")}</span>
-                                <span><kbd>"esc"</kbd>{move || t(locale.get(), "projects.search_close")}</span>
-                            </div>
+                                        "ArrowDown" => {
+                                            ev.prevent_default();
+                                            search_active.update(|i| *i = (*i + 1).min(last));
+                                        }
+                                        "ArrowUp" => {
+                                            ev.prevent_default();
+                                            search_active.update(|i| *i = i.saturating_sub(1));
+                                        }
+                                        "Enter" => {
+                                            ev.prevent_default();
+                                            run_search_action.call(search_active.get().min(last));
+                                        }
+                                        _ => {}
+                                    }
+                                } />
+                        </div>
+                        <div class="project-search-results">
+                            {move || {
+                                let loc = locale.get();
+                                let q = search_query.get().trim().to_lowercase();
+                                let mut idx = 0usize;
+
+                                let project_start = idx;
+                                let project_rows = projects
+                                    .get()
+                                    .into_iter()
+                                    .filter(|p| contains_search(&q, &[&p.name, &p.description]))
+                                    .take(HOME_SEARCH_PROJECT_LIMIT)
+                                    .map(|p| {
+                                        let row_idx = idx;
+                                        idx += 1;
+                                        let open = run_search_action;
+                                        let sessions = tf(loc, "projects.sessions_n", &[("n", &p.session_count.to_string())]);
+                                        let when = format_relative_time(p.updated_at, loc);
+                                        view! {
+                                            <button type="button" class="project-search-row" class:active=move || search_active.get() == row_idx
+                                                on:click=move |_| open.call(row_idx)>
+                                                <span class="gi folder"></span>
+                                                <span class="project-search-main">
+                                                    <span class="project-search-title">{p.name.clone()}</span>
+                                                    <span class="project-search-sub">
+                                                        {sessions}{(!when.is_empty()).then(|| format!(" · {when}")).unwrap_or_default()}
+                                                    </span>
+                                                </span>
+                                            </button>
+                                        }
+                                    })
+                                    .collect_view();
+                                let has_project_rows = idx > project_start;
+                                let artifact_start = idx;
+                                let artifact_rows = artifact_hits
+                                    .get()
+                                    .into_iter()
+                                    .take(HOME_SEARCH_ARTIFACT_LIMIT)
+                                    .map(|a| {
+                                        let row_idx = idx;
+                                        idx += 1;
+                                        let open = run_search_action;
+                                        let badge = artifact_badge(&a.kind, &a.name);
+                                        let when = format_relative_time(a.ts, loc);
+                                        view! {
+                                            <button type="button" class="project-search-row" class:active=move || search_active.get() == row_idx
+                                                on:click=move |_| open.call(row_idx)>
+                                                <span class="gi doc"></span>
+                                                <span class="project-search-main">
+                                                    <span class="project-search-title">{a.name.clone()}</span>
+                                                    <span class="project-search-sub">
+                                                        {a.path.clone()}{(!when.is_empty()).then(|| format!(" · {when}")).unwrap_or_default()}
+                                                    </span>
+                                                </span>
+                                                <span class="project-search-badge">{badge}</span>
+                                            </button>
+                                        }
+                                    })
+                                    .collect_view();
+                                let has_artifact_rows = idx > artifact_start;
+                                let session_start = idx;
+                                let session_rows = recent
+                                    .get()
+                                    .into_iter()
+                                    .filter(|s| contains_search(&q, &[&s.title]))
+                                    .take(HOME_SEARCH_SESSION_LIMIT)
+                                    .map(|s| {
+                                        let row_idx = idx;
+                                        idx += 1;
+                                        let open = run_search_action;
+                                        let status = SessionStatusKind::from_str(&s.status);
+                                        view! {
+                                            <button type="button" class="project-search-row" class:active=move || search_active.get() == row_idx
+                                                on:click=move |_| open.call(row_idx)>
+                                                <span class="gi bubble"></span>
+                                                <span class="project-search-main">
+                                                    <span class="project-search-title">{s.title.clone()}</span>
+                                                    <span class="project-search-sub">{format_relative_time(s.ts, loc)}</span>
+                                                </span>
+                                                <SessionStatusBadge status=status locale=locale />
+                                            </button>
+                                        }
+                                    })
+                                    .collect_view();
+                                let has_session_rows = idx > session_start;
+                                view! {
+                                    {has_project_rows.then(|| view! {
+                                        <div class="project-search-section">
+                                            <div class="project-search-label">{move || t(locale.get(), "projects.title")}</div>
+                                            {project_rows}
+                                        </div>
+                                    })}
+                                    {has_artifact_rows.then(|| view! {
+                                        <div class="project-search-section">
+                                            <div class="project-search-label">{move || t(locale.get(), "projects.search_artifacts")}</div>
+                                            {artifact_rows}
+                                        </div>
+                                    })}
+                                    {has_session_rows.then(|| view! {
+                                        <div class="project-search-section">
+                                            <div class="project-search-label">{move || t(locale.get(), "projects.recent")}</div>
+                                            {session_rows}
+                                        </div>
+                                    })}
+                                }.into_view()
+                            }}
+                        </div>
+                        <button type="button" class="project-search-new"
+                            class:active=move || search_active.get() + 1 == search_count()
+                            on:click=move |_| {
+                                search_open.set(false);
+                                creating.set(true);
+                            }>
+                            <span class="gi plus"></span>
+                            <span>{move || t(locale.get(), "projects.new")}</span>
+                        </button>
+                        <div class="project-search-foot">
+                            <span><kbd>"↑↓"</kbd>{move || t(locale.get(), "projects.search_nav")}</span>
+                            <span><kbd>"↵"</kbd>{move || t(locale.get(), "projects.search_open")}</span>
+                            <span><kbd>"esc"</kbd>{move || t(locale.get(), "projects.search_close")}</span>
                         </div>
                     </div>
-                }
+                </div>
             })}
             <div class="projects-cols">
                 <div class="projects-col">
@@ -2977,7 +3081,8 @@ pub(super) fn ProjectsScreen(
                                 </div>
                                 <label>
                                     {move || t(locale.get(), "proj_settings.name")}
-                                    <input placeholder=move || t(locale.get(), "projects.name_ph")
+                                    <input id="new-project-name" autofocus=true
+                                        placeholder=move || t(locale.get(), "projects.name_ph")
                                         prop:value=move || new_name.get()
                                         on:input=move |e| new_name.set(event_target_value(&e)) />
                                 </label>
@@ -3236,55 +3341,55 @@ pub(super) fn CommandPalette(
         focus_composer();
     });
     view! {
-        {move || open.get().then(|| {
-            let rows = items.get();
-            view! {
-                <div class="project-search-overlay" on:click=move |_| open.set(false)>
-                    <div class="project-search-dialog" role="dialog" aria-label="Search"
-                        on:click=|ev| ev.stop_propagation()>
-                        <div class="project-search-input">
-                            <span class="gi search"></span>
-                            <input id="command-palette-input" type="search" autofocus=true placeholder="Search this project…"
-                                prop:value=move || query.get()
-                                on:input=move |ev| query.set(event_target_value(&ev))
-                                on:keydown=move |ev: web_sys::KeyboardEvent| {
-                                    if ev.is_composing() { return; }
-                                    let n = items.get().len();
-                                    match ev.key().as_str() {
-                                        "Escape" => { ev.prevent_default(); open.set(false); }
-                                        "ArrowDown" => { ev.prevent_default(); if n > 0 { let next = (active.get() + 1) % n; active.set(next); scroll_picker_item(".project-search-overlay .project-search-row", next); } }
-                                        "ArrowUp" => { ev.prevent_default(); if n > 0 { let next = (active.get() + n - 1) % n; active.set(next); scroll_picker_item(".project-search-overlay .project-search-row", next); } }
-                                        "Enter" if ev.shift_key() => { ev.prevent_default(); attach_item.call(active.get()); }
-                                        "Enter" => { ev.prevent_default(); open_item.call(active.get()); }
-                                        _ => {}
-                                    }
-                                } />
-                        </div>
-                        <div class="project-search-results">
-                            {rows.into_iter().enumerate().map(|(i, item)| {
-                                let (icon, title, sub) = match item {
-                                    CommandPaletteItem::Project(p) => ("folder", p.name, p.description),
-                                    CommandPaletteItem::Artifact(a) => ("doc", a.name, a.project_name.unwrap_or_default()),
-                                    CommandPaletteItem::Session(s) => ("chat", s.title, s.project_name),
-                                    CommandPaletteItem::Command("new") => ("plus", t(locale.get(), "projects.new").to_string(), "Command".into()),
-                                    CommandPaletteItem::Command("settings") => ("gear", t(locale.get(), "proj_settings.title").to_string(), "Command".into()),
-                                    CommandPaletteItem::Command("skills") => ("skill", t(locale.get(), "skills.title").to_string(), "Command".into()),
-                                    CommandPaletteItem::Command(_) => ("doc", String::new(), String::new()),
-                                };
-                                view! {
-                                    <button type="button" class="project-search-row" class:active=move || active.get() == i
-                                        on:mousemove=move |_| active.set(i)
-                                        on:click=move |_| open_item.call(i)>
-                                        <span class=format!("gi {icon}")></span>
-                                        <span class="project-search-main"><span class="project-search-title">{title}</span><span class="project-search-sub">{sub}</span></span>
-                                    </button>
+        {move || open.get().then(|| view! {
+            <div class="project-search-overlay" on:click=move |_| open.set(false)>
+                <div class="project-search-dialog" role="dialog" aria-label="Search"
+                    on:click=|ev| ev.stop_propagation()>
+                    <div class="project-search-input">
+                        <span class="gi search"></span>
+                        <input id="command-palette-input" type="search" autofocus=true placeholder="Search this project…"
+                            prop:value=move || query.get()
+                            on:input=move |ev| query.set(event_target_value(&ev))
+                            on:keydown=move |ev: web_sys::KeyboardEvent| {
+                                if ev.is_composing() { return; }
+                                let n = items.get().len();
+                                match ev.key().as_str() {
+                                    "Escape" => { ev.prevent_default(); open.set(false); }
+                                    "ArrowDown" => { ev.prevent_default(); if n > 0 { let next = (active.get() + 1) % n; active.set(next); scroll_picker_item(".project-search-overlay .project-search-row", next); } }
+                                    "ArrowUp" => { ev.prevent_default(); if n > 0 { let next = (active.get() + n - 1) % n; active.set(next); scroll_picker_item(".project-search-overlay .project-search-row", next); } }
+                                    "Enter" if ev.shift_key() => { ev.prevent_default(); attach_item.call(active.get()); }
+                                    "Enter" => { ev.prevent_default(); open_item.call(active.get()); }
+                                    _ => {}
                                 }
-                            }).collect_view()}
-                        </div>
-                        <div class="project-search-foot"><span><kbd>"↑↓"</kbd>"navigate"</span><span><kbd>"↵"</kbd>"open"</span><span><kbd>"⇧↵"</kbd>"attach"</span><span><kbd>"esc"</kbd>"close"</span></div>
+                            } />
                     </div>
+                    <div class="project-search-results">
+                        {move || items.get().into_iter().enumerate().map(|(i, item)| {
+                            let (icon, title, sub) = match item {
+                                CommandPaletteItem::Project(p) => ("folder", p.name, p.description),
+                                CommandPaletteItem::Artifact(a) => ("doc", a.name, a.project_name.unwrap_or_default()),
+                                CommandPaletteItem::Session(s) => ("bubble", s.title, s.project_name),
+                                CommandPaletteItem::Command("new") => ("plus", t(locale.get(), "projects.new").to_string(), "Command".into()),
+                                CommandPaletteItem::Command("settings") => ("gear", t(locale.get(), "proj_settings.title").to_string(), "Command".into()),
+                                CommandPaletteItem::Command("skills") => ("grid", t(locale.get(), "skills.title").to_string(), "Command".into()),
+                                CommandPaletteItem::Command(_) => ("doc", String::new(), String::new()),
+                            };
+                            view! {
+                                <button type="button" class="project-search-row" class:active=move || active.get() == i
+                                    on:mousemove=move |_| active.set(i)
+                                    on:click=move |_| open_item.call(i)>
+                                    <span class=format!("gi {icon}")></span>
+                                    <span class="project-search-main">
+                                        <span class="project-search-title">{title}</span>
+                                        {(!sub.trim().is_empty()).then(|| view! { <span class="project-search-sub">{sub}</span> })}
+                                    </span>
+                                </button>
+                            }
+                        }).collect_view()}
+                    </div>
+                    <div class="project-search-foot"><span><kbd>"↑↓"</kbd>"navigate"</span><span><kbd>"↵"</kbd>"open"</span><span><kbd>"⇧↵"</kbd>"attach"</span><span><kbd>"esc"</kbd>"close"</span></div>
                 </div>
-            }
+            </div>
         })}
     }
 }
@@ -3325,7 +3430,7 @@ pub(super) fn ActionPalette(open: RwSignal<bool>, on_action: Callback<&'static s
             ("files", "doc", "command.files", navigate.clone(), ""),
             ("provenance", "copy", "command.provenance", navigate.clone(), ""),
             ("contexts", "server", "command.contexts", navigate.clone(), ""),
-            ("side-chat", "chat", "command.side_chat", navigate.clone(), ""),
+            ("side-chat", "bubble", "command.side_chat", navigate.clone(), ""),
             ("close-panel", "panel", "command.close_panel", navigate, ""),
             ("theme-light", "gear", "command.theme_light", appearance.clone(), ""),
             ("theme-dark", "gear", "command.theme_dark", appearance.clone(), ""),
@@ -3343,32 +3448,32 @@ pub(super) fn ActionPalette(open: RwSignal<bool>, on_action: Callback<&'static s
         on_action.call(action.id);
     });
     view! {
-        {move || open.get().then(|| {
-            let rows = actions.get();
-            view! {
-                <div class="project-search-overlay action-palette-overlay" on:click=move |_| open.set(false)>
-                    <div class="project-search-dialog action-palette" role="dialog" aria-label="Command Palette"
-                        on:click=|ev| ev.stop_propagation()>
-                        <div class="project-search-input">
-                            <span class="gi search"></span>
-                            <input id="action-palette-input" type="search" autofocus=true
-                                placeholder=move || t(locale.get(), "command.placeholder")
-                                prop:value=move || query.get()
-                                on:input=move |ev| { query.set(event_target_value(&ev)); active.set(0); }
-                                on:keydown=move |ev: web_sys::KeyboardEvent| {
-                                    if ev.is_composing() { return; }
-                                    let n = actions.get().len();
-                                    match ev.key().as_str() {
-                                        "Escape" => { ev.prevent_default(); open.set(false); }
-                                        "ArrowDown" => { ev.prevent_default(); if n > 0 { active.update(|i| *i = (*i + 1) % n); } }
-                                        "ArrowUp" => { ev.prevent_default(); if n > 0 { active.update(|i| *i = (*i + n - 1) % n); } }
-                                        "Enter" => { ev.prevent_default(); run.call(active.get()); }
-                                        _ => {}
-                                    }
-                                } />
-                        </div>
-                        <div class="project-search-results action-palette-results">
-                            {rows.into_iter().enumerate().map(|(i, action)| {
+        {move || open.get().then(|| view! {
+            <div class="project-search-overlay action-palette-overlay" on:click=move |_| open.set(false)>
+                <div class="project-search-dialog action-palette" role="dialog" aria-label="Command Palette"
+                    on:click=|ev| ev.stop_propagation()>
+                    <div class="project-search-input">
+                        <span class="gi search"></span>
+                        <input id="action-palette-input" type="search" autofocus=true
+                            placeholder=move || t(locale.get(), "command.placeholder")
+                            prop:value=move || query.get()
+                            on:input=move |ev| { query.set(event_target_value(&ev)); active.set(0); }
+                            on:keydown=move |ev: web_sys::KeyboardEvent| {
+                                if ev.is_composing() { return; }
+                                let n = actions.get().len();
+                                match ev.key().as_str() {
+                                    "Escape" => { ev.prevent_default(); open.set(false); }
+                                    "ArrowDown" => { ev.prevent_default(); if n > 0 { active.update(|i| *i = (*i + 1) % n); } }
+                                    "ArrowUp" => { ev.prevent_default(); if n > 0 { active.update(|i| *i = (*i + n - 1) % n); } }
+                                    "Enter" => { ev.prevent_default(); run.call(active.get()); }
+                                    _ => {}
+                                }
+                            } />
+                    </div>
+                    <div class="project-search-results action-palette-results">
+                        {move || {
+                            let rows = actions.get();
+                            rows.into_iter().enumerate().map(|(i, action)| {
                                 let previous_group = (i > 0).then(|| actions.get().get(i - 1).map(|a| a.group.clone())).flatten();
                                 let show_group = previous_group.as_deref() != Some(action.group.as_str());
                                 view! {
@@ -3381,12 +3486,12 @@ pub(super) fn ActionPalette(open: RwSignal<bool>, on_action: Callback<&'static s
                                         {(!action.shortcut.is_empty()).then(|| view! { <kbd class="action-shortcut">{action.shortcut}</kbd> })}
                                     </button>
                                 }
-                            }).collect_view()}
-                        </div>
-                        <div class="project-search-foot"><span><kbd>"↑↓"</kbd>"navigate"</span><span><kbd>"↵"</kbd>"run"</span><span><kbd>"esc"</kbd>"close"</span></div>
+                            }).collect_view()
+                        }}
                     </div>
+                    <div class="project-search-foot"><span><kbd>"↑↓"</kbd>"navigate"</span><span><kbd>"↵"</kbd>"run"</span><span><kbd>"esc"</kbd>"close"</span></div>
                 </div>
-            }
+            </div>
         })}
     }
 }

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -256,6 +256,7 @@ fn App() -> impl IntoView {
     let show_art_preview = create_rw_signal(false);
     let modal_artifact = create_rw_signal(None::<(String, String, String)>); // (path, name, kind)
     let artifact_menu = create_rw_signal(None::<(usize, i32, i32)>); // (open tile idx, cursor x, y) — fixed-positioned so the `.rp-tiles` overflow doesn't clip it
+    let collapsed_art_groups = create_rw_signal::<HashSet<String>>(HashSet::new());
     let right_tab = create_rw_signal(RightTab::Artifacts);
     let open_right_tabs = create_rw_signal(vec![RightTab::Artifacts]);
     let right_tab_add_menu_open = create_rw_signal(false);
@@ -1660,6 +1661,21 @@ fn App() -> impl IntoView {
         });
         refresh.forget();
     }
+    create_effect(move |_| {
+        if rename_session_target.get().is_some() {
+            focus_and_select_soon("rename-session-input");
+        }
+    });
+    create_effect(move |_| {
+        if folder_modal.get().is_some() {
+            focus_and_select_soon("folder-modal-input");
+        }
+    });
+    create_effect(move |_| {
+        if show_add_host.get() {
+            focus_and_select_soon("add-host-alias");
+        }
+    });
     let open_session = load_session.clone();
     let on_ctx_pick = {
         let open_session = open_session.clone();
@@ -2917,6 +2933,9 @@ fn App() -> impl IntoView {
                                 let tile_groups = groups.into_iter().map(|(key, indices)| {
                                     let label = artifact_group_label(&key, loc);
                                     let count = indices.len();
+                                    let key_toggle = key.clone();
+                                    let key_class = key.clone();
+                                    let key_aria = key.clone();
                                     let tiles = indices.into_iter().map(|i| {
                                         let a = &arts[i];
                                         let name = a.name.clone();
@@ -3011,12 +3030,22 @@ fn App() -> impl IntoView {
                                     }.into_view()
                                     }).collect_view();
                                     view! {
-                                        <div class="rp-art-group">
-                                            <div class="rp-art-group-label">
-                                                {label}
+                                        <div class="rp-art-group"
+                                            class:collapsed=move || collapsed_art_groups.get().contains(&key_class)
+                                            data-art-group=key.clone()>
+                                            <button type="button" class="rp-art-group-label"
+                                                aria-expanded=move || (!collapsed_art_groups.get().contains(&key_aria)).to_string()
+                                                on:click=move |_| {
+                                                    collapsed_art_groups.update(|set| {
+                                                        if set.contains(&key_toggle) { set.remove(&key_toggle); }
+                                                        else { set.insert(key_toggle.clone()); }
+                                                    });
+                                                }>
+                                                <span class="rp-art-group-caret">"▾"</span>
+                                                <span class="rp-art-group-name">{label}</span>
                                                 <span class="rp-art-group-count">{count}</span>
-                                            </div>
-                                            {tiles}
+                                            </button>
+                                            <div class="rp-art-group-items">{tiles}</div>
                                         </div>
                                     }.into_view()
                                 }).collect_view();
@@ -3513,7 +3542,9 @@ fn App() -> impl IntoView {
                     <h2>{move || t(locale.get(), "session.rename_title")}</h2>
                     <label>
                         <input
+                            id="rename-session-input"
                             type="text"
+                            autofocus=true
                             prop:value=move || rename_session_input.get()
                             on:input=move |ev| rename_session_input.set(dom_value(&ev))
                             on:keydown=move |ev: web_sys::KeyboardEvent| {
@@ -3573,7 +3604,9 @@ fn App() -> impl IntoView {
                     <label>
                         {move || t(locale.get(), label_key)}
                         <input
+                            id="folder-modal-input"
                             type="text"
+                            autofocus=true
                             prop:value=move || folder_modal_input.get()
                             on:input=move |ev| folder_modal_input.set(dom_value(&ev))
                             on:keydown=move |ev: web_sys::KeyboardEvent| {

--- a/ui/src/overlays.rs
+++ b/ui/src/overlays.rs
@@ -29,7 +29,7 @@ pub(super) fn AddHostOverlay(
                 {move || config_aliases.get().into_iter().map(|a| view! { <option value=a.clone()>{a}</option> }).collect_view()}
             </select>
             <label class="host-label">{move || t(locale.get(), "hosts.or_type")}</label>
-            <input class="host-input" prop:value=move || host_alias.get() on:input=move |ev| host_alias.set(event_target_value(&ev)) />
+            <input id="add-host-alias" class="host-input" autofocus=true prop:value=move || host_alias.get() on:input=move |ev| host_alias.set(event_target_value(&ev)) />
             <label class="host-label">{move || t(locale.get(), "hosts.notes")}</label>
             <textarea class="host-input" prop:value=move || host_notes.get()
                 placeholder=move || t(locale.get(), "hosts.notes_ph")

--- a/ui/src/styles/alignment.css
+++ b/ui/src/styles/alignment.css
@@ -72,7 +72,7 @@
   font-family: var(--font-mono); font-size: 12px; line-height: 1.5; resize: vertical; outline: none;
   transition: border-color .12s ease, box-shadow .12s ease;
 }
-.proj-settings-modal .ps-textarea:focus { border-color: var(--clay); box-shadow: 0 0 0 3px rgba(13, 148, 136, 0.14); }
+.proj-settings-modal .ps-textarea:focus { border-color: var(--clay); box-shadow: 0 0 0 3px var(--focus-ring); }
 .proj-settings-modal .ps-ctx { min-height: 150px; }
 
 /* --- Session group headers inside the list (Today / Earlier) --- */
@@ -159,4 +159,3 @@ details.step > summary .step-count { flex: 0 0 auto; font-size: 11.5px; color: v
 .finding-title { font-size: 13px; font-weight: 600; color: var(--text); flex: 1 1 auto; min-width: 0; }
 .finding-body { padding: 0 13px 12px; font-size: 12.5px; color: var(--text-muted); line-height: 1.58; }
 .finding-note { padding: 8px 13px; font-size: 11.5px; color: var(--text-faint); border-top: 1px solid var(--border); background: var(--bg-sunken); font-style: italic; }
-

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -5,6 +5,8 @@
   --bg-sunken: #f3f1ec;
   --bg-input: #ffffff;
   --bg-panel: #f0eee6;
+  --surface-hover: #f7f6f2;
+  --surface-active: #ffffff;
 
   --text: #141413;
   --text-muted: #5a574e;
@@ -13,6 +15,10 @@
 
   --border: rgba(60, 55, 45, 0.1);
   --border-strong: #d6d4cc;
+  --focus-ring: rgba(13, 148, 136, 0.16);
+  --shadow-color: rgba(20, 20, 19, 0.12);
+  --scrollbar-thumb: rgba(138, 135, 127, 0.45);
+  --scrollbar-thumb-hover: rgba(90, 87, 78, 0.55);
 
   /* Brand accent: icon (DNA double-helix) teal from ui/logo.svg (#0D9488 / teal-600).
      Token name kept as --clay to avoid churn across ~30 usages. */
@@ -30,7 +36,7 @@
 
   --radius: 16px;
   --radius-sm: 10px;
-  --shadow: 0 16px 32px -12px rgba(20, 20, 19, 0.12);
+  --shadow: 0 16px 32px -12px var(--shadow-color);
   --shadow-sm: 0 1px 2px rgba(20, 20, 19, 0.06), 0 0 0 1px rgba(20, 20, 19, 0.04);
 
   /* Latin first for UI chrome; CJK immediately after so mixed text doesn't fall through Segoe. */
@@ -48,45 +54,57 @@
 }
 
 :root[data-theme="dark"] {
-  --bg-app: #171816;
-  --bg-elev: #22231f;
-  --bg-sunken: #1c1d1a;
-  --bg-input: #282923;
-  --bg-panel: #2b2c26;
-  --text: #f1f0ea;
-  --text-muted: #b8b6ac;
-  --text-faint: #918f87;
-  --border: rgba(255, 255, 255, 0.09);
-  --border-strong: #3d3e37;
-  --clay: #2dd4bf;
-  --clay-strong: #5eead4;
-  --clay-soft: rgba(45, 212, 191, 0.14);
-  --on-clay: #092f2b;
-  --warm: #5eead4;
-  --shadow: 0 16px 36px -12px rgba(0, 0, 0, 0.55);
-  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.35), 0 0 0 1px rgba(255, 255, 255, 0.04);
+  --bg-app: #101714;
+  --bg-elev: #18211d;
+  --bg-sunken: #121b17;
+  --bg-input: #1d2823;
+  --bg-panel: #1a2520;
+  --surface-hover: #202c27;
+  --surface-active: #24332c;
+  --text: #edf5f0;
+  --text-muted: #acb9b1;
+  --text-faint: #7e8d85;
+  --border: rgba(218, 239, 229, 0.085);
+  --border-strong: #31423a;
+  --focus-ring: rgba(78, 220, 196, 0.2);
+  --shadow-color: rgba(0, 8, 5, 0.5);
+  --scrollbar-thumb: rgba(139, 166, 154, 0.32);
+  --scrollbar-thumb-hover: rgba(171, 203, 189, 0.46);
+  --clay: #48d7bf;
+  --clay-strong: #83f0dc;
+  --clay-soft: rgba(72, 215, 191, 0.14);
+  --on-clay: #08231d;
+  --warm: #83f0dc;
+  --shadow: 0 18px 42px -16px var(--shadow-color);
+  --shadow-sm: 0 1px 2px rgba(0, 8, 5, 0.32), 0 0 0 1px rgba(218, 239, 229, 0.035);
   color-scheme: dark;
 }
 
 @media (prefers-color-scheme: dark) {
   :root[data-theme="system"] {
-    --bg-app: #171816;
-    --bg-elev: #22231f;
-    --bg-sunken: #1c1d1a;
-    --bg-input: #282923;
-    --bg-panel: #2b2c26;
-    --text: #f1f0ea;
-    --text-muted: #b8b6ac;
-    --text-faint: #918f87;
-    --border: rgba(255, 255, 255, 0.09);
-    --border-strong: #3d3e37;
-    --clay: #2dd4bf;
-    --clay-strong: #5eead4;
-    --clay-soft: rgba(45, 212, 191, 0.14);
-    --on-clay: #092f2b;
-    --warm: #5eead4;
-    --shadow: 0 16px 36px -12px rgba(0, 0, 0, 0.55);
-    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.35), 0 0 0 1px rgba(255, 255, 255, 0.04);
+    --bg-app: #101714;
+    --bg-elev: #18211d;
+    --bg-sunken: #121b17;
+    --bg-input: #1d2823;
+    --bg-panel: #1a2520;
+    --surface-hover: #202c27;
+    --surface-active: #24332c;
+    --text: #edf5f0;
+    --text-muted: #acb9b1;
+    --text-faint: #7e8d85;
+    --border: rgba(218, 239, 229, 0.085);
+    --border-strong: #31423a;
+    --focus-ring: rgba(78, 220, 196, 0.2);
+    --shadow-color: rgba(0, 8, 5, 0.5);
+    --scrollbar-thumb: rgba(139, 166, 154, 0.32);
+    --scrollbar-thumb-hover: rgba(171, 203, 189, 0.46);
+    --clay: #48d7bf;
+    --clay-strong: #83f0dc;
+    --clay-soft: rgba(72, 215, 191, 0.14);
+    --on-clay: #08231d;
+    --warm: #83f0dc;
+    --shadow: 0 18px 42px -16px var(--shadow-color);
+    --shadow-sm: 0 1px 2px rgba(0, 8, 5, 0.32), 0 0 0 1px rgba(218, 239, 229, 0.035);
     color-scheme: dark;
   }
 }
@@ -138,5 +156,5 @@ html, body {
 /* ---------- Scrollbars ---------- */
 ::-webkit-scrollbar { width: 10px; height: 10px; }
 ::-webkit-scrollbar-track { background: transparent; }
-::-webkit-scrollbar-thumb { background: rgba(138, 135, 127, 0.45); border-radius: 8px; border: 2px solid transparent; background-clip: padding-box; }
-::-webkit-scrollbar-thumb:hover { background: rgba(90, 87, 78, 0.55); border: 2px solid transparent; background-clip: padding-box; }
+::-webkit-scrollbar-thumb { background: var(--scrollbar-thumb); border-radius: 8px; border: 2px solid transparent; background-clip: padding-box; }
+::-webkit-scrollbar-thumb:hover { background: var(--scrollbar-thumb-hover); border: 2px solid transparent; background-clip: padding-box; }

--- a/ui/src/styles/chat.css
+++ b/ui/src/styles/chat.css
@@ -144,7 +144,7 @@ button.tool-btn.card-copy { margin-left: auto; flex: 0 0 auto; padding: 2px 8px;
   font: inherit; font-size: 13px; font-weight: 600; border-radius: 10px;
   padding: 8px 14px; cursor: pointer; border: 1px solid var(--border-strong); background: var(--bg-elev); color: var(--text);
 }
-.approval-actions button.primary { background: var(--clay); border-color: var(--clay); color: #fff; }
+.approval-actions button.primary { background: var(--clay); border-color: var(--clay); color: var(--on-clay); }
 .approval-actions button:hover { filter: brightness(0.97); }
 
 /* Dedicated plan card (update_plan approval) */
@@ -153,7 +153,7 @@ button.tool-btn.card-copy { margin-left: auto; flex: 0 0 auto; padding: 2px 8px;
 .plan-step { display: flex; align-items: flex-start; gap: 10px; padding: 5px 4px; font-size: 13.5px; line-height: 1.45; }
 .plan-step-mark { flex: 0 0 auto; width: 16px; height: 16px; margin-top: 1px; border-radius: 5px; border: 1.5px solid var(--border-strong); background: var(--bg-elev); position: relative; }
 .plan-step.done .plan-step-mark { background: var(--clay); border-color: var(--clay); }
-.plan-step.done .plan-step-mark::after { content: "✓"; position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; font-size: 11px; color: #fff; }
+.plan-step.done .plan-step-mark::after { content: "✓"; position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; font-size: 11px; color: var(--on-clay); }
 .plan-step.running .plan-step-mark { border-color: var(--clay); }
 .plan-step.running .plan-step-mark::after { content: ""; position: absolute; inset: 3px; border-radius: 2px; background: var(--clay); }
 .plan-step.done .plan-step-text { color: var(--text-muted); text-decoration: line-through; text-decoration-color: var(--text-faint); }
@@ -171,7 +171,7 @@ button.tool-btn.card-copy { margin-left: auto; flex: 0 0 auto; padding: 2px 8px;
   border-radius: 8px; padding: 7px 12px; cursor: pointer;
   border: 1px solid var(--border-strong); background: var(--bg-elev); color: var(--text);
 }
-.plan-feedback-actions button.primary { background: var(--clay); border-color: var(--clay); color: #fff; }
+.plan-feedback-actions button.primary { background: var(--clay); border-color: var(--clay); color: var(--on-clay); }
 .plan-feedback-actions button:disabled { opacity: .45; cursor: default; }
 
 /* Collapsible reasoning ("thinking") block */
@@ -402,20 +402,34 @@ details.tool:not([open]) > summary.head .run-dot { animation: tool-pulse 1.1s ea
 .md table { border-collapse: collapse; width: 100%; font-size: 12.5px; margin: 0 0 10px; display: block; overflow: auto; }
 .md th, .md td { padding: 6px 10px; border: 1px solid var(--border); text-align: left; white-space: normal; word-break: break-word; vertical-align: top; }
 .md thead th { background: var(--bg-elev); font-weight: 650; position: sticky; top: 0; }
+/* File chips in table cells often arrive as mini-lists ("- `file`"). Hide the
+   custom bullets and lay chips out as a wrapping row instead of a dotted list. */
+.md td ul, .md th ul, .md td ol, .md th ol {
+  display: flex; flex-wrap: wrap; align-items: center; gap: 6px;
+  margin: 0; padding: 0;
+}
+.md td ul > li, .md th ul > li, .md td ol > li, .md th ol > li {
+  display: inline-flex; align-items: center; margin: 0; gap: 0;
+}
+.md td ul > li::before, .md th ul > li::before,
+.md td ol > li::before, .md th ol > li::before {
+  content: none; display: none;
+}
+.md td .art-ref, .md th .art-ref { margin: 0; }
 
 /* Composer */
 .composer { flex: 0 0 auto; position: relative; padding: 2px 0 12px; background: var(--bg-app); }
 .composer-inner {
   display: flex; flex-direction: column;
   max-width: var(--chat-col-max); width: 100%; margin: 0 auto;
-  background: var(--bg-input); border: 1px solid hsl(48 12% 88%); border-radius: var(--radius);
+  background: var(--bg-input); border: 1px solid var(--border-strong); border-radius: var(--radius);
   padding: 0 12px 10px 14px;
-  box-shadow: 0 1px 2px rgba(20, 20, 19, 0.04), 0 16px 32px -12px rgba(20, 20, 19, 0.1);
+  box-shadow: var(--shadow-sm), var(--shadow);
   transition: border-color .15s ease, box-shadow .15s ease;
 }
 .composer-inner:focus-within, .composer-inner.composer-dragover {
   border-color: color-mix(in srgb, var(--clay) 45%, var(--border-strong));
-  box-shadow: 0 1px 2px rgba(20, 20, 19, 0.04), 0 16px 32px -12px rgba(20, 20, 19, 0.1), 0 0 0 3px rgba(13, 148, 136, 0.14);
+  box-shadow: var(--shadow-sm), var(--shadow), 0 0 0 3px var(--focus-ring);
 }
 .composer-resizer {
   flex: 0 0 8px; width: calc(100% + 26px); margin: 0 -12px 4px -14px;
@@ -430,10 +444,10 @@ details.tool:not([open]) > summary.head .run-dot { animation: tool-pulse 1.1s ea
 .composer-file-input { display: none; }
 .composer-attachments { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 8px; }
 .composer-attachment-row { display: inline-flex; align-items: center; gap: 4px; max-width: 100%; }
-.composer-attachment { display: inline-block; max-width: 220px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 12px; line-height: 1.4; padding: 3px 8px; border-radius: 999px; border: 1px solid hsl(48 12% 86%); background: hsl(48 20% 97%); color: var(--text-muted); }
+.composer-attachment { display: inline-block; max-width: 220px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 12px; line-height: 1.4; padding: 3px 8px; border-radius: 999px; border: 1px solid var(--border); background: var(--bg-sunken); color: var(--text-muted); }
 .composer-attachment.ready { color: var(--text); }
 .composer-attachment.uploading { opacity: .75; }
-.composer-attachment.error { border-color: color-mix(in srgb, var(--err) 35%, white); color: var(--err); background: color-mix(in srgb, var(--err) 8%, white); }
+.composer-attachment.error { border-color: color-mix(in srgb, var(--err) 35%, var(--border-strong)); color: var(--err); background: color-mix(in srgb, var(--err) 8%, var(--bg-sunken)); }
 .composer-attachment-remove { border: none; background: transparent; color: var(--text-faint); cursor: pointer; font-size: 14px; line-height: 1; padding: 0 2px; }
 .composer-attachment-remove:hover { color: var(--text); }
 .composer textarea {
@@ -469,11 +483,11 @@ details.tool:not([open]) > summary.head .run-dot { animation: tool-pulse 1.1s ea
 
 /* Compose ("+") menu */
 .composer-tools { position: relative; display: flex; align-items: center; gap: 6px; flex: 0 0 auto; }
-.composer-plus { display: inline-flex; align-items: center; justify-content: center; width: 32px; height: 32px; flex: 0 0 auto; border-radius: 999px; border: 1px solid hsl(48 12% 86%); background: hsl(48 20% 98%); color: var(--text-muted); cursor: pointer; transition: background .12s ease, color .12s ease, border-color .12s ease; }
-.composer-plus:hover, .composer-plus.active { background: var(--bg-sunken); color: var(--text); border-color: hsl(48 10% 78%); }
+.composer-plus { display: inline-flex; align-items: center; justify-content: center; width: 32px; height: 32px; flex: 0 0 auto; border-radius: 999px; border: 1px solid var(--border-strong); background: var(--bg-elev); color: var(--text-muted); cursor: pointer; transition: background .12s ease, color .12s ease, border-color .12s ease; }
+.composer-plus:hover, .composer-plus.active { background: var(--surface-hover); color: var(--text); border-color: var(--text-faint); }
 .composer-plus .gi { width: 17px; height: 17px; opacity: .9; }
-.composer-compute { display: inline-flex; align-items: center; justify-content: center; width: 32px; height: 32px; flex: 0 0 auto; border-radius: 999px; border: 1px solid hsl(48 12% 86%); background: hsl(48 20% 98%); color: var(--text-muted); cursor: pointer; transition: background .12s ease, color .12s ease, border-color .12s ease; }
-.composer-compute:hover, .composer-compute.active { background: var(--bg-sunken); color: var(--text); border-color: hsl(48 10% 78%); }
+.composer-compute { display: inline-flex; align-items: center; justify-content: center; width: 32px; height: 32px; flex: 0 0 auto; border-radius: 999px; border: 1px solid var(--border-strong); background: var(--bg-elev); color: var(--text-muted); cursor: pointer; transition: background .12s ease, color .12s ease, border-color .12s ease; }
+.composer-compute:hover, .composer-compute.active { background: var(--surface-hover); color: var(--text); border-color: var(--text-faint); }
 .composer-compute svg { width: 17px; height: 17px; }
 .compute-menu, .specialist-menu { width: 280px; }
 .compose-backdrop { position: fixed; inset: 0; z-index: 60; }
@@ -548,7 +562,7 @@ button.stop:disabled { opacity: .6; cursor: default; }
 .sidechat-thinking { color: var(--text-faint); font-size: 13px; }
 .sidechat-composer { flex: 0 0 auto; padding: 12px 14px 14px; border-top: 1px solid var(--border); background: var(--bg-app); }
 .sidechat-composer textarea { width: 100%; min-height: 78px; max-height: 180px; resize: vertical; box-sizing: border-box; border: 1px solid var(--border-strong); border-radius: var(--radius-sm); background: var(--bg-input); color: var(--text); font: inherit; font-size: 13.5px; line-height: 1.45; padding: 10px 11px; outline: none; }
-.sidechat-composer textarea:focus { border-color: color-mix(in srgb, var(--clay) 45%, var(--border-strong)); box-shadow: 0 0 0 3px rgba(13, 148, 136, 0.12); }
+.sidechat-composer textarea:focus { border-color: color-mix(in srgb, var(--clay) 45%, var(--border-strong)); box-shadow: 0 0 0 3px var(--focus-ring); }
 .sidechat-actions { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-top: 8px; }
 .sidechat-model { position: relative; min-width: 0; }
 .sidechat-model-btn { display: inline-flex; align-items: center; gap: 5px; max-width: 220px; height: 30px; padding: 0 10px; border: 1px solid var(--border-strong); border-radius: 999px; background: var(--bg-elev); color: var(--text-muted); font: inherit; font-family: var(--font-mono); font-size: 11.5px; cursor: pointer; }

--- a/ui/src/styles/explorer.css
+++ b/ui/src/styles/explorer.css
@@ -75,7 +75,7 @@
   background: var(--bg-sunken);
   flex-shrink: 0;
 }
-.skill-tags-filter button.active { color: var(--clay-strong); background: var(--clay-soft); border-color: rgba(13, 148, 136, .28); }
+.skill-tags-filter button.active { color: var(--clay-strong); background: var(--clay-soft); border-color: color-mix(in srgb, var(--clay) 28%, var(--border-strong)); }
 .skill-list { display: flex; flex-direction: column; gap: 7px; overflow-y: auto; max-height: min(48vh, 420px); padding: 2px; }
 .skill-row { display: flex; align-items: flex-start; gap: 10px; padding: 10px; background: var(--bg-input); border: 1px solid var(--border); border-radius: var(--radius-sm); }
 .skill-enable { flex: 0 0 auto; padding-top: 2px; }
@@ -99,6 +99,5 @@
 .skill-tags-input::placeholder { color: var(--text-faint); }
 .skill-tags-input:focus {
   border-color: var(--clay);
-  box-shadow: 0 0 0 3px rgba(13, 148, 136, 0.1);
+  box-shadow: 0 0 0 3px var(--focus-ring);
 }
-

--- a/ui/src/styles/modals.css
+++ b/ui/src/styles/modals.css
@@ -1,5 +1,6 @@
 /* ---------- Modals ---------- */
-.overlay { position: fixed; inset: 0; z-index: 50; background: hsl(215 25% 14% / 0.28); backdrop-filter: blur(3px); display: flex; align-items: center; justify-content: center; padding: 20px; }
+.overlay { position: fixed; inset: 0; z-index: 50; background: hsl(215 25% 14% / 0.28); backdrop-filter: blur(3px); display: flex; align-items: center; justify-content: center; padding: 20px; user-select: none; }
+.overlay input, .overlay textarea, .overlay [contenteditable="true"] { user-select: text; }
 /* Cap height to the viewport (overlay has 20px padding each side) and scroll
    internally, so a long confirm/approval message can't push the button row
    off-screen and out of reach (#63). .modal-wide overrides height below. */
@@ -7,7 +8,7 @@
 .modal h2 { margin: 0; font-size: 17px; font-weight: 650; letter-spacing: -0.01em; }
 .modal label { font-size: 12px; color: var(--text-muted); display: flex; flex-direction: column; gap: 5px; font-weight: 500; }
 .modal input, .modal select { background: var(--bg-input); color: var(--text); border: 1px solid var(--border-strong); border-radius: var(--radius-sm); padding: 9px 11px; font: inherit; font-size: 14px; outline: none; transition: border-color .12s ease, box-shadow .12s ease; }
-.modal input:focus, .modal select:focus { border-color: var(--clay); box-shadow: 0 0 0 3px rgba(13, 148, 136, 0.14); }
+.modal input:focus, .modal select:focus { border-color: var(--clay); box-shadow: 0 0 0 3px var(--focus-ring); }
 .modal .row { display: flex; gap: 10px; justify-content: flex-end; margin-top: 4px; }
 .modal .row button { background: var(--bg-input); color: var(--text); border: 1px solid var(--border-strong); border-radius: var(--radius-sm); padding: 9px 16px; font: inherit; font-size: 13.5px; cursor: pointer; transition: background .12s ease, border-color .12s ease; }
 .modal .row button:hover { border-color: var(--text-faint); }

--- a/ui/src/styles/projects.css
+++ b/ui/src/styles/projects.css
@@ -53,10 +53,13 @@ button.proj-card { width: 100%; padding: 16px 18px; color: var(--text); font: in
 .btn-ghost:hover { background: var(--bg-sunken); }
 
 .gi.search { -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='black' d='M10.5 4a6.5 6.5 0 014.96 10.7l4.42 4.42-1.41 1.41-4.42-4.42A6.5 6.5 0 1110.5 4zm0 2a4.5 4.5 0 100 9 4.5 4.5 0 000-9z'/%3E%3C/svg%3E"); mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='black' d='M10.5 4a6.5 6.5 0 014.96 10.7l4.42 4.42-1.41 1.41-4.42-4.42A6.5 6.5 0 1110.5 4zm0 2a4.5 4.5 0 100 9 4.5 4.5 0 000-9z'/%3E%3C/svg%3E"); }
-.gi.chat { -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='black' d='M4 5.5A3.5 3.5 0 017.5 2h9A3.5 3.5 0 0120 5.5v6A3.5 3.5 0 0116.5 15H10l-5 4v-4.35A3.5 3.5 0 014 11.5zM7.5 4A1.5 1.5 0 006 5.5v6A1.5 1.5 0 007.5 13H7v1.84L9.3 13h7.2a1.5 1.5 0 001.5-1.5v-6A1.5 1.5 0 0016.5 4z'/%3E%3C/svg%3E"); mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='black' d='M4 5.5A3.5 3.5 0 017.5 2h9A3.5 3.5 0 0120 5.5v6A3.5 3.5 0 0116.5 15H10l-5 4v-4.35A3.5 3.5 0 014 11.5zM7.5 4A1.5 1.5 0 006 5.5v6A1.5 1.5 0 007.5 13H7v1.84L9.3 13h7.2a1.5 1.5 0 001.5-1.5v-6A1.5 1.5 0 0016.5 4z'/%3E%3C/svg%3E"); }
+/* Named `bubble` (not `chat`) so it doesn't collide with the main `.chat` scroller's
+   `flex: 1 1 auto`, which was stretching palette icons and shoving labels right. */
+.gi.bubble { -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='black' d='M4 5.5A3.5 3.5 0 017.5 2h9A3.5 3.5 0 0120 5.5v6A3.5 3.5 0 0116.5 15H10l-5 4v-4.35A3.5 3.5 0 014 11.5zM7.5 4A1.5 1.5 0 006 5.5v6A1.5 1.5 0 007.5 13H7v1.84L9.3 13h7.2a1.5 1.5 0 001.5-1.5v-6A1.5 1.5 0 0016.5 4z'/%3E%3C/svg%3E"); mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='black' d='M4 5.5A3.5 3.5 0 017.5 2h9A3.5 3.5 0 0120 5.5v6A3.5 3.5 0 0116.5 15H10l-5 4v-4.35A3.5 3.5 0 014 11.5zM7.5 4A1.5 1.5 0 006 5.5v6A1.5 1.5 0 007.5 13H7v1.84L9.3 13h7.2a1.5 1.5 0 001.5-1.5v-6A1.5 1.5 0 0016.5 4z'/%3E%3C/svg%3E"); }
 
 .project-search-overlay { position: fixed; inset: 0; z-index: 60; display: flex; align-items: flex-start; justify-content: center;
-  padding: min(18vh, 150px) 20px 24px; background: hsl(0 0% 100% / .38); backdrop-filter: blur(8px); }
+  padding: min(18vh, 150px) 20px 24px; background: hsl(0 0% 100% / .38); backdrop-filter: blur(8px); user-select: none; }
+.project-search-overlay input, .project-search-overlay textarea { user-select: text; }
 .project-search-dialog { width: min(760px, 100%); max-height: min(820px, calc(100vh - 48px)); display: flex; flex-direction: column;
   background: var(--bg-elev); border: 1px solid var(--border-strong); border-radius: 13px; box-shadow: var(--shadow); overflow: hidden; }
 .action-palette { width: min(720px, 100%); }
@@ -76,11 +79,12 @@ button.proj-card { width: 100%; padding: 16px 18px; color: var(--text); font: in
   padding: 8px 18px; border: 0; border-left: 3px solid transparent; background: transparent; color: var(--text);
   font: inherit; text-align: left; cursor: pointer; }
 .project-search-row:hover, .project-search-row.active, .project-search-new:hover, .project-search-new.active { background: var(--bg-sunken); }
-.project-search-row.active, .project-search-new.active { border-left-color: var(--info); }
-.project-search-row .gi, .project-search-new .gi { width: 18px; height: 18px; color: var(--text-faint); }
+.project-search-row.active, .project-search-new.active { border-left-color: var(--clay); }
+.project-search-row .gi, .project-search-new .gi { width: 18px; height: 18px; flex: 0 0 auto; color: var(--text-faint); }
 .project-search-main { flex: 1 1 auto; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
 .project-search-title { font-size: 15px; font-weight: 560; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .project-search-sub { font-size: 13px; color: var(--text-faint); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.project-search-sub:empty { display: none; }
 .project-search-badge { flex: 0 0 auto; max-width: 92px; padding: 2px 7px; border: 1px solid var(--border-strong);
   border-radius: 999px; color: var(--text-muted); font-size: 11px; font-weight: 650; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .project-search-new { color: var(--clay-strong); border-top: 1px solid var(--border); min-height: 52px; }

--- a/ui/src/styles/right-pane.css
+++ b/ui/src/styles/right-pane.css
@@ -85,17 +85,27 @@
 .rp-art-group { display: flex; flex-direction: column; gap: 6px; }
 .rp-art-group + .rp-art-group { margin-top: 12px; padding-top: 12px; border-top: 1px solid var(--border); }
 .rp-art-group-label {
-  display: flex; align-items: center; gap: 6px;
-  font-size: 11px; font-weight: 700; color: var(--text-faint);
-  text-transform: uppercase; letter-spacing: .04em;
-  padding: 0 2px; position: sticky; top: 0; z-index: 1;
-  background: var(--bg-sunken);
+  display: flex; align-items: center; gap: 6px; width: 100%;
+  font: inherit; font-size: 11px; font-weight: 700; color: var(--text-faint);
+  text-transform: uppercase; letter-spacing: .04em; text-align: left;
+  padding: 2px; margin: 0; border: none; border-radius: 6px;
+  position: sticky; top: 0; z-index: 1;
+  background: var(--bg-sunken); cursor: pointer;
 }
+.rp-art-group-label:hover { color: var(--text-muted); }
+.rp-art-group-caret {
+  flex: 0 0 auto; font-size: 10px; color: var(--text-faint);
+  transition: transform .15s ease; line-height: 1;
+}
+.rp-art-group.collapsed .rp-art-group-caret { transform: rotate(-90deg); }
+.rp-art-group-name { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .rp-art-group-count {
   font-size: 10px; font-weight: 600; color: var(--text-muted);
   background: var(--bg-elev); border: 1px solid var(--border-strong);
   border-radius: 999px; padding: 1px 6px; font-variant-numeric: tabular-nums;
 }
+.rp-art-group-items { display: flex; flex-direction: column; gap: 6px; }
+.rp-art-group.collapsed .rp-art-group-items { display: none; }
 .rp-tiles {
   display: flex; flex-direction: column; gap: 6px;
   padding: 12px; border-bottom: 1px solid var(--border-strong);
@@ -110,8 +120,8 @@
   transition: border-color .12s ease, background .12s ease, box-shadow .12s ease;
   min-width: 0; box-shadow: var(--shadow-sm);
 }
-.rp-tile:hover { border-color: #c7c4bb; }
-.rp-tile.active { border-color: color-mix(in srgb, var(--clay) 40%, var(--border-strong)); background: #fff; box-shadow: 0 0 0 1px rgba(13, 148, 136, 0.18); }
+.rp-tile:hover { border-color: var(--text-faint); background: var(--surface-hover); }
+.rp-tile.active { border-color: color-mix(in srgb, var(--clay) 52%, var(--border-strong)); background: var(--surface-active); box-shadow: 0 0 0 1px var(--focus-ring); }
 .rp-tile-main {
   display: flex; flex-direction: row; align-items: center; justify-content: space-between; gap: 10px;
   flex: 1 1 auto; min-width: 0;
@@ -144,7 +154,7 @@
   align-self: flex-start; margin-top: 4px;
   padding: 8px 14px; border-radius: 9px; cursor: pointer;
   font: inherit; font-size: 13px; font-weight: 600;
-  color: #fff; background: var(--clay); border: 1px solid var(--clay);
+  color: var(--on-clay); background: var(--clay); border: 1px solid var(--clay);
 }
 .rp-open-viewer:hover { filter: brightness(0.97); }
 .rp-tile-text { display: flex; flex-direction: column; gap: 2px; min-width: 0; flex: 1 1 auto; }

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -408,7 +408,7 @@
 }
 .settings-search:focus {
   border-color: var(--clay);
-  box-shadow: 0 0 0 3px rgba(13, 148, 136, 0.14);
+  box-shadow: 0 0 0 3px var(--focus-ring);
 }
 .settings-add-menu { position: relative; }
 .settings-add-menu > summary {
@@ -791,13 +791,13 @@
   width: 16px;
   height: 16px;
   border-radius: 50%;
-  background: #fff;
-  box-shadow: 0 1px 2px rgba(20, 20, 19, 0.18);
+  background: var(--text);
+  box-shadow: 0 1px 2px var(--shadow-color);
   transition: transform .15s ease;
 }
 .toggle input:checked + .toggle-track { background: var(--clay); }
 .toggle input:checked + .toggle-track::after { transform: translateX(16px); }
-.toggle input:focus-visible + .toggle-track { box-shadow: 0 0 0 3px rgba(13, 148, 136, 0.14); }
+.toggle input:focus-visible + .toggle-track { box-shadow: 0 0 0 3px var(--focus-ring); }
 
 .settings-pane .list { gap: 8px; margin-top: 4px; }
 .settings-pane .list-row {


### PR DESCRIPTION
## Summary
- Keep Ctrl/Cmd+P and Ctrl/Cmd+K search inputs focused while results re-filter, so arrow keys navigate the palette instead of the page behind it.
- Autofocus and select text in rename/create modals; collapse artifact category headers; fix palette icon/`chat` class collision and stray dashes beside table file chips.
- Minor theme token polish for focus rings and dark surfaces used by these surfaces.

## Test plan
- [x] Open Ctrl+P, type a letter, confirm focus stays in the input and ↑/↓ move the active row
- [x] Open Ctrl+K, type a letter, confirm the same focus/arrow behavior
- [x] Rename a session and confirm the title is focused/selected (Ctrl+A works without clicking)
- [x] In Artifacts, click a category header to collapse/expand
- [x] Confirm file chips in markdown tables no longer show leading dashes
- [x] `cd ui && cargo check --target wasm32-unknown-unknown`
- [x] `cd ui-tests && npx playwright test -g "command palette|rename session|artifact category"`

Made with [Cursor](https://cursor.com)