### PR TITLE
Support Wisp references in ACP sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ In a desktop conversation, type `@` to attach a saved artifact, `#` to attach
 a saved session (including another project), or `/` to apply an enabled skill
 to the next turn. Attachments are explicit, removable chips; cross-project
 artifacts stay at their original local path and are never copied automatically.
+The same references work with ACP Agents: selected skills and session context
+are sent as ACP text blocks, while artifacts are sent as file links.
 
 Use Ctrl+K on Windows/Linux or Cmd+K on macOS to search projects, artifacts,
 sessions, and common commands. Enter opens the selected result; Shift+Enter

--- a/docs/acp-agents.md
+++ b/docs/acp-agents.md
@@ -115,7 +115,19 @@ npm install -g @agentclientprotocol/claude-agent-acp
 - Stop cancels the active ACP turn for the bound session.
 - After restart, Wisp reconnects only when the same profile fingerprint and project path still match and the agent supports resume/load. Editing Command/Arguments creates a new fingerprint; start a fresh session.
 
-Wisp also injects its scientific MCP bridge into the ACP session, so the external agent can call bundled Wisp tools while it works in the project directory.
+Wisp injects its scientific MCP bridge into the ACP session, so the external
+agent can call bundled Wisp tools while it works in the project directory. The
+bridge exposes `wisp_list_skills` and `wisp_use_skill`, plus Wisp Run controls,
+enabled scientific tools, and enabled custom MCP connections.
+
+Composer references work in ACP sessions too:
+
+- `/` adds the selected enabled skill's rendered `SKILL.md` guidance to that
+  ACP prompt as text.
+- `#` adds the selected session transcript as reference-only text, with the
+  same size limits and prompt-injection guard as Wisp's built-in agent.
+- `@` sends the selected artifact as a standard ACP file link. Cross-project
+  artifacts remain at their original validated local path.
 
 ## Troubleshooting
 
@@ -126,6 +138,7 @@ Wisp also injects its scientific MCP bridge into the ACP session, so the externa
 | “selection is locked after the first prompt” | Expected; create a new empty session to change backend |
 | “profile or project path changed” | Profile Command/Arguments or project cwd changed; start a new ACP session |
 | Agent runs but has no science tools | Confirm the session started through Wisp (MCP bridge is injected automatically) |
+| Agent does not call a bridge tool | Verify the selected ACP adapter supports MCP servers; the bridge tools are available to the agent, but its model decides when to invoke them |
 
 ## Current limits
 

--- a/src-tauri/src/acp.rs
+++ b/src-tauri/src/acp.rs
@@ -1,6 +1,11 @@
 use crate::{acp_bridge_launch, ActiveProject, AgentEvent, AppState};
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, path::PathBuf, sync::Arc, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Duration,
+};
 use tauri::{AppHandle, Emitter, State};
 use tokio::sync::Mutex;
 use uuid::Uuid;
