### PR TITLE
fix(ui): rebuild running set from backend snapshot on session refresh

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -593,6 +593,7 @@ struct SessionInfo {
     ts: i64,
     #[serde(skip_serializing_if = "Option::is_none")]
     folder_id: Option<String>,
+    running: bool,
 }
 
 #[derive(Serialize, Clone)]
@@ -3532,9 +3533,11 @@ async fn list_sessions(
         .list_sessions(&ap.id)
         .await
         .map_err(|e| format!("{e}"))?;
+    let running = state.running_turns.lock().await.clone();
     Ok(rows
         .into_iter()
         .map(|(id, title, ts, folder_id)| SessionInfo {
+            running: running.contains(&id),
             id,
             title,
             ts,

--- a/ui/src/app_support.rs
+++ b/ui/src/app_support.rs
@@ -2507,13 +2507,60 @@ pub(super) fn handle_md_click(
     }
 }
 
-pub(super) fn refresh_sessions(sessions: RwSignal<Vec<SessionInfo>>) {
+pub(super) fn refresh_sessions(
+    sessions: RwSignal<Vec<SessionInfo>>,
+    pending: RwSignal<HashMap<String, usize>>,
+    running: RwSignal<HashSet<String>>,
+) {
     spawn_local(async move {
         let v = invoke("list_sessions", JsValue::UNDEFINED).await;
         if let Ok(list) = serde_wasm_bindgen::from_value::<Vec<SessionInfo>>(v) {
+            let set = pending.with_untracked(|m| rebuilt_running_set(&list, m));
+            running.set(set);
             sessions.set(list);
         }
     });
+}
+
+/// Rebuild the local `running` set from the backend's `list_sessions` snapshot
+/// so restarts, project switches and other windows' turns are reflected. Keeps
+/// locally pending sends the backend may not have registered yet.
+pub(super) fn rebuilt_running_set(
+    list: &[SessionInfo],
+    pending: &HashMap<String, usize>,
+) -> HashSet<String> {
+    let mut set: HashSet<String> = list
+        .iter()
+        .filter(|s| s.running)
+        .map(|s| s.id.clone())
+        .collect();
+    set.extend(pending.keys().cloned());
+    set
+}
+
+#[cfg(test)]
+mod rebuilt_running_set_tests {
+    use super::*;
+
+    fn session(id: &str, running: bool) -> SessionInfo {
+        SessionInfo {
+            id: id.into(),
+            title: String::new(),
+            ts: 0,
+            folder_id: None,
+            running,
+        }
+    }
+
+    #[test]
+    fn keeps_server_running_and_local_pending() {
+        let list = vec![session("a", true), session("b", false)];
+        let pending = HashMap::from([("c".to_string(), 1)]);
+        let set = rebuilt_running_set(&list, &pending);
+        assert!(set.contains("a"), "server-running kept");
+        assert!(!set.contains("b"), "stale local state dropped");
+        assert!(set.contains("c"), "local pending send kept");
+    }
 }
 
 pub(super) fn refresh_folders(folders: RwSignal<Vec<FolderInfo>>) {

--- a/ui/src/dto.rs
+++ b/ui/src/dto.rs
@@ -496,6 +496,8 @@ pub(crate) struct SessionInfo {
     pub(crate) ts: i64,
     #[serde(default)]
     pub(crate) folder_id: Option<String>,
+    #[serde(default)]
+    pub(crate) running: bool,
 }
 
 #[derive(Deserialize, Clone)]

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -543,7 +543,7 @@ fn App() -> impl IntoView {
             active_acp_agent_id.set(next);
         });
     });
-    refresh_sessions(sessions);
+    refresh_sessions(sessions, pending_turns, running);
     refresh_folders(folders);
 
     // `busy` is "the active session is currently streaming" — derived from the
@@ -1112,7 +1112,7 @@ fn App() -> impl IntoView {
                 if stopping_session.get().as_deref() == Some(&frame_id) {
                     stopping_session.set(None);
                 }
-                refresh_sessions(sessions);
+                refresh_sessions(sessions, pending_turns, running);
             }
             AgentEvent::Error { frame_id, message } => {
                 flush_now();
@@ -1577,7 +1577,7 @@ fn App() -> impl IntoView {
                     if let Some(agent_id) = agent_id {
                         active_acp_agent_id.set(Some(agent_id));
                     }
-                    refresh_sessions(sessions);
+                    refresh_sessions(sessions, pending_turns, running);
                 }
                 Err(error) => {
                     let raw = js_error_text(error);
@@ -1765,7 +1765,7 @@ fn App() -> impl IntoView {
                 items.set(prefix_items);
                 input.set(draft);
                 active_session.set(Some(id));
-                refresh_sessions(sessions);
+                refresh_sessions(sessions, pending_turns, running);
                 focus_composer();
             });
         }
@@ -1850,7 +1850,7 @@ fn App() -> impl IntoView {
                                 }
                             }
                         }
