### PR TITLE
Fix docx modal scroll + clean up math option (#274)

### DIFF
--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -1010,6 +1010,7 @@ export function tauriMock(): void {
               { name: "sequences.fasta", is_dir: false, size: 256 },
               { name: "analysis.R", is_dir: false, size: 128 },
               { name: "analysis.unknown", is_dir: false, size: 128 },
+              { name: "manuscript.docx", is_dir: false, size: 11351 },
             ];
           case "list_remote_dir": {
             const path = String(arg("path") ?? "~");

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -1868,6 +1868,34 @@ test("DOCX artifacts render offline with headings, tables, and equations", async
   await expect(docx.locator("math").first()).toBeAttached();
   // The wrapping preview carries data-file-path so P2 selection/annotate works here too.
   await expect(page.locator('.rp-file-preview[data-file-path*="manuscript.docx"]')).toBeVisible();
+
+  // #274: a tall docx must be scrollable in the right pane (not trapped by a
+  // fixed-height .rp-docx). The .rp-view container owns the scroll.
+  const view = page.locator(".rp-view");
+  await docx.locator(".docx-wrapper").evaluate((el) => {
+    (el as HTMLElement).style.minHeight = "4000px";
+  });
+  await expect.poll(() => view.evaluate((el) => el.scrollHeight - el.clientHeight)).toBeGreaterThan(100);
+  await view.evaluate((el) => { el.scrollTop = 500; });
+  await expect.poll(() => view.evaluate((el) => el.scrollTop)).toBeGreaterThan(0);
+});
+
+test("DOCX opened from the Files browser scrolls inside the modal (#274)", async ({ page }) => {
+  await enterApp(page);
+  // Files browser → docx opens in the artifact modal (like the tester's flow).
+  await page.getByRole("button", { name: "Files" }).click();
+  await page.locator('.fb-row[data-workspace-path*="manuscript.docx"]').click();
+
+  const docx = page.locator(".artifact-modal .rp-docx");
+  await expect(docx.locator(".docx-wrapper section.docx").first()).toBeVisible();
+  // A tall document must scroll inside .rp-docx — the modal figure clips, so the
+  // bounded height has to reach .rp-docx (the #274 "can't scroll down" bug).
+  await docx.locator(".docx-wrapper").evaluate((el) => {
+    (el as HTMLElement).style.minHeight = "4000px";
+  });
+  await expect.poll(() => docx.evaluate((el) => el.scrollHeight - el.clientHeight)).toBeGreaterThan(100);
+  await docx.evaluate((el) => { el.scrollTop = 800; });
+  await expect.poll(() => docx.evaluate((el) => el.scrollTop)).toBeGreaterThan(0);
 });
 
 test("Markdown center preview can be edited in place and saved", async ({ page }) => {

--- a/ui/src/api.js
+++ b/ui/src/api.js
@@ -309,8 +309,11 @@ async function renderDocx(el, payload) {
     const container = document.createElement("div");
     container.className = "rp-docx";
     el.replaceChildren(container);
-    // renderAsync takes a Blob/ArrayBuffer; ignoreWidth/Height lets the page
-    // reflow to the preview column instead of a fixed A4 canvas width.
+    // renderAsync takes a Blob/ArrayBuffer; ignoreHeight lets the page reflow to
+    // the preview column instead of a fixed A4 height. `experimental` enables
+    // docx-preview's fuller feature set (incl. its OMML→MathML math rendering).
+    // OMML support covers standard Word math; WPS's OMML dialect is only
+    // partially handled upstream, so some WPS formulas can still garble (#274).
     await lib.renderAsync(base64Bytes(payload.b64).buffer, container, null, {
       className: "docx",
       inWrapper: true,
@@ -318,7 +321,6 @@ async function renderDocx(el, payload) {
       ignoreHeight: true,
       breakPages: true,
       experimental: true,
-      useMathMLPolyfill: true,
     });
     if (el.__wispPreviewToken !== renderToken) return;
     el.__wispPreviewCleanup = () => { container.replaceChildren(); };

--- a/ui/src/styles/chat.css
+++ b/ui/src/styles/chat.css
@@ -38,7 +38,7 @@
 .center-file-preview[data-preview-kind="structure"] .rp-3dmol { flex: 1 1 auto; min-height: 0; height: auto; }
 .center-file-preview[data-preview-kind="fasta"] .rp-fasta-wrap { flex: 1 1 auto; min-height: 0; max-height: none; }
 .center-file-preview[data-preview-kind="docx"] { padding: 0; }
-.center-file-preview[data-preview-kind="docx"] .rp-docx { flex: 1 1 auto; min-height: 0; }
+.center-file-preview[data-preview-kind="docx"] .rp-docx { flex: 1 1 auto; min-height: 0; overflow: auto; }
 @keyframes center-tab-content-in {
   from { opacity: 0; transform: translate3d(0, var(--motion-distance-sm), 0); }
   to { opacity: 1; transform: none; }

--- a/ui/src/styles/modals.css
+++ b/ui/src/styles/modals.css
@@ -225,9 +225,13 @@ textarea.host-input { min-height:64px; resize:vertical; }
 }
 /* Image/PDF pan inside their own zoom viewport, so the figure box must clip, not scroll. */
 .artifact-modal .am-figure.zoomable-preview { height: 52vh; overflow: hidden; }
-/* DOCX renders a tall document that scrolls inside its own .rp-docx surface. */
-.artifact-modal .am-figure.docx-preview { height: 66vh; max-height: 66vh; overflow: hidden; padding: 0; }
-.artifact-modal .am-figure.docx-preview .rp-docx { height: 100%; }
+/* DOCX renders a tall document that scrolls inside its own .rp-docx surface.
+   The mount div (.rp-heavy) must be a flex-column filler so the bounded height
+   reaches .rp-docx — otherwise its auto height breaks the chain and the figure
+   just clips the overflow (#274). Mirrors the center-preview treatment. */
+.artifact-modal .am-figure.docx-preview { height: 66vh; max-height: 66vh; overflow: hidden; padding: 0; flex-direction: column; }
+.artifact-modal .am-figure.docx-preview > .rp-heavy { display: flex; flex: 1 1 auto; min-height: 0; flex-direction: column; }
+.artifact-modal .am-figure.docx-preview .rp-docx { flex: 1 1 auto; min-height: 0; overflow: auto; }
 .artifact-modal.html-preview .am-figure { overflow: auto; }
 .artifact-modal .am-figure > * { flex: 1 1 auto; min-width: 0; min-height: 0; }
 .artifact-modal .am-figure img,

--- a/ui/src/styles/right-pane.css
+++ b/ui/src/styles/right-pane.css
@@ -353,7 +353,10 @@
 .rp-pdf-loading, .rp-pdf-error { display: flex; min-height: 120px; align-items: center; justify-content: center; padding: 16px; text-align: center; }
 /* docx-preview renders its own `.docx-wrapper` of white A4 "pages"; give it a
    scroll surface and neutral gutter. Always light "paper" for print fidelity. */
-.rp-docx { width: 100%; height: 100%; overflow: auto; background: var(--bg-sunken); }
+/* Base: flow at natural height so the right-pane preview scrolls via its own
+   .rp-view container (a fixed height here traps the scroll — #274). The modal
+   and center variants below re-bound it for internal scrolling. */
+.rp-docx { width: 100%; overflow: visible; background: var(--bg-sunken); }
 .rp-docx .docx-wrapper { background: transparent; padding: 16px 0; display: flex; flex-direction: column; align-items: center; gap: 16px; }
 .rp-docx .docx-wrapper > section.docx { box-shadow: 0 1px 6px rgba(0, 0, 0, .2); margin: 0 !important; }
 .rp-docx-loading { display: flex; min-height: 120px; align-items: center; justify-content: center; padding: 16px; text-align: center; }


### PR DESCRIPTION
Addresses the #274 feedback (Phase 0 — the concrete bug fixes; the larger "side panel becomes the primary agent" design is tracked separately).

## Fixes

**docx can't scroll when opened from the Files browser** — a docx from the Files browser routes to the artifact modal, whose figure clips at 66vh. A tall document couldn't scroll: the `.rp-heavy` mount div has an auto height, so `.rp-docx { height: 100% }` resolved to *content* height and broke the bounded-height chain, then the figure's `overflow: hidden` clipped it (measured: `.rp-docx` grew to 4000px while the figure stayed 456px, scrollable = 0). Fix mirrors the center-preview treatment that already worked ("全屏" scrolled): make the mount div a flex-column filler so the bounded height reaches `.rp-docx`, which then scrolls internally (now: `.rp-docx` bounded to 456px, scrollable 3544). The right-pane inline preview now flows at natural height and scrolls via its own `.rp-view`.

**Ineffective math option removed** — `useMathMLPolyfill` is not a real docx-preview 0.4.0 option (not in `defaultOptions`, silently ignored). Removed it. Standard Word OMML renders as MathML (verified on a pandoc-built manuscript); **WPS's OMML dialect is only partially handled upstream**, so some WPS formulas can still garble — documented in-code. There is no newer docx-preview with better WPS coverage (0.4.0 is latest).

## Testing

- New Playwright spec: open a docx from the Files browser → assert the modal scrolls a tall document.
- Existing docx spec: assert the right-pane inline preview scrolls a tall document.
- Full suite: **136 passed**.

## Note for the reporter

The scroll fix covers the modal + right-pane + center surfaces. For the formula garbling: standard Word `.docx` should render correctly; the WPS OMML cases are an upstream docx-preview limitation. A Word-authored sample (as you planned) will confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)