### PR TITLE
Add durable message resource bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3085,6 +3085,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14"
+dependencies = [
+ "bitflags 2.13.0",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5076,6 +5087,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6171,6 +6188,7 @@ dependencies = [
  "flate2",
  "glob",
  "portable-pty",
+ "pulldown-cmark",
  "regex",
  "reqwest 0.12.28",
  "same-file",

--- a/crates/wisp-store/migrations/0000_init.sql
+++ b/crates/wisp-store/migrations/0000_init.sql
@@ -84,6 +84,29 @@ CREATE TABLE IF NOT EXISTS artifacts (
 );
 CREATE INDEX IF NOT EXISTS ix_artifacts_project ON artifacts(project_id);
 
+-- Structured resource references discovered when a new assistant message is
+-- persisted. The transcript keeps the agent's original Markdown; rendering
+-- uses these bindings and the immutable artifact version instead of guessing a
+-- filesystem path from an href at click time.
+CREATE TABLE IF NOT EXISTS message_resource_links (
+    id                  TEXT PRIMARY KEY,
+    frame_id            TEXT NOT NULL REFERENCES frames(id) ON DELETE CASCADE,
+    message_seq         INTEGER NOT NULL,
+    ordinal             INTEGER NOT NULL,
+    original_reference  TEXT NOT NULL,
+    artifact_id         TEXT REFERENCES artifacts(id) ON DELETE SET NULL,
+    artifact_version_id TEXT REFERENCES artifact_versions(id) ON DELETE SET NULL,
+    display_name        TEXT NOT NULL,
+    resource_kind       TEXT NOT NULL,
+    mime_type           TEXT NOT NULL,
+    status              TEXT NOT NULL,
+    error               TEXT,
+    created_at          INTEGER NOT NULL,
+    UNIQUE(frame_id, message_seq, ordinal)
+);
+CREATE INDEX IF NOT EXISTS ix_message_resource_links_message
+    ON message_resource_links(frame_id, message_seq, ordinal);
+
 CREATE TABLE IF NOT EXISTS settings (
     key   TEXT PRIMARY KEY,
     value TEXT NOT NULL

--- a/crates/wisp-store/src/artifacts.rs
+++ b/crates/wisp-store/src/artifacts.rs
@@ -88,6 +88,18 @@ impl Store {
         rows.into_iter().map(artifact_version_from_row).collect()
     }
 
+    pub async fn get_artifact_version(&self, version_id: &str) -> Result<Option<ArtifactVersion>> {
+        let row = sqlx::query(
+            "SELECT id,artifact_id,version_number,content_type,storage_path,size_bytes,checksum,\
+                    parent_version_id,producing_run_id,env_snapshot_hash,created_at \
+             FROM artifact_versions WHERE id=?",
+        )
+        .bind(version_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        row.map(artifact_version_from_row).transpose()
+    }
+
     pub async fn set_artifact_version_provenance(
         &self,
         version_id: &str,

--- a/crates/wisp-store/src/lib.rs
+++ b/crates/wisp-store/src/lib.rs
@@ -13,6 +13,7 @@ mod project_transfer;
 mod projects;
 mod provenance;
 mod research;
+mod resources;
 mod runs;
 pub mod secrets;
 mod sessions;
@@ -45,6 +46,7 @@ const SESSION_REVIEWS_MIGRATION: &str = "0008_session_reviews";
 const SESSION_UI_EVENTS_MIGRATION: &str = "0009_session_ui_events";
 const PROJECT_SYNC_STATE_MIGRATION: &str = "0010_project_sync_state";
 const SESSION_HISTORY_INDEX_MIGRATION: &str = "0011_session_history_index";
+const MESSAGE_RESOURCE_LINKS_MIGRATION: &str = "0012_message_resource_links";
 
 #[derive(Clone)]
 pub struct Store {
@@ -173,6 +175,34 @@ impl Store {
             }
             Self::record_migration(pool, SESSION_HISTORY_INDEX_MIGRATION).await?;
         }
+        if !Self::migration_applied(pool, MESSAGE_RESOURCE_LINKS_MIGRATION).await? {
+            Self::apply_message_resource_links(pool).await?;
+            Self::record_migration(pool, MESSAGE_RESOURCE_LINKS_MIGRATION).await?;
+        }
+        Ok(())
+    }
+
+    async fn apply_message_resource_links(pool: &SqlitePool) -> Result<()> {
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS message_resource_links (\
+             id TEXT PRIMARY KEY, \
+             frame_id TEXT NOT NULL REFERENCES frames(id) ON DELETE CASCADE, \
+             message_seq INTEGER NOT NULL, ordinal INTEGER NOT NULL, \
+             original_reference TEXT NOT NULL, \
+             artifact_id TEXT REFERENCES artifacts(id) ON DELETE SET NULL, \
+             artifact_version_id TEXT REFERENCES artifact_versions(id) ON DELETE SET NULL, \
+             display_name TEXT NOT NULL, resource_kind TEXT NOT NULL, mime_type TEXT NOT NULL, \
+             status TEXT NOT NULL, error TEXT, created_at INTEGER NOT NULL, \
+             UNIQUE(frame_id,message_seq,ordinal))",
+        )
+        .execute(pool)
+        .await?;
+        sqlx::query(
+            "CREATE INDEX IF NOT EXISTS ix_message_resource_links_message \
+             ON message_resource_links(frame_id,message_seq,ordinal)",
+        )
+        .execute(pool)
+        .await?;
         Ok(())
     }
 

--- a/crates/wisp-store/src/models.rs
+++ b/crates/wisp-store/src/models.rs
@@ -35,6 +35,23 @@ pub struct ArtifactVersion {
     pub created_at: i64,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MessageResourceLink {
+    pub id: String,
+    pub frame_id: String,
+    pub message_seq: i64,
+    pub ordinal: i64,
+    pub original_reference: String,
+    pub artifact_id: Option<String>,
+    pub artifact_version_id: Option<String>,
+    pub display_name: String,
+    pub resource_kind: String,
+    pub mime_type: String,
+    pub status: String,
+    pub error: Option<String>,
+    pub created_at: i64,
+}
+
 #[derive(Debug, Clone)]
 pub struct RecentSessionDetail {
     pub id: String,

--- a/crates/wisp-store/src/project_transfer.rs
+++ b/crates/wisp-store/src/project_transfer.rs
@@ -61,6 +61,9 @@ async fn copy_project_children(tx: &mut Transaction<'_, Sqlite>, project_id: &st
         "INSERT INTO artifact_versions(id,artifact_id,version_number,content_type,storage_path,size_bytes,checksum,parent_version_id,producing_run_id,env_snapshot_hash,created_at) \
          SELECT av.id,av.artifact_id,av.version_number,av.content_type,av.storage_path,av.size_bytes,av.checksum,av.parent_version_id,av.producing_run_id,av.env_snapshot_hash,av.created_at \
          FROM transfer.artifact_versions av JOIN transfer.artifacts a ON a.id=av.artifact_id WHERE a.project_id=?",
+        "INSERT INTO message_resource_links(id,frame_id,message_seq,ordinal,original_reference,artifact_id,artifact_version_id,display_name,resource_kind,mime_type,status,error,created_at) \
+         SELECT id,frame_id,message_seq,ordinal,original_reference,artifact_id,artifact_version_id,display_name,resource_kind,mime_type,status,error,created_at \
+         FROM transfer.message_resource_links WHERE frame_id IN (SELECT id FROM transfer.frames WHERE project_id=?)",
         "INSERT INTO artifact_dependencies(id,artifact_version_id,depends_on_version_id,reference_name,created_at) \
          SELECT d.id,d.artifact_version_id,d.depends_on_version_id,d.reference_name,d.created_at FROM transfer.artifact_dependencies d \
          WHERE d.artifact_version_id IN (SELECT av.id FROM transfer.artifact_versions av JOIN transfer.artifacts a ON a.id=av.artifact_id WHERE a.project_id=?)",
@@ -91,6 +94,7 @@ pub(crate) async fn delete_project_children(
 ) -> Result<()> {
     const QUERIES: &[&str] = &[
         "DELETE FROM artifact_dependencies WHERE artifact_version_id IN (SELECT av.id FROM artifact_versions av JOIN artifacts a ON a.id=av.artifact_id WHERE a.project_id=?)",
+        "DELETE FROM message_resource_links WHERE frame_id IN (SELECT id FROM frames WHERE project_id=?)",
         "DELETE FROM artifact_versions WHERE artifact_id IN (SELECT id FROM artifacts WHERE project_id=?)",
         "DELETE FROM run_artifacts WHERE run_id IN (SELECT id FROM runs WHERE project_id=?)",
         "DELETE FROM session_reviews WHERE frame_id IN (SELECT id FROM frames WHERE project_id=?)",
@@ -453,6 +457,7 @@ impl Store {
             ("runs", "*", "id"),
             ("artifacts", "*", "id"),
             ("artifact_versions", "*", "id"),
+            ("message_resource_links", "*", "id"),
             ("artifact_dependencies", "*", "id"),
             ("run_artifacts", "*", "id"),
             ("research_nodes", "*", "id"),
@@ -801,14 +806,36 @@ mod tests {
             .append_message("frame-1", 1, &Message::user("hello"))
             .await
             .unwrap();
-        source
+        let artifact_version_id = source
             .save_artifact(
                 "artifact-1",
                 "project-1",
                 "frame-1",
                 "plot.png",
                 "image/png",
-                r"C:\Users\Alice\Study\figures\plot.png",
+                r"C:\Users\Alice\Study\.wisp\artifacts\sha256\ab\abcdef.png",
+            )
+            .await
+            .unwrap();
+        source
+            .replace_message_resource_links(
+                "frame-1",
+                1,
+                &[crate::MessageResourceLink {
+                    id: "resource-link-1".into(),
+                    frame_id: "frame-1".into(),
+                    message_seq: 1,
+                    ordinal: 0,
+                    original_reference: r"D:/original/location/plot.png".into(),
+                    artifact_id: Some("artifact-1".into()),
+                    artifact_version_id: Some(artifact_version_id.clone()),
+                    display_name: "plot.png".into(),
+                    resource_kind: "image".into(),
+                    mime_type: "image/png".into(),
+                    status: "ready".into(),
+                    error: None,
+                    created_at: 1,
+                }],
             )
             .await
             .unwrap();
@@ -849,9 +876,31 @@ mod tests {
             "/Users/alice/Study"
         );
         assert_eq!(target.load_messages("frame-1").await.unwrap().len(), 1);
+        let imported_resources = target
+            .list_message_resource_links("frame-1", 1, None)
+            .await
+            .unwrap();
+        assert_eq!(imported_resources.len(), 1);
+        assert_eq!(
+            imported_resources[0].artifact_version_id.as_deref(),
+            Some(artifact_version_id.as_str())
+        );
+        assert_eq!(
+            imported_resources[0].original_reference,
+            "D:/original/location/plot.png"
+        );
         assert_eq!(
             target.get_artifact("artifact-1").await.unwrap().unwrap().2,
-            "/Users/alice/Study/figures/plot.png"
+            "/Users/alice/Study/.wisp/artifacts/sha256/ab/abcdef.png"
+        );
+        assert_eq!(
+            target
+                .get_artifact_version(&artifact_version_id)
+                .await
+                .unwrap()
+                .unwrap()
+                .storage_path,
+            "/Users/alice/Study/.wisp/artifacts/sha256/ab/abcdef.png"
         );
         let imported_run = target.get_run("run-1").await.unwrap().unwrap();
         assert_eq!(imported_run.status, RunStatus::Lost);

--- a/crates/wisp-store/src/resources.rs
+++ b/crates/wisp-store/src/resources.rs
@@ -1,0 +1,113 @@
+use super::{ArtifactVersion, MessageResourceLink, Store};
+use anyhow::Result;
+use sqlx::Row;
+
+impl Store {
+    pub async fn replace_message_resource_links(
+        &self,
+        frame_id: &str,
+        message_seq: i64,
+        links: &[MessageResourceLink],
+    ) -> Result<()> {
+        let mut tx = self.pool.begin().await?;
+        sqlx::query("DELETE FROM message_resource_links WHERE frame_id=? AND message_seq=?")
+            .bind(frame_id)
+            .bind(message_seq)
+            .execute(&mut *tx)
+            .await?;
+        for link in links {
+            sqlx::query(
+                "INSERT INTO message_resource_links(\
+                 id,frame_id,message_seq,ordinal,original_reference,artifact_id,\
+                 artifact_version_id,display_name,resource_kind,mime_type,status,error,created_at) \
+                 VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?)",
+            )
+            .bind(&link.id)
+            .bind(frame_id)
+            .bind(message_seq)
+            .bind(link.ordinal)
+            .bind(&link.original_reference)
+            .bind(link.artifact_id.as_deref())
+            .bind(link.artifact_version_id.as_deref())
+            .bind(&link.display_name)
+            .bind(&link.resource_kind)
+            .bind(&link.mime_type)
+            .bind(&link.status)
+            .bind(link.error.as_deref())
+            .bind(link.created_at)
+            .execute(&mut *tx)
+            .await?;
+        }
+        tx.commit().await?;
+        Ok(())
+    }
+
+    pub async fn list_message_resource_links(
+        &self,
+        frame_id: &str,
+        start_seq: i64,
+        before_seq: Option<i64>,
+    ) -> Result<Vec<MessageResourceLink>> {
+        let rows = sqlx::query(
+            "SELECT id,frame_id,message_seq,ordinal,original_reference,artifact_id,\
+             artifact_version_id,display_name,resource_kind,mime_type,status,error,created_at \
+             FROM message_resource_links WHERE frame_id=? AND message_seq>=? \
+             AND (? IS NULL OR message_seq<?) ORDER BY message_seq,ordinal",
+        )
+        .bind(frame_id)
+        .bind(start_seq)
+        .bind(before_seq)
+        .bind(before_seq)
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter()
+            .map(|row| {
+                Ok(MessageResourceLink {
+                    id: row.try_get("id")?,
+                    frame_id: row.try_get("frame_id")?,
+                    message_seq: row.try_get("message_seq")?,
+                    ordinal: row.try_get("ordinal")?,
+                    original_reference: row.try_get("original_reference")?,
+                    artifact_id: row.try_get("artifact_id")?,
+                    artifact_version_id: row.try_get("artifact_version_id")?,
+                    display_name: row.try_get("display_name")?,
+                    resource_kind: row.try_get("resource_kind")?,
+                    mime_type: row.try_get("mime_type")?,
+                    status: row.try_get("status")?,
+                    error: row.try_get("error")?,
+                    created_at: row.try_get("created_at")?,
+                })
+            })
+            .collect()
+    }
+
+    pub async fn latest_artifact_version(
+        &self,
+        artifact_id: &str,
+    ) -> Result<Option<ArtifactVersion>> {
+        let row = sqlx::query(
+            "SELECT id,artifact_id,version_number,content_type,storage_path,size_bytes,checksum,\
+             parent_version_id,producing_run_id,env_snapshot_hash,created_at \
+             FROM artifact_versions WHERE artifact_id=? ORDER BY version_number DESC LIMIT 1",
+        )
+        .bind(artifact_id)
+        .fetch_optional(&self.pool)
+        .await?;
+        row.map(super::artifact_version_from_row).transpose()
+    }
+
+    pub async fn set_artifact_version_file_metadata(
+        &self,
+        version_id: &str,
+        size_bytes: i64,
+        checksum: &str,
+    ) -> Result<()> {
+        sqlx::query("UPDATE artifact_versions SET size_bytes=?,checksum=? WHERE id=?")
+            .bind(size_bytes)
+            .bind(checksum)
+            .bind(version_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+}

--- a/crates/wisp-store/src/sessions.rs
+++ b/crates/wisp-store/src/sessions.rs
@@ -1,4 +1,7 @@
-use super::{parse_role, session_display_title, RecentSessionDetail, SessionSearchResult, Store};
+use super::{
+    parse_role, session_display_title, MessageResourceLink, RecentSessionDetail,
+    SessionSearchResult, Store,
+};
 use anyhow::Result;
 use sqlx::{Row, Sqlite, Transaction};
 use wisp_llm::Message;
@@ -8,6 +11,7 @@ pub struct SessionTranscriptPage {
     pub messages: Vec<(i64, Message)>,
     pub reviews: Vec<(i64, String)>,
     pub ui_events: Vec<String>,
+    pub resources: Vec<MessageResourceLink>,
     pub next_before_seq: Option<i64>,
     pub user_offset: usize,
     pub latest_seq: i64,
@@ -20,6 +24,14 @@ pub struct SessionTranscriptPage {
 async fn delete_session_rows(tx: &mut Transaction<'_, Sqlite>, frame_id: &str) -> Result<()> {
     sqlx::query(
         "UPDATE runs SET frame_id=NULL \
+         WHERE frame_id IN (SELECT id FROM frames WHERE root_frame_id=?)",
+    )
+    .bind(frame_id)
+    .execute(&mut **tx)
+    .await?;
+
+    sqlx::query(
+        "DELETE FROM message_resource_links \
          WHERE frame_id IN (SELECT id FROM frames WHERE root_frame_id=?)",
     )
     .bind(frame_id)
@@ -244,6 +256,11 @@ impl Store {
 
     /// Drop persisted turns after `keep` (seq is 1-based; keep=3 retains seq 1..=3).
     pub async fn truncate_messages(&self, frame_id: &str, keep: i64) -> Result<()> {
+        sqlx::query("DELETE FROM message_resource_links WHERE frame_id=? AND message_seq>?")
+            .bind(frame_id)
+            .bind(keep)
+            .execute(&self.pool)
+            .await?;
         sqlx::query(
             "DELETE FROM session_ui_events WHERE frame_id=? AND seq > COALESCE((\
              SELECT MAX(seq) FROM session_ui_events WHERE frame_id=? \
@@ -446,11 +463,15 @@ impl Store {
             .into_iter()
             .map(|row| Ok((row.try_get("message_seq")?, row.try_get("report_json")?)))
             .collect::<Result<Vec<_>>>()?;
+        let resources = self
+            .list_message_resource_links(frame_id, start_seq, before_seq)
+            .await?;
 
         Ok(SessionTranscriptPage {
             messages,
             reviews,
             ui_events,
+            resources,
             next_before_seq,
             user_offset: user_offset as usize,
             latest_seq,

--- a/crates/wisp-store/src/store_tests.rs
+++ b/crates/wisp-store/src/store_tests.rs
@@ -819,6 +819,7 @@ async fn store_open_records_migrations_and_seeds_local_context() {
             SESSION_UI_EVENTS_MIGRATION.to_string(),
             PROJECT_SYNC_STATE_MIGRATION.to_string(),
             SESSION_HISTORY_INDEX_MIGRATION.to_string(),
+            MESSAGE_RESOURCE_LINKS_MIGRATION.to_string(),
         ]
     );
 

--- a/docs/superpowers/specs/2026-07-15-message-resource-bindings.md
+++ b/docs/superpowers/specs/2026-07-15-message-resource-bindings.md
@@ -1,0 +1,52 @@
+# Message Resource Bindings
+
+## Problem
+
+Assistant and ACP output can contain relative paths, Windows drive paths,
+`file://` URIs, percent-encoded paths, and Codex `<image path="...">` blocks.
+Passing those strings through Markdown, a WebView URL parser, and then back to
+the filesystem makes preview behavior dependent on quoting, operating system,
+and the UI surface that opened the file.
+
+## Design
+
+For every newly persisted assistant message, the backend parses local Markdown
+links and images exactly once. It resolves each reference against the owning
+project root, applies the normal path-containment checks, and snapshots supported
+files into project-local content-addressed storage. A `message_resource_links`
+row binds the original reference to an immutable `ArtifactVersion`.
+
+The original message text is not rewritten. The UI matches rendered Markdown
+tags to the structured bindings and opens the bound artifact version. Inline
+images are also loaded from that version. Markdown and text resources use the
+center file preview, which owns its scrolling; image, PDF, and table resources
+use the artifact preview policy.
+
+Unresolvable references are persisted as structured failures. Their raw paths
+are not sent back through the WebView navigation path.
+
+## Scope boundary
+
+This design applies only when a new assistant message is persisted after the
+feature is installed. Existing messages are not scanned, migrated, backfilled,
+or reinterpreted. There is no compatibility parser that manufactures bindings
+for historical transcript rows.
+
+Project export/import carries bindings that already exist, together with their
+artifacts and immutable versions. That preserves new-format project data without
+upgrading old messages.
+
+During export, artifact and artifact-version storage paths are normalized to
+project-relative forward-slash paths. Content-addressed snapshots therefore
+travel as `.wisp/artifacts/sha256/...` workspace files. Import restores those
+paths under the newly selected project directory, including across Windows and
+macOS. The Markdown text and `original_reference` are deliberately not rewritten:
+they identify the original tag, while preview always reads the imported immutable
+version. References that never produced a snapshot remain unresolved after a
+move rather than being guessed against the destination machine.
+
+## Supported previews
+
+The first version snapshots PNG, JPEG, GIF, WebP, SVG, PDF, Markdown, CSV, TSV,
+JSON, HTML, text, and log files up to 32 MiB. Unsupported, missing, oversized,
+or out-of-project resources remain explicit unresolved bindings.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,6 +33,7 @@ glob = { workspace = true }
 flate2 = { workspace = true }
 tar = { workspace = true }
 base64 = { workspace = true }
+pulldown-cmark = { version = "0.12", default-features = false }
 same-file = { workspace = true }
 portable-pty = { workspace = true }
 async-trait = { workspace = true }

--- a/src-tauri/src/acp.rs
+++ b/src-tauri/src/acp.rs
@@ -778,6 +778,25 @@ pub(crate) async fn run_acp_turn(
         .append_message(frame_id, next_seq, &persisted)
         .await
         .map_err(|error| error.to_string())?;
+    let resources = crate::resource_refs::bind_new_message_resources(
+        &state.store,
+        &project.root,
+        &project.id,
+        frame_id,
+        next_seq,
+        &persisted.content.as_text(),
+    )
+    .await;
+    if !resources.is_empty() {
+        let _ = app.emit(
+            "agent",
+            AgentEvent::Resources {
+                frame_id: frame_id.to_string(),
+                seq: next_seq,
+                resources: resources.iter().map(Into::into).collect(),
+            },
+        );
+    }
     cancel_pending_permissions(state, frame_id, &runtime).await;
     Ok(stop_reason(outcome.stop_reason).into())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -33,6 +33,7 @@ mod pet_commands;
 mod project_sync;
 mod project_transfer;
 mod research_graph;
+mod resource_refs;
 mod review;
 mod run_context;
 mod runtime_config_tool;
@@ -65,6 +66,11 @@ enum AgentEvent {
     MessageBoundary {
         frame_id: String,
         seq: i64,
+    },
+    Resources {
+        frame_id: String,
+        seq: i64,
+        resources: Vec<resource_refs::UiMessageResource>,
     },
     Text {
         frame_id: String,
@@ -750,6 +756,8 @@ struct UiItem {
     status: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     locations: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    resources: Vec<resource_refs::UiMessageResource>,
 }
 
 /// Index in `msgs` where the `user_index`‑th user turn starts (0-based user count).
@@ -800,6 +808,7 @@ fn messages_to_items(msgs: &[wisp_llm::Message]) -> Vec<UiItem> {
                         kind: None,
                         status: None,
                         locations: None,
+                        resources: Vec::new(),
                     });
                 }
             }
@@ -818,6 +827,7 @@ fn messages_to_items(msgs: &[wisp_llm::Message]) -> Vec<UiItem> {
                             kind: None,
                             status: None,
                             locations: None,
+                            resources: Vec::new(),
                         });
                     }
                 }
@@ -835,6 +845,7 @@ fn messages_to_items(msgs: &[wisp_llm::Message]) -> Vec<UiItem> {
                         kind: None,
                         status: None,
                         locations: None,
+                        resources: Vec::new(),
                     });
                 }
             }
@@ -854,6 +865,7 @@ fn messages_to_items(msgs: &[wisp_llm::Message]) -> Vec<UiItem> {
                             kind: None,
                             status: None,
                             locations: None,
+                            resources: Vec::new(),
                         });
                     }
                 } else if let Some(envelope) =
@@ -871,6 +883,7 @@ fn messages_to_items(msgs: &[wisp_llm::Message]) -> Vec<UiItem> {
                         kind: (!envelope.kind.is_empty()).then_some(envelope.kind),
                         status: Some(envelope.status),
                         locations: (!envelope.locations.is_empty()).then_some(envelope.locations),
+                        resources: Vec::new(),
                     });
                 } else {
                     out.push(UiItem {
@@ -889,6 +902,7 @@ fn messages_to_items(msgs: &[wisp_llm::Message]) -> Vec<UiItem> {
                         kind: None,
                         status: None,
                         locations: None,
+                        resources: Vec::new(),
                     });
                 }
             }
@@ -915,6 +929,7 @@ fn events_to_items(events: &[AgentEvent]) -> (Vec<UiItem>, HashMap<i64, usize>) 
                 kind: None,
                 status: None,
                 locations: None,
+                resources: Vec::new(),
             }),
             AgentEvent::Text { delta, .. } | AgentEvent::Reasoning { delta, .. } => {
                 let role = if matches!(event, AgentEvent::Text { .. }) {
@@ -937,6 +952,7 @@ fn events_to_items(events: &[AgentEvent]) -> (Vec<UiItem>, HashMap<i64, usize>) 
                         kind: None,
                         status: None,
                         locations: None,
+                        resources: Vec::new(),
                     });
                 }
             }
@@ -952,6 +968,7 @@ fn events_to_items(events: &[AgentEvent]) -> (Vec<UiItem>, HashMap<i64, usize>) 
                 kind: None,
                 status: None,
                 locations: None,
+                resources: Vec::new(),
             }),
             AgentEvent::ToolResult {
                 name,
@@ -989,12 +1006,18 @@ fn events_to_items(events: &[AgentEvent]) -> (Vec<UiItem>, HashMap<i64, usize>) 
                             kind: None,
                             status: None,
                             locations: None,
+                            resources: Vec::new(),
                         });
                     }
                 }
             }
             AgentEvent::MessageBoundary { seq, .. } => {
                 boundaries.insert(*seq, items.len());
+            }
+            AgentEvent::Resources { resources, .. } => {
+                if let Some(item) = items.iter_mut().rev().find(|item| item.role == "assistant") {
+                    item.resources = resources.clone();
+                }
             }
             AgentEvent::Stdout { chunk, .. } => {
                 if let Some(item) = items.iter_mut().rev().find(|item| item.role == "tool") {
@@ -1012,6 +1035,7 @@ fn events_to_items(events: &[AgentEvent]) -> (Vec<UiItem>, HashMap<i64, usize>) 
                         kind: None,
                         status: None,
                         locations: None,
+                        resources: Vec::new(),
                     });
                 }
             }
