### PR TITLE
Fix center pane minimum width

### DIFF
--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -55,10 +55,29 @@ const HOME_SEARCH_ARTIFACT_LIMIT: usize = 8;
 const HOME_SEARCH_SESSION_LIMIT: usize = 6;
 const TRANSCRIPT_RENDER_TURNS: usize = 40;
 const TRANSCRIPT_WINDOW_STEP: usize = 20;
+const CENTER_PANE_MIN_WIDTH: f64 = 360.0;
+const RIGHT_PANE_MIN_WIDTH: f64 = 320.0;
+const RIGHT_PANE_MAX_WIDTH: f64 = 900.0;
+const PANE_RESIZER_WIDTH: f64 = 5.0;
+const SIDEBAR_RESIZER_WIDTH: f64 = 10.0;
 const THEME_STORAGE_KEY: &str = "wisp-theme";
 /// Reserved `acp_config_menu_open` key for the session-mode dropdown, kept
 /// distinct from any agent-supplied config option id.
 const ACP_MODE_MENU: &str = "__acp_session_mode";
+
+fn max_right_pane_width(sidebar_open: bool, sidebar_width: f64) -> f64 {
+    let viewport_width = web_sys::window()
+        .and_then(|window| window.inner_width().ok())
+        .and_then(|width| width.as_f64())
+        .unwrap_or(RIGHT_PANE_MAX_WIDTH + CENTER_PANE_MIN_WIDTH + SIDEBAR_W_DEFAULT);
+    let sidebar_space = if sidebar_open {
+        sidebar_width + SIDEBAR_RESIZER_WIDTH
+    } else {
+        0.0
+    };
+    let available = viewport_width - sidebar_space - CENTER_PANE_MIN_WIDTH - PANE_RESIZER_WIDTH;
+    available.clamp(RIGHT_PANE_MIN_WIDTH, RIGHT_PANE_MAX_WIDTH)
+}
 
 #[derive(Default)]
 struct ProjectOpenGate {
@@ -3145,7 +3164,8 @@ fn App() -> impl IntoView {
     let on_resize_move = move |ev: web_sys::MouseEvent| {
         if dragging.get() {
             let dx = drag_start_x.get() - ev.client_x() as f64;
-            right_w.set((drag_start_w.get() + dx).clamp(320.0, 900.0));
+            let max_width = max_right_pane_width(show_sidebar.get(), sidebar_w.get());
+            right_w.set((drag_start_w.get() + dx).clamp(RIGHT_PANE_MIN_WIDTH, max_width));
         }
     };
 
@@ -5933,7 +5953,12 @@ fn App() -> impl IntoView {
             <button type="button" class="rightpane-backdrop"
                 aria-label=move || t(locale.get(), "right.close")
                 on:click=move |_| show_right.set(false)></button>
-            <section class="rightpane" style=move || format!("width:{}px", right_w.get())>
+            <section class="rightpane" style=move || {
+                let width = right_w
+                    .get()
+                    .min(max_right_pane_width(show_sidebar.get(), sidebar_w.get()));
+                format!("width:{width}px")
+            }>
                 <div class="rp-tabs">
                     {move || {
                         let loc = locale.get();

--- a/ui/src/styles/chat.css
+++ b/ui/src/styles/chat.css
@@ -1,6 +1,6 @@
 /* ---------- Center (conversation) ---------- */
 .center {
-  flex: 1 1 0; min-width: 0; display: flex; flex-direction: column;
+  flex: 1 1 0; min-width: min(360px, 100%); display: flex; flex-direction: column;
   background: var(--bg-app);
   container-type: inline-size;
   /* Scale with the center pane; cap keeps prose readable on ultra-wide layouts. */


### PR DESCRIPTION
## What changed
- add a minimum width guard to the center conversation pane so it cannot collapse into a near-zero column
- cap right-pane resizing based on the current viewport and sidebar width instead of only using a static max width
- clamp the rendered right-pane width with the same calculation so previously saved widths cannot squeeze the center pane on reopen

## Why
The environment view allowed the middle pane to be resized down until content wrapped one character per line. This happened because the center pane had no minimum width and the right pane drag logic only respected a fixed upper bound.

## Impact
Users can still resize the right pane, but the center workspace now keeps a usable minimum width and no longer collapses into a vertical text strip.

## Validation
- `cargo fmt --all -- --check`
- `cd ui && cargo check --target wasm32-unknown-unknown`
- `cargo test --workspace`
