### PR TITLE
feat(acp): 会话模式选择器 + 侧边问答支持 ACP Agent (#247, #250)

### DIFF
--- a/crates/wisp-acp/src/lib.rs
+++ b/crates/wisp-acp/src/lib.rs
@@ -19,8 +19,8 @@ use agent_client_protocol::{
             PermissionOptionId, PromptRequest, RequestPermissionOutcome, RequestPermissionRequest,
             RequestPermissionResponse, ResumeSessionRequest, SelectedPermissionOutcome,
             SessionConfigOption, SessionConfigOptionValue, SessionId, SessionModeState,
-            SessionNotification, SessionUpdate, SetSessionConfigOptionRequest, StopReason,
-            TextContent,
+            SessionNotification, SessionUpdate, SetSessionConfigOptionRequest,
+            SetSessionModeRequest, StopReason, TextContent,
         },
         ProtocolVersion,
     },
@@ -205,6 +205,7 @@ enum Command {
         SessionConfigOptionValue,
         Reply<Vec<SessionConfigOption>>,
     ),
+    SetMode(SessionId, String, Reply<()>),
     Close(SessionId, Reply<()>),
     Shutdown,
 }
@@ -345,6 +346,15 @@ impl AcpSessionHandle {
         value: SessionConfigOptionValue,
     ) -> Result<Vec<SessionConfigOption>, AcpError> {
         self.request(|reply| Command::SetConfig(session_id, config_id.into(), value, reply))
+            .await
+    }
+
+    pub async fn set_mode(
+        &self,
+        session_id: SessionId,
+        mode_id: impl Into<String>,
+    ) -> Result<(), AcpError> {
+        self.request(|reply| Command::SetMode(session_id, mode_id.into(), reply))
             .await
     }
 
@@ -650,6 +660,17 @@ async fn run_actor(
                                 .block_task()
                                 .await
                                 .map(|response| response.config_options),
+                        );
+                    }
+                    Command::SetMode(session_id, mode_id, reply) => {
+                        let request = SetSessionModeRequest::new(session_id, mode_id);
+                        answer(
+                            reply,
+                            connection
+                                .send_request(request)
+                                .block_task()
+                                .await
+                                .map(|_| ()),
                         );
                     }
                     Command::Close(session_id, reply) => {

--- a/crates/wisp-acp/tests/process.rs
+++ b/crates/wisp-acp/tests/process.rs
@@ -21,9 +21,10 @@ use wisp_acp::{
                 PromptResponse, RequestPermissionOutcome, RequestPermissionRequest,
                 ResumeSessionRequest, ResumeSessionResponse, SessionCapabilities,
                 SessionCloseCapabilities, SessionConfigOption, SessionConfigOptionValue,
-                SessionNotification, SessionResumeCapabilities, SessionUpdate,
-                SetSessionConfigOptionRequest, SetSessionConfigOptionResponse, StopReason,
-                TextContent, ToolCallUpdate, ToolCallUpdateFields,
+                SessionMode, SessionModeState, SessionNotification, SessionResumeCapabilities,
+                SessionUpdate, SetSessionConfigOptionRequest, SetSessionConfigOptionResponse,
+                SetSessionModeRequest, SetSessionModeResponse, StopReason, TextContent,
+                ToolCallUpdate, ToolCallUpdateFields,
             },
             ProtocolVersion,
         },
@@ -112,6 +113,16 @@ async fn test_full_lifecycle() -> Result<(), String> {
             .is_some_and(|options| options.len() == 1),
         "initial session config options",
     )?;
+    check(
+        start
+            .state
+            .modes
+            .as_ref()
+            .and_then(|modes| modes.get("availableModes"))
+            .and_then(serde_json::Value::as_array)
+            .is_some_and(|modes| modes.len() == 2),
+        "initial session modes",
+    )?;
     let session_id = start.session_id;
 
     let prompt = handle.prompt_text(session_id.clone(), "permissions");
