### PR TITLE
fix(ui): dismiss composer picker before right pane

### DIFF
--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -2986,7 +2986,7 @@ test("project cards use semantic buttons for keyboard access", async ({ page }) 
   await expect(project.evaluate((el) => el.tagName)).resolves.toBe("BUTTON");
 });
 
-test("Escape closes settings on the projects landing and the right pane from the composer", async ({ page }) => {
+test("Escape closes settings and unwinds the composer picker before the right pane", async ({ page }) => {
   await page.goto("/");
   await page.getByRole("button", { name: "Settings" }).click();
   await expect(page.locator(".settings-page")).toBeVisible();
@@ -2996,7 +2996,11 @@ test("Escape closes settings on the projects landing and the right pane from the
   await enterApp(page);
   await page.getByRole("button", { name: "Toggle panel" }).click();
   await expect(page.locator(".rightpane")).toBeVisible();
-  await composer(page).focus();
+  await composer(page).fill("@");
+  await expect(page.locator(".mention-menu")).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(page.locator(".mention-menu")).toHaveCount(0);
+  await expect(page.locator(".rightpane")).toBeVisible();
   await page.keyboard.press("Escape");
   await expect(page.locator(".rightpane")).toHaveCount(0);
 });

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -5397,7 +5397,7 @@ fn App() -> impl IntoView {
                                 }
                                 input.set(v);
                             }
-                            on:keydown=on_send
+                            on:keydown:undelegated=on_send
                             on:paste=on_paste
                             prop:placeholder=move || tf(
                                 locale.get(),


### PR DESCRIPTION
## Problem

When the composer @ picker and right pane are both open, pressing Escape closes the right pane as well as the picker. The delegated composer keydown handler runs after the global window Escape listener.

## Changes

- Bind the composer keydown handler directly to the textarea so picker handling runs before the global Escape stack.
- Extend the Playwright regression test to verify that the first Escape closes only the picker and the second closes the right pane.
- No new abstractions or dependencies.

## Verification

- cargo fmt --all -- --check
- cargo fmt --all --manifest-path ui/Cargo.toml -- --check
- cargo test --workspace
- cd ui && cargo check --target wasm32-unknown-unknown
- cd ui-tests && npm ci
- cd ui-tests && npx playwright test (141 passed)

## Manual smoke

1. Open a project and the right pane.
2. Focus the composer and type @ to open the artifact picker.
3. Press Escape and confirm the picker closes while the right pane stays open.
4. Press Escape again and confirm the right pane closes.

## Known limitations / follow-up

None.