### PR TITLE
fix: persist reviews and streamed step layout

### DIFF
--- a/crates/wisp-store/migrations/0000_init.sql
+++ b/crates/wisp-store/migrations/0000_init.sql
@@ -65,6 +65,13 @@ CREATE TABLE IF NOT EXISTS session_reviews (
 CREATE INDEX IF NOT EXISTS ix_session_reviews_frame
     ON session_reviews(frame_id, message_seq);
 
+CREATE TABLE IF NOT EXISTS session_ui_events (
+    frame_id  TEXT NOT NULL REFERENCES frames(id) ON DELETE CASCADE,
+    seq       INTEGER NOT NULL,
+    event_json TEXT NOT NULL,
+    PRIMARY KEY(frame_id, seq)
+);
+
 CREATE TABLE IF NOT EXISTS artifacts (
     id              TEXT PRIMARY KEY,
     project_id      TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,

--- a/crates/wisp-store/migrations/0000_init.sql
+++ b/crates/wisp-store/migrations/0000_init.sql
@@ -54,6 +54,17 @@ CREATE TABLE IF NOT EXISTS messages (
 );
 CREATE INDEX IF NOT EXISTS ix_messages_frame ON messages(frame_id);
 
+CREATE TABLE IF NOT EXISTS session_reviews (
+    id          TEXT PRIMARY KEY,
+    frame_id    TEXT NOT NULL REFERENCES frames(id) ON DELETE CASCADE,
+    message_seq INTEGER NOT NULL,
+    report_json TEXT NOT NULL,
+    created_at  INTEGER NOT NULL,
+    updated_at  INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS ix_session_reviews_frame
+    ON session_reviews(frame_id, message_seq);
+
 CREATE TABLE IF NOT EXISTS artifacts (
     id              TEXT PRIMARY KEY,
     project_id      TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,

--- a/crates/wisp-store/src/lib.rs
+++ b/crates/wisp-store/src/lib.rs
@@ -35,6 +35,7 @@ const PROPOSED_PLANS_MIGRATION: &str = "0005_proposed_plans";
 const CODEX_TURN_CONFIGS_MIGRATION: &str = "0006_codex_turn_configs";
 const ACP_SESSIONS_MIGRATION: &str = "0007_acp_sessions";
 const SESSION_REVIEWS_MIGRATION: &str = "0008_session_reviews";
+const SESSION_UI_EVENTS_MIGRATION: &str = "0009_session_ui_events";
 
 #[derive(Clone)]
 pub struct Store {
@@ -122,6 +123,16 @@ impl Store {
             .execute(pool)
             .await?;
             Self::record_migration(pool, SESSION_REVIEWS_MIGRATION).await?;
+        }
+        if !Self::migration_applied(pool, SESSION_UI_EVENTS_MIGRATION).await? {
+            sqlx::query(
+                "CREATE TABLE IF NOT EXISTS session_ui_events (\
+                 frame_id TEXT NOT NULL REFERENCES frames(id) ON DELETE CASCADE, \
+                 seq INTEGER NOT NULL, event_json TEXT NOT NULL, PRIMARY KEY(frame_id,seq))",
+            )
+            .execute(pool)
+            .await?;
+            Self::record_migration(pool, SESSION_UI_EVENTS_MIGRATION).await?;
         }
         Ok(())
     }

--- a/crates/wisp-store/src/lib.rs
+++ b/crates/wisp-store/src/lib.rs
@@ -34,6 +34,7 @@ const RUN_LIFECYCLE_LEASE_MIGRATION: &str = "0004_run_lifecycle_lease";
 const PROPOSED_PLANS_MIGRATION: &str = "0005_proposed_plans";
 const CODEX_TURN_CONFIGS_MIGRATION: &str = "0006_codex_turn_configs";
 const ACP_SESSIONS_MIGRATION: &str = "0007_acp_sessions";
+const SESSION_REVIEWS_MIGRATION: &str = "0008_session_reviews";
 
 #[derive(Clone)]
 pub struct Store {
@@ -104,6 +105,23 @@ impl Store {
         if !Self::migration_applied(pool, ACP_SESSIONS_MIGRATION).await? {
             Self::apply_acp_sessions(pool).await?;
             Self::record_migration(pool, ACP_SESSIONS_MIGRATION).await?;
+        }
+        if !Self::migration_applied(pool, SESSION_REVIEWS_MIGRATION).await? {
+            sqlx::query(
+                "CREATE TABLE IF NOT EXISTS session_reviews (\
+                 id TEXT PRIMARY KEY, frame_id TEXT NOT NULL REFERENCES frames(id) ON DELETE CASCADE, \
+                 message_seq INTEGER NOT NULL, report_json TEXT NOT NULL, \
+                 created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)",
+            )
+            .execute(pool)
+            .await?;
+            sqlx::query(
+                "CREATE INDEX IF NOT EXISTS ix_session_reviews_frame \
+                 ON session_reviews(frame_id, message_seq)",
+            )
+            .execute(pool)
+            .await?;
+            Self::record_migration(pool, SESSION_REVIEWS_MIGRATION).await?;
         }
         Ok(())
     }

--- a/crates/wisp-store/src/sessions.rs
+++ b/crates/wisp-store/src/sessions.rs
@@ -134,6 +134,17 @@ impl Store {
 
     /// Drop persisted turns after `keep` (seq is 1-based; keep=3 retains seq 1..=3).
     pub async fn truncate_messages(&self, frame_id: &str, keep: i64) -> Result<()> {
+        sqlx::query(
+            "DELETE FROM session_ui_events WHERE frame_id=? AND seq > COALESCE((\
+             SELECT MAX(seq) FROM session_ui_events WHERE frame_id=? \
+             AND json_extract(event_json,'$.kind')='MessageBoundary' \
+             AND CAST(json_extract(event_json,'$.seq') AS INTEGER)<=?), 0)",
+        )
+        .bind(frame_id)
+        .bind(frame_id)
+        .bind(keep)
+        .execute(&self.pool)
+        .await?;
         sqlx::query("DELETE FROM session_reviews WHERE frame_id = ? AND message_seq > ?")
             .bind(frame_id)
             .bind(keep)
@@ -217,6 +228,41 @@ impl Store {
         rows.into_iter()
             .map(|row| Ok((row.try_get("message_seq")?, row.try_get("report_json")?)))
             .collect()
+    }
+
+    pub async fn append_session_ui_event(
+        &self,
+        frame_id: &str,
+        seq: i64,
+        event_json: &str,
+    ) -> Result<()> {
+        sqlx::query("INSERT INTO session_ui_events(frame_id,seq,event_json) VALUES(?,?,?)")
+            .bind(frame_id)
+            .bind(seq)
+            .bind(event_json)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    pub async fn load_session_ui_events(&self, frame_id: &str) -> Result<Vec<String>> {
+        let rows =
+            sqlx::query("SELECT event_json FROM session_ui_events WHERE frame_id=? ORDER BY seq")
+                .bind(frame_id)
+                .fetch_all(&self.pool)
+                .await?;
+        rows.into_iter()
+            .map(|row| row.try_get("event_json").map_err(Into::into))
+            .collect()
+    }
+
+    pub async fn next_session_ui_event_seq(&self, frame_id: &str) -> Result<i64> {
+        let row: (i64,) =
+            sqlx::query_as("SELECT COALESCE(MAX(seq),0)+1 FROM session_ui_events WHERE frame_id=?")
+                .bind(frame_id)
+                .fetch_one(&self.pool)
+                .await?;
+        Ok(row.0)
     }
 
     /// Root frames that have at least one user turn, newest first, each with a

--- a/crates/wisp-store/src/sessions.rs
+++ b/crates/wisp-store/src/sessions.rs
@@ -134,6 +134,11 @@ impl Store {
 
     /// Drop persisted turns after `keep` (seq is 1-based; keep=3 retains seq 1..=3).
     pub async fn truncate_messages(&self, frame_id: &str, keep: i64) -> Result<()> {
+        sqlx::query("DELETE FROM session_reviews WHERE frame_id = ? AND message_seq > ?")
+            .bind(frame_id)
+            .bind(keep)
+            .execute(&self.pool)
+            .await?;
         sqlx::query("DELETE FROM messages WHERE frame_id = ? AND seq > ?")
             .bind(frame_id)
             .bind(keep)
@@ -175,6 +180,43 @@ impl Store {
             });
         }
         Ok(out)
+    }
+
+    pub async fn upsert_session_review(
+        &self,
+        frame_id: &str,
+        id: &str,
+        message_seq: i64,
+        report_json: &str,
+    ) -> Result<()> {
+        let now = chrono::Utc::now().timestamp();
+        sqlx::query(
+            "INSERT INTO session_reviews(id,frame_id,message_seq,report_json,created_at,updated_at) \
+             VALUES(?,?,?,?,?,?) ON CONFLICT(id) DO UPDATE SET \
+             report_json=excluded.report_json,updated_at=excluded.updated_at",
+        )
+        .bind(id)
+        .bind(frame_id)
+        .bind(message_seq)
+        .bind(report_json)
+        .bind(now)
+        .bind(now)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn load_session_reviews(&self, frame_id: &str) -> Result<Vec<(i64, String)>> {
+        let rows = sqlx::query(
+            "SELECT message_seq,report_json FROM session_reviews \
+             WHERE frame_id=? ORDER BY message_seq,created_at",
+        )
+        .bind(frame_id)
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter()
+            .map(|row| Ok((row.try_get("message_seq")?, row.try_get("report_json")?)))
+            .collect()
     }
 
     /// Root frames that have at least one user turn, newest first, each with a

--- a/crates/wisp-store/src/store_tests.rs
+++ b/crates/wisp-store/src/store_tests.rs
@@ -201,6 +201,32 @@ async fn truncate_messages() {
 }
 
 #[tokio::test]
+async fn session_reviews_are_upserted_and_truncated_with_the_transcript() {
+    let tmp =
+        std::env::temp_dir().join(format!("wisp_review_test_{}.sqlite", uuid::Uuid::new_v4()));
+    let store = Store::open(&tmp).await.unwrap();
+    store.create_project("p", "P", "").await.unwrap();
+    store.create_frame("f", "p", "OPERON", "m").await.unwrap();
+
+    store
+        .upsert_session_review("f", "review-1", 2, r#"{"summary":"first"}"#)
+        .await
+        .unwrap();
+    store
+        .upsert_session_review("f", "review-1", 3, r#"{"summary":"verified"}"#)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        store.load_session_reviews("f").await.unwrap(),
+        vec![(2, r#"{"summary":"verified"}"#.into())]
+    );
+
+    store.truncate_messages("f", 1).await.unwrap();
+    assert!(store.load_session_reviews("f").await.unwrap().is_empty());
+}
+
+#[tokio::test]
 async fn project_crud_and_listing() {
     let tmp = std::env::temp_dir().join(format!("wisp_store_proj_{}.sqlite", uuid::Uuid::new_v4()));
     let store = Store::open(&tmp).await.unwrap();
@@ -520,6 +546,7 @@ async fn store_open_records_migrations_and_seeds_local_context() {
             PROPOSED_PLANS_MIGRATION.to_string(),
             CODEX_TURN_CONFIGS_MIGRATION.to_string(),
             ACP_SESSIONS_MIGRATION.to_string(),
+            SESSION_REVIEWS_MIGRATION.to_string(),
         ]
     );
 

--- a/crates/wisp-store/src/store_tests.rs
+++ b/crates/wisp-store/src/store_tests.rs
@@ -227,6 +227,30 @@ async fn session_reviews_are_upserted_and_truncated_with_the_transcript() {
 }
 
 #[tokio::test]
+async fn session_ui_events_keep_insertion_order() {
+    let tmp = std::env::temp_dir().join(format!("wisp_ui_events_{}.sqlite", uuid::Uuid::new_v4()));
+    let store = Store::open(&tmp).await.unwrap();
+    store.create_project("p", "P", "").await.unwrap();
+    store.create_frame("f", "p", "OPERON", "m").await.unwrap();
+
+    assert_eq!(store.next_session_ui_event_seq("f").await.unwrap(), 1);
+    let first = r#"{"kind":"MessageBoundary","frame_id":"f","seq":1}"#;
+    let second = r#"{"kind":"MessageBoundary","frame_id":"f","seq":2}"#;
+    store.append_session_ui_event("f", 1, first).await.unwrap();
+    store.append_session_ui_event("f", 2, second).await.unwrap();
+    assert_eq!(
+        store.load_session_ui_events("f").await.unwrap(),
+        vec![first, second]
+    );
+    assert_eq!(store.next_session_ui_event_seq("f").await.unwrap(), 3);
+    store.truncate_messages("f", 1).await.unwrap();
+    assert_eq!(
+        store.load_session_ui_events("f").await.unwrap(),
+        vec![first]
+    );
+}
+
+#[tokio::test]
 async fn project_crud_and_listing() {
     let tmp = std::env::temp_dir().join(format!("wisp_store_proj_{}.sqlite", uuid::Uuid::new_v4()));
     let store = Store::open(&tmp).await.unwrap();
@@ -547,6 +571,7 @@ async fn store_open_records_migrations_and_seeds_local_context() {
             CODEX_TURN_CONFIGS_MIGRATION.to_string(),
             ACP_SESSIONS_MIGRATION.to_string(),
             SESSION_REVIEWS_MIGRATION.to_string(),
+            SESSION_UI_EVENTS_MIGRATION.to_string(),
         ]
     );
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2582,6 +2582,27 @@ async fn generate_review(store: &Store, msgs: &[Message]) -> Result<review::Revi
     Ok(report)
 }
 
+async fn persist_review(
+    store: &Store,
+    frame_id: &str,
+    message_seq: usize,
+    report: &review::ReviewReport,
+) {
+    let json = match serde_json::to_string(report) {
+        Ok(json) => json,
+        Err(error) => {
+            tracing::warn!("serialize review {} failed: {error}", report.id);
+            return;
+        }
+    };
+    if let Err(error) = store
+        .upsert_session_review(frame_id, &report.id, message_seq as i64, &json)
+        .await
+    {
+        tracing::warn!("persist review {} failed: {error}", report.id);
+    }
+}
+
 fn emit_review(app: &AppHandle, frame_id: &str, report: review::ReviewReport) {
     let _ = app.emit(
         "agent",
@@ -2628,6 +2649,7 @@ async fn automatic_review(
     match generate_review(&state.store, &agent.ctx.messages).await {
         Err(error) => tracing::warn!("automatic review failed for {frame_id}: {error}"),
         Ok(mut report) => {
+            persist_review(&state.store, frame_id, agent.ctx.messages.len(), &report).await;
             emit_review(app, frame_id, report.clone());
             if report.has_findings() {
                 agent.ctx.inject_user(review::correction_prompt(&report));
@@ -2656,6 +2678,7 @@ async fn automatic_review(
                         }
                     }
                 }
+                persist_review(&state.store, frame_id, agent.ctx.messages.len(), &report).await;
                 emit_review(app, frame_id, report);
             }
         }
@@ -2709,6 +2732,7 @@ async fn review_session(
         )
         .map_err(|e| format!("{e}"))?;
         let report = generate_review(&state.store, &msgs).await?;
+        persist_review(&state.store, &frame_id, msgs.len(), &report).await;
         app.emit(
             "agent",
             AgentEvent::Review {
@@ -3595,6 +3619,11 @@ async fn load_session(
         .load_messages(&id)
         .await
         .map_err(|e| format!("{e}"))?;
+    let reviews = state
+        .store
+        .load_session_reviews(&id)
+        .await
+        .map_err(|e| format!("{e}"))?;
     // Track which session the UI is viewing. If a runtime exists for it (e.g.
     // it's mid-stream), keep the in-memory agent context authoritative — the UI
     // will render the cached streaming transcript instead of this DB snapshot.
@@ -3602,7 +3631,31 @@ async fn load_session(
     if let Some(rt) = state.sessions.lock().await.get(&id).cloned() {
         rt.set_last_seq(msgs.len() as i64);
     }
-    Ok(messages_to_items(&msgs))
+    let mut items = messages_to_items(&msgs);
+    let mut inserted = 0usize;
+    for (message_seq, report_json) in reviews {
+        let report: review::ReviewReport = serde_json::from_str(&report_json)
+            .map_err(|e| format!("invalid persisted review: {e}"))?;
+        let at = messages_to_items(&msgs[..(message_seq.max(0) as usize).min(msgs.len())]).len()
+            + inserted;
+        items.insert(
+            at,
+            UiItem {
+                role: "review".into(),
+                text: serde_json::to_string(&report).map_err(|e| format!("{e}"))?,
+                tool_name: None,
+                ok: None,
+                input: None,
+                model_name: None,
+                call_id: None,
+                kind: None,
+                status: None,
+                locations: None,
+            },
+        );
+        inserted += 1;
+    }
+    Ok(items)
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -43,12 +43,16 @@ use session_export::{capture_env, export_session, get_artifact_provenance};
 use skill_commands::{copy_dir_recursive, validate_skill_name};
 
 /// One streamed agent event, tagged for the frontend to match on.
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 #[serde(tag = "kind")]
 enum AgentEvent {
     User {
         frame_id: String,
         text: String,
+    },
+    MessageBoundary {
+        frame_id: String,
+        seq: i64,
     },
     Text {
         frame_id: String,
@@ -686,6 +690,8 @@ struct UiItem {
     text: String,
     tool_name: Option<String>,
     ok: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    duration_ms: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     input: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -741,6 +747,7 @@ fn messages_to_items(msgs: &[wisp_llm::Message]) -> Vec<UiItem> {
                         text: t,
                         tool_name: None,
                         ok: None,
+                        duration_ms: None,
                         input: None,
                         model_name: None,
                         call_id: None,
@@ -758,6 +765,7 @@ fn messages_to_items(msgs: &[wisp_llm::Message]) -> Vec<UiItem> {
                             text: r.clone(),
                             tool_name: None,
                             ok: None,
+                            duration_ms: None,
                             input: None,
                             model_name: None,
                             call_id: None,
@@ -774,6 +782,7 @@ fn messages_to_items(msgs: &[wisp_llm::Message]) -> Vec<UiItem> {
                         text: t,
                         tool_name: None,
                         ok: None,
+                        duration_ms: None,
                         input: None,
                         model_name: m.model_name.clone(),
                         call_id: None,
@@ -792,6 +801,7 @@ fn messages_to_items(msgs: &[wisp_llm::Message]) -> Vec<UiItem> {
                             text,
                             tool_name: None,
                             ok: None,
+                            duration_ms: None,
                             input: None,
                             model_name: m.model_name.clone(),
                             call_id: None,
@@ -808,6 +818,7 @@ fn messages_to_items(msgs: &[wisp_llm::Message]) -> Vec<UiItem> {
                         text: envelope.content,
                         tool_name: Some(envelope.title),
                         ok: Some(matches!(envelope.status.as_str(), "completed" | "failed")),
+                        duration_ms: None,
                         input: None,
                         model_name: None,
                         call_id: Some(envelope.call_id),
@@ -821,6 +832,7 @@ fn messages_to_items(msgs: &[wisp_llm::Message]) -> Vec<UiItem> {
                         text,
                         tool_name: m.tool_name.clone(),
                         ok: Some(true),
+                        duration_ms: None,
                         input: m
                             .tool_call_id
                             .as_deref()
@@ -838,6 +850,129 @@ fn messages_to_items(msgs: &[wisp_llm::Message]) -> Vec<UiItem> {
         }
     }
     out
+}
+
+fn events_to_items(events: &[AgentEvent]) -> (Vec<UiItem>, HashMap<i64, usize>) {
+    let mut items: Vec<UiItem> = Vec::new();
+    let mut boundaries = HashMap::new();
+    for event in events {
+        match event {
+            AgentEvent::User { text, .. } => items.push(UiItem {
+                role: "user".into(),
+                text: text.clone(),
+                tool_name: None,
+                ok: None,
+                duration_ms: None,
+                input: None,
+                model_name: None,
+                call_id: None,
+                kind: None,
+                status: None,
+                locations: None,
+            }),
+            AgentEvent::Text { delta, .. } | AgentEvent::Reasoning { delta, .. } => {
+                let role = if matches!(event, AgentEvent::Text { .. }) {
+                    "assistant"
+                } else {
+                    "reasoning"
+                };
+                if let Some(last) = items.last_mut().filter(|item| item.role == role) {
+                    last.text.push_str(delta);
+                } else {
+                    items.push(UiItem {
+                        role: role.into(),
+                        text: delta.clone(),
+                        tool_name: None,
+                        ok: None,
+                        duration_ms: None,
+                        input: None,
+                        model_name: None,
+                        call_id: None,
+                        kind: None,
+                        status: None,
+                        locations: None,
+                    });
+                }
+            }
+            AgentEvent::ToolCall { name, preview, .. } => items.push(UiItem {
+                role: "tool".into(),
+                text: String::new(),
+                tool_name: Some(name.clone()),
+                ok: None,
+                duration_ms: None,
+                input: Some(preview.clone()),
+                model_name: None,
+                call_id: None,
+                kind: None,
+                status: None,
+                locations: None,
+            }),
+            AgentEvent::ToolResult {
+                name,
+                ok,
+                content,
+                duration_ms,
+                ..
+            } => {
+                if let Some(item) = items.iter_mut().rev().find(|item| {
+                    item.role == "tool"
+                        && item.tool_name.as_deref() == Some(name)
+                        && item.ok.is_none()
+                }) {
+                    item.ok = Some(*ok);
+                    item.text = content.clone();
+                    item.duration_ms = (*duration_ms > 0).then_some(*duration_ms);
+                }
+                if name == "attempt_completion" && *ok && !content.trim().is_empty() {
+                    if let Some(item) = items
+                        .iter_mut()
+                        .rev()
+                        .find(|item| item.role == "assistant" && item.text.is_empty())
+                    {
+                        item.text = content.clone();
+                    } else {
+                        items.push(UiItem {
+                            role: "assistant".into(),
+                            text: content.clone(),
+                            tool_name: None,
+                            ok: None,
+                            duration_ms: None,
+                            input: None,
+                            model_name: None,
+                            call_id: None,
+                            kind: None,
+                            status: None,
+                            locations: None,
+                        });
+                    }
+                }
+            }
+            AgentEvent::MessageBoundary { seq, .. } => {
+                boundaries.insert(*seq, items.len());
+            }
+            AgentEvent::Stdout { chunk, .. } => {
+                if let Some(item) = items.iter_mut().rev().find(|item| item.role == "tool") {
+                    item.text.push_str(chunk);
+                } else {
+                    items.push(UiItem {
+                        role: "tool".into(),
+                        text: chunk.clone(),
+                        tool_name: Some("stdout".into()),
+                        ok: None,
+                        duration_ms: None,
+                        input: None,
+                        model_name: None,
+                        call_id: None,
+                        kind: None,
+                        status: None,
+                        locations: None,
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+    (items, boundaries)
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -1032,6 +1167,9 @@ struct TauriOutput {
     /// and written to SQLite by a background task, so a crash or mid-turn "new
     /// session" no longer discards the whole turn. `None` disables it.
     persist: Option<tokio::sync::mpsc::UnboundedSender<Message>>,
+    /// Ordered UI events used to rebuild the same transcript layout after a restart.
+    ui_events: Option<tokio::sync::mpsc::UnboundedSender<AgentEvent>>,
+    message_seq: std::sync::atomic::AtomicI64,
     /// Provenance sink: each tool-execution record the turn produces is sent here
     /// and persisted as an `execution_log` row by a background drain task.
     /// `None` disables it.
@@ -1040,6 +1178,20 @@ struct TauriOutput {
 
 impl TauriOutput {
     fn emit(&self, event: AgentEvent) {
+        if matches!(
+            event,
+            AgentEvent::User { .. }
+                | AgentEvent::MessageBoundary { .. }
+                | AgentEvent::Text { .. }
+                | AgentEvent::Reasoning { .. }
+                | AgentEvent::ToolCall { .. }
+                | AgentEvent::ToolResult { .. }
+                | AgentEvent::Stdout { .. }
+        ) {
+            if let Some(tx) = &self.ui_events {
+                let _ = tx.send(event.clone());
+            }
+        }
         let _ = self.app.emit("agent", event);
     }
 }
@@ -1166,6 +1318,11 @@ impl Output for TauriOutput {
         if let Some(tx) = &self.persist {
             let _ = tx.send(msg.clone());
         }
+        let seq = self.message_seq.fetch_add(1, Ordering::SeqCst) + 1;
+        self.emit(AgentEvent::MessageBoundary {
+            frame_id: self.frame_id.clone(),
+            seq,
+        });
     }
     fn provenance(&self, rec: &wisp_core::ProvenanceRecord) {
         if let Some(tx) = &self.prov {
@@ -2440,6 +2597,57 @@ async fn send_message(
         (handle, tx)
     };
 
+    let (ui_event_handle, ui_event_tx) = {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<AgentEvent>();
+        let store = state.store.clone();
+        let fid = frame_id.clone();
+        let mut seq = store
+            .next_session_ui_event_seq(&fid)
+            .await
+            .map_err(|e| format!("{e}"))?;
+        let handle = tokio::spawn(async move {
+            let mut events: Vec<AgentEvent> = Vec::new();
+            while let Some(event) = rx.recv().await {
+                let merged = match (events.last_mut(), &event) {
+                    (
+                        Some(AgentEvent::Text { delta, .. }),
+                        AgentEvent::Text { delta: next, .. },
+                    )
+                    | (
+                        Some(AgentEvent::Reasoning { delta, .. }),
+                        AgentEvent::Reasoning { delta: next, .. },
+                    )
+                    | (
+                        Some(AgentEvent::Stdout { chunk: delta, .. }),
+                        AgentEvent::Stdout { chunk: next, .. },
+                    ) => {
+                        delta.push_str(next);
+                        true
+                    }
+                    _ => false,
+                };
+                if !merged {
+                    events.push(event);
+                }
+            }
+            for event in events {
+                let json = match serde_json::to_string(&event) {
+                    Ok(json) => json,
+                    Err(error) => {
+                        tracing::warn!("serialize UI event failed: {error}");
+                        continue;
+                    }
+                };
+                if let Err(error) = store.append_session_ui_event(&fid, seq, &json).await {
+                    tracing::warn!("persist UI event {seq} failed: {error}");
+                } else {
+                    seq += 1;
+                }
+            }
+        });
+        (handle, tx)
+    };
+
     let output = TauriOutput {
         app: app.clone(),
         frame_id: frame_id.clone(),
@@ -2449,6 +2657,8 @@ async fn send_message(
         approvals: state.approvals.clone(),
         approval_grants: state.approval_grants.clone(),
         persist: Some(persist_tx),
+        ui_events: Some(ui_event_tx),
+        message_seq: std::sync::atomic::AtomicI64::new(start_seq),
         prov: Some(prov_tx),
     };
 
@@ -2483,6 +2693,12 @@ async fn send_message(
     // Close the persist channel and wait for the task to flush; its final seq is
     // the authoritative persisted count.
     drop(output);
+    if tokio::time::timeout(std::time::Duration::from_secs(5), ui_event_handle)
+        .await
+        .is_err()
+    {
+        tracing::warn!("UI event persistence did not finish cleanly");
+    }
     match tokio::time::timeout(std::time::Duration::from_secs(5), persist_handle).await {
         Ok(Ok(final_seq)) => rt.set_last_seq(final_seq),
         other => {
@@ -3624,6 +3840,11 @@ async fn load_session(
         .load_session_reviews(&id)
         .await
         .map_err(|e| format!("{e}"))?;
+    let event_json = state
+        .store
+        .load_session_ui_events(&id)
+        .await
+        .map_err(|e| format!("{e}"))?;
     // Track which session the UI is viewing. If a runtime exists for it (e.g.
     // it's mid-stream), keep the in-memory agent context authoritative — the UI
     // will render the cached streaming transcript instead of this DB snapshot.
@@ -3631,13 +3852,41 @@ async fn load_session(
     if let Some(rt) = state.sessions.lock().await.get(&id).cloned() {
         rt.set_last_seq(msgs.len() as i64);
     }
-    let mut items = messages_to_items(&msgs);
+    let events: Vec<AgentEvent> = event_json
+        .iter()
+        .map(|json| serde_json::from_str(json))
+        .collect::<Result<_, _>>()
+        .map_err(|e| format!("invalid persisted UI event: {e}"))?;
+    let (mut items, boundaries) = if events.is_empty() {
+        (messages_to_items(&msgs), HashMap::new())
+    } else {
+        let first_seq = events.iter().find_map(|event| match event {
+            AgentEvent::MessageBoundary { seq, .. } => Some(*seq),
+            _ => None,
+        });
+        let prefix_len = first_seq
+            .map(|seq| seq.saturating_sub(1) as usize)
+            .unwrap_or(msgs.len())
+            .min(msgs.len());
+        let mut prefix = messages_to_items(&msgs[..prefix_len]);
+        let prefix_items = prefix.len();
+        let (event_items, event_boundaries) = events_to_items(&events);
+        prefix.extend(event_items);
+        (
+            prefix,
+            event_boundaries
+                .into_iter()
+                .map(|(seq, offset)| (seq, prefix_items + offset))
+                .collect(),
+        )
+    };
     let mut inserted = 0usize;
     for (message_seq, report_json) in reviews {
         let report: review::ReviewReport = serde_json::from_str(&report_json)
             .map_err(|e| format!("invalid persisted review: {e}"))?;
-        let at = messages_to_items(&msgs[..(message_seq.max(0) as usize).min(msgs.len())]).len()
-            + inserted;
+        let at = boundaries.get(&message_seq).copied().unwrap_or_else(|| {
+            messages_to_items(&msgs[..(message_seq.max(0) as usize).min(msgs.len())]).len()
+        }) + inserted;
         items.insert(
             at,
             UiItem {
@@ -3645,6 +3894,7 @@ async fn load_session(
                 text: serde_json::to_string(&report).map_err(|e| format!("{e}"))?,
                 tool_name: None,
                 ok: None,
+                duration_ms: None,
                 input: None,
                 model_name: None,
                 call_id: None,

--- a/src-tauri/src/lib_tests.rs
+++ b/src-tauri/src/lib_tests.rs
@@ -1,9 +1,10 @@
 use super::{
-    branch_title, copy_dir_recursive, messages_to_items, parse_disabled_skills,
+    branch_title, copy_dir_recursive, events_to_items, messages_to_items, parse_disabled_skills,
     parse_enabled_skill_names, parse_skill_tags, resolve_acp_artifact_references,
     resolve_composer_references, resolve_workspace, session_runtime_status,
     should_hide_app_on_macos_close, side_chat_prompt, update_check_from_release,
-    user_message_start, ComposerReferenceArg, GithubRelease, McpConnection, McpTransport,
+    user_message_start, AgentEvent, ComposerReferenceArg, GithubRelease, McpConnection,
+    McpTransport,
 };
 use std::collections::HashSet;
 use std::path::PathBuf;
@@ -56,6 +57,57 @@ fn reloaded_tool_items_keep_notebook_source() {
     assert_eq!(items[0].tool_name.as_deref(), Some("python"));
     assert_eq!(items[0].input.as_deref(), Some("print(1)"));
     assert_eq!(items[0].text, "1");
+}
+
+#[test]
+fn persisted_ui_events_keep_live_step_order_and_boundaries() {
+    let frame_id = "f".to_string();
+    let events = vec![
+        AgentEvent::User {
+            frame_id: frame_id.clone(),
+            text: "question".into(),
+        },
+        AgentEvent::MessageBoundary {
+            frame_id: frame_id.clone(),
+            seq: 1,
+        },
+        AgentEvent::Text {
+            frame_id: frame_id.clone(),
+            delta: "I will check.".into(),
+        },
+        AgentEvent::Reasoning {
+            frame_id: frame_id.clone(),
+            delta: "thinking".into(),
+        },
+        AgentEvent::ToolCall {
+            frame_id: frame_id.clone(),
+            name: "shell".into(),
+            preview: "pwd".into(),
+        },
+        AgentEvent::MessageBoundary {
+            frame_id: frame_id.clone(),
+            seq: 2,
+        },
+        AgentEvent::ToolResult {
+            frame_id: frame_id.clone(),
+            name: "shell".into(),
+            ok: true,
+            content: "/tmp".into(),
+            duration_ms: 12,
+        },
+        AgentEvent::MessageBoundary { frame_id, seq: 3 },
+    ];
+
+    let (items, boundaries) = events_to_items(&events);
+    assert_eq!(
+        items
+            .iter()
+            .map(|item| item.role.as_str())
+            .collect::<Vec<_>>(),
+        vec!["user", "assistant", "reasoning", "tool"]
+    );
+    assert_eq!(items[3].text, "/tmp");
+    assert_eq!(boundaries.get(&2), Some(&4));
 }
 
 #[tokio::test]

--- a/ui/src/dto.rs
+++ b/ui/src/dto.rs
@@ -18,6 +18,10 @@ pub(crate) enum AgentEvent {
         frame_id: String,
         text: String,
     },
+    MessageBoundary {
+        frame_id: String,
+        seq: i64,
+    },
     Text {
         frame_id: String,
         delta: String,
@@ -467,6 +471,8 @@ pub(crate) struct LoadedItem {
     pub(crate) tool_name: Option<String>,
     pub(crate) ok: Option<bool>,
     #[serde(default)]
+    pub(crate) duration_ms: Option<u64>,
+    #[serde(default)]
     pub(crate) input: String,
     #[serde(default)]
     pub(crate) model_name: Option<String>,
@@ -505,7 +511,7 @@ impl LoadedItem {
                 input: self.input,
                 output: self.text,
                 started_at_ms: None,
-                duration_ms: None,
+                duration_ms: self.duration_ms,
             },
             _ => ChatItem::Assistant {
                 text: self.text,

--- a/ui/src/dto.rs
+++ b/ui/src/dto.rs
@@ -485,6 +485,12 @@ impl LoadedItem {
         match self.role.as_str() {
             "user" => ChatItem::User(self.text),
             "reasoning" => ChatItem::Reasoning(self.text),
+            "review" => serde_json::from_str(&self.text)
+                .map(ChatItem::Review)
+                .unwrap_or_else(|_| ChatItem::Assistant {
+                    text: self.text,
+                    model: None,
+                }),
             "acp_tool" => ChatItem::AcpTool {
                 call_id: self.call_id.unwrap_or_default(),
                 title: self.tool_name.unwrap_or_else(|| "ACP tool".into()),

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -991,6 +991,7 @@ fn App() -> impl IntoView {
                     start_user_turn(v, text, model);
                 })
             }
+            AgentEvent::MessageBoundary { .. } => {}
             AgentEvent::Text { frame_id, delta } => queue(frame_id, PendingDelta::Text(delta)),
             AgentEvent::Reasoning { frame_id, delta } => {
                 queue(frame_id, PendingDelta::Reasoning(delta))


### PR DESCRIPTION
## Problem

Live sessions render conversation text, execution steps, and reviewer cards from ordered agent events, but reloaded sessions previously rebuilt only from `messages`. Closing and reopening a session therefore changed step grouping and discarded reviewer results.

## Changes

- add idempotent `session_reviews` persistence keyed by review ID and message position
- persist automatic, follow-up, and manual reviewer reports and restore them in `load_session`
- add compressed `session_ui_events` for the display-relevant event order and stable message boundaries
- restore reasoning, assistant text, tool calls/results, stdout, status, output, and tool duration from those events
- retain message-based reconstruction for existing history and splice event-backed turns onto it
- truncate review/event state together with transcript rollback
- add store and Tauri regression coverage for upsert/truncation and live-order reconstruction

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p wisp-store --lib -- --skip secrets::tests::set_get_delete_roundtrip` (26 passed)
- `cargo test -p wisp-tauri --lib -- --skip models::tests::credential_registry_roundtrip --skip models::tests::secret_cache_write_through` (102 passed)
- `cargo check -p wisp-tauri`
- `cd ui && cargo check --target wasm32-unknown-unknown`

The skipped keyring tests fail in the sandbox because its keyring path is read-only.

## Manual smoke

1. Run a turn that emits reasoning and at least one tool call.
2. Let automatic review finish, including a correction pass if findings exist.
3. Close and reopen the app/session.
4. Confirm text and execution steps retain their ordering/grouping and the reviewer card retains its report and resolved state.

## Known limitation

Sessions created before this migration remain readable, but event order, duration, and review data that were never persisted cannot be reconstructed retroactively. New turns use the durable event layout.