### PR TITLE
feat(ui): show app version in titlebar, command palette, settings

### DIFF
--- a/ui/src/app_support.rs
+++ b/ui/src/app_support.rs
@@ -5179,7 +5179,7 @@ pub(super) fn CommandPalette(
                             }
                         }).collect_view()}
                     </div>
-                    <div class="project-search-foot"><span><kbd>"↑↓"</kbd>"navigate"</span><span><kbd>"↵"</kbd>"open"</span><span><kbd>"⇧↵"</kbd>"attach"</span><span><kbd>"esc"</kbd>"close"</span></div>
+                    <div class="project-search-foot"><span><kbd>"↑↓"</kbd>"navigate"</span><span><kbd>"↵"</kbd>"open"</span><span><kbd>"⇧↵"</kbd>"attach"</span><span><kbd>"esc"</kbd>"close"</span><span class="palette-version">{concat!("v", env!("CARGO_PKG_VERSION"))}</span></div>
                 </div>
             </div>
         })}

--- a/ui/src/settings_view.rs
+++ b/ui/src/settings_view.rs
@@ -430,6 +430,7 @@ pub(super) fn SettingsView(
                                 class:fail=move || !ok>{text}</div>
                         })}
                         <div class="row settings-footer">
+                                <span class="settings-version">{concat!("wisp-science v", env!("CARGO_PKG_VERSION"))}</span>
                                 <button type="button" disabled=move || settings_busy.get() on:click=move |ev| check_updates.call(ev)>{move || t(locale.get(), "settings.check_updates")}</button>
                             <button type="button" disabled=move || settings_busy.get() on:click=move |_| show_settings.set(false)>{move || t(locale.get(), "settings.cancel")}</button>
                                 <button type="button" class="primary" disabled=move || settings_busy.get() on:click=move |ev| save_settings.call(ev)>{move || t(locale.get(), "settings.save")}</button>

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -277,6 +277,7 @@ html, body {
 }
 .window-brand { display: flex; align-items: center; gap: 7px; padding: 0 12px; font-size: 12px; color: var(--text); }
 .window-brand-icon { width: 18px; height: 18px; border-radius: 5px; background: center / contain no-repeat url("logo.svg"); }
+.window-brand-version { color: var(--text-faint); font-size: 11px; }
 .window-menu { display: flex; align-items: stretch; height: 100%; font-size: 13px; }
 .window-menu-group { position: relative; display: flex; align-items: stretch; }
 .window-menu-btn {

--- a/ui/src/styles/projects.css
+++ b/ui/src/styles/projects.css
@@ -161,6 +161,7 @@ body:has(.window-titlebar) .project-search-dialog { max-height: min(480px, calc(
 .project-search-foot kbd { display: inline-flex; align-items: center; justify-content: center; min-width: 22px; height: 20px;
   margin-right: 5px; padding: 0 5px; border: 1px solid var(--border-strong); border-radius: 999px; background: var(--bg-elev);
   color: var(--text-muted); font: 11px var(--font-ui); box-shadow: 0 1px 0 rgba(20, 20, 19, .08); }
+.project-search-foot .palette-version { margin-left: auto; color: var(--text-faint); }
 
 @media (max-width: 820px) {
   .projects-screen { padding-top: 28px; }

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -394,6 +394,7 @@ body:has(.settings-page) .projects-screen { display: none; }
   flex-wrap: wrap;
 }
 .settings-footer button { min-width: 84px; }
+.settings-version { margin-right: auto; align-self: center; color: var(--text-muted); font-size: 12px; }
 
 /* Settings list panes (Skills / Connections) — clean rows like reference UI */
 .settings-pane-list {

--- a/ui/src/window_titlebar.rs
+++ b/ui/src/window_titlebar.rs
@@ -100,6 +100,7 @@ pub(super) fn WindowTitlebar(
             <div class="window-brand" data-tauri-drag-region>
                 <span class="window-brand-icon"></span>
                 <span>"wisp-science"</span>
+                <span class="window-brand-version">{concat!("v", env!("CARGO_PKG_VERSION"))}</span>
             </div>
             <nav class="window-menu" aria-label="Application menu">
                 {menus.iter().map(|(id, label_key, items)| {


### PR DESCRIPTION
## What

Surface the app version in three UI spots so users can tell which build they're running:

- **Windows integrated titlebar** — `v0.11.0` next to the brand name
- **Command palette** — `v0.11.0` at the right of the footer
- **Settings** (general page) — `wisp-science v0.11.0` in the footer, next to "Check for updates"; buttons stay right-aligned

## Why

No version was visible anywhere in the UI. Handy for bug reports and confirming update status.

## Notes for reviewer

- Version comes from `env!("CARGO_PKG_VERSION")` of the `wisp-ui` crate — resolved at compile time, no runtime IPC. It tracks the workspace/tauri version (all bumped together, currently `0.11.0`).
- The titlebar is Windows-only (`is_windows()`), so on macOS only the command palette and settings entries are visible.
- Styling reuses existing muted-text vars (`--text-faint` / `--text-muted`); `cargo check` on the `ui` crate passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)