### PR TITLE
fix(ui): 修复会话拖入文件夹失效 (#280) 与右侧多余主滚动条 (#279)

### DIFF
--- a/ui/src/sidebar.rs
+++ b/ui/src/sidebar.rs
@@ -154,19 +154,21 @@ pub(super) fn Sidebar(
                     if list.is_empty() && folder_list.is_empty() {
                         return view! { <div class="side-hint">{t(loc, "sidebar.no_sessions")}</div> }.into_view();
                     }
-                    let dragging = drag_session.get();
-                    let dragging_for_make = dragging.clone();
+                    // Whether any folder exists — used to keep the "ungrouped" drop
+                    // zone available (so a session can be dragged out of a folder) without
+                    // reading drag_session here, which would rebuild the whole list mid-drag.
+                    let has_folders = !folder_list.is_empty();
                     let make = move |s: &SessionInfo| {
                         let id = s.id.clone();
                         let id_active = id.clone();
                         let id_attr = id.clone();
                         let id_running = id.clone();
                         let id_drag = id.clone();
+                        let id_dragcls = id.clone();
                         let title = if s.title.trim().is_empty() { t(loc, "sidebar.untitled").into() } else { s.title.clone() };
                         let title_attr = title.clone();
                         let title_tooltip = title.clone();
                         let open = load_session.clone();
-                        let is_dragging = dragging_for_make.as_deref() == Some(id_drag.as_str());
                         let id_click = id.clone();
                         let id_key = id.clone();
                         let id_rename = id.clone();
@@ -180,7 +182,7 @@ pub(super) fn Sidebar(
                                     title=title_tooltip
                                     class:active=move || active_session.get().as_deref() == Some(id_active.as_str())
                                     class:running=move || running.get().contains(&id_running)
-                                    class:dragging=is_dragging
+                                    class:dragging=move || drag_session.get().as_deref() == Some(id_dragcls.as_str())
                                     attr:draggable="true"
                                     data-session-id=id_attr
                                     data-session-title=title_attr
@@ -226,7 +228,6 @@ pub(super) fn Sidebar(
                         .cloned()
                         .collect();
                     let (today, earlier) = bucket_sessions_by_date(&ungrouped);
-                    let target = drop_target.get();
                     let move_to = move_session_to.clone();
                     let folder_views = folder_list.into_iter().map(|f| {
                         let fid = f.id.clone();
@@ -245,7 +246,7 @@ pub(super) fn Sidebar(
                             .filter(|s| s.folder_id.as_deref() == Some(fid.as_str()))
                             .cloned()
                             .collect();
-                        let is_target = target.as_deref() == Some(fid_target.as_str());
+                        let fid_target_cls = fid_target.clone();
                         let fid_target_over_enter = fid_target_over.clone();
                         let fid_rename = fid.clone();
                         let fname_rename = fname.clone();
@@ -254,7 +255,7 @@ pub(super) fn Sidebar(
                         let show_folder_actions = open_folder_actions.clone();
                         view! {
                             <div class="side-folder-wrap"
-                                class:drop-target=is_target
+                                class:drop-target=move || drop_target.get().as_deref() == Some(fid_target_cls.as_str())
                                 data-folder-id=fid.clone()
                                 on:dragenter=move |ev: web_sys::DragEvent| {
                                     allow_drop(&ev);
@@ -315,12 +316,11 @@ pub(super) fn Sidebar(
                             </div>
                         }
                     }).collect_view();
-                    let ungrouped_target = target.as_deref() == Some("ungrouped");
                     view! {
                         {folder_views}
-                        {( !ungrouped.is_empty() || dragging.is_some() ).then(|| view! {
+                        {( !ungrouped.is_empty() || has_folders ).then(|| view! {
                             <div class="side-ungrouped"
-                                class:drop-target=ungrouped_target
+                                class:drop-target=move || drop_target.get().as_deref() == Some("ungrouped")
                                 on:dragenter=move |ev: web_sys::DragEvent| {
                                     allow_drop(&ev);
                                     if drop_target.get().as_deref() != Some("ungrouped") {

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -250,8 +250,13 @@ html, body {
   background: var(--bg-app); color: var(--text);
   -webkit-font-smoothing: antialiased; text-rendering: optimizeLegibility;
 }
+/* Fixed-viewport desktop shell: the title bar (when present) and .app split the
+   viewport via flex, so the window never grows a page-level scrollbar. Avoids the
+   brittle `100vh` + `:has()` arithmetic that left a ~38px master scrollbar on some
+   WebView2 builds (issue #279). overflow:hidden guarantees no page scroll. */
+body { display: flex; flex-direction: column; overflow: hidden; }
 
-.app { height: 100vh; display: flex; flex-direction: row; overflow: hidden; }
+.app { flex: 1 1 auto; min-height: 0; display: flex; flex-direction: row; overflow: hidden; }
 
 @keyframes motion-fade-in {
   from { opacity: 0; }
@@ -363,8 +368,6 @@ html, body {
 }
 .window-controls button:hover { background: color-mix(in srgb, var(--text) 8%, transparent); }
 .window-controls .window-close:hover { color: #fff; background: #c42b1c; }
-
-body:has(.window-titlebar) .app { height: calc(100vh - 38px); }
 
 @media (prefers-reduced-motion: reduce) {
   .app.app-entering .sidebar,


### PR DESCRIPTION
## 修复的问题

- Closes #280 — 会话无法拖动到会话文件夹
- Closes #279 — 0.14 右侧多出一个整窗"总滑块"

## #280 会话拖不进文件夹

**根因**:`ui/src/sidebar.rs` 里 `.side-list` 是单个响应式闭包,顶层读取了 `drag_session` 和 `drop_target`。拖拽时 `dragstart` / `dragenter` / `dragover` 会 `.set()` 这两个信号 → 整个会话列表 DOM 被重建 → 正在被拖拽的 `<button>` 节点被销毁 → 浏览器**中止原生 HTML5 拖拽**,`drop` 永不触发,所以会话永远拖不进文件夹。(右键菜单 "Move to folder" 走的是后端命令,不受影响,所以之前一直能用。)

**修复**:把 drag 状态下沉到各元素自己的 `class:` 闭包(与现有的 `class:active=move || ...` 同一模式):
- `class:dragging=move || drag_session.get()...`
- `class:drop-target=move || drop_target.get()...`

这样只更新单个 class 属性,不再重建列表,原生拖拽得以存活。"ungrouped" 落区的可见性改用 `has_folders`(非拖拽依赖)代替 `dragging.is_some()`,避免重新引入对 `drag_session` 的顶层读取。

## #279 右侧多余主滚动条

**根因**:外壳布局用 `.app { height: 100vh }` + `body:has(.window-titlebar) .app { height: calc(100vh - 38px) }` 来给 Windows 标题栏(38px)做补偿。当 WebView2 不支持 `:has()`(或分数 DPI 舍入)时,补偿失效 → 标题栏 38px + `.app` 100vh 超出视口 38px → 整窗出现主滚动条。

**修复**:改用 flex 外壳,不再依赖 `:has()` 算术:
- `body { display: flex; flex-direction: column; overflow: hidden }`
- `.app { flex: 1 1 auto; min-height: 0 }`

flex 精确分配视口高度,标题栏在/不在都填满;`overflow: hidden` 符合桌面应用本意(各面板/覆盖层各自内部滚动),彻底杜绝主滚动条。

## 验证(真实 trunk 构建 + 浏览器实测)

- **#280**:派发真实 `dragstart` 后会话节点存活(不再被重建)、拖到文件夹时 `.drop-target` 高亮、`drop` 正确触发 `move_session({id, folderId})`。
- **#279**:注入标题栏后 `scrollHeight - innerHeight = 0`(无主滚动条),`.app` 从 y=38 铺满到视口底部、侧栏底部对齐、无内容裁切;无标题栏(macOS)同样 overflow=0。
- `cargo check --target wasm32-unknown-unknown` 通过。

## Reviewer note

覆盖层(projects/library/settings)的 `top: 38px` 偏移仍使用 `body:has(.window-titlebar)`——那只影响定位、不会产生滚动条,本次未改。若确认目标 WebView2 完全不支持 `:has()`,可作为后续单独处理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)