### PR TITLE
Fix unreadable code blocks in dark mode

### DIFF
--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -1228,6 +1228,33 @@ export function tauriMock(): void {
               }, 30);
               return fid;
             }
+            if (String(arg("message") ?? "").includes("MDCODE")) {
+              const md = [
+                "缺少的是：",
+                "",
+                "```text",
+                "CAF状态 → 免疫变化",
+                "CAF状态 → 上皮变化",
+                "```",
+                "",
+                "```python",
+                "def immune_change(caf_status):",
+                "    # 暗色代码注释",
+                "    return \"免疫变化\" if caf_status else None",
+                "```",
+                "",
+                "```diff",
+                "-CAF状态 → 未知",
+                "+CAF状态 → 免疫变化",
+                "```",
+              ].join("\n");
+              setTimeout(() => {
+                emit("agent", { kind: "User", frame_id: fid, text: msg });
+                emit("agent", { kind: "Text", frame_id: fid, delta: md });
+                emit("agent", { kind: "Done", frame_id: fid });
+              }, 30);
+              return fid;
+            }
             setTimeout(() => {
               emit("agent", { kind: "User", frame_id: fid, text: msg });
               emit("agent", { kind: "Text", frame_id: fid, delta: "Hello " });

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -392,6 +392,73 @@ test("assistant markdown table can be copied separately", async ({ page, context
   );
 });
 
+test("dark palettes keep rendered markdown code readable", async ({ page }) => {
+  await page.emulateMedia({ colorScheme: "dark" });
+  await enterApp(page);
+  await composer(page).fill("MDCODE");
+  await page.getByRole("button", { name: "Send" }).click();
+
+  const highlightedBlocks = page.locator(".msg.assistant .md pre code[data-hl='1']");
+  await expect(highlightedBlocks).toHaveCount(3);
+  await expect(page.locator(".msg.assistant code.language-text")).toContainText("CAF状态 → 免疫变化");
+  await expect(page.locator(".msg.assistant code.language-python .hljs-comment")).toContainText("暗色代码注释");
+  await expect(page.locator(".msg.assistant code.language-diff .hljs-addition")).toContainText("CAF状态 → 免疫变化");
+  await expect(page.locator(".msg.assistant code.language-diff .hljs-deletion")).toContainText("CAF状态 → 未知");
+
+  const auditContrast = () => page.locator(".msg.assistant .md").evaluate((root) => {
+    const channels = (value: string) => (value.match(/[\d.]+/g) ?? []).slice(0, 3).map(Number);
+    const luminance = (value: string) => {
+      const rgb = channels(value).map((channel) => channel / 255)
+        .map((channel) => channel <= 0.04045
+          ? channel / 12.92
+          : ((channel + 0.055) / 1.055) ** 2.4);
+      return 0.2126 * rgb[0] + 0.7152 * rgb[1] + 0.0722 * rgb[2];
+    };
+    const contrast = (foreground: string, background: string) => {
+      const foregroundLuminance = luminance(foreground);
+      const backgroundLuminance = luminance(background);
+      return (Math.max(foregroundLuminance, backgroundLuminance) + 0.05)
+        / (Math.min(foregroundLuminance, backgroundLuminance) + 0.05);
+    };
+    const samples = [...root.querySelectorAll("pre code.hljs")].flatMap((code) => {
+      const preBackground = getComputedStyle(code.closest("pre")!).backgroundColor;
+      return [code, ...code.querySelectorAll("span")]
+        .filter((element) => element.textContent?.trim())
+        .map((element) => {
+          const style = getComputedStyle(element);
+          const background = style.backgroundColor === "rgba(0, 0, 0, 0)"
+            ? preBackground
+            : style.backgroundColor;
+          return {
+            text: element.textContent?.trim().slice(0, 40),
+            color: style.color,
+            background,
+            ratio: contrast(style.color, background),
+          };
+        });
+    });
+    return {
+      minimum: Math.min(...samples.map((sample) => sample.ratio)),
+      samples,
+    };
+  });
+
+  await openSettingsSection(page, "Appearance");
+  await page.getByTestId("theme-mode-dark").click();
+  const paletteSelect = page.getByTestId("appearance-palette-select");
+  for (const palette of ["charcoal", "codex", "github", "catppuccin", "gruvbox"]) {
+    await paletteSelect.selectOption(palette);
+    await expect(page.locator("html")).toHaveAttribute("data-dark-palette", palette);
+    const audit = await auditContrast();
+    expect(audit.minimum, `${palette}: ${JSON.stringify(audit.samples)}`).toBeGreaterThanOrEqual(4.5);
+  }
+
+  await page.getByTestId("theme-mode-system").click();
+  await expect(page.locator("html")).toHaveAttribute("data-theme", "system");
+  const systemAudit = await auditContrast();
+  expect(systemAudit.minimum, `system dark: ${JSON.stringify(systemAudit.samples)}`).toBeGreaterThanOrEqual(4.5);
+});
+
 test("composer @ # and / add typed context references", async ({ page }) => {
   await enterApp(page);
   const composerInput = composer(page);

--- a/ui/mock-bridge.js
+++ b/ui/mock-bridge.js
@@ -200,7 +200,7 @@
           case "read_memory_file":
             return "User prefers DeepSeek.\n";
           case "send_message": {
-            const fid = (args && args.session_id) || "mock-frame";
+            const fid = (args && (args.sessionId ?? args.session_id)) || "mock-frame";
             const msg = (args && args.message) || "";
             if (String(msg).includes("MDLIST")) {
               const md = [
@@ -211,6 +211,33 @@
                 "- **优势**：转染效率高，适合大规模病毒生产",
                 "",
                 "有什么我可以帮你的吗？",
+              ].join("\n");
+              setTimeout(() => {
+                emit("agent", { kind: "User", frame_id: fid, text: msg });
+                emit("agent", { kind: "Text", frame_id: fid, delta: md });
+                emit("agent", { kind: "Done", frame_id: fid });
+              }, 80);
+              return fid;
+            }
+            if (String(msg).includes("MDCODE")) {
+              const md = [
+                "缺少的是：",
+                "",
+                "```text",
+                "CAF状态 → 免疫变化",
+                "CAF状态 → 上皮变化",
+                "```",
+                "",
+                "```python",
+                "def immune_change(caf_status):",
+                "    # 暗色代码注释",
+                "    return \"免疫变化\" if caf_status else None",
+                "```",
+                "",
+                "```diff",
+                "-CAF状态 → 未知",
+                "+CAF状态 → 免疫变化",
+                "```",
               ].join("\n");
               setTimeout(() => {
                 emit("agent", { kind: "User", frame_id: fid, text: msg });

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -34,6 +34,24 @@
   --info: hsl(213 68% 50%);
   --info-soft: hsl(213 68% 50% / 0.12);
 
+  /* Syntax colors mirror the bundled GitHub light highlight.js theme. Keeping
+     them semantic lets rendered code follow the app theme without swapping a
+     stylesheet after every appearance change. */
+  --syntax-text: #24292e;
+  --syntax-keyword: #d73a49;
+  --syntax-title: #6f42c1;
+  --syntax-variable: #005cc5;
+  --syntax-string: #032f62;
+  --syntax-symbol: #e36209;
+  --syntax-comment: #6a737d;
+  --syntax-name: #22863a;
+  --syntax-section: #005cc5;
+  --syntax-bullet: #735c0f;
+  --syntax-addition: #22863a;
+  --syntax-addition-bg: #f0fff4;
+  --syntax-deletion: #b31d28;
+  --syntax-deletion-bg: #ffeef0;
+
   --radius: 16px;
   --radius-sm: 10px;
   --shadow: 0 16px 32px -12px var(--shadow-color);
@@ -92,6 +110,20 @@
   --warn-soft: hsl(43 80% 50% / 0.18);
   --info: hsl(213 60% 62%);
   --info-soft: hsl(213 60% 55% / 0.14);
+  --syntax-text: #c9d1d9;
+  --syntax-keyword: #ff7b72;
+  --syntax-title: #d2a8ff;
+  --syntax-variable: #79c0ff;
+  --syntax-string: #a5d6ff;
+  --syntax-symbol: #ffa657;
+  --syntax-comment: #8b949e;
+  --syntax-name: #7ee787;
+  --syntax-section: #58a6ff;
+  --syntax-bullet: #f2cc60;
+  --syntax-addition: #aff5b4;
+  --syntax-addition-bg: #033a16;
+  --syntax-deletion: #ffdcd7;
+  --syntax-deletion-bg: #67060c;
   --shadow: 0 18px 40px -18px var(--shadow-color);
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.28), 0 0 0 1px rgba(245, 240, 230, 0.04);
   color-scheme: dark;
@@ -126,6 +158,20 @@
     --warn-soft: hsl(43 80% 50% / 0.18);
     --info: hsl(213 60% 62%);
     --info-soft: hsl(213 60% 55% / 0.14);
+    --syntax-text: #c9d1d9;
+    --syntax-keyword: #ff7b72;
+    --syntax-title: #d2a8ff;
+    --syntax-variable: #79c0ff;
+    --syntax-string: #a5d6ff;
+    --syntax-symbol: #ffa657;
+    --syntax-comment: #8b949e;
+    --syntax-name: #7ee787;
+    --syntax-section: #58a6ff;
+    --syntax-bullet: #f2cc60;
+    --syntax-addition: #aff5b4;
+    --syntax-addition-bg: #033a16;
+    --syntax-deletion: #ffdcd7;
+    --syntax-deletion-bg: #67060c;
     --shadow: 0 18px 40px -18px var(--shadow-color);
     --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.28), 0 0 0 1px rgba(245, 240, 230, 0.04);
     color-scheme: dark;

--- a/ui/src/styles/chat.css
+++ b/ui/src/styles/chat.css
@@ -356,9 +356,26 @@ details.rz .body { margin-top: 6px; }
 }
 .md pre.md-code code {
   display: block; padding: 12px 14px; background: transparent; border: none;
-  font-size: 12.5px; line-height: 1.55; white-space: pre; overflow-x: auto;
+  color: var(--syntax-text); font-size: 12.5px; line-height: 1.55; white-space: pre; overflow-x: auto;
 }
 .md pre.md-code .hljs { background: transparent; }
+
+/* The bundled highlight.js stylesheet is the GitHub light theme and is loaded
+   lazily after this file. These more-specific semantic overrides prevent its
+   hard-coded dark text from winning on dark code-block backgrounds. */
+code.hljs { color: var(--syntax-text); background: transparent; }
+code.hljs :is(.hljs-doctag, .hljs-keyword, .hljs-template-tag, .hljs-template-variable, .hljs-type, .hljs-variable.language_) { color: var(--syntax-keyword); }
+code.hljs :is(.hljs-title, .hljs-title.class_, .hljs-title.class_.inherited__, .hljs-title.function_) { color: var(--syntax-title); }
+code.hljs :is(.hljs-attr, .hljs-attribute, .hljs-literal, .hljs-meta, .hljs-number, .hljs-operator, .hljs-selector-attr, .hljs-selector-class, .hljs-selector-id, .hljs-variable) { color: var(--syntax-variable); }
+code.hljs :is(.hljs-regexp, .hljs-string), code.hljs .hljs-meta .hljs-string { color: var(--syntax-string); }
+code.hljs :is(.hljs-built_in, .hljs-symbol) { color: var(--syntax-symbol); }
+code.hljs :is(.hljs-code, .hljs-comment, .hljs-formula) { color: var(--syntax-comment); }
+code.hljs :is(.hljs-name, .hljs-quote, .hljs-selector-pseudo, .hljs-selector-tag) { color: var(--syntax-name); }
+code.hljs :is(.hljs-subst, .hljs-emphasis, .hljs-strong) { color: var(--syntax-text); }
+code.hljs .hljs-section { color: var(--syntax-section); }
+code.hljs .hljs-bullet { color: var(--syntax-bullet); }
+code.hljs .hljs-addition { color: var(--syntax-addition); background-color: var(--syntax-addition-bg); }
+code.hljs .hljs-deletion { color: var(--syntax-deletion); background-color: var(--syntax-deletion-bg); }
 /* Dense tool/API name dumps: keep scannable instead of a wall of text. */
 .md pre.md-code code.language-catalog {
   column-count: 2; column-gap: 1.4rem; column-fill: auto;


### PR DESCRIPTION
## Problem

Rendered Markdown code blocks used dark GitHub syntax colors on dark application backgrounds, making pasted or generated code unreadable in dark mode.

## Root cause

The bundled highlight.js GitHub light stylesheet is loaded lazily after the app styles and hard-codes `.hljs` text to `#24292e`. Dark palettes changed the code-block background but did not override those syntax colors.

## Changes

- add semantic light and dark syntax-highlight tokens
- override highlight.js token classes with theme-aware colors
- cover plain fenced text, Python syntax, and diff additions/deletions
- add a regression that audits every rendered token at a minimum 4.5:1 contrast ratio across all five dark palettes and system dark mode
- extend the development mock for manual reproduction and smoke testing

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cd ui && cargo check --target wasm32-unknown-unknown`
- `cd ui-tests && npx playwright test` — 112 passed
- manual browser smoke of the issue's Chinese code-block example, Python syntax, and diff lines

## Known limitation

The dark syntax palette is shared across the five application palettes rather than customized per palette; each tested combination remains above the required contrast threshold.

Closes #226