### PR TITLE
feat(pet): open sessions that need attention

### DIFF
--- a/docs/pet.md
+++ b/docs/pet.md
@@ -12,7 +12,7 @@ The pet folder must use `spriteVersionNumber: 2` and contain a `1536x2288` PNG o
 
 The app uses the standard animation rows for idle, directional walking, waving, jumping, failure, waiting for user input, active work, review, and 16-direction pointer tracking. Clicking an idle pet makes it wave. Reduced-motion system preferences disable roaming and animated playback.
 
-On Windows, the pet lives in its own transparent always-on-top window instead of inside the main workspace. Drag the pet to move it. Closing the main Wisp Science window hides the workspace to the system tray while the pet and active agent work continue; click the tray icon, choose **Open Wisp Science**, or launch Wisp Science again to restore the existing workspace. Only one desktop app instance runs at a time. Choose **Quit** to stop the app. The pet animation and status badge show when the agent is working, reviewing, waiting for approval, finished, or failed.
+On Windows, the pet lives in its own transparent always-on-top window instead of inside the main workspace. Drag the pet to move it. When it shows **Needs you**, click it to restore the workspace and open the session waiting for input. Closing the main Wisp Science window hides the workspace to the system tray while the pet and active agent work continue; click the tray icon, choose **Open Wisp Science**, or launch Wisp Science again to restore the existing workspace. Only one desktop app instance runs at a time. Choose **Quit** to stop the app. The pet animation and status badge show when the agent is working, reviewing, waiting for approval, finished, or failed.
 
 ## 配置宠物
 
@@ -20,4 +20,4 @@ Wisp Science 只加载一个由用户明确选择的 Codex v2 宠物，默认关
 
 打开 **设置 > 宠物**，选择包含 `pet.json` 和精灵表的安装目录，开启 **显示宠物** 后保存。目录必须使用 `spriteVersionNumber: 2`，精灵表必须是 `1536x2288` 的 PNG 或 WebP 文件。更换配置目录即可更换宠物；关闭开关后，应用不会再加载或显示该目录中的宠物。
 
-在 Windows 上，宠物运行在独立的透明置顶窗口中，而不是嵌在主工作区内，可以拖动到屏幕上的其他位置。关闭 Wisp Science 主窗口会把工作区隐藏到系统托盘，宠物和正在执行的 agent 任务会继续工作；点击托盘图标、选择 **Open Wisp Science** 或再次启动 Wisp Science 都会恢复现有工作区。桌面应用全局只运行一个实例，选择 **Quit** 才会真正退出。宠物动画、状态点和文字会显示工作中、review、等待批准、完成或失败状态。
+在 Windows 上，宠物运行在独立的透明置顶窗口中，而不是嵌在主工作区内，可以拖动到屏幕上的其他位置。显示 **Needs you** 时，点击宠物会恢复工作区并打开正在等待操作的 session。关闭 Wisp Science 主窗口会把工作区隐藏到系统托盘，宠物和正在执行的 agent 任务会继续工作；点击托盘图标、选择 **Open Wisp Science** 或再次启动 Wisp Science 都会恢复现有工作区。桌面应用全局只运行一个实例，选择 **Quit** 才会真正退出。宠物动画、状态点和文字会显示工作中、review、等待批准、完成或失败状态。

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6356,6 +6356,7 @@ pub fn run() {
             settings_commands::set_credential,
             pet_commands::get_pet,
             pet_commands::get_pet_runtime_status,
+            pet_commands::open_pet_session,
             desktop_lifecycle::set_pet_window_visible,
             models::list_models,
             models::save_model,

--- a/src-tauri/src/pet_commands.rs
+++ b/src-tauri/src/pet_commands.rs
@@ -1,8 +1,8 @@
-use super::AppState;
+use super::{desktop_lifecycle, AppState};
 use base64::{engine::general_purpose::STANDARD, Engine as _};
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, fs, path::Path};
-use tauri::State;
+use tauri::{Emitter, State};
 
 const MAX_SPRITESHEET_BYTES: u64 = 16 * 1024 * 1024;
 const SPRITE_WIDTH: u32 = 1536;
