### PR TITLE
fix: preview source files as highlighted code (#307)

### DIFF
--- a/src-tauri/src/file_browser.rs
+++ b/src-tauri/src/file_browser.rs
@@ -104,6 +104,13 @@ fn is_text_mime(mime: &str) -> bool {
     mime.starts_with("text/") || mime == "application/json" || mime == "text/markdown"
 }
 
+/// An extension allowlist always lags reality — `.toml`, `.lock`, `.yaml`, `.R`
+/// and friends previewed as "unsupported" purely because nothing named them.
+/// For anything without an explicit mime, let the bytes decide instead.
+fn looks_like_text(bytes: &[u8]) -> bool {
+    !bytes.contains(&0) && std::str::from_utf8(bytes).is_ok()
+}
+
 /// Skip bulky or hidden trees during project-wide filename search.
 fn search_skip_dir(name: &str) -> bool {
     name.starts_with('.')
@@ -401,11 +408,9 @@ pub(super) fn read_file_at(
     let bytes = std::fs::read(&real).map_err(|e| format!("{e}"))?;
     let path_str = real.to_string_lossy().into_owned();
     if is_text_mime(mime)
-        || mime == "text/csv"
-        || mime == "text/tab-separated-values"
-        || mime == "text/x-fasta"
         || mime == "chemical/x-pdb"
         || mime == "chemical/x-mdl-molfile"
+        || (mime == "application/octet-stream" && looks_like_text(&bytes))
     {
         let text = String::from_utf8_lossy(&bytes).into_owned();
         Ok(FileContent {
@@ -675,7 +680,7 @@ mod tests {
     }
 
     #[test]
-    fn script_files_are_text_and_unknown_extensions_remain_binary() {
+    fn script_files_are_text_and_unnamed_extensions_fall_back_to_sniffing() {
         let base = std::env::temp_dir().join(format!(
             "wisp_script_preview_test_{}_{}",
             std::process::id(),
@@ -695,11 +700,20 @@ mod tests {
             assert!(content.base64.is_none());
         }
 
+        // #307: an extension nothing has a mime for (.toml, .lock, .unknown) used
+        // to preview as "unsupported file type" even when it was plainly text.
+        // The bytes decide now, so the mime stays octet-stream but text comes back.
         std::fs::write(base.join("analysis.unknown"), b"plain but unsupported\n").unwrap();
-        let unsupported = read_file_at(&base, "analysis.unknown".into(), None).unwrap();
-        assert_eq!(unsupported.mime, "application/octet-stream");
-        assert!(unsupported.text.is_none());
-        assert!(unsupported.base64.is_some());
+        let unnamed = read_file_at(&base, "analysis.unknown".into(), None).unwrap();
+        assert_eq!(unnamed.mime, "application/octet-stream");
+        assert_eq!(unnamed.text.as_deref(), Some("plain but unsupported\n"));
+        assert!(unnamed.base64.is_none());
+
+        // ...but a NUL byte still means binary, even amid valid UTF-8.
+        std::fs::write(base.join("blob.unknown"), b"MZ\0\x01binary").unwrap();
+        let binary = read_file_at(&base, "blob.unknown".into(), None).unwrap();
+        assert!(binary.text.is_none(), "binary must not be sent as text");
+        assert!(binary.base64.is_some());
 
         let _ = std::fs::remove_dir_all(&base);
     }

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -1014,6 +1014,7 @@ export function tauriMock(): void {
               { name: "model.pdb", is_dir: false, size: 256 },
               { name: "sequences.fasta", is_dir: false, size: 256 },
               { name: "analysis.R", is_dir: false, size: 128 },
+              { name: "pixi.toml", is_dir: false, size: 64 },
               { name: "analysis.unknown", is_dir: false, size: 128 },
               { name: "manuscript.docx", is_dir: false, size: 11351 },
             ];
@@ -1067,7 +1068,12 @@ export function tauriMock(): void {
               return { path, mime: "text/plain", text: ">seq1\nMKTIIALSYIFCLVFADYKDDDDK\n>seq2\nMKTIIALSYIFCLVFADYKDDDDK\n", base64: null };
             }
             if (path.toLowerCase().endsWith(".r")) {
-              return { path, mime: "text/x-r", text: "plot(1:3)\n", base64: null };
+              // Multi-line on purpose: #307 collapsed a script's newlines into one
+              // paragraph, which a single-line fixture cannot catch.
+              return { path, mime: "text/x-r", text: 'library(Seurat)\nin_dir <- "data"\nplot(1:3)\n', base64: null };
+            }
+            if (path.toLowerCase().endsWith(".toml")) {
+              return { path, mime: "application/octet-stream", text: '[project]\nname = "x"\n', base64: null };
             }
             if (path.toLowerCase().endsWith(".unknown")) {
               return { path, mime: "application/octet-stream", text: null, base64: "AA==" };

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -1088,6 +1088,19 @@ test("script previews show source while unknown file types are explicitly unsupp
   await expect(page.locator(".center-file-preview")).toContainText("plot(1:3)");
   await expect.poll(() => lastInvokeArgs(page, "read_file")).toMatchObject({ path: "analysis.R" });
 
+  // #307: the script rendered as one unhighlighted paragraph. It must come back
+  // as R-tagged code, one line per line, with a matching line-number gutter.
+  const rCode = page.locator(".center-file-preview .rp-code-body code");
+  await expect(rCode).toHaveClass(/language-r/);
+  await expect(rCode.locator(".hljs-string")).toHaveText('"data"');
+  await expect(page.locator(".center-file-preview .rp-code-gutter")).toHaveText("1\n2\n3\n4");
+
+  // An extension no mime claims (#307: pixi.toml) is still text — preview it.
+  await openInCenter("pixi.toml");
+  await expect(page.locator(".center-file-preview .rp-code-body code")).toHaveClass(/language-ini/);
+  await expect(page.locator(".center-file-preview")).toContainText("[project]");
+
+  // Genuinely binary payloads stay explicitly unsupported.
   await openInCenter("analysis.unknown");
   await expect(page.locator(".center-file-preview .rp-error")).toHaveText(
     "Preview is not supported for this file type.",

--- a/ui/mock-bridge.js
+++ b/ui/mock-bridge.js
@@ -46,6 +46,46 @@
       use_for_vision: true,
     },
   ];
+  // Preview fixtures, keyed by extension, so the file-preview kinds (#307:
+  // code / toml / notebook) can be exercised without a real workspace.
+  const mockFiles = {
+    r: [
+      "#### ---- Init ---- ####",
+      "library(Seurat)",
+      'in_dir <- "../data/ifnb_pbmc"  # 输入目录',
+      "seu <- CreateSeuratObject(counts = counts, meta.data = metadata)",
+      "for (i in 1:10) {",
+      "  message(sprintf('step %d', i))",
+      "}",
+    ].join("\n"),
+    py: "import scanpy as sc\n\ndef load(path: str):\n    # 读取 h5ad\n    return sc.read_h5ad(path)\n",
+    toml: '[project]\nname = "ifnb-pbmc"\nchannels = ["conda-forge"]\n\n[tasks]\nrun = "Rscript 01-metacell.R"\n',
+    ipynb: JSON.stringify({
+      metadata: { kernelspec: { language: "python" } },
+      cells: [
+        { cell_type: "markdown", source: ["## Metacell QC\n", "\n", "Counts per **resolution**.\n"] },
+        {
+          cell_type: "code",
+          source: ["import scanpy as sc\n", "adata = sc.read_h5ad('pbmc.h5ad')\n", "adata"],
+          outputs: [
+            { output_type: "stream", name: "stdout", text: ["AnnData object with n_obs = 2638\n"] },
+            { output_type: "error", ename: "ValueError", evalue: "bad", traceback: ["\u001b[0;31mValueError\u001b[0m: bad input"] },
+          ],
+        },
+      ],
+    }),
+  };
+  // serde-wasm-bindgen hands invoke a Map, not a plain object, so `args?.path`
+  // is always undefined — read both shapes.
+  function argValue(args, key) {
+    return args instanceof Map ? args.get(key) : args?.[key];
+  }
+  function mockFile(path) {
+    const name = String(path ?? "report.csv");
+    const text = mockFiles[name.split(".").pop().toLowerCase()];
+    if (text !== undefined) return { path: name, mime: "text/plain", text, base64: null };
+    return { path: name, mime: "text/csv", text: "gene,score\nFX-cell,0.91", base64: null };
+  }
   const mockCredentials = {
     openalex_api_key: false,
     infinisynapse_api_key: false,
@@ -216,9 +256,13 @@
             return [
               { name: "data", is_dir: true, size: 0 },
               { name: "report.csv", is_dir: false, size: 4096 },
+              { name: "01-metacell.R", is_dir: false, size: 2048 },
+              { name: "run.py", is_dir: false, size: 1024 },
+              { name: "pixi.toml", is_dir: false, size: 512 },
+              { name: "analysis.ipynb", is_dir: false, size: 8192 },
             ];
           case "read_file":
-            return { path: args?.path ?? "report.csv", mime: "text/csv", text: "gene,score\nFX-cell,0.91", base64: null };
+            return mockFile(argValue(args, "path"));
           case "set_settings":
           case "set_api_key":
           case "new_session":

--- a/ui/src/api.js
+++ b/ui/src/api.js
@@ -942,7 +942,13 @@ export async function mount_preview(kind, elId, payloadJson) {
       tag.data = text;
       break;
     }
-    default:
-      el.textContent = p.text || "";
+    default: {
+      // textContent on a plain div collapses the file's newlines — a <pre> is
+      // what keeps an unrecognised kind readable instead of one long paragraph.
+      const pre = document.createElement("pre");
+      pre.className = "rp-pre";
+      pre.textContent = p.text || "";
+      el.appendChild(pre);
+    }
   }
 }

--- a/ui/src/app_support.rs
+++ b/ui/src/app_support.rs
@@ -9,11 +9,12 @@ use crate::bindings::{
 use crate::dto::*;
 use crate::i18n::{localize_backend, t, tf, use_locale, Locale};
 use crate::text::{
-    decode_href, dom_value, event_target_value, extract_href_from_tag, fasta_seq_count,
+    code_lang, decode_href, dom_value, event_target_value, extract_href_from_tag, fasta_seq_count,
     fenced_blocks, file_kind, format_bytes, format_duration_ms, html_escape, is_external_href,
     is_separator, is_table_row, md_inline_to_html, md_to_html, next_artifact_id, normalize_path,
-    opens_in_system_browser, parent_path, parse_csv_line, pretty_json, provider_defaults,
-    provider_value, split_row, tool_lang, unique_dom_id, user_message_presentation,
+    opens_in_system_browser, parent_path, parse_csv_line, parse_notebook, pretty_json,
+    provider_defaults, provider_value, split_row, tool_lang, unique_dom_id,
+    user_message_presentation, NbOutput, Notebook,
 };
 use leptos::{ev, window_event_listener, *};
 use serde_wasm_bindgen::to_value;
@@ -4505,6 +4506,12 @@ pub(super) fn file_proto(word: &str) -> Option<ProtoArtifact> {
         return None;
     }
     let kind = file_kind(&p)?;
+    // Source files preview fine once opened, but this scan runs over every word
+    // of tool output — auto-promoting each .py/.R path it mentions (tracebacks,
+    // import lists, pip logs) would bury the pane. Code belongs in Notebook.
+    if kind == "code" {
+        return None;
+    }
     Some(ProtoArtifact::File { path: p, kind })
 }
 
@@ -4860,6 +4867,24 @@ mod artifact_scan_tests {
         collect_artifacts(items, locale, &mut ProtoCache::new())
     }
 
+    /// #307 made .R/.py previewable, which must not also turn every source path
+    /// this scan walks past (tracebacks, import lists) into an artifact chip.
+    #[test]
+    fn source_paths_do_not_become_artifacts() {
+        assert!(file_proto("scripts/deseq2.R").is_none());
+        assert!(file_proto("/mock/root/train.py").is_none());
+        assert!(file_proto("pixi.toml").is_none());
+        // Data and documents still do.
+        assert!(matches!(
+            file_proto("out/report.csv"),
+            Some(ProtoArtifact::File { kind: "csv", .. })
+        ));
+        assert!(matches!(
+            file_proto("notes.md"),
+            Some(ProtoArtifact::File { kind: "markdown", .. })
+        ));
+    }
+
     /// Streaming reuses cached extractions for untouched messages; the result
     /// must be identical to a from-scratch scan (ids, names, order, dedup).
     #[test]
@@ -5026,7 +5051,7 @@ pub(super) fn artifact_group_label(key: &str, locale: Locale) -> String {
             "csv" => "artifact.group.csv",
             "fasta" => "artifact.group.fasta",
             "msa" => "artifact.group.msa",
-            "text" | "markdown" => "artifact.group.text",
+            "text" | "markdown" | "code" | "notebook" => "artifact.group.text",
             _ => return kind.to_string(),
         };
         t(locale, i18n).into()
@@ -5165,61 +5190,155 @@ pub(super) fn CsvFilePreview(path: String) -> impl IntoView {
     }
 }
 
+/// Read a workspace file, an artifact, or a pinned artifact version — the three
+/// path spellings a preview can be handed — into its `FileContent`.
+async fn load_file_content(path: &str, loc: Locale) -> Result<FileContent, String> {
+    let result = match artifact_version_id_path(path) {
+        Some(version_id) => {
+            invoke_checked(
+                "read_artifact_version",
+                to_value(&serde_json::json!({ "versionId": version_id })).unwrap(),
+            )
+            .await
+        }
+        None => match artifact_id_path(path) {
+            Some(id) => {
+                invoke_checked("read_artifact", to_value(&serde_json::json!({ "id": id })).unwrap())
+                    .await
+            }
+            None => {
+                invoke_checked(
+                    "read_file",
+                    to_value(&tauri_args::read_file(path, Some(32 * 1024 * 1024))).unwrap(),
+                )
+                .await
+            }
+        },
+    };
+    match result {
+        Ok(v) => serde_wasm_bindgen::from_value::<FileContent>(v)
+            .map_err(|_| tf(loc, "err.file_not_found", &[("path", path)])),
+        Err(err_value) => Err(localize_backend(loc, &js_error_text(err_value))),
+    }
+}
+
+/// Text/source preview: line-numbered and syntax-highlighted via `RpCodeView`.
+/// The old plain-text mount dropped the file's newlines (`textContent` on a
+/// non-`pre` div), which is what made R/shell scripts render as one paragraph.
 #[component]
-pub(super) fn JsonFilePreview(path: String) -> impl IntoView {
+pub(super) fn CodeFilePreview(path: String, lang: String) -> impl IntoView {
     let locale = use_locale();
     let body = create_rw_signal::<Option<String>>(None);
     let err = create_rw_signal::<Option<String>>(None);
+    let is_json = lang == "json";
     create_effect(move |_| {
         let path = path.clone();
         let loc = locale.get();
         spawn_local(async move {
             body.set(None);
             err.set(None);
-            let result = match artifact_version_id_path(&path) {
-                Some(version_id) => {
-                    invoke_checked(
-                        "read_artifact_version",
-                        to_value(&serde_json::json!({ "versionId": version_id })).unwrap(),
-                    )
-                    .await
-                }
-                None => match artifact_id_path(&path) {
-                    Some(id) => {
-                        invoke_checked(
-                            "read_artifact",
-                            to_value(&serde_json::json!({ "id": id })).unwrap(),
-                        )
-                        .await
-                    }
-                    None => {
-                        invoke_checked(
-                            "read_file",
-                            to_value(&tauri_args::read_file(&path, Some(32 * 1024 * 1024)))
-                                .unwrap(),
-                        )
-                        .await
-                    }
-                },
-            };
-            let fc = match result {
-                Ok(v) => match serde_wasm_bindgen::from_value::<FileContent>(v) {
-                    Ok(fc) => fc,
-                    Err(_) => {
-                        err.set(Some(tf(loc, "err.file_not_found", &[("path", &path)])));
-                        return;
-                    }
-                },
-                Err(err_value) => {
-                    err.set(Some(localize_backend(loc, &js_error_text(err_value))));
+            let fc = match load_file_content(&path, loc).await {
+                Ok(fc) => fc,
+                Err(e) => {
+                    err.set(Some(e));
                     return;
                 }
             };
-            body.set(Some(pretty_json(fc.text.as_deref().unwrap_or(""))));
+            // No text means the backend judged it binary; an empty code view
+            // would just look like an empty file.
+            let Some(text) = fc.text.as_deref() else {
+                err.set(Some(t(loc, "preview.unsupported_file")));
+                return;
+            };
+            body.set(Some(if is_json {
+                pretty_json(text)
+            } else {
+                text.to_string()
+            }));
         });
     });
     move || match (body.get(), err.get()) {
-        (Some(text), _) => view! { <RpCodeView lang="json".to_string() body=text /> }.into_view(),
+        (Some(text), _) => view! { <RpCodeView lang=lang.clone() body=text /> }.into_view(),
+        (_, Some(e)) => view! { <div class="rp-error">{e}</div> }.into_view(),
+        _ => view! { <div class="rp-heavy">{move || t(locale.get(), "loading")}</div> }.into_view(),
+    }
+}
+
+/// `.ipynb` preview: Markdown cells rendered, code cells highlighted in the
+/// kernel's language, outputs (text + inline images) under each cell. Reuses the
+/// chat Notebook pane's styling so both read the same.
+#[component]
+pub(super) fn NotebookFilePreview(path: String) -> impl IntoView {
+    let locale = use_locale();
+    let nb = create_rw_signal::<Option<Notebook>>(None);
+    let err = create_rw_signal::<Option<String>>(None);
+    let hid = unique_dom_id("nb");
+    create_effect(move |_| {
+        let path = path.clone();
+        let loc = locale.get();
+        spawn_local(async move {
+            nb.set(None);
+            err.set(None);
+            match load_file_content(&path, loc).await {
+                // A .ipynb that doesn't parse is corrupt or not really a notebook;
+                // say so rather than drawing an empty cell list.
+                Ok(fc) => match parse_notebook(fc.text.as_deref().unwrap_or("")) {
+                    Some(parsed) => nb.set(Some(parsed)),
+                    None => err.set(Some(t(loc, "preview.unsupported_file"))),
+                },
+                Err(e) => err.set(Some(e)),
+            }
+        });
+    });
+    let hid_effect = hid.clone();
+    // One pass over the whole list: highlights the fenced code and math inside
+    // rendered Markdown cells. Code cells highlight themselves via RpCodeView.
+    create_effect(move |_| {
+        let _ = nb.get();
+        schedule_highlight(hid_effect.clone());
+    });
+    move || match (nb.get(), err.get()) {
+        (Some(parsed), _) => {
+            let lang = parsed.lang.clone();
+            view! {
+                <div class="notebook-cells" id=hid.clone()>
+                    {parsed.cells.iter().enumerate().map(|(i, cell)| {
+                        let outputs = cell.outputs.iter().map(|out| match out {
+                            NbOutput::Text { text, error } => view! {
+                                <pre class=if *error { "nb-out-error" } else { "" }>{text.clone()}</pre>
+                            }.into_view(),
+                            NbOutput::Image { mime, b64 } => view! {
+                                <img class="rp-img" src=format!("data:{mime};base64,{b64}") alt="" />
+                            }.into_view(),
+                        }).collect_view();
+                        let body = if cell.markdown {
+                            view! { <div class="md" inner_html=md_to_html(&cell.source)></div> }.into_view()
+                        } else {
+                            view! {
+                                <div class="notebook-source">
+                                    <RpCodeView lang=lang.clone() body=cell.source.clone() />
+                                </div>
+                            }.into_view()
+                        };
+                        view! {
+                            <div class="notebook-cell">
+                                <div class="notebook-cell-head">
+                                    <span class="notebook-index">{i + 1}</span>
+                                    <span class="notebook-language">
+                                        {if cell.markdown { "markdown".to_string() } else { lang.clone() }}
+                                    </span>
+                                </div>
+                                {body}
+                                {(!cell.outputs.is_empty()).then(|| view! {
+                                    <div class="notebook-output">{outputs}</div>
+                                })}
+                            </div>
+                        }
+                    }).collect_view()}
+                </div>
+            }
+            .into_view()
+        }
         (_, Some(e)) => view! { <div class="rp-error">{e}</div> }.into_view(),
         _ => view! { <div class="rp-heavy">{move || t(locale.get(), "loading")}</div> }.into_view(),
     }
@@ -5229,7 +5348,14 @@ pub(super) fn JsonFilePreview(path: String) -> impl IntoView {
 pub(super) fn WorkspaceFilePreview(dom_id: String, path: String, kind: String) -> impl IntoView {
     match kind.as_str() {
         "csv" => view! { <CsvFilePreview path=path /> }.into_view(),
-        "json" => view! { <JsonFilePreview path=path /> }.into_view(),
+        // Artifact/version tabs aren't real paths, so the extension can't be read
+        // back off them — the kind is the only language signal here.
+        "json" => view! { <CodeFilePreview path=path lang="json".to_string() /> }.into_view(),
+        "code" | "text" => {
+            let lang = code_lang(&path).unwrap_or("plaintext").to_string();
+            view! { <CodeFilePreview path=path lang=lang /> }.into_view()
+        }
+        "notebook" => view! { <NotebookFilePreview path=path /> }.into_view(),
         // Image + PDF share the zoom viewport: the wheel zooms, and PDF pages are
         // stepped with the toolbar buttons / arrow keys / Page Up-Down.
         "image" | "pdf" => {
@@ -5636,10 +5762,10 @@ pub(super) fn opens_in_modal(kind: &str) -> bool {
     matches!(kind, "image" | "pdf" | "csv")
 }
 
-/// Preview kinds whose raw text can be edited in place (Markdown + plain text).
+/// Preview kinds whose raw text can be edited in place (Markdown + source).
 /// Everything else (binary, rendered, or structured) stays read-only.
 pub(super) fn editable_center_kind(kind: &str) -> bool {
-    matches!(kind, "markdown" | "text")
+    matches!(kind, "markdown" | "text" | "code")
 }
 
 /// Fire the native save dialog to download a workspace file (backend copies it).

--- a/ui/src/styles/right-pane.css
+++ b/ui/src/styles/right-pane.css
@@ -184,6 +184,8 @@
 .notebook-output { margin-top:8px; color:var(--text-muted); font-size:12px; }
 .notebook-output > summary { cursor:pointer; user-select:none; }
 .notebook-output > pre { max-height:320px; margin:8px 0 0; padding:10px 12px; overflow:auto; border:1px solid var(--border); background:var(--bg-sunken); color:var(--text); font:11.5px/1.5 var(--font-mono); white-space:pre-wrap; overflow-wrap:anywhere; }
+.notebook-output > pre.nb-out-error { color:var(--err); }
+.notebook-output > .rp-img { margin-top:8px; }
 
 .rp-artifacts-body { display: flex; flex-direction: column; flex: 1 1 auto; min-height: 0; }
 .rp-artifacts-body.preview-hidden .rp-tiles {

--- a/ui/src/text.rs
+++ b/ui/src/text.rs
@@ -659,6 +659,177 @@ pub(crate) fn parse_csv_line(line: &str) -> Vec<String> {
         .collect()
 }
 
+/// A `.ipynb` cell, flattened to what the preview actually draws.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct NbCell {
+    pub(crate) markdown: bool,
+    pub(crate) source: String,
+    pub(crate) outputs: Vec<NbOutput>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum NbOutput {
+    Text { text: String, error: bool },
+    Image { mime: String, b64: String },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct Notebook {
+    /// highlight.js id for the kernel language; code cells are all this language.
+    pub(crate) lang: String,
+    pub(crate) cells: Vec<NbCell>,
+}
+
+/// nbformat spells every text field as either a string or a list of lines
+/// (already newline-terminated); both appear in real notebooks.
+fn nb_text(v: &serde_json::Value) -> String {
+    match v {
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Array(a) => a.iter().filter_map(|x| x.as_str()).collect(),
+        _ => String::new(),
+    }
+}
+
+/// Tracebacks arrive with the kernel's ANSI colour codes baked in, which would
+/// otherwise render as literal `[0;31m` noise.
+pub(crate) fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars();
+    while let Some(c) = chars.next() {
+        if c != '\u{1b}' {
+            out.push(c);
+            continue;
+        }
+        // CSI: ESC [ params... final-byte in @-~. Anything else: drop the ESC only.
+        if chars.clone().next() == Some('[') {
+            chars.next();
+            for c in chars.by_ref() {
+                if ('\u{40}'..='\u{7e}').contains(&c) {
+                    break;
+                }
+            }
+        }
+    }
+    out
+}
+
+fn nb_outputs(v: &serde_json::Value) -> Vec<NbOutput> {
+    let mut out = Vec::new();
+    for o in v.as_array().map(|a| a.as_slice()).unwrap_or_default() {
+        match o.get("output_type").and_then(|t| t.as_str()).unwrap_or("") {
+            "stream" => out.push(NbOutput::Text {
+                text: nb_text(&o["text"]),
+                error: o.get("name").and_then(|n| n.as_str()) == Some("stderr"),
+            }),
+            "error" => {
+                let tb = nb_text(&o["traceback"]);
+                let text = if tb.trim().is_empty() {
+                    format!(
+                        "{}: {}",
+                        o.get("ename").and_then(|e| e.as_str()).unwrap_or("Error"),
+                        o.get("evalue").and_then(|e| e.as_str()).unwrap_or(""),
+                    )
+                } else {
+                    strip_ansi(&tb)
+                };
+                out.push(NbOutput::Text { text, error: true });
+            }
+            // Rich output: prefer the image, fall back to the text/plain repr.
+            "execute_result" | "display_data" => {
+                let data = &o["data"];
+                let img = ["image/png", "image/jpeg", "image/gif"]
+                    .iter()
+                    .find_map(|m| data.get(*m).and_then(|b| b.as_str()).map(|b| (*m, b)));
+                match img {
+                    Some((mime, b64)) => out.push(NbOutput::Image {
+                        mime: mime.to_string(),
+                        // Line-wrapped base64 is legal in nbformat but not in a data: URL.
+                        b64: b64.split_whitespace().collect(),
+                    }),
+                    None => {
+                        let text = nb_text(&data["text/plain"]);
+                        if !text.trim().is_empty() {
+                            out.push(NbOutput::Text { text, error: false });
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    out
+}
+
+/// Parse a Jupyter notebook into cells. `None` when the text isn't a notebook,
+/// which lets the caller fall back to showing the raw JSON.
+pub(crate) fn parse_notebook(text: &str) -> Option<Notebook> {
+    let v: serde_json::Value = serde_json::from_str(text).ok()?;
+    let cells = v.get("cells")?.as_array()?;
+    let meta = &v["metadata"];
+    let lang = meta["language_info"]["name"]
+        .as_str()
+        .or_else(|| meta["kernelspec"]["language"].as_str())
+        .unwrap_or("python");
+    // The kernel names its language ("R", "python3"); hljs wants its own ids.
+    let lang = tool_lang(lang);
+    Some(Notebook {
+        lang: lang.to_string(),
+        cells: cells
+            .iter()
+            .filter_map(|c| {
+                let kind = c.get("cell_type").and_then(|t| t.as_str()).unwrap_or("");
+                let source = nb_text(&c["source"]);
+                // Raw cells carry no rendering semantics worth guessing at.
+                if kind == "raw" || source.trim().is_empty() {
+                    return None;
+                }
+                Some(NbCell {
+                    markdown: kind == "markdown",
+                    source,
+                    outputs: nb_outputs(&c["outputs"]),
+                })
+            })
+            .collect(),
+    })
+}
+
+/// Source-file extension → highlight.js language id, for the languages the
+/// vendored highlight.min.js build actually registers. `None` means "not code
+/// we can colour", not "not text" — plain text still previews, just unstyled.
+pub(crate) fn code_lang(path: &str) -> Option<&'static str> {
+    let (_, ext) = path.rsplit_once('.')?;
+    Some(match ext.to_ascii_lowercase().as_str() {
+        "r" => "r",
+        "py" | "pyw" => "python",
+        "sh" | "bash" | "zsh" => "bash",
+        "js" | "mjs" | "cjs" => "javascript",
+        "ts" | "tsx" | "mts" | "cts" => "typescript",
+        "rs" => "rust",
+        "go" => "go",
+        "java" => "java",
+        "kt" | "kts" => "kotlin",
+        "swift" => "swift",
+        "rb" => "ruby",
+        "pl" | "pm" => "perl",
+        "lua" => "lua",
+        "php" => "php",
+        "c" | "h" => "c",
+        "cpp" | "cc" | "cxx" | "hpp" | "hh" => "cpp",
+        "cs" => "csharp",
+        "m" => "objectivec",
+        "sql" => "sql",
+        "css" => "css",
+        "scss" => "scss",
+        "less" => "less",
+        "xml" | "xsl" | "rss" => "xml",
+        "yaml" | "yml" => "yaml",
+        "toml" | "ini" | "cfg" | "conf" => "ini",
+        "diff" | "patch" => "diff",
+        "json" | "jsonl" | "ipynb" => "json",
+        _ => return None,
+    })
+}
+
 pub(crate) fn file_kind(path: &str) -> Option<&'static str> {
     let (_, ext) = path.rsplit_once('.')?;
     if ext.is_empty() {
@@ -676,12 +847,16 @@ pub(crate) fn file_kind(path: &str) -> Option<&'static str> {
         "aln" | "clustal" | "clustalw" | "sto" | "stockholm" | "stk" | "afa" | "mfa" => "msa",
         // Plain FASTA → syntax-highlighted text (web-dist Hae → text preview)
         "fasta" | "fa" | "fas" | "fna" | "faa" | "ffn" | "frn" => "fasta",
-        "md" => "markdown",
+        // Rmd/qmd are Markdown with code chunks: the Markdown preview already
+        // renders + highlights fenced blocks, so they need nothing of their own.
+        "md" | "rmd" | "qmd" | "markdown" => "markdown",
         "docx" => "docx",
         "html" | "htm" => "html",
         "nwk" | "newick" | "treefile" | "tre" => "text",
+        "ipynb" => "notebook",
         "json" => "json",
         "txt" | "log" => "text",
+        _ if code_lang(path).is_some() => "code",
         _ => return None,
     })
 }
@@ -738,8 +913,8 @@ pub(crate) fn fasta_seq_count(text: &str) -> usize {
 #[cfg(test)]
 mod md_catalog_tests {
     use super::{
-        decode_href, fence_identifier_line_runs, file_kind, format_bytes, md_to_html, parent_path,
-        pretty_json, user_message_presentation,
+        code_lang, decode_href, fence_identifier_line_runs, file_kind, format_bytes, md_to_html,
+        parent_path, parse_notebook, pretty_json, strip_ansi, user_message_presentation, NbOutput,
     };
 
     #[test]
@@ -884,6 +1059,69 @@ mod md_catalog_tests {
     #[test]
     fn detects_json_files_for_preview() {
         assert_eq!(file_kind("report.json"), Some("json"));
+    }
+
+    #[test]
+    fn detects_source_files_as_highlightable_code() {
+        // #307: these previewed as one unhighlighted paragraph because nothing
+        // claimed the extension.
+        assert_eq!(file_kind("01-metacell.R"), Some("code"));
+        assert_eq!(file_kind("02-run_pyscenic.sh"), Some("code"));
+        assert_eq!(file_kind("scripts/regulon2gmt.py"), Some("code"));
+        assert_eq!(file_kind("pixi.toml"), Some("code"));
+        assert_eq!(code_lang("01-metacell.R"), Some("r"));
+        assert_eq!(code_lang("a.py"), Some("python"));
+        assert_eq!(code_lang("pixi.toml"), Some("ini"));
+        assert_eq!(code_lang("notes.txt"), None);
+        // Rmd/qmd are Markdown with chunks — the Markdown preview already
+        // highlights fenced code, so they must not fall into the code branch.
+        assert_eq!(file_kind("analysis.Rmd"), Some("markdown"));
+        assert_eq!(file_kind("analysis.qmd"), Some("markdown"));
+        assert_eq!(file_kind("analysis.ipynb"), Some("notebook"));
+    }
+
+    #[test]
+    fn strips_ansi_colour_codes_from_kernel_output() {
+        assert_eq!(strip_ansi("\u{1b}[0;31mNameError\u{1b}[0m: x"), "NameError: x");
+        assert_eq!(strip_ansi("plain"), "plain");
+    }
+
+    #[test]
+    fn parses_notebook_cells_sources_and_outputs() {
+        // r##"..."## because the Markdown heading below contains `"#`.
+        let nb = parse_notebook(
+            r##"{
+              "metadata": {"kernelspec": {"language": "R"}},
+              "cells": [
+                {"cell_type": "markdown", "source": ["# Title\n", "text"]},
+                {"cell_type": "raw", "source": "dropped"},
+                {"cell_type": "code", "source": "plot(1)", "outputs": [
+                  {"output_type": "stream", "name": "stdout", "text": ["hi\n"]},
+                  {"output_type": "display_data", "data": {"image/png": "AAA\nBBB", "text/plain": "<fig>"}},
+                  {"output_type": "error", "ename": "E", "evalue": "v", "traceback": ["\u001b[0;31mboom\u001b[0m"]}
+                ]}
+              ]
+            }"##,
+        )
+        .expect("valid notebook");
+        assert_eq!(nb.lang, "r");
+        // Raw + empty cells are dropped; markdown and code survive.
+        assert_eq!(nb.cells.len(), 2);
+        assert!(nb.cells[0].markdown);
+        assert_eq!(nb.cells[0].source, "# Title\ntext");
+        assert_eq!(nb.cells[1].source, "plot(1)");
+        assert_eq!(
+            nb.cells[1].outputs,
+            vec![
+                NbOutput::Text { text: "hi\n".into(), error: false },
+                // Image wins over text/plain, and its wrapped base64 is joined
+                // so the data: URL stays valid.
+                NbOutput::Image { mime: "image/png".into(), b64: "AAABBB".into() },
+                NbOutput::Text { text: "boom".into(), error: true },
+            ]
+        );
+        assert!(parse_notebook("not json").is_none());
+        assert!(parse_notebook(r#"{"no":"cells"}"#).is_none());
     }
 
     #[test]


### PR DESCRIPTION
Fixes #307.

R scripts previewed as one long unhighlighted paragraph, and `pixi.toml` / `pixi.lock` claimed 不支持预览此文件类型. These turned out to be **two independent root causes**, both extension allowlists that had fallen behind reality — so fixing them properly covers Python, shell, and everything else at the same time.

## 1. Collapsed newlines (the screenshot in the issue)

`mount_preview`'s fallback did `el.textContent = text` on a plain `div`, which has no `white-space: pre` — so the whole script became one paragraph, unhighlighted. Every unrecognised extension landed there, because `file_kind` had no entry for `.R`, `.py`, `.sh`, etc.

Added `code_lang` (extension → highlight.js id, limited to the languages the vendored `highlight.min.js` actually registers — R was already bundled, it was never reachable) and routed those files through the existing `RpCodeView`, which already does the gutter + highlighting. `JsonFilePreview` was doing exactly this for JSON, so it's generalised into `CodeFilePreview` rather than adding a second one.

## 2. "Unsupported file type" for `.toml` / `.lock`

Separate cause, in the backend. `read_file_at` only returned text for an allowlist of mimes, so anything unnamed came back as base64 with no text at all. Now, when no mime claims the extension, the bytes decide (valid UTF-8, no NUL). This also fixes **`.txt`**, which was silently broken the same way.

## Rmd / ipynb

`.Rmd` / `.qmd` route to the existing Markdown preview, which already renders and highlights fenced chunks — no new code. `.ipynb` needed a real parser: cells render as markdown / highlighted code with their outputs, including inline images and tracebacks with the kernel's ANSI codes stripped.

## For the reviewer

**One judgment call worth a second opinion.** Adding a `code` kind had a side effect: the artifact scan walks every word of tool output, so *any* `.py`/`.R` path in a traceback or import list would have become an artifact chip. A test explicitly guards this (`code lives in Notebook instead of Artifacts`), so I excluded `code` from that scan rather than weaken the test — data and documents still promote as before. If you'd rather written scripts *did* appear in Artifacts, that's a one-line change, but it belongs in its own PR.

**The test suite caught a real bug mid-change**: `CodeFilePreview` rendered a blank view for genuinely binary files instead of "unsupported" — a guard the old code had that I hadn't carried over. Fixed, and covered.

`mock-bridge.js` picked up a fix beyond the fixtures: `invoke` args arrive as a `Map` (serde-wasm-bindgen), so `args?.path` was always `undefined` and the dev mock could only ever serve one canned file.

## Verification

- `cargo test --workspace` — 350 passed
- `cargo test` (ui) — 73 passed
- `cargo check --target wasm32-unknown-unknown` — clean
- Playwright — 142 passed
- Confirmed the new Playwright assertion **fails against the old code** (`Expected pattern: /language-r/`), so it actually catches the reported bug
- Driven manually in the running app: R script, `pixi.toml`, and the notebook all render correctly in light and dark

One image/provenance test flaked once during a full run and passed in isolation plus two subsequent full runs — pre-existing, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
