### PR TITLE
fix: bound Python and R preview consoles

### DIFF
--- a/docs/superpowers/specs/2026-07-14-wisp-runtime-design.md
+++ b/docs/superpowers/specs/2026-07-14-wisp-runtime-design.md
@@ -557,7 +557,9 @@ Anthropic API rejects. Flooding the transcript with every REPL iteration would
 also re-send that output on every later turn. The existing "add to chat" action
 remains the way to hand a result to the agent. The console is in-memory for the
 same reason the runtime is: a log that outlived its process would describe
-variables that no longer exist.
+variables that no longer exist. In the center preview it is a bounded bottom
+dock with its own normal scroll surface; it does not overlay the source, and a
+long submitted script is summarized instead of duplicated in full.
 
 R is optional. Missing `Rscript`/`jsonlite` is a capability state, not a global app
 bootstrap failure. Existing Python bootstrap remains because the app-managed Python

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -1135,6 +1135,23 @@ test("R scripts bind to a runtime and run selections or the whole file in it", a
   // Submitted code is echoed behind a prompt, then its output.
   await expect(console_).toContainText("> library(Seurat)");
   await expect(console_).toContainText("[r @ ssh:gpu-server] library(Seurat)");
+  await expect(page.locator(".center-file-preview")).toHaveCSS("overflow", "hidden");
+  await expect(page.locator(".center-file-console")).not.toHaveCSS("position", "sticky");
+
+  // The output is a bounded dock below the independently scrolling source,
+  // never a sticky layer covering the code preview.
+  const dockLayout = await page.locator(".center-file-preview").evaluate((preview) => {
+    const source = preview.querySelector(".rp-code")!.getBoundingClientRect();
+    const console_ = preview.querySelector(".center-file-console")!.getBoundingClientRect();
+    return {
+      sourceBottom: Math.round(source.bottom),
+      consoleTop: Math.round(console_.top),
+      consoleHeight: Math.round(console_.height),
+      viewportHeight: window.innerHeight,
+    };
+  });
+  expect(dockLayout.consoleTop).toBeGreaterThanOrEqual(dockLayout.sourceBottom);
+  expect(dockLayout.consoleHeight).toBeLessThanOrEqual(Math.round(dockLayout.viewportHeight * 0.32) + 1);
 
   // Selecting code offers running just that selection — the RStudio reflex.
   // highlight.js splits the source into spans, so select one it produces.

--- a/ui/src/app_support.rs
+++ b/ui/src/app_support.rs
@@ -876,6 +876,7 @@ fn context_runtime_available(ctx: &ExecutionContext, language: &str) -> bool {
 mod runtime_slot_tests {
     use super::{context_runtime_available, mention_compute_entries, ComposerPickerItem};
     use crate::dto::ExecutionContext;
+    use crate::i18n::Locale;
 
     fn context(
         kind: &str,
@@ -979,8 +980,33 @@ mod runtime_slot_tests {
     #[test]
     fn console_echo_prefixes_every_submitted_line() {
         assert_eq!(
-            super::console_echo("library(Seurat)\nlibrary(dplyr)"),
+            super::console_echo("library(Seurat)\nlibrary(dplyr)", Locale::En),
             "> library(Seurat)\n> library(dplyr)"
+        );
+    }
+
+    #[test]
+    fn console_echo_bounds_long_script_previews() {
+        let code = (1..=40)
+            .map(|line| format!("line_{line}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let echo = super::console_echo(&code, Locale::En);
+        assert_eq!(echo.lines().count(), 11);
+        assert!(echo.contains("> line_1"));
+        assert!(echo.contains("> … 30 submitted lines omitted …"));
+        assert!(echo.contains("> line_40"));
+        assert!(!echo.contains("> line_20"));
+
+        let zh_echo = super::console_echo(&code, Locale::Zh);
+        assert!(zh_echo.contains("> … 已省略 30 行提交代码 …"));
+    }
+
+    #[test]
+    fn closed_worker_error_is_user_facing() {
+        assert_eq!(
+            crate::i18n::localize_backend(Locale::Zh, "kernel worker closed protocol stdout"),
+            "Runtime 进程意外退出，请重启后再运行代码。"
         );
     }
 
@@ -1187,8 +1213,36 @@ pub(super) type RuntimeConsoles = HashMap<String, String>;
 
 /// R and Python consoles echo submitted code behind a prompt. Keeping that here
 /// is what lets one flat log stay readable as alternating input and output.
-fn console_echo(code: &str) -> String {
-    code.lines()
+fn console_echo(code: &str, locale: Locale) -> String {
+    const MAX_LINES: usize = 12;
+    const HEAD_LINES: usize = 7;
+    const TAIL_LINES: usize = 3;
+
+    let lines = code.lines().collect::<Vec<_>>();
+    let visible = if lines.len() <= MAX_LINES {
+        lines
+            .into_iter()
+            .map(str::to_string)
+            .collect::<Vec<_>>()
+    } else {
+        let omitted = lines.len() - HEAD_LINES - TAIL_LINES;
+        lines[..HEAD_LINES]
+            .iter()
+            .map(|line| (*line).to_string())
+            .chain(std::iter::once(tf(
+                locale,
+                "runtime.console_omitted",
+                &[("n", &omitted.to_string())],
+            )))
+            .chain(
+                lines[lines.len() - TAIL_LINES..]
+                    .iter()
+                    .map(|line| (*line).to_string()),
+            )
+            .collect::<Vec<_>>()
+    };
+    visible
+        .into_iter()
         .map(|line| format!("> {line}"))
         .collect::<Vec<_>>()
         .join("\n")
@@ -1230,7 +1284,7 @@ pub(super) fn run_in_runtime(
     if code.is_empty() || ctx.busy.get_untracked().is_some() {
         return;
     }
-    append_console(ctx.consoles, &path, &console_echo(&code));
+    append_console(ctx.consoles, &path, &console_echo(&code, locale));
     ctx.busy.set(Some(path.clone()));
     spawn_local(async move {
         let args = to_value(&serde_json::json!({

--- a/ui/src/i18n.rs
+++ b/ui/src/i18n.rs
@@ -370,6 +370,8 @@ fn lookup(locale: Locale, key: &str) -> Option<&'static str> {
         (Locale::En, "runtime.run_file") => Some("Run this script in its runtime"),
         (Locale::En, "runtime.console") => Some("Runtime console"),
         (Locale::En, "runtime.console_clear") => Some("Clear console"),
+        (Locale::En, "runtime.console_omitted") => Some("… {n} submitted lines omitted …"),
+        (Locale::En, "runtime.worker_closed") => Some("The runtime process exited unexpectedly. Restart it before running more code."),
         (Locale::En, "runtime.unavailable") => Some("Unavailable"),
         (Locale::En, "runtime.unavailable_hint") => Some("Probe this context or configure its interpreter. R also requires jsonlite."),
         (Locale::En, "runtime.generation") => Some("Generation"),
@@ -1289,6 +1291,8 @@ fn lookup(locale: Locale, key: &str) -> Option<&'static str> {
         (Locale::Zh, "runtime.run_file") => Some("在 runtime 中运行整个脚本"),
         (Locale::Zh, "runtime.console") => Some("Runtime 控制台"),
         (Locale::Zh, "runtime.console_clear") => Some("清空控制台"),
+        (Locale::Zh, "runtime.console_omitted") => Some("… 已省略 {n} 行提交代码 …"),
+        (Locale::Zh, "runtime.worker_closed") => Some("Runtime 进程意外退出，请重启后再运行代码。"),
         (Locale::Zh, "runtime.unavailable") => Some("不可用"),
         (Locale::Zh, "runtime.unavailable_hint") => Some("请先探测该环境或配置解释器；R 还需要 jsonlite。"),
         (Locale::Zh, "runtime.generation") => Some("代次"),
@@ -1954,6 +1958,7 @@ pub fn localize_backend(locale: Locale, msg: &str) -> String {
         "Synchronize this project successfully before copying its device code." => {
             t(locale, "err.sync_code_before_first")
         }
+        "kernel worker closed protocol stdout" => t(locale, "runtime.worker_closed"),
         "selected folder has no SKILL.md" => t(locale, "err.skill_no_md"),
         "select a skill folder or a SKILL.md file" => t(locale, "err.skill_pick"),
         "SKILL.md has no frontmatter (--- block)" => t(locale, "err.skill_no_frontmatter"),

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -82,6 +82,46 @@ fn max_right_pane_width(sidebar_open: bool, sidebar_width: f64) -> f64 {
     available.clamp(RIGHT_PANE_MIN_WIDTH, RIGHT_PANE_MAX_WIDTH)
 }
 
+#[component]
+fn CenterRuntimeConsole(path: String, consoles: RwSignal<RuntimeConsoles>) -> impl IntoView {
+    let locale = use_locale();
+    let log_path = path.clone();
+    let clear_path = path;
+    let log = create_memo(move |_| consoles.get().get(&log_path).cloned());
+    let output_ref = create_node_ref::<html::Pre>();
+
+    // Follow appended output with ordinary positive scrollTop. The old
+    // column-reverse trick made WebKit's scrollbar direction and selection
+    // behavior backwards, especially once a whole script filled the console.
+    create_effect(move |_| {
+        let _ = log.get();
+        if let Some(output) = output_ref.get() {
+            request_animation_frame(move || output.set_scroll_top(output.scroll_height()));
+        }
+    });
+
+    move || {
+        log.get().map(|text| {
+            let clear_path = clear_path.clone();
+            view! {
+                <div class="center-file-console">
+                    <div class="center-file-console-head">
+                        <span>{move || t(locale.get(), "runtime.console")}</span>
+                        <div class="spacer"></div>
+                        <button type="button" class="center-file-btn"
+                            title=move || t(locale.get(), "runtime.console_clear")
+                            aria-label=move || t(locale.get(), "runtime.console_clear")
+                            on:click=move |_| consoles.update(|logs| {
+                                logs.remove(&clear_path);
+                            })>{compose_icon("close")}</button>
+                    </div>
+                    <pre node_ref=output_ref>{text}</pre>
+                </div>
+            }
+        })
+    }
+}
+
 #[derive(Default)]
 struct ProjectOpenGate {
     held: bool,
@@ -4991,7 +5031,13 @@ fn App() -> impl IntoView {
                     }
                 };
                 view! {
-                    <div class="center-file-preview" data-preview-kind=kind.clone()
+                    <div
+                        class=if run_language.is_some() {
+                            "center-file-preview center-file-runtime-preview"
+                        } else {
+                            "center-file-preview"
+                        }
+                        data-preview-kind=kind.clone()
                         data-file-path=path.clone()>
                         <div class="center-file-head">
                             <span>{path.clone()}</span>
@@ -5113,28 +5159,8 @@ fn App() -> impl IntoView {
                         }}
                         // Runtime console for this script. Only appears once
                         // something has run, so non-runtime files are unaffected.
-                        {run_language.map(|_| {
-                            let console_path = console_file.clone();
-                            let clear_path = console_file;
-                            let log = create_memo(move |_| center_console.get().get(&console_path).cloned());
-                            move || log.get().map(|text| {
-                                let clear_path = clear_path.clone();
-                                view! {
-                                    <div class="center-file-console">
-                                        <div class="center-file-console-head">
-                                            <span>{move || t(locale.get(), "runtime.console")}</span>
-                                            <div class="spacer"></div>
-                                            <button type="button" class="center-file-btn"
-                                                title=move || t(locale.get(), "runtime.console_clear")
-                                                aria-label=move || t(locale.get(), "runtime.console_clear")
-                                                on:click=move |_| center_console.update(|logs| {
-                                                    logs.remove(&clear_path);
-                                                })>{compose_icon("close")}</button>
-                                        </div>
-                                        <pre>{text}</pre>
-                                    </div>
-                                }
-                            })
+                        {run_language.map(|_| view! {
+                            <CenterRuntimeConsole path=console_file consoles=center_console />
                         })}
                     </div>
                 }

--- a/ui/src/styles/chat.css
+++ b/ui/src/styles/chat.css
@@ -32,17 +32,21 @@
 .center-file-btn.primary { border-color: var(--clay); background: var(--clay); color: var(--on-clay); }
 .center-file-btn.primary:hover:not(:disabled) { background: var(--clay-strong); }
 .center-file-editor { display: block; width: 100%; box-sizing: border-box; min-height: calc(100vh - 180px); padding: 12px 14px; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--bg-elev); color: var(--text); font-family: var(--font-mono); font-size: 13px; line-height: 1.6; resize: vertical; }
-/* Runtime binding picker + console for R/Python scripts. The console is sticky
-   to the foot of the preview the way .center-file-head is sticky to its top, so
-   output stays visible while a long script scrolls behind it. */
+/* Runtime binding picker + console for R/Python scripts. Runtime previews own
+   three bounded rows: toolbar, independently scrolling source, and output dock.
+   Keeping the console out of the source scroller prevents long output from
+   becoming a sticky overlay over the code. */
 .center-file-runtime { flex: 0 0 auto; max-width: 220px; padding: 3px 8px; border: 1px solid var(--border-strong); border-radius: 7px; background: var(--bg-elev); color: var(--text); font-family: var(--font-sans); font-size: 12px; cursor: pointer; }
-.center-file-console { position: sticky; bottom: -28px; z-index: 1; margin: 16px -20px -28px; border-top: 1px solid var(--border); background: var(--bg-app); }
+.center-file-runtime-preview { display: grid; grid-template-rows: auto minmax(0, 1fr) auto; overflow: hidden; padding-bottom: 0; }
+.center-file-runtime-preview .center-file-head { position: static; }
+.center-file-runtime-preview > :is(.rp-code, .center-file-editor) { min-height: 0; height: auto; max-height: none; }
+.center-file-runtime-preview > .center-file-editor { resize: none; }
+.center-file-console { display: flex; min-height: 0; max-height: min(300px, 32vh); flex-direction: column; margin: 12px -20px 0; border-top: 1px solid var(--border); background: var(--bg-app); }
 .center-file-console-head { display: flex; align-items: center; gap: 8px; padding: 5px 16px; border-bottom: 1px solid var(--border); color: var(--text-faint); font-family: var(--font-mono); font-size: 11px; }
 .center-file-console-head .spacer { flex: 1; }
 .center-file-console-head .center-file-btn { display: flex; padding: 2px 6px; }
-/* column-reverse keeps the scroll pinned to the newest output without JS. */
-.center-file-console pre { display: flex; flex-direction: column-reverse; margin: 0; padding: 10px 16px; max-height: 40vh; overflow: auto; font-family: var(--font-mono); font-size: 12px; line-height: 1.55; white-space: pre-wrap; overflow-wrap: anywhere; }
-.center-file-preview .rp-code { min-height: calc(100% - 20px); }
+.center-file-console pre { min-height: 0; margin: 0; padding: 10px 16px; overflow: auto; font-family: var(--font-mono); font-size: 12px; line-height: 1.55; white-space: pre-wrap; overflow-wrap: anywhere; }
+.center-file-preview:not(.center-file-runtime-preview) .rp-code { min-height: calc(100% - 20px); }
 /* These kinds own their internal scrolling, so the outer box must not also
    scroll — two scroll containers means the sticky head and the inner toolbars
    fight over the same overflow. */


### PR DESCRIPTION
## Problem

Running code from a Python or R center preview opened the Runtime console as a sticky layer inside the source scroller. Long submissions expanded the layer to 40vh, covered or squeezed the code, and used reverse flex scrolling that made the preview jump to the script tail. Whole-file runs also duplicated every submitted line, which could bury the actual runtime error. R worker exits surfaced the internal `kernel worker closed protocol stdout` message.

## What changed

- Rebuilt runtime-backed source previews as three bounded rows: toolbar, independently scrolling source/editor, and output dock.
- Capped the console at 300px / 32vh and switched it to normal scrolling that follows newly appended output.
- Summarized long submitted scripts using localized head/tail output instead of echoing the entire file.
- Localized unexpected worker exits into an actionable user-facing message.
- Added layout, echo-bounding, localization, and Python/R preview regression coverage.
- Updated the runtime design documentation.

## User impact

Python and R source stays readable after a run, output no longer overlays the preview, and long scripts do not flood the console. If an R process itself exits, the console now explains that it must be restarted instead of exposing a protocol-level error.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo check --manifest-path ui/Cargo.toml --target wasm32-unknown-unknown`
- UI runtime unit tests: 7 passed
- Targeted Playwright Python/R preview tests: 2 passed
- Full Playwright suite: 145 passed, 1 unrelated existing failure. The failing pet-navigation test was reproduced unchanged in a detached clean `main` worktree.

## Manual smoke steps

1. Open a long `.py` or `.R` file in the center preview.
2. Run the whole file and confirm the console docks below the source without overlap.
3. Run a selected block and confirm output follows the latest entry with normal scrolling.
4. Confirm long submissions show a localized omitted-line marker and retain the beginning/end of the submission.

## Known limitations

- This does not prevent an interpreter from exiting because of OOM or a native package crash; it makes that failure readable and preserves the preview layout.
- The pre-existing pet-navigation Playwright failure remains out of scope.