### PR TITLE
fix(ui): rebuild the center-pane PDF preview layout

### DIFF
--- a/ui/src/api.js
+++ b/ui/src/api.js
@@ -470,9 +470,14 @@ async function renderPdf(el, payload) {
   let pdf;
   let renderTask;
   let disconnectObserver;
+  let resizeObserver;
+  let refitTimer;
   let currentPage = 1;
   let rendering = false;
   let disposed = false;
+  // Width the current canvas was rasterised for; a resize past it means the page
+  // is being upscaled/downscaled by the browser and needs a re-render.
+  let renderedFitWidth = null;
   try {
     const lib = await pdfjs();
     const source = payload.b64 ? { data: base64Bytes(payload.b64) } : payload.url ? { url: payload.url } : null;
@@ -527,12 +532,24 @@ async function renderPdf(el, payload) {
     // clicks on the page navigation controls once the preview is zoomed in.
     nav.addEventListener("pointerdown", (event) => event.stopPropagation());
     nav.append(prevButton, pageIndicator, nextButton);
-    toolbar.appendChild(nav);
+
+    // Page nav and zoom are one control set, so they share one bar. The zoom bar
+    // is Leptos-owned and sits outside .file-preview-zoom-content, which also
+    // keeps the nav from scaling with the page. Previews mounted without the
+    // zoom wrapper (right pane, plain modal) keep the toolbar inside .rp-pdf.
+    const zoomBar = el
+      .closest(".file-preview-zoom")
+      ?.querySelector(".file-preview-zoom-bar");
+    if (zoomBar) {
+      zoomBar.prepend(nav);
+    } else {
+      toolbar.appendChild(nav);
+    }
 
     const viewer = document.createElement("div");
     viewer.className = "rp-pdf-viewer";
 
-    root.append(toolbar, viewer);
+    root.append(...(zoomBar ? [viewer] : [toolbar, viewer]));
     el.replaceChildren(root);
 
     const syncControls = () => {
@@ -554,6 +571,12 @@ async function renderPdf(el, payload) {
       el.__wispPreviewCleanup?.();
     };
 
+    // Fit-to-width base for the page, independent of --preview-zoom: the zoom is
+    // a pure CSS multiple of this. Read off the viewer, whose width tracks the
+    // pane and not the (possibly zoomed) page inside it.
+    const fitWidth = () =>
+      Math.max(240, Math.min(viewer.clientWidth || el.clientWidth || 800, 1000));
+
     const renderPage = async (pageNumber) => {
       rendering = true;
       syncControls();
@@ -562,10 +585,8 @@ async function renderPdf(el, payload) {
       try {
         // Render at up to 2x the displayed width so text remains crisp on HiDPI
         // screens without making the single-page preview consume unbounded canvas memory.
-        const availableWidth = Math.max(
-          240,
-          Math.min(viewer.clientWidth || el.clientWidth || 800, 1000),
-        );
+        const availableWidth = fitWidth();
+        renderedFitWidth = availableWidth;
         const pixelRatio = Math.min(window.devicePixelRatio || 1, 2);
         const natural = page.getViewport({ scale: 1 });
         const cssScale = availableWidth / natural.width;
@@ -573,10 +594,11 @@ async function renderPdf(el, payload) {
         const wrapper = document.createElement("div");
         wrapper.className = "rp-pdf-page";
         wrapper.dataset.page = String(pageNumber);
-        // Keep the initial fit-to-width cap, but let the shared preview zoom
-        // scale it. A fixed max-width made the toolbar percentage change while
-        // PDF pages stayed at their original size.
-        wrapper.style.maxWidth =
+        // The page itself is the only thing the zoom scales: availableWidth is
+        // the fit-to-width base and --preview-zoom multiplies it. This must be
+        // `width`, not `max-width` — .rp-pdf-page is width:100% of the viewer,
+        // so a max-width above 100% would never win and zoom-in would no-op.
+        wrapper.style.width =
           `calc(${Math.floor(availableWidth)}px * var(--preview-zoom, 1))`;
         wrapper.setAttribute(
           "aria-label",
@@ -683,7 +705,12 @@ async function renderPdf(el, payload) {
     const cleanup = () => {
       if (disposed) return;
       disposed = true;
+      // When portalled into the zoom bar the nav lives outside el, so it
+      // survives the el.replaceChildren() on the error paths — take it down here.
+      nav.remove();
       document.removeEventListener("keydown", onKeyDown);
+      clearTimeout(refitTimer);
+      resizeObserver?.disconnect();
       disconnectObserver?.disconnect();
       if (renderTask) {
         try {
@@ -715,6 +742,26 @@ async function renderPdf(el, payload) {
       });
       disconnectObserver.observe(observerTarget, { childList: true, subtree: true });
     }
+
+    // The canvas is rasterised for one fitWidth, so a pane resize (split toggled,
+    // window resized, right pane dragged) otherwise leaves the page frozen at the
+    // width it was first rendered at. Debounced; re-queues rather than running
+    // while a render is in flight, so two renderTasks never race for the viewer.
+    // The initial observation fires harmlessly — by then renderedFitWidth matches.
+    const scheduleRefit = () => {
+      clearTimeout(refitTimer);
+      refitTimer = setTimeout(() => {
+        if (disposed || !el.isConnected) return;
+        if (rendering) {
+          scheduleRefit();
+          return;
+        }
+        if (fitWidth() === renderedFitWidth) return;
+        void renderPage(currentPage).catch(showPageError);
+      }, 150);
+    };
+    resizeObserver = new ResizeObserver(scheduleRefit);
+    resizeObserver.observe(viewer);
 
     syncControls();
     await renderPage(currentPage);

--- a/ui/src/app_support.rs
+++ b/ui/src/app_support.rs
@@ -5658,7 +5658,7 @@ fn ZoomableFilePreview(dom_id: String, path: String, kind: String) -> impl IntoV
                         adjust_zoom(-25);
                     }
                 }>
-                <div class="file-preview-zoom-content"
+                <div class="file-preview-zoom-content" data-zoom-kind=kind.clone()
                     style=move || format!("--preview-zoom:{}", zoom.get() as f32 / 100.0)>
                     <FilePreview dom_id=dom_id path=path kind=kind />
                 </div>

--- a/ui/src/styles/chat.css
+++ b/ui/src/styles/chat.css
@@ -33,12 +33,27 @@
 .center-file-btn.primary:hover:not(:disabled) { background: var(--clay-strong); }
 .center-file-editor { display: block; width: 100%; box-sizing: border-box; min-height: calc(100vh - 180px); padding: 12px 14px; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--bg-elev); color: var(--text); font-family: var(--font-mono); font-size: 13px; line-height: 1.6; resize: vertical; }
 .center-file-preview .rp-code { min-height: calc(100% - 20px); }
-.center-file-preview:is([data-preview-kind="structure"], [data-preview-kind="fasta"], [data-preview-kind="docx"]) { display: flex; flex-direction: column; overflow: hidden; }
+/* These kinds own their internal scrolling, so the outer box must not also
+   scroll — two scroll containers means the sticky head and the inner toolbars
+   fight over the same overflow. */
+.center-file-preview:is([data-preview-kind="structure"], [data-preview-kind="fasta"], [data-preview-kind="docx"], [data-preview-kind="pdf"], [data-preview-kind="image"]) { display: flex; flex-direction: column; overflow: hidden; }
 .center-file-preview:is([data-preview-kind="structure"], [data-preview-kind="fasta"], [data-preview-kind="docx"]) > .rp-heavy { display: flex; flex: 1 1 auto; min-height: 0; flex-direction: column; }
 .center-file-preview[data-preview-kind="structure"] .rp-3dmol { flex: 1 1 auto; min-height: 0; height: auto; }
 .center-file-preview[data-preview-kind="fasta"] .rp-fasta-wrap { flex: 1 1 auto; min-height: 0; max-height: none; }
 .center-file-preview[data-preview-kind="docx"] { padding: 0; }
 .center-file-preview[data-preview-kind="docx"] .rp-docx { flex: 1 1 auto; min-height: 0; overflow: auto; }
+/* .rp-pdf's sunken card is right-pane chrome, where it frames a thumbnail. In
+   the center it wraps the whole document instead, so the page reads as a card
+   inside a card. Drop the card and let the scroll viewport be the desk. */
+.center-file-preview[data-preview-kind="pdf"] .rp-pdf { padding: 0; background: none; border-radius: 0; }
+.center-file-preview[data-preview-kind="pdf"] .file-preview-zoom-viewport {
+  padding: 16px 0; background: var(--bg-sunken); border-radius: var(--radius-sm);
+}
+/* --bg-sunken sits ~4% off white, so a drop shadow alone leaves the page and the
+   desk as one mush. The hairline ring is what makes it read as paper. */
+.center-file-preview[data-preview-kind="pdf"] .rp-pdf-page {
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, .07), 0 1px 2px rgba(0, 0, 0, .06), 0 4px 16px rgba(0, 0, 0, .10);
+}
 /* Split view: document left, the main conversation right. Grid so the four
    existing children (topbar / preview / chat / composer) re-flow without any
    extra wrapper — .selection-popup is position:fixed and stays out of it. */

--- a/ui/src/styles/right-pane.css
+++ b/ui/src/styles/right-pane.css
@@ -349,8 +349,12 @@
 .rp-pdf-nav-btn:disabled { opacity: .4; cursor: default; }
 .rp-pdf-nav-btn svg { width: 16px; height: 16px; fill: none; stroke: currentColor; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
 .rp-pdf-page-indicator { min-width: 112px; padding: 0 6px; color: var(--text-muted); font-size: 12px; font-weight: 600; text-align: center; white-space: nowrap; }
-.rp-pdf-viewer { display: flex; justify-content: center; align-items: flex-start; min-height: 0; }
-.rp-pdf-page { position: relative; width: 100%; overflow: hidden; background: #fff; box-shadow: 0 1px 5px rgba(0, 0, 0, .18); }
+/* Block + auto margins, not flex centering: zoomed past 100% the page is wider
+   than the viewer, and a centered flex item overflows equally into both sides —
+   the left half is then unreachable by scroll. Auto margins collapse to 0 once
+   the page outgrows the viewer, so it stays fully scrollable. */
+.rp-pdf-viewer { min-height: 0; }
+.rp-pdf-page { position: relative; width: 100%; margin: 0 auto; overflow: hidden; background: #fff; box-shadow: 0 1px 5px rgba(0, 0, 0, .18); }
 .rp-pdf-page canvas { display: block; width: 100%; height: auto; }
 .rp-pdf-loading, .rp-pdf-error { display: flex; min-height: 120px; align-items: center; justify-content: center; padding: 16px; text-align: center; }
 /* pdf.js text layer — transparent selectable glyphs positioned over the canvas
@@ -379,11 +383,31 @@
 .file-preview-zoom-bar button { min-width: 30px; height: 28px; padding: 0 8px; border: 1px solid var(--border-strong); background: var(--bg-elev); color: var(--text-muted); border-radius: 7px; font: inherit; font-size: 12px; cursor: pointer; }
 .file-preview-zoom-bar button:hover:not(:disabled) { color: var(--text); background: var(--surface-hover); }
 .file-preview-zoom-bar button:disabled { opacity: .4; cursor: default; }
-.file-preview-zoom-viewport { position: relative; flex: 1 1 auto; min-height: 0; overflow: auto; text-align: center; overscroll-behavior: contain; }
+/* PDF page nav is portalled in here (api.js) to share one bar with the zoom.
+   Its pill chrome belongs to the standalone .rp-pdf fallback; in the bar it is
+   just another group, and `.file-preview-zoom-bar button` above already wins on
+   the buttons' own styling. The right edge divides page nav from zoom. */
+.file-preview-zoom-bar .rp-pdf-nav {
+  gap: 4px; padding: 0 12px 0 0; margin-right: 8px;
+  border: 0; border-right: 1px solid var(--border); border-radius: 0;
+  background: none; box-shadow: none;
+}
+/* scrollbar-gutter: the PDF page is sized from a clientWidth measured before the
+   vertical scrollbar exists; once it appears the container narrows and the page
+   overflows by the scrollbar's width. Reserving the gutter up front keeps that
+   measurement honest, and stops pages of differing height shifting the view
+   sideways as you page through. */
+.file-preview-zoom-viewport { position: relative; flex: 1 1 auto; min-height: 0; overflow: auto; scrollbar-gutter: stable; text-align: center; overscroll-behavior: contain; }
 .file-preview-zoom-viewport.is-zoomed { cursor: grab; }
 .file-preview-zoom-viewport.is-dragging { cursor: grabbing; user-select: none; }
 .file-preview-zoom-viewport.is-cropping { cursor: crosshair; }
-.file-preview-zoom-content { display: inline-block; width: calc(var(--preview-zoom, 1) * 100%); min-width: 25%; vertical-align: top; }
+/* --preview-zoom is set here (inline style) for descendants to read, but only
+   the image preview scales by this wrapper's width. PDF pages size themselves
+   off the same var in api.js, so scaling here too would apply the zoom twice —
+   and worse, feed the zoomed width back into the fit-to-width measurement that
+   reads viewer.clientWidth on the next page render. */
+.file-preview-zoom-content { display: inline-block; width: 100%; vertical-align: top; }
+.file-preview-zoom-content[data-zoom-kind="image"] { width: calc(var(--preview-zoom, 1) * 100%); min-width: 25%; }
 /* Region crop: toggle button + full-viewport capture layer + rubber-band. */
 .file-preview-crop-btn { display: inline-flex; align-items: center; justify-content: center; min-width: 30px; height: 28px; padding: 0 7px; border: 1px solid var(--border-strong); background: var(--bg-elev); color: var(--text-muted); border-radius: 7px; cursor: pointer; }
 .file-preview-crop-btn:hover:not(:disabled) { color: var(--text); background: var(--surface-hover); }


### PR DESCRIPTION
## 背景

中间栏的 PDF 预览观感很差。根因是它整套复用了右侧栏的 `.rp-pdf` —— 在右侧窄栏里那是个装缩略图的下沉小卡片，逻辑成立；铺到中间栏全宽后，它变成包住整篇文档的巨型圆角灰盒，纸读起来像"卡片套卡片"。而 chat.css 里 `pdf` 是唯一没有自己 `[data-preview-kind]` 规则的预览类型。

## 改了什么

**布局归属** — 给 pdf/image 补上其他重类型早就有的 `flex + overflow: hidden`。此前外层是第二个滚动容器，`.center-file-head` 和 `.file-preview-zoom-bar` 是两个互不知情的 sticky 在抢同一份 overflow，而 `.file-preview-zoom` 的 flex 尺寸设置全是死代码。

**剥掉灰卡片** — 中间栏不要那层下沉卡片，让滚动 viewport 当"桌面"。`--bg-sunken` 离白只有约 4%，光靠投影纸和桌面糊成一坨，纸需要一道 hairline ring 才读得出是纸。

**缩放只作用于纸，不作用于 chrome** — 原来 zoom 被应用了两次（CSS wrapper 的 width + 纸自己的 maxWidth），而且 wrapper 被缩放后的宽度会回灌进读 `viewer.clientWidth` 的 fit-to-width 测量，形成反馈环 —— 所以 `75%` 是"面板宽度的 75%"而不是文档真实尺寸的 75%。现在缩放载体改成 `width`（`max-width` 超过 100% 永远赢不了 `width: 100%`，放大会直接失效），并且 `.rp-pdf-viewer` 从 flex 居中换成 block + auto margins：居中的 flex item 会向两侧等量溢出，放大超过 100% 后左半边滚不到。

**预留滚动条槽** — 纸的尺寸取自垂直滚动条出现**之前**测到的 clientWidth，滚动条一出来纸就会顶出去一个滚动条宽度。顺带消除翻页时不同高度页面导致的左右抖动。

**工具栏合一** — 翻页 nav portal 进 Leptos 那侧的 zoom bar，同时把它带出了缩放 wrapper。没有该 wrapper 的场景（右侧栏、普通 modal）保留 `.rp-pdf` 内的行内 toolbar。

**面板 resize 后重新渲染** — canvas 是按某一个 fitWidth 光栅化的，切分屏或改窗口大小后纸会冻结在首次渲染的宽度上，孤零零飘在过大的桌面中央。

## 验证

搭了一套用真实 CSS / 真实 DOM 结构 / 真实 pdf.js / 真实 PDF 的验证页逐条实测（验证完已清理）：

- **滚动归属**：`outerScrolls: false`、`bodyScrolls: false`，滚动归 viewport 独有
- **缩放矩阵 25–400%**：纸 230/461/921/1842/3684 严格线性；桌面与 chrome 恒定 921 不跟着缩；左边缘始终可达；仅在 >100% 时横向溢出
- **反馈环已断**：`viewer.clientWidth` 恒定 921，翻页重渲染不再漂移
- **工具栏**：`sameRow: true`、barHeight 28（两行→一行）；圆角/高度/边框色/背景色与 zoom 按钮完全一致；`navScalesWithZoom: false`
- **image 路径**：仍按 wrapper 缩放（`image_at_200: 1842`），未被破坏
- **dark mode**：深色桌面 + 白纸，灰卡片同样剥掉

过程中修了一个自己引入的回归：改成固定 width 后丢掉了 `width: 100%` 自动吸收滚动条宽度的能力，导致 100% 时横向溢出 10px —— 用 `scrollbar-gutter: stable` 修根源，测量随之变准（`calc(921px * ...)` 而非 931）。

## Reviewer 需要知道的

⚠️ **resize 重渲染（ResizeObserver）只做了静态复核，没有运行时验证。** 验证环境的浏览器 canvas 管线在反复 reload 后卡死（`page.render()` 永不返回）；裸 pdf.js 和一个 550 字节的合成 PDF 都能复现，确认与本改动无关，但也因此没法实测这一条。逻辑上它是收敛的（初始触发时 `rendering` 为 true → 重新排队；首次渲染后 `renderedFitWidth` 判等 → return；并发由 `if (rendering)` 挡掉），失败模式是"不生效"而非"更糟"。**建议真机上开个 PDF、拖右侧栏或切分屏看一眼纸是否跟随重新 fit。**

`.rp-pdf-viewer` 改 block 和 `maxWidth`→`width` 对右侧栏 / modal 的 fallback 路径同样生效，这条路径只做了推理未实测。当前安全边界来自 `RIGHT_PANE_MIN_WIDTH = 320`（减去各层 padding 后 viewer ≈ 296 > `availableWidth` 的 240 下限）；若将来把它调到 240 以下，这里需要补一个 `min(_, 100%)`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

