### PR TITLE
fix(ui): decode percent-encoded file hrefs; scroll markdown in artifact modal

### DIFF
--- a/ui/src/app_support.rs
+++ b/ui/src/app_support.rs
@@ -9,9 +9,9 @@ use crate::bindings::{
 use crate::dto::*;
 use crate::i18n::{localize_backend, t, tf, use_locale, Locale};
 use crate::text::{
-    dom_value, event_target_value, extract_href_from_tag, fasta_seq_count, fenced_blocks,
-    file_kind, format_bytes, format_duration_ms, html_escape, is_external_href, is_separator,
-    is_table_row, md_inline_to_html, md_to_html, next_artifact_id, normalize_path,
+    decode_href, dom_value, event_target_value, extract_href_from_tag, fasta_seq_count,
+    fenced_blocks, file_kind, format_bytes, format_duration_ms, html_escape, is_external_href,
+    is_separator, is_table_row, md_inline_to_html, md_to_html, next_artifact_id, normalize_path,
     opens_in_system_browser, parent_path, parse_csv_line, pretty_json, provider_defaults,
     provider_value, split_row, tool_lang, unique_dom_id, user_message_presentation,
 };
@@ -2972,7 +2972,7 @@ pub(super) fn replace_file_links(html: String, arts: &[Artifact]) -> String {
         let inner = &after[..end];
         rest = &after[end + 4..];
 
-        if let Some(href) = extract_href_from_tag(tag) {
+        if let Some(href) = extract_href_from_tag(tag).map(|h| decode_href(&h)) {
             if !is_external_href(&href) {
                 if let Some(idx) = artifact_index_for_href(arts, &href) {
                     out.push_str(&art_chip(idx, &arts[idx]));
@@ -3261,7 +3261,7 @@ pub(super) fn handle_md_click(
                 if !is_external_href(&href) {
                     ev.prevent_default();
                     ev.stop_propagation();
-                    let path = normalize_path(&href);
+                    let path = normalize_path(&decode_href(&href));
                     if let Some(idx) = artifact_index_for_href(arts, &path) {
                         on_artifact.call(idx);
                     } else {

--- a/ui/src/styles/modals.css
+++ b/ui/src/styles/modals.css
@@ -209,10 +209,11 @@ textarea.host-input { min-height:64px; resize:vertical; }
 .artifact-modal .am-nav-btn:disabled { opacity: .35; cursor: default; }
 .artifact-modal .am-nav-btn:disabled:hover { background: transparent; color: var(--text-muted); }
 .artifact-modal .am-figure {
-  max-height: 52vh; overflow: hidden; display: flex; justify-content: flex-start; align-items: flex-start;
+  max-height: 52vh; overflow: auto; display: flex; justify-content: flex-start; align-items: flex-start;
   background: var(--bg-sunken); border-radius: var(--radius-sm); padding: 8px;
 }
-.artifact-modal .am-figure.zoomable-preview { height: 52vh; }
+/* Image/PDF pan inside their own zoom viewport, so the figure box must clip, not scroll. */
+.artifact-modal .am-figure.zoomable-preview { height: 52vh; overflow: hidden; }
 .artifact-modal.html-preview .am-figure { overflow: auto; }
 .artifact-modal .am-figure > * { flex: 1 1 auto; min-width: 0; min-height: 0; }
 .artifact-modal .am-figure img,

--- a/ui/src/text.rs
+++ b/ui/src/text.rs
@@ -399,6 +399,31 @@ pub(crate) fn normalize_path(path: &str) -> String {
     strip_image_pdf_shorthand(path).to_string()
 }
 
+/// Percent-decode an href read back from rendered HTML. pulldown-cmark
+/// percent-encodes link destinations (a Windows path `D:\a\b` becomes
+/// `D:%5Ca%5Cb`), so an href taken straight off the DOM never matches a real
+/// file path until it is decoded. Decodes byte-wise so multi-byte UTF-8
+/// filenames (e.g. Chinese) round-trip; a malformed `%` sequence is left as-is.
+pub(crate) fn decode_href(href: &str) -> String {
+    let bytes = href.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            let hi = (bytes[i + 1] as char).to_digit(16);
+            let lo = (bytes[i + 2] as char).to_digit(16);
+            if let (Some(hi), Some(lo)) = (hi, lo) {
+                out.push((hi * 16 + lo) as u8);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
 fn strip_image_pdf_shorthand(path: &str) -> &str {
     const IMAGE_EXTS: [&str; 6] = ["png", "jpg", "jpeg", "gif", "webp", "svg"];
     let lower = path.to_ascii_lowercase();
@@ -597,9 +622,30 @@ pub(crate) fn fasta_seq_count(text: &str) -> usize {
 #[cfg(test)]
 mod md_catalog_tests {
     use super::{
-        fence_identifier_line_runs, file_kind, format_bytes, md_to_html, parent_path, pretty_json,
-        user_message_presentation,
+        decode_href, fence_identifier_line_runs, file_kind, format_bytes, md_to_html, parent_path,
+        pretty_json, user_message_presentation,
     };
+
+    #[test]
+    fn decodes_percent_encoded_windows_href() {
+        // pulldown-cmark percent-encodes the backslashes of an absolute Windows
+        // path in the rendered <a href>; clicking it must round-trip back to the
+        // real path, not hit the filesystem as `D:%5C...` (#outside-project-root).
+        assert_eq!(
+            decode_href("D:%5CPHD_project%5CAI4drug%5CPeptide%5Cfig.png"),
+            "D:\\PHD_project\\AI4drug\\Peptide\\fig.png"
+        );
+    }
+
+    #[test]
+    fn decodes_multibyte_and_leaves_plain_and_malformed_untouched() {
+        // Chinese filename: pulldown-cmark encodes each UTF-8 byte.
+        assert_eq!(decode_href("out/%E5%9B%BE1.png"), "out/图1.png");
+        // No encoding: unchanged.
+        assert_eq!(decode_href("results/fig.png"), "results/fig.png");
+        // A lone/percent-with-non-hex stays literal.
+        assert_eq!(decode_href("100%done/%zz"), "100%done/%zz");
+    }
 
     #[test]
     fn formats_large_runtime_memory_in_gigabytes() {


### PR DESCRIPTION
## 背景

Codex(ACP)在 Windows 上写文件后,会用带反斜杠的**绝对路径**输出 Markdown 链接,例如 `[fig.png](D:\PHD_project\AI4drug\Peptide\fig.png)`。视频里点这类 md/png 链接会直接报 `path 'D:%5CPHD_project%5C...%5Cfig.png' is outside project root`,既不渲染也打不开。

## 根因

1. 前端用 `pulldown-cmark` 渲染链接时会对 href 做 percent 编码,反斜杠 `\` → `%5C`(冒号/正斜杠保留),于是 `<a href="D:%5CPHD_project%5C...">`。
2. `handle_md_click` 直接用 `get_attribute("href")` 拿到这串**未解码**的 href,经 `normalize_path`(不解码)就交给后端 `read_file`。
3. 后端 `validate_file_path` 收到 `D:%5C...`,在磁盘上永远匹配不到真实文件,`starts_with(root)` 失败 → "outside project root"。与文件类型无关,md/png 都中招。

另有一个独立问题:产物弹窗里打开长 md 无法下滑,但右侧产物面板可以。

## 改动

- 新增纯函数 `decode_href`(按字节 percent 解码,UTF-8 lossy,坏的 `%` 原样保留 → 中文文件名也能还原),在两个"从 DOM/HTML 取 href 当路径"的唯一入口各解码一次:
  - `handle_md_click`(点击打开/匹配产物)
  - `replace_file_links`(把已登记文件链接渲染成 chip)
  解码后 `D:\...` 能正确匹配已登记产物、标题显示成文件名而非 `%5C` 串,或按真实路径读盘。
- CSS:`.am-figure` 原为 `overflow: hidden`,滚动例外只覆盖 image/pdf 和 html,markdown/文本被裁剪。改为默认 `overflow: auto`,只对图片/PDF(有自己的缩放视口)保留 `hidden`。修复弹窗里 md 不能下滑。

## 验证

- `decode_href` 用视频里的 `D:%5C…fig.png` 和中文文件名做了 RED→GREEN 单测。
- `cargo test --bin wisp-ui` 全绿(52 个,含新增 2 个)。
- CSS 为纯样式改动,需真机肉眼确认弹窗内长 md 可滚;端到端(Windows + Codex)未在 macOS 复现,但触发缺陷的核心已被确定性单测锁定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)