### PR TITLE
fix(ui): preserve model editor selections after save

### DIFF
--- a/src-tauri/src/file_browser.rs
+++ b/src-tauri/src/file_browser.rs
@@ -84,9 +84,7 @@ pub(super) fn mime_for_path(path: &Path) -> &'static str {
         Some("webp") => "image/webp",
         Some("svg") => "image/svg+xml",
         Some("pdf") => "application/pdf",
-        Some("docx") => {
-            "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-        }
+        Some("docx") => "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
         Some("csv") => "text/csv",
         Some("tsv") => "text/tab-separated-values",
         Some("html" | "htm") => "text/html",
@@ -724,8 +722,13 @@ mod tests {
         assert!(body.contains("— manuscript.docx"));
 
         // A second note with a comment appends without re-adding the heading.
-        append_review_note_at(&base, "paper/manuscript.docx", "another passage", Some("fix wording"))
-            .unwrap();
+        append_review_note_at(
+            &base,
+            "paper/manuscript.docx",
+            "another passage",
+            Some("fix wording"),
+        )
+        .unwrap();
         let body = std::fs::read_to_string(base.join(&rel)).unwrap();
         assert_eq!(body.matches("# Review notes").count(), 1);
         assert!(body.contains("> another passage"));

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -31,8 +31,8 @@ pub struct ModelProfile {
     #[serde(default)]
     pub supports_vision: bool,
     /// Computed on read / accepted on save; true when this profile is assigned
-    /// to image analysis. Not persisted inside the profile list.
-    #[serde(default, skip_serializing)]
+    /// to image analysis. Serialized so the UI can restore the checkbox.
+    #[serde(default)]
     pub use_for_vision: bool,
 }
 
@@ -646,13 +646,18 @@ mod tests {
         assert!(m1.supports_vision, "capability lost in persistence");
         assert!(m1.use_for_vision, "vision assignment lost after reload");
         assert!(!out.iter().find(|p| p.id == "m0").unwrap().use_for_vision);
+        let json = serde_json::to_value(out).unwrap();
+        assert_eq!(
+            json[1]["use_for_vision"], true,
+            "IPC response lost vision assignment"
+        );
         let _ = std::fs::remove_file(&tmp);
     }
 
     #[test]
     fn use_for_vision_survives_deserialization() {
-        // repro for the "checkbox lost after save" report: does the incoming
-        // command payload keep use_for_vision despite skip_serializing?
+        // Repro for the "checkbox lost after save" report: the incoming
+        // command payload must keep use_for_vision.
         let p: ModelProfile = serde_json::from_str(
             r#"{"id":"m1","label":"l","provider":"anthropic","api_url":"u","model":"m",
                 "max_tokens":8192,"reasoning_effort":"medium",
@@ -671,13 +676,13 @@ mod tests {
     }
 
     #[test]
-    fn vision_assignment_marker_is_not_persisted() {
+    fn vision_assignment_marker_is_serialized_for_ui() {
         let mut profile = test_profile("m1", "vision", "v");
         profile.supports_vision = true;
         profile.use_for_vision = true;
         let json = serde_json::to_string(&profile).unwrap();
         assert!(json.contains("supports_vision"));
-        assert!(!json.contains("use_for_vision"));
+        assert!(json.contains("\"use_for_vision\":true"));
     }
 
     #[test]

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -2039,8 +2039,10 @@ test("vision assignment keeps model fields and stored key placeholder untouched"
   const key = page.getByLabel("API key (stored in OS keyring)");
   const useForVision = page.getByLabel("Use for image analysis");
 
-  await expect(providerSelect(page)).toHaveValue("openai");
-  await expect(effort).toHaveValue("default");
+  await providerSelect(page).selectOption("openai_responses");
+  await page.getByLabel("API URL").fill("https://api.openai-proxy.org/v1");
+  await page.getByLabel("Model").fill("gpt-5.6-luna");
+  await effort.selectOption("medium");
   await expect(key).toHaveValue("");
   await expect(key).toHaveAttribute("placeholder", "(stored — leave blank to keep)");
 
@@ -2049,8 +2051,8 @@ test("vision assignment keeps model fields and stored key placeholder untouched"
   }
   await useForVision.check();
 
-  await expect(providerSelect(page)).toHaveValue("openai");
-  await expect(effort).toHaveValue("default");
+  await expect(providerSelect(page)).toHaveValue("openai_responses");
+  await expect(effort).toHaveValue("medium");
   await expect(key).toHaveValue("");
 
   await page.getByRole("button", { name: "Save" }).click();
@@ -2068,13 +2070,15 @@ test("vision assignment keeps model fields and stored key placeholder untouched"
     key: null,
     useForVision: true,
     profile: {
-      provider: "openai",
-      reasoning_effort: "",
+      provider: "openai_responses",
+      reasoning_effort: "medium",
       use_for_vision: true,
     },
   });
 
   await page.locator(".settings-list-row").first().click();
+  await expect(providerSelect(page)).toHaveValue("openai_responses");
+  await expect(effort).toHaveValue("medium");
   await expect(page.getByLabel("Use for image analysis")).toBeChecked();
 });
 

--- a/ui/src/settings_view.rs
+++ b/ui/src/settings_view.rs
@@ -824,10 +824,19 @@ pub(super) fn SettingsView(
                                                         o.model = model.into();
                                                     });
                                                 }
-                                                prop:value=move || model_form.get().map(|f| settings_provider_value(&f.provider).to_string()).unwrap_or_else(|| "openai".into())>
-                                                <option value="openai">{move || t(locale.get(), "settings.provider.openai")}</option>
-                                                <option value="openai_responses">{move || t(locale.get(), "settings.provider.openai_responses")}</option>
-                                                <option value="anthropic">{move || t(locale.get(), "settings.provider.anthropic")}</option>
+                                                >
+                                                <option value="openai"
+                                                    prop:selected=move || model_form.get().is_some_and(|f| settings_provider_value(&f.provider) == "openai")>
+                                                    {move || t(locale.get(), "settings.provider.openai")}
+                                                </option>
+                                                <option value="openai_responses"
+                                                    prop:selected=move || model_form.get().is_some_and(|f| settings_provider_value(&f.provider) == "openai_responses")>
+                                                    {move || t(locale.get(), "settings.provider.openai_responses")}
+                                                </option>
+                                                <option value="anthropic"
+                                                    prop:selected=move || model_form.get().is_some_and(|f| settings_provider_value(&f.provider) == "anthropic")>
+                                                    {move || t(locale.get(), "settings.provider.anthropic")}
+                                                </option>
                                             </select>
                                         </label>
                                         <label class="span-2">{move || t(locale.get(), "settings.api_url")}
@@ -854,19 +863,19 @@ pub(super) fn SettingsView(
                                                     let v = dom_value(&ev);
                                                     o.reasoning_effort = if v == "default" { String::new() } else { v };
                                                 })
