### PR TITLE
Fix 100% image and PDF preview panning

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,9 @@ outputs are isolated in `ui/dist-dev` and `ui/dist-test`; release packaging
 continues to use `ui/dist`. This prevents a running dev/test server from racing
 with `cargo tauri build` while it copies the optimized WASM bundle.
 
+Image and PDF previews can be zoomed and drag-panned whenever their content
+extends beyond the visible viewport, including at 100% zoom.
+
 On macOS, run the same commands from a shell (`cargo tauri build` emits a
 `.app` and `.dmg` under `target/release/bundle`). `src-tauri/tauri.macos.conf.json`
 is auto-merged by Tauri to replace the PowerShell `beforeBuildCommand` with a

--- a/README_zh.md
+++ b/README_zh.md
@@ -115,6 +115,8 @@ cargo tauri build    # 在 target/release/bundle 下生成 MSI/NSIS 安装程序
 隔离在 `ui/dist-dev` 与 `ui/dist-test`，发布构建继续使用 `ui/dist`，避免正在
 运行的开发或测试服务器与 `cargo tauri build` 并发复制优化后的 WASM 文件。
 
+当图片或 PDF 内容超出可见区域时，预览支持缩放和拖拽平移，包括 100% 缩放状态。
+
 在 macOS 上使用相同命令（`cargo tauri build` 会在
 `target/release/bundle` 下生成 `.app` 和 `.dmg`）。
 `src-tauri/tauri.macos.conf.json` 会由 Tauri 自动合并，以跨平台的

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -1960,6 +1960,39 @@ test("PDF artifacts render inside the app without a browser PDF plugin", async (
   const pageWidthAt100 = await renderedPage.evaluate((el) => el.getBoundingClientRect().width);
   const textSpan = renderedPage.locator(".rp-pdf-textlayer span").first();
   const textWidthAt100 = await textSpan.evaluate((el) => el.getBoundingClientRect().width);
+  // A fit-width page can still be taller than the modal. It must be pannable at
+  // 100%; panning depends on actual overflow, not on zoom being above 100%.
+  const viewport = modal.locator(".file-preview-zoom-viewport");
+  await expect.poll(() => viewport.evaluate((el) => el.scrollHeight > el.clientHeight)).toBe(true);
+  await viewport.evaluate((el) => {
+    const rect = el.getBoundingClientRect();
+    const x = rect.left + rect.width * 0.5;
+    const startY = rect.top + rect.height * 0.7;
+    const endY = rect.top + rect.height * 0.25;
+    el.dispatchEvent(new PointerEvent("pointerdown", {
+      bubbles: true,
+      button: 0,
+      pointerId: 3,
+      clientX: x,
+      clientY: startY,
+    }));
+    el.dispatchEvent(new PointerEvent("pointermove", {
+      bubbles: true,
+      button: 0,
+      buttons: 1,
+      pointerId: 3,
+      clientX: x,
+      clientY: endY,
+    }));
+    el.dispatchEvent(new PointerEvent("pointerup", {
+      bubbles: true,
+      button: 0,
+      pointerId: 3,
+      clientX: x,
+      clientY: endY,
+    }));
+  });
+  await expect.poll(() => viewport.evaluate((el) => el.scrollTop)).toBeGreaterThan(0);
   await page.getByRole("button", { name: "Zoom in" }).click();
   await page.getByRole("button", { name: "Zoom in" }).click();
   await expect(page.getByRole("button", { name: "Reset zoom" })).toHaveText("150%");
@@ -2032,16 +2065,17 @@ test("PDF text can be selected and added to chat", async ({ page }) => {
   const layer = page.locator(".artifact-modal .rp-pdf-textlayer");
   await expect(layer).toContainText("PDF preview works");
 
-  // Select a text-layer span and raise the shared quote popup (the modal
-  // figure's data-file-path ancestor drives it — same path as md/docx).
-  await layer.locator("span").first().evaluate((el) => {
-    const range = document.createRange();
-    range.selectNodeContents(el);
-    const sel = window.getSelection()!;
-    sel.removeAllRanges();
-    sel.addRange(range);
-    window.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, cancelable: true }));
-  });
+  // Drag-select a text-layer span with real pointer input. The zoom viewport
+  // must leave glyph drags to text selection while blank-page drags pan.
+  const span = layer.locator("span").first();
+  await span.scrollIntoViewIfNeeded();
+  const box = await span.boundingBox();
+  if (!box) throw new Error("PDF text span has no bounding box");
+  const y = box.y + box.height * 0.5;
+  await page.mouse.move(box.x + 2, y);
+  await page.mouse.down();
+  await page.mouse.move(box.x + box.width - 2, y, { steps: 5 });
+  await page.mouse.up();
   const popup = page.locator(".selection-popup");
   await expect(popup).toBeVisible();
   await popup.getByRole("button", { name: "Add to chat" }).click();

--- a/ui/src/app_support.rs
+++ b/ui/src/app_support.rs
@@ -5822,16 +5822,34 @@ fn ZoomableFilePreview(dom_id: String, path: String, kind: String) -> impl IntoV
                 })}
             </div>
             <div id=viewport_id class="file-preview-zoom-viewport"
