### PR TITLE
Fix saved model validation using the edited profile key

### DIFF
--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -437,6 +437,13 @@ pub async fn profile_llm(
     ))
 }
 
+/// Stored key for a specific profile id, or None when the profile does not
+/// exist. The returned string may still be empty when the profile has no key.
+pub async fn profile_key(store: &wisp_store::Store, id: &str) -> Option<String> {
+    let profiles = ensure(store).await;
+    profiles.iter().any(|p| p.id == id).then(|| key_for(id))
+}
+
 /// Whether the active profile has a key stored (for `get_settings`).
 pub async fn active_has_key(store: &wisp_store::Store) -> bool {
     let profiles = ensure(store).await;
@@ -721,5 +728,34 @@ mod tests {
         assert!(!service_env().iter().any(|(k, _)| k == "NCBI_EMAIL"));
 
         assert!(store_credential("nonexistent", "x").is_err());
+    }
+
+    #[tokio::test]
+    async fn profile_key_reads_the_requested_profile() {
+        let tmp =
+            std::env::temp_dir().join(format!("wisp_profile_key_{}.sqlite", uuid::Uuid::new_v4()));
+        let store = wisp_store::Store::open(&tmp).await.unwrap();
+        save_raw(
+            &store,
+            &[
+                test_profile("default", "deepseek", "deepseek-v4-pro"),
+                test_profile("glm", "glm", "glm-5.2"),
+            ],
+        )
+        .await
+        .unwrap();
+        secret_set(&secret_name("default"), "sk-default").unwrap();
+        secret_set(&secret_name("glm"), "sk-glm").unwrap();
+
+        assert_eq!(profile_key(&store, "glm").await.as_deref(), Some("sk-glm"));
+        assert_eq!(
+            profile_key(&store, "default").await.as_deref(),
+            Some("sk-default")
+        );
+        assert_eq!(profile_key(&store, "missing").await, None);
+
+        let _ = secret_del(&secret_name("default"));
+        let _ = secret_del(&secret_name("glm"));
+        let _ = std::fs::remove_file(&tmp);
     }
 }

--- a/src-tauri/src/settings_commands.rs
+++ b/src-tauri/src/settings_commands.rs
@@ -384,9 +384,22 @@ pub(super) async fn validate_settings(
     state: State<'_, AppState>,
     settings: Settings,
     key: Option<String>,
+    profile_id: Option<String>,
 ) -> Result<String, String> {
     let provider_name = normalized_provider(&settings.provider);
-    let (_, _, _, stored_key) = load_settings(&state.store).await;
+    let stored_key = match profile_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+    {
+        Some(id) => models::profile_key(&state.store, id)
+            .await
+            .unwrap_or_default(),
+        None => {
+            let (_, _, _, stored_key) = load_settings(&state.store).await;
+            stored_key
+        }
+    };
     let api_key = effective_api_key(key, stored_key);
     let mut cfg = build_provider_config(
         &settings.provider,

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -1378,6 +1378,25 @@ test("settings can validate current API config", async ({ page }) => {
   await expect(page.locator(".settings-status")).toHaveText("Validated openai with deepseek-v4-pro");
 });
 
+test("editing a saved model validates with that model profile id", async ({ page }) => {
+  await enterApp(page);
+  await page.getByRole("button", { name: "Settings" }).click();
+  await page.getByRole("button", { name: "Models" }).click();
+  await page.locator(".settings-list-row", { hasText: "opus-4.8" }).click();
+  await expect(providerSelect(page)).toBeVisible();
+  await expect(page.getByLabel("Model ID")).toHaveValue("opus-4.8");
+
+  await page.getByRole("button", { name: "Valid" }).click();
+  await expect(page.locator(".settings-status")).toHaveText("Validated openai with deepseek-v4-pro");
+  await expect.poll(() => lastInvokeArgs(page, "validate_settings")).toMatchObject({
+    profileId: "opus",
+    key: "",
+    settings: {
+      model: "opus-4.8",
+    },
+  });
+});
+
 test("check for updates shows an up-to-date modal", async ({ page }) => {
   await enterApp(page);
   await page.getByRole("button", { name: "Settings" }).click();

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -2341,7 +2341,12 @@ fn App() -> impl IntoView {
         spawn_local(async move {
             let res = invoke_timeout(
                 "validate_settings",
-                to_value(&serde_json::json!({ "settings": cfg, "key": key })).unwrap(),
+                to_value(&serde_json::json!({
+                    "settings": cfg,
+                    "key": key,
+                    "profileId": form.id.clone(),
+                }))
+                .unwrap(),
                 35_000,
             )
             .await;


### PR DESCRIPTION
## Summary
This fixes a model-settings regression where validating an already-saved model from the edit form could use the wrong stored API key and fail with a 401 even though the model itself was still usable.

## What changed
- pass the edited model's `profileId` from the UI when invoking `validate_settings`
- resolve validation credentials from that specific saved model before falling back to the active profile key
- add a backend regression test for per-profile key lookup
- add a UI regression test that verifies saved-model validation sends the correct `profileId`

## Root cause
`validate_settings` previously fell back to the active model's keyring secret. When the user edited a different saved model and left the key field blank, validation could reuse the active model's token instead of the edited model's token.

## User impact
Users can now reopen a saved model and click Validate without re-entering its API key, and validation will use that model's own stored credential.

## Validation
- `cargo fmt --all -- --check`
- `cd ui && cargo check --target wasm32-unknown-unknown`
- `cargo test -p wisp-tauri profile_key_reads_the_requested_profile`
- `cd ui-tests && npx playwright test`

## Notes
- `cargo test --workspace` still reports two pre-existing failures in `wisp-store` project-transfer path normalization tests:
  - `project_transfer::tests::windows_paths_become_portable_and_restore_on_macos`
  - `project_transfer::tests::project_database_roundtrip_rebinds_paths_and_stops_live_runs`