### PR TITLE
feat(ui): 渲染 markdown 中的数学公式 (#249)

### DIFF
--- a/ui/mock-bridge.js
+++ b/ui/mock-bridge.js
@@ -113,7 +113,7 @@
               { role: "tool", text: "12 hits written to report.csv", tool_name: "python", ok: true },
               {
                 role: "assistant",
-                text: "## FX-cell literature\n\n| gene | score |\n| --- | --- |\n| FX-cell | 0.91 |\n\nSee `report.csv` or {{artifact:00000001}}.\n\n```python\nimport pandas as pd\ndf = pd.read_csv('report.csv')\nprint(df.head())\n```",
+                text: "## FX-cell literature\n\n| gene | score |\n| --- | --- |\n| FX-cell | 0.91 |\n\nThe score follows $s = \\frac{1}{1 + e^{-x}}$ and GPT-style \\(a_i^2 + b_i^2\\) too.\n\n$$\\int_0^1 x^2 \\, dx = \\frac{1}{3}$$\n\nSee `report.csv` or {{artifact:00000001}}.\n\n```python\nimport pandas as pd\ndf = pd.read_csv('report.csv')\nprint(df.head())\n```",
                 tool_name: null,
                 ok: null,
               },

--- a/ui/src/app_support.rs
+++ b/ui/src/app_support.rs
@@ -4205,6 +4205,7 @@ pub(super) fn FilePreview(dom_id: String, path: String, kind: String) -> impl In
                 if let Some(el) = el {
                     el.set_class_name("rp-heavy md");
                     el.set_inner_html(&md_to_html(fc.text.as_deref().unwrap_or("")));
+                    schedule_highlight(dom_id.clone());
                 }
                 return;
             }
