### PR TITLE
fix: stop turns from clobbering the window's active frame

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1126,6 +1126,11 @@ struct AppState {
     project_activity: StdMutex<HashMap<String, Arc<tokio::sync::RwLock<()>>>>,
     /// The frame id the UI is currently viewing. Drives artifact attachment
     /// (`upload_file`/`register_artifact`) and `list_artifacts` fallback.
+    /// Written only by view-navigation commands (`load_session`/`new_session`/
+    /// `branch_session`, project switch, deletes). Turn paths must never write
+    /// it: a backgrounded turn racing a session switch would repoint the
+    /// window's uploads at the wrong frame (#194) — turns carry their own
+    /// frame id explicitly (`TauriOutput.frame_id`).
     active_frame: std::sync::RwLock<HashMap<String, String>>,
     /// Per-session confirm channels, keyed by frame id.
     confirms: ConfirmMap,
@@ -2720,7 +2725,6 @@ async fn send_message(
             }
             None => create_session_frame(&state.store, &ap.id).await?,
         };
-        state.set_active_frame(window.label(), Some(frame_id.clone()));
         let refs = references.as_deref().unwrap_or_default();
         let skills = active_skill_index(&state.store, &ap).await;
         let injected_context =
@@ -2812,7 +2816,8 @@ async fn send_message(
         }
         None => create_session_frame(&state.store, &ap.id).await?,
     };
-    state.set_active_frame(window.label(), Some(frame_id.clone()));
+    // Deliberately no set_active_frame here: see the `AppState::active_frame`
+    // doc — a turn writing view state races the user's session/project switch.
 
     let specialist = specialists::session_specialist(&state.store, &frame_id).await;
     let (provider, api_url, model, api_key, max_tokens, reasoning_effort) = match &specialist {


### PR DESCRIPTION
## What

Removes the two unconditional `set_active_frame` writes at turn start in `send_message` (ACP branch and native branch), and documents the ownership invariant on `AppState::active_frame`: only view-navigation commands (`load_session` / `new_session` / `branch_session`, project switch, deletes) may write it — turn paths must not.

## Why

`active_frame` tracks "the frame this window is viewing" and drives artifact attachment (`upload_file` / `register_artifact`) plus the `list_artifacts` fallback. Every UI send path already establishes it via `new_session` / `branch_session` / `load_session` before invoking `send_message` with an explicit `session_id`, so the writes were redundant — and they were the only channel through which a turn could race the user's session or project switch:

- Send in session A, then switch to session B (or `open_project`, which clears the frame): if A's turn-start write lands after the switch, the window's uploads and artifact listings silently repoint at A.
- The cross-project variant produces artifact rows with `project_id` of the new project but `frame_id` of the old project's session.

This is part of the "不同对话的工作目录串扰" report in #194.

## Audit notes for reviewers

Full trace of every `active_frame` reader confirmed the rest is sound:

- **Turn-internal artifact registration never reads it** — harvest (`harvest.rs`), `RunInContextTool`, the MCP bridge (`--frame-id`), and `TauriOutput` all carry an explicit frame id already. No changes needed there.
- **All remaining readers are window-scoped commands** (`upload_file`/`register_artifact`, `list_artifacts`, `review_session`, `side_chat`, `rewind_session`, `get_artifact_provenance`, cleanup in `delete_session`/project sync) where the UI passes an explicit `sessionId` and the fallback only fires when no session is being viewed — correct window semantics, kept as is.

Known related gap left out of scope (UI workspace): switching **to a running session** skips the backend `load_session` call (deliberately, to protect `set_last_seq`), so `active_frame` stays stale until the session is reloaded — uploads made while viewing a running session can still attach to the previously viewed frame. Needs a UI-side fix (explicit `sessionId` on upload, or a lightweight view-sync command); tracked separately.

## Verification

- `cargo check -p wisp-tauri` — clean
- `cargo test -p wisp-tauri --lib` — 117 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)