-                        refresh_sessions(sessions);
+                        refresh_sessions(sessions, pending_turns, running);
                     }
                     Err(err) => {
                         let loc = locale.get();
@@ -2410,7 +2410,7 @@ fn App() -> impl IntoView {
             };
             active_session.set(Some(id));
             items.set(vec![]);
-            refresh_sessions(sessions);
+            refresh_sessions(sessions, pending_turns, running);
             focus_composer();
         });
     };
@@ -2457,7 +2457,7 @@ fn App() -> impl IntoView {
                 running.update(|r| {
                     r.insert(id.clone());
                 });
-                refresh_sessions(sessions);
+                refresh_sessions(sessions, pending_turns, running);
                 let arg = to_value(&SendMessageArgs {
                     session_id: Some(id.clone()),
                     message: text,
@@ -2475,7 +2475,7 @@ fn App() -> impl IntoView {
                         running.update(|r| {
                             r.remove(&id);
                         });
-                        refresh_sessions(sessions);
+                        refresh_sessions(sessions, pending_turns, running);
                     }
                     Err(err) => {
                         let loc = locale.get();
@@ -2688,7 +2688,7 @@ fn App() -> impl IntoView {
             };
             active_session.set(Some(id.clone()));
             items.set(vec![]);
-            refresh_sessions(sessions);
+            refresh_sessions(sessions, pending_turns, running);
             let arg = to_value(&SendMessageArgs {
                 session_id: Some(id.clone()),
                 message: prompt,
@@ -2700,7 +2700,7 @@ fn App() -> impl IntoView {
             .unwrap();
             begin_pending_turn(pending_turns, running, &id);
             match invoke_checked("send_message", arg).await {
-                Ok(_) => refresh_sessions(sessions),
+                Ok(_) => refresh_sessions(sessions, pending_turns, running),
                 Err(err) => {
                     let raw = js_error_text(err);
                     if raw.contains(NO_API_KEY_MARK) {
@@ -2989,7 +2989,7 @@ fn App() -> impl IntoView {
                                 to_value(&serde_json::json!({ "id": id, "folderId": folder_id }))
                                     .unwrap();
                             if invoke_checked("move_session", arg).await.is_ok() {
-                                refresh_sessions(sessions);
+                                refresh_sessions(sessions, pending_turns, running);
                             }
                         });
                     }
@@ -3346,7 +3346,7 @@ fn App() -> impl IntoView {
                 if let Some(session_id) = session_id {
                     load_session.call(session_id);
                 }
-                refresh_sessions(sessions);
+                refresh_sessions(sessions, pending_turns, running);
                 refresh_folders(folders);
             });
         })
@@ -3417,7 +3417,7 @@ fn App() -> impl IntoView {
                 let arg = to_value(&serde_json::json!({ "id": session_id, "folderId": folder_id }))
                     .unwrap();
                 if invoke_checked("move_session", arg).await.is_ok() {
-                    refresh_sessions(sessions);
+                    refresh_sessions(sessions, pending_turns, running);
                 }
             });
         })
@@ -3481,7 +3481,7 @@ fn App() -> impl IntoView {
             };
             active_session.set(Some(id));
             items.set(vec![]);
-            refresh_sessions(sessions);
+            refresh_sessions(sessions, pending_turns, running);
             focus_composer();
         });
     });
