### PR TITLE
fix(ui): make PDF preview zoom effective

### DIFF
--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -1852,6 +1852,24 @@ test("PDF artifacts render inside the app without a browser PDF plugin", async (
   await expect.poll(() => canvas.evaluate(
     (el: HTMLCanvasElement) => el.width * el.height,
   )).toBeGreaterThan(0);
+  const pageWidthAt100 = await renderedPage.evaluate((el) => el.getBoundingClientRect().width);
+  const textSpan = renderedPage.locator(".rp-pdf-textlayer span").first();
+  const textWidthAt100 = await textSpan.evaluate((el) => el.getBoundingClientRect().width);
+  await page.getByRole("button", { name: "Zoom in" }).click();
+  await page.getByRole("button", { name: "Zoom in" }).click();
+  await expect(page.getByRole("button", { name: "Reset zoom" })).toHaveText("150%");
+  await expect.poll(() => renderedPage.evaluate((el) => el.getBoundingClientRect().width))
+    .toBeGreaterThan(pageWidthAt100 * 1.4);
+  await expect.poll(() => textSpan.evaluate((el) => el.getBoundingClientRect().width))
+    .toBeGreaterThan(textWidthAt100 * 1.4);
+  await page.getByRole("button", { name: "Reset zoom" }).click();
+  await page.getByRole("button", { name: "Zoom out" }).click();
+  await page.getByRole("button", { name: "Zoom out" }).click();
+  await expect(page.getByRole("button", { name: "Reset zoom" })).toHaveText("50%");
+  await expect.poll(() => renderedPage.evaluate((el) => el.getBoundingClientRect().width))
+    .toBeLessThan(pageWidthAt100 * 0.6);
+  await expect.poll(() => textSpan.evaluate((el) => el.getBoundingClientRect().width))
+    .toBeLessThan(textWidthAt100 * 0.6);
   await expect(page.getByRole("button", { name: "Previous page" })).toBeDisabled();
   await expect(page.getByRole("button", { name: "Next page" }).locator("svg")).toBeVisible();
   await expect(modal.locator('embed[type="application/pdf"]')).toHaveCount(0);
@@ -1870,10 +1888,19 @@ test("PDF artifacts switch pages with toolbar buttons, arrow keys, and Page Up/D
   await expect(modal.locator('.rp-pdf[data-current-page="1"]')).toBeVisible();
   await expect(modal.locator('.rp-pdf-page[data-page="1"][data-rendered="true"]')).toBeVisible();
 
+  await page.getByRole("button", { name: "Zoom in" }).click();
+  await page.getByRole("button", { name: "Zoom in" }).click();
+  await expect(page.getByRole("button", { name: "Reset zoom" })).toHaveText("150%");
+
   // Toolbar button steps forward.
   await page.getByRole("button", { name: "Next page" }).click();
   await expect(modal.locator('.rp-pdf[data-current-page="2"]')).toBeVisible();
-  await expect(modal.locator('.rp-pdf-page[data-page="2"][data-rendered="true"]')).toBeVisible();
+  const secondPage = modal.locator('.rp-pdf-page[data-page="2"][data-rendered="true"]');
+  await expect(secondPage).toBeVisible();
+  await expect.poll(() => secondPage.evaluate((el) => Math.abs(
+    el.getBoundingClientRect().width
+      - el.querySelector(".rp-pdf-textlayer")!.getBoundingClientRect().width,
+  ))).toBeLessThan(2);
   await expect(page.getByRole("button", { name: "Next page" })).toBeDisabled();
 
   // Page Up steps back. Wait for the page to finish rendering (rendered="true")

--- a/ui/src/api.js
+++ b/ui/src/api.js
@@ -523,6 +523,9 @@ async function renderPdf(el, payload) {
     );
     nextButton.innerHTML = pdfNavIcon(1);
 
+    // The zoom viewport owns pointer drags for panning; do not let it swallow
+    // clicks on the page navigation controls once the preview is zoomed in.
+    nav.addEventListener("pointerdown", (event) => event.stopPropagation());
     nav.append(prevButton, pageIndicator, nextButton);
     toolbar.appendChild(nav);
 
@@ -570,9 +573,11 @@ async function renderPdf(el, payload) {
         const wrapper = document.createElement("div");
         wrapper.className = "rp-pdf-page";
         wrapper.dataset.page = String(pageNumber);
-        // Cap the displayed width to availableWidth so the canvas renders at
-        // exactly cssScale — the text layer below is positioned at that scale.
-        wrapper.style.maxWidth = `${Math.floor(availableWidth)}px`;
+        // Keep the initial fit-to-width cap, but let the shared preview zoom
+        // scale it. A fixed max-width made the toolbar percentage change while
+        // PDF pages stayed at their original size.
+        wrapper.style.maxWidth =
+          `calc(${Math.floor(availableWidth)}px * var(--preview-zoom, 1))`;
         wrapper.setAttribute(
           "aria-label",
           pdfPageLabel(payload.pageLabel, pageNumber, pdf.numPages),
@@ -602,6 +607,10 @@ async function renderPdf(el, payload) {
           const textLayerDiv = document.createElement("div");
           textLayerDiv.className = "rp-pdf-textlayer textLayer";
           textLayerDiv.style.setProperty("--scale-factor", String(cssScale));
+          textLayerDiv.style.setProperty(
+            "--total-scale-factor",
+            `calc(${cssScale} * var(--preview-zoom, 1))`,
+          );
           const textLayer = new lib.TextLayer({
             textContentSource: page.streamTextContent(),
             container: textLayerDiv,

--- a/ui/src/channels_view.rs
+++ b/ui/src/channels_view.rs
@@ -108,8 +108,7 @@ pub(super) fn ChannelsPane(
         msg.set(None);
         spawn_local(async move {
             if let Some(flow_id) = previous_flow_id {
-                let cancel_arg =
-                    to_value(&serde_json::json!({ "flowId": flow_id })).unwrap();
+                let cancel_arg = to_value(&serde_json::json!({ "flowId": flow_id })).unwrap();
                 let _ = invoke_checked("feishu_bind_cancel", cancel_arg).await;
             }
             let arg = to_value(&serde_json::json!({
@@ -339,14 +338,19 @@ pub(super) fn ChannelsPane(
         });
     });
 
-    let msg_view = move || {
-        msg.get().map(|(ok, text)| view! {
+    let msg_view =
+        move || {
+            msg.get().map(|(ok, text)| view! {
             <div class="settings-status" class:ok=move || ok class:fail=move || !ok>{text}</div>
         })
-    };
+        };
     let feishu_badge = move || {
         let s = status.get().unwrap_or_default();
-        let state = if s.feishu_bound { s.feishu_state.clone() } else { "stopped".into() };
+        let state = if s.feishu_bound {
+            s.feishu_state.clone()
+        } else {
+            "stopped".into()
+        };
         view! {
             <span class=format!("badge channel-state-{}", state_tone(&state)) data-testid="feishu-state">
                 {if s.feishu_bound {
@@ -359,7 +363,11 @@ pub(super) fn ChannelsPane(
     };
     let weixin_badge = move || {
         let s = status.get().unwrap_or_default();
-        let state = if s.weixin_bound { s.weixin_state.clone() } else { "stopped".into() };
+        let state = if s.weixin_bound {
+            s.weixin_state.clone()
+        } else {
+            "stopped".into()
+        };
         view! {
             <span class=format!("badge channel-state-{}", state_tone(&state)) data-testid="weixin-state">
                 {if s.weixin_bound {
@@ -383,7 +391,8 @@ pub(super) fn ChannelsPane(
         )
     };
 
-    move || match open.get().as_deref() {
+    move || {
+        match open.get().as_deref() {
         Some("feishu") => view! {
             <div class="settings-pane settings-pane-subpage" data-testid="feishu-channel-card">
                 {msg_view}
@@ -655,5 +664,6 @@ pub(super) fn ChannelsPane(
                 </div>
             </div>
         }.into_view(),
+    }
     }
 }


### PR DESCRIPTION
## Problem

The PDF zoom percentage changed, but the rendered page stayed at its initial width because PDF.js applied a fixed `max-width`. At zoom levels above 100%, the shared pan handler also intercepted PDF page-navigation pointer events.

## Changes

- scale the PDF page width cap with the shared preview zoom variable
- keep the PDF.js selectable text layer aligned with the canvas at every zoom level
- keep page navigation clickable while zoomed and pannable
- add Playwright coverage for 150% zoom, 50% zoom, text-layer alignment, and page navigation while zoomed
- apply pre-existing UI rustfmt drift in a separate formatting-only commit

## Verification

- `cargo fmt --all -- --check`
- `cd ui && cargo fmt --all -- --check`
- `cd ui && cargo check --target wasm32-unknown-unknown`
- `cargo test --workspace`
- `cd ui-tests && npm ci && npx playwright test` — 141 passed

## Manual smoke steps

1. Open a multi-page PDF in the artifact modal or center preview.
2. Use minus, reset, plus, and the mouse wheel; confirm both the page and selectable text layer resize.
3. At a zoom above 100%, click previous and next, then drag the viewport to pan.

## Known limitations

- Zoom reuses the current rendered canvas rather than re-rendering PDF raster content on every step, so extreme zoom does not add raster detail.
- No follow-up is required for the reported behavior.