@@ -3184,6 +3208,9 @@ async fn send_message(
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Message>();
         let store = state.store.clone();
         let fid = frame_id.clone();
+        let resource_root = ap.root.clone();
+        let resource_project_id = ap.id.clone();
+        let resource_app = app.clone();
         let stamp = model_label.clone();
         let mut seq = start_seq;
         let handle = tokio::spawn(async move {
@@ -3194,6 +3221,28 @@ async fn send_message(
                 seq += 1;
                 if let Err(e) = store.append_message(&fid, seq, &msg).await {
                     tracing::warn!("incremental persist seq {seq} failed: {e}");
+                    continue;
+                }
+                if message_uses_resource_bindings(&msg) {
+                    let resources = resource_refs::bind_new_message_resources(
+                        &store,
+                        &resource_root,
+                        &resource_project_id,
+                        &fid,
+                        seq,
+                        &msg.content.as_text(),
+                    )
+                    .await;
+                    if !resources.is_empty() {
+                        let _ = resource_app.emit(
+                            "agent",
+                            AgentEvent::Resources {
+                                frame_id: fid.clone(),
+                                seq,
+                                resources: resources.iter().map(Into::into).collect(),
+                            },
+                        );
+                    }
                 }
             }
             seq
@@ -3348,6 +3397,12 @@ async fn send_message(
             Err(format!("{e}"))
         }
     }
+}
+
+fn message_uses_resource_bindings(message: &Message) -> bool {
+    message.role == wisp_llm::Role::Assistant
+        || (message.role == wisp_llm::Role::Tool
+            && message.tool_name.as_deref() == Some("attempt_completion"))
 }
 
 #[tauri::command]
@@ -4800,6 +4855,31 @@ fn transcript_page_items(page: &wisp_store::SessionTranscriptPage) -> Result<Vec
                 .collect(),
         )
     };
