### PR TITLE
fix(wisp-acp): poll for child stderr instead of a fixed sleep (#179)

### DIFF
--- a/crates/wisp-acp/src/lib.rs
+++ b/crates/wisp-acp/src/lib.rs
@@ -383,10 +383,12 @@ async fn launch_transport(
     let info = match ready_rx.await {
         Ok(result) => result?,
         Err(_) => {
-            // The process waiter and stderr reader finish independently;
-            // give a just-exited child a brief chance to flush diagnostics.
-            tokio::time::sleep(Duration::from_millis(25)).await;
-            let message = stderr.snapshot();
+            // The process waiter and stderr reader finish independently, so a
+            // just-exited child may not have surfaced its diagnostics yet. The
+            // child is dead (its stderr pipe hits EOF), so poll briefly until
+            // the reader flushes rather than betting on one fixed delay — a
+            // fixed 25ms raced the reader under slow CI and flaked (#179).
+            let message = wait_for_stderr(&stderr).await;
             actor.abort();
             return Err(if message.is_empty() {
                 AcpError::Closed
@@ -403,6 +405,22 @@ async fn launch_transport(
         stderr,
         actor: Mutex::new(Some(actor)),
     })
+}
+
+/// Wait for a just-exited child's stderr reader to flush, returning as soon as
+/// anything is captured. Bounded so a genuinely silent exit still returns.
+async fn wait_for_stderr(stderr: &BoundedStderr) -> String {
+    // ponytail: 500ms ceiling (50×10ms). Only the fully-elapsed, no-stderr case
+    // waits the whole budget, and it's already an error path. Raise if a slower
+    // agent ever needs longer to flush.
+    for _ in 0..50 {
+        let snapshot = stderr.snapshot();
+        if !snapshot.is_empty() {
+            return snapshot;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    stderr.snapshot()
 }
 
 impl Drop for AcpSessionHandle {


### PR DESCRIPTION
Closes #179.

## 问题

`crates/wisp-acp/tests/process.rs` 的 `test_child_exit` 在 CI `rust (1.88.0)` job 下偶发失败（`child stderr surfaced`），未改代码原地 rerun 即通过 → flaky。

## 根因

当子进程在完成 ACP 握手前就退出时，`ready` 通道被 drop，`launch_transport` 走 `Err(_)` 回退分支去 surface 子进程的 stderr——但它**固定 sleep 25ms** 后才 snapshot。stderr 读取是一个独立 spawn 的任务；在慢/满载的 runner 上它还没把子进程那行推进 `BoundedStderr`，snapshot 为空，于是 launch 返回 `AcpError::Closed` 而非 `AcpError::Agent("...fake early exit")`，断言落空。

用一个固定睡眠去同步"stderr 已排空"本身就不可靠。

## 修法

子进程已死 → 其 stderr 管道必然 EOF、读取任务会自行结束。把固定睡眠换成**有界轮询**：一旦捕获到内容立即返回（常态极快），只有"确实无 stderr"的退出才会等满 500ms 上限（本就是错误路径，无所谓）。

```rust
async fn wait_for_stderr(stderr: &BoundedStderr) -> String {
    for _ in 0..50 {
        let snapshot = stderr.snapshot();
        if !snapshot.is_empty() { return snapshot; }
        tokio::time::sleep(Duration::from_millis(10)).await;
    }
    stderr.snapshot()
}
```

## 验证

- 编译后的 process 测试二进制循环跑 **40/40 全过**（时序修复需重复验证，非单次）
- `cargo test --workspace` 全绿，无回归

改动仅 `crates/wisp-acp/src/lib.rs`，+22/-4。

🤖 Generated with [Claude Code](https://claude.com/claude-code)