### PR TITLE
Add persistent Windows pet and preserve Contexts scrolling

### DIFF
--- a/docs/pet.md
+++ b/docs/pet.md
@@ -12,8 +12,12 @@ The pet folder must use `spriteVersionNumber: 2` and contain a `1536x2288` PNG o
 
 The app uses the standard animation rows for idle, directional walking, waving, jumping, failure, waiting for user input, active work, review, and 16-direction pointer tracking. Clicking an idle pet makes it wave. Reduced-motion system preferences disable roaming and animated playback.
 
+On Windows, the pet lives in its own transparent always-on-top window instead of inside the main workspace. Drag the pet to move it. Closing the main Wisp Science window hides the workspace to the system tray while the pet and active agent work continue; click the tray icon or choose **Open Wisp Science** to restore the workspace, and choose **Quit** to stop the app. The pet animation and status badge show when the agent is working, reviewing, waiting for approval, finished, or failed.
+
 ## 配置宠物
 
 Wisp Science 只加载一个由用户明确选择的 Codex v2 宠物，默认关闭，也不会自动扫描任何目录。
 
 打开 **设置 > 宠物**，选择包含 `pet.json` 和精灵表的安装目录，开启 **显示宠物** 后保存。目录必须使用 `spriteVersionNumber: 2`，精灵表必须是 `1536x2288` 的 PNG 或 WebP 文件。更换配置目录即可更换宠物；关闭开关后，应用不会再加载或显示该目录中的宠物。
+
+在 Windows 上，宠物运行在独立的透明置顶窗口中，而不是嵌在主工作区内，可以拖动到屏幕上的其他位置。关闭 Wisp Science 主窗口会把工作区隐藏到系统托盘，宠物和正在执行的 agent 任务会继续工作；点击托盘图标或选择 **Open Wisp Science** 可恢复窗口，选择 **Quit** 才会真正退出。宠物动画、状态点和文字会显示工作中、review、等待批准、完成或失败状态。

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = ["devtools"] }
+tauri = { version = "2", features = ["devtools", "tray-icon"] }
 tauri-plugin-dialog = "2"
 tauri-plugin-opener = "2"
 serde = { workspace = true }

--- a/src-tauri/capabilities/pet.json
+++ b/src-tauri/capabilities/pet.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "pet",
+  "description": "Pet window IPC and native dragging",
+  "windows": ["pet"],
+  "remote": {
+    "urls": ["http://localhost:1420", "http://127.0.0.1:1420"]
+  },
+  "permissions": [
+    "core:default",
+    "core:window:allow-start-dragging"
+  ]
+}

