### PR TITLE
feat: add integrated macOS title bar

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3116,6 +3116,10 @@ async fn spawn_project_window(
         .resizable(true);
     #[cfg(target_os = "windows")]
     let builder = builder.decorations(false).shadow(true);
+    #[cfg(target_os = "macos")]
+    let builder = builder
+        .title_bar_style(tauri::TitleBarStyle::Overlay)
+        .hidden_title(true);
     let win = builder.build().map_err(|e| e.to_string())?;
     let evt_app = app.clone();
     let evt_label = label.clone();

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -12,7 +12,7 @@
   "app": {
     "withGlobalTauri": true,
     "windows": [
-      { "title": "wisp-science", "width": 1100, "height": 760, "resizable": true, "dragDropEnabled": false }
+      { "title": "wisp-science", "width": 1100, "height": 760, "resizable": true, "dragDropEnabled": false, "titleBarStyle": "Overlay", "hiddenTitle": true }
     ],
     "security": { "csp": null }
   },

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -983,6 +983,25 @@ test("Windows uses the integrated title bar without covering the project landing
   await context.close();
 });
 
+test("macOS uses the integrated title bar but keeps native traffic lights", async ({ browser }) => {
+  const context = await browser.newContext({
+    userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 Safari/605.1.15",
+  });
+  const page = await context.newPage();
+  await page.addInitScript(tauriMock);
+  await page.goto("/");
+
+  await expect(page.locator(".window-titlebar.mac")).toBeVisible();
+  // Native traffic lights (Overlay title bar) replace our own window controls.
+  await expect(page.locator(".window-controls")).toHaveCount(0);
+
+  await page.getByRole("button", { name: "File" }).click();
+  await page.getByRole("menuitem", { name: "Open projects" }).click();
+  await expect(page.locator(".projects-screen")).toBeVisible();
+
+  await context.close();
+});
+
 test("project cards use semantic buttons for keyboard access", async ({ page }) => {
   await page.goto("/");
   const project = page.locator(".proj-card-main").first();

--- a/ui/src/api.js
+++ b/ui/src/api.js
@@ -12,6 +12,10 @@ export function is_windows() {
   return navigator.userAgent.includes("Windows");
 }
 
+export function is_mac() {
+  return navigator.userAgent.includes("Macintosh");
+}
+
 export async function window_control(action) {
   const current = window.__TAURI__?.window?.getCurrentWindow?.();
   if (!current) return;

--- a/ui/src/bindings.rs
+++ b/ui/src/bindings.rs
@@ -31,6 +31,7 @@ extern "C" {
     pub(crate) fn pasted_image_count(event: JsValue) -> usize;
     pub(crate) async fn upload_files(files: JsValue) -> JsValue;
     pub(crate) fn is_windows() -> bool;
+    pub(crate) fn is_mac() -> bool;
     pub(crate) async fn window_control(action: &str);
     #[wasm_bindgen(js_name = upload_pasted_images)]
     pub(crate) async fn upload_pasted_images(event: JsValue) -> JsValue;

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -12,7 +12,7 @@ mod window_titlebar;
 
 use bindings::{
     attach_chat_autoscroll, force_chat_bottom, invoke, invoke_checked, invoke_timeout, listen,
-    is_windows, open_external_url, pasted_image_count, schedule_chat_follow,
+    is_mac, is_windows, open_external_url, pasted_image_count, schedule_chat_follow,
     CHAT_SCROLLER_ID, CHAT_THREAD_ID,
 };
 use context_menu::{ContextMenuPortal, CtxMenu};
@@ -2330,8 +2330,8 @@ fn App() -> impl IntoView {
     });
 
     view! {
-        {is_windows().then(|| view! {
-            <WindowTitlebar locale=locale on_action=palette_action.clone() />
+        {(is_windows() || is_mac()).then(|| view! {
+            <WindowTitlebar locale=locale on_action=palette_action.clone() mac=is_mac() />
         })}
         <ActionPalette open=action_palette_open on_action=palette_action />
         <CommandPalette open=command_palette_open current_project_id=palette_project_id

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -157,6 +157,8 @@ html, body {
   color: var(--text-muted); background: var(--bg-app);
   border-bottom: 1px solid var(--border); user-select: none;
 }
+/* macOS keeps native traffic lights (top-left); inset so the brand clears them. */
+.window-titlebar.mac { padding-left: 70px; }
 .window-brand { display: flex; align-items: center; gap: 7px; padding: 0 12px; font-size: 12px; color: var(--text); }
 .window-brand-icon { width: 18px; height: 18px; border-radius: 5px; background: center / contain no-repeat url("logo.svg"); }
 .window-menu { display: flex; align-items: stretch; height: 100%; font-size: 13px; }

--- a/ui/src/window_titlebar.rs
+++ b/ui/src/window_titlebar.rs
@@ -47,6 +47,9 @@ const HELP_ITEMS: &[MenuItem] = &[
 pub(super) fn WindowTitlebar(
     locale: RwSignal<Locale>,
     on_action: Callback<&'static str>,
+    /// macOS keeps native traffic lights (Overlay title bar); we hide our own
+    /// min/max/close and inset the brand so it clears the lights.
+    mac: bool,
 ) -> impl IntoView {
     let open = create_rw_signal(None::<&'static str>);
 
@@ -86,7 +89,7 @@ pub(super) fn WindowTitlebar(
     });
 
     view! {
-        <header class="window-titlebar" data-tauri-drag-region>
+        <header class="window-titlebar" class:mac=mac data-tauri-drag-region>
             <div class="window-brand" data-tauri-drag-region>
                 <span class="window-brand-icon"></span>
                 <span>"wisp-science"</span>
@@ -143,14 +146,16 @@ pub(super) fn WindowTitlebar(
                 <div class="window-menu-backdrop" on:click=move |_| open.set(None)></div>
             })}
             <div class="window-drag" data-tauri-drag-region></div>
-            <div class="window-controls">
-                <button type="button" aria-label="Minimize"
-                    on:click=move |_| spawn_local(async { window_control("minimize").await })>"−"</button>
-                <button type="button" aria-label="Maximize"
-                    on:click=move |_| spawn_local(async { window_control("toggle-maximize").await })>"□"</button>
-                <button type="button" class="window-close" aria-label="Close"
-                    on:click=move |_| spawn_local(async { window_control("close").await })>"×"</button>
-            </div>
+            {(!mac).then(|| view! {
+                <div class="window-controls">
+                    <button type="button" aria-label="Minimize"
+                        on:click=move |_| spawn_local(async { window_control("minimize").await })>"−"</button>
+                    <button type="button" aria-label="Maximize"
+                        on:click=move |_| spawn_local(async { window_control("toggle-maximize").await })>"□"</button>
+                    <button type="button" class="window-close" aria-label="Close"
+                        on:click=move |_| spawn_local(async { window_control("close").await })>"×"</button>
+                </div>
+            })}
         </header>
     }
 }


### PR DESCRIPTION
## What

Bring the integrated File/Edit/View/Help title bar to macOS so it matches the Windows one (#previous titlebar work). Reuses the existing `WindowTitlebar` component — no duplicated menus, i18n, or actions.

## macOS approach: keep native traffic lights

Per the chosen design, macOS keeps its native red/yellow/green window controls instead of drawing our own:

- Main window + per-project windows use `titleBarStyle: Overlay` + `hiddenTitle` on macOS — the webview extends under a transparent title bar and the OS renders the traffic lights on top-left.
- `WindowTitlebar` gains a `mac` flag: on macOS it adds a `.mac` class and skips the self-drawn minimize/maximize/close controls (the traffic lights replace them).
- `.window-titlebar.mac` gets `padding-left: 70px` so the brand clears the lights.

Windows behavior is unchanged (decorations off, self-drawn controls on the right).

## Changes

- `ui/src/window_titlebar.rs` — add `mac` prop; gate the custom window controls.
- `ui/src/api.js` + `ui/src/bindings.rs` — add `is_mac()`.
- `ui/src/main.rs` — render on `is_windows() || is_mac()`, pass `mac=is_mac()`.
- `ui/src/styles/base.css` — `.window-titlebar.mac` left inset for traffic lights.
- `src-tauri/tauri.conf.json` + `src-tauri/src/lib.rs` — macOS Overlay title bar for main and per-project windows.
- `ui-tests/tests/ui.spec.ts` — macOS test: `.window-titlebar.mac` visible, no `.window-controls`, File menu works.

## Verification

- `cargo check` on both `ui` (wasm32) and `src-tauri` (macOS) — clean.
- New macOS Playwright test passes; existing Windows title bar tests still pass.

## Known tuning knob

Traffic-light vertical position uses the system default in the 38px bar (sits a bit high). Add `.traffic_light_position(LogicalPosition)` if it needs centering — left as a knob to tune after seeing it live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)