### PR TITLE
Unify UI surfaces and controls

### DIFF
--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -2285,6 +2285,19 @@ test("macOS uses the native title bar without the integrated header", async ({ b
   await expect.poll(async () => page.locator(".settings-page").evaluate((el) =>
     Math.round(el.getBoundingClientRect().top)
   )).toBe(0);
+  await page.getByRole("button", { name: "Back to app" }).click();
+
+  await page.locator(".proj-card-main").first().click();
+  await expect(newSessionButton(page)).toBeVisible();
+  await page.getByRole("button", { name: "Compute hosts", exact: true }).click();
+  await page.getByRole("menu", { name: "Compute hosts" })
+    .getByRole("button", { name: "gpu-server", exact: true }).click();
+  const card = page.getByRole("dialog", { name: "Environment info" });
+  await expect.poll(() => card.evaluate((element) => {
+    const toggle = document.querySelector('.topbar [title="Toggle panel"]');
+    if (!(toggle instanceof HTMLElement)) return null;
+    return Math.round(element.getBoundingClientRect().top - toggle.getBoundingClientRect().bottom);
+  })).toBe(18);
 
   await context.close();
 });

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -27,11 +27,15 @@ async function openSettingsSection(page: Page, name: string) {
 async function enterApp(page: Page) {
   await page.goto("/");
   await page.locator(".proj-card-main").first().click();
-  await expect(page.getByRole("button", { name: "New session" })).toBeVisible();
+  await expect(newSessionButton(page)).toBeVisible();
 }
 
 function composer(page: Page) {
   return page.locator("#composer-input");
+}
+
+function newSessionButton(page: Page) {
+  return page.locator(".sidebar").getByRole("button", { name: "New session" });
 }
 
 function commandPalette(page: Page) {
@@ -127,8 +131,10 @@ test("Settings Models page can open ACP Agents dialog", async ({ page }) => {
 
 test("ACP Agent settings create, test, and authenticate an installed agent", async ({ page }) => {
   await enterApp(page);
-  await page.locator(".model-picker-btn").click();
-  await page.getByTestId("add-acp-agent").click();
+  await page.getByRole("button", { name: "Settings" }).click();
+  await page.getByRole("button", { name: "Models", exact: true }).click();
+  await page.getByTestId("open-acp-agents-from-settings").click();
+  await page.getByTestId("add-acp-agent-settings").click();
   const settings = page.getByTestId("acp-agents-settings");
   await expect(settings).toBeVisible();
   await expect(page.locator(".settings-breadcrumb")).toContainText(/ACP/);
@@ -178,7 +184,7 @@ test("selecting an ACP Agent from a populated HTTP session starts a fresh sessio
 
 test("ACP turn maps config, overlapping tools, plan, usage, and exact permission response", async ({ page }) => {
   await enterApp(page);
-  await page.getByRole("button", { name: "New session" }).click();
+  await newSessionButton(page).click();
   await page.locator(".model-picker-btn").click();
   await page.getByRole("button", { name: /Test ACP Agent/ }).click();
   await composer(page).fill("ACP PERMISSION");
@@ -218,7 +224,7 @@ test("ACP turn maps config, overlapping tools, plan, usage, and exact permission
 
 test("ACP turns retain explicitly selected Wisp skills", async ({ page }) => {
   await enterApp(page);
-  await page.getByRole("button", { name: "New session" }).click();
+  await newSessionButton(page).click();
   await page.locator(".model-picker-btn").click();
   await page.getByRole("button", { name: /Test ACP Agent/ }).click();
   await composer(page).fill("/alpha");
@@ -234,7 +240,7 @@ test("ACP turns retain explicitly selected Wisp skills", async ({ page }) => {
 
 test("ACP cancellation is scoped to the active bound frame", async ({ page }) => {
   await enterApp(page);
-  await page.getByRole("button", { name: "New session" }).click();
+  await newSessionButton(page).click();
   await page.locator(".model-picker-btn").click();
   await page.getByRole("button", { name: /Test ACP Agent/ }).click();
   await composer(page).fill("ACP LONG");
@@ -542,7 +548,7 @@ test("Ctrl+P command palette runs commands and switches themes", async ({ page }
 
 test("new session focuses the composer", async ({ page }) => {
   await enterApp(page);
-  await page.getByRole("button", { name: "New session" }).click();
+  await newSessionButton(page).click();
   await expect(composer(page)).toBeFocused();
 });
 
@@ -550,7 +556,7 @@ test("rename session modal autofocuses so Ctrl+A selects the title", async ({ pa
   await page.addInitScript(parallelMock);
   await page.goto("/");
   await page.locator(".proj-card-main").first().click();
-  await expect(page.getByRole("button", { name: "New session" })).toBeVisible();
+  await expect(newSessionButton(page)).toBeVisible();
 
   await composer(page).fill("rename-me");
   await page.getByRole("button", { name: "Send" }).click();
@@ -576,7 +582,7 @@ test("conversation action button renames, transfers, and deletes sessions", asyn
   await page.addInitScript(parallelMock);
   await page.goto("/");
   await page.locator(".proj-card-main").first().click();
-  await expect(page.getByRole("button", { name: "New session" })).toBeVisible();
+  await expect(newSessionButton(page)).toBeVisible();
 
   await composer(page).fill("actions-manage-me");
   await page.getByRole("button", { name: "Send" }).click();
@@ -631,7 +637,7 @@ test("conversation action button renames, transfers, and deletes sessions", asyn
   })).toMatchObject({ targetProjectId: "other", mode: "move" });
   await expect(session).toHaveCount(0);
 
-  await page.getByRole("button", { name: "New session" }).click();
+  await newSessionButton(page).click();
   await composer(page).fill("actions-delete-me");
   await page.getByRole("button", { name: "Send" }).click();
   await expect(page.getByText("echo:actions-delete-me")).toBeVisible({ timeout: 10_000 });
@@ -829,7 +835,7 @@ test("uploaded file shows up in the artifacts panel after send", async ({ page }
   await expect(page.locator(".msg.user")).toHaveCount(1);
   await expect(page.locator(".msg.user .user-attachment-file")).toContainText("counts.csv");
   await expect(page.locator(".msg.user")).not.toContainText("Uploaded files:");
-  await expect(page.locator(".center-title")).not.toContainText("Uploaded files:");
+  await expect(page.locator(".center-tab.active")).not.toContainText("Uploaded files:");
   // The right panel starts collapsed; open it to see the collected artifact.
   await page.getByRole("button", { name: "Toggle panel" }).click();
   // The upload path lives in the user turn; the panel must pick it up from there.
@@ -839,7 +845,7 @@ test("uploaded file shows up in the artifacts panel after send", async ({ page }
   await page.locator(".ctx-menu").getByRole("button", { name: "Open in center" }).click();
   await expect(page.locator(".center-tab.active")).toContainText("counts.csv");
   await expect(page.locator(".center-file-preview")).toContainText("a");
-  await page.getByRole("button", { name: "Conversation" }).click();
+  await page.locator(".center-tabs > .center-tab").click();
   await tile.click({ button: "right" });
   await page.locator(".ctx-menu").getByRole("button", { name: "Download" }).click();
   await expect.poll(() => lastInvokeArgs(page, "download_file")).toMatchObject({ path: "uploads/counts.csv" });
@@ -1123,6 +1129,11 @@ test("right panel shows execution contexts and runs", async ({ page }) => {
   const firstTerminal = terminalDock.locator('.terminal-dock-frame[data-terminal-session="terminal-mock-1"]');
   await expect(firstTerminal).toHaveClass(/active/);
   await expect(firstTerminal.locator(".xterm-rows")).toContainText("terminal ready");
+  await expect.poll(() => firstTerminal.locator(".xterm-viewport").evaluate((viewport) => ({
+    standardWidth: getComputedStyle(viewport).scrollbarWidth,
+    themedWidth: getComputedStyle(viewport, "::-webkit-scrollbar").width,
+    thumbInset: getComputedStyle(viewport, "::-webkit-scrollbar-thumb").borderTopWidth,
+  }))).toEqual({ standardWidth: "auto", themedWidth: "10px", thumbInset: "2px" });
   await expect.poll(async () => (await invokeArgsList(page, "resize_terminal")).some((args: any) =>
     args.sessionId === "terminal-mock-1" && args.rows > 0 && args.cols > 0,
   )).toBe(true);
@@ -1186,6 +1197,17 @@ test("selected context detail keeps its scroll position across background refres
 
   const panel = page.locator('.context-detail-pane[data-context-id="local"]');
   await expect(panel).toBeVisible();
+  await expect.poll(() => page.locator(".rightpane").evaluate((pane) => ({
+    paneBorder: getComputedStyle(pane).borderLeftWidth,
+    dividerWidth: getComputedStyle(document.querySelector(".resizer")!, "::after").width,
+    listSurface: getComputedStyle(document.querySelector(".context-list-pane")!).backgroundColor,
+    detailSurface: getComputedStyle(document.querySelector(".context-detail-pane")!).backgroundColor,
+  }))).toEqual({
+    paneBorder: "0px",
+    dividerWidth: "1px",
+    listSurface: "rgb(243, 241, 236)",
+    detailSurface: "rgb(243, 241, 236)",
+  });
   const scrollTop = await panel.evaluate((element) => {
     const target = Math.min(200, element.scrollHeight - element.clientHeight);
     element.scrollTop = target;
@@ -1211,6 +1233,13 @@ test("execution contexts remember Python and R interpreter paths", async ({ page
 
   const local = page.locator(".context-card", { hasText: "local" });
   await local.getByRole("button", { name: "Configure runtime interpreters" }).click();
+  const runtimeModal = page.locator(".runtime-config-modal");
+  await expect.poll(() => runtimeModal.locator(".ps-close").evaluate((button) => ({
+    headDisplay: getComputedStyle(button.parentElement!).display,
+    buttonDisplay: getComputedStyle(button).display,
+    width: getComputedStyle(button).width,
+    border: getComputedStyle(button).borderTopWidth,
+  }))).toEqual({ headDisplay: "flex", buttonDisplay: "flex", width: "30px", border: "0px" });
   const python = page.locator("#runtime-python-executable");
   const rscript = page.locator("#runtime-rscript-executable");
   await python.fill(String.raw`C:\Tools\Python\python.exe`);
@@ -2090,7 +2119,7 @@ test("home search opens artifacts, sessions, and settings", async ({ page }) => 
 test("long transcripts load earlier turns without jumping to the new top", async ({ page }) => {
   await page.goto("/?mockLongSession=1");
   await page.locator(".proj-card-main").first().click();
-  await expect(page.getByRole("button", { name: "New session" })).toBeVisible();
+  await expect(newSessionButton(page)).toBeVisible();
   await page.getByText("Long transcript", { exact: true }).click();
 
   await expect(page.getByText("Newest page first question", { exact: true })).toBeVisible();
@@ -2222,7 +2251,7 @@ test("Windows uses the integrated title bar without covering the project landing
   await expect(page.locator(".projects-screen")).toBeVisible();
 
   await page.locator(".proj-card-main").first().click();
-  await expect(page.getByRole("button", { name: "New session" })).toBeVisible();
+  await expect(newSessionButton(page)).toBeVisible();
   await page.getByRole("button", { name: "File", exact: true }).click();
   const exportCurrentProject = page.getByRole("menuitem", { name: "Export current project" });
   await expect(exportCurrentProject).toBeEnabled();
@@ -2335,7 +2364,7 @@ test("default workspace keeps history labels and compact navigation keeps hover 
 
   await page.setViewportSize({ width: 800, height: 720 });
   await expect.poll(async () => sidebar.evaluate((el) => Math.round(el.getBoundingClientRect().width))).toBeLessThanOrEqual(64);
-  await expect(page.getByRole("button", { name: "New session" })).toHaveAttribute("title", "New session");
+  await expect(newSessionButton(page)).toHaveAttribute("title", "New session");
   await expect(page.locator(".proj-switch")).toHaveAttribute("title", /.+/);
 
   await page.locator(".proj-switch").click();
@@ -2527,7 +2556,7 @@ test("a second conversation can run in parallel without interleaving transcripts
   await page.addInitScript(parallelMock);
   await page.goto("/");
   await page.locator(".proj-card-main").first().click();
-  await expect(page.getByRole("button", { name: "New session" })).toBeVisible();
+  await expect(newSessionButton(page)).toBeVisible();
 
   // Start conversation A. The mock streams "echo:alpha" at once but delays Done,
   // so A stays "running".
@@ -2537,7 +2566,7 @@ test("a second conversation can run in parallel without interleaving transcripts
 
   // While A is still running, open a fresh session. The composer must be usable
   // (per-session busy: A running does NOT block B).
-  await page.getByRole("button", { name: "New session" }).click();
+  await newSessionButton(page).click();
   await expect(composer(page)).toBeEmpty();
   await composer(page).fill("beta");
   await page.getByRole("button", { name: "Send" }).click();
@@ -2559,7 +2588,7 @@ test("a running conversation accepts another message for queueing", async ({ pag
   await page.addInitScript(parallelMock);
   await page.goto("/");
   await page.locator(".proj-card-main").first().click();
-  await expect(page.getByRole("button", { name: "New session" })).toBeVisible();
+  await expect(newSessionButton(page)).toBeVisible();
 
   await composer(page).fill("alpha");
   await page.getByRole("button", { name: "Send" }).click();
@@ -2620,7 +2649,7 @@ test("external links open in the system browser, not the app webview (#97)", asy
   )).toContain("https://example.com/paper.pdf");
   // The app itself must still be on screen — the click was intercepted, not
   // followed as a top-level navigation.
-  await expect(page.getByRole("button", { name: "New session" })).toBeVisible();
+  await expect(newSessionButton(page)).toBeVisible();
 });
 
 test("assistant markdown uses normal whitespace (no phantom blank lines)", async ({ page }) => {
@@ -2686,7 +2715,7 @@ test("live step disclosure choices survive tool updates and completion (#172)", 
 
 test("ACP thinking folds into the steps panel instead of dangling under the reply", async ({ page }) => {
   await enterApp(page);
-  await page.getByRole("button", { name: "New session" }).click();
+  await newSessionButton(page).click();
   await page.locator(".model-picker-btn").click();
   await page.getByRole("button", { name: /Test ACP Agent/ }).click();
   await composer(page).fill("ACPTHINK");
@@ -2819,7 +2848,7 @@ test("a ?project window opens straight into the project, skipping the landing (#
   // A dedicated project window carries ?project=<id>; it must open that project
   // directly (per-window active) instead of showing the projects landing.
   await page.goto("/?project=default");
-  await expect(page.getByRole("button", { name: "New session" })).toBeVisible({ timeout: 10_000 });
+  await expect(newSessionButton(page)).toBeVisible({ timeout: 10_000 });
   // The landing (project cards) must NOT be shown in a dedicated project window.
   await expect(page.locator(".proj-card")).toHaveCount(0);
   await expect.poll(async () => page.evaluate(() =>
@@ -2859,7 +2888,7 @@ test("new session can pick a specialist and it locks after the first message", a
 
   // Picking a specialist requires an active session (set lazily on first send
   // otherwise), so start one explicitly via "New session".
-  await page.getByRole("button", { name: "New session" }).click();
+  await newSessionButton(page).click();
   await page.getByRole("button", { name: "Specialist" }).click();
   await page.getByRole("button", { name: "Paper hunter" }).click();
   await expect(page.locator(".session-specialist")).toHaveText("Paper hunter");

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -5432,8 +5432,9 @@ fn App() -> impl IntoView {
                                                     view! {
                                                         <div class="model-menu-row" class:active=is_active>
                                                             <button type="button" class="model-menu-pick"
+                                                                disabled=acp_locked
                                                                 on:click=move |_| {
-                                                                if acp_locked && !is_active {
+                                                                if acp_locked {
                                                                     show_warning_toast(&t(locale.get(), "models.locked_hint"));
                                                                     return;
                                                                 }

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -19,6 +19,9 @@
   --shadow-color: rgba(20, 20, 19, 0.12);
   --scrollbar-thumb: rgba(138, 135, 127, 0.45);
   --scrollbar-thumb-hover: rgba(90, 87, 78, 0.55);
+  --scrollbar-size: 10px;
+  --scrollbar-thumb-inset: 2px;
+  --scrollbar-radius: 8px;
 
   /* Brand accent: icon (DNA double-helix) teal from ui/logo.svg (#0D9488 / teal-600).
      Token name kept as --clay to avoid churn across ~30 usages. */
@@ -371,7 +374,7 @@ body:has(.window-titlebar) .app { height: calc(100vh - 38px); }
 
 
 /* ---------- Scrollbars ---------- */
-::-webkit-scrollbar { width: 10px; height: 10px; }
+::-webkit-scrollbar { width: var(--scrollbar-size); height: var(--scrollbar-size); }
 ::-webkit-scrollbar-track { background: transparent; }
-::-webkit-scrollbar-thumb { background: var(--scrollbar-thumb); border-radius: 8px; border: 2px solid transparent; background-clip: padding-box; }
-::-webkit-scrollbar-thumb:hover { background: var(--scrollbar-thumb-hover); border: 2px solid transparent; background-clip: padding-box; }
+::-webkit-scrollbar-thumb { background: var(--scrollbar-thumb); border-radius: var(--scrollbar-radius); border: var(--scrollbar-thumb-inset) solid transparent; background-clip: padding-box; }
+::-webkit-scrollbar-thumb:hover { background: var(--scrollbar-thumb-hover); border: var(--scrollbar-thumb-inset) solid transparent; background-clip: padding-box; }

--- a/ui/src/styles/chat.css
+++ b/ui/src/styles/chat.css
@@ -747,7 +747,7 @@ details.tool:not([open]) > summary.head .run-dot { animation: tool-pulse 1.1s ea
 .composer-compute svg { width: 17px; height: 17px; }
 .compute-menu, .specialist-menu { width: 280px; }
 .compute-info-card {
-  position: fixed; z-index: 61; top: 101px; right: 14px; bottom: auto; left: auto;
+  position: fixed; z-index: 61; top: 58px; right: 14px; bottom: auto; left: auto;
   display: flex; flex-direction: column; width: 360px; max-width: min(360px, calc(100vw - 32px));
   max-height: min(560px, calc(100vh - 160px)); overflow: hidden;
   background: var(--bg-elev); border: 1px solid var(--border-strong); border-radius: 18px;

--- a/ui/src/styles/chat.css
+++ b/ui/src/styles/chat.css
@@ -659,6 +659,7 @@ details.tool:not([open]) > summary.head .run-dot { animation: tool-pulse 1.1s ea
 .model-menu-row { display: flex; align-items: center; gap: 2px; border-radius: 8px; }
 .model-menu-row:hover { background: var(--bg-sunken); }
 .model-menu-pick { flex: 1 1 auto; display: flex; align-items: center; gap: 8px; min-width: 0; background: transparent; border: none; padding: 8px 10px; font: inherit; color: var(--text); cursor: pointer; text-align: left; }
+.model-menu-pick:disabled { color: var(--text-faint); cursor: not-allowed; opacity: .62; }
 .model-menu-text { display: flex; flex-direction: column; gap: 1px; min-width: 0; flex: 1 1 auto; }
 .model-menu-label { font-size: 13px; font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .model-menu-sub { font-size: 11px; color: var(--text-faint); font-family: var(--font-mono); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
@@ -753,7 +754,7 @@ details.tool:not([open]) > summary.head .run-dot { animation: tool-pulse 1.1s ea
   box-shadow: 0 16px 44px rgba(0, 0, 0, .16); transform-origin: top right;
   animation: motion-surface-in-soft var(--motion-duration-fast) var(--motion-ease-decelerate) both;
 }
-body:has(.window-titlebar) .compute-info-card { top: 139px; }
+body:has(.window-titlebar) .compute-info-card { top: 96px; }
 .compute-info-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; min-height: 48px; padding: 7px 10px 7px 16px; border-bottom: 1px solid var(--border); color: var(--text-muted); font-size: 13px; font-weight: 650; }
 .compute-info-close { display: inline-flex; align-items: center; justify-content: center; width: 30px; height: 30px; padding: 0; border: none; border-radius: 8px; background: transparent; color: var(--text-faint); cursor: pointer; }
 .compute-info-close:hover { background: var(--bg-sunken); color: var(--text); }

--- a/ui/src/styles/modals.css
+++ b/ui/src/styles/modals.css
@@ -9,6 +9,16 @@
    internally, so a long confirm/approval message can't push the button row
    off-screen and out of reach (#63). .modal-wide overrides height below. */
 .modal { background: var(--bg-elev); border: 1px solid var(--border-strong); border-radius: 18px; box-shadow: var(--shadow); padding: 22px; width: 100%; max-width: 480px; display: flex; flex-direction: column; gap: 14px; max-height: calc(100vh - 40px); overflow-y: auto; transform-origin: 50% 38%; animation: motion-surface-in var(--motion-duration-medium) var(--motion-ease-decelerate) both; }
+.modal .ps-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.modal .ps-close {
+  display: inline-flex; align-items: center; justify-content: center; flex: 0 0 auto;
+  width: 30px; height: 30px; padding: 0; border: 0; border-radius: 8px;
+  background: transparent; color: var(--text-faint); cursor: pointer;
+  transition: background .12s ease, color .12s ease, opacity .12s ease;
+}
+.modal .ps-close:hover:not(:disabled) { color: var(--text); background: var(--surface-hover); }
+.modal .ps-close:disabled { opacity: .45; cursor: default; }
+.modal .ps-close .gi { width: 16px; height: 16px; }
 .modal h2 { margin: 0; font-size: 17px; font-weight: 650; letter-spacing: -0.01em; }
 .modal label { font-size: 12px; color: var(--text-muted); display: flex; flex-direction: column; gap: 5px; font-weight: 500; }
 .modal input, .modal select { background: var(--bg-input); color: var(--text); border: 1px solid var(--border-strong); border-radius: var(--radius-sm); padding: 9px 11px; font: inherit; font-size: 14px; outline: none; transition: border-color .12s ease, box-shadow .12s ease; }

--- a/ui/src/styles/right-pane.css
+++ b/ui/src/styles/right-pane.css
@@ -1,11 +1,11 @@
 /* ---------- Resizer + right pane ---------- */
-.resizer { flex: 0 0 auto; width: 6px; cursor: col-resize; background: transparent; position: relative; }
-.resizer::after { content: ""; position: absolute; inset: 0 2px; border-radius: 3px; background: var(--border); transition: background .12s ease; }
+.resizer { flex: 0 0 auto; width: 5px; cursor: col-resize; background: transparent; position: relative; }
+.resizer::after { content: ""; position: absolute; top: 0; bottom: 0; left: 2px; width: 1px; background: var(--border-strong); transition: background .12s ease; }
 .resizer:hover::after { background: var(--clay); }
 .drag-overlay { position: fixed; inset: 0; z-index: 40; cursor: col-resize; }
 .drag-overlay-row { cursor: row-resize; }
 
-.rightpane { flex: 0 0 auto; display: flex; flex-direction: column; background: var(--bg-sunken); border-left: 1px solid var(--border-strong); min-width: 0; animation: motion-drawer-in var(--motion-duration-medium) var(--motion-ease-decelerate) both; }
+.rightpane { flex: 0 0 auto; display: flex; flex-direction: column; background: var(--bg-sunken); border-left: 0; min-width: 0; animation: motion-drawer-in var(--motion-duration-medium) var(--motion-ease-decelerate) both; }
 .rp-tabs { display: flex; align-items: center; gap: 4px; padding: 8px 8px 8px 10px; border-bottom: 1px solid var(--border-strong); flex: 0 0 auto; background: var(--bg-sunken); min-width: 0; overflow: visible; }
 .rp-tab-wrap { display: inline-flex; align-items: stretch; flex: 0 0 auto; max-width: 180px; border: 1px solid transparent; border-radius: 8px; background: transparent; }
 .rp-tab-wrap:has(.rp-tab.active) { border-color: var(--border-strong); background: var(--bg-elev); box-shadow: var(--shadow-sm); }
@@ -55,7 +55,7 @@
 
 .rp-contexts { flex:1 1 auto; min-height:0; overflow:hidden; display:flex; flex-direction:column; background:var(--bg-elev); }
 .context-list-pane { flex:0 1 42%; min-height:150px; max-height:min(360px, 46%); overflow:auto; padding:12px; border-bottom:1px solid var(--border-strong); background:var(--bg-sunken); }
-.context-detail-pane { flex:1 1 auto; min-height:0; overflow:auto; display:flex; flex-direction:column; gap:12px; padding:12px; background:var(--bg-elev); }
+.context-detail-pane { flex:1 1 auto; min-height:0; overflow:auto; display:flex; flex-direction:column; gap:12px; padding:14px 12px 16px; background:var(--bg-sunken); }
 .context-detail-empty { flex:1 1 auto; min-height:0; display:flex; flex-direction:column; align-items:center; justify-content:center; gap:8px; padding:24px; color:var(--text-faint); text-align:center; }
 .context-detail-empty .rp-empty-title { color:var(--text-muted); }
 .context-detail-empty p { max-width:260px; margin:0; font-size:12px; line-height:1.5; }
@@ -256,7 +256,7 @@
 .rp-tiles.grid .rp-tile-name { white-space: normal; overflow-wrap: anywhere; }
 .rp-tiles.grid .rp-tile-tools { position: absolute; top: 4px; right: 4px; padding: 0; }
 
-.rp-view { flex: 1 1 auto; min-height: 0; overflow: auto; padding: 14px 12px 16px; display: flex; flex-direction: column; gap: 10px; background: var(--bg-elev); }
+.rp-view { flex: 1 1 auto; min-height: 0; overflow: auto; padding: 14px 12px 16px; display: flex; flex-direction: column; gap: 10px; background: var(--bg-sunken); }
 .rp-view-head { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; padding-bottom: 2px; border-bottom: 1px solid var(--border); margin-bottom: 2px; }
 .rp-view-head .spacer { flex: 1; }
 .rp-view-head .icon-btn { flex-shrink: 0; }

--- a/ui/src/styles/terminal-dock.css
+++ b/ui/src/styles/terminal-dock.css
@@ -201,7 +201,10 @@
   background: var(--bg-app);
 }
 .terminal-dock-frame .xterm-viewport {
-  scrollbar-width: thin;
+  /* Keep xterm on the shared WebKit scrollbar path. Chromium gives the
+     standardized `thin` value precedence over our themed pseudo-elements,
+     producing a wider, solid thumb beside the chat's inset thumb. */
+  scrollbar-width: auto;
   background: var(--bg-app);
 }
 .terminal-dock-frame .xterm-screen,


### PR DESCRIPTION
## Problem

Several adjacent UI surfaces used conflicting scrollbar, divider, modal-control, and detail-panel styles. This made the terminal scrollbar appear heavier than the chat scrollbar, produced duplicate right-pane divider lines, exposed a browser-default close button in runtime interpreter settings, and made Artifacts/Contexts detail surfaces feel detached from the rest of the pane.

## What changed

- centralize scrollbar size, inset, and radius tokens and keep xterm on the shared themed scrollbar path
- unify modal header and close-button styling
- collapse the right-pane boundary to one draggable 1px divider
- align Artifacts and Contexts detail surfaces with the pane background
- keep HTTP models disabled once an ACP conversation has content
- correct the integrated-titlebar offset for the environment information card
- update UI test selectors for the duplicate “New session” labels and current navigation structure
- add computed-style regression coverage for scrollbars, pane dividers, detail surfaces, and runtime modal controls

## User impact

Scrollbars and right-pane surfaces now use consistent visual weight. Runtime interpreter settings use the same close control as other dialogs, and the Contexts/Artifacts lower detail areas blend into the surrounding inspector instead of appearing as separate white containers.

## Root cause

A component-specific `scrollbar-width: thin` declaration took precedence over the shared WebKit scrollbar styling. The right pane rendered both a resize divider and a left border, while runtime interpreter settings reused class names whose styles were scoped only to project settings. Detail panes also used elevated white backgrounds independently of their surrounding sunken workspace.

## Validation

- `cargo fmt --all -- --check`
- `cd ui && cargo check --target wasm32-unknown-unknown`
- `cargo test --workspace`
- Playwright UI suite: 114 passed
- `git diff --check`
