### PR TITLE
Fix duplicate artifact code scrollbars

### DIFF
--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -1332,6 +1332,19 @@ test("clicking a figure opens the artifact modal with provenance", async ({ page
   // Code tab renders the recorded source (from get_artifact_provenance).
   await page.locator(".am-tab", { hasText: "Code" }).click();
   await expect(page.locator(".artifact-modal")).toContainText("savefig");
+  const codeScrollOwners = await page.locator(".artifact-modal .am-panel").evaluate((panel) => {
+    const code = panel.querySelector<HTMLElement>(".rp-code")!;
+    code.querySelector("code")!.textContent = Array.from({ length: 200 }, (_, i) => `line ${i + 1}`).join("\n");
+    const scrollsVertically = (element: HTMLElement) => {
+      const overflow = getComputedStyle(element).overflowY;
+      return (overflow === "auto" || overflow === "scroll") && element.scrollHeight > element.clientHeight;
+    };
+    return {
+      panel: scrollsVertically(panel as HTMLElement),
+      code: scrollsVertically(code),
+    };
+  });
+  expect(codeScrollOwners).toEqual({ panel: true, code: false });
   // Environment tab renders the captured package list.
   await page.locator(".am-tab", { hasText: "Environment" }).click();
   await expect(page.locator(".am-env")).toContainText("matplotlib");

--- a/ui/src/styles/modals.css
+++ b/ui/src/styles/modals.css
@@ -230,6 +230,7 @@ textarea.host-input { min-height:64px; resize:vertical; }
 .artifact-modal .am-tab { padding: 6px 10px; border: none; background: transparent; color: var(--text-faint); font: inherit; font-size: 12px; cursor: pointer; border-radius: 8px 8px 0 0; }
 .artifact-modal .am-tab.active { background: var(--bg-sunken); color: var(--text); }
 .artifact-modal .am-panel { max-height: 30vh; overflow: auto; flex: 0 0 auto; min-width: 0; }
+.artifact-modal .am-panel > .rp-code { max-height: none; overflow: visible; }
 .artifact-modal .am-log { font-family: var(--font-mono); font-size: 12px; white-space: pre-wrap; margin: 0; }
 .artifact-modal .am-empty { color: var(--text-faint); font-size: 12.5px; padding: 16px; }
 .artifact-modal .am-inputs { display: flex; flex-direction: column; gap: 4px; }


### PR DESCRIPTION
## Problem

Long generating code in the artifact modal created nested vertical scroll containers: the provenance panel and the shared code viewer. This rendered two adjacent scrollbars.

## Changes

- Make the artifact provenance panel the only scroll owner for code content.
- Keep shared code-view scrolling unchanged outside the artifact modal.
- Add a Playwright regression that expands the source to 200 lines and asserts only the panel scrolls.

## Tests

- cargo fmt --all -- --check
- cargo test --workspace
- cd ui && cargo check --target wasm32-unknown-unknown
- cd ui-tests && npm ci
- cd ui-tests && npx playwright test (108 passed)

## Manual smoke

1. Open an image artifact with long generating code.
2. Select the Code tab.
3. Scroll through the source and confirm that only one vertical scrollbar appears.

## Known limitations

- The change is scoped to the artifact provenance Code tab.
- No follow-up work is required.