### PR TITLE
fix: drain agent stderr on an independent task (test_child_exit flake)

### DIFF
--- a/crates/wisp-acp/src/lib.rs
+++ b/crates/wisp-acp/src/lib.rs
@@ -847,14 +847,19 @@ impl ConnectTo<Client> for ProcessTransport {
 
         let captured = self.stderr.clone();
         let child_stderr = self.stderr.clone();
-        let stderr_future = async move {
+        // Drain stderr on an independent task. Racing the reader inside the
+        // transport select dropped it as soon as the protocol or the child
+        // ended — sometimes before a just-exited child's diagnostics were
+        // read, losing them for good (#179). The pipe hits EOF once the child
+        // dies, so the task always terminates.
+        tokio::spawn(async move {
             let mut lines = BufReader::new(stderr).lines();
             while let Some(line) = lines.next().await {
                 if let Ok(line) = line {
                     captured.push(line.as_bytes());
                 }
             }
-        };
+        });
         let incoming = Box::pin(BufReader::new(stdout).lines());
         let outgoing = Box::pin(futures::sink::unfold(
             stdin,
@@ -886,19 +891,11 @@ impl ConnectTo<Client> for ProcessTransport {
             }
         };
 
-        let stderr_future = pin!(stderr_future);
         let protocol = pin!(protocol);
         let child_monitor = pin!(child_monitor);
-        let race = async {
-            match futures::future::select(protocol, child_monitor).await {
-                futures::future::Either::Left((result, _))
-                | futures::future::Either::Right((result, _)) => result,
-            }
-        };
-        let race = pin!(race);
-        match futures::future::select(race, stderr_future).await {
-            futures::future::Either::Left((result, _)) => result,
-            futures::future::Either::Right(((), protocol)) => protocol.await,
+        match futures::future::select(protocol, child_monitor).await {
+            futures::future::Either::Left((result, _))
+            | futures::future::Either::Right((result, _)) => result,
         }
     }
 }


### PR DESCRIPTION
## 问题

#179 的 `test_child_exit` flake 又在 [PR #202 的 CI](https://github.com/xuzhougeng/wisp-science/actions/runs/29239752682) 上出现，这次 1.88.0 和 stable 两个 job 同时失败。

## 根因

`ProcessTransport::connect_to` 里 stderr reader 和 protocol/child_monitor 在同一个 select 里赛跑：race 一结束（子进程退出被 child_monitor 先观察到），reader future 就被丢弃。如果那一刻 "fake early exit" 还没被读进 `BoundedStderr`，缓冲区就**永远**空了——之前 #179 加的 `wait_for_stderr` 500ms 轮询只是加宽窗口，reader 已死时轮询多久都没用。

## 修复

stderr reader 改为独立 `tokio::spawn` 任务，不再参与 select。子进程死掉后管道 EOF，任务自然结束，不泄漏；外层 select 也少了一个分支（净删 3 行）。

## 验证

本地用 12 并发 × 多轮压满 CPU 复现竞态：修复前 **4/96 失败**（与 CI 相同的 `child stderr surfaced`），修复后 **0/192**。`cargo test -p wisp-acp` 全绿。

Refs #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)