### PR TITLE
fix: retarget active_frame when viewing a running session

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4408,6 +4408,16 @@ async fn load_session(
     Ok(items)
 }
 
+/// Mark which session this window is viewing without loading it. The UI calls
+/// this instead of `load_session` when switching to a *running* session (it
+/// renders the cached streaming transcript), so uploads still attach to the
+/// viewed session (#194) — `load_session` would clobber the runtime's
+/// `last_seq` with the DB snapshot mid-stream.
+#[tauri::command]
+fn set_viewed_session(state: State<'_, AppState>, window: tauri::WebviewWindow, id: String) {
+    state.set_active_frame(window.label(), Some(id));
+}
+
 #[tauri::command]
 async fn list_artifacts(
     state: State<'_, AppState>,
@@ -5272,6 +5282,7 @@ pub fn run() {
             search_sessions,
             read_artifact,
             missing_files,
+            set_viewed_session,
             upload_file,
             register_artifact,
             save_workspace_file_by_kind,

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -2515,6 +2515,16 @@ fn App() -> impl IntoView {
             // session switching and restart semantics identical.
             items.set(transcripts.with(|m| m.get(&id).cloned().unwrap_or_default()));
             force_chat_bottom();
+            // Still retarget the backend's viewed-session marker so uploads
+            // attach here (#194). Not `load_session`: that would overwrite the
+            // running turn's persisted seq with the DB snapshot.
+            spawn_local(async move {
+                let _ = invoke(
+                    "set_viewed_session",
+                    to_value(&serde_json::json!({ "id": id })).unwrap(),
+                )
+                .await;
+            });
             return;
         }
         // Idle session: load from DB and overwrite any stale cache entry.


### PR DESCRIPTION
## What

Fixes the other half of the #194 artifact crosstalk: attaching a file while viewing a **running** session registered the artifact under the previously viewed session.

- `src-tauri/src/lib.rs`: new lightweight `set_viewed_session` command that only writes the window's `active_frame` (does **not** touch the runtime's `last_seq`).
- `ui/src/main.rs`: the `load_session` callback's `is_running` branch now fire-and-forgets `set_viewed_session` after rendering the cached transcript.

## Why

Switching to a running session early-returns in the UI (renders the cached streaming transcript) and never calls the backend `load_session`, so `AppState.active_frame` stayed pointing at the previous session. `upload_file → ensure_active_frame` then attached the upload to the wrong session.

Calling the full `load_session` command in that branch is not safe: it does `rt.set_last_seq(msgs.len())`, which would clobber the running turn's persisted sequence with the DB snapshot mid-stream — hence the dedicated marker-only command.

## Notes for review

- The `send_message` side of #194 (turn writing to `active_frame`) was already removed on another branch; this PR only covers the upload/registration path.
- No id validation in `set_viewed_session` — same trust level as `load_session` (ids come from the session list).
- Verified: `cargo check -p wisp-tauri`, `cargo test -p wisp-tauri --lib` (117 passed), and `cargo check` in the `ui/` workspace (no fmt run, per repo convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)