### PR TITLE
feat(ui): add GitHub star footer on home screen

### DIFF
--- a/ui/src/app_support.rs
+++ b/ui/src/app_support.rs
@@ -4693,6 +4693,13 @@ pub(super) fn ProjectsScreen(
                     }).collect_view()}
                 </div>
             </div>
+            <div class="projects-footer">
+                <span>{move || t(locale.get(), "projects.star_hint")}</span>
+                <button type="button" class="projects-star-link"
+                    on:click=move |_| open_external_url("https://github.com/xuzhougeng/wisp-science".into())>
+                    {move || t(locale.get(), "projects.star_link")}
+                </button>
+            </div>
             {move || pending_delete.get().map(|id| {
                 let confirm_del = delete_confirmed.clone();
                 view! {

--- a/ui/src/i18n.rs
+++ b/ui/src/i18n.rs
@@ -647,6 +647,8 @@ fn lookup(locale: Locale, key: &str) -> Option<&'static str> {
         (Locale::En, "projects.delete_confirm") => Some("Remove this project from Wisp? Your files on disk are kept."),
         (Locale::En, "projects.open_failed") => Some("Could not open the project: {msg}"),
         (Locale::En, "projects.back") => Some("Projects"),
+        (Locale::En, "projects.star_hint") => Some("If Wisp is helpful to your work, please"),
+        (Locale::En, "projects.star_link") => Some("give us a star on GitHub ★"),
 
         (Locale::En, "proj_menu.settings") => Some("Project settings"),
         (Locale::En, "proj_settings.title") => Some("Project Settings"),
@@ -1249,6 +1251,8 @@ fn lookup(locale: Locale, key: &str) -> Option<&'static str> {
         (Locale::Zh, "projects.delete_confirm") => Some("从 Wisp 移除该项目？磁盘上的文件会保留。"),
         (Locale::Zh, "projects.open_failed") => Some("无法打开项目：{msg}"),
         (Locale::Zh, "projects.back") => Some("项目"),
+        (Locale::Zh, "projects.star_hint") => Some("如果 Wisp 对你的工作有帮助，欢迎到"),
+        (Locale::Zh, "projects.star_link") => Some("GitHub 点个 Star ★"),
 
         (Locale::Zh, "proj_menu.settings") => Some("项目设置"),
         (Locale::Zh, "proj_settings.title") => Some("项目设置"),

--- a/ui/src/styles/projects.css
+++ b/ui/src/styles/projects.css
@@ -18,6 +18,11 @@ body:has(.window-titlebar) .projects-screen { top: 38px; }
 .projects-icon-btn .gi { width: 18px; height: 18px; opacity: .95; }
 .new-plus { margin-right: 2px; font-size: 18px; line-height: 0; }
 .projects-cols { display: grid; grid-template-columns: 1fr 1fr; gap: 40px; width: min(100%, 1200px); }
+.projects-footer { margin-top: auto; padding-top: 40px; display: flex; gap: 6px; align-items: center; flex-wrap: wrap;
+  justify-content: center; font-size: 13px; color: var(--text-faint); }
+.projects-star-link { background: transparent; border: none; padding: 0; font-size: 13px; color: var(--clay);
+  cursor: pointer; text-decoration: underline; text-underline-offset: 2px; }
+.projects-star-link:hover { opacity: .8; }
 .projects-col:first-child { animation: motion-surface-in var(--motion-duration-medium) var(--motion-ease-decelerate) 70ms both; }
 .projects-col:last-child { animation: motion-surface-in var(--motion-duration-medium) var(--motion-ease-decelerate) 120ms both; }
 .projects-col h2 { font-size: 18px; margin-bottom: 14px; display: flex; align-items: center; gap: 8px; color: var(--text); }


### PR DESCRIPTION
## What changed
在首页（projects landing screen）最下方新增一个居中页脚，邀请用户到 GitHub 给项目点 Star。

- **app_support.rs** — 在 `projects-cols` 下方加页脚，点击链接复用现成的 `open_external_url` 在外部浏览器打开 `github.com/xuzhougeng/wisp-science`
- **i18n.rs** — 新增 En/Zh 文案（`projects.star_hint` / `projects.star_link`）
- **projects.css** — `.projects-footer` 用 `margin-top:auto` 顶到页面底部并居中，链接用品牌色 `--clay`

## Why
首页底部空白，加一个低干扰的 star 引导。

## Notes for reviewer
- `cargo check` 已通过。
- 这是 WASM(Trunk) 前端，无对应 launch 配置，未在浏览器预览验证渲染；需 `trunk serve` 手动确认。
- 未做独立星标图标或 star 计数，保持最小改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)