@@ -291,6 +291,27 @@ pub(super) async fn get_pet_runtime_status(
         waiting,
         reviewing,
     })
+}
+
+#[tauri::command]
+pub(super) async fn open_pet_session(
+    app: tauri::AppHandle,
+    state: State<'_, AppState>,
+    session_id: String,
+) -> Result<(), String> {
+    let project_id = state
+        .store
+        .frame_project_id(&session_id)
+        .await
+        .map_err(|error| error.to_string())?
+        .ok_or_else(|| "Session not found".to_string())?;
+    desktop_lifecycle::activate_workspace(&app);
+    app.emit_to(
+        "main",
+        "pet-open-session",
+        serde_json::json!({ "projectId": project_id, "sessionId": session_id }),
+    )
+    .map_err(|error| error.to_string())
 }
 
 #[cfg(test)]

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -3239,6 +3239,10 @@ test("desktop pet remains independent and reflects global agent state", async ({
   });
   await expect(pet).toHaveAttribute("data-state", "waiting");
   await expect(pet.getByText("Needs you")).toBeVisible();
+  await pet.click();
+  await expect.poll(() => lastInvokeArgs(page, "open_pet_session")).toMatchObject({
+    sessionId: "pet-frame",
+  });
 
   await page.evaluate(() => {
     (window as any).__tauriEmit("agent", { kind: "Text", frame_id: "pet-frame", delta: "continuing" });
@@ -3257,6 +3261,19 @@ test("desktop pet remains independent and reflects global agent state", async ({
     (window as any).__tauriEmit("agent", { kind: "Done", frame_id: "pet-frame" });
   });
   await expect(pet).toHaveAttribute("data-state", "jumping");
+});
+
+test("pet navigation opens the project and session that need the user", async ({ page }) => {
+  await page.goto("/");
+  await page.evaluate(() => {
+    (window as any).__tauriEmit("pet-open-session", {
+      projectId: "other",
+      sessionId: "pet-frame",
+    });
+  });
+
+  await expect.poll(() => lastInvokeArgs(page, "open_project")).toMatchObject({ id: "other" });
+  await expect.poll(() => lastInvokeArgs(page, "load_session")).toMatchObject({ id: "pet-frame" });
 });
 
 test("a sync conflict requires an explicit authoritative device choice", async ({ page }) => {

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -4170,6 +4170,27 @@ fn App() -> impl IntoView {
             });
         })
     };