@@ -4252,7 +4253,9 @@ pub(super) fn artifact_preview(a: &Artifact, dom_id: String, locale: Locale) -> 
         PreviewData::Table(t) => table_view(t, locale).into_view(),
         PreviewData::Text(s) => view! { <pre class="rp-pre">{s.clone()}</pre> }.into_view(),
         PreviewData::Markdown(s) => {
-            view! { <div class="md rp-md" inner_html=md_to_html(s)></div> }.into_view()
+            let hid_for_effect = dom_id.clone();
+            create_effect(move |_| schedule_highlight(hid_for_effect.clone()));
+            view! { <div class="md rp-md" id=dom_id inner_html=md_to_html(s)></div> }.into_view()
         }
         PreviewData::Latex { tex, display } => {
             let payload = serde_json::json!({ "tex": tex, "display": display }).to_string();

--- a/ui/src/highlight.js
+++ b/ui/src/highlight.js
@@ -1,5 +1,6 @@
-// Lazy highlight.js for markdown + tool code blocks.
+// Lazy highlight.js + KaTeX post-processing for rendered markdown.
 let loading;
+let katexLoading;
 
 function ensure() {
   if (window.hljs) return Promise.resolve(window.hljs);
@@ -19,12 +20,41 @@ function ensure() {
   return loading;
 }
 
+function ensureKatex() {
+  if (!katexLoading) {
+    const css = document.createElement("link");
+    css.rel = "stylesheet";
+    css.href = "/vendor/katex-DwwF5kvc.css";
+    document.head.appendChild(css);
+    katexLoading = import("/vendor/katex-Dn761jRB.js").then((m) => m.k);
+  }
+  return katexLoading;
+}
+
 /** @param {ParentNode} root */
 async function highlight_root(root) {
-  const hljs = await ensure();
   // Re-rendered blocks are fresh DOM nodes without the marker, so content
-  // changes still re-highlight; untouched siblings are skipped.
-  root.querySelectorAll("pre code:not([data-hl])").forEach((node) => {
+  // changes still re-render; untouched siblings are skipped.
+  const math = root.querySelectorAll(".math:not([data-math])");
+  if (math.length) {
+    const katex = await ensureKatex();
+    math.forEach((node) => {
+      const tex = node.textContent;
+      node.dataset.math = "1";
+      try {
+        katex.render(tex, node, {
+          displayMode: node.classList.contains("math-display"),
+          throwOnError: false,
+        });
+      } catch {
+        node.textContent = tex;
+      }
+    });
+  }
+  const code = root.querySelectorAll("pre code:not([data-hl])");
+  if (!code.length) return;
+  const hljs = await ensure();
+  code.forEach((node) => {
     hljs.highlightElement(node);
     node.dataset.hl = "1";
   });

--- a/ui/src/styles/chat.css
+++ b/ui/src/styles/chat.css
@@ -334,6 +334,8 @@ details.rz .body { margin-top: 6px; }
 }
 .md > :first-child { margin-top: 0; }
 .md > :last-child { margin-bottom: 0; }
+/* KaTeX display math: block-level, scroll long equations instead of overflowing. */
+.md .math-display { display: block; overflow-x: auto; overflow-y: hidden; }
 .md p:empty { display: none; margin: 0; }
 .md p { margin: 0 0 0.55em; }
 .md p + ul,

--- a/ui/src/text.rs
+++ b/ui/src/text.rs
@@ -132,6 +132,7 @@ pub(crate) fn md_to_html(src: &str) -> String {
     opts.insert(Options::ENABLE_STRIKETHROUGH);
     opts.insert(Options::ENABLE_TASKLISTS);
     opts.insert(Options::ENABLE_FOOTNOTES);
+    opts.insert(Options::ENABLE_MATH);
     let parser = Parser::new_ext(src.as_ref(), opts);
     let mut out = String::new();
     html::push_html(&mut out, parser);
@@ -140,10 +141,124 @@ pub(crate) fn md_to_html(src: &str) -> String {
 
 fn preprocess_markdown(src: &str) -> std::borrow::Cow<'_, str> {
     let src = strip_yaml_front_matter(src);
-    match rewrite_image_tags(src.as_ref()) {
+    let src = match rewrite_image_tags(src.as_ref()) {
+        std::borrow::Cow::Borrowed(_) => src,
+        std::borrow::Cow::Owned(s) => std::borrow::Cow::Owned(s),
+    };
+    match normalize_math_delimiters(src.as_ref()) {
         std::borrow::Cow::Borrowed(_) => src,
         std::borrow::Cow::Owned(s) => std::borrow::Cow::Owned(s),
     }
+}
+
+/// GPT-family models emit LaTeX with `\(...\)` / `\[...\]` delimiters, but
+/// pulldown-cmark's math extension only knows `$...$` / `$$...$$`. Rewrite the
+/// former into the latter so both styles render (#249). Fenced code blocks and
+/// inline code spans are left untouched.
+fn normalize_math_delimiters(src: &str) -> std::borrow::Cow<'_, str> {
+    if !src.contains("\\(") && !src.contains("\\[") {
+        return std::borrow::Cow::Borrowed(src);
+    }
+    let mut out = String::with_capacity(src.len());
+    let mut seg = String::new();
+    let mut changed = false;
+    let mut fence: Option<(char, usize)> = None;
+    for chunk in src.split_inclusive('\n') {
+        let line = chunk.trim_end_matches(['\r', '\n']);
+        let stripped = line.trim_start();
+        let mark = stripped.chars().next().filter(|c| matches!(c, '`' | '~'));
+        let run = mark.map_or(0, |m| stripped.chars().take_while(|&c| c == m).count());
+        match fence {
+            Some((m, n)) => {
+                out.push_str(chunk);
+                if mark == Some(m) && run >= n && stripped[run..].trim().is_empty() {
+                    fence = None;
+                }
+            }
+            None if run >= 3 => {
+                convert_math_spans(&seg, &mut out, &mut changed);
+                seg.clear();
+                out.push_str(chunk);
+                fence = Some((mark.unwrap(), run));
+            }
+            None => seg.push_str(chunk),
+        }
+    }
+    convert_math_spans(&seg, &mut out, &mut changed);
+    if changed {
+        std::borrow::Cow::Owned(out)
+    } else {
+        std::borrow::Cow::Borrowed(src)
+    }
+}
+
+/// Rewrite `\(...\)` → `$...$` and `\[...\]` → `$$...$$` in one non-fenced
+/// segment, skipping inline code spans. Unpaired delimiters pass through.
+fn convert_math_spans(seg: &str, out: &mut String, changed: &mut bool) {
+    let mut rest = seg;
+    loop {
+        let bt = rest.find('`');
+        let par = rest.find("\\(");
+        let brk = rest.find("\\[");
+        let Some(pos) = [bt, par, brk].into_iter().flatten().min() else {
+            out.push_str(rest);
+            return;
+        };
+        out.push_str(&rest[..pos]);
+        rest = &rest[pos..];
+        if Some(pos) == bt {
+            // Inline code span: copy verbatim through the matching backtick
+            // run; an unmatched opener is literal text, keep scanning after it.
+            let n = rest.chars().take_while(|&c| c == '`').count();
+            out.push_str(&rest[..n]);
+            rest = &rest[n..];
+            if let Some(end) = find_backtick_run(rest, n) {
+                out.push_str(&rest[..end + n]);
+                rest = &rest[end + n..];
+            }
+            continue;
+        }
+        let (close, wrap) = if Some(pos) == par {
+            ("\\)", "$")
+        } else {
+            ("\\]", "$$")
+        };
+        let paired = rest[2..].find(close).filter(|&end| {
+            // A blank line between the delimiters means this is not real math.
+            let body = &rest[2..2 + end];
+            !body.contains("\n\n") && !body.contains("\n\r\n")
+        });
+        match paired {
+            Some(end) if !rest[2..2 + end].trim().is_empty() => {
+                *changed = true;
+                out.push_str(wrap);
+                out.push_str(rest[2..2 + end].trim());
+                out.push_str(wrap);
+                rest = &rest[2 + end + 2..];
+            }
+            Some(end) => {
+                out.push_str(&rest[..2 + end + 2]);
+                rest = &rest[2 + end + 2..];
+            }
+            None => {
+                out.push_str(&rest[..2]);
+                rest = &rest[2..];
+            }
+        }
+    }
+}
+
+fn find_backtick_run(s: &str, n: usize) -> Option<usize> {
+    let mut from = 0;
+    while let Some(p) = s[from..].find('`') {
+        let at = from + p;
+        let run = s[at..].chars().take_while(|&c| c == '`').count();
+        if run == n {
+            return Some(at);
+        }
+        from = at + run;
+    }
+    None
 }
 
 /// Treat leading YAML front matter like normal Markdown tooling does: metadata
@@ -667,6 +782,38 @@ mod md_catalog_tests {
             "{html}"
         );
         assert!(!html.contains("<image"), "{html}");
+    }
+
+    #[test]
+    fn renders_dollar_math_as_math_spans() {
+        let html = md_to_html("质能方程 $E = mc^2$ 成立。\n\n$$\\int_0^1 x^2 dx$$\n");
+        assert!(html.contains(r#"<span class="math math-inline">"#), "{html}");
+        assert!(html.contains(r#"<span class="math math-display">"#), "{html}");
+    }
+
+    #[test]
+    fn converts_gpt_style_math_delimiters() {
+        let html = md_to_html("Inline \\(a_i^2\\) and display:\n\n\\[\nE = mc^2\n\\]\n");
+        assert!(html.contains(r#"<span class="math math-inline">a_i^2</span>"#), "{html}");
+        assert!(html.contains(r#"<span class="math math-display">E = mc^2</span>"#), "{html}");
+    }
+
+    #[test]
+    fn leaves_math_delimiters_in_code_alone() {
+        let src = "Use `\\(x\\)` here.\n\n```tex\n\\[ y \\]\n```\n";
+        let html = md_to_html(src);
+        assert!(!html.contains("math-inline"), "{html}");
+        assert!(!html.contains("math-display"), "{html}");
+        assert!(html.contains("\\(x\\)"), "{html}");
+    }
+
+    #[test]
+    fn leaves_unpaired_math_delimiters_alone() {
+        let src = "A stray \\( paren and \\[ bracket.\n";
+        assert!(matches!(
+            super::normalize_math_delimiters(src),
+            std::borrow::Cow::Borrowed(_)
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## 背景

Issue #249:GPT 模式回复里的 LaTeX 公式不渲染。根因不是渲染有 bug,而是 markdown 管线**压根没解析数学**——`md_to_html` 从未开启 pulldown-cmark 的 math 特性,KaTeX(已经 vendored)也没被调用。

## 改动

**Rust 侧** (`ui/src/text.rs`)
- `md_to_html` 打开 `ENABLE_MATH`,`$...$` / `$$...$$` 解析成 `<span class="math math-inline|display">`。
- 新增 `normalize_math_delimiters`:GPT 系模型输出 `\(...\)` / `\[...\]`,pulldown 不认,预处理时转成 `$` 形式。跳过 fenced/inline 代码,未配对的分隔符原样放过。

**JS 侧** (`ui/src/highlight.js`)
- 复用已内置的 KaTeX,在高亮代码前先渲染 `.math` 节点。懒加载,和 highlight.js 同一套路;`data-math` 标记避免重复渲染。

**接线** (`ui/src/app_support.rs`)
- 聊天/工具/计划消息本就走 `schedule_highlight`;给两处只 `set_inner_html` 的 markdown 预览(文件预览、artifact 预览)补上调用。

**CSS** (`ui/src/styles/chat.css`)
- display 公式加 `overflow-x: auto`,长公式横向滚动而非撑破布局。

**Mock** (`ui/mock-bridge.js`)
- 给 mock 会话加了含公式的消息,方便 `?mock=1` 下验证渲染路径。

## 验证

- **Rust**:4 个新单测覆盖 `$`、GPT 风格 `\(\)` `\[\]`、代码块豁免、未配对分隔符;`cargo test` 54 项全过。
- **JS**:headless Chrome 加载真实 vendored KaTeX,确认 inline(上下标)和 display(积分 + 分数)均正确渲染。

## 审阅提示

- 分隔符转换是逐行扫描,不是完整解析器;跨行 `\(` 暂不处理(极罕见),需要时再升级。
- 没有引入新依赖,完全复用现有的 KaTeX vendor。

🤖 Generated with [Claude Code](https://claude.com/claude-code)