### PR TITLE
Fix streamed OpenAI tool call name loss on GLM/SiliconFlow

### DIFF
--- a/crates/wisp-llm/src/openai.rs
+++ b/crates/wisp-llm/src/openai.rs
@@ -230,6 +230,28 @@ fn normalize_tool_calls(msg: &Value) -> Vec<ToolCall> {
     out
 }
 
+fn merge_stream_tool_call_delta(entry: &mut (String, String, String), tc: &Value) {
+    if let Some(id) = tc
+        .get("id")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+    {
+        entry.0 = id.to_string();
+    }
+    if let Some(f) = tc.get("function").and_then(|v| v.as_object()) {
+        if let Some(n) = f
+            .get("name")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+        {
+            entry.1 = n.to_string();
+        }
+        if let Some(a) = f.get("arguments").and_then(|v| v.as_str()) {
+            entry.2.push_str(a);
+        }
+    }
+}
+
 #[async_trait]
 impl Provider for OpenAiProvider {
     fn name(&self) -> &str {
@@ -340,17 +362,7 @@ impl Provider for OpenAiProvider {
                             let entry = tool_calls
                                 .entry(i)
                                 .or_insert_with(|| (String::new(), String::new(), String::new()));
-                            if let Some(id) = tc.get("id").and_then(|v| v.as_str()) {
-                                entry.0 = id.to_string();
-                            }
-                            if let Some(f) = tc.get("function").and_then(|v| v.as_object()) {
-                                if let Some(n) = f.get("name").and_then(|v| v.as_str()) {
-                                    entry.1 = n.to_string();
-                                }
-                                if let Some(a) = f.get("arguments").and_then(|v| v.as_str()) {
-                                    entry.2.push_str(a);
-                                }
-                            }
+                            merge_stream_tool_call_delta(entry, tc);
                             sink.on_tool_call(i, &entry.1, &entry.2);
                         }
                     }
@@ -480,5 +492,31 @@ mod tests {
         let out = OpenAiProvider::sanitize(&msgs);
         assert_eq!(out[0]["tool_calls"].as_array().unwrap().len(), 1);
         assert_eq!(out[1]["tool_call_id"], "a");
+    }
+
+    #[test]
+    fn stream_delta_keeps_first_non_empty_tool_name() {
+        let mut entry = ("".to_string(), "".to_string(), "".to_string());
+        merge_stream_tool_call_delta(
+            &mut entry,
+            &json!({
+                "index": 0,
+                "id": "call_1",
+                "type": "function",
+                "function": { "name": "read", "arguments": "" }
+            }),
+        );
+        merge_stream_tool_call_delta(
+            &mut entry,
+            &json!({
+                "index": 0,
+                "id": null,
+                "type": null,
+                "function": { "name": "", "arguments": "{\"file_path\":\"C:/test.txt\"}" }
+            }),
+        );
+        assert_eq!(entry.0, "call_1");
+        assert_eq!(entry.1, "read");
+        assert_eq!(entry.2, "{\"file_path\":\"C:/test.txt\"}");
     }
 }


### PR DESCRIPTION
## Summary

This PR fixes a streamed OpenAI-compatible tool-call parsing bug that showed up with SiliconFlow `zai-org/GLM-5.2` as `unknown tool ''` during real tool execution.

Closes #222.

## What changed

- preserve the first non-empty streamed tool-call `id`
- preserve the first non-empty streamed tool-call `function.name`
- continue appending streamed `function.arguments` fragments as before
- add a regression test for the `name="read"` followed by `name=""` delta pattern

## Root cause

The settings validation flow uses a cheap non-streaming completion without tools, so it never exercised the streamed tool-call parser.

The normal chat path uses SSE streaming and incrementally merges `delta.tool_calls`. For this model/provider combination, the first delta contained a correct tool name, but later argument deltas repeated the same tool call with an empty `function.name`. Our previous merge logic overwrote the correct name with the empty string, so tool dispatch failed with `unknown tool ''`.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p wisp-llm`
- `cargo test --workspace` *(currently fails in pre-existing `wisp-store` `project_transfer` path normalization tests on this machine; unrelated to this diff)*

## Notes

The workspace test failures observed during validation were:

- `project_transfer::tests::windows_paths_become_portable_and_restore_on_macos`
- `project_transfer::tests::project_database_roundtrip_rebinds_paths_and_stops_live_runs`