@@ -502,6 +507,8 @@ pub(crate) async fn run_acp_turn(
     profile_id: Option<&str>,
     message: &str,
     attachments: &[String],
+    injected_context: &[String],
+    artifact_references: &[PathBuf],
 ) -> Result<String, String> {
     let runtime = runtime_for(state, project, frame_id, profile_id).await?;
     if let Some(session_state) = runtime.session_state.lock().await.take() {
@@ -519,24 +526,19 @@ pub(crate) async fn run_acp_turn(
             return Err("The ACP Agent selection is locked after the first prompt.".into());
         }
     }
-    let mut content = vec![ContentBlock::Text(TextContent::new(message.to_string()))];
+    let mut content = acp_text_content(message, injected_context);
+    let mut linked_paths = HashSet::new();
     for attachment in attachments {
         let path = wisp_tools::safety::validate_file_path(project.root.as_path(), attachment)
             .map_err(|_| format!("Attachment '{attachment}' is outside the active project."))?;
-        let uri = url::Url::from_file_path(&path).map_err(|_| {
-            format!(
-                "Attachment path '{}' cannot be represented as a file URI.",
-                path.display()
-            )
-        })?;
-        let name = path
-            .file_name()
-            .and_then(|name| name.to_str())
-            .unwrap_or("attachment");
-        content.push(ContentBlock::ResourceLink(ResourceLink::new(
-            name,
-            uri.to_string(),
-        )));
+        if linked_paths.insert(path.clone()) {
+            content.push(acp_resource_link(&path)?);
+        }
+    }
+    for path in artifact_references {
+        if linked_paths.insert(path.clone()) {
+            content.push(acp_resource_link(path)?);
+        }
     }
     let seq = state
         .store
@@ -638,7 +640,10 @@ pub(crate) async fn run_acp_turn(
                     kind,
                     AcpUpdateKind::AgentMessage | AcpUpdateKind::AgentThought
                 ) {
-                    if matches!(kind, AcpUpdateKind::ToolCall | AcpUpdateKind::ToolCallUpdate) {
+                    if matches!(
+                        kind,
+                        AcpUpdateKind::ToolCall | AcpUpdateKind::ToolCallUpdate
+                    ) {
                         upsert_acp_tool_envelope(&mut tools, &payload);
                     }
                     let _ = app.emit(
@@ -681,6 +686,35 @@ pub(crate) async fn run_acp_turn(
         .map_err(|error| error.to_string())?;
     cancel_pending_permissions(state, frame_id, &runtime).await;
     Ok(stop_reason(outcome.stop_reason).into())
+}
+
+/// ACP has no Wisp-reference block type. Render trusted, host-resolved Wisp
+/// context as ordinary text blocks, which every ACP v1 Agent accepts.
+fn acp_text_content(message: &str, injected_context: &[String]) -> Vec<ContentBlock> {
+    let mut content = vec![ContentBlock::Text(TextContent::new(message.to_string()))];
+    content.extend(
+        injected_context
+            .iter()
+            .map(|text| ContentBlock::Text(TextContent::new(text.clone()))),
+    );
+    content
+}
+
+fn acp_resource_link(path: &Path) -> Result<ContentBlock, String> {
+    let uri = url::Url::from_file_path(path).map_err(|_| {
+        format!(
+            "Attachment path '{}' cannot be represented as a file URI.",
+            path.display()
+        )
+    })?;
+    let name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("attachment");
+    Ok(ContentBlock::ResourceLink(ResourceLink::new(
+        name,
+        uri.to_string(),
+    )))
 }
 
 fn stop_reason(reason: AcpStopReason) -> &'static str {
@@ -871,6 +905,17 @@ mod tests {
             Some("a")
         );
         assert_eq!(text_from_payload(&serde_json::json!({"future":true})), None);
+    }
+
+    #[test]
+    fn explicit_wisp_context_becomes_standard_acp_text() {
+        let content = acp_text_content(
+            "analyse this",
+            &["The user explicitly selected these skills:\n# Skill: bear-map".into()],
+        );
+        let json = serde_json::to_value(content).unwrap().to_string();
+        assert!(json.contains("analyse this"));
+        assert!(json.contains("bear-map"));
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -802,10 +802,7 @@ fn messages_to_items(msgs: &[wisp_llm::Message]) -> Vec<UiItem> {
                         role: "acp_tool".into(),
                         text: envelope.content,
                         tool_name: Some(envelope.title),
-                        ok: Some(matches!(
-                            envelope.status.as_str(),
-                            "completed" | "failed"
-                        )),
+                        ok: Some(matches!(envelope.status.as_str(), "completed" | "failed")),
                         input: None,
                         model_name: None,
                         call_id: Some(envelope.call_id),
@@ -2044,6 +2041,49 @@ async fn resolve_composer_references(
     Ok(injections)
 }
 
+/// Resolve artifact references to files that can be passed to an ACP Agent as
+/// standard `ResourceLink` blocks. Unlike ordinary composer attachments, an
+/// artifact may belong to another Wisp project, so validate it against its
+/// recorded project root rather than the currently active project.
+async fn resolve_acp_artifact_references(
+    store: &Store,
+    refs: &[ComposerReferenceArg],
+) -> Result<Vec<PathBuf>, String> {
+    let mut seen = HashSet::new();
+    let mut paths = Vec::new();
+    for reference in refs {
+        let ComposerReferenceArg::Artifact { id } = reference else {
+            continue;
+        };
+        if !seen.insert(id) {
+            continue;
+        }
+        let artifact = store
+            .get_artifact_detail(id)
+            .await
+            .map_err(|e| e.to_string())?
+            .ok_or_else(|| format!("Attached artifact '{id}' no longer exists."))?;
+        let path = wisp_tools::safety::validate_file_path(
+            Path::new(&artifact.project_root),
+            &artifact.path,
+        )
+        .map_err(|_| {
+            format!(
+                "Attached artifact '{}' is no longer readable.",
+                artifact.name
+            )
+        })?;
+        if !path.is_file() {
+            return Err(format!(
+                "Attached artifact '{}' is no longer readable.",
+                artifact.name
+            ));
+        }
+        paths.push(path);
+    }
+    Ok(paths)
+}
+
 #[tauri::command]
 async fn send_message(
     state: State<'_, AppState>,
@@ -2077,12 +2117,6 @@ async fn send_message(
         if resume {
             return Err("ACP turns cannot use Wisp's transcript replay command.".into());
         }
-        if references
-            .as_ref()
-            .is_some_and(|references| !references.is_empty())
-        {
-            return Err("ACP v1 sessions currently accept text and file attachments, not Wisp transcript/skill references.".into());
-        }
         let frame_id = match session_id.as_deref().filter(|id| !id.is_empty()) {
             Some(id) => {
                 let owner = state
@@ -2098,6 +2132,11 @@ async fn send_message(
             None => create_session_frame(&state.store, &ap.id).await?,
         };
         state.set_active_frame(window.label(), Some(frame_id.clone()));
+        let refs = references.as_deref().unwrap_or_default();
+        let skills = active_skill_index(&state.store, &ap).await;
+        let injected_context =
+            resolve_composer_references(&state.store, refs, &frame_id, &skills).await?;
+        let artifact_references = resolve_acp_artifact_references(&state.store, refs).await?;
         let runtime = {
             let mut sessions = state.sessions.lock().await;
             sessions
@@ -2116,6 +2155,8 @@ async fn send_message(
             acp_agent_id.as_deref().filter(|id| !id.trim().is_empty()),
             &message,
             attachments.as_deref().unwrap_or_default(),
+            &injected_context,
+            &artifact_references,
         )
         .await;
         state.running_turns.lock().await.remove(&frame_id);

--- a/src-tauri/src/lib_tests.rs
+++ b/src-tauri/src/lib_tests.rs
@@ -1,8 +1,8 @@
 use super::{
     branch_title, copy_dir_recursive, messages_to_items, parse_disabled_skills,
-    parse_enabled_skill_names, parse_skill_tags, resolve_composer_references,
-    resolve_workspace, session_runtime_status, side_chat_prompt, user_message_start,
-    ComposerReferenceArg, McpConnection, McpTransport,
+    parse_enabled_skill_names, parse_skill_tags, resolve_acp_artifact_references,
+    resolve_composer_references, resolve_workspace, session_runtime_status, side_chat_prompt,
+    user_message_start, ComposerReferenceArg, McpConnection, McpTransport,
 };
 use std::collections::HashSet;
 use std::path::PathBuf;
@@ -100,6 +100,15 @@ async fn composer_references_resolve_artifact_session_and_skill() {
     assert!(injected.contains("data.csv"));
     assert!(injected.contains("prior result"));
     assert!(injected.contains("Use the test workflow"));
+    let acp_artifacts = resolve_acp_artifact_references(&store, &refs)
+        .await
+        .unwrap();
+    assert_eq!(acp_artifacts.len(), 1);
+    assert_eq!(
+        acp_artifacts[0].file_name().and_then(|name| name.to_str()),
+        Some("data.csv")
+    );
+    assert!(acp_artifacts[0].is_file());
     assert!(resolve_composer_references(
         &store,
         &[ComposerReferenceArg::Session {

--- a/src-tauri/src/mcp_bridge.rs
+++ b/src-tauri/src/mcp_bridge.rs
@@ -659,7 +659,13 @@ mod tests {
 
     #[test]
     fn run_control_plane_names_are_reserved() {
-        for name in ["wisp_run_in_context", "wisp_get_run", "wisp_cancel_run"] {
+        for name in [
+            "wisp_list_skills",
+            "wisp_use_skill",
+            "wisp_run_in_context",
+            "wisp_get_run",
+            "wisp_cancel_run",
+        ] {
             assert!(is_builtin_tool(name), "{name} must be reserved");
         }
         assert!(!is_builtin_tool("third_party_run"));

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -163,6 +163,22 @@ test("ACP turn maps config, overlapping tools, plan, usage, and exact permission
   await expect(page.getByRole("button", { name: /deepseek-v4-pro/ })).toBeDisabled();
 });
 
+test("ACP turns retain explicitly selected Wisp skills", async ({ page }) => {
+  await enterApp(page);
+  await page.getByRole("button", { name: "New session" }).click();
+  await page.locator(".model-picker-btn").click();
+  await page.getByRole("button", { name: /Test ACP Agent/ }).click();
+  await composer(page).fill("/alpha");
+  await page.locator(".mention-menu .mention-item").first().click();
+  await composer(page).fill("use this skill");
+  await page.getByRole("button", { name: "Send" }).click();
+
+  await expect.poll(() => lastInvokeArgs(page, "send_message")).toMatchObject({
+    acpAgentId: "acp-test",
+    references: [{ kind: "skill", name: "alphafold2" }],
+  });
+});
+
 test("ACP cancellation is scoped to the active bound frame", async ({ page }) => {
   await enterApp(page);
   await page.getByRole("button", { name: "New session" }).click();

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -1377,13 +1377,6 @@ fn App() -> impl IntoView {
             status.set("ACP protocol v1 does not support branching a bound session.".into());
             return;
         }
-        if active_acp_agent_id.get().is_some() && !reference_args.is_empty() {
-            status.set(
-                "ACP sessions currently support text and file attachments, not Wisp references."
-                    .into(),
-            );
-            return;
-        }
         let active = active_session.get();
         let branch = action == ComposerSendAction::BranchNew;
         let agent_id = active_acp_agent_id.get();


### PR DESCRIPTION
## Summary

ACP sessions now accept Wisp composer references instead of rejecting them.

- Render selected skills and referenced session transcripts as standard ACP text blocks.
- Send saved artifacts as validated ACP file links, including cross-project artifacts.
- Keep the Wisp MCP bridge available to ACP Agents and document its skill, Run, scientific-tool, and custom-MCP capabilities.
- Add Rust and Playwright coverage for ACP skill references.

## Why

ACP v1 has no Wisp-specific reference block, but it supports text and resource links. The previous UI and backend guards therefore blocked a capability that can be represented safely using standard ACP content.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cd ui && cargo check --target wasm32-unknown-unknown`
- `cargo run -p wisp-mcp --example smoke`
- `cd ui-tests && npx playwright test tests/ui.spec.ts --grep "ACP turns retain explicitly selected Wisp skills"`

## Known limitation

The full Playwright suite has an unrelated existing failure in the rename-session Ctrl+A selection test; the new ACP coverage passes.