@@ -4595,7 +4595,7 @@ fn App() -> impl IntoView {
                                                                         active_acp_agent_id.set(Some(agent_id));
                                                                         active_session.set(Some(frame_id));
                                                                         items.set(vec![]);
-                                                                        refresh_sessions(sessions);
+                                                                        refresh_sessions(sessions, pending_turns, running);
                                                                         focus_composer();
                                                                         show_toast(&t(locale.get(), "composer.acp_new_session_toast"));
                                                                     });
@@ -5498,7 +5498,7 @@ fn App() -> impl IntoView {
                                     spawn_local(async move {
                                         let arg = to_value(&serde_json::json!({ "id": id, "title": title })).unwrap();
                                         if invoke_checked("rename_session", arg).await.is_ok() {
-                                            refresh_sessions(sessions);
+                                            refresh_sessions(sessions, pending_turns, running);
                                         }
                                     });
                                 }
@@ -5516,7 +5516,7 @@ fn App() -> impl IntoView {
                             spawn_local(async move {
                                 let arg = to_value(&serde_json::json!({ "id": id, "title": title })).unwrap();
                                 if invoke_checked("rename_session", arg).await.is_ok() {
-                                    refresh_sessions(sessions);
+                                    refresh_sessions(sessions, pending_turns, running);
                                 }
                             });
                         }>{move || t(locale.get(), "settings.save")}</button>
@@ -5589,7 +5589,7 @@ fn App() -> impl IntoView {
                                         let arg = to_value(&serde_json::json!({ "id": id })).unwrap();
                                         if invoke_checked("delete_folder", arg).await.is_ok() {
                                             refresh_folders(folders);
-                                            refresh_sessions(sessions);
+                                            refresh_sessions(sessions, pending_turns, running);
                                         }
                                     });
                                 }
@@ -5610,7 +5610,7 @@ fn App() -> impl IntoView {
                                                 active_session.set(None);
                                                 items.set(vec![]);
                                             }
-                                            refresh_sessions(sessions);
+                                            refresh_sessions(sessions, pending_turns, running);
                                         }
                                     });
                                 }


### PR DESCRIPTION
## What

The frontend `running: HashSet<frame_id>` signal (ui/src/main.rs) was purely local state — added on send (`begin_pending_turn`), cleared on Done/Error events — and never reconciled with the backend's `AppState.running_turns`. After an app restart, project switch, or a turn started from another window, the sidebar running dot and the composer busy gate went stale.

## How

- **Backend**: `SessionInfo` (the `list_sessions` DTO) gains a `running: bool`, filled from a `running_turns` snapshot. `frame_id` and session id are the same key (`session_runtime_status` already relies on this), so no mapping needed and no new command / extra invoke round-trip.
- **Frontend**: `refresh_sessions` rebuilds the local set as **(server running) ∪ (local pending sends)**. The union with `pending_turns` keeps sends the backend hasn't registered yet (the invoke-in-flight race); everything else — missed Done events, pre-restart leftovers — is overwritten by the snapshot. `refresh_sessions` is already the single refresh entry point for startup, project switch, and Done/Error handlers, so all 19 call sites reconcile automatically.
- One unit test for the rebuild logic (`rebuilt_running_set_tests`).

## Notes for review

- On project switch the set is rebuilt from the new project's sessions only, so other projects' running ids are dropped — nothing in the UI references them while inactive, and switching back restores them from the snapshot.
- `#[serde(default)]` on the new DTO field keeps mock-bridge / older payloads deserializing.
- Verified with `cargo check` in both workspaces (ui/ is a separate workspace; no fmt run per repo convention) and `cargo test rebuilt_running`.

Fixes #194.

🤖 Generated with [Claude Code](https://claude.com/claude-code)