### PR TITLE
fix(ui): preserve artifact previews when opening in center

### DIFF
--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -204,6 +204,7 @@ export function tauriMock(): void {
     { id: "art-profile", name: "plddt_profile.png", kind: "image/png", path: "plddt_profile.png", ts: Math.floor(Date.now() / 1000), project_id: "default", project_name: "wisp-science", session_id: "s-old", session_title: "Older structure run", origin: "output" },
     { id: "art-counts", name: "counts.csv", kind: "text/csv", path: "counts.csv", ts: Math.floor(Date.now() / 1000), project_id: "other", project_name: "Other project", session_id: "s-other", session_title: "Cross-project counts", origin: "upload" },
     { id: "art-html", name: "dashboard.html", kind: "text/html", path: "dashboard.html", ts: Math.floor(Date.now() / 1000), project_id: "default", project_name: "wisp-science", session_id: "s-current", session_title: "Current analysis", origin: "output" },
+    { id: "art-markdown", name: "analysis-report.md", kind: "text/markdown", path: "analysis-report.md", ts: Math.floor(Date.now() / 1000), project_id: "default", project_name: "wisp-science", session_id: "s-current", session_title: "Current analysis", origin: "output" },
   ];
 
   (window as any).__TAURI__ = {
@@ -508,6 +509,9 @@ export function tauriMock(): void {
           case "read_artifact":
             if (arg("id") === "art-html") {
               return { path: "artifact:art-html", mime: "text/html", text: '<style>#mode::after{content:"Desktop"}@media(max-width:900px){#mode::after{content:"Mobile"}}</style><div id="mode"></div>', base64: null };
+            }
+            if (arg("id") === "art-markdown") {
+              return { path: "artifact:art-markdown", mime: "text/markdown", text: "# Differential expression report\n\nRendered Markdown body.", base64: null };
             }
             return { path: `artifact:${arg("id")}`, mime: "text/csv", text: "a,b\n1,2", base64: null };
           case "missing_files": {

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -1327,6 +1327,25 @@ test("HTML artifact modal uses a desktop preview viewport", async ({ page }) => 
   )).toBe('"Desktop"');
 });
 
