### PR TITLE
fix(llm): stop dropping streamed content on UTF-8 chunk boundaries

### DIFF
--- a/crates/wisp-llm/src/anthropic.rs
+++ b/crates/wisp-llm/src/anthropic.rs
@@ -7,7 +7,7 @@
 //! - assistant tool calls become `tool_use` content blocks
 
 use crate::message::{Content, Message, Role, ToolCall, ToolSchema};
-use crate::provider::{LlmError, Provider, Result, StreamSink};
+use crate::provider::{LlmError, Provider, Result, StreamSink, Utf8Stream};
 use crate::{Completion, FunctionCall, Usage};
 use async_trait::async_trait;
 use futures_util::StreamExt;
@@ -277,6 +277,7 @@ impl Provider for AnthropicProvider {
         }
         let mut stream = resp.bytes_stream();
         let mut buf = String::new();
+        let mut utf8 = Utf8Stream::default();
         // index -> (type, id, name, input_json_accumulator, text_accumulator)
         let mut blocks: std::collections::BTreeMap<usize, BlockAcc> =
             std::collections::BTreeMap::new();
@@ -291,7 +292,7 @@ impl Provider for AnthropicProvider {
                 break;
             }
             let bytes = chunk?;
-            buf.push_str(std::str::from_utf8(&bytes).unwrap_or(""));
+            buf.push_str(&utf8.push(&bytes));
             while let Some(idx) = buf.find("\n\n") {
                 let event = buf[..idx].to_string();
                 buf.drain(..idx + 2);

--- a/crates/wisp-llm/src/openai.rs
+++ b/crates/wisp-llm/src/openai.rs
@@ -7,7 +7,7 @@
 //! - MiniMax: `reasoning_details` (array of `{text}`)
 
 use crate::message::{Content, Message, Part, Role, ToolCall, ToolSchema};
-use crate::provider::{LlmError, Provider, Result, StreamSink};
+use crate::provider::{LlmError, Provider, Result, StreamSink, Utf8Stream};
 use crate::{Completion, FunctionCall, Usage};
 use async_trait::async_trait;
 use futures_util::StreamExt;
@@ -313,6 +313,7 @@ impl Provider for OpenAiProvider {
         }
         let mut stream = resp.bytes_stream();
         let mut buf = String::new();
+        let mut utf8 = Utf8Stream::default();
         let mut content = String::new();
         let mut reasoning = String::new();
         // index -> (id, name, arguments)
@@ -328,7 +329,7 @@ impl Provider for OpenAiProvider {
                 break;
             }
             let bytes = chunk?;
-            buf.push_str(std::str::from_utf8(&bytes).unwrap_or(""));
+            buf.push_str(&utf8.push(&bytes));
             while let Some(idx) = buf.find("\n\n") {
                 let event = buf[..idx].to_string();
                 buf.drain(..idx + 2);

--- a/crates/wisp-llm/src/provider.rs
+++ b/crates/wisp-llm/src/provider.rs
@@ -173,3 +173,71 @@ pub fn build(cfg: ProviderConfig) -> Box<dyn Provider> {
         ProviderKind::Anthropic => Box::new(crate::anthropic::AnthropicProvider::new(cfg)),
     }
 }
+
+/// Incremental UTF-8 decoder for a chunked byte stream.
+///
+/// Network/TLS framing splits multi-byte characters across chunks (pervasive
+/// with CJK text). Decoding each chunk in isolation with
+/// `from_utf8(&bytes).unwrap_or("")` drops the *entire* chunk whenever it ends
+/// (or begins) mid-character, silently gutting streamed content — the cause of
+/// truncated/garbled writes. This holds back the incomplete trailing bytes and
+/// emits them once the rest of the character arrives.
+#[derive(Default)]
+pub struct Utf8Stream {
+    tail: Vec<u8>,
+}
+
+impl Utf8Stream {
+    /// Feed one chunk; return the text that is now complete. Any incomplete
+    /// trailing multi-byte sequence is retained until the next `push`.
+    pub fn push(&mut self, bytes: &[u8]) -> String {
+        self.tail.extend_from_slice(bytes);
+        match std::str::from_utf8(&self.tail) {
+            Ok(s) => {
+                let out = s.to_string();
+                self.tail.clear();
+                out
+            }
+            Err(e) => {
+                let valid = e.valid_up_to();
+                // `valid_up_to()` bytes are guaranteed valid UTF-8.
+                let out = String::from_utf8_lossy(&self.tail[..valid]).into_owned();
+                match e.error_len() {
+                    // A genuinely invalid sequence (not a boundary split): drop
+                    // it so a malformed stream can never stall the buffer.
+                    Some(bad) => self.tail.drain(..valid + bad),
+                    // Incomplete trailing char: keep it for the next chunk.
+                    None => self.tail.drain(..valid),
+                };
+                out
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn utf8_stream_reassembles_char_split_across_chunks() {
+        // "支气管" streamed with the byte boundaries falling *inside* each
+        // 3-byte character — the exact case that the old per-chunk decode drops.
+        let full = "支气管扩张 review body\n\n";
+        let bytes = full.as_bytes();
+        let mut s = Utf8Stream::default();
+        let mut out = String::new();
+        // 2-byte chunks guarantee splits mid-character for 3-byte CJK codepoints.
+        for chunk in bytes.chunks(2) {
+            out.push_str(&s.push(chunk));
+        }
+        assert_eq!(out, full, "content lost across chunk boundaries");
+        assert!(s.tail.is_empty(), "no bytes left dangling at stream end");
+    }
+
+    #[test]
+    fn utf8_stream_matches_whole_input_for_ascii() {
+        let mut s = Utf8Stream::default();
+        assert_eq!(s.push(b"data: {\"x\":1}\n\n"), "data: {\"x\":1}\n\n");
+    }
+}


### PR DESCRIPTION
## 症状

GLM-5.2 写中文调研综述时正文严重截断（引言直接跳到参考文献、参考文献乱码），反复重写仍失败；把 max_tokens 从 8K 调到 128K 后反而恶化为「说要写却什么都不写」。见 #229。

## 根因

网络/TLS 分帧不尊重字符边界，一个 3 字节中文字常被切成「上一块结尾 + 下一块开头」。两个流式 provider 都用

```rust
buf.push_str(std::str::from_utf8(&bytes).unwrap_or(""));
```

逐块独立解码——只要某块在多字节字符中间开始或结束，`from_utf8` 对**整块**返回 `Err`，`unwrap_or("")` 就把这几 KB 内容默默丢弃。对纯 ASCII 永不触发，对流式中文频繁触发：

- `write` 工具调用的 `content` 参数被掏空中段（往往仍是合法 JSON）→ 正文缺失的文件落盘；
- 内容更长时连承载 tool-call 的 SSE 分块都丢失 → 工具调用消失、什么都不写。

这行自**初始 commit** 就存在，概率性发作，所以 v0.9「感觉没问题」（短任务运气好），而长中文综述几乎必现；也解释了为什么调大 max_tokens 无效——问题不在 token 预算。

**排查结论：与 reviewer 无关。** reviewer 在 v0.9.0 已在运行，`review.rs`/`agent.rs`/`write.rs` 自那以后未改；它只是检测到截断并触发纠错循环，把偶发故障放大成死循环——是报警器，不是纵火犯。

## 改动

- `provider.rs`：新增共享的增量解码器 `Utf8Stream`，跨块累积字节、只输出已完整字符、把被切断的尾字节留给下一块（`error_len() == Some` 的真·非法序列会跳过以防止 buffer 卡死）。
- `openai.rs`（GLM 路径）、`anthropic.rs`：把逐块 lossy 解码换成 `buf.push_str(&utf8.push(&bytes))`。
- `responses.rs` 不走字节流，无此问题。

## 测试

`cargo test -p wisp-llm` **11/11 通过**，含两个新单测。`utf8_stream_reassembles_char_split_across_chunks` 把中文按 2 字节切片（强制每个汉字都被切断）——旧逻辑会大量丢内容，新逻辑完整无损重组。现有流式测试无一破坏。

## Reviewer 须知

- 无法在此对真实 GLM 流量做端到端验证（无凭据），确认需重新构建 desktop app 再跑一遍那篇综述。
- 修好后建议把 max_tokens 从 128K 调回正常值（16K–32K）；128K 作为输出上限可能超过 GLM-5.2 实际能力甚至被 API 拒绝。

🤖 Generated with [Claude Code](https://claude.com/claude-code)