+    let pet_open_project = open_project_transition;
+    let pet_open_cb = Closure::wrap(Box::new(move |payload: JsValue| {
+        let Ok(target) = serde_wasm_bindgen::from_value::<serde_json::Value>(payload) else {
+            return;
+        };
+        let Some(project_id) = target.get("projectId").and_then(serde_json::Value::as_str) else {
+            return;
+        };
+        let Some(session_id) = target.get("sessionId").and_then(serde_json::Value::as_str) else {
+            return;
+        };
+        pet_open_project.call((project_id.to_string(), Some(session_id.to_string())));
+    }) as Box<dyn FnMut(JsValue)>);
+    let pet_open_js = pet_open_cb
+        .as_ref()
+        .unchecked_ref::<js_sys::Function>()
+        .clone();
+    pet_open_cb.forget();
+    spawn_local(async move {
+        let _ = listen("pet-open-session", &pet_open_js).await;
+    });
     // Switch the active project inline (same guarded flow as the Projects screen).
     let switch_project = {
         let open_project_transition = open_project_transition;

--- a/ui/src/pet.rs
+++ b/ui/src/pet.rs
@@ -11,6 +11,7 @@ use wasm_bindgen::{closure::Closure, JsCast, JsValue};
 struct DesktopPetActivity {
     running: HashSet<String>,
     waiting: HashSet<String>,
+    waiting_target: Option<String>,
     reviewing: HashSet<String>,
     transient: String,
     sequence: u64,
@@ -31,12 +32,24 @@ impl DesktopPetActivity {
     fn replace_from_snapshot(&mut self, snapshot: PetRuntimeSnapshot) {
         self.running = snapshot.running.into_iter().collect();
         self.waiting = snapshot.waiting.into_iter().collect();
+        self.retarget_waiting();
         self.reviewing = snapshot.reviewing.into_iter().collect();
         self.transient.clear();
     }
 
+    fn retarget_waiting(&mut self) {
+        if self
+            .waiting_target
+            .as_ref()
+            .is_none_or(|frame_id| !self.waiting.contains(frame_id))
+        {
+            self.waiting_target = self.waiting.iter().next().cloned();
+        }
+    }
+
     fn mark_running(&mut self, frame_id: String) {
         self.waiting.remove(&frame_id);
+        self.retarget_waiting();
         self.reviewing.remove(&frame_id);
         self.running.insert(frame_id);
         self.transient.clear();
@@ -44,13 +57,15 @@ impl DesktopPetActivity {
 
     fn mark_waiting(&mut self, frame_id: String) {
         self.running.insert(frame_id.clone());
-        self.waiting.insert(frame_id);
+        self.waiting.insert(frame_id.clone());
+        self.waiting_target = Some(frame_id);
         self.transient.clear();
     }
 
     fn finish(&mut self, frame_id: &str, transient: &str) {
         self.running.remove(frame_id);
         self.waiting.remove(frame_id);
+        self.retarget_waiting();
         self.reviewing.remove(frame_id);
         self.transient = transient.to_string();
         self.sequence = self.sequence.wrapping_add(1);
@@ -76,6 +91,7 @@ impl DesktopPetActivity {
             } => self.mark_running(frame_id),
             AgentEvent::ReviewStarted { frame_id } | AgentEvent::Review { frame_id, .. } => {
                 self.waiting.remove(&frame_id);
+                self.retarget_waiting();
                 self.running.insert(frame_id.clone());
                 self.reviewing.insert(frame_id);
                 self.transient.clear();
@@ -231,6 +247,18 @@ pub(crate) fn PetDesktop() -> impl IntoView {
             <button id="wisp-pet" class="wisp-pet desktop-pet" type="button"
                 data-testid="wisp-pet"
                 data-tauri-drag-region="deep"
+                on:click:undelegated=move |_| {
+                    let Some(session_id) = activity.with_untracked(|current| current.waiting_target.clone()) else {
+                        return;
+                    };
+                    spawn_local(async move {
+                        let args = serde_wasm_bindgen::to_value(
+                            &serde_json::json!({ "sessionId": session_id }),
+                        )
+                        .unwrap_or(JsValue::UNDEFINED);
+                        let _ = invoke("open_pet_session", args).await;
+                    });
+                }
                 aria-label=move || {
                     let current = activity.get();
                     let name = status.get().asset.map(|asset| asset.display_name)


### PR DESCRIPTION
## Problem

When the desktop pet shows **Needs you**, clicking it does not take the user to the session waiting for input. This is especially confusing when the workspace is hidden or another session is active.

## Changes

- Track the most recent session that put the desktop pet into the waiting state.
- Add a Tauri command that restores the workspace, resolves the session project, and targets the main window.
- Reuse the existing guarded project/session transition in the UI to open the waiting conversation.
- Document the new click behavior.

## Tests

- `cargo fmt --all -- --check`
- `cargo fmt --manifest-path ui/Cargo.toml -- --check`
- `cargo check -p wisp-tauri`
- `cd ui && cargo check --target wasm32-unknown-unknown`
- `cargo test --workspace`
- `cd ui-tests && npm ci && npx playwright test` (142 passed)

## Manual smoke

1. Enable a desktop pet on Windows.
2. Start a turn that requests confirmation, then hide or switch away from its workspace.
3. Wait for the pet to show **Needs you**.
4. Click the pet and verify the workspace is restored on the matching project and session.

## Known limitations / follow-up

- If multiple sessions are already waiting when the pet window cold-starts, one waiting session is selected because persisted runtime state has no request ordering. New live requests always target the most recent session.
- No real SSH host, API key, or network access is required by the automated tests.