### PR TITLE
Fix macOS native paste shortcuts

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1460,6 +1460,12 @@ struct MacMenuLabels {
     check_updates: &'static str,
     file: &'static str,
     edit: &'static str,
+    undo: &'static str,
+    redo: &'static str,
+    cut: &'static str,
+    copy: &'static str,
+    paste: &'static str,
+    select_all: &'static str,
     view: &'static str,
     window: &'static str,
     help: &'static str,
@@ -1495,6 +1501,12 @@ fn mac_menu_labels(locale: AppMenuLocale) -> MacMenuLabels {
             check_updates: "检查更新…",
             file: "文件",
             edit: "编辑",
+            undo: "撤销",
+            redo: "重做",
+            cut: "剪切",
+            copy: "复制",
+            paste: "粘贴",
+            select_all: "全选",
             view: "视图",
             window: "窗口",
             help: "帮助",
@@ -1526,6 +1538,12 @@ fn mac_menu_labels(locale: AppMenuLocale) -> MacMenuLabels {
             check_updates: "Check for Updates…",
             file: "File",
             edit: "Edit",
+            undo: "Undo",
+            redo: "Redo",
+            cut: "Cut",
+            copy: "Copy",
+            paste: "Paste",
+            select_all: "Select All",
             view: "View",
             window: "Window",
             help: "Help",
@@ -1676,6 +1694,20 @@ fn install_macos_app_menu(app: &AppHandle, locale_tag: &str) -> Result<(), Strin
         .map_err(|error| error.to_string())?;
 
     let edit_menu = SubmenuBuilder::new(app, labels.edit)
+        .item(&PredefinedMenuItem::undo(app, Some(labels.undo)).map_err(|error| error.to_string())?)
+        .item(&PredefinedMenuItem::redo(app, Some(labels.redo)).map_err(|error| error.to_string())?)
+        .separator()
+        .item(&PredefinedMenuItem::cut(app, Some(labels.cut)).map_err(|error| error.to_string())?)
+        .item(&PredefinedMenuItem::copy(app, Some(labels.copy)).map_err(|error| error.to_string())?)
+        .item(
+            &PredefinedMenuItem::paste(app, Some(labels.paste))
+                .map_err(|error| error.to_string())?,
+        )
+        .item(
+            &PredefinedMenuItem::select_all(app, Some(labels.select_all))
+                .map_err(|error| error.to_string())?,
+        )
+        .separator()
         .item(
             &build_menu_item(app, "action.search", labels.search, Some("CmdOrCtrl+K"))
                 .map_err(|error| error.to_string())?,

--- a/src-tauri/src/lib_tests.rs
+++ b/src-tauri/src/lib_tests.rs
@@ -44,6 +44,21 @@ fn mac_menu_locale_uses_saved_zh_labels() {
     let labels = super::mac_menu_labels(super::AppMenuLocale::from_tag("zh-CN"));
     assert_eq!(labels.help, "帮助");
     assert_eq!(labels.check_updates, "检查更新…");
+    assert_eq!(labels.copy, "复制");
+    assert_eq!(labels.paste, "粘贴");
+    assert_eq!(labels.select_all, "全选");
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn mac_menu_locale_includes_english_edit_labels() {
+    let labels = super::mac_menu_labels(super::AppMenuLocale::from_tag("en"));
+    assert_eq!(labels.undo, "Undo");
+    assert_eq!(labels.redo, "Redo");
+    assert_eq!(labels.cut, "Cut");
+    assert_eq!(labels.copy, "Copy");
+    assert_eq!(labels.paste, "Paste");
+    assert_eq!(labels.select_all, "Select All");
 }
 
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
## Problem

On macOS v0.11, `Cmd+V` no longer pasted text into any WebView input, including the new-project form, API key fields, and the chat composer. This addresses the paste regression reported in #207.

## Root cause

The custom macOS Edit menu replaced Tauri's standard Edit menu without restoring its predefined native edit items. macOS relies on those native selectors to route Edit commands such as Paste to the focused WebView control.

## Changes

- restore Tauri's predefined Undo, Redo, Cut, Copy, Paste, and Select All items in the macOS Edit menu
- add Chinese and English labels for the restored native items
- add unit coverage for both locale variants

## User impact

`Cmd+V` works again across macOS input fields. The other standard Edit shortcuts (`Cmd+X`, `Cmd+C`, `Cmd+A`, undo, and redo) are restored as well.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cd ui && cargo check --target wasm32-unknown-unknown`
- `cd ui-tests && npm ci && npx playwright test` (90 passed)

## Manual smoke steps

1. Launch a macOS build.
2. Paste text into the new-project name/path form.
3. Paste an API key in Settings.
4. Paste text into the chat composer.
5. Confirm Undo, Redo, Cut, Copy, and Select All remain available from the Edit menu.

## Known limitations

This PR addresses only the paste/edit-command regression described in issue #207. The separate new-project window positioning/occlusion report in that issue is not changed.