+    let mut resources_by_seq = HashMap::<i64, Vec<resource_refs::UiMessageResource>>::new();
+    for resource in &page.resources {
+        resources_by_seq
+            .entry(resource.message_seq)
+            .or_default()
+            .push(resource.into());
+    }
+    for (message_seq, resources) in resources_by_seq {
+        let end = boundaries.get(&message_seq).copied().unwrap_or_else(|| {
+            let message_count = page
+                .messages
+                .iter()
+                .take_while(|(seq, _)| *seq <= message_seq)
+                .count();
+            messages_to_items(&msgs[..message_count]).len()
+        });
+        let end = end.min(items.len());
+        if let Some(item) = items[..end]
+            .iter_mut()
+            .rev()
+            .find(|item| item.role == "assistant")
+        {
+            item.resources = resources;
+        }
+    }
     let mut inserted = 0usize;
     for (message_seq, report_json) in &page.reviews {
         let report: review::ReviewReport = serde_json::from_str(&report_json)
@@ -4826,6 +4906,7 @@ fn transcript_page_items(page: &wisp_store::SessionTranscriptPage) -> Result<Vec
                 kind: None,
                 status: None,
                 locations: None,
+                resources: Vec::new(),
             },
         );
         inserted += 1;
@@ -5013,6 +5094,31 @@ async fn read_artifact(state: State<'_, AppState>, id: String) -> Result<FileCon
         .ok_or_else(|| format!("artifact '{id}' not found"))?;
     let root = PathBuf::from(row.project_root);
     tokio::task::spawn_blocking(move || read_file_at(&root, row.path, None))
+        .await
+        .map_err(|e| format!("{e}"))?
+}
+
+/// Read the immutable artifact version captured by a message resource binding.
+/// Resource previews must never follow the artifact's mutable latest-version pointer.
+#[tauri::command]
+async fn read_artifact_version(
+    state: State<'_, AppState>,
+    version_id: String,
+) -> Result<FileContent, String> {
+    let version = state
+        .store
+        .get_artifact_version(&version_id)
+        .await
+        .map_err(|e| format!("{e}"))?
+        .ok_or_else(|| format!("artifact version '{version_id}' not found"))?;
+    let artifact = state
+        .store
+        .get_artifact_detail(&version.artifact_id)
+        .await
+        .map_err(|e| format!("{e}"))?
+        .ok_or_else(|| format!("artifact '{}' not found", version.artifact_id))?;
+    let root = PathBuf::from(artifact.project_root);
+    tokio::task::spawn_blocking(move || read_file_at(&root, version.storage_path, None))
         .await
         .map_err(|e| format!("{e}"))?
 }