@@ -166,6 +177,16 @@ async fn test_full_lifecycle() -> Result<(), String> {
         .await
         .map_err(stringify)?;
     check(changed.len() == 1, "set config response")?;
+    handle
+        .set_mode(session_id.clone(), "full-access")
+        .await
+        .map_err(stringify)?;
+    let bad_mode = handle
+        .set_mode(session_id.clone(), "nonexistent")
+        .await
+        .err()
+        .ok_or("unknown mode unexpectedly accepted")?;
+    check(bad_mode.to_string().contains("unknown mode"), "set mode rejects unknown id")?;
     handle
         .resume_session(
             session_id.clone(),
@@ -421,9 +442,19 @@ async fn serve_fake(scenario: &str) -> acp::Result<()> {
                         return responder
                             .respond_with_error(acp::util::internal_error("auth required"));
                     }
-                    responder.respond(NewSessionResponse::new("fake-session").config_options(vec![
-                        SessionConfigOption::boolean("thinking", "Thinking", false),
-                    ]))
+                    responder.respond(
+                        NewSessionResponse::new("fake-session")
+                            .config_options(vec![SessionConfigOption::boolean(
+                                "thinking", "Thinking", false,
+                            )])
+                            .modes(SessionModeState::new(
+                                "agent",
+                                vec![
+                                    SessionMode::new("agent", "Agent"),
+                                    SessionMode::new("full-access", "Full Access"),
+                                ],
+                            )),
+                    )
                 }
             },
             acp::on_receive_request!(),
@@ -502,6 +533,21 @@ async fn serve_fake(scenario: &str) -> acp::Result<()> {
                 responder.respond(SetSessionConfigOptionResponse::new(vec![
                     SessionConfigOption::boolean("thinking", "Thinking", true),
                 ]))
+            },
+            acp::on_receive_request!(),
+        )
+        .on_receive_request(
+            async move |request: SetSessionModeRequest, responder, _cx| {
+                // Reject unknown ids so the client-side round-trip actually
+                // asserts the selected mode reached the agent intact.
+                match request.mode_id.to_string().as_str() {
+                    "agent" | "full-access" => {
+                        responder.respond(SetSessionModeResponse::new())
+                    }
+                    other => responder.respond_with_error(acp::util::internal_error(format!(
+                        "unknown mode {other}"
+                    ))),
+                }
             },
             acp::on_receive_request!(),
         )

--- a/src-tauri/src/acp.rs
+++ b/src-tauri/src/acp.rs
@@ -13,8 +13,8 @@ use wisp_acp::{
     acp::schema::v1::{
         ContentBlock, McpServer, McpServerStdio, ResourceLink, SessionId, TextContent,
     },
-    AcpAgentProfile as LaunchProfile, AcpPermissionRequest, AcpSessionEvent, AcpSessionHandle,
-    AcpStopReason, AcpUpdateKind,
+    AcpAgentProfile as LaunchProfile, AcpPermissionKind, AcpPermissionRequest, AcpSessionEvent,
+    AcpSessionHandle, AcpStopReason, AcpUpdateKind,
 };
 use wisp_llm::Message;
 
@@ -237,6 +237,86 @@ pub(crate) async fn authenticate_acp_agent(
         .map_err(|error| error.to_string());
     handle.shutdown(Duration::from_secs(2)).await;
     result
+}
+
+/// One-shot, read-only ACP answer for the side chat: launch a throwaway
+/// session, prompt once with the transcript+question, collect the reply, and
+/// shut the agent down. Tool-use requests are auto-rejected so the side chat
+/// never mutates the workspace or blocks waiting on approval.
+pub(crate) async fn acp_side_chat_once(
+    state: &AppState,
+    cwd: &Path,
+    profile_id: &str,
+    prompt_text: &str,
+) -> Result<String, String> {
+    let profile = profiles(&state.store)
+        .await
+        .into_iter()
+        .find(|profile| profile.id == profile_id)
+        .ok_or_else(|| "Unknown ACP Agent.".to_string())?;
+    let handle = AcpSessionHandle::launch(launch_profile(&profile))
+        .await
+        .map_err(|error| error.to_string())?;
+    let result = acp_side_chat_turn(&handle, cwd, prompt_text).await;
+    handle.shutdown(Duration::from_secs(2)).await;
+    result
+}
+
+async fn acp_side_chat_turn(
+    handle: &AcpSessionHandle,
+    cwd: &Path,
+    prompt_text: &str,
+) -> Result<String, String> {
+    let start = handle
+        .new_session(cwd, vec![])
+        .await
+        .map_err(|error| error.to_string())?;
+    let content = vec![ContentBlock::Text(TextContent::new(prompt_text.to_string()))];
+    let prompt = handle.prompt(start.session_id, content);
+    tokio::pin!(prompt);
+    let mut answer = String::new();
+    loop {
+        tokio::select! {
+            result = &mut prompt => {
+                result.map_err(|error| error.to_string())?;
+                break;
+            }
+            event = handle.next_event() => match event {
+                Some(AcpSessionEvent::Update { kind, payload, .. }) => {
+                    if kind == AcpUpdateKind::AgentMessage {
+                        if let Some(text) = text_from_payload(&payload) {
+                            answer.push_str(text);
+                        }
+                    }
+                }
+                Some(AcpSessionEvent::Permission(request)) => {
+                    // Read-only side chat: reject the tool without cancelling the
+                    // turn when the agent offers a reject option; else cancel.
+                    let reject = request
+                        .options
+                        .iter()
+                        .find(|option| {
+                            matches!(
+                                option.kind,
+                                AcpPermissionKind::RejectOnce | AcpPermissionKind::RejectAlways
+                            )
+                        })
+                        .map(|option| option.id.clone());
+                    let _ = handle.respond_permission(request.request_id, reject);
+                }
+                Some(AcpSessionEvent::Exited { error }) => {
+                    return Err(error.unwrap_or_else(|| "ACP Agent exited.".into()));
+                }
+                None => return Err("ACP Agent event stream closed.".into()),
+            }
+        }
+    }
+    let answer = answer.trim();
+    if answer.is_empty() {
+        Err("The ACP Agent returned no answer.".into())
+    } else {
+        Ok(answer.to_string())
+    }
 }
 
 fn mcp_server(
@@ -827,6 +907,43 @@ pub(crate) async fn set_acp_session_config(
         }),
     );
     Ok(value)