-                                                prop:value=move || {
-                                                    let v = model_form.get().map(|f| f.reasoning_effort).unwrap_or_default();
-                                                    if v.is_empty() { "default".to_string() } else { v }
-                                                }>
-                                                <option value="default">{move || t(locale.get(), "settings.reasoning_effort.default")}</option>
-                                                <option value="none">"none"</option>
-                                                <option value="minimal">"minimal"</option>
-                                                <option value="low">"low"</option>
-                                                <option value="medium">"medium"</option>
-                                                <option value="high">"high"</option>
-                                                <option value="xhigh">"xhigh"</option>
-                                                <option value="max">"max"</option>
-                                                <option value="ultra">"ultra"</option>
+                                                >
+                                                <option value="default"
+                                                    prop:selected=move || model_form.get().is_some_and(|f| f.reasoning_effort.is_empty())>
+                                                    {move || t(locale.get(), "settings.reasoning_effort.default")}
+                                                </option>
+                                                <option value="none" prop:selected=move || model_form.get().is_some_and(|f| f.reasoning_effort == "none")>"none"</option>
+                                                <option value="minimal" prop:selected=move || model_form.get().is_some_and(|f| f.reasoning_effort == "minimal")>"minimal"</option>
+                                                <option value="low" prop:selected=move || model_form.get().is_some_and(|f| f.reasoning_effort == "low")>"low"</option>
+                                                <option value="medium" prop:selected=move || model_form.get().is_some_and(|f| f.reasoning_effort == "medium")>"medium"</option>
+                                                <option value="high" prop:selected=move || model_form.get().is_some_and(|f| f.reasoning_effort == "high")>"high"</option>
+                                                <option value="xhigh" prop:selected=move || model_form.get().is_some_and(|f| f.reasoning_effort == "xhigh")>"xhigh"</option>
+                                                <option value="max" prop:selected=move || model_form.get().is_some_and(|f| f.reasoning_effort == "max")>"max"</option>
+                                                <option value="ultra" prop:selected=move || model_form.get().is_some_and(|f| f.reasoning_effort == "ultra")>"ultra"</option>
                                             </select>
                                         </label>
                                         <div class="span-2 settings-form-grid">


### PR DESCRIPTION
## Problem

Saving an OpenAI Responses model for image analysis and reopening the editor showed OpenAI-compatible instead, reset non-default reasoning effort, and cleared the image-analysis checkbox.

## Changes

- Restore provider and reasoning-effort selects through explicit option selection when the conditional editor mounts.
- Serialize the computed `use_for_vision` value back to the UI so the checkbox survives save and reopen.
- Extend the model round-trip and Playwright regression coverage for OpenAI Responses, reasoning effort, and vision assignment.
- Keep the repository rustfmt drift in a separate formatting-only commit.

## Tests

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cd ui && cargo check --target wasm32-unknown-unknown`
- `cd ui-tests && npm ci && npx playwright test` — 135 passed

## Manual smoke

1. Edit an API model and choose OpenAI Responses.
2. Select a non-default reasoning effort and enable image analysis.
3. Save, reopen the same model, and confirm all three values remain selected.

## Known limitations / follow-ups

None. Existing stored model profiles remain compatible and require no migration.