### PR TITLE
Persist UI transcript events incrementally

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -998,6 +998,77 @@ fn events_to_items(events: &[AgentEvent]) -> (Vec<UiItem>, HashMap<i64, usize>) 
     (items, boundaries)
 }
 
+const MAX_PENDING_UI_EVENT_BYTES: usize = 64 * 1024;
+const UI_EVENT_FLUSH_INTERVAL: std::time::Duration = std::time::Duration::from_millis(250);
+
+fn merge_pending_ui_event(
+    pending: &mut Option<AgentEvent>,
+    event: AgentEvent,
+) -> Option<AgentEvent> {
+    let merged = match (pending.as_mut(), &event) {
+        (Some(AgentEvent::Text { delta, .. }), AgentEvent::Text { delta: next, .. })
+        | (Some(AgentEvent::Reasoning { delta, .. }), AgentEvent::Reasoning { delta: next, .. })
+        | (Some(AgentEvent::Stdout { chunk: delta, .. }), AgentEvent::Stdout { chunk: next, .. })
+            if delta.len().saturating_add(next.len()) <= MAX_PENDING_UI_EVENT_BYTES =>
+        {
+            delta.push_str(next);
+            true
+        }
+        _ => false,
+    };
+    if merged {
+        None
+    } else {
+        pending.replace(event)
+    }
+}
+
+async fn append_ui_event(store: &Store, frame_id: &str, seq: &mut i64, event: AgentEvent) {
+    let json = match serde_json::to_string(&event) {
+        Ok(json) => json,
+        Err(error) => {
+            tracing::warn!("serialize UI event failed: {error}");
+            return;
+        }
+    };
+    if let Err(error) = store.append_session_ui_event(frame_id, *seq, &json).await {
+        tracing::warn!("persist UI event {} failed: {error}", *seq);
+    } else {
+        *seq += 1;
+    }
+}
+
+async fn persist_ui_events(
+    store: Store,
+    frame_id: String,
+    mut seq: i64,
+    mut rx: tokio::sync::mpsc::UnboundedReceiver<AgentEvent>,
+    flush_interval: std::time::Duration,
+) {
+    let mut pending = None;
+    let mut ticker = tokio::time::interval(flush_interval);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    ticker.tick().await;
+    loop {
+        tokio::select! {
+            event = rx.recv() => match event {
+                Some(event) => {
+                    if let Some(event) = merge_pending_ui_event(&mut pending, event) {
+                        append_ui_event(&store, &frame_id, &mut seq, event).await;
+                    }
+                }
+                None => break,
+            },
+            _ = ticker.tick(), if pending.is_some() => {
+                append_ui_event(&store, &frame_id, &mut seq, pending.take().unwrap()).await;
+            }
+        }
+    }
+    if let Some(event) = pending {
+        append_ui_event(&store, &frame_id, &mut seq, event).await;
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone)]
 struct Settings {
     provider: String,
@@ -3137,53 +3208,20 @@ async fn send_message(
     };
 
     let (ui_event_handle, ui_event_tx) = {
-        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<AgentEvent>();
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<AgentEvent>();
         let store = state.store.clone();
         let fid = frame_id.clone();
-        let mut seq = store
+        let seq = store
             .next_session_ui_event_seq(&fid)
             .await
             .map_err(|e| format!("{e}"))?;
-        let handle = tokio::spawn(async move {
-            let mut events: Vec<AgentEvent> = Vec::new();
-            while let Some(event) = rx.recv().await {
-                let merged = match (events.last_mut(), &event) {
-                    (
-                        Some(AgentEvent::Text { delta, .. }),
-                        AgentEvent::Text { delta: next, .. },
-                    )
-                    | (
-                        Some(AgentEvent::Reasoning { delta, .. }),
-                        AgentEvent::Reasoning { delta: next, .. },
-                    )
-                    | (
-                        Some(AgentEvent::Stdout { chunk: delta, .. }),
-                        AgentEvent::Stdout { chunk: next, .. },
-                    ) => {
-                        delta.push_str(next);
-                        true
-                    }
-                    _ => false,
-                };
-                if !merged {
-                    events.push(event);
-                }
-            }
-            for event in events {
-                let json = match serde_json::to_string(&event) {
-                    Ok(json) => json,
-                    Err(error) => {
-                        tracing::warn!("serialize UI event failed: {error}");
-                        continue;
-                    }
-                };
-                if let Err(error) = store.append_session_ui_event(&fid, seq, &json).await {
-                    tracing::warn!("persist UI event {seq} failed: {error}");
-                } else {
-                    seq += 1;
-                }
-            }
-        });
+        let handle = tokio::spawn(persist_ui_events(
+            store,
+            fid,
+            seq,
+            rx,
+            UI_EVENT_FLUSH_INTERVAL,
+        ));
         (handle, tx)
     };
 

--- a/src-tauri/src/lib_tests.rs
+++ b/src-tauri/src/lib_tests.rs
@@ -1,11 +1,11 @@
 use super::desktop_lifecycle::should_hide_workspace_on_close;
 use super::{
-    branch_title, copy_dir_recursive, events_to_items, messages_to_items, parse_disabled_skills,
-    parse_enabled_skill_names, parse_skill_tags, parse_ssh_artifact_uri,
-    resolve_acp_artifact_references, resolve_composer_references, resolve_workspace,
-    session_runtime_status, should_hide_app_on_macos_close, side_chat_prompt,
+    branch_title, copy_dir_recursive, events_to_items, merge_pending_ui_event, messages_to_items,
+    parse_disabled_skills, parse_enabled_skill_names, parse_skill_tags, parse_ssh_artifact_uri,
+    persist_ui_events, resolve_acp_artifact_references, resolve_composer_references,
+    resolve_workspace, session_runtime_status, should_hide_app_on_macos_close, side_chat_prompt,
     update_check_from_release, user_message_start, AgentEvent, ComposerReferenceArg, GithubRelease,
-    McpConnection, McpTransport,
+    McpConnection, McpTransport, MAX_PENDING_UI_EVENT_BYTES,
 };
 use std::collections::HashSet;
 use std::path::PathBuf;
@@ -188,6 +188,79 @@ fn persisted_ui_events_ignore_ephemeral_reviewer_handoffs() {
 
     let (items, _) = events_to_items(&events);
     assert!(items.is_empty());
+}
+
+#[test]
+fn pending_ui_event_merge_stays_bounded() {
+    let frame_id = "f".to_string();
+    let mut pending = Some(AgentEvent::Text {
+        frame_id: frame_id.clone(),
+        delta: "a".repeat(MAX_PENDING_UI_EVENT_BYTES - 1),
+    });
+    assert!(merge_pending_ui_event(
+        &mut pending,
+        AgentEvent::Text {
+            frame_id: frame_id.clone(),
+            delta: "b".into(),
+        }
+    )
+    .is_none());
+    let flushed = merge_pending_ui_event(
+        &mut pending,
+        AgentEvent::Text {
+            frame_id,
+            delta: "c".into(),
+        },
+    )
+    .unwrap();
+    assert!(
+        matches!(flushed, AgentEvent::Text { delta, .. } if delta.len() == MAX_PENDING_UI_EVENT_BYTES)
+    );
+    assert!(matches!(pending, Some(AgentEvent::Text { ref delta, .. }) if delta == "c"));
+}
+
+#[tokio::test]
+async fn ui_events_are_persisted_before_the_turn_ends() {
+    let base = std::env::temp_dir().join(format!("wisp_ui_flush_{}", uuid::Uuid::new_v4()));
+    let store = wisp_store::Store::open(&base.join("wisp.sqlite"))
+        .await
+        .unwrap();
+    store
+        .create_project("p", "Project", &base.to_string_lossy())
+        .await
+        .unwrap();
+    store
+        .create_frame("f", "p", "OPERON", "model")
+        .await
+        .unwrap();
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+    let handle = tokio::spawn(persist_ui_events(
+        store.clone(),
+        "f".into(),
+        1,
+        rx,
+        std::time::Duration::from_millis(5),
+    ));
+    tx.send(AgentEvent::Text {
+        frame_id: "f".into(),
+        delta: "still running".into(),
+    })
+    .unwrap();
+
+    tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        loop {
+            if !store.load_session_ui_events("f").await.unwrap().is_empty() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .unwrap();
+    assert!(!handle.is_finished());
+    drop(tx);
+    handle.await.unwrap();
+    let _ = std::fs::remove_dir_all(base);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Problem

UI transcript events were collected in a turn-sized `Vec<AgentEvent>` and written to SQLite only after the agent turn ended. Long streaming turns could therefore grow memory continuously, and a crash could discard the current turn's UI layout events.

## What changed

- Keep only one mergeable UI event pending instead of the full turn.
- Flush pending events when the event type changes, after 64 KiB of merged text, every 250 ms, or when the channel closes.
- Reuse the existing event schema and reload-time merge behavior; no migration or UI protocol change is required.
- Add tests for the merge bound and persistence while a turn is still active.

## Tests

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --workspace`
- `cd ui && cargo check --target wasm32-unknown-unknown`
- `cd ui-tests && npm ci && npx playwright test` (108 passed)

## Manual smoke steps

1. Start a long streaming response and close the app before the turn finishes.
2. Reopen the project and confirm the already-streamed transcript layout is restored.
3. Complete a response containing reasoning, tools, and stdout, then reopen it and confirm ordering matches the live view.

## Known limitation

The synchronous output interface still uses its existing unbounded event channel. This PR removes turn-sized accumulation in the consumer; producer backpressure would require a separate output-interface contract change.
