### PR TITLE
fix(ui): fill center previews for PDB and FASTA

### DIFF
--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -747,6 +747,8 @@ export function tauriMock(): void {
               { name: "data", is_dir: true, size: 0 },
               { name: "report.csv", is_dir: false, size: 4096 },
               { name: "config.json", is_dir: false, size: 64 },
+              { name: "model.pdb", is_dir: false, size: 256 },
+              { name: "sequences.fasta", is_dir: false, size: 256 },
             ];
           case "list_remote_dir": {
             const path = String(arg("path") ?? "~");
@@ -791,6 +793,12 @@ export function tauriMock(): void {
           }
           case "read_file": {
             const path = String(arg("path") ?? "report.csv");
+            if (path.toLowerCase().endsWith(".pdb")) {
+              return { path, mime: "chemical/x-pdb", text: "ATOM      1  CA  ALA A   1      11.104  13.207   9.132  1.00 20.00           C\nEND\n", base64: null };
+            }
+            if (path.toLowerCase().endsWith(".fasta")) {
+              return { path, mime: "text/plain", text: ">seq1\nMKTIIALSYIFCLVFADYKDDDDK\n>seq2\nMKTIIALSYIFCLVFADYKDDDDK\n", base64: null };
+            }
             if (path.toLowerCase().includes(".pdf")) {
               return { path, mime: "application/pdf", text: null, base64: pdfBase64 };
             }

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -794,6 +794,30 @@ test("workspace file context menu attaches its path to the composer", async ({ p
   await expect(composer(page)).toHaveValue("");
 });
 
+test("center structure and FASTA previews fill the available height", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 1200 });
+  await enterApp(page);
+  await page.getByRole("button", { name: "Files" }).click();
+
+  const openInCenter = async (path: string) => {
+    await page.locator(`[data-workspace-path="${path}"]`).click({ button: "right" });
+    await page.locator(".ctx-menu").getByRole("button", { name: "Open in center" }).click();
+  };
+  const heightRatio = (selector: string) => page.locator(".center-file-preview").evaluate((preview, childSelector) => {
+    const child = preview.querySelector<HTMLElement>(childSelector);
+    return child ? child.getBoundingClientRect().height / preview.getBoundingClientRect().height : 0;
+  }, selector);
+
+  await openInCenter("model.pdb");
+  await expect(page.locator('.center-file-preview[data-preview-kind="structure"] .rp-3dmol')).toBeVisible();
+  await expect(page.locator('.center-file-preview[data-preview-kind="structure"] .rp-3dmol canvas')).toBeVisible();
+  await expect.poll(() => heightRatio(".rp-3dmol")).toBeGreaterThan(0.75);
+
+  await openInCenter("sequences.fasta");
+  await expect(page.locator('.center-file-preview[data-preview-kind="fasta"] .rp-fasta-wrap')).toBeVisible();
+  await expect.poll(() => heightRatio(".rp-fasta-wrap")).toBeGreaterThan(0.75);
+});
+
 test("Files browses registered SSH contexts without a real remote host", async ({ page }) => {
   await enterApp(page);
   await page.getByRole("button", { name: "Files" }).click();

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -4045,7 +4045,7 @@ fn App() -> impl IntoView {
             }).map(|file| {
                 let dom_id = format!("center-file-{}", file.path);
                 view! {
-                    <div class="center-file-preview">
+                    <div class="center-file-preview" data-preview-kind=file.kind.clone()>
                         <div class="center-file-head"><span>{file.path.clone()}</span></div>
                         <WorkspaceFilePreview dom_id=dom_id path=file.path kind=file.kind />
                     </div>

--- a/ui/src/styles/chat.css
+++ b/ui/src/styles/chat.css
@@ -24,6 +24,10 @@
 .center-file-preview { flex: 1 1 auto; min-height: 0; overflow: auto; padding: 16px 20px 28px; }
 .center-file-head { position: sticky; top: -16px; z-index: 1; margin: -16px -20px 16px; padding: 9px 16px; border-bottom: 1px solid var(--border); background: color-mix(in srgb, var(--bg-app) 92%, transparent); color: var(--text-faint); font-family: var(--font-mono); font-size: 11px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .center-file-preview .rp-code { min-height: calc(100% - 20px); }
+.center-file-preview:is([data-preview-kind="structure"], [data-preview-kind="fasta"]) { display: flex; flex-direction: column; overflow: hidden; }
+.center-file-preview:is([data-preview-kind="structure"], [data-preview-kind="fasta"]) > .rp-heavy { display: flex; flex: 1 1 auto; min-height: 0; flex-direction: column; }
+.center-file-preview[data-preview-kind="structure"] .rp-3dmol { flex: 1 1 auto; min-height: 0; height: auto; }
+.center-file-preview[data-preview-kind="fasta"] .rp-fasta-wrap { flex: 1 1 auto; min-height: 0; max-height: none; }
 @keyframes center-tab-content-in {
   from { opacity: 0; transform: translate3d(0, var(--motion-distance-sm), 0); }
   to { opacity: 1; transform: none; }


### PR DESCRIPTION
## Problem

PDB and FASTA previews opened in the center workspace inherited sizing intended for the narrow right panel. The 3D viewer stayed at 480 px and FASTA content was capped at 640 px / 62vh, leaving much of a tall center pane unused.

## Changes

- Mark center file previews with their preview kind.
- Give structure and FASTA previews center-only flex sizing so they consume the available height.
- Keep right-panel and artifact-modal sizing unchanged.
- Add mocked PDB/FASTA fixtures and a browser regression test that verifies the 3D canvas renders and both previews occupy at least 75% of the center height.

## Tests

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cd ui && cargo check --target wasm32-unknown-unknown`
- `cd ui-tests && npm ci && npx playwright test` — 100 passed

## Manual smoke

1. Open a PDB file from Files with **Open in center** and confirm the dark 3D viewport fills the remaining center height.
2. Resize the window and confirm the 3D viewport follows the available space.
3. Open a FASTA file in center and confirm its sequence table fills the pane while scrolling internally.
4. Open Markdown and PNG previews and confirm their existing document and zoom behavior is unchanged.

## Known limitations and follow-up

- The right panel and artifact modal intentionally retain their compact sizing.
- MSA uses a separate custom element with an explicit numeric height; responsive MSA resizing should be handled in a follow-up with its component lifecycle.