### PR TITLE
Deduplicate artifact panel entries

### DIFF
--- a/ui/src/app_support.rs
+++ b/ui/src/app_support.rs
@@ -3784,6 +3784,73 @@ pub(super) fn collect_artifacts(
     artifacts
 }
 
+/// Stable file identity for the current workspace. Agent and tool messages may
+/// refer to the same file using either an absolute path or a workspace-relative
+/// path; the Artifacts panel should still treat those references as one file.
+fn artifact_file_identity(path: &str, project_root: &str) -> String {
+    fn slash_path(path: &str) -> String {
+        let mut normalized = path.trim().replace('\\', "/");
+        while normalized.contains("//") {
+            normalized = normalized.replace("//", "/");
+        }
+        while normalized.starts_with("./") {
+            normalized.drain(..2);
+        }
+        normalized.trim_end_matches('/').to_string()
+    }
+
+    let path = slash_path(path);
+    let root = slash_path(project_root);
+    let windows_workspace = root.as_bytes().get(1) == Some(&b':');
+    let comparable_path = if windows_workspace {
+        path.to_ascii_lowercase()
+    } else {
+        path.clone()
+    };
+    let comparable_root = if windows_workspace {
+        root.to_ascii_lowercase()
+    } else {
+        root.clone()
+    };
+
+    let relative = comparable_path
+        .strip_prefix(&(comparable_root + "/"))
+        .unwrap_or(&comparable_path);
+    relative.to_string()
+}
+
+/// Current artifact projection for the right-hand panel. The full scan is kept
+/// for transcript cards and provenance, while this view shows only the latest
+/// live reference for each physical workspace file.
+pub(super) fn current_artifacts(
+    artifacts: &[Artifact],
+    project_root: &str,
+    missing_paths: &HashSet<String>,
+) -> Vec<Artifact> {
+    let mut seen_files = HashSet::new();
+    let mut current = Vec::with_capacity(artifacts.len());
+    for artifact in artifacts.iter().rev() {
+        if artifact.superseded {
+            continue;
+        }
+        match &artifact.data {
+            PreviewData::File { path, .. } => {
+                if missing_paths.contains(path) {
+                    continue;
+                }
+                let identity = artifact_file_identity(path, project_root);
+                if !seen_files.insert(identity) {
+                    continue;
+                }
+            }
+            _ => {}
+        }
+        current.push(artifact.clone());
+    }
+    current.reverse();
+    current
+}
+
 #[cfg(test)]
 mod artifact_scan_tests {
     use super::*;
@@ -3865,6 +3932,51 @@ mod artifact_scan_tests {
         let artifacts = fresh(&items, Locale::En);
         assert_eq!(artifacts.len(), 1);
         assert_eq!(artifacts[0].source_item, 1);
+    }
+
+    #[test]
+    fn artifact_panel_deduplicates_message_versions_and_path_forms() {
+        let items = vec![
+            ChatItem::Tool {
+                name: "write".into(),
+                ok: Some(true),
+                input: String::new(),
+                output: "wrote sample_statistics.png".into(),
+                started_at_ms: None,
+                duration_ms: None,
+            },
+            ChatItem::Assistant {
+                text: "Created `sample_statistics.png`".into(),
+                model: None,
+            },
+            ChatItem::Tool {
+                name: "write".into(),
+                ok: Some(true),
+                input: String::new(),
+                output: r"wrote E:\cross-species-root\sample_statistics.png".into(),
+                started_at_ms: None,
+                duration_ms: None,
+            },
+            ChatItem::Assistant {
+                text: r"Updated `E:\cross-species-root\sample_statistics.png`".into(),
+                model: None,
+            },
+        ];
+        let all = fresh(&items, Locale::En);
+        assert_eq!(all.len(), 4);
+
+        let current = current_artifacts(
+            &all,
+            r"E:\cross-species-root",
+            &HashSet::<String>::new(),
+        );
+        assert_eq!(current.len(), 1);
+        assert_eq!(current[0].name, "sample_statistics.png");
+        assert!(matches!(
+            &current[0].data,
+            PreviewData::File { path, .. }
+                if path == r"E:\cross-species-root\sample_statistics.png"
+        ));
     }
 }
 

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -722,14 +722,11 @@ fn App() -> impl IntoView {
     });
     let artifacts = create_memo(move |_| {
         let miss = missing_paths.get();
-        artifacts_all
+        let root = project_info
             .get()
-            .into_iter()
-            .filter(|a| match &a.data {
-                PreviewData::File { path, .. } => !miss.contains(path),
-                _ => true,
-            })
-            .collect::<Vec<_>>()
+            .map(|project| project.root)
+            .unwrap_or_default();
+        current_artifacts(&artifacts_all.get(), &root, &miss)
     });
     let notebook_cache = Rc::new(RefCell::new(NotebookCache::new()));
     let notebook_cells = create_memo(move |_| {


### PR DESCRIPTION
## Problem

The Artifacts panel rendered duplicate tiles when the same physical file was mentioned more than once in the transcript. Tool output and assistant replies could each produce an artifact record, and absolute and workspace-relative forms of the same path were treated as different files.

## Changes

- derive a stable workspace-relative identity for file-backed artifacts
- show only the latest live record for each file identity in the Artifacts panel
- keep the full artifact history available to transcript cards and provenance
- add a regression test covering repeated Tool/Assistant references and mixed Windows absolute/relative paths

## User impact

A file such as `sample_statistics.png` now appears once in the Artifacts panel even when the transcript contains several references or mixes `sample_statistics.png` with `E:\cross-species-root\sample_statistics.png`.

## Root cause

Artifact extraction deduplicated only within a single transcript item. Older cross-item records were marked `superseded`, but the panel filtered only missing files and still rendered every surviving record. Path comparison also used the raw path string.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo test --manifest-path ui/Cargo.toml` — 60 passed
- `cargo check --manifest-path ui/Cargo.toml --target wasm32-unknown-unknown`
- `npx playwright test` — 114 passed
- `git diff --check`

## Manual smoke steps

1. Open a project whose transcript mentions the same image in Tool output and the assistant response.
2. Mix an absolute workspace path and its workspace-relative equivalent.
3. Open the Artifacts panel and verify that only one tile is shown and that preview/download still target the latest path.

## Known limitations

Identity normalization is lexical within the active project root; filesystem aliases outside the workspace, such as symlinks to the same file, are not canonicalized.

## Follow-up

No required follow-up.