+}
+
+/// Set the ACP session mode (e.g. Codex approval mode: read-only / agent /
+/// full-access). `session/set_mode` returns no state, so the caller applies the
+/// selected `mode_id` optimistically; the agent will confirm with a
+/// `CurrentModeUpdate` notification during the next turn if it disagrees.
+#[tauri::command]
+pub(crate) async fn set_acp_session_mode(
+    state: State<'_, AppState>,
+    window: tauri::WebviewWindow,
+    frame_id: String,
+    mode_id: String,
+) -> Result<String, String> {
+    let project = state.active(window.label());
+    if state
+        .store
+        .frame_project_id(&frame_id)
+        .await
+        .map_err(|error| error.to_string())?
+        .as_deref()
+        != Some(project.id.as_str())
+    {
+        return Err("Session does not belong to the active project.".into());
+    }
+    let runtime = state
+        .acp_sessions
+        .lock()
+        .await
+        .get(&frame_id)
+        .cloned()
+        .ok_or_else(|| "ACP session is not active.".to_string())?;
+    runtime
+        .handle
+        .set_mode(runtime.session_id.clone(), mode_id.clone())
+        .await
+        .map_err(|error| error.to_string())?;
+    Ok(mode_id)
 }
 
 pub(crate) async fn cancel_frame(state: &AppState, frame_id: &str) {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3589,6 +3589,7 @@ async fn side_chat(
     window: tauri::WebviewWindow,
     session_id: Option<String>,
     question: String,
+    acp_agent_id: Option<String>,
 ) -> Result<String, String> {
     let question = question.trim();
     if question.is_empty() {
@@ -3618,6 +3619,13 @@ async fn side_chat(
         None => Vec::new(),
     };
     let transcript = review::serialize_transcript(&msgs);
+    let prompt = side_chat_prompt(&transcript, question);
+    // ACP side chat: one-shot, read-only answer from the selected ACP Agent,
+    // running in the active project root. Never touches the main thread.
+    if let Some(agent_id) = acp_agent_id.as_deref().filter(|id| !id.is_empty()) {
+        let cwd = state.active(window.label()).root;
+        return acp::acp_side_chat_once(&state, &cwd, agent_id, &prompt).await;
+    }
     let (provider, api_url, model, api_key) = load_settings(&state.store).await;
     let (max_tokens, reasoning_effort) = models::active_llm_advanced(&state.store).await;
     let cfg = build_provider_config(
@@ -3629,7 +3637,6 @@ async fn side_chat(
         &reasoning_effort,
     )?;
     let llm = wisp_llm::build(cfg);
-    let prompt = side_chat_prompt(&transcript, question);
     let completion = llm
         .complete(
             &[
@@ -5663,6 +5670,7 @@ pub fn run() {
             acp::authenticate_acp_agent,
             acp::respond_acp_permission,
             acp::set_acp_session_config,
+            acp::set_acp_session_mode,
             review_session,
             side_chat,
             context_probe::probe_execution_context,

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -549,6 +549,8 @@ export function tauriMock(): void {
             return null;
           case "set_acp_session_config":
             return [{ id: "model", name: "Model", type: "select", currentValue: arg("value")?.value ?? "fast", options: [{ value: "fast", name: "Fast" }, { value: "smart", name: "Smart" }] }];
+          case "set_acp_session_mode":
+            return String(arg("modeId") ?? "");
           case "respond_acp_permission":
             setTimeout(() => {
               const requestId = String(arg("requestId"));
@@ -1015,7 +1017,7 @@ export function tauriMock(): void {
                 emit("agent", { kind: "User", frame_id: fid, text: msg });
                 emit("acp-session-state", {
                   frameId: fid,
-                  modes: { currentModeId: "code", availableModes: [{ id: "code", name: "Code" }] },
+                  modes: { currentModeId: "agent", availableModes: [{ id: "read-only", name: "Read Only" }, { id: "agent", name: "Agent" }, { id: "full-access", name: "Full Access" }] },
                   configOptions: [{ id: "model", name: "Model", type: "select", currentValue: "fast", options: [{ value: "fast", name: "Fast" }, { value: "smart", name: "Smart" }] }],
                 });
                 emit("acp-session-update", { frameId: fid, kind: "ToolCall", payload: { toolCallId: "tool-a", title: "Read files", kind: "read", status: "in_progress" } });

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -263,13 +263,20 @@ test("ACP turn maps config, overlapping tools, plan, usage, and exact permission
   await expect(page.getByTestId("acp-tool")).toHaveCount(2);
   await expect(page.getByText("Inspect")).toBeVisible();
   const config = page.getByTestId("acp-session-config");
-  await expect(config).toContainText("code");
+  await expect(config).toContainText("Agent");
   await expect(config).toContainText("Smart");
   await config.getByRole("button", { name: "Model" }).click();
   await page.getByRole("option", { name: "Fast" }).click();
   await expect.poll(() => lastInvokeArgs(page, "set_acp_session_config")).toMatchObject({
     configId: "model", value: { value: "fast" },
   });
+  // Session mode is now a selector (#247): switching invokes set_acp_session_mode.
+  await config.getByRole("button", { name: "Session mode" }).click();
+  await page.getByRole("option", { name: "Full Access" }).click();
+  await expect.poll(() => lastInvokeArgs(page, "set_acp_session_mode")).toMatchObject({
+    modeId: "full-access",
+  });
+  await expect(config).toContainText("Full Access");
 
   const permission = page.getByTestId("acp-permission-card");
   await expect(permission).toBeVisible();
@@ -801,6 +808,16 @@ test("side chat answers in a temporary side panel and can switch model", async (
   await panel.getByRole("button", { name: /deepseek-v4-pro/ }).click();
   await panel.getByRole("button", { name: "opus-4.8" }).click();
   await expect(panel.getByRole("button", { name: /opus-4.8/ })).toBeVisible();
+
+  // Side chat can route through an ACP Agent (#250).
+  await panel.getByRole("button", { name: /opus-4.8/ }).click();
+  await panel.getByRole("button", { name: "Test ACP Agent" }).click();
+  await expect(panel.getByRole("button", { name: /Test ACP Agent/ })).toBeVisible();
+  await panel.getByPlaceholder("Follow up…").fill("acp side question");
+  await panel.getByRole("button", { name: "Send" }).click();
+  await expect.poll(() => lastInvokeArgs(page, "side_chat")).toMatchObject({
+    question: "acp side question", acpAgentId: "acp-test",
+  });
 });
 
 test("branch in new session starts a new frame from the current session", async ({ page }) => {

--- a/ui/src/app_support.rs
+++ b/ui/src/app_support.rs
@@ -1660,6 +1660,48 @@ pub(super) fn acp_agent_selection_after_fetch(
     }
 }
 
+/// Fold a `CurrentModeUpdate` payload into the stored SessionModeState.
+///
+/// The update only carries `currentModeId`, so when we already hold the initial
+/// `SessionModeState` we keep its `availableModes` (which the mode picker needs)
+/// and only swap the current id. With no prior object, the payload stands alone.
+pub(super) fn merge_current_mode(
+    existing: Option<&serde_json::Value>,
+    payload: serde_json::Value,
+) -> serde_json::Value {
+    if let (Some(serde_json::Value::Object(existing)), Some(id)) =
+        (existing, payload.get("currentModeId"))
+    {
+        let mut merged = existing.clone();
+        merged.insert("currentModeId".into(), id.clone());
+        return serde_json::Value::Object(merged);
+    }
+    payload
+}
+
+#[cfg(test)]
+mod merge_current_mode_tests {
+    use super::merge_current_mode;
+    use serde_json::json;
+
+    #[test]
+    fn preserves_available_modes_on_update() {
+        let existing = json!({
+            "currentModeId": "full-access",
+            "availableModes": [{"id": "agent", "name": "Agent"}, {"id": "full-access", "name": "Full Access"}],
+        });
+        let merged = merge_current_mode(Some(&existing), json!({ "currentModeId": "agent" }));
+        assert_eq!(merged["currentModeId"], json!("agent"));
+        assert_eq!(merged["availableModes"], existing["availableModes"]);
+    }
+
+    #[test]
+    fn falls_back_to_payload_without_prior_state() {
+        let merged = merge_current_mode(None, json!({ "currentModeId": "agent" }));
+        assert_eq!(merged, json!({ "currentModeId": "agent" }));
+    }
+}
+
 #[cfg(test)]
 mod acp_agent_selection_tests {
     use super::acp_agent_selection_after_fetch;

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -54,6 +54,9 @@ const HOME_SEARCH_PROJECT_LIMIT: usize = 6;
 const HOME_SEARCH_ARTIFACT_LIMIT: usize = 8;
 const HOME_SEARCH_SESSION_LIMIT: usize = 6;
 const THEME_STORAGE_KEY: &str = "wisp-theme";
+/// Reserved `acp_config_menu_open` key for the session-mode dropdown, kept
+/// distinct from any agent-supplied config option id.
+const ACP_MODE_MENU: &str = "__acp_session_mode";
 
 #[derive(Default)]
 struct ProjectOpenGate {
@@ -415,6 +418,8 @@ fn App() -> impl IntoView {
     let side_chat_items = create_rw_signal::<Vec<ChatItem>>(vec![]);
     let side_chat_busy = create_rw_signal(false);
     let side_chat_model_menu_open = create_rw_signal(false);
+    // Side chat routes through this ACP Agent when set; None = the active model.
+    let side_chat_acp_agent = create_rw_signal::<Option<String>>(None);
     let settings_busy = create_rw_signal(false);
     let settings_message = create_rw_signal::<Option<(bool, String)>>(None);
     let update_check_busy = create_rw_signal(false);
@@ -1431,8 +1436,12 @@ fn App() -> impl IntoView {
                 }
             }
             "CurrentMode" => {
+                // A CurrentModeUpdate only carries `currentModeId`; merge it into
+                // the existing state so the `availableModes` captured from the
+                // initial SessionModeState (and needed by the mode picker) survive.
                 acp_session_modes.update(|all| {
-                    all.insert(update.frame_id, update.payload);
+                    let merged = merge_current_mode(all.get(&update.frame_id), update.payload);
+                    all.insert(update.frame_id, merged);
                 });
             }
             "Usage" => {
@@ -1692,11 +1701,21 @@ fn App() -> impl IntoView {
         side_chat_items.update(|v| v.push(ChatItem::User(question.clone())));
         side_chat_busy.set(true);
         let sid = active_session.get();
-        let model = active_model_label(&models.get());
+        let acp_agent = side_chat_acp_agent.get();
+        let model = match acp_agent.as_ref() {
+            Some(id) => acp_agents
+                .get()
+                .into_iter()
+                .find(|agent| &agent.id == id)
+                .map(|agent| agent.label)
+                .or_else(|| Some("ACP Agent".into())),
+            None => active_model_label(&models.get()),
+        };
         spawn_local(async move {
             let arg = to_value(&serde_json::json!({
                 "sessionId": sid,
                 "question": question,
+                "acpAgentId": acp_agent,
             }))
             .unwrap();
             match invoke_checked("side_chat", arg).await {
@@ -4710,9 +4729,21 @@ fn App() -> impl IntoView {
                     {move || active_session.get().and_then(|session_id| {
                         active_acp_agent_id.get()?;
                         let options = acp_session_configs.get().get(&session_id).cloned().unwrap_or_default();
-                        let mode = acp_session_modes.get().get(&session_id)
+                        let modes_state = acp_session_modes.get().get(&session_id).cloned();
+                        let mode = modes_state.as_ref()
                             .and_then(|state| state.get("currentModeId"))
                             .and_then(serde_json::Value::as_str).map(str::to_string);
+                        // `availableModes` from the initial SessionModeState drives the
+                        // picker; a single-mode agent stays a read-only chip.
+                        let available_modes: Vec<(String, String)> = modes_state.as_ref()
+                            .and_then(|state| state.get("availableModes"))
+                            .and_then(serde_json::Value::as_array)
+                            .map(|arr| arr.iter().filter_map(|m| {
+                                let id = m.get("id").and_then(serde_json::Value::as_str)?.to_string();
+                                let name = m.get("name").and_then(serde_json::Value::as_str).unwrap_or(&id).to_string();
+                                Some((id, name))
+                            }).collect())
+                            .unwrap_or_default();
                         (!options.is_empty() || mode.is_some()).then(|| view! {
                             <div class="acp-composer-config" data-testid="acp-session-config">
                                 {(!options.iter().any(|option| {
@@ -4724,12 +4755,76 @@ fn App() -> impl IntoView {
                                 }))
                                     .then(|| {
                                         mode.map(|mode| {
-                                            view! {
-                                                <span class="acp-config-chip acp-mode" title="Session mode">
-                                                    <span class="acp-config-key">"mode"</span>
-                                                    <span class="acp-config-val">{mode}</span>
-                                                </span>
+                                            let current_label = available_modes.iter()
+                                                .find(|(id, _)| id == &mode)
+                                                .map(|(_, name)| name.clone())
+                                                .unwrap_or_else(|| mode.clone());
+                                            if available_modes.len() < 2 {
+                                                return view! {
+                                                    <span class="acp-config-chip acp-mode" title="Session mode">
+                                                        <span class="acp-config-key">"mode"</span>
+                                                        <span class="acp-config-val">{current_label}</span>
+                                                    </span>
+                                                }.into_view();
                                             }
+                                            let session_id = session_id.clone();
+                                            view! {
+                                                <div class="acp-config-chip acp-config-select acp-mode-select" title="Session mode"
+                                                    class:open=move || acp_config_menu_open.get().as_deref() == Some(ACP_MODE_MENU)>
+                                                    <button type="button" class="acp-config-trigger" aria-label="Session mode"
+                                                        on:click=move |_| {
+                                                            acp_config_menu_open.update(|open| {
+                                                                *open = if open.as_deref() == Some(ACP_MODE_MENU) { None } else { Some(ACP_MODE_MENU.into()) };
+                                                            });
+                                                        }>
+                                                        <span class="acp-config-key">"mode"</span>
+                                                        <span class="acp-config-val">{current_label}</span>
+                                                    </button>
+                                                    {move || (acp_config_menu_open.get().as_deref() == Some(ACP_MODE_MENU)).then(|| {
+                                                        let session_id = session_id.clone();
+                                                        let current_mode = mode.clone();
+                                                        view! {
+                                                            <div class="acp-config-backdrop" on:click=move |_| acp_config_menu_open.set(None)></div>
+                                                            <div class="acp-config-menu" role="listbox">
+                                                                {available_modes.clone().into_iter().map(|(mode_id, label)| {
+                                                                    let selected = mode_id == current_mode;
+                                                                    let session_id = session_id.clone();
+                                                                    view! {
+                                                                        <button type="button" class="acp-config-option" class:active=selected
+                                                                            role="option" aria-selected=selected
+                                                                            on:click=move |_| {
+                                                                                acp_config_menu_open.set(None);
+                                                                                let frame_id = session_id.clone();
+                                                                                let mode_id = mode_id.clone();
+                                                                                let args = to_value(&serde_json::json!({
+                                                                                    "frameId": frame_id,
+                                                                                    "modeId": mode_id,
+                                                                                })).unwrap();
+                                                                                spawn_local(async move {
+                                                                                    if let Ok(value) = invoke_checked("set_acp_session_mode", args).await {
+                                                                                        if let Some(applied) = value.as_string() {
+                                                                                            // `session/set_mode` returns no state, so apply the
+                                                                                            // selected id locally, preserving availableModes.
+                                                                                            acp_session_modes.update(|all| {
+                                                                                                let entry = all.entry(frame_id).or_insert_with(|| serde_json::json!({}));
+                                                                                                if let serde_json::Value::Object(map) = entry {
+                                                                                                    map.insert("currentModeId".into(), serde_json::Value::String(applied));
+                                                                                                }
+                                                                                            });
+                                                                                        }
+                                                                                    }
+                                                                                });
+                                                                            }>
+                                                                            <span class="acp-config-option-label">{label}</span>
+                                                                            {selected.then(|| view! { <span class="acp-config-option-check">"✓"</span> })}
+                                                                        </button>
+                                                                    }
+                                                                }).collect_view()}
+                                                            </div>
+                                                        }
+                                                    })}
+                                                </div>
+                                            }.into_view()
                                         })
                                     })}
                                 {options.into_iter().map(|option| {
@@ -6186,14 +6281,18 @@ fn App() -> impl IntoView {
                                             }
                                         ></textarea>
                                         <div class="sidechat-actions">
-                                            {move || (!models.get().is_empty()).then(|| view! {
+                                            {move || (!models.get().is_empty() || !acp_agents.get().is_empty()).then(|| view! {
                                                 <div class="sidechat-model">
                                                     <button type="button" class="sidechat-model-btn"
                                                         class:active=move || side_chat_model_menu_open.get()
                                                         on:click=move |_| side_chat_model_menu_open.update(|o| *o = !*o)>
                                                         {move || {
-                                                            let l = models.get();
-                                                            l.iter().find(|m| m.active).or_else(|| l.first()).map(|m| m.label.clone()).unwrap_or_default()
+                                                            if let Some(id) = side_chat_acp_agent.get() {
+                                                                acp_agents.get().into_iter().find(|agent| agent.id == id).map(|agent| agent.label).unwrap_or_else(|| "ACP Agent".into())
+                                                            } else {
+                                                                let l = models.get();
+                                                                l.iter().find(|m| m.active).or_else(|| l.first()).map(|m| m.label.clone()).unwrap_or_default()
+                                                            }
                                                         }}
                                                         <span>"▾"</span>
                                                     </button>
@@ -6202,11 +6301,12 @@ fn App() -> impl IntoView {
                                                         <div class="sidechat-model-menu">
                                                             {move || models.get().into_iter().map(|m| {
                                                                 let pick_id = m.id.clone();
-                                                                let is_active = m.active;
+                                                                let is_active = m.active && side_chat_acp_agent.get().is_none();
                                                                 view! {
                                                                     <button type="button" class="sidechat-model-row" class:active=is_active
                                                                         on:click=move |_| {
                                                                             side_chat_model_menu_open.set(false);
+                                                                            side_chat_acp_agent.set(None);
                                                                             let id = pick_id.clone();
                                                                             spawn_local(async move {
                                                                                 let arg = to_value(&serde_json::json!({ "id": id })).unwrap();
@@ -6222,6 +6322,23 @@ fn App() -> impl IntoView {
                                                                     </button>
                                                                 }
                                                             }).collect_view()}
+                                                            {move || (!acp_agents.get().is_empty()).then(|| view! {
+                                                                <div class="sidechat-model-group">"ACP Agents"</div>
+                                                                {acp_agents.get().into_iter().map(|agent| {
+                                                                    let id = agent.id.clone();
+                                                                    let selected = side_chat_acp_agent.get().as_deref() == Some(agent.id.as_str());
+                                                                    view! {
+                                                                        <button type="button" class="sidechat-model-row" class:active=selected
+                                                                            on:click=move |_| {
+                                                                                side_chat_model_menu_open.set(false);
+                                                                                side_chat_acp_agent.set(Some(id.clone()));
+                                                                            }>
+                                                                            <span>{agent.label.clone()}</span>
+                                                                            {selected.then(|| view! { <span>"✓"</span> })}
+                                                                        </button>
+                                                                    }
+                                                                }).collect_view()}
+                                                            })}
                                                         </div>
                                                     })}
                                                 </div>

--- a/ui/src/styles/chat.css
+++ b/ui/src/styles/chat.css
@@ -863,6 +863,7 @@ button.stop:disabled { opacity: .6; cursor: default; }
 .sidechat-model-menu { position: absolute; z-index: 82; left: 0; bottom: calc(100% + 8px); min-width: 220px; max-height: 260px; overflow-y: auto; padding: 6px; background: var(--bg-elev); border: 1px solid var(--border-strong); border-radius: var(--radius-sm); box-shadow: var(--shadow); transform-origin: bottom left; animation: motion-surface-in-soft var(--motion-duration-fast) var(--motion-ease-decelerate) both; }
 .sidechat-model-row { display: flex; align-items: center; justify-content: space-between; gap: 12px; width: 100%; padding: 8px 9px; border: none; border-radius: 7px; background: transparent; color: var(--text); font: inherit; font-size: 12.5px; text-align: left; cursor: pointer; }
 .sidechat-model-row:hover, .sidechat-model-row.active { background: var(--bg-sunken); }
+.sidechat-model-group { padding: 8px 9px 4px; font-size: 10.5px; font-weight: 650; letter-spacing: .04em; text-transform: uppercase; color: var(--text-muted); }
 .sidechat-send { height: 30px; padding: 0 13px; border: none; border-radius: 999px; background: var(--clay); color: var(--on-clay); font: inherit; font-size: 12.5px; font-weight: 650; cursor: pointer; }
 .sidechat-send:disabled { opacity: .45; cursor: default; }
 .sidechat-send:hover:not(:disabled) { background: var(--clay-strong); }


### PR DESCRIPTION
强化 ACP 模式，修复 #247、实现 #250。

## #247 — Full Access 发消息后跳回 Agent

**根因**：wisp 只把 ACP 会话模式显示成一个**只读标签**，且**从未实现 `session/set_mode`**（`Command` 里只有 `SetConfig`）。用户根本无法在 wisp 里控制模式——看到的 Full Access 是 agent 的默认值；一旦 agent（Codex/GPT）回发 `CurrentModeUpdate` 或进程崩溃后 relaunch+resume 回到默认模式，标签就变回 Agent，而用户束手无策。

**修复**（三层补全 `session/set_mode`）：
- `crates/wisp-acp` — 新增 `Command::SetMode` + `handle.set_mode()`，向 agent 发 `SetSessionModeRequest`。
- `src-tauri/src/acp.rs` — 新增 `set_acp_session_mode` 命令（`session/set_mode` 无返回态，回传选中的 `mode_id` 供前端乐观更新）。
- `ui/src/main.rs` — 只读标签 → **模式下拉选择器**（Read Only / Agent / Full Access 任选），选中即调 `set_acp_session_mode`。
- 顺带修好一个隐藏 bug：`CurrentMode` 更新原本**整体覆盖** modes 值、丢掉 `availableModes`（模式下拉需要它）。抽成纯函数 `merge_current_mode` 合并，只换 `currentModeId`、保留 `availableModes`。

> 关于"有时候"跳回：进程崩溃后 wisp 会 relaunch+resume，agent 真的回到默认模式，此时 wisp 正确显示重置后的模式——以前用户改不回，现在能一键改回。这是根治而非遮症状。

## #250 — 侧边问答支持 ACP

侧边问答原本是**无状态一次性**、只用默认模型的只读问答。现在模型菜单多了 "ACP Agents" 分组；选中某个 ACP Agent 后，`side_chat` 走新的 `acp_side_chat_once`：起一个**临时会话**跑一轮，收集回答后关闭，**工具授权一律拒绝**（保持只读、不动工作区、不影响主线程）。选默认模型即回到原路径。

## 验证

| 层 | 结果 |
|---|---|
| wisp-acp process 测试（新增 set_mode 往返 + 拒绝未知 mode id） | ✓ |
| wisp-tauri lib 测试 | 154 passed |
| ui 单测（新增 `merge_current_mode`） | 52 passed |
| e2e（7 个 ACP + 侧边问答，新增模式下拉/ACP 路由断言） | ✓ |

## Reviewer notes

- 侧边 ACP 每次问答起一个 agent 进程（~1-2s 冷启动），未做会话池化——有性能诉求再加。
- ACP UI 目前全英文，本 PR 保持一致，未动 i18n/docs。
- 若 agent 把审批模式暴露为 config option（而非 `SessionModeState`），既有的 config-option 下拉照旧接管，模式选择器会被抑制，不会双重出现。

🤖 Generated with [Claude Code](https://claude.com/claude-code)