### PR TITLE
fix: IME confirm Enter no longer sends the message on macOS

### DIFF
--- a/ui/src/app_support.rs
+++ b/ui/src/app_support.rs
@@ -10,7 +10,8 @@ use crate::dto::*;
 use crate::i18n::{localize_backend, t, tf, use_locale, Locale};
 use crate::text::{
     code_lang, decode_href, dom_value, event_target_value, extract_href_from_tag, fasta_seq_count,
-    fenced_blocks, file_kind, format_bytes, format_duration_ms, html_escape, is_external_href,
+    fenced_blocks, file_kind, format_bytes, format_duration_ms, html_escape, ime_composing,
+    is_external_href,
     is_separator, is_table_row, md_inline_to_html, md_to_html, next_artifact_id, normalize_path,
     opens_in_system_browser, parent_path, parse_csv_line, parse_notebook, pretty_json,
     provider_defaults, provider_value, split_row, tool_lang, unique_dom_id,
@@ -6858,7 +6859,7 @@ pub(super) fn ApprovalCard(
                         <Show when=move || show_feedback.get()>
                             <div class="plan-feedback"
                                 on:keydown=move |ev: web_sys::KeyboardEvent| {
-                                    if ev.key() == "Escape" && !ev.is_composing() {
+                                    if ev.key() == "Escape" && !ime_composing(&ev) {
                                         // Collapse feedback before the window-level
                                         // handler rejects the whole plan.
                                         ev.prevent_default();
@@ -7197,7 +7198,7 @@ pub(super) fn ProjectsScreen(
         let Some(ev) = ev.dyn_ref::<web_sys::KeyboardEvent>() else {
             return;
         };
-        if ev.key() != "Escape" || ev.default_prevented() || ev.is_composing() {
+        if ev.key() != "Escape" || ev.default_prevented() || ime_composing(ev) {
             return;
         }
         if pending_delete.get().is_some() {
@@ -7269,7 +7270,7 @@ pub(super) fn ProjectsScreen(
                                 prop:value=move || search_query.get()
                                 on:input=move |ev| search_query.set(event_target_value(&ev))
                                 on:keydown=move |ev: web_sys::KeyboardEvent| {
-                                    if ev.is_composing() { return; }
+                                    if ime_composing(&ev) { return; }
                                     let key = ev.key();
                                     let last = search_count().saturating_sub(1);
                                     match key.as_str() {
@@ -7902,7 +7903,7 @@ pub(super) fn CommandPalette(
                             prop:value=move || query.get()
                             on:input=move |ev| query.set(event_target_value(&ev))
                             on:keydown=move |ev: web_sys::KeyboardEvent| {
-                                if ev.is_composing() { return; }
+                                if ime_composing(&ev) { return; }
                                 let n = items.get().len();
                                 match ev.key().as_str() {
                                     "Escape" => { ev.prevent_default(); open.set(false); }
@@ -8123,7 +8124,7 @@ pub(super) fn ActionPalette(
                             prop:value=move || query.get()
                             on:input=move |ev| { query.set(event_target_value(&ev)); active.set(0); }
                             on:keydown=move |ev: web_sys::KeyboardEvent| {
-                                if ev.is_composing() { return; }
+                                if ime_composing(&ev) { return; }
                                 let n = actions.get().len();
                                 match ev.key().as_str() {
                                     "Escape" => { ev.prevent_default(); open.set(false); }

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -42,8 +42,9 @@ use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 use text::{
     dom_value, event_target_checked, event_target_value, file_kind, format_bytes,
-    format_duration_ms, group_artifact_indices, join_path, md_to_html, opens_in_system_browser,
-    parent_path, provider_defaults, provider_value, user_message_presentation,
+    format_duration_ms, group_artifact_indices, ime_composing, join_path, md_to_html,
+    opens_in_system_browser, parent_path, provider_defaults, provider_value,
+    user_message_presentation,
 };
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
@@ -1970,9 +1971,9 @@ fn App() -> impl IntoView {
 
     let on_send = move |ev: web_sys::KeyboardEvent| {
         // While an IME is composing (e.g. Chinese pinyin), Enter confirms the
-        // candidate — its keydown reports isComposing — so let the IME handle
-        // every key and never send/navigate mid-composition (#108).
-        if ev.is_composing() {
+        // candidate, so let the IME handle every key and never send/navigate
+        // mid-composition (#108; keyCode-229 quirk in ime_composing).
+        if ime_composing(&ev) {
             return;
         }
         if picker_mode.get().is_some() {
@@ -3781,7 +3782,7 @@ fn App() -> impl IntoView {
         let Some(ev) = ev.dyn_ref::<web_sys::KeyboardEvent>() else {
             return;
         };
-        if ev.key() != "Escape" || ev.default_prevented() || ev.is_composing() {
+        if ev.key() != "Escape" || ev.default_prevented() || ime_composing(ev) {
             return;
         }
         if update_check_modal.get().is_some() {
@@ -4576,7 +4577,7 @@ fn App() -> impl IntoView {
         let Some(ev) = ev.dyn_ref::<web_sys::KeyboardEvent>() else {
             return;
         };
-        if ev.is_composing() || !(ev.ctrl_key() || ev.meta_key()) {
+        if ime_composing(ev) || !(ev.ctrl_key() || ev.meta_key()) {
             return;
         }
         let key = ev.key().to_lowercase();
@@ -4611,7 +4612,7 @@ fn App() -> impl IntoView {
             return;
         };
         if ev.default_prevented()
-            || ev.is_composing()
+            || ime_composing(ev)
             || ev.alt_key()
             || ev.ctrl_key()
             || ev.meta_key()
@@ -7028,7 +7029,7 @@ fn App() -> impl IntoView {
                                             prop:placeholder=move || t(locale.get(), "sidechat.placeholder")
                                             on:input=move |ev| side_chat_input.set(event_target_value(&ev))
                                             on:keydown=move |ev: web_sys::KeyboardEvent| {
-                                                if ev.is_composing() { return; }
+                                                if ime_composing(&ev) { return; }
                                                 if ev.key() == "Enter" && !ev.shift_key() {
                                                     ev.prevent_default();
                                                     send_side_chat(side_chat_input.get());

--- a/ui/src/text.rs
+++ b/ui/src/text.rs
@@ -17,6 +17,14 @@ pub(crate) fn unique_dom_id(prefix: &str) -> String {
     format!("{prefix}-{}", NEXT_DOM_ID.fetch_add(1, Ordering::Relaxed))
 }
 
+/// True while an IME is composing. WebKit (macOS WKWebView) fires the Enter
+/// keydown that confirms a candidate *after* `compositionend`, so
+/// `isComposing` is already false there — but `keyCode` is still 229, the
+/// IME-processed sentinel. Check both or that Enter sends the message.
+pub(crate) fn ime_composing(ev: &web_sys::KeyboardEvent) -> bool {
+    ev.is_composing() || ev.key_code() == 229
+}
+
 pub(crate) fn dom_value(ev: &web_sys::Event) -> String {
     ev.target()
         .and_then(|target| js_sys::Reflect::get(&target, &JsValue::from_str("value")).ok())

--- a/ui/src/window_titlebar.rs
+++ b/ui/src/window_titlebar.rs
@@ -88,7 +88,7 @@ pub(super) fn WindowTitlebar(
         let Some(ev) = ev.dyn_ref::<web_sys::KeyboardEvent>() else {
             return;
         };
-        if ev.key() != "Escape" || ev.default_prevented() || ev.is_composing() {
+        if ev.key() != "Escape" || ev.default_prevented() || crate::text::ime_composing(ev) {
             return;
         }
         if open.get().is_some() {


### PR DESCRIPTION
## What

Typing with a Chinese IME on macOS, pressing Enter to confirm a candidate sent the message instead of committing the composition.

## Why

The composer keydown handler already guards with `ev.is_composing()` (#108), but WebKit (the WKWebView wry uses) fires the confirm-Enter keydown **after** `compositionend`, so `isComposing` is already `false` there. That keydown still carries `keyCode == 229`, the IME-processed sentinel — the only reliable signal on this engine.

## How

- New shared helper `text::ime_composing(ev)` = `is_composing() || keyCode == 229` ([ui/src/text.rs](../blob/claude/macos-enter-send-bug-c4ed74/ui/src/text.rs))
- All 11 existing IME guards now route through it: main composer send, side-chat send, @ pickers, project search, Ctrl/Cmd shortcut palette, and the Escape-closes-modal handlers — same quirk would misfire in each of them.

## Notes for review

- `keyCode` is deprecated in the spec but is exactly the field engines still populate with 229 for IME-processed keys; there is no non-deprecated equivalent for this case.
- Chrome/Windows WebView2 report `isComposing == true` on that keydown, so the extra check is a no-op there.
- Verified with `cargo check --target wasm32-unknown-unknown` in `ui/`; behavior needs a manual macOS IME check (type pinyin, Enter to confirm — text commits, nothing sends).

🤖 Generated with [Claude Code](https://claude.com/claude-code)