### PR TITLE
Enforce single-instance desktop activation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4610,6 +4610,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3214becf9ef5783c0ae99a3bb25adf5353a7a16ebf53e74b909e29205735c6c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6370,6 +6386,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
+ "tauri-plugin-single-instance",
  "tokio",
  "tokio-tungstenite",
  "tracing",

--- a/docs/pet.md
+++ b/docs/pet.md
@@ -12,7 +12,7 @@ The pet folder must use `spriteVersionNumber: 2` and contain a `1536x2288` PNG o
 
 The app uses the standard animation rows for idle, directional walking, waving, jumping, failure, waiting for user input, active work, review, and 16-direction pointer tracking. Clicking an idle pet makes it wave. Reduced-motion system preferences disable roaming and animated playback.
 
-On Windows, the pet lives in its own transparent always-on-top window instead of inside the main workspace. Drag the pet to move it. Closing the main Wisp Science window hides the workspace to the system tray while the pet and active agent work continue; click the tray icon or choose **Open Wisp Science** to restore the workspace, and choose **Quit** to stop the app. The pet animation and status badge show when the agent is working, reviewing, waiting for approval, finished, or failed.
+On Windows, the pet lives in its own transparent always-on-top window instead of inside the main workspace. Drag the pet to move it. Closing the main Wisp Science window hides the workspace to the system tray while the pet and active agent work continue; click the tray icon, choose **Open Wisp Science**, or launch Wisp Science again to restore the existing workspace. Only one desktop app instance runs at a time. Choose **Quit** to stop the app. The pet animation and status badge show when the agent is working, reviewing, waiting for approval, finished, or failed.
 
 ## 配置宠物
 
@@ -20,4 +20,4 @@ Wisp Science 只加载一个由用户明确选择的 Codex v2 宠物，默认关
 
 打开 **设置 > 宠物**，选择包含 `pet.json` 和精灵表的安装目录，开启 **显示宠物** 后保存。目录必须使用 `spriteVersionNumber: 2`，精灵表必须是 `1536x2288` 的 PNG 或 WebP 文件。更换配置目录即可更换宠物；关闭开关后，应用不会再加载或显示该目录中的宠物。
 
-在 Windows 上，宠物运行在独立的透明置顶窗口中，而不是嵌在主工作区内，可以拖动到屏幕上的其他位置。关闭 Wisp Science 主窗口会把工作区隐藏到系统托盘，宠物和正在执行的 agent 任务会继续工作；点击托盘图标或选择 **Open Wisp Science** 可恢复窗口，选择 **Quit** 才会真正退出。宠物动画、状态点和文字会显示工作中、review、等待批准、完成或失败状态。
+在 Windows 上，宠物运行在独立的透明置顶窗口中，而不是嵌在主工作区内，可以拖动到屏幕上的其他位置。关闭 Wisp Science 主窗口会把工作区隐藏到系统托盘，宠物和正在执行的 agent 任务会继续工作；点击托盘图标、选择 **Open Wisp Science** 或再次启动 Wisp Science 都会恢复现有工作区。桌面应用全局只运行一个实例，选择 **Quit** 才会真正退出。宠物动画、状态点和文字会显示工作中、review、等待批准、完成或失败状态。

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,6 +16,7 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = ["devtools", "tray-icon"] }
 tauri-plugin-dialog = "2"
 tauri-plugin-opener = "2"
+tauri-plugin-single-instance = "2"
 serde = { workspace = true }
 serde_json = { workspace = true }
 semver = { workspace = true }

--- a/src-tauri/src/desktop_lifecycle.rs
+++ b/src-tauri/src/desktop_lifecycle.rs
@@ -2,8 +2,9 @@
 use tauri::{
     menu::{Menu, MenuItemBuilder},
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
-    App, AppHandle, Emitter, Manager, WebviewUrl, WebviewWindowBuilder,
+    App, Emitter, WebviewUrl, WebviewWindowBuilder,
 };
+use tauri::{AppHandle, Manager};
 
 #[cfg(target_os = "windows")]
 pub(crate) const PET_WINDOW_LABEL: &str = "pet";
@@ -13,10 +14,16 @@ pub(crate) fn should_hide_workspace_on_close(window_label: &str) -> bool {
     window_label == "main"
 }
 