+test("Markdown artifact modal opens its rendered preview in center", async ({ page }) => {
+  await page.goto("/");
+  await page.getByRole("button", { name: "Search" }).click();
+  const search = commandPalette(page);
+  await search.fill("analysis-report");
+  await search.press("Enter");
+
+  const modal = page.locator(".artifact-modal");
+  await expect(modal).toBeVisible();
+  await expect(modal.locator(".am-name")).toHaveText("analysis-report.md");
+  await expect(modal.locator(".am-figure h1")).toHaveText("Differential expression report");
+  await modal.getByRole("button", { name: "Open in center" }).click();
+
+  await expect(modal).toHaveCount(0);
+  await expect(page.locator('.center-tab[data-center-path="artifact:art-markdown"]')).toContainText("analysis-report.md");
+  await expect(page.locator(".center-file-preview h1")).toHaveText("Differential expression report");
+  await expect(page.locator(".center-file-preview")).toContainText("Rendered Markdown body.");
+});
+
 test("projects landing stays centered on wide windows", async ({ page }) => {
   await page.setViewportSize({ width: 1600, height: 900 });
   await page.goto("/");

--- a/ui/src/app_support.rs
+++ b/ui/src/app_support.rs
@@ -2002,6 +2002,25 @@ pub(super) fn contains_search(q: &str, parts: &[&str]) -> bool {
 
 pub(super) type ModalArtifact = (String, String, String);
 
+#[derive(Clone, PartialEq, Eq)]
+pub(super) struct CenterFileTab {
+    pub(super) path: String,
+    pub(super) name: String,
+    pub(super) kind: String,
+}
+
+impl CenterFileTab {
+    pub(super) fn new(path: String, name: String, kind: String) -> Self {
+        Self { path, name, kind }
+    }
+
+    pub(super) fn from_path(path: String) -> Self {
+        let name = path.rsplit(['/', '\\']).next().unwrap_or(&path).to_string();
+        let kind = file_kind(&path).unwrap_or("text").to_string();
+        Self { path, name, kind }
+    }
+}
+
 pub(super) fn open_workspace_file(path: String, modal_artifact: RwSignal<Option<ModalArtifact>>) {
     let name = path.rsplit(['/', '\\']).next().unwrap_or(&path).to_string();
     let kind = file_kind(&path).unwrap_or("text").to_string();
@@ -3493,7 +3512,7 @@ pub(super) fn ArtifactModal(
     on_prev: Callback<()>,
     on_next: Callback<()>,
     on_close: Callback<()>,
-    on_open_center: Callback<String>,
+    on_open_center: Callback<ModalArtifact>,
     on_open_path: Callback<(String, String)>, // open an input file (path, kind)
 ) -> impl IntoView {
     let locale = use_locale();
@@ -3516,7 +3535,7 @@ pub(super) fn ArtifactModal(
     }
     let path_head = path.clone();
     let path_dl = path.clone();
-    let path_center = path.clone();
+    let center_artifact = (path.clone(), name.clone(), kind.clone());
     let is_html = kind == "html";
     let is_zoomable = matches!(kind.as_str(), "image" | "pdf");
     view! {
@@ -3539,8 +3558,10 @@ pub(super) fn ArtifactModal(
                         </div>
                     })}
                     <div class="spacer"></div>
-                    <button class="icon-btn" title=move || t(locale.get(), "center.open_file")
-                        on:click=move |_| on_open_center.call(path_center.clone())>{compose_icon("expand")}</button>
+                    <button type="button" class="icon-btn"
+                        aria-label=move || t(locale.get(), "center.open_file")
+                        title=move || t(locale.get(), "center.open_file")
+                        on:click=move |_| on_open_center.call(center_artifact.clone())>{compose_icon("expand")}</button>
                     <button class="icon-btn" title=move || t(locale.get(), "artifact.download")
                         on:click=move |_| download_artifact(path_dl.clone())>{compose_icon("download")}</button>
                     <button class="icon-btn" title=move || t(locale.get(), "right.close")
@@ -3702,6 +3723,7 @@ pub(super) fn compose_icon(kind: &str) -> impl IntoView {
         "chevron-down" => view! { <path d="m6 9 6 6 6-6"/> }.into_view(),
         "chevron-left" => view! { <path d="m15 18-6-6 6-6"/> }.into_view(),
         "chevron-right" => view! { <path d="m9 18 6-6-6-6"/> }.into_view(),
+        "expand" => view! { <path d="M15 3h6v6"/><path d="m21 3-7 7"/><path d="M9 21H3v-6"/><path d="m3 21 7-7"/> }.into_view(),
         "download" => view! { <path d="M12 3v12"/><path d="m7 10 5 5 5-5"/><path d="M5 21h14"/> }.into_view(),
         "close" => view! { <path d="M18 6 6 18"/><path d="m6 6 12 12"/> }.into_view(),
         "more" => view! { <circle cx="12" cy="5" r="1" fill="currentColor" stroke="none"/><circle cx="12" cy="12" r="1" fill="currentColor" stroke="none"/><circle cx="12" cy="19" r="1" fill="currentColor" stroke="none"/> }.into_view(),

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -34,9 +34,9 @@ use std::collections::VecDeque;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 use text::{
-    dom_value, event_target_checked, event_target_value, file_kind, format_bytes,
-    format_duration_ms, group_artifact_indices, join_path, md_to_html, opens_in_system_browser,
-    parent_path, provider_defaults, provider_value,
+    dom_value, event_target_checked, event_target_value, format_bytes, format_duration_ms,
+    group_artifact_indices, join_path, md_to_html, opens_in_system_browser, parent_path,
+    provider_defaults, provider_value,
 };
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
@@ -682,10 +682,10 @@ fn App() -> impl IntoView {
     let file_cwd = create_rw_signal(".".to_string());
     let file_entries = create_rw_signal::<Vec<DirEntry>>(vec![]);
     let file_search_hits = create_rw_signal::<Vec<FileSearchHit>>(vec![]);
-    let center_files = create_rw_signal::<Vec<String>>(vec![]);
+    let center_files = create_rw_signal::<Vec<CenterFileTab>>(vec![]);
     let center_file = create_rw_signal::<Option<String>>(None);
     let center_tabs_by_session =
-        create_rw_signal::<HashMap<String, (Vec<String>, Option<String>)>>(HashMap::new());
+        create_rw_signal::<HashMap<String, (Vec<CenterFileTab>, Option<String>)>>(HashMap::new());
     let previous_center_session = Rc::new(RefCell::new(None::<String>));
     create_effect(move |_| {
         let current_session = active_session.get();
@@ -2853,16 +2853,17 @@ fn App() -> impl IntoView {
                 return;
             }
             if action == "openWorkspaceFileCenter" {
+                let tab = CenterFileTab::from_path(payload.clone());
                 center_files.update(|files| {
-                    if !files.contains(&payload) {
-                        files.push(payload.clone());
+                    if !files.iter().any(|file| file.path == payload) {
+                        files.push(tab.clone());
                     }
                 });
                 center_file.set(Some(payload));
                 return;
             }
             if action == "closeCenterCurrent" {
-                center_files.update(|files| files.retain(|path| path != &payload));
+                center_files.update(|files| files.retain(|file| file.path != payload));
                 if center_file.get_untracked().as_ref() == Some(&payload) {
                     center_file.set(None);
                 }
@@ -2870,13 +2871,14 @@ fn App() -> impl IntoView {
             }
             if action == "closeCenterRight" {
                 center_files.update(|files| {
-                    if let Some(index) = files.iter().position(|path| path == &payload) {
+                    if let Some(index) = files.iter().position(|file| file.path == payload) {
                         files.truncate(index + 1);
                     }
                 });
                 if !center_files
                     .get_untracked()
-                    .contains(&center_file.get_untracked().unwrap_or_default())
+                    .iter()
+                    .any(|file| Some(&file.path) == center_file.get_untracked().as_ref())
                 {
                     center_file.set(Some(payload));
                 }
@@ -3634,11 +3636,12 @@ fn App() -> impl IntoView {
                 </button>
                 <For
                     each=move || center_files.get()
-                    key=|path| path.clone()
-                    children=move |path| {
+                    key=|file| file.path.clone()
+                    children=move |file| {
+                        let path = file.path;
                         let select_path = path.clone();
                         let close_path = path.clone();
-                        let label = path.rsplit(['/', '\\']).next().unwrap_or(&path).to_string();
+                        let label = file.name;
                         view! {
                             <div class="center-tab-wrap">
                                 <button type="button" class="center-tab" class:active=move || center_file.get().as_ref() == Some(&path)
@@ -3651,7 +3654,7 @@ fn App() -> impl IntoView {
                                     on:click=move |ev| {
                                         ev.stop_propagation();
                                         let was_active = center_file.get_untracked().as_ref() == Some(&close_path);
-                                        center_files.update(|files| files.retain(|p| p != &close_path));
+                                        center_files.update(|files| files.retain(|file| file.path != close_path));
                                         if was_active { center_file.set(None); }
                                     }>{compose_icon("close")}</button>
                             </div>
@@ -3713,13 +3716,14 @@ fn App() -> impl IntoView {
                     }><span class="gi panel"></span></button>
             </div>
 
-            {move || center_file.get().map(|path| {
-                let kind = file_kind(&path).unwrap_or("text").to_string();
-                let dom_id = format!("center-file-{path}");
+            {move || center_file.get().and_then(|path| {
+                center_files.get().into_iter().find(|file| file.path == path)
+            }).map(|file| {
+                let dom_id = format!("center-file-{}", file.path);
                 view! {
                     <div class="center-file-preview">
-                        <div class="center-file-head"><span>{path.clone()}</span></div>
-                        <WorkspaceFilePreview dom_id=dom_id path=path kind=kind />
+                        <div class="center-file-head"><span>{file.path.clone()}</span></div>
+                        <WorkspaceFilePreview dom_id=dom_id path=file.path kind=file.kind />
                     </div>
                 }
             })}
@@ -4658,7 +4662,8 @@ fn App() -> impl IntoView {
                                                 let (mi, cx, cy) = artifact_menu.get()?;
                                                 (mi == i).then(|| {
                                                 let (p, n, k) = (path.clone(), vn.clone(), fkind.clone());
-                                                let (mv, sp, dw, oc) = (p.clone(), p.clone(), p.clone(), p.clone());
+                                                let (mv, sp, dw) = (p.clone(), p.clone(), p.clone());
+                                                let oc = CenterFileTab::new(p.clone(), n.clone(), k.clone());
                                                 let (mvn, mvk) = (n.clone(), k.clone());
                                                 view! {
                                                     <div class="rp-tile-menu-backdrop" on:click=move |_| artifact_menu.set(None)></div>
@@ -4671,9 +4676,11 @@ fn App() -> impl IntoView {
                                                             on:click=move |_| {
                                                                 artifact_menu.set(None);
                                                                 center_files.update(|files| {
-                                                                    if !files.contains(&oc) { files.push(oc.clone()); }
+                                                                    if !files.iter().any(|file| file.path == oc.path) {
+                                                                        files.push(oc.clone());
+                                                                    }
                                                                 });
-                                                                center_file.set(Some(oc.clone()));
+                                                                center_file.set(Some(oc.path.clone()));
                                                             }>
                                                             {move || t(locale.get(), "center.open_file")}</button>
                                                         <button type="button" class="rp-tile-menu-item"
@@ -5457,11 +5464,15 @@ fn App() -> impl IntoView {
                         }
                     })
                     on_close=Callback::new(move |_| modal_artifact.set(None))
-                    on_open_center=Callback::new(move |path: String| {
+                    on_open_center=Callback::new(move |(path, name, kind): ModalArtifact| {
+                        let tab = CenterFileTab::new(path.clone(), name, kind);
                         center_files.update(|files| {
-                            if !files.contains(&path) { files.push(path.clone()); }
+                            if !files.iter().any(|file| file.path == path) {
+                                files.push(tab.clone());
+                            }
                         });
                         center_file.set(Some(path));
+                        show_projects.set(false);
                         modal_artifact.set(None);
                     })
                     on_open_path=Callback::new(move |(p, _k): (String, String)| {


### PR DESCRIPTION
## Problem

Artifact modals could lose the original preview type when opening an artifact-backed file in the center. Persisted artifacts use paths such as `artifact:<id>`, so recomputing the type from the path treated Markdown as plain text. Opening from the projects landing page could also leave the center workspace hidden.

## Changes

- store the path, display name, and preview kind in each center file tab
- pass complete artifact metadata from the modal into the center workspace
- reveal the workspace when opening an artifact from the projects landing page
- add a visible, accessible expand icon for the modal action
- add a Playwright regression covering rendered Markdown opened from a persisted artifact

## User impact

Markdown and other artifact-backed preview types now keep their renderer when moved from a modal into the center, regardless of whether the artifact path has a file extension.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --target wasm32-unknown-unknown` in `ui/`
- `cargo test --workspace`
- `npm ci && npx playwright test` in `ui-tests/` (78 passed)

## Manual smoke

1. Open Search from the projects landing page.
2. Open a Markdown artifact.
3. Select **Open in center**.
4. Confirm the modal closes, the workspace appears, and Markdown remains rendered.

## Known limitations

Center tabs remain in-memory per conversation and are not restored after an application restart; this is unchanged by this fix.

## Follow-up

None required.