### PR TITLE
fix: download remote artifacts over SSH

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3397,6 +3397,20 @@ async fn pick_directory(app: AppHandle) -> Result<Option<String>, String> {
 
 /// Copy a workspace file to a user-chosen location via the native save dialog.
 /// Returns the saved path, or `None` if the user cancelled.
+fn parse_ssh_artifact_uri(uri: &str) -> Option<(String, String)> {
+    let rest = uri.strip_prefix("ssh://")?;
+    let (context, path) = rest.split_once('/')?;
+    if context.is_empty() || path.is_empty() {
+        return None;
+    }
+    let remote_path = if path.starts_with("~/") {
+        path.to_string()
+    } else {
+        format!("/{path}")
+    };
+    Some((format!("ssh:{context}"), remote_path))
+}
+
 #[tauri::command]
 async fn download_file(
     app: AppHandle,
@@ -3405,19 +3419,27 @@ async fn download_file(
     path: String,
 ) -> Result<Option<String>, String> {
     use tauri_plugin_dialog::DialogExt;
-    // Resolve + validate against the active workspace root, same as read_file.
-    let real = {
+    let remote = parse_ssh_artifact_uri(&path);
+    let local = if remote.is_none() {
         let ap = state.active(window.label());
-        wisp_tools::safety::validate_file_path(&ap.root, &path)?
+        let real = wisp_tools::safety::validate_file_path(&ap.root, &path)?;
+        if !real.is_file() {
+            return Err(format!("file not found: {path}"));
+        }
+        Some(real)
+    } else {
+        None
     };
-    if !real.is_file() {
-        return Err(format!("file not found: {path}"));
-    }
-    let default_name = real
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("download")
-        .to_string();
+    let default_name = std::path::Path::new(
+        remote
+            .as_ref()
+            .map(|(_, path)| path.as_str())
+            .unwrap_or_else(|| local.as_ref().unwrap().to_str().unwrap_or("download")),
+    )
+    .file_name()
+    .and_then(|n| n.to_str())
+    .unwrap_or("download")
+    .to_string();
     let (tx, rx) = tokio::sync::oneshot::channel();
     app.dialog()
         .file()
@@ -3429,9 +3451,22 @@ async fn download_file(
         return Ok(None); // user cancelled
     };
     let dest_path = std::path::PathBuf::from(dest.to_string());
-    tokio::fs::copy(&real, &dest_path)
-        .await
-        .map_err(|e| format!("copy failed: {e}"))?;
+    if let Some((context_id, remote_path)) = remote {
+        let context = state
+            .store
+            .get_execution_context(&context_id)
+            .await
+            .map_err(|e| format!("{e}"))?
+            .ok_or_else(|| format!("SSH execution context not found: {context_id}"))?;
+        state
+            .run_manager
+            .download_ssh_file(&context, &remote_path, &dest_path)
+            .await?;
+    } else {
+        tokio::fs::copy(local.unwrap(), &dest_path)
+            .await
+            .map_err(|e| format!("copy failed: {e}"))?;
+    }
     Ok(Some(dest_path.to_string_lossy().into_owned()))
 }
 

--- a/src-tauri/src/lib_tests.rs
+++ b/src-tauri/src/lib_tests.rs
@@ -1,10 +1,10 @@
 use super::{
     branch_title, copy_dir_recursive, events_to_items, messages_to_items, parse_disabled_skills,
-    parse_enabled_skill_names, parse_skill_tags, resolve_acp_artifact_references,
-    resolve_composer_references, resolve_workspace, session_runtime_status,
-    should_hide_app_on_macos_close, side_chat_prompt, update_check_from_release,
-    user_message_start, AgentEvent, ComposerReferenceArg, GithubRelease, McpConnection,
-    McpTransport,
+    parse_enabled_skill_names, parse_skill_tags, parse_ssh_artifact_uri,
+    resolve_acp_artifact_references, resolve_composer_references, resolve_workspace,
+    session_runtime_status, should_hide_app_on_macos_close, side_chat_prompt,
+    update_check_from_release, user_message_start, AgentEvent, ComposerReferenceArg, GithubRelease,
+    McpConnection, McpTransport,
 };
 use std::collections::HashSet;
 use std::path::PathBuf;
@@ -57,6 +57,19 @@ fn reloaded_tool_items_keep_notebook_source() {
     assert_eq!(items[0].tool_name.as_deref(), Some("python"));
     assert_eq!(items[0].input.as_deref(), Some("print(1)"));
     assert_eq!(items[0].text, "1");
+}
+
+#[test]
+fn ssh_artifact_uri_maps_to_execution_context_and_remote_path() {
+    assert_eq!(
+        parse_ssh_artifact_uri("ssh://CPU/home/xzg/results.tar.gz"),
+        Some(("ssh:CPU".into(), "/home/xzg/results.tar.gz".into()))
+    );
+    assert_eq!(
+        parse_ssh_artifact_uri("ssh://CPU/~/results.tar.gz"),
+        Some(("ssh:CPU".into(), "~/results.tar.gz".into()))
+    );
+    assert_eq!(parse_ssh_artifact_uri("ssh://CPU"), None);
 }
 
 #[test]

--- a/src-tauri/src/run_context.rs
+++ b/src-tauri/src/run_context.rs
@@ -198,6 +198,48 @@ impl RunManager {
         }
     }
 
+    pub async fn download_ssh_file(
+        &self,
+        context: &wisp_store::ExecutionContext,
+        remote_path: &str,
+        destination: &std::path::Path,
+    ) -> Result<(), String> {
+        if remote_path.is_empty() || remote_path.contains(['\0', '\n', '\r']) {
+            return Err("Invalid remote file path".into());
+        }
+        let connection = crate::ssh_hosts::SshConnection::from_execution_context(context)?;
+        let mut args = connection.scp_option_args()?;
+        args.push(format!("{}:{remote_path}", connection.target()?));
+        args.push(destination.to_string_lossy().into_owned());
+        let output = self
+            .runner
+            .run(
+                RunCommand {
+                    context_id: context.id.clone(),
+                    program: "scp".into(),
+                    args,
+                    script: format!("download {remote_path}"),
+                    cwd: destination.parent().map(std::path::Path::to_path_buf),
+                    stdin: None,
+                },
+                Duration::from_secs(4 * 60 * 60),
+            )
+            .await?;
+        if output.exit_code == 0 {
+            Ok(())
+        } else {
+            let detail = if output.stderr.trim().is_empty() {
+                output.stdout.trim()
+            } else {
+                output.stderr.trim()
+            };
+            Err(format!(
+                "scp download failed (exit {}): {detail}",
+                output.exit_code
+            ))
+        }
+    }
+
     pub async fn recover(&self, store: &wisp_store::Store) -> Result<u64, String> {
         self.start_reconciler(store.clone());
         self.reconcile_once(store).await

--- a/src-tauri/src/run_context/tests.rs
+++ b/src-tauri/src/run_context/tests.rs
@@ -576,6 +576,45 @@ fn ok_output(stdout: &str) -> Result<RunCommandOutput, String> {
     })
 }
 
+#[tokio::test]
+async fn ssh_download_uses_context_connection_options() {
+    let runner = Arc::new(ScriptedRunRunner::new(vec![ok_output("")]));
+    let manager = RunManager::with_runner(runner.clone());
+    let mut context = wisp_store::ExecutionContext::new("ssh:CPU", "CPU").unwrap();
+    context.config_json = serde_json::json!({
+        "alias": "cpu.example",
+        "user": "alice",
+        "port": 2222,
+        "identity_file": "/keys/cpu"
+    })
+    .to_string();
+    let destination = std::env::temp_dir().join("results.tar.gz");
+
+    manager
+        .download_ssh_file(&context, "/data/results.tar.gz", &destination)
+        .await
+        .unwrap();
+
+    let commands = runner.commands.lock().unwrap();
+    assert_eq!(commands.len(), 1);
+    assert_eq!(commands[0].program, "scp");
+    assert!(commands[0]
+        .args
+        .windows(2)
+        .any(|args| args == ["-P", "2222"]));
+    assert!(commands[0]
+        .args
+        .windows(2)
+        .any(|args| args == ["-i", "/keys/cpu"]));
+    assert_eq!(
+        &commands[0].args[commands[0].args.len() - 2..],
+        [
+            "alice@cpu.example:/data/results.tar.gz".to_string(),
+            destination.to_string_lossy().into_owned()
+        ]
+    );
+}
+
 fn poll_response(status: &str, stdout: &str, stderr: &str) -> String {
     format!("__WISP_RUN_STATUS__:{status}\n__WISP_STDOUT__\n{stdout}\n__WISP_STDERR__\n{stderr}\n")
 }


### PR DESCRIPTION
## Problem

SSH run outputs are registered as durable `ssh://<context>/<path>` artifact references, but the artifact Download action only accepts local workspace paths. In the attached session this forced the agent through failed remote-reference and base64/stdout workarounds before it eventually invoked Windows `scp` directly.

## Changes

- teach the existing `download_file` command to recognize SSH artifact URIs
- support both absolute paths (`ssh://CPU/home/user/file`) and home-relative paths (`ssh://CPU/~/file`)
- resolve the matching SSH `ExecutionContext` and reuse its alias, user, port, and identity-file settings
- transfer into the user-selected save path through the existing injectable run command runner
- preserve the current validated local-workspace copy behavior for local artifacts
- return SCP exit status and stderr when the transfer fails

## Tests

- URI parsing covers absolute paths, home-relative paths, and malformed references
- command-runner regression test verifies SCP uses the configured user, port, identity file, source, and destination
- `cargo fmt --all -- --check`
- `cargo test -p wisp-tauri --lib -- --skip models::tests::credential_registry_roundtrip --skip models::tests::secret_cache_write_through` (104 passed)
- `cargo check -p wisp-tauri`
- `cd ui && cargo check --target wasm32-unknown-unknown`

The two skipped keyring tests require a writable OS keyring path, which is unavailable in the sandbox. No real SSH host is required by the automated tests.

## Manual smoke

1. Complete an SSH run with an explicit `ssh://` output spec.
2. Open the resulting remote artifact and click Download.
3. Choose a local destination.
4. Confirm SCP completes and the downloaded bytes match the remote file.
5. Repeat with a context using a non-default SSH port or identity file.