### PR TITLE
fix: ACP camelCase wire format, dead-runtime eviction, agent version display

### DIFF
--- a/crates/wisp-acp/src/lib.rs
+++ b/crates/wisp-acp/src/lib.rs
@@ -248,6 +248,13 @@ impl AcpSessionHandle {
         &self.info
     }
 
+    /// False once the agent actor has stopped — child exit, connection
+    /// failure, or shutdown. Every request on a dead handle fails, so callers
+    /// caching handles should relaunch instead of retrying.
+    pub fn is_alive(&self) -> bool {
+        !self.command_tx.is_closed()
+    }
+
     pub fn stderr(&self) -> String {
         self.stderr.snapshot()
     }

--- a/crates/wisp-acp/tests/process.rs
+++ b/crates/wisp-acp/tests/process.rs
@@ -84,6 +84,7 @@ async fn test_full_lifecycle() -> Result<(), String> {
         .await
         .map_err(|error| error.to_string())?;
     check(handle.info().protocol_version == 1, "ACP v1 handshake")?;
+    check(handle.is_alive(), "handle alive after launch")?;
     check(
         handle.info().auth_methods.len() == 1,
         "auth method discovery",
@@ -215,6 +216,7 @@ async fn test_full_lifecycle() -> Result<(), String> {
 
     handle.close_session(session_id).await.map_err(stringify)?;
     handle.shutdown(Duration::from_secs(1)).await;
+    check(!handle.is_alive(), "handle dead after shutdown")?;
     Ok(())
 }
 

--- a/src-tauri/src/acp.rs
+++ b/src-tauri/src/acp.rs
@@ -30,7 +30,12 @@ pub(crate) struct AcpAgentProfile {
     pub args: Vec<String>,
 }
 
+// The webview DTOs (ui/src/dto.rs) deserialize with rename_all = "camelCase";
+// without the matching attribute here `protocolVersion`/`authMethods` fall back
+// to defaults (the "ACP v0" bug) and permission events fail to parse at all,
+// hanging the turn (#200, #201).
 #[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 pub(crate) struct AcpAgentInfoDto {
     protocol_version: u16,
     implementation: Option<serde_json::Value>,
@@ -39,6 +44,7 @@ pub(crate) struct AcpAgentInfoDto {
 }
 
 #[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
 struct PermissionEvent {
     request_id: String,
     frame_id: String,
@@ -251,18 +257,24 @@ async fn runtime_for(
     requested_profile_id: Option<&str>,
 ) -> Result<Arc<AcpRuntime>, String> {
     if let Some(runtime) = state.acp_sessions.lock().await.get(frame_id).cloned() {
-        let profile = profiles(&state.store)
-            .await
-            .into_iter()
-            .find(|profile| profile.id == runtime.profile_id)
-            .ok_or_else(|| "The attached ACP Agent profile no longer exists.".to_string())?;
-        if requested_profile_id.is_some_and(|id| id != runtime.profile_id)
-            || fingerprint(&profile) != runtime.fingerprint
-            || project.root != runtime.cwd
-        {
-            return Err("The ACP Agent selection, launch command, or project path changed; start a new session.".into());
+        if runtime.handle.is_alive() {
+            let profile = profiles(&state.store)
+                .await
+                .into_iter()
+                .find(|profile| profile.id == runtime.profile_id)
+                .ok_or_else(|| "The attached ACP Agent profile no longer exists.".to_string())?;
+            if requested_profile_id.is_some_and(|id| id != runtime.profile_id)
+                || fingerprint(&profile) != runtime.fingerprint
+                || project.root != runtime.cwd
+            {
+                return Err("The ACP Agent selection, launch command, or project path changed; start a new session.".into());
+            }
+            return Ok(runtime);
         }
-        return Ok(runtime);
+        // The agent process died (crash, host reboot mid-run). Evict the dead
+        // runtime and fall through to relaunch + resume from the saved binding
+        // instead of failing every turn until the user starts a new session.
+        state.acp_sessions.lock().await.remove(frame_id);
     }
     let binding = state
         .store
@@ -896,6 +908,32 @@ mod tests {
         changed = base.clone();
         changed.command = "other-agent".into();
         assert_ne!(fingerprint(&base), fingerprint(&changed));
+    }
+
+    #[test]
+    fn acp_wire_dtos_serialize_as_camel_case() {
+        let info = serde_json::to_value(AcpAgentInfoDto {
+            protocol_version: 1,
+            implementation: None,
+            capabilities: serde_json::json!({}),
+            auth_methods: vec![],
+        })
+        .unwrap();
+        assert!(info.get("protocolVersion").is_some());
+        assert!(info.get("authMethods").is_some());
+        let event = serde_json::to_value(permission_event(
+            "frame-1",
+            &AcpPermissionRequest {
+                request_id: "permission-1".into(),
+                session_id: "session-1".into(),
+                tool_call: serde_json::json!({}),
+                options: vec![],
+            },
+        ))
+        .unwrap();
+        assert!(event.get("requestId").is_some());
+        assert!(event.get("frameId").is_some());
+        assert!(event.get("toolCall").is_some());
     }
 
     #[test]

--- a/ui/src/settings_view.rs
+++ b/ui/src/settings_view.rs
@@ -913,10 +913,25 @@ pub(super) fn SettingsView(
                                                             {move || {
                                                                 let id = agent.id.clone();
                                                                 acp_infos.get().get(&id).cloned().map(|info| {
+                                                                    // "Codex 1.1.2 · ACP v1": the agent's own version first, so the
+                                                                    // protocol version is not mistaken for it (#200).
+                                                                    let mut version_label = format!("ACP v{}", info.protocol_version);
+                                                                    if let Some(implementation) = info.implementation.as_ref() {
+                                                                        let name = implementation.get("title").and_then(serde_json::Value::as_str)
+                                                                            .or_else(|| implementation.get("name").and_then(serde_json::Value::as_str));
+                                                                        if let Some(name) = name {
+                                                                            let version = implementation.get("version").and_then(serde_json::Value::as_str).unwrap_or("");
+                                                                            version_label = if version.is_empty() {
+                                                                                format!("{name} · {version_label}")
+                                                                            } else {
+                                                                                format!("{name} {version} · {version_label}")
+                                                                            };
+                                                                        }
+                                                                    }
                                                                     let methods = info.auth_methods;
                                                                     view! {
                                                                         <div class="acp-agent-info" data-testid="acp-agent-info" on:click=|ev| ev.stop_propagation()>
-                                                                            <span>{format!("ACP v{}", info.protocol_version)}</span>
+                                                                            <span>{version_label}</span>
                                                                             {methods.into_iter().map(|method| {
                                                                                 let id = id.clone();
                                                                                 let method_id = method.id.clone();


### PR DESCRIPTION
## 问题

**#200 / #201：ACP 连接后显示 "ACP v0"，但 codex-acp 实际是 1.1.2**

实测 codex-acp 1.1.2 的 initialize 响应是 `protocolVersion: 1` + `agentInfo.version: "1.1.2"`，握手本身没问题。根因是后端 `AcpAgentInfoDto` 序列化为 snake_case（`protocol_version`），而 webview 端 DTO 声明了 `rename_all = "camelCase"`（期望 `protocolVersion`），字段对不上后 `#[serde(default)]` 兜底成 0。同一个 bug 还把 `authMethods` 弄丢了——设置页的认证按钮从未显示过。

**#201：恢复 codex 会话卡住 / 中断后必须重建会话**

两个独立缺陷：

1. `PermissionEvent` 同样缺 `rename_all = "camelCase"`，webview 反序列化权限请求失败后静默丢弃 → 权限弹窗永远不出现 → agent 无限等待授权，整轮卡死。恢复被中断的会话时 codex 往往立刻请求权限（如沙箱初始化失败后询问是否重试），所以恢复场景必卡。
2. agent 进程死掉（崩溃、宿主机重启）后，runtime 一直留在 `acp_sessions` 缓存里，之后每轮都撞死进程报同一错误，用户被迫新建会话。现在 `runtime_for` 检测到 `is_alive() == false` 时驱逐死 runtime，走保存的 binding 自动重连（relaunch + session/resume）。

## 改动

- `src-tauri/src/acp.rs`：`AcpAgentInfoDto`、`PermissionEvent` 加 `#[serde(rename_all = "camelCase")]`；`runtime_for` 驱逐死 runtime 并自动重连；新增单测锁定 camelCase 键名
- `crates/wisp-acp`：`AcpSessionHandle::is_alive()`；进程测试补充存活状态断言
- `ui/src/settings_view.rs`：设置页显示 agent 自身版本（"Codex 1.1.2 · ACP v1"），协议版本不再被误认为软件版本

## 验证

- `cargo test --workspace` 全绿；`ui/` `cargo check` 通过
- 实测 `npx -y @agentclientprotocol/codex-acp@latest` 握手确认线上格式（camelCase、protocolVersion 1、authMethods 两项）

备注：重启后报的"ACL 初始化错误"本身来自 codex 的 Windows 沙箱，不在本仓可修范围；本 PR 修复的是它引发的连锁症状（权限弹窗不显示导致卡死、死进程导致必须重建会话）。

Closes #200
Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)