--- a/src-tauri/src/desktop_lifecycle.rs
+++ b/src-tauri/src/desktop_lifecycle.rs
@@ -1,0 +1,159 @@
+#[cfg(target_os = "windows")]
+use tauri::{
+    menu::{Menu, MenuItemBuilder},
+    tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
+    App, AppHandle, Emitter, Manager, WebviewUrl, WebviewWindowBuilder,
+};
+
+pub(crate) const PET_WINDOW_LABEL: &str = "pet";
+
+#[cfg(any(target_os = "windows", test))]
+pub(crate) fn should_hide_workspace_on_close(window_label: &str) -> bool {
+    window_label == "main"
+}
+
+#[cfg(target_os = "windows")]
+fn show_workspace_windows(app: &AppHandle) {
+    for (label, window) in app.webview_windows() {
+        if label != PET_WINDOW_LABEL {
+            let _ = window.show();
+            let _ = window.unminimize();
+        }
+    }
+    if let Some(main) = app.get_webview_window("main") {
+        let _ = main.set_focus();
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn hide_workspace_windows(app: &AppHandle) {
+    for (label, window) in app.webview_windows() {
+        if label != PET_WINDOW_LABEL {
+            let _ = window.hide();
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn default_pet_position(app: &AppHandle) -> Option<(f64, f64)> {
+    let monitor = app.primary_monitor().ok().flatten()?;
+    let origin = monitor.position();
+    let size = monitor.size();
+    Some((
+        f64::from(origin.x) + f64::from(size.width.saturating_sub(152)),
+        f64::from(origin.y) + f64::from(size.height.saturating_sub(230)),
+    ))
+}
+
+#[cfg(target_os = "windows")]
+fn ensure_pet_window(app: &AppHandle) -> Result<(), String> {
+    if app.get_webview_window(PET_WINDOW_LABEL).is_some() {
+        return Ok(());
+    }
+    let url = WebviewUrl::App("index.html?pet=desktop".into());
+    let mut builder = WebviewWindowBuilder::new(app, PET_WINDOW_LABEL, url)
+        .title("Wisp pet")
+        .inner_size(128.0, 140.0)
+        .resizable(false)
+        .maximizable(false)
+        .minimizable(false)
+        .closable(false)
+        .decorations(false)
+        .transparent(true)
+        .shadow(false)
+        .always_on_top(true)
+        .skip_taskbar(true)
+        .focused(false)
+        .visible(false);
+    if let Some((x, y)) = default_pet_position(app) {
+        builder = builder.position(x, y);
+    }
+    builder.build().map_err(|error| error.to_string())?;
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+pub(crate) fn sync_pet_window(app: &AppHandle, enabled: bool) -> Result<(), String> {
+    if !enabled {
+        if let Some(window) = app.get_webview_window(PET_WINDOW_LABEL) {
+            let _ = window.hide();
+        }
+        return Ok(());
+    }
+    ensure_pet_window(app)?;
+    let _ = app.emit_to(PET_WINDOW_LABEL, "pet-config-changed", ());
+    Ok(())
+}
+
+#[cfg(not(target_os = "windows"))]
+pub(crate) fn sync_pet_window(_app: &tauri::AppHandle, _enabled: bool) -> Result<(), String> {
+    Ok(())
+}
+
+#[tauri::command]
+pub(crate) fn set_pet_window_visible(app: tauri::AppHandle, visible: bool) -> Result<(), String> {
+    #[cfg(target_os = "windows")]
+    {
+        if visible {
+            ensure_pet_window(&app)?;
+        }
+        if let Some(window) = app.get_webview_window(PET_WINDOW_LABEL) {
+            if visible {
+                window.show().map_err(|error| error.to_string())?;
+            } else {
+                window.hide().map_err(|error| error.to_string())?;
+            }
+        }
+    }
+    #[cfg(not(target_os = "windows"))]
+    let _ = (app, visible);
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+pub(crate) fn install_windows_shell(app: &mut App) -> tauri::Result<()> {
+    let show = MenuItemBuilder::with_id("tray-show", "Open Wisp Science").build(app)?;
+    let quit = MenuItemBuilder::with_id("tray-quit", "Quit").build(app)?;
+    let menu = Menu::with_items(app, &[&show, &quit])?;
+    let mut tray = TrayIconBuilder::with_id("wisp-tray")
+        .menu(&menu)
+        .tooltip("Wisp Science")
+        .show_menu_on_left_click(false)
+        .on_menu_event(|app, event| match event.id().as_ref() {
+            "tray-show" => show_workspace_windows(app),
+            "tray-quit" => app.exit(0),
+            _ => {}
+        })
+        .on_tray_icon_event(|tray, event| {
+            if matches!(
+                event,
+                TrayIconEvent::Click {
+                    button: MouseButton::Left,
+                    button_state: MouseButtonState::Up,
+                    ..
+                } | TrayIconEvent::DoubleClick {
+                    button: MouseButton::Left,
+                    ..
+                }
+            ) {
+                show_workspace_windows(tray.app_handle());
+            }
+        });
+    if let Some(icon) = app.default_window_icon() {
+        tray = tray.icon(icon.clone());
+    }
+    tray.build(app)?;
+
+    if let Some(main) = app.get_webview_window("main") {
+        let app_handle = app.handle().clone();
+        main.on_window_event(move |event| {
+            if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                if should_hide_workspace_on_close("main") {
+                    api.prevent_close();
+                    hide_workspace_windows(&app_handle);
+                }
+            }
+        });
+    }
+    Ok(())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -22,6 +22,7 @@ mod approval_commands;
 mod artifact_commands;
 mod connector_commands;
 mod context_probe;
+mod desktop_lifecycle;
 mod file_browser;
 mod harvest;
 mod library_commands;
@@ -5467,14 +5468,29 @@ pub fn run() {
                 bootstrap,
                 reviewing: Arc::new(StdMutex::new(HashSet::new())),
             };
+            let pet_enabled = tauri::async_runtime::block_on(async {
+                state
+                    .store
+                    .get_setting("pet_enabled")
+                    .await
+                    .ok()
+                    .flatten()
+                    .is_some_and(|value| value == "true")
+            });
             app.manage(state);
             app.manage(terminal_sessions::TerminalManager::new());
             start_python_bootstrap(app.handle());
             set_dev_flag(app.handle());
             #[cfg(target_os = "windows")]
-            if let Some(window) = app.get_webview_window("main") {
-                let _ = window.set_decorations(false);
-                let _ = window.set_shadow(true);
+            {
+                desktop_lifecycle::install_windows_shell(app)?;
+                if let Err(error) = desktop_lifecycle::sync_pet_window(app.handle(), pet_enabled) {
+                    tracing::warn!(target: "wisp", %error, "failed to initialize pet window");
+                }
+                if let Some(window) = app.get_webview_window("main") {
+                    let _ = window.set_decorations(false);
+                    let _ = window.set_shadow(true);
+                }
             }
             #[cfg(target_os = "macos")]
             if let Some(window) = app.get_webview_window("main") {
@@ -5606,6 +5622,8 @@ pub fn run() {
             settings_commands::credential_status,
             settings_commands::set_credential,
             pet_commands::get_pet,
+            pet_commands::get_pet_runtime_status,
+            desktop_lifecycle::set_pet_window_visible,
             models::list_models,
             models::save_model,
             models::remove_model,

--- a/src-tauri/src/lib_tests.rs
+++ b/src-tauri/src/lib_tests.rs
@@ -1,3 +1,4 @@
+use super::desktop_lifecycle::should_hide_workspace_on_close;
 use super::{
     branch_title, copy_dir_recursive, events_to_items, messages_to_items, parse_disabled_skills,
     parse_enabled_skill_names, parse_skill_tags, parse_ssh_artifact_uri,
@@ -677,4 +678,11 @@ fn macos_close_hides_only_main_window_when_not_quitting() {
     assert!(should_hide_app_on_macos_close("main", false));
     assert!(!should_hide_app_on_macos_close("proj-default", false));
     assert!(!should_hide_app_on_macos_close("main", true));
+}
+
+#[test]
+fn windows_close_to_tray_applies_only_to_the_main_window() {
+    assert!(should_hide_workspace_on_close("main"));
+    assert!(!should_hide_workspace_on_close("proj-default"));
+    assert!(!should_hide_workspace_on_close("pet"));
 }

--- a/src-tauri/src/pet_commands.rs
+++ b/src-tauri/src/pet_commands.rs
@@ -39,6 +39,14 @@ pub(super) struct PetStatus {
     error: Option<String>,
 }
 
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct PetRuntimeStatus {
+    running: Vec<String>,
+    waiting: Vec<String>,
+    reviewing: Vec<String>,
+}
+
 #[derive(Deserialize)]
 struct ValidationReport {
     ok: bool,
@@ -263,6 +271,26 @@ pub(super) async fn get_pet(state: State<'_, AppState>) -> Result<PetStatus, Str
             error: Some(error),
         }),
     }
+}
+
+#[tauri::command]
+pub(super) async fn get_pet_runtime_status(
+    state: State<'_, AppState>,
+) -> Result<PetRuntimeStatus, String> {
+    let running = state.running_turns.lock().await.iter().cloned().collect();
+    let waiting = state
+        .awaiting_confirm
+        .lock()
+        .unwrap()
+        .iter()
+        .cloned()
+        .collect();
+    let reviewing = state.reviewing.lock().unwrap().iter().cloned().collect();
+    Ok(PetRuntimeStatus {
+        running,
+        waiting,
+        reviewing,
+    })
 }
 
 #[cfg(test)]

--- a/src-tauri/src/settings_commands.rs
+++ b/src-tauri/src/settings_commands.rs
@@ -1,6 +1,6 @@
 use super::{
-    build_provider_config, clear_idle_agents, effective_api_key, load_locale, load_settings,
-    models, normalized_provider, pet_commands::load_pet_asset, AppState, Settings,
+    build_provider_config, clear_idle_agents, desktop_lifecycle, effective_api_key, load_locale,
+    load_settings, models, normalized_provider, pet_commands::load_pet_asset, AppState, Settings,
 };
 use serde_json::json;
 use std::{
@@ -209,6 +209,7 @@ pub(super) async fn set_settings(
         .set_setting("pet_directory", pet_directory)
         .await
         .map_err(|e| e.to_string())?;
+    desktop_lifecycle::sync_pet_window(&app, settings.pet_enabled)?;
 
     // Workspace directory: persist an absolute, creatable path. Takes effect on
     // next launch (AppState.root is fixed at startup — restart, not hot-swap).

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -48,8 +48,9 @@ export function tauriMock(): void {
     release_url: "https://github.com/xuzhougeng/wisp-science/releases",
   };
   let mockUpdateCheckPending = false;
-  let mockPetEnabled = false;
-  let mockPetDirectory = "";
+  let mockPetEnabled = new URLSearchParams(window.location.search).get("mockPet") === "1";
+  let mockPetDirectory = mockPetEnabled ? "C:\\Users\\tester\\.codex\\pets\\wispy" : "";
+  (window as any).__petWindowVisible = false;
   let resolveMockUpdateCheck: (() => void) | null = null;
   const syncedProjects = new Set<string>();
   const nextProjectOpenDelayMs: Record<string, number> = {};
@@ -460,6 +461,11 @@ export function tauriMock(): void {
                 frameCounts: { idle: 7, "running-right": 8, "running-left": 8, waving: 4, jumping: 5, failed: 8, waiting: 6, running: 6, review: 6 },
               } : null,
             };
+          case "get_pet_runtime_status":
+            return { running: [], waiting: [], reviewing: [] };
+          case "set_pet_window_visible":
+            (window as any).__petWindowVisible = Boolean(arg("visible"));
+            return null;
           case "list_models":
             return mockModels;
           case "list_acp_agents":
@@ -1212,6 +1218,13 @@ export function tauriMock(): void {
           listeners[event] = undefined;
         };
       },
+    },
+    window: {
+      getCurrentWindow: () => ({
+        startDragging: async () => {
+          (window as any).__petDragStarted = true;
+        },
+      }),
     },
   };
 }

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -1080,6 +1080,31 @@ test("right panel shows execution contexts and runs", async ({ page }) => {
   )).toBeGreaterThan(1);
 });
 
+test("contexts panel keeps its scroll position across background refreshes", async ({ page }) => {
+  await enterApp(page);
+  await page.getByRole("button", { name: "Toggle panel" }).click();
+  await page.getByRole("button", { name: "Add panel" }).click();
+  await page.getByRole("button", { name: "Contexts" }).click();
+
+  const panel = page.locator(".rp-contexts");
+  await expect(panel).toBeVisible();
+  const scrollTop = await panel.evaluate((element) => {
+    const target = Math.min(200, element.scrollHeight - element.clientHeight);
+    element.scrollTop = target;
+    return element.scrollTop;
+  });
+  expect(scrollTop).toBeGreaterThan(0);
+
+  const refreshCount = await page.evaluate(() =>
+    ((window as any).__skillInvokeLog ?? []).filter((call: any) => call.cmd === "list_runtimes").length,
+  );
+  await expect.poll(async () => page.evaluate(() =>
+    ((window as any).__skillInvokeLog ?? []).filter((call: any) => call.cmd === "list_runtimes").length,
+  )).toBeGreaterThan(refreshCount);
+
+  await expect.poll(() => panel.evaluate((element) => element.scrollTop)).toBe(scrollTop);
+});
+
 test("execution contexts remember Python and R interpreter paths", async ({ page }) => {
   await enterApp(page);
   await page.getByRole("button", { name: "Toggle panel" }).click();
@@ -2239,12 +2264,52 @@ test("pet stays off until the user explicitly configures its directory", async (
     },
   });
 
-  await page.locator(".proj-card-main").first().click();
+  await page.goto("/?pet=desktop&mockPet=1");
   const pet = page.getByTestId("wisp-pet");
   await expect(pet).toBeVisible();
   await expect.poll(() => pet.getAttribute("data-state")).toMatch(/^(idle|looking)$/);
   await pet.click();
   await expect(pet).toHaveAttribute("data-state", "waving");
+});
+
+test("desktop pet remains independent and reflects global agent state", async ({ page }) => {
+  await page.goto("/?pet=desktop&mockPet=1");
+
+  const pet = page.getByTestId("wisp-pet");
+  await expect(page.getByTestId("pet-window-root")).toBeVisible();
+  await expect(pet).toBeVisible();
+  await expect(pet).toHaveAttribute("data-tauri-drag-region", "deep");
+  await expect.poll(() => page.evaluate(() => (window as any).__petWindowVisible)).toBe(true);
+
+  await page.evaluate(() => {
+    (window as any).__tauriEmit("agent", { kind: "User", frame_id: "pet-frame", text: "run" });
+  });
+  await expect(pet).toHaveAttribute("data-state", "running");
+  await expect(pet.getByText("Working")).toBeVisible();
+
+  await page.evaluate(() => {
+    (window as any).__tauriEmit("confirm-request", { frame_id: "pet-frame", message: "Approve?" });
+  });
+  await expect(pet).toHaveAttribute("data-state", "waiting");
+  await expect(pet.getByText("Needs you")).toBeVisible();
+
+  await page.evaluate(() => {
+    (window as any).__tauriEmit("agent", { kind: "Text", frame_id: "pet-frame", delta: "continuing" });
+    (window as any).__tauriEmit("agent", { kind: "ReviewStarted", frame_id: "pet-frame" });
+  });
+  await expect(pet).toHaveAttribute("data-state", "review");
+  await expect(pet.getByText("Reviewing")).toBeVisible();
+
+  await page.evaluate(() => {
+    (window as any).__tauriEmit("agent", { kind: "Error", frame_id: "pet-frame", message: "failed" });
+  });
+  await expect(pet).toHaveAttribute("data-state", "failed");
+  await expect(pet.getByText("Failed")).toBeVisible();
+
+  await page.evaluate(() => {
+    (window as any).__tauriEmit("agent", { kind: "Done", frame_id: "pet-frame" });
+  });
+  await expect(pet).toHaveAttribute("data-state", "jumping");
 });
 
 test("a sync conflict requires an explicit authoritative device choice", async ({ page }) => {

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -30,7 +30,7 @@ use notebook::{collect_notebook_cells, NotebookCache, NotebookView};
 use overlays::{
     AddHostOverlay, CapabilitiesOverlay, OnboardingOverlay, RuntimeInterpreterOverlay,
 };
-use pet::PetOverlay;
+use pet::{PetDesktop, PetOverlay};
 use project_landing::{ProjectLanding, ProjectLandingState};
 use serde_wasm_bindgen::to_value;
 use settings_view::{SettingsView, SettingsViewState};
@@ -5668,18 +5668,14 @@ fn App() -> impl IntoView {
                         }
                         RightTab::Hosts => {
                             let loc = locale.get();
-                            let contexts = execution_contexts.get();
-                            let runtime_rows = runtime_slots(
-                                runtime_infos.get(),
-                                &contexts,
-                                project_info.get(),
-                                &proj_list.get(),
-                            );
-                            let runs = run_records.get();
-                            let hs = ssh_hosts.get();
                             view! {
                                 <div class="rp-contexts">
-                                    <section class="control-section">
+                                    // Keep the scroll container outside these reactive children:
+                                    // runtime/run polling must update sections without replacing
+                                    // `.rp-contexts` and resetting its scrollTop.
+                                    {move || {
+                                        let contexts = execution_contexts.get();
+                                        view! { <section class="control-section">
                                         <div class="control-section-head">
                                             <span>{t(loc, "contexts.execution")}</span>
                                             <span class="control-count">{contexts.len().to_string()}</span>
@@ -5795,8 +5791,17 @@ fn App() -> impl IntoView {
                                                     }><span class="gi server"></span>{t(loc, "contexts.import_wsl")}</button>
                                             })}
                                         </div>
-                                    </section>
-                                    <section class="control-section runtime-section">
+                                    </section> }.into_view()
+                                    }}
+                                    {move || {
+                                        let contexts = execution_contexts.get();
+                                        let runtime_rows = runtime_slots(
+                                            runtime_infos.get(),
+                                            &contexts,
+                                            project_info.get(),
+                                            &proj_list.get(),
+                                        );
+                                        view! { <section class="control-section runtime-section">
                                         <div class="control-section-head">
                                             <span>{t(loc, "contexts.runtimes")}</span>
                                             <div class="control-head-actions">
@@ -5818,8 +5823,11 @@ fn App() -> impl IntoView {
                                                     object_states=runtime_object_states />
                                             }).collect_view()
                                         }}
-                                    </section>
-                                    <section class="control-section">
+                                    </section> }.into_view()
+                                    }}
+                                    {move || {
+                                        let runs = run_records.get();
+                                        view! { <section class="control-section">
                                         <div class="control-section-head">
                                             <span>{t(loc, "contexts.runs")}</span>
                                             <div class="control-head-actions">
@@ -5901,8 +5909,11 @@ fn App() -> impl IntoView {
                                                 }.into_view()
                                             }).collect_view()
                                         }}