@@ -5795,6 +5901,7 @@ pub fn run() {
             search_artifacts,
             search_sessions,
             read_artifact,
+            read_artifact_version,
             missing_files,
             set_viewed_session,
             upload_file,

--- a/src-tauri/src/lib_tests.rs
+++ b/src-tauri/src/lib_tests.rs
@@ -1,9 +1,10 @@
 use super::desktop_lifecycle::should_hide_workspace_on_close;
 use super::{
-    branch_title, copy_dir_recursive, events_to_items, merge_pending_ui_event, messages_to_items,
-    parse_disabled_skills, parse_enabled_skill_names, parse_skill_tags, parse_ssh_artifact_uri,
-    persist_ui_events, resolve_acp_artifact_references, resolve_composer_references,
-    resolve_workspace, session_runtime_status, should_hide_app_on_macos_close, side_chat_prompt,
+    branch_title, copy_dir_recursive, events_to_items, merge_pending_ui_event,
+    message_uses_resource_bindings, messages_to_items, parse_disabled_skills,
+    parse_enabled_skill_names, parse_skill_tags, parse_ssh_artifact_uri, persist_ui_events,
+    resolve_acp_artifact_references, resolve_composer_references, resolve_workspace,
+    session_runtime_status, should_hide_app_on_macos_close, side_chat_prompt,
     transcript_page_items, update_check_from_release, user_message_start, AgentEvent,
     ComposerReferenceArg, GithubRelease, McpConnection, McpTransport, MAX_PENDING_UI_EVENT_BYTES,
 };
@@ -441,6 +442,7 @@ fn transcript_page_reconstructs_legacy_prefix_before_persisted_events() {
             (2, wisp_llm::Message::assistant("fallback answer")),
         ],
         reviews: vec![],
+        resources: vec![],
         ui_events: events
             .iter()
             .map(|event| serde_json::to_string(event).unwrap())
@@ -456,6 +458,17 @@ fn transcript_page_reconstructs_legacy_prefix_before_persisted_events() {
     assert_eq!(items[0].text, "legacy question");
     assert_eq!(items[1].role, "assistant");
     assert_eq!(items[1].text, "new answer");
+}
+
+#[test]
+fn resource_bindings_cover_messages_rendered_as_assistant_output() {
+    assert!(message_uses_resource_bindings(
+        &wisp_llm::Message::assistant("answer")
+    ));
+    let completion = wisp_llm::Message::tool("call-1", "attempt_completion", "result");
+    assert!(message_uses_resource_bindings(&completion));
+    let ordinary_tool = wisp_llm::Message::tool("call-2", "read_file", "result");
+    assert!(!message_uses_resource_bindings(&ordinary_tool));
 }
 
 #[test]

--- a/src-tauri/src/project_transfer.rs
+++ b/src-tauri/src/project_transfer.rs
@@ -721,6 +721,9 @@ mod tests {
         let archive = base.join("project.zip");
         std::fs::create_dir_all(workspace.join("figures")).unwrap();
         std::fs::write(workspace.join("figures/plot.txt"), b"plot").unwrap();
+        let snapshot = workspace.join(".wisp/artifacts/sha256/ab/abcdef.png");
+        std::fs::create_dir_all(snapshot.parent().unwrap()).unwrap();
+        std::fs::write(&snapshot, b"snapshot").unwrap();
         std::fs::write(&database, b"sqlite-placeholder").unwrap();
         let stats = wisp_store::ProjectTransferStats::default();
         write_project_archive(
@@ -733,13 +736,17 @@ mod tests {
         .unwrap();
         let manifest = read_manifest(&archive).unwrap();
         assert_eq!(manifest.source_os, std::env::consts::OS);
-        assert_eq!(manifest.contents.workspace_files, 1);
-        assert_eq!(manifest.contents.workspace_bytes, 4);
+        assert_eq!(manifest.contents.workspace_files, 2);
+        assert_eq!(manifest.contents.workspace_bytes, 12);
         std::fs::create_dir_all(&extracted).unwrap();
         extract_project_archive(&archive, &extracted, &extracted_database, &manifest).unwrap();
         assert_eq!(
             std::fs::read(extracted.join("figures/plot.txt")).unwrap(),
             b"plot"
+        );
+        assert_eq!(
+            std::fs::read(extracted.join(".wisp/artifacts/sha256/ab/abcdef.png")).unwrap(),
+            b"snapshot"
         );
         assert_eq!(
             std::fs::read(extracted_database).unwrap(),

--- a/src-tauri/src/resource_refs.rs
+++ b/src-tauri/src/resource_refs.rs
@@ -1,0 +1,571 @@
+//! Durable resource references for newly persisted assistant messages.
+//!
+//! Agent Markdown is preserved verbatim. File destinations are parsed once at
+//! persistence time, validated against the message's project, snapshotted into
+//! content-addressed project storage, and bound to an immutable artifact
+//! version. The UI consumes these bindings and never reparses their paths.
+
+use pulldown_cmark::{Event, Options, Parser, Tag};
+use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use wisp_store::{MessageResourceLink, Store};
+
+const MAX_SNAPSHOT_BYTES: u64 = 32 * 1024 * 1024;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct MarkdownResource {
+    ordinal: i64,
+    reference: String,
+    kind: String,
+}
+
+#[derive(Clone, Debug)]
+struct ResolvedFile {
+    real: PathBuf,
+    display_name: String,
+    kind: String,
+    mime_type: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct UiMessageResource {
+    pub id: String,
+    pub ordinal: i64,
+    pub original_reference: String,
+    pub artifact_id: Option<String>,
+    pub artifact_version_id: Option<String>,
+    pub display_name: String,
+    pub kind: String,
+    pub mime_type: String,
+    pub status: String,
+    pub error: Option<String>,
+}
+
+impl From<&MessageResourceLink> for UiMessageResource {
+    fn from(link: &MessageResourceLink) -> Self {
+        Self {
+            id: link.id.clone(),
+            ordinal: link.ordinal,
+            original_reference: link.original_reference.clone(),
+            artifact_id: link.artifact_id.clone(),
+            artifact_version_id: link.artifact_version_id.clone(),
+            display_name: link.display_name.clone(),
+            kind: link.resource_kind.clone(),
+            mime_type: link.mime_type.clone(),
+            status: link.status.clone(),
+            error: link.error.clone(),
+        }
+    }
+}
+
+fn markdown_resources(markdown: &str) -> Vec<MarkdownResource> {
+    let markdown = rewrite_codex_image_tags(markdown);
+    let parser = Parser::new_ext(&markdown, Options::ENABLE_TABLES);
+    let mut resources = Vec::new();
+    for event in parser {
+        let (reference, kind) = match event {
+            Event::Start(Tag::Image { dest_url, .. }) => (dest_url, "image"),
+            Event::Start(Tag::Link { dest_url, .. }) => (dest_url, "file"),
+            _ => continue,
+        };
+        let reference = reference.trim();
+        if reference.is_empty() || is_external_reference(reference) {
+            continue;
+        }
+        resources.push(MarkdownResource {
+            ordinal: resources.len() as i64,
+            reference: reference.to_string(),
+            kind: kind.to_string(),
+        });
+    }
+    resources
+}
+
+/// Normalize Codex ACP image blocks before the one-time Markdown parse. The
+/// original message remains untouched; only the binding input is normalized.
+fn rewrite_codex_image_tags(markdown: &str) -> Cow<'_, str> {
+    if !markdown.contains("<image") {
+        return Cow::Borrowed(markdown);
+    }
+    let mut out = String::with_capacity(markdown.len());
+    let mut rest = markdown;
+    let mut changed = false;
+    while let Some(start) = rest.find("<image") {
+        out.push_str(&rest[..start]);
+        let tag_source = &rest[start..];
+        let Some(open_end) = tag_source.find('>') else {
+            out.push_str(tag_source);
+            rest = "";
+            break;
+        };
+        let Some(close_offset) = tag_source[open_end + 1..].find("</image>") else {
+            out.push_str(tag_source);
+            rest = "";
+            break;
+        };
+        let whole_end = open_end + 1 + close_offset + "</image>".len();
+        let open_tag = &tag_source[..=open_end];
+        if let Some(path) = image_tag_attribute(open_tag, "path") {
+            out.push_str("[ACP image](<");
+            out.push_str(path.trim());
+            out.push_str(">)");
+            changed = true;
+        } else {
+            out.push_str(&tag_source[..whole_end]);
+        }
+        rest = &tag_source[whole_end..];
+    }
+    out.push_str(rest);
+    if changed {
+        Cow::Owned(out)
+    } else {
+        Cow::Borrowed(markdown)
+    }
+}
+
+fn image_tag_attribute<'a>(tag: &'a str, name: &str) -> Option<&'a str> {
+    let needle = format!("{name}=");
+    let start = tag.find(&needle)? + needle.len();
+    let value = &tag[start..];
+    let quote = value.chars().next()?;
+    if quote == '\'' || quote == '"' {
+        let value = &value[1..];
+        return Some(&value[..value.find(quote)?]);
+    }
+    if quote == '[' {
+        return Some(&value[1..value.find(']')?]);
+    }
+    Some(&value[..value.find([' ', '>']).unwrap_or(value.len())])
+}
+
+fn is_external_reference(reference: &str) -> bool {
+    let lower = reference.trim().to_ascii_lowercase();
+    lower.starts_with("http://")
+        || lower.starts_with("https://")
+        || lower.starts_with("mailto:")
+        || lower.starts_with("data:")
+        || lower.starts_with('#')
+}
+
+fn percent_decode(reference: &str) -> String {
+    let bytes = reference.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'%' && index + 2 < bytes.len() {
+            let hi = (bytes[index + 1] as char).to_digit(16);
+            let lo = (bytes[index + 2] as char).to_digit(16);
+            if let (Some(hi), Some(lo)) = (hi, lo) {
+                out.push((hi * 16 + lo) as u8);
+                index += 3;
+                continue;
+            }
+        }
+        out.push(bytes[index]);
+        index += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+fn strip_markdown_wrapper(reference: &str) -> &str {
+    let trimmed = reference.trim();
+    if let Some(inner) = trimmed
+        .strip_prefix('<')
+        .and_then(|value| value.strip_suffix('>'))
+    {
+        return inner.trim();
+    }
+    for quote in ['\'', '"'] {
+        if let Some(inner) = trimmed
+            .strip_prefix(quote)
+            .and_then(|value| value.strip_suffix(quote))
+        {
+            return inner.trim();
+        }
+    }
+    trimmed
+}
+
+fn reference_path(reference: &str) -> Result<PathBuf, String> {
+    let reference = strip_markdown_wrapper(reference);
+    if reference.to_ascii_lowercase().starts_with("file:") {
+        let url = url::Url::parse(reference)
+            .map_err(|error| format!("invalid file URI '{reference}': {error}"))?;
+        return url
+            .to_file_path()
+            .map_err(|_| format!("file URI cannot be converted to a native path: {reference}"));
+    }
+    let decoded = percent_decode(reference);
+    #[cfg(windows)]
+    let decoded = {
+        let bytes = decoded.as_bytes();
+        if bytes.len() >= 4
+            && bytes[0] == b'/'
+            && bytes[1].is_ascii_alphabetic()
+            && bytes[2] == b':'
+            && matches!(bytes[3], b'/' | b'\\')
+        {
+            decoded[1..].to_string()
+        } else {
+            decoded
+        }
+    };
+    Ok(PathBuf::from(decoded))
+}
+
+fn kind_and_mime(path: &Path, requested_kind: &str) -> Option<(String, String)> {
+    let ext = path.extension()?.to_str()?.to_ascii_lowercase();
+    let (kind, mime) = match ext.as_str() {
+        "png" => ("image", "image/png"),
+        "jpg" | "jpeg" => ("image", "image/jpeg"),
+        "gif" => ("image", "image/gif"),
+        "webp" => ("image", "image/webp"),
+        "svg" => ("image", "image/svg+xml"),
+        "pdf" => ("pdf", "application/pdf"),
+        "md" | "markdown" => ("markdown", "text/markdown"),
+        "csv" => ("csv", "text/csv"),
+        "tsv" => ("csv", "text/tab-separated-values"),
+        "json" => ("json", "application/json"),
+        "html" | "htm" => ("html", "text/html"),
+        "txt" | "log" => ("text", "text/plain"),
+        _ => return None,
+    };
+    let kind = if requested_kind == "image" && kind == "image" {
+        "image"
+    } else {
+        kind
+    };
+    Some((kind.into(), mime.into()))
+}
+
+fn resolve_reference(
+    root: &Path,
+    reference: &str,
+    requested_kind: &str,
+) -> Result<ResolvedFile, String> {
+    let mut candidates = vec![reference_path(reference)?];
+    // Some ACP Markdown destinations contain one unmatched terminal quote.
+    // Treat it as syntax only after the literal path fails, so a legitimate
+    // apostrophe in a filename remains valid.
+    let trimmed = reference.trim();
+    if trimmed.ends_with(['\'', '"']) && trimmed.len() > 1 {
+        if let Ok(candidate) = reference_path(&trimmed[..trimmed.len() - 1]) {
+            candidates.push(candidate);
+        }
+    }
+    let mut last_error = None;
+    for candidate in candidates {
+        let candidate_text = candidate.to_string_lossy();
+        match wisp_tools::safety::validate_file_path(root, &candidate_text) {
+            Ok(real) => {
+                let metadata = std::fs::metadata(&real).map_err(|error| error.to_string())?;
+                if metadata.len() > MAX_SNAPSHOT_BYTES {
+                    return Err(format!(
+                        "resource exceeds {} byte preview snapshot limit",
+                        MAX_SNAPSHOT_BYTES
+                    ));
+                }
+                let (kind, mime_type) = kind_and_mime(&real, requested_kind)
+                    .ok_or_else(|| "unsupported preview resource type".to_string())?;
+                let display_name = real
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .unwrap_or("resource")
+                    .to_string();
+                return Ok(ResolvedFile {
+                    real,
+                    display_name,
+                    kind,
+                    mime_type,
+                });
+            }
+            Err(error) => last_error = Some(error),
+        }
+    }
+    Err(last_error.unwrap_or_else(|| "resource path could not be resolved".into()))
+}
+
+fn snapshot_path(root: &Path, checksum: &str, source: &Path) -> PathBuf {
+    let extension = source
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .map(|extension| format!(".{extension}"))
+        .unwrap_or_default();
+    root.join(".wisp")
+        .join("artifacts")
+        .join("sha256")
+        .join(&checksum[..2])
+        .join(format!("{checksum}{extension}"))
+}
+
+fn source_artifact_identity(path: &Path) -> String {
+    let normalized = path.to_string_lossy().replace('\\', "/");
+    #[cfg(windows)]
+    {
+        normalized.to_ascii_lowercase()
+    }
+    #[cfg(not(windows))]
+    {
+        normalized
+    }
+}
+
+async fn bind_resolved(
+    store: &Store,
+    root: &Path,
+    project_id: &str,
+    frame_id: &str,
+    resource: &MarkdownResource,
+    resolved: ResolvedFile,
+) -> Result<MessageResourceLink, String> {
+    let bytes = std::fs::read(&resolved.real).map_err(|error| error.to_string())?;
+    let checksum = wisp_sync::sha256_hex(&bytes);
+    let snapshot = snapshot_path(root, &checksum, &resolved.real);
+    if !snapshot.exists() {
+        if let Some(parent) = snapshot.parent() {
+            std::fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+        }
+        std::fs::write(&snapshot, &bytes).map_err(|error| error.to_string())?;
+    }
+    let source_identity = source_artifact_identity(&resolved.real);
+    let artifact_key = wisp_sync::sha256_hex(format!("{project_id}\0{source_identity}").as_bytes());
+    let artifact_id = format!("resource-{}", &artifact_key[..32]);
+    let relative_snapshot = snapshot
+        .strip_prefix(root)
+        .unwrap_or(&snapshot)
+        .to_string_lossy()
+        .replace('\\', "/");
+    let current = store
+        .latest_artifact_version(&artifact_id)
+        .await
+        .map_err(|error| error.to_string())?;
+    let version_id = if let Some(version) =
+        current.filter(|version| version.checksum.as_deref() == Some(checksum.as_str()))
+    {
+        version.id
+    } else {
+        let version_id = store
+            .save_artifact(
+                &artifact_id,
+                project_id,
+                frame_id,
+                &resolved.display_name,
+                &resolved.mime_type,
+                &relative_snapshot,
+            )
+            .await
+            .map_err(|error| error.to_string())?;
+        store
+            .set_artifact_version_file_metadata(&version_id, bytes.len() as i64, &checksum)
+            .await
+            .map_err(|error| error.to_string())?;
+        version_id
+    };
+    Ok(MessageResourceLink {
+        id: uuid::Uuid::new_v4().to_string(),
+        frame_id: frame_id.to_string(),
+        message_seq: 0,
+        ordinal: resource.ordinal,
+        original_reference: resource.reference.clone(),
+        artifact_id: Some(artifact_id),
+        artifact_version_id: Some(version_id),
+        display_name: resolved.display_name,
+        resource_kind: resolved.kind,
+        mime_type: resolved.mime_type,
+        status: "ready".into(),
+        error: None,
+        created_at: chrono::Utc::now().timestamp(),
+    })
+}
+
+pub(crate) async fn bind_new_message_resources(
+    store: &Store,
+    root: &Path,
+    project_id: &str,
+    frame_id: &str,
+    message_seq: i64,
+    markdown: &str,
+) -> Vec<MessageResourceLink> {
+    let resources = markdown_resources(markdown);
+    if resources.is_empty() {
+        return Vec::new();
+    }
+    let mut resolved_cache = HashMap::<String, Result<ResolvedFile, String>>::new();
+    let mut links = Vec::with_capacity(resources.len());
+    for resource in resources {
+        let resolved = resolved_cache
+            .entry(resource.reference.clone())
+            .or_insert_with(|| resolve_reference(root, &resource.reference, &resource.kind))
+            .clone();
+        let mut link = match resolved {
+            Ok(resolved) => bind_resolved(store, root, project_id, frame_id, &resource, resolved)
+                .await
+                .unwrap_or_else(|error| failed_link(frame_id, &resource, error)),
+            Err(error) => failed_link(frame_id, &resource, error),
+        };
+        link.message_seq = message_seq;
+        links.push(link);
+    }
+    if let Err(error) = store
+        .replace_message_resource_links(frame_id, message_seq, &links)
+        .await
+    {
+        tracing::warn!(%frame_id, message_seq, %error, "failed to persist message resources");
+        return Vec::new();
+    }
+    links
+}
+
+fn failed_link(frame_id: &str, resource: &MarkdownResource, error: String) -> MessageResourceLink {
+    let display_name = reference_path(&resource.reference)
+        .ok()
+        .and_then(|path| {
+            path.file_name()
+                .map(|name| name.to_string_lossy().into_owned())
+        })
+        .unwrap_or_else(|| resource.reference.clone());
+    MessageResourceLink {
+        id: uuid::Uuid::new_v4().to_string(),
+        frame_id: frame_id.to_string(),
+        message_seq: 0,
+        ordinal: resource.ordinal,
+        original_reference: resource.reference.clone(),
+        artifact_id: None,
+        artifact_version_id: None,
+        display_name,
+        resource_kind: resource.kind.clone(),
+        mime_type: "application/octet-stream".into(),
+        status: "unresolved".into(),
+        error: Some(error),
+        created_at: chrono::Utc::now().timestamp(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_only_local_markdown_resources_in_document_order() {
+        let resources = markdown_resources(
+            "[report](<reports/a b.md>) ![plot](figures/a.png) [web](https://example.com)",
+        );
+        assert_eq!(resources.len(), 2);
+        assert_eq!(resources[0].reference, "reports/a b.md");
+        assert_eq!(resources[0].kind, "file");
+        assert_eq!(resources[1].reference, "figures/a.png");
+        assert_eq!(resources[1].kind, "image");
+    }
+
+    #[test]
+    fn extracts_codex_acp_image_blocks() {
+        let resources = markdown_resources(
+            r#"before <image name=[Image #1] path="D:/work/plot one.png">ignored</image> after"#,
+        );
+        assert_eq!(resources.len(), 1);
+        assert_eq!(resources[0].reference, "D:/work/plot one.png");
+        assert_eq!(resources[0].kind, "file");
+    }
+
+    #[test]
+    fn decodes_file_uris_and_percent_encoded_paths() {
+        let path = reference_path("file:///D:/ZZM/03.%20figures/table.png").unwrap();
+        #[cfg(windows)]
+        assert_eq!(path, PathBuf::from(r"D:\ZZM\03. figures\table.png"));
+        assert_eq!(
+            percent_decode("figures/%E5%9B%BE%201.png"),
+            "figures/图 1.png"
+        );
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn normalizes_webview_windows_drive_paths() {
+        assert_eq!(
+            reference_path("/D:/ZZM/03.%20figures/table.png").unwrap(),
+            PathBuf::from(r"D:\ZZM\03. figures\table.png")
+        );
+    }
+
+    #[tokio::test]
+    async fn new_message_bindings_snapshot_and_reuse_immutable_versions() {
+        let root =
+            std::env::temp_dir().join(format!("wisp_resource_refs_{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(root.join("figures")).unwrap();
+        std::fs::write(root.join("figures/plot.png"), b"png-v1").unwrap();
+        let store = Store::open(&root.join("store.sqlite")).await.unwrap();
+        store
+            .create_project("project", "Project", &root.to_string_lossy())
+            .await
+            .unwrap();
+        store
+            .create_frame("frame", "project", "OPERON", "model")
+            .await
+            .unwrap();
+
+        let first = bind_new_message_resources(
+            &store,
+            &root,
+            "project",
+            "frame",
+            2,
+            "![plot](figures/plot.png)",
+        )
+        .await;
+        assert_eq!(first.len(), 1);
+        assert_eq!(first[0].status, "ready");
+        let artifact_id = first[0].artifact_id.clone().unwrap();
+        let first_version = first[0].artifact_version_id.clone().unwrap();
+        let version = store
+            .latest_artifact_version(&artifact_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(version.id, first_version);
+        assert!(root.join(version.storage_path).is_file());
+
+        let repeated = bind_new_message_resources(
+            &store,
+            &root,
+            "project",
+            "frame",
+            3,
+            "![same](<figures/plot.png>)",
+        )
+        .await;
+        assert_eq!(
+            repeated[0].artifact_version_id.as_deref(),
+            Some(first_version.as_str())
+        );
+
+        std::fs::write(root.join("figures/plot.png"), b"png-v2").unwrap();
+        let changed = bind_new_message_resources(
+            &store,
+            &root,
+            "project",
+            "frame",
+            4,
+            "[updated](figures/plot.png)",
+        )
+        .await;
+        assert_ne!(
+            changed[0].artifact_version_id,
+            repeated[0].artifact_version_id
+        );
+
+        let missing = bind_new_message_resources(
+            &store,
+            &root,
+            "project",
+            "frame",
+            5,
+            "[missing](figures/missing.md)",
+        )
+        .await;
+        assert_eq!(missing[0].status, "unresolved");
+        assert!(missing[0].error.is_some());
+    }
+}

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -43,6 +43,7 @@ export function tauriMock(): void {
   const query = new URLSearchParams(window.location.search);
   const mockLongPages = Number(query.get("mockLongPages") ?? 0);
   const mockLongSession = query.get("mockLongSession") === "1" || mockLongPages > 0;
+  const mockResourceSession = query.get("mockResourceSession") === "1";
   const mockSessions = query.get("mockManySessions") === "1"
     ? Array.from({ length: 101 }, (_, index) => ({
         id: `session-${String(index + 1).padStart(3, "0")}`,
@@ -369,6 +370,30 @@ export function tauriMock(): void {
           case "load_demo":
             return demo;
           case "load_session":
+            if (mockResourceSession) {
+              return {
+                items: [{
+                  role: "assistant",
+                  text: "[Open bound report](D:/ZZM/03.%20figures/report.md')",
+                  tool_name: null,
+                  ok: null,
+                  resources: [{
+                    id: "resource-link-markdown",
+                    ordinal: 0,
+                    originalReference: "D:/ZZM/03.%20figures/report.md'",
+                    artifactId: "resource-artifact-markdown",
+                    artifactVersionId: "resource-version-markdown",
+                    displayName: "report.md",
+                    kind: "markdown",
+                    mimeType: "text/markdown",
+                    status: "ready",
+                    error: null,
+                  }],
+                }],
+                next_before_seq: null,
+                user_offset: 0,
+              };
+            }
             if (mockLongSession) {
               const before = arg("beforeSeq");
               ((window as any).__transcriptPageCalls ??= []).push(before ?? null);
@@ -939,6 +964,16 @@ export function tauriMock(): void {
               return { path: "artifact:art-markdown", mime: "text/markdown", text: "# Differential expression report\n\nRendered Markdown body.", base64: null };
             }
             return { path: `artifact:${arg("id")}`, mime: "text/csv", text: "a,b\n1,2", base64: null };
+          case "read_artifact_version":
+            if (arg("versionId") === "resource-version-markdown") {
+              return {
+                path: "artifact-version:resource-version-markdown",
+                mime: "text/markdown",
+                text: `# Bound report\n\n${Array.from({ length: 120 }, (_, index) => `Scrollable row ${index + 1}`).join("\n\n")}`,
+                base64: null,
+              };
+            }
+            throw new Error("Artifact version not found");
           case "missing_files": {
             const paths = Array.isArray(arg("paths")) ? arg("paths") : [];
             return paths.filter((p) => String(p).includes("/.pdf") || String(p).includes("\\.pdf"));

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -2264,6 +2264,34 @@ test("Markdown artifact modal opens its rendered preview in center", async ({ pa
   await expect(page.locator(".center-file-preview")).toContainText("Rendered Markdown body.");
 });
 
+test("bound Markdown resources use immutable versions and a scrollable center preview", async ({ page }) => {
+  await page.goto("/?mockResourceSession=1");
+  await page.getByRole("button", { name: "Search" }).click();
+  const search = commandPalette(page);
+  await search.fill("Enumerate");
+  await search.press("Enter");
+
+  await page.getByRole("link", { name: "Open bound report" }).click();
+  const tab = page.locator('.center-tab[data-center-path="artifact-version:resource-version-markdown"]');
+  await expect(tab).toContainText("report.md");
+  const preview = page.locator(".center-file-preview");
+  await expect(preview.locator("h1")).toHaveText("Bound report");
+  await expect(preview).toContainText("Scrollable row 120");
+  await expect.poll(() => preview.evaluate((element) => ({
+    clientHeight: element.clientHeight,
+    scrollHeight: element.scrollHeight,
+  }))).toMatchObject({ clientHeight: expect.any(Number), scrollHeight: expect.any(Number) });
+  const dimensions = await preview.evaluate((element) => ({
+    clientHeight: element.clientHeight,
+    scrollHeight: element.scrollHeight,
+  }));
+  expect(dimensions.scrollHeight).toBeGreaterThan(dimensions.clientHeight);
+  await preview.evaluate((element) => { element.scrollTop = element.scrollHeight; });
+  await expect.poll(() => preview.evaluate((element) => element.scrollTop)).toBeGreaterThan(0);
+  await expect.poll(() => lastInvokeArgs(page, "read_artifact_version"))
+    .toMatchObject({ versionId: "resource-version-markdown" });
+});
+
 test("projects landing stays centered on wide windows", async ({ page }) => {
   await page.setViewportSize({ width: 1600, height: 900 });
   await page.goto("/");

--- a/ui/src/app_support.rs
+++ b/ui/src/app_support.rs
@@ -1797,6 +1797,7 @@ mod tauri_args_tests {
         let items = vec![ChatItem::Assistant {
             text: "`figures/panel_I_heatmap_4genes_median.png/.pdf`".into(),
             model: None,
+            resources: Vec::new(),
         }];
         let arts = collect_artifacts(&items, Locale::En, &mut ProtoCache::new());
         let a = arts
@@ -2078,6 +2079,7 @@ mod review_tests {
         let mut items = vec![ChatItem::Assistant {
             text: "answer".into(),
             model: None,
+            resources: Vec::new(),
         }];
         upsert_review(&mut items, report("r1", "first"));
         upsert_review(&mut items, report("r1", "verified"));
@@ -2112,6 +2114,7 @@ pub(super) fn ensure_streaming_assistant(items: &mut Vec<ChatItem>, model: Optio
             ChatItem::Assistant {
                 text: String::new(),
                 model,
+                resources: Vec::new(),
             },
         );
     }
@@ -2173,6 +2176,7 @@ mod acp_tool_insert_tests {
             ChatItem::Assistant {
                 text: String::new(),
                 model: None,
+                resources: Vec::new(),
             },
         ];
         assert_eq!(acp_tool_insert_index(&items), 1);
@@ -2193,6 +2197,7 @@ mod acp_tool_insert_tests {
             ChatItem::Assistant {
                 text: "done".into(),
                 model: Some("Codex".into()),
+                resources: Vec::new(),
             },
         ];
         assert_eq!(acp_tool_insert_index(&items), 2);
@@ -2224,6 +2229,7 @@ pub(super) fn start_user_turn(items: &mut Vec<ChatItem>, text: String, model: Op
                 ChatItem::Assistant {
                     text: String::new(),
                     model,
+                    resources: Vec::new(),
                 },
             ],
         );
@@ -2248,6 +2254,7 @@ pub(super) fn start_user_turn(items: &mut Vec<ChatItem>, text: String, model: Op
         items.push(ChatItem::Assistant {
             text: String::new(),
             model,
+            resources: Vec::new(),
         });
     }
 }
@@ -2303,6 +2310,7 @@ mod start_user_turn_tests {
             ChatItem::Assistant {
                 text: String::new(),
                 model: Some("gpt".into()),
+                resources: Vec::new(),
             },
         ];
         start_user_turn(&mut items, "图片里有啥文字?".into(), Some("gpt".into()));
@@ -2318,6 +2326,7 @@ mod start_user_turn_tests {
             ChatItem::Assistant {
                 text: String::new(),
                 model: None,
+                resources: Vec::new(),
             },
         ];
         start_user_turn(&mut items, display.clone(), None);
@@ -2337,6 +2346,7 @@ mod start_user_turn_tests {
             ChatItem::Assistant {
                 text: "我先查近年文献".into(),
                 model: Some("Codex".into()),
+                resources: Vec::new(),
             },
         ];
 
@@ -2371,6 +2381,7 @@ mod start_user_turn_tests {
             ChatItem::Assistant {
                 text: String::new(),
                 model: None,
+                resources: Vec::new(),
             },
         ];
 
@@ -2387,6 +2398,7 @@ mod start_user_turn_tests {
             ChatItem::Assistant {
                 text: "echo:alpha".into(),
                 model: None,
+                resources: Vec::new(),
             },
             ChatItem::QueuedUser("queued".into()),
         ];
@@ -2409,6 +2421,7 @@ mod start_user_turn_tests {
             ChatItem::Assistant {
                 text: "done".into(),
                 model: None,
+                resources: Vec::new(),
             },
             ChatItem::QueuedUser(display.clone()),
         ];
@@ -2430,6 +2443,7 @@ mod start_user_turn_tests {
             ChatItem::Assistant {
                 text: "done".into(),
                 model: None,
+                resources: Vec::new(),
             },
             ChatItem::QueuedUser("queued".into()),
             ChatItem::QueuedUser("later".into()),
@@ -2440,7 +2454,7 @@ mod start_user_turn_tests {
         assert!(matches!(&items[2], ChatItem::User(text) if text == "queued"));
         assert!(matches!(
             &items[3],
-            ChatItem::Assistant { text, model } if text.is_empty() && model.as_deref() == Some("model")
+            ChatItem::Assistant { text, model, .. } if text.is_empty() && model.as_deref() == Some("model")
         ));
         assert!(matches!(&items[4], ChatItem::QueuedUser(text) if text == "later"));
     }
@@ -2530,7 +2544,14 @@ pub(super) fn append_assistant_delta(
             return;
         }
     }
-    items.insert(queue_start, ChatItem::Assistant { text: delta, model });
+    items.insert(
+        queue_start,
+        ChatItem::Assistant {
+            text: delta,
+            model,
+            resources: Vec::new(),
+        },
+    );
 }
 
 pub(super) fn append_reasoning_delta(items: &mut Vec<ChatItem>, delta: String) {
@@ -3407,8 +3428,110 @@ fn strip_trailing_list_marker(before: &str) -> &str {
     }
 }
 
-/// Post-process rendered Markdown: artifact chips, code wrappers, filename links.
-pub(super) fn enrich_md_html(mut html: String, arts: &[Artifact], locale: Locale) -> String {
+fn html_attr(tag: &str, name: &str) -> Option<String> {
+    let needle = format!(r#"{name}=""#);
+    let start = tag.find(&needle)? + needle.len();
+    let end = tag[start..].find('"')? + start;
+    Some(tag[start..end].to_string())
+}
+
+fn resource_reference_matches(rendered: &str, original: &str) -> bool {
+    fn decode_html_attribute(value: &str) -> String {
+        value
+            .replace("&#x27;", "'")
+            .replace("&#39;", "'")
+            .replace("&quot;", "\"")
+            .replace("&lt;", "<")
+            .replace("&gt;", ">")
+            .replace("&amp;", "&")
+    }
+    normalize_path(&decode_href(&decode_html_attribute(rendered)))
+        == normalize_path(&decode_href(original))
+}
+
+/// Replace path-bearing Markdown tags with durable resource identities. Only
+/// bindings persisted with this exact message are considered; old unbound
+/// messages intentionally retain their original behavior.
+fn replace_bound_resource_tags(html: String, resources: &[MessageResource]) -> String {
+    if resources.is_empty() {
+        return html;
+    }
+    let mut out = String::with_capacity(html.len() + resources.len() * 48);
+    let mut rest = html.as_str();
+    let mut consumed = vec![false; resources.len()];
+    loop {
+        let next = [(rest.find("<a "), "href"), (rest.find("<img "), "src")]
+            .into_iter()
+            .filter_map(|(position, attribute)| position.map(|position| (position, attribute)))
+            .min_by_key(|(position, _)| *position);
+        let Some((position, attribute)) = next else {
+            out.push_str(rest);
+            break;
+        };
+        out.push_str(&rest[..position]);
+        rest = &rest[position..];
+        let Some(end) = rest.find('>') else {
+            out.push_str(rest);
+            break;
+        };
+        let tag = &rest[..=end];
+        rest = &rest[end + 1..];
+        let Some(reference) = html_attr(tag, attribute) else {
+            out.push_str(tag);
+            continue;
+        };
+        let Some(resource_index) = resources.iter().enumerate().position(|(index, resource)| {
+            !consumed[index] && resource_reference_matches(&reference, &resource.original_reference)
+        }) else {
+            out.push_str(tag);
+            continue;
+        };
+        consumed[resource_index] = true;
+        let resource = &resources[resource_index];
+        let old = format!(r#"{attribute}="{}""#, reference);
+        let title = html_escape(
+            resource
+                .error
+                .as_deref()
+                .unwrap_or(resource.display_name.as_str()),
+        );
+        if attribute == "src" && resource.status != "ready" {
+            out.push_str(&format!(
+                r#"<span class="resource-unresolved" data-resource-id="{}" data-resource-status="unresolved" title="{title}">{}</span>"#,
+                html_escape(&resource.id),
+                html_escape(&format!("{} — {title}", resource.display_name)),
+            ));
+            continue;
+        }
+        let replacement = if resource.status == "ready" && resource.artifact_version_id.is_some() {
+            let value = if attribute == "src" { "" } else { "#" };
+            format!(
+                r#"{attribute}="{value}" data-resource-id="{}" data-resource-kind="{}" data-resource-status="ready" title="{title}""#,
+                html_escape(&resource.id),
+                html_escape(&resource.kind),
+            )
+        } else {
+            let value = if attribute == "src" { "" } else { "#" };
+            format!(
+                r#"{attribute}="{value}" data-resource-id="{}" data-resource-kind="{}" data-resource-status="unresolved" title="{title}""#,
+                html_escape(&resource.id),
+                html_escape(&resource.kind),
+            )
+        };
+        out.push_str(&tag.replacen(&old, &replacement, 1));
+    }
+    out
+}
+
+/// Post-process rendered Markdown: durable resources, artifact chips, code
+/// wrappers, and filename links.
+pub(super) fn enrich_md_html(
+    mut html: String,
+    arts: &[Artifact],
+    resources: &[MessageResource],
+    locale: Locale,
+) -> String {
+    html = replace_bound_resource_tags(html, resources);
     html = replace_artifact_tokens(html, arts);
     html = replace_file_links(html, arts);
     for (i, a) in arts.iter().enumerate() {
@@ -3426,6 +3549,73 @@ pub(super) fn enrich_md_html(mut html: String, arts: &[Artifact], locale: Locale
 #[cfg(test)]
 mod art_ref_marker_tests {
     use super::*;
+
+    fn message_resource(reference: &str, kind: &str, ready: bool) -> MessageResource {
+        MessageResource {
+            id: "resource-link".into(),
+            ordinal: 0,
+            original_reference: reference.into(),
+            artifact_id: ready.then(|| "artifact-id".into()),
+            artifact_version_id: ready.then(|| "version-id".into()),
+            display_name: "plot.png".into(),
+            kind: kind.into(),
+            mime_type: "image/png".into(),
+            status: if ready { "ready" } else { "unresolved" }.into(),
+            error: (!ready).then(|| "not found".into()),
+        }
+    }
+
+    #[test]
+    fn replaces_bound_links_and_images_with_resource_identity() {
+        let html = r#"<p><a href="D:/work/report.md">report</a><img src="figures/plot.png" alt="plot" /></p>"#;
+        let resources = vec![
+            message_resource("D:/work/report.md", "markdown", true),
+            message_resource("figures/plot.png", "image", true),
+        ];
+        let out = replace_bound_resource_tags(html.into(), &resources);
+        assert_eq!(out.matches(r#"data-resource-status="ready""#).count(), 2);
+        assert!(out.contains(r##"href="#" data-resource-id="resource-link""##));
+        assert!(out.contains(r#"src="" data-resource-id="resource-link""#));
+        assert!(!out.contains("D:/work/report.md"));
+    }
+
+    #[test]
+    fn unresolved_binding_is_visible_and_never_keeps_the_raw_path() {
+        let html = r#"<p><a href="figures/missing.md">missing</a></p>"#;
+        let out = replace_bound_resource_tags(
+            html.into(),
+            &[message_resource("figures/missing.md", "markdown", false)],
+        );
+        assert!(out.contains(r#"data-resource-status="unresolved""#));
+        assert!(out.contains(r#"title="not found""#));
+        assert!(!out.contains("figures/missing.md"));
+    }
+
+    #[test]
+    fn unresolved_image_becomes_an_error_placeholder() {
+        let html = r#"<p><img src="figures/missing.png" alt="plot" /></p>"#;
+        let out = replace_bound_resource_tags(
+            html.into(),
+            &[message_resource("figures/missing.png", "image", false)],
+        );
+        assert!(out.contains(r#"class="resource-unresolved""#));
+        assert!(out.contains("plot.png — not found"));
+        assert!(!out.contains("<img"));
+        assert!(!out.contains("figures/missing.png"));
+    }
+
+    #[test]
+    fn matches_html_escaped_quotes_in_rendered_destinations() {
+        let markdown = "[report](D:/work/report.md')";
+        let out = enrich_md_html(
+            md_to_html(markdown),
+            &[],
+            &[message_resource("D:/work/report.md'", "markdown", true)],
+            Locale::En,
+        );
+        assert!(out.contains(r#"data-resource-status="ready""#));
+        assert!(!out.contains("D:/work/report.md"));
+    }
 
     #[test]
     fn strips_list_dashes_before_chips_in_table_cells() {
@@ -3513,8 +3703,9 @@ mod art_ref_marker_tests {
 pub(super) fn handle_md_click(
     ev: &web_sys::MouseEvent,
     arts: &[Artifact],
+    resources: &[MessageResource],
     on_artifact: &Callback<usize>,
-    on_file: &Callback<(String, String)>,
+    on_file: &Callback<ModalArtifact>,
 ) {
     use wasm_bindgen::JsCast;
     let mut el = ev
@@ -3546,6 +3737,25 @@ pub(super) fn handle_md_click(
             return;
         }
         if n.tag_name().eq_ignore_ascii_case("a") {
+            if let Some(resource_id) = n.get_attribute("data-resource-id") {
+                ev.prevent_default();
+                ev.stop_propagation();
+                if let Some(resource) = resources.iter().find(|resource| resource.id == resource_id)
+                {
+                    if let Some(version_id) = resource
+                        .artifact_version_id
+                        .as_ref()
+                        .filter(|_| resource.status == "ready")
+                    {
+                        on_file.call((
+                            format!("artifact-version:{version_id}"),
+                            resource.display_name.clone(),
+                            resource.kind.clone(),
+                        ));
+                    }
+                }
+                return;
+            }
             if let Some(href) = n.get_attribute("href") {
                 if opens_in_system_browser(&href) {
                     ev.prevent_default();
@@ -3561,7 +3771,8 @@ pub(super) fn handle_md_click(
                         on_artifact.call(idx);
                     } else {
                         let kind = file_kind(&path).unwrap_or("text").to_string();
-                        on_file.call((path, kind));
+                        let name = attachment_name(&path);
+                        on_file.call((path, name, kind));
                     }
                     return;
                 }
@@ -3966,6 +4177,7 @@ pub(super) fn promote_assistant_text(items: &mut Vec<ChatItem>, text: &str) {
     items.push(ChatItem::Assistant {
         text: text.to_string(),
         model: None,
+        resources: Vec::new(),
     });
 }
 
@@ -4106,6 +4318,7 @@ mod artifact_scan_tests {
             ChatItem::Assistant {
                 text: "| a | b |\n|---|---|\n| 1 | 2 |\n\n```csv\nx,y\n1,2\n```".into(),
                 model: None,
+                resources: Vec::new(),
             },
         ];
         let a1 = collect_artifacts(&items, Locale::En, &mut cache);
@@ -4136,10 +4349,12 @@ mod artifact_scan_tests {
             ChatItem::Assistant {
                 text: "Created `result.csv`".into(),
                 model: None,
+                resources: Vec::new(),
             },
             ChatItem::Assistant {
                 text: "Updated `result.csv`".into(),
                 model: None,
+                resources: Vec::new(),
             },
         ];
         let artifacts = fresh(&items, Locale::En);
@@ -4164,6 +4379,7 @@ mod artifact_scan_tests {
             ChatItem::Assistant {
                 text: "Done.".into(),
                 model: None,
+                resources: Vec::new(),
             },
         ];
         let artifacts = fresh(&items, Locale::En);
@@ -4185,6 +4401,7 @@ mod artifact_scan_tests {
             ChatItem::Assistant {
                 text: "Created `sample_statistics.png`".into(),
                 model: None,
+                resources: Vec::new(),
             },
             ChatItem::Tool {
                 name: "write".into(),
@@ -4197,16 +4414,13 @@ mod artifact_scan_tests {
             ChatItem::Assistant {
                 text: r"Updated `E:\cross-species-root\sample_statistics.png`".into(),
                 model: None,
+                resources: Vec::new(),
             },
         ];
         let all = fresh(&items, Locale::En);
         assert_eq!(all.len(), 4);
 
-        let current = current_artifacts(
-            &all,
-            r"E:\cross-species-root",
-            &HashSet::<String>::new(),
-        );
+        let current = current_artifacts(&all, r"E:\cross-species-root", &HashSet::<String>::new());
         assert_eq!(current.len(), 1);
         assert_eq!(current[0].name, "sample_statistics.png");
         assert!(matches!(
@@ -4341,6 +4555,11 @@ pub(super) fn artifact_id_path(path: &str) -> Option<&str> {
     path.strip_prefix("artifact:").filter(|id| !id.is_empty())
 }
 
+pub(super) fn artifact_version_id_path(path: &str) -> Option<&str> {
+    path.strip_prefix("artifact-version:")
+        .filter(|id| !id.is_empty())
+}
+
 #[component]
 pub(super) fn CsvFilePreview(path: String) -> impl IntoView {
     let locale = use_locale();
@@ -4352,21 +4571,30 @@ pub(super) fn CsvFilePreview(path: String) -> impl IntoView {
         spawn_local(async move {
             table.set(None);
             err.set(None);
-            let v = match artifact_id_path(&path) {
-                Some(id) => {
+            let v = match artifact_version_id_path(&path) {
+                Some(version_id) => {
                     invoke(
-                        "read_artifact",
-                        to_value(&serde_json::json!({ "id": id })).unwrap(),
+                        "read_artifact_version",
+                        to_value(&serde_json::json!({ "versionId": version_id })).unwrap(),
                     )
                     .await
                 }
-                None => {
-                    invoke(
-                        "read_file",
-                        to_value(&serde_json::json!({ "path": path })).unwrap(),
-                    )
-                    .await
-                }
+                None => match artifact_id_path(&path) {
+                    Some(id) => {
+                        invoke(
+                            "read_artifact",
+                            to_value(&serde_json::json!({ "id": id })).unwrap(),
+                        )
+                        .await
+                    }
+                    None => {
+                        invoke(
+                            "read_file",
+                            to_value(&serde_json::json!({ "path": path })).unwrap(),
+                        )
+                        .await
+                    }
+                },
             };
             let Ok(fc) = serde_wasm_bindgen::from_value::<FileContent>(v) else {
                 err.set(Some(tf(loc, "err.file_not_found", &[("path", &path)])));
@@ -4396,21 +4624,31 @@ pub(super) fn JsonFilePreview(path: String) -> impl IntoView {
         spawn_local(async move {
             body.set(None);
             err.set(None);
-            let result = match artifact_id_path(&path) {
-                Some(id) => {
+            let result = match artifact_version_id_path(&path) {
+                Some(version_id) => {
                     invoke_checked(
-                        "read_artifact",
-                        to_value(&serde_json::json!({ "id": id })).unwrap(),
+                        "read_artifact_version",
+                        to_value(&serde_json::json!({ "versionId": version_id })).unwrap(),
                     )
                     .await
                 }
-                None => {
-                    invoke_checked(
-                        "read_file",
-                        to_value(&tauri_args::read_file(&path, Some(32 * 1024 * 1024))).unwrap(),
-                    )
-                    .await
-                }
+                None => match artifact_id_path(&path) {
+                    Some(id) => {
+                        invoke_checked(
+                            "read_artifact",
+                            to_value(&serde_json::json!({ "id": id })).unwrap(),
+                        )
+                        .await
+                    }
+                    None => {
+                        invoke_checked(
+                            "read_file",
+                            to_value(&tauri_args::read_file(&path, Some(32 * 1024 * 1024)))
+                                .unwrap(),
+                        )
+                        .await
+                    }
+                },
             };
             let fc = match result {
                 Ok(v) => match serde_wasm_bindgen::from_value::<FileContent>(v) {
@@ -4569,21 +4807,31 @@ pub(super) fn FilePreview(dom_id: String, path: String, kind: String) -> impl In
             // PDF still renders (the default 8 MB cap silently rejected them, #35).
             // On failure, surface the real backend error (size limit / outside project
             // root / …) instead of a blanket "file not found".
-            let result = match artifact_id_path(&path) {
-                Some(id) => {
+            let result = match artifact_version_id_path(&path) {
+                Some(version_id) => {
                     invoke_checked(
-                        "read_artifact",
-                        to_value(&serde_json::json!({ "id": id })).unwrap(),
+                        "read_artifact_version",
+                        to_value(&serde_json::json!({ "versionId": version_id })).unwrap(),
                     )
                     .await
                 }
-                None => {
-                    invoke_checked(
-                        "read_file",
-                        to_value(&tauri_args::read_file(&path, Some(32 * 1024 * 1024))).unwrap(),
-                    )
-                    .await
-                }
+                None => match artifact_id_path(&path) {
+                    Some(id) => {
+                        invoke_checked(
+                            "read_artifact",
+                            to_value(&serde_json::json!({ "id": id })).unwrap(),
+                        )
+                        .await
+                    }
+                    None => {
+                        invoke_checked(
+                            "read_file",
+                            to_value(&tauri_args::read_file(&path, Some(32 * 1024 * 1024)))
+                                .unwrap(),
+                        )
+                        .await
+                    }
+                },
             };
             let fc = match result {
                 Ok(v) => match serde_wasm_bindgen::from_value::<FileContent>(v) {
@@ -5032,6 +5280,7 @@ mod transcript_render_window_tests {
                     ChatItem::Assistant {
                         text: format!("answer {turn}"),
                         model: None,
+                        resources: Vec::new(),
                     },
                 ]
             })
@@ -5204,7 +5453,7 @@ pub(super) fn UserMessage(
     on_copy: Callback<String>,
     on_edit: Callback<usize>,
     on_branch: Callback<usize>,
-    on_file: Callback<(String, String)>,
+    on_file: Callback<ModalArtifact>,
 ) -> impl IntoView {
     let locale = use_locale();
     let presentation = user_message_presentation(&text);
@@ -5223,12 +5472,13 @@ pub(super) fn UserMessage(
         .into_iter()
         .map(|path| {
             let name = attachment_name(&path);
+            let name_for_click = name.clone();
             let path_for_click = path.clone();
             let on_file = on_file.clone();
             view! {
                 <button type="button" class="user-attachment-image"
                     title=name.clone()
-                    on:click=move |_| on_file.call((path_for_click.clone(), "image".into()))>
+                    on:click=move |_| on_file.call((path_for_click.clone(), name_for_click.clone(), "image".into()))>
                     <AttachmentThumbnail path=path alt=name.clone() />
                     <span class="user-attachment-image-name">{name}</span>
                 </button>
@@ -5239,6 +5489,7 @@ pub(super) fn UserMessage(
         .into_iter()
         .map(|path| {
             let name = attachment_name(&path);
+            let name_for_click = name.clone();
             let kind = file_kind(&path).unwrap_or("text").to_string();
             let path_for_click = path.clone();
             let kind_for_click = kind.clone();
@@ -5246,7 +5497,7 @@ pub(super) fn UserMessage(
             view! {
                 <button type="button" class="user-attachment-file"
                     title=path.clone()
-                    on:click=move |_| on_file.call((path_for_click.clone(), kind_for_click.clone()))>
+                    on:click=move |_| on_file.call((path_for_click.clone(), name_for_click.clone(), kind_for_click.clone()))>
                     <span class="user-attachment-file-icon">{compose_icon("doc")}</span>
                     <span class="user-attachment-file-copy">
                         <span class="user-attachment-file-name">{name}</span>
@@ -5315,17 +5566,24 @@ pub(super) fn UserMessage(
 pub(super) fn AssistantMessage(
     text: String,
     model: Option<String>,
+    resources: Vec<MessageResource>,
     artifacts: Vec<Artifact>,
     source_item: usize,
     on_artifact: Callback<usize>,
-    on_file: Callback<(String, String)>,
+    on_file: Callback<ModalArtifact>,
     on_copy: Callback<String>,
 ) -> impl IntoView {
     let locale = use_locale();
     let arts_for_html = artifacts.clone();
+    let resources_for_html = resources.clone();
     let text_for_html = text.clone();
     let html = create_memo(move |_| {
-        enrich_md_html(md_to_html(&text_for_html), &arts_for_html, locale.get())
+        enrich_md_html(
+            md_to_html(&text_for_html),
+            &arts_for_html,
+            &resources_for_html,
+            locale.get(),
+        )
     });
     let hid = unique_dom_id("md");
     let hid_for_effect = hid.clone();
@@ -5333,9 +5591,50 @@ pub(super) fn AssistantMessage(
         let _ = html.get();
         schedule_highlight(hid_for_effect.clone());
     });
+    let hid_for_resources = hid.clone();
+    let resources_for_effect = resources.clone();
+    create_effect(move |_| {
+        let _ = html.get();
+        let dom_id = hid_for_resources.clone();
+        let resources = resources_for_effect.clone();
+        spawn_local(async move {
+            for resource in resources
+                .into_iter()
+                .filter(|resource| resource.status == "ready" && resource.kind == "image")
+            {
+                let Some(version_id) = resource.artifact_version_id else {
+                    continue;
+                };
+                let Ok(value) = invoke_checked(
+                    "read_artifact_version",
+                    to_value(&serde_json::json!({ "versionId": version_id })).unwrap(),
+                )
+                .await
+                else {
+                    continue;
+                };
+                let Ok(file) = serde_wasm_bindgen::from_value::<FileContent>(value) else {
+                    continue;
+                };
+                let Some(base64) = file.base64 else {
+                    continue;
+                };
+                let selector = format!(r#"#{dom_id} [data-resource-id="{}"]"#, resource.id);
+                if let Some(element) = web_sys::window()
+                    .and_then(|window| window.document())
+                    .and_then(|document| document.query_selector(&selector).ok().flatten())
+                {
+                    let _ = element
+                        .set_attribute("src", &format!("data:{};base64,{base64}", file.mime));
+                    let _ = element.set_attribute("class", "resource-inline-image");
+                }
+            }
+        });
+    });
     let on_artifact = on_artifact.clone();
     let on_file = on_file.clone();
     let arts_for_click = artifacts.clone();
+    let resources_for_click = resources.clone();
     let generated = artifacts
         .iter()
         .enumerate()
@@ -5376,7 +5675,13 @@ pub(super) fn AssistantMessage(
             <div class="body md" id=hid.clone()
                 inner_html=move || html.get()
                 on:click=move |ev: web_sys::MouseEvent| {
-                    handle_md_click(&ev, &arts_for_click, &on_artifact, &on_file)
+                    handle_md_click(
+                        &ev,
+                        &arts_for_click,
+                        &resources_for_click,
+                        &on_artifact,
+                        &on_file,
+                    )
                 }></div>
             {(generated_count > 0).then(|| view! {
                 <div class="message-artifacts">

--- a/ui/src/dto.rs
+++ b/ui/src/dto.rs
@@ -10,6 +10,21 @@
 use crate::i18n::Locale;
 use serde::{Deserialize, Serialize};
 
+#[derive(Deserialize, Clone, Debug, Hash, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct MessageResource {
+    pub(crate) id: String,
+    pub(crate) ordinal: i64,
+    pub(crate) original_reference: String,
+    pub(crate) artifact_id: Option<String>,
+    pub(crate) artifact_version_id: Option<String>,
+    pub(crate) display_name: String,
+    pub(crate) kind: String,
+    pub(crate) mime_type: String,
+    pub(crate) status: String,
+    pub(crate) error: Option<String>,
+}
+
 #[derive(Deserialize, Clone)]
 #[allow(dead_code)]
 #[serde(tag = "kind")]
@@ -21,6 +36,11 @@ pub(crate) enum AgentEvent {
     MessageBoundary {
         frame_id: String,
         seq: i64,
+    },
+    Resources {
+        frame_id: String,
+        seq: i64,
+        resources: Vec<MessageResource>,
     },
     Text {
         frame_id: String,
@@ -128,6 +148,7 @@ pub(crate) enum ChatItem {
     Assistant {
         text: String,
         model: Option<String>,
+        resources: Vec<MessageResource>,
     },
     Reasoning(String),
     Tool {
@@ -185,7 +206,11 @@ impl ChatItem {
         match self {
             Self::User(s) => (0u8, s).hash(&mut h),
             Self::QueuedUser(s) => (1u8, s).hash(&mut h),
-            Self::Assistant { text, model } => (2u8, text, model).hash(&mut h),
+            Self::Assistant {
+                text,
+                model,
+                resources,
+            } => (2u8, text, model, resources).hash(&mut h),
             Self::Reasoning(s) => (3u8, s).hash(&mut h),
             Self::Tool {
                 name,
@@ -613,6 +638,8 @@ pub(crate) struct LoadedItem {
     pub(crate) status: Option<String>,
     #[serde(default)]
     pub(crate) locations: Option<String>,
+    #[serde(default)]
+    pub(crate) resources: Vec<MessageResource>,
 }
 
 #[derive(Deserialize)]
@@ -640,6 +667,7 @@ impl LoadedItem {
                 .unwrap_or_else(|_| ChatItem::Assistant {
                     text: self.text,
                     model: None,
+                    resources: self.resources,
                 }),
             "acp_tool" => ChatItem::AcpTool {
                 call_id: self.call_id.unwrap_or_default(),
@@ -660,6 +688,7 @@ impl LoadedItem {
             _ => ChatItem::Assistant {
                 text: self.text,
                 model: self.model_name,
+                resources: self.resources,
             },
         }
     }

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -268,6 +268,7 @@ fn mark_optimistic_send_failed(rows: &mut Vec<ChatItem>, display_message: &str, 
             ChatItem::Assistant {
                 text: format!("Error: {error}"),
                 model: None,
+                resources: Vec::new(),
             },
         );
         return;
@@ -805,15 +806,26 @@ fn App() -> impl IntoView {
         refresh_file_search(file_query, file_search_hits);
     });
 
+    let open_resource = Callback::new(move |(path, name, kind): ModalArtifact| {
+        if opens_in_modal(&kind) {
+            modal_artifact.set(Some((path, name, kind)));
+            return;
+        }
+        let tab = CenterFileTab::new(path.clone(), name, kind);
+        center_files.update(|files| {
+            if !files.iter().any(|file| file.path == path) {
+                files.push(tab.clone());
+            }
+        });
+        center_file.set(Some(path));
+        show_projects.set(false);
+    });
+
     let on_artifact_select = Callback::new(move |idx: usize| {
         let arts = artifacts.get();
         if let Some(a) = arts.get(idx) {
             if let PreviewData::File { path, kind } = &a.data {
-                if opens_in_modal(kind) {
-                    modal_artifact.set(Some((path.clone(), a.name.clone(), kind.clone())));
-                    return;
-                }
-                open_workspace_file(path.clone(), modal_artifact);
+                open_resource.call((path.clone(), a.name.clone(), kind.clone()));
             } else {
                 ensure_right_tab(RightTab::Artifacts, show_right, open_right_tabs, right_tab);
                 sel_artifact.set(idx);
@@ -822,8 +834,8 @@ fn App() -> impl IntoView {
         }
     });
 
-    let on_file_link = Callback::new(move |(path, _kind): (String, String)| {
-        open_workspace_file(path, modal_artifact);
+    let on_file_link = Callback::new(move |resource: ModalArtifact| {
+        open_resource.call(resource);
     });
 
     // Inline @ artifact, # session, and / skill pickers all share one cursor
@@ -1085,6 +1097,24 @@ fn App() -> impl IntoView {
                 })
             }
             AgentEvent::MessageBoundary { .. } => {}
+            AgentEvent::Resources {
+                frame_id,
+                resources,
+                ..
+            } => {
+                flush_now();
+                route_items(active_cb, items_cb, transcripts_cb, &frame_id, |items| {
+                    if let Some(ChatItem::Assistant {
+                        resources: current, ..
+                    }) = items
+                        .iter_mut()
+                        .rev()
+                        .find(|item| matches!(item, ChatItem::Assistant { .. }))
+                    {
+                        *current = resources;
+                    }
+                });
+            }
             AgentEvent::Text { frame_id, delta } => {
                 set_pet_activity(&frame_id, "running");
                 queue(frame_id, PendingDelta::Text(delta));
@@ -1235,6 +1265,7 @@ fn App() -> impl IntoView {
                     v.push(ChatItem::Assistant {
                         text: format!("Error: {message}"),
                         model,
+                        resources: Vec::new(),
                     });
                 });
                 approval_cb.update(|s| {
@@ -1280,6 +1311,7 @@ fn App() -> impl IntoView {
                         ChatItem::Assistant {
                             text: String::new(),
                             model: (!model.is_empty()).then_some(model),
+                            resources: Vec::new(),
                         },
                     );
                 });
@@ -1679,6 +1711,7 @@ fn App() -> impl IntoView {
                     rows.push(ChatItem::Assistant {
                         text: String::new(),
                         model: turn_model.clone(),
+                        resources: Vec::new(),
                     });
                 }
             });
@@ -1771,6 +1804,7 @@ fn App() -> impl IntoView {
                         items.push(ChatItem::Assistant {
                             text,
                             model: model.clone(),
+                            resources: Vec::new(),
                         });
                     });
                 }
@@ -1782,6 +1816,7 @@ fn App() -> impl IntoView {
                                 localize_backend(locale.get(), &js_error_text(err))
                             ),
                             model: model.clone(),
+                            resources: Vec::new(),
                         });
                     });
                 }
@@ -2627,6 +2662,7 @@ fn App() -> impl IntoView {
                 ChatItem::Assistant {
                     text: String::new(),
                     model: turn_model,
+                    resources: Vec::new(),
                 },
             ]);
             force_chat_bottom();
@@ -2890,6 +2926,7 @@ fn App() -> impl IntoView {
                 view.push(ChatItem::Assistant {
                     text: demo.response.clone(),
                     model: None,
+                    resources: Vec::new(),
                 });
                 items.set(view);
                 force_chat_bottom();
@@ -3172,8 +3209,7 @@ fn App() -> impl IntoView {
     let ssh_hosts = create_rw_signal::<Vec<SshHost>>(vec![]);
     let execution_contexts = create_rw_signal::<Vec<ExecutionContext>>(vec![]);
     let selected_context_id = create_rw_signal::<Option<String>>(None);
-    let context_details_modal =
-        create_rw_signal::<Option<(String, ContextModalKind)>>(None);
+    let context_details_modal = create_rw_signal::<Option<(String, ContextModalKind)>>(None);
     let runtime_interpreter_form = create_rw_signal(None::<RuntimeInterpreterForm>);
     let runtime_infos = create_rw_signal::<Vec<RuntimeInfo>>(vec![]);
     let runtime_object_states =
@@ -6555,7 +6591,7 @@ fn App() -> impl IntoView {
                                                     ChatItem::User(text) => view! {
                                                         <div class="sidechat-row user"><div class="sidechat-bubble">{text}</div></div>
                                                     }.into_view(),
-                                                    ChatItem::Assistant { text, model } => {
+                                                    ChatItem::Assistant { text, model, .. } => {
                                                         let error = text.starts_with("Error: ");
                                                         view! {
                                                             <div class="sidechat-row assistant">
@@ -7450,7 +7486,7 @@ fn render_item(
     item: &ChatItem,
     artifacts: &[Artifact],
     on_artifact: Callback<usize>,
-    on_file: Callback<(String, String)>,
+    on_file: Callback<ModalArtifact>,
     busy: ReadSignal<bool>,
     is_last: bool,
     can_modify: bool,
@@ -7505,10 +7541,11 @@ fn render_item(
                 </div>
             }.into_view()
         }
-        ChatItem::Assistant { text, model } => view! {
+        ChatItem::Assistant { text, model, resources } => view! {
             <AssistantMessage
                 text=text.clone()
                 model=model.clone()
+                resources=resources.clone()
                 artifacts=artifacts.to_vec()
                 source_item=ui_index
                 on_artifact=on_artifact

--- a/ui/src/notebook.rs
+++ b/ui/src/notebook.rs
@@ -260,6 +260,7 @@ mod tests {
                 text: "```python\nprint(1)\n```\n```rust\nfn main() {}\n```\n```csv\na,b\n1,2\n```"
                     .into(),
                 model: None,
+                resources: Vec::new(),
             },
             ChatItem::Tool {
                 name: "python".into(),

--- a/ui/src/pet.rs
+++ b/ui/src/pet.rs
@@ -83,7 +83,8 @@ impl DesktopPetActivity {
             AgentEvent::MessageBoundary { .. }
             | AgentEvent::Usage { .. }
             | AgentEvent::Compaction { .. }
-            | AgentEvent::Diff { .. } => {}
+            | AgentEvent::Diff { .. }
+            | AgentEvent::Resources { .. } => {}
         }
     }
 

--- a/ui/src/styles/chat.css
+++ b/ui/src/styles/chat.css
@@ -322,6 +322,18 @@ details.rz[open] > summary::before { content: "\25BE  "; }
 details.rz .body { margin-top: 6px; }
 
 /* ---------- Rendered Markdown (assistant messages) ---------- */
+.md .resource-inline-image {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  margin: 12px 0;
+  border-radius: var(--radius-sm);
+}
+.md [data-resource-status="unresolved"] {
+  color: var(--err);
+  text-decoration-style: dotted;
+  cursor: help;
+}
 .md {
   font-family: var(--font-response);
   font-size: 15px;


### PR DESCRIPTION
## Problem

Markdown and ACP output can contain relative paths, Windows drive paths, `file://` URIs, percent-encoded paths, and Codex `<image path="...">` blocks. Passing these strings through Markdown and WebView URL parsing caused paths such as `/D:/...` to fail, made previews surface-dependent, and left Markdown chat previews with inconsistent scrolling.

## What changed

- Parse local resources once when a new assistant message is persisted.
- Validate references against the owning project root.
- Snapshot supported files into SHA-256 content-addressed project storage.
- Persist `message_resource_links` to immutable `ArtifactVersion` records.
- Read the exact bound version instead of an artifact's mutable latest version.
- Route Markdown/text resources to the scrollable center preview and image/PDF/table resources through the unified artifact preview policy.
- Support normal assistant output, Wisp `attempt_completion`, ACP final output, Windows paths, file URIs, encoded paths, unmatched terminal quotes, and ACP image blocks.
- Persist structured unresolved states instead of sending invalid raw paths through WebView navigation.
- Carry bindings and content-addressed snapshots through project export/import with portable project-relative storage paths.

## Scope boundary

This applies only to newly persisted messages. Existing messages are not scanned, migrated, backfilled, or reinterpreted.

## User impact

New local resource links no longer depend on runtime path guessing. A message continues to render the exact snapshotted file version even if the source file changes later or the project is exported and imported under a different Windows/macOS directory.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cd ui && cargo check --target wasm32-unknown-unknown`
- `cd ui-tests && npx playwright test` — 118 passed
- Focused export/import tests verify that `.wisp/artifacts/sha256/...` snapshots and immutable bindings survive cross-directory path restoration.