-                class:is-zoomed=move || { zoom.get() > 100 }
                 class:is-dragging=move || { is_dragging.get() }
                 class:is-cropping=move || { crop_mode.get() }
                 on:pointerdown=move |ev: web_sys::PointerEvent| {
-                    if ev.button() != 0 || crop_mode.get_untracked() || zoom.get_untracked() <= 100 {
+                    if ev.button() != 0 || crop_mode.get_untracked() {
+                        return;
+                    }
+                    // PDF glyphs remain drag-selectable for quoting. Starting
+                    // on the surrounding page/whitespace pans the preview.
+                    if ev
+                        .target()
+                        .and_then(|target| target.dyn_into::<web_sys::Element>().ok())
+                        .and_then(|target| target.closest(".rp-pdf-textlayer span").ok().flatten())
+                        .is_some()
+                    {
                         return;
                     }
                     let Some(viewport) = viewport_for_pointerdown() else {
                         return;
                     };
+                    // Zoom percentage is not a reliable proxy for pannability:
+                    // a tall image or PDF page can overflow the modal at 100%.
+                    // Only capture the drag when there is actual scrollable
+                    // content in at least one direction.
+                    if viewport.scroll_width() <= viewport.client_width()
+                        && viewport.scroll_height() <= viewport.client_height()
+                    {
+                        return;
+                    }
                     ev.prevent_default();
                     let _ = viewport.set_pointer_capture(ev.pointer_id());
                     drag_start_down.set(Some((

--- a/ui/src/styles/modals.css
+++ b/ui/src/styles/modals.css
@@ -223,8 +223,11 @@ textarea.host-input { min-height:64px; resize:vertical; }
   max-height: 52vh; overflow: auto; display: flex; justify-content: flex-start; align-items: flex-start;
   background: var(--bg-sunken); border-radius: var(--radius-sm); padding: 8px;
 }
-/* Image/PDF pan inside their own zoom viewport, so the figure box must clip, not scroll. */
-.artifact-modal .am-figure.zoomable-preview { height: 52vh; overflow: hidden; }
+/* Image/PDF pan inside their own zoom viewport, so the figure box must clip, not
+   scroll. Column layout puts the zoom wrapper on the bounded main axis; leaving
+   the default row axis lets a tall 100% page grow to its intrinsic height and
+   then get clipped without creating overflow in the viewport. */
+.artifact-modal .am-figure.zoomable-preview { height: 52vh; overflow: hidden; flex-direction: column; }
 /* DOCX renders a tall document that scrolls inside its own .rp-docx surface.
    The mount div (.rp-heavy) must be a flex-column filler so the bounded height
    reaches .rp-docx — otherwise its auto height breaks the chain and the figure

--- a/ui/src/styles/right-pane.css
+++ b/ui/src/styles/right-pane.css
@@ -397,8 +397,7 @@
    overflows by the scrollbar's width. Reserving the gutter up front keeps that
    measurement honest, and stops pages of differing height shifting the view
    sideways as you page through. */
-.file-preview-zoom-viewport { position: relative; flex: 1 1 auto; min-height: 0; overflow: auto; scrollbar-gutter: stable; text-align: center; overscroll-behavior: contain; }
-.file-preview-zoom-viewport.is-zoomed { cursor: grab; }
+.file-preview-zoom-viewport { position: relative; flex: 1 1 auto; min-height: 0; overflow: auto; scrollbar-gutter: stable; text-align: center; overscroll-behavior: contain; cursor: grab; }
 .file-preview-zoom-viewport.is-dragging { cursor: grabbing; user-select: none; }
 .file-preview-zoom-viewport.is-cropping { cursor: crosshair; }
 /* --preview-zoom is set here (inline style) for descendants to read, but only


### PR DESCRIPTION
## Problem

Image and PDF previews could be clipped inside the artifact modal at 100% zoom, but drag panning was hard-disabled until the zoom exceeded 100%. Tall PDF pages could also grow to their intrinsic height and be clipped by the modal instead of producing overflow in the inner viewport.

## Changes

- Bound zoomable modal previews on the vertical flex axis so the inner viewport owns scrolling.
- Enable drag panning whenever the viewport has real horizontal or vertical overflow, independent of zoom percentage.
- Preserve PDF glyph drag-selection for quoting while allowing blank-page drags to pan.
- Add Playwright coverage for vertical panning at 100% and real pointer-based PDF text selection.
- Document the image/PDF preview behavior in the English and Chinese READMEs.

## User impact

Tall PNG and PDF previews can now be dragged at 100% zoom instead of requiring an unnecessary zoom-in first. PDF text selection and image region cropping continue to work.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cd ui && cargo check --target wasm32-unknown-unknown`
- `cd ui-tests && npm ci && npx playwright test` — 146 passed
- Final focused PDF pan and text-selection run — 2 passed

## Manual smoke steps

1. Open a tall PNG or PDF in the artifact modal at 100%.
2. Drag on the page/blank area and confirm both axes pan when content overflows.
3. Drag across PDF text and confirm it remains selectable and can be added to chat.
4. Zoom in/out and, for images, confirm region crop still works.

## Known limitations / follow-up

Dragging directly from PDF glyphs intentionally selects text; start a pan from page whitespace or use the scrollbars/wheel. No follow-up is required for this fix.