-#[cfg(target_os = "windows")]
-fn show_workspace_windows(app: &AppHandle) {
+pub(crate) fn should_activate_workspace_window(window_label: &str) -> bool {
+    window_label != "pet"
+}
+
+pub(crate) fn activate_workspace(app: &AppHandle) {
+    #[cfg(target_os = "macos")]
+    let _ = app.show();
+
     for (label, window) in app.webview_windows() {
-        if label != PET_WINDOW_LABEL {
+        if should_activate_workspace_window(&label) {
             let _ = window.show();
             let _ = window.unminimize();
         }
@@ -121,7 +128,7 @@ pub(crate) fn install_windows_shell(app: &mut App) -> tauri::Result<()> {
         .tooltip("Wisp Science")
         .show_menu_on_left_click(false)
         .on_menu_event(|app, event| match event.id().as_ref() {
-            "tray-show" => show_workspace_windows(app),
+            "tray-show" => activate_workspace(app),
             "tray-quit" => app.exit(0),
             _ => {}
         })
@@ -137,7 +144,7 @@ pub(crate) fn install_windows_shell(app: &mut App) -> tauri::Result<()> {
                     ..
                 }
             ) {
-                show_workspace_windows(tray.app_handle());
+                activate_workspace(tray.app_handle());
             }
         });
     if let Some(icon) = app.default_window_icon() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6032,6 +6032,11 @@ pub fn run() {
     let macos_exit_for_setup = Arc::clone(&macos_exit_in_progress);
 
     tauri::Builder::default()
+        // Keep this first so a repeated launch is intercepted before other plugins
+        // and application state are initialized in a second process.
+        .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+            desktop_lifecycle::activate_workspace(app);
+        }))
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())
         .setup(move |app| {

--- a/src-tauri/src/lib_tests.rs
+++ b/src-tauri/src/lib_tests.rs
@@ -1,4 +1,4 @@
-use super::desktop_lifecycle::should_hide_workspace_on_close;
+use super::desktop_lifecycle::{should_activate_workspace_window, should_hide_workspace_on_close};
 use super::{
     branch_title, copy_dir_recursive, events_to_items, merge_pending_ui_event,
     message_uses_resource_bindings, messages_to_items, parse_disabled_skills,
@@ -870,4 +870,11 @@ fn windows_close_to_tray_applies_only_to_the_main_window() {
     assert!(should_hide_workspace_on_close("main"));
     assert!(!should_hide_workspace_on_close("proj-default"));
     assert!(!should_hide_workspace_on_close("pet"));
+}
+
+#[test]
+fn app_activation_restores_workspace_windows_but_not_the_pet() {
+    assert!(should_activate_workspace_window("main"));
+    assert!(should_activate_workspace_window("proj-default"));
+    assert!(!should_activate_workspace_window("pet"));
 }


### PR DESCRIPTION
## Problem

Launching Wisp Science again could initialize a second desktop process instead of returning the user to the workspace that was already running in the tray or hidden on macOS.

## Changes

- register Tauri's single-instance plugin before all other plugins so duplicate desktop launches are intercepted before app state initialization
- share one workspace activation path across duplicate launches and the Windows tray
- restore and unminimize workspace windows, focus the main window, and leave the independent pet window untouched
- show the hidden application before restoring windows on macOS
- document the single-instance and relaunch behavior in both English and Chinese
- add a regression test for which windows participate in activation

## User impact

Only one Wisp Science desktop app instance runs at a time. Launching it again restores and focuses the existing workspace instead of starting another copy. The standalone MCP bridge CLI remains outside the desktop lifecycle.

## Root cause

The tray restore behavior already existed on Windows, but startup had no process-level single-instance guard and that restore helper was Windows-only.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- focused regression: `cargo test -p wisp-tauri app_activation_restores_workspace_windows_but_not_the_pet`

## Manual smoke steps

1. Start the packaged desktop app.
2. Hide it to the Windows tray or minimize it.
3. Launch Wisp Science again from its shortcut.
4. Confirm the existing workspace is restored and focused, no second app instance remains, and the pet window is not forced open.
5. On macOS, hide the app and repeat the relaunch check.

## Known limitations / follow-up

Automated tests cover activation window selection but do not launch two packaged GUI processes. A packaged Windows/macOS smoke test is still recommended before release.