### PR TITLE
fix: bind agent turns to the session's own project, not the window slot

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2688,7 +2688,22 @@ async fn send_message(
     if !resume && message.trim().is_empty() {
         return Err("message is empty".into());
     }
-    let ap = state.active(window.label());
+    let mut ap = state.active(window.label());
+    // A session belongs to one project for life, but the per-window active slot
+    // can drift while it keeps running (another project opened in this window,
+    // the "main" fallback, an agent rebuild). For explicit session ids, always
+    // run the turn in the owner project — never error out on a mismatch or,
+    // worse, run tools in a stranger's workspace (#182, #194).
+    if let Some(id) = session_id.as_deref().filter(|id| !id.is_empty()) {
+        let owner = state
+            .store
+            .frame_project_id(id)
+            .await
+            .map_err(|error| error.to_string())?;
+        if let Some(owner_id) = owner.filter(|owner_id| owner_id != &ap.id) {
+            ap = load_active_project(&state, &owner_id).await?.0;
+        }
+    }
     let _project_activity = state.begin_project_activity(&ap.id)?;
     let saved_binding = match session_id.as_deref().filter(|id| !id.is_empty()) {
         Some(id) => state
@@ -2846,6 +2861,12 @@ async fn send_message(
     let mut guard = rt.agent.lock().await;
     if rt.deleted.load(Ordering::SeqCst) {
         return Err("This session was deleted while the turn was queued.".into());
+    }
+    if guard.as_ref().is_some_and(|agent| agent.root != ap.root) {
+        // The cached agent was built from a stale window slot — its shell CWD
+        // and session file point into another project. Rebuild it below on the
+        // session's own root (#182).
+        *guard = None;
     }
     if guard.is_none() {
         let skills = active_skill_index(&state.store, &ap).await;
@@ -4023,11 +4044,13 @@ async fn cancel_project_sessions(state: &AppState, project_id: &str) {
 /// each session's agent already captured its own root/skills/memory at creation,
 /// so cross-project turns run in parallel and stay monitorable on the dashboard
 /// (#52). Deleting a project stops only *its* sessions (see `delete_project`).
-async fn set_active_project(
+/// Build a project's ActiveProject bundle (root, skills, memory) by id, plus
+/// its (name, workspace) for callers that need them. Pure load — does not touch
+/// the per-window active slot.
+async fn load_active_project(
     state: &AppState,
-    label: &str,
     id: &str,
-) -> Result<(String, String), String> {
+) -> Result<(ActiveProject, String, String), String> {
     let (name, ws) = state
         .store
         .get_project(id)
@@ -4037,15 +4060,26 @@ async fn set_active_project(
     let root = ensure_writable(PathBuf::from(&ws), &state.app_data);
     let skills = Arc::new(SkillIndex::load(&skill_paths(&root)));
     let memory = Arc::new(MemoryManager::new(&root));
-    state.set_active(
-        label,
+    Ok((
         ActiveProject {
             id: id.to_string(),
-            root: root.clone(),
+            root,
             skills,
             memory,
         },
-    );
+        name,
+        ws,
+    ))
+}
+
+async fn set_active_project(
+    state: &AppState,
+    label: &str,
+    id: &str,
+) -> Result<(String, String), String> {
+    let (ap, name, ws) = load_active_project(state, id).await?;
+    let root = ap.root.clone();
+    state.set_active(label, ap);
     state.set_active_frame(label, None);
     {
         state.bootstrap.lock().unwrap().workspace = root.to_string_lossy().into_owned();

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -3243,6 +3243,13 @@ fn App() -> impl IntoView {
             status.set(String::new());
             show_proj_menu.set(false);
             demo_mode.set(false);
+            // Stash the transcript we're leaving, like every other switch path —
+            // dropping it made running sessions "roll back" on return (#194).
+            if let Some(old) = active_session.get() {
+                transcripts.update(|m| {
+                    m.insert(old, items.get());
+                });
+            }
             items.set(vec![]);
             active_session.set(None);
             collapsed_folders.set(HashSet::new());


### PR DESCRIPTION
Fixes #182, addresses the core of #194.

## Root cause

The project context for an agent turn was resolved from the **per-window active slot** (`AppState.active`, keyed by window label, with a silent fallback to `"main"`) instead of from the **session's owning project**. With parallel sessions across projects, the slot drifts while a session keeps running:

- **#182** (Windows, "只认 .wisp"): after a project switch / idle-agent eviction, the session's Agent was rebuilt from the drifted slot and froze the wrong `root`. Its PowerShell CWD then pointed into another, nearly-empty project — bare `dir` / `Get-ChildItem` saw only `.wisp`, while absolute-path access (`os.walk("D:\\...")`, `attrib`) still worked because the seeded system prompt keeps the original real path. This matches every screenshot in the issue.
- **#194**: sending into a session whose owner no longer matched the window slot errored with *"Session does not belong to the active project"* (can't continue the conversation); switching projects mid-stream dropped the live transcript, so returning showed the conversation "rolled back" several turns.

## Changes

| Where | What |
|---|---|
| `src-tauri/src/lib.rs` — `send_message` | For explicit session ids, resolve the owner via `frame_project_id` and load that project's `ActiveProject` when it differs from the window slot. The `begin_project_activity` guard now locks the project that actually runs. The old mismatch error can no longer trigger for owned frames. |
| `src-tauri/src/lib.rs` — agent cache | Drop a cached `Agent` whose `root` doesn't match the session's project root, so already-polluted agents rebuild on the correct root instead of keeping the wrong CWD until app restart. |
| `src-tauri/src/lib.rs` — `load_active_project` | New helper extracted from `set_active_project` (same load logic, no behavior change for the existing caller). |
| `ui/src/main.rs` — `open_project_transition` | Stash the live transcript into `transcripts` before clearing — every other switch path (branch / new_session / load_session / load_demo / palette) already did this; this was the one that didn't, and it's the direct cause of the "rolled back" transcript. |

## Verification

- `cargo test -p wisp-tauri --lib`: 117 passed; `cargo check -p wisp-tauri` clean.
- `ui`: `cargo test` 40 passed; `cargo check` clean.
- No automated scaffolding exists for multi-window/multi-session turns, so the concurrency scenario was verified by code-trace against both issue reports. Recommend a manual repro on Windows before release: two projects, start a long turn in A, switch to B, send in B, switch back to A.

## Known follow-ups (out of scope, tracked separately)

- Frontend `running` set is window-local and never reconciled with backend `running_turns` (sidebar dot / composer busy gate can go stale across restarts).
- `active_frame` is stored per window label, so artifacts registered by a background turn can attach to the session the user is currently viewing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)