-                                    </section>
-                                    {(!hs.is_empty()).then(|| view! {
+                                    </section> }.into_view()
+                                    }}
+                                    {move || {
+                                        let hs = ssh_hosts.get();
+                                        (!hs.is_empty()).then(|| view! {
                                         <section class="control-section">
                                             <div class="control-section-head">
                                                 <span>{t(loc, "hosts.title")}</span>
@@ -5940,7 +5951,8 @@ fn App() -> impl IntoView {
                                                 }
                                             }).collect_view()}
                                         </section>
-                                    })}
+                                        })
+                                    }}
                                 </div>
                             }.into_view()
                         }
@@ -6448,9 +6460,11 @@ fn App() -> impl IntoView {
             remove_specialist=Callback::new(remove_specialist_fn)
         />
 
-        <PetOverlay status=pet_status active_session=active_session running=running
-            approval_pending=approval_pending activity=pet_activity show_projects=show_projects
-            show_settings=show_settings center_file_open=center_file_open />
+        {(!is_windows()).then(|| view! {
+            <PetOverlay status=pet_status active_session=active_session running=running
+                approval_pending=approval_pending activity=pet_activity show_projects=show_projects
+                show_settings=show_settings center_file_open=center_file_open />
+        })}
 
 
 
@@ -7019,5 +7033,14 @@ fn render_item(
 
 pub fn main() {
     console_error_panic_hook::set_once();
-    mount_to_body(App);
+    let is_pet_window = window()
+        .location()
+        .search()
+        .ok()
+        .is_some_and(|query| query.split('&').any(|part| part == "?pet=desktop" || part == "pet=desktop"));
+    if is_pet_window {
+        mount_to_body(PetDesktop);
+    } else {
+        mount_to_body(App);
+    }
 }

--- a/ui/src/pet.js
+++ b/ui/src/pet.js
@@ -43,6 +43,8 @@ class PetRuntime {
 
   configure(config) {
     this.config = config;
+    this.desktop = !!config.desktop;
+    this.element.classList.toggle("is-desktop", this.desktop);
     this.element.classList.toggle("is-visible", !!config.visible && !!config.src);
     this.element.title = config.name || "Pet";
     if (this.src !== config.src) {
@@ -114,7 +116,7 @@ class PetRuntime {
 
   scheduleRoam() {
     clearTimeout(this.roamTimer);
-    if (this.reduceMotion || this.externalState !== "idle") return;
+    if (this.reduceMotion || this.externalState !== "idle" || this.config?.roam === false) return;
     this.roamTimer = setTimeout(() => this.roam(), 5000 + Math.random() * 6000);
   }
 

--- a/ui/src/pet.rs
+++ b/ui/src/pet.rs
@@ -1,6 +1,250 @@
-use crate::{bindings::sync_pet, dto::PetStatus};
+use crate::{
+    bindings::{invoke, listen, sync_pet},
+    dto::{AgentEvent, PetStatus},
+};
 use leptos::*;
+use serde::Deserialize;
 use std::collections::HashSet;
+use wasm_bindgen::{closure::Closure, JsCast, JsValue};
+
+#[derive(Clone, Default, PartialEq, Eq)]
+struct DesktopPetActivity {
+    running: HashSet<String>,
+    waiting: HashSet<String>,
+    reviewing: HashSet<String>,
+    transient: String,
+    sequence: u64,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PetRuntimeSnapshot {
+    #[serde(default)]
+    running: Vec<String>,
+    #[serde(default)]
+    waiting: Vec<String>,
+    #[serde(default)]
+    reviewing: Vec<String>,
+}
+
+impl DesktopPetActivity {
+    fn replace_from_snapshot(&mut self, snapshot: PetRuntimeSnapshot) {
+        self.running = snapshot.running.into_iter().collect();
+        self.waiting = snapshot.waiting.into_iter().collect();
+        self.reviewing = snapshot.reviewing.into_iter().collect();
+        self.transient.clear();
+    }
+
+    fn mark_running(&mut self, frame_id: String) {
+        self.waiting.remove(&frame_id);
+        self.reviewing.remove(&frame_id);
+        self.running.insert(frame_id);
+        self.transient.clear();
+    }
+
+    fn mark_waiting(&mut self, frame_id: String) {
+        self.running.insert(frame_id.clone());
+        self.waiting.insert(frame_id);
+        self.transient.clear();
+    }
+
+    fn finish(&mut self, frame_id: &str, transient: &str) {
+        self.running.remove(frame_id);
+        self.waiting.remove(frame_id);
+        self.reviewing.remove(frame_id);
+        self.transient = transient.to_string();
+        self.sequence = self.sequence.wrapping_add(1);
+    }
+
+    fn apply_agent_event(&mut self, event: AgentEvent) {
+        match event {
+            AgentEvent::User { frame_id, .. }
+            | AgentEvent::Text { frame_id, .. }
+            | AgentEvent::Reasoning { frame_id, .. }
+            | AgentEvent::ToolCall { frame_id, .. }
+            | AgentEvent::Stdout { frame_id, .. }
+            | AgentEvent::CorrectionStarted { frame_id, .. } => self.mark_running(frame_id),
+            AgentEvent::ToolResult {
+                frame_id, ok: false, ..
+            }
+            | AgentEvent::Error { frame_id, .. } => self.finish(&frame_id, "failed"),
+            AgentEvent::ToolResult {
+                frame_id, ok: true, ..
+            } => self.mark_running(frame_id),
+            AgentEvent::ReviewStarted { frame_id } | AgentEvent::Review { frame_id, .. } => {
+                self.waiting.remove(&frame_id);
+                self.running.insert(frame_id.clone());
+                self.reviewing.insert(frame_id);
+                self.transient.clear();
+            }
+            AgentEvent::Done { frame_id, .. } => self.finish(&frame_id, "jumping"),
+            AgentEvent::MessageBoundary { .. }
+            | AgentEvent::Usage { .. }
+            | AgentEvent::Compaction { .. }
+            | AgentEvent::Diff { .. } => {}
+        }
+    }
+
+    fn state(&self) -> &str {
+        if !self.waiting.is_empty() {
+            "waiting"
+        } else if self.transient == "failed" {
+            "failed"
+        } else if !self.reviewing.is_empty() {
+            "review"
+        } else if !self.running.is_empty() {
+            "running"
+        } else if self.transient == "jumping" {
+            "jumping"
+        } else {
+            "idle"
+        }
+    }
+}
+
+fn install_listener(event: &'static str, callback: Closure<dyn FnMut(JsValue)>) {
+    let function = callback
+        .as_ref()
+        .unchecked_ref::<js_sys::Function>()
+        .clone();
+    callback.forget();
+    spawn_local(async move {
+        let _ = listen(event, &function).await;
+    });
+}
+
+fn refresh_desktop_pet(
+    status: RwSignal<PetStatus>,
+    activity: RwSignal<DesktopPetActivity>,
+) {
+    spawn_local(async move {
+        let value = invoke("get_pet", JsValue::UNDEFINED).await;
+        let visible = serde_wasm_bindgen::from_value::<PetStatus>(value)
+            .map(|next| {
+                let visible = next.enabled && next.asset.is_some();
+                status.set(next);
+                visible
+            })
+            .unwrap_or(false);
+        let args = serde_wasm_bindgen::to_value(&serde_json::json!({ "visible": visible }))
+            .unwrap_or(JsValue::UNDEFINED);
+        let _ = invoke("set_pet_window_visible", args).await;
+
+        let snapshot = invoke("get_pet_runtime_status", JsValue::UNDEFINED).await;
+        if let Ok(snapshot) = serde_wasm_bindgen::from_value::<PetRuntimeSnapshot>(snapshot) {
+            activity.update(|current| current.replace_from_snapshot(snapshot));
+        }
+    });
+}
+
+fn desktop_state_label(state: &str) -> &'static str {
+    match state {
+        "running" => "Working",
+        "review" => "Reviewing",
+        "waiting" => "Needs you",
+        "failed" => "Failed",
+        "jumping" => "Done",
+        _ => "Idle",
+    }
+}
+
+#[component]
+pub(crate) fn PetDesktop() -> impl IntoView {
+    let status = create_rw_signal(PetStatus::default());
+    let activity = create_rw_signal(DesktopPetActivity::default());
+
+    if let Some(root) = document().document_element() {
+        let _ = root.set_attribute("class", "pet-window-shell");
+    }
+    if let Some(body) = document().body() {
+        body.set_class_name("pet-window-shell");
+    }
+
+    refresh_desktop_pet(status, activity);
+    install_listener(
+        "pet-config-changed",
+        Closure::wrap(Box::new(move |_: JsValue| {
+            refresh_desktop_pet(status, activity);
+        }) as Box<dyn FnMut(JsValue)>),
+    );
+    install_listener(
+        "agent",
+        Closure::wrap(Box::new(move |payload: JsValue| {
+            if let Ok(event) = serde_wasm_bindgen::from_value::<AgentEvent>(payload) {
+                activity.update(|current| current.apply_agent_event(event));
+            }
+        }) as Box<dyn FnMut(JsValue)>),
+    );
+    for event_name in ["confirm-request", "permission-request"] {
+        install_listener(
+            event_name,
+            Closure::wrap(Box::new(move |payload: JsValue| {
+                let Ok(value) = serde_wasm_bindgen::from_value::<serde_json::Value>(payload) else {
+                    return;
+                };
+                let frame_id = value
+                    .get("frame_id")
+                    .or_else(|| value.get("frameId"))
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or_default();
+                if !frame_id.is_empty() {
+                    activity.update(|current| current.mark_waiting(frame_id.to_string()));
+                }
+            }) as Box<dyn FnMut(JsValue)>),
+        );
+    }
+
+    create_effect(move |_| {
+        let status = status.get();
+        let activity = activity.get();
+        let state = activity.state();
+        let visible = status.enabled && status.asset.is_some();
+        let (src, name, frame_counts) = status
+            .asset
+            .as_ref()
+            .map(|asset| {
+                (
+                    asset.spritesheet_data_url.clone(),
+                    asset.display_name.clone(),
+                    asset.frame_counts.clone(),
+                )
+            })
+            .unwrap_or_default();
+        let config = serde_json::json!({
+            "visible": visible,
+            "src": src,
+            "name": name,
+            "state": state,
+            "sequence": activity.sequence,
+            "frameCounts": frame_counts,
+            "desktop": true,
+            "roam": false,
+        });
+        if let Ok(json) = serde_json::to_string(&config) {
+            sync_pet("wisp-pet", &json);
+        }
+    });
+
+    view! {
+        <main class="pet-window-root" data-testid="pet-window-root">
+            <button id="wisp-pet" class="wisp-pet desktop-pet" type="button"
+                data-testid="wisp-pet"
+                data-tauri-drag-region="deep"
+                aria-label=move || {
+                    let current = activity.get();
+                    let name = status.get().asset.map(|asset| asset.display_name)
+                        .unwrap_or_else(|| "Pet".into());
+                    format!("{name}: {}", desktop_state_label(current.state()))
+                }>
+                <span class="wisp-pet-sprite" aria-hidden="true"></span>
+                <span class="wisp-pet-status" aria-hidden="true"></span>
+                <span class="wisp-pet-state-label">
+                    {move || desktop_state_label(activity.get().state())}
+                </span>
+            </button>
+        </main>
+    }
+}
 
 #[component]
 pub(crate) fn PetOverlay(

--- a/ui/src/styles/pet.css
+++ b/ui/src/styles/pet.css
@@ -29,6 +29,51 @@
 .wisp-pet[data-state="running"] .wisp-pet-status { background: var(--info); }
 .wisp-pet[data-state="review"] .wisp-pet-status { background: var(--clay); }
 .wisp-pet[data-state="waiting"] .wisp-pet-status { background: var(--warn); animation: pet-status-pulse 1.3s ease-in-out infinite; }
+.wisp-pet-state-label { display: none; }
+
+html.pet-window-shell,
+html.pet-window-shell body {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  overflow: hidden;
+  background: transparent !important;
+}
+
+.pet-window-root { position: relative; width: 100%; height: 100%; background: transparent; }
+.pet-window-root .wisp-pet {
+  right: 16px;
+  bottom: 25px;
+  width: 96px;
+  height: 104px;
+  animation: none;
+  cursor: grab;
+  user-select: none;
+  touch-action: none;
+}
+.pet-window-root .wisp-pet:active { cursor: grabbing; }
+.pet-window-root .wisp-pet-status { border-color: rgba(255, 255, 255, .9); }
+.pet-window-root .wisp-pet-state-label {
+  position: absolute;
+  left: 50%;
+  bottom: -19px;
+  display: none;
+  min-width: 52px;
+  padding: 2px 7px;
+  border: 1px solid rgba(25, 29, 34, .13);
+  border-radius: 999px;
+  background: rgba(252, 250, 246, .9);
+  box-shadow: 0 3px 10px rgba(20, 23, 28, .13);
+  color: #34383e;
+  font: 600 10px/1.35 "Segoe UI Variable", "Segoe UI", sans-serif;
+  text-align: center;
+  transform: translateX(-50%);
+  backdrop-filter: blur(8px);
+}
+.pet-window-root .wisp-pet[data-state="running"] .wisp-pet-state-label,
+.pet-window-root .wisp-pet[data-state="review"] .wisp-pet-state-label,
+.pet-window-root .wisp-pet[data-state="waiting"] .wisp-pet-state-label,
+.pet-window-root .wisp-pet[data-state="failed"] .wisp-pet-state-label { display: block; }
 
 @keyframes pet-arrive { from { opacity: 0; transform: translateX(var(--pet-x)) translateY(12px) scale(.92); } to { opacity: 1; transform: translateX(var(--pet-x)) translateY(0) scale(1); } }
 @keyframes pet-status-pulse { 50% { box-shadow: 0 0 0 5px color-mix(in srgb, var(--warn) 20%, transparent); } }


### PR DESCRIPTION
## Problem

On Windows, closing the main Wisp Science window also removed the pet, so it could not remain visible and report agent activity while the workspace was minimized to the tray. The pet window also could not be dragged. Separately, polling updates in the right-side Contexts panel reset its scroll position.

## Changes

- Hide workspace windows to the Windows system tray when the main window is closed, with tray actions to restore Wisp Science or quit explicitly.
- Run the pet in an independent transparent, always-on-top, taskbar-hidden window so it remains active while the workspace is hidden.
- Reflect global agent states in the pet: working, reviewing, waiting for approval, failed, and done.
- Keep pet support disabled until the user explicitly configures a pet path; no implicit `~/.codex/pets/wispy` default is used.
- Add the pet window to the Tauri capability scope and enable deep drag regions so the native pet window can be moved.
- Preserve the right Contexts sidebar container during polling updates, preventing its `scrollTop` from resetting.
- Add regression coverage for pet behavior and Contexts scroll preservation.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p wisp-tauri`
- `cargo test -p wisp-tauri --lib` (140 passed)
- `cd ui && cargo check --target wasm32-unknown-unknown`
- Targeted Playwright regression suite (9 passed)
- Windows smoke test confirmed the native pet window can be dragged and continues working while workspace windows are hidden.

## Known limitations

- `cargo test --workspace` still reports two pre-existing Windows path portability failures in `wisp-store/project_transfer.rs`.
- A full Playwright run was disrupted by concurrent Trunk hot reload/file locking; all six affected tests passed in an isolated targeted rerun.