### PR TITLE
Fix unresponsive first launch during Python setup

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -887,6 +887,7 @@ fn default_locale() -> String {
 struct BootstrapStatus {
     skills_loaded: usize,
     python_ok: bool,
+    python_initializing: bool,
     mcp_catalog: usize,
     uv_ok: bool,
     node_ok: bool,
@@ -3947,14 +3948,11 @@ async fn get_onboarding_state(state: State<'_, AppState>) -> Result<OnboardingSt
     })
 }
 
-fn initial_bootstrap(
-    app_data: &std::path::Path,
-    workspace: &std::path::Path,
-    skills: usize,
-) -> BootstrapStatus {
+fn initial_bootstrap(workspace: &std::path::Path, skills: usize) -> BootstrapStatus {
     let mut status = BootstrapStatus {
         skills_loaded: skills,
         python_ok: false,
+        python_initializing: true,
         mcp_catalog: list_mcp_servers(workspace).len(),
         uv_ok: wisp_python::PythonEnv::find_uv().is_some(),
         node_ok: wisp_python::PythonEnv::find_node().is_some(),
@@ -3994,16 +3992,45 @@ fn initial_bootstrap(
             "pixi not found on PATH; optional for local bioinformatics multi-env workflows.".into(),
         );
     }
-    match wisp_python::PythonEnv::ensure(app_data) {
-        Ok(_) => status.python_ok = true,
-        Err(e) => status.errors.push(format!("Python environment: {e}")),
-    }
     if wisp_paths::bio_tools_dir().is_none() {
         status
             .errors
             .push("Bundled bio-tools MCP catalog not found.".into());
     }
     status
+}
+
+fn finish_python_bootstrap(status: &mut BootstrapStatus, result: Result<(), String>) {
+    status.python_initializing = false;
+    match result {
+        Ok(()) => status.python_ok = true,
+        Err(error) => status.errors.push(format!("Python environment: {error}")),
+    }
+}
+
+fn start_python_bootstrap(app: &tauri::AppHandle) {
+    let handle = app.clone();
+    let app_data = app.state::<AppState>().app_data.clone();
+    tauri::async_runtime::spawn(async move {
+        // Environment creation invokes uv and may download/install large wheels.
+        // Keep all of it off Tauri's event-loop thread so the first window stays
+        // responsive while the one-time bootstrap runs.
+        let result = tokio::task::spawn_blocking(move || {
+            wisp_python::PythonEnv::ensure(&app_data)
+                .map(|_| ())
+                .map_err(|error| error.to_string())
+        })
+        .await
+        .unwrap_or_else(|error| Err(format!("bootstrap task failed: {error}")));
+
+        let status = {
+            let state = handle.state::<AppState>();
+            let mut status = state.bootstrap.lock().unwrap();
+            finish_python_bootstrap(&mut status, result);
+            status.clone()
+        };
+        let _ = handle.emit("bootstrap-status", status);
+    });
 }
 
 #[tauri::command]
@@ -4162,7 +4189,7 @@ pub fn run() {
 
             let skills = Arc::new(SkillIndex::load(&skill_paths(&root)));
             let memory = Arc::new(MemoryManager::new(&root));
-            let bootstrap = StdMutex::new(initial_bootstrap(&app_data, &root, skills.all().len()));
+            let bootstrap = StdMutex::new(initial_bootstrap(&root, skills.all().len()));
             let approvals = Arc::new(StdRwLock::new(tauri::async_runtime::block_on(
                 build_approval_policy(&store),
             )));
@@ -4195,6 +4222,7 @@ pub fn run() {
                 reviewing: Arc::new(StdMutex::new(HashSet::new())),
             };
             app.manage(state);
+            start_python_bootstrap(app.handle());
             set_dev_flag(app.handle());
             #[cfg(target_os = "windows")]
             if let Some(window) = app.get_webview_window("main") {

--- a/src-tauri/src/lib_tests.rs
+++ b/src-tauri/src/lib_tests.rs
@@ -475,3 +475,29 @@ fn specialist_section_marker_detects_prior_append() {
     }
     assert_eq!(prompt.matches("## Specialist: Paper hunter").count(), 1);
 }
+
+#[test]
+fn python_bootstrap_success_marks_initialization_complete() {
+    let mut status = crate::initial_bootstrap(std::path::Path::new("/tmp/workspace"), 3);
+    assert!(status.python_initializing);
+    assert!(!status.python_ok);
+
+    crate::finish_python_bootstrap(&mut status, Ok(()));
+
+    assert!(!status.python_initializing);
+    assert!(status.python_ok);
+}
+
+#[test]
+fn python_bootstrap_failure_is_reported_after_initialization() {
+    let mut status = crate::initial_bootstrap(std::path::Path::new("/tmp/workspace"), 3);
+
+    crate::finish_python_bootstrap(&mut status, Err("download failed".into()));
+
+    assert!(!status.python_initializing);
+    assert!(!status.python_ok);
+    assert!(status
+        .errors
+        .iter()
+        .any(|error| error == "Python environment: download failed"));
+}

--- a/ui/src/dto.rs
+++ b/ui/src/dto.rs
@@ -836,6 +836,8 @@ pub(crate) struct MemoryView {
 pub(crate) struct BootstrapStatus {
     pub(crate) skills_loaded: usize,
     pub(crate) python_ok: bool,
+    #[serde(default)]
+    pub(crate) python_initializing: bool,
     pub(crate) mcp_catalog: usize,
     pub(crate) uv_ok: bool,
     pub(crate) node_ok: bool,

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -840,6 +840,24 @@ fn App() -> impl IntoView {
         refresh_models();
     });
 
+    // The native shell publishes the result of its one-time Python setup after
+    // the UI is already interactive. Keep the capabilities view in sync without
+    // polling or delaying the first window.
+    {
+        let bootstrap_js = Closure::<dyn Fn(JsValue)>::new(move |event: JsValue| {
+            if let Ok(payload) = js_sys::Reflect::get(&event, &JsValue::from_str("payload")) {
+                if let Ok(status) = serde_wasm_bindgen::from_value::<BootstrapStatus>(payload) {
+                    bootstrap.set(Some(status));
+                }
+            }
+        });
+        let bootstrap_fn = bootstrap_js.as_ref().unchecked_ref::<js_sys::Function>().clone();
+        bootstrap_js.forget();
+        spawn_local(async move {
+            let _ = listen("bootstrap-status", &bootstrap_fn).await;
+        });
+    }
+
     create_effect(move |_| {
         attach_chat_autoscroll();
     });

--- a/ui/src/overlays.rs
+++ b/ui/src/overlays.rs
@@ -127,7 +127,7 @@ pub(super) fn CapabilitiesOverlay(
             })}
             <div class="row">
                 <button on:click=move |_| show_capabilities.set(false)>{move || t(locale.get(), "caps.close")}</button>
-                {move || bootstrap.get().filter(|b| !b.python_ok || !b.uv_ok || !b.node_ok || !b.sci_ok || !b.pixi_ok).map(|_| view! {
+                {move || bootstrap.get().filter(|b| !b.python_initializing && (!b.python_ok || !b.uv_ok || !b.node_ok || !b.sci_ok || !b.pixi_ok)).map(|_| view! {
                     <button class="primary" disabled=move || busy.get() on:click=move |ev| start_env_setup.call(ev)>
                         {move || t(locale.get(), "caps.setup_env")}
                     </button>


### PR DESCRIPTION
## Summary

Move first-run Python environment provisioning off the Tauri startup thread. The app window can now become responsive while `uv venv` and dependency installation run in the background.

The backend publishes the completion state to the UI, which refreshes capability status and prevents duplicate setup actions while provisioning is in progress.

## Root cause

`initial_bootstrap` synchronously called `PythonEnv::ensure` from Tauri `.setup()`. On a clean install this runs `uv venv` followed by `uv pip install`, including network downloads, before the macOS event loop can respond.

## Validation

- `cargo test --workspace`
- `cargo check -p wisp-tauri`
- `cd ui && cargo check --target wasm32-unknown-unknown`
- `npx playwright test` (69 passed; one existing rename-session focus test failed consistently and is unrelated)