### PR TITLE
Fix file source switching and default sidebar tabs

### DIFF
--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -1259,6 +1259,7 @@ test("Files browses registered SSH contexts without a real remote host", async (
   await page.getByRole("button", { name: "Files" }).click();
 
   await page.getByRole("combobox", { name: "File location" }).selectOption("ssh:gpu-server");
+  await expect(page.getByRole("combobox", { name: "File location" })).toHaveValue("ssh:gpu-server");
   await expect(page.getByRole("textbox", { name: "Remote path" })).toHaveValue("/home/research");
   await expect(page.locator('.remote-dir[data-remote-path="/home/research/projects"]')).toBeVisible();
   const remoteFile = page.locator('.remote-file[data-remote-path="/home/research/notes.txt"]');
@@ -1287,6 +1288,11 @@ test("Files browses registered SSH contexts without a real remote host", async (
 
   await page.getByRole("button", { name: "Parent directory" }).click();
   await expect(page.getByRole("textbox", { name: "Remote path" })).toHaveValue("/home/research");
+
+  await page.getByRole("combobox", { name: "File location" }).selectOption("local");
+  await expect(page.getByRole("combobox", { name: "File location" })).toHaveValue("local");
+  await expect(page.getByRole("textbox", { name: "Remote path" })).toHaveCount(0);
+  await expect(page.locator('[data-workspace-path="report.csv"]')).toBeVisible();
 });
 
 test("pasted image attaches to the composer", async ({ page }) => {
@@ -1462,13 +1468,13 @@ test("right panel shows execution contexts and runs", async ({ page }) => {
   await enterApp(page);
   await selectRemoteContext(page);
   await page.getByRole("button", { name: "Toggle panel" }).click();
-  await page.getByRole("button", { name: "Add panel" }).click();
-  await expect.poll(() => page.locator(".rp-tab-add-menu").evaluate((menu) => {
-    const rect = menu.getBoundingClientRect();
-    const hit = document.elementFromPoint(rect.left + 8, rect.top + 8);
-    return hit === menu || menu.contains(hit);
-  })).toBe(true);
-  await page.getByRole("button", { name: "Environment" }).click();
+  const rightPanel = page.locator(".rightpane");
+  await expect(rightPanel.locator(".rp-tab")).toHaveCount(3);
+  await expect(rightPanel.getByRole("button", { name: "Artifacts", exact: true })).toBeVisible();
+  await expect(rightPanel.getByRole("button", { name: "Files", exact: true })).toBeVisible();
+  await expect(rightPanel.getByRole("button", { name: "Environment", exact: true })).toBeVisible();
+  await expect(rightPanel.getByRole("button", { name: /^Notebook/ })).toHaveCount(0);
+  await rightPanel.getByRole("button", { name: "Environment", exact: true }).click();
 
   await expect(page.locator(".context-card", { hasText: "local" })).toBeVisible();
   await expect(page.locator(".context-card", { hasText: "ssh:gpu-server" })).toContainText("NVIDIA A100");
@@ -1548,8 +1554,7 @@ test("SSH failures show that automatic retry was stopped", async ({ page }) => {
   await enterApp(page);
   await selectRemoteContext(page);
   await page.getByRole("button", { name: "Toggle panel" }).click();
-  await page.getByRole("button", { name: "Add panel" }).click();
-  await page.getByRole("button", { name: "Environment" }).click();
+  await page.getByRole("button", { name: "Environment", exact: true }).click();
 
   await page.evaluate(() => {
     const context = (window as any).__mockExecutionContexts.find(
@@ -1584,8 +1589,7 @@ test("context cards open machine, runtime, and runs details in modals", async ({
   await enterApp(page);
   await selectRemoteContext(page);
   await page.getByRole("button", { name: "Toggle panel" }).click();
-  await page.getByRole("button", { name: "Add panel" }).click();
-  await page.getByRole("button", { name: "Environment" }).click();
+  await page.getByRole("button", { name: "Environment", exact: true }).click();
 
   await expect(page.locator(".context-detail-pane")).toHaveCount(0);
   await expect(page.locator(".runtime-card")).toHaveCount(0);
@@ -1619,8 +1623,7 @@ test("execution contexts remember Python and R interpreter paths", async ({ page
   await enterApp(page);
   await selectRemoteContext(page);
   await page.getByRole("button", { name: "Toggle panel" }).click();
-  await page.getByRole("button", { name: "Add panel" }).click();
-  await page.getByRole("button", { name: "Environment" }).click();
+  await page.getByRole("button", { name: "Environment", exact: true }).click();
 
   const remote = page.locator(".context-card", { hasText: "ssh:gpu-server" });
   await remote.getByRole("button", { name: "Configure runtime interpreters" }).click();
@@ -1674,8 +1677,7 @@ test("runtime panel shows lifecycle state and controls start stop restart", asyn
   await enterApp(page);
   await selectRemoteContext(page);
   await page.getByRole("button", { name: "Toggle panel" }).click();
-  await page.getByRole("button", { name: "Add panel" }).click();
-  await page.getByRole("button", { name: "Environment" }).click();
+  await page.getByRole("button", { name: "Environment", exact: true }).click();
 
   await expect(page.locator(".runtime-card")).toHaveCount(0);
   await page.locator(".context-card", { hasText: "ssh:gpu-server" }).getByRole("button", { name: "View runtimes" }).click();
@@ -1711,8 +1713,7 @@ test("runtime inspector lists object metadata without loading object contents", 
   await enterApp(page);
   await selectRemoteContext(page);
   await page.getByRole("button", { name: "Toggle panel" }).click();
-  await page.getByRole("button", { name: "Add panel" }).click();
-  await page.getByRole("button", { name: "Environment" }).click();
+  await page.getByRole("button", { name: "Environment", exact: true }).click();
   await page.locator(".context-card", { hasText: "ssh:gpu-server" }).getByRole("button", { name: "View runtimes" }).click();
 
   const runtime = page.locator('.runtime-card[data-runtime-language="python"][data-runtime-context="ssh:gpu-server"]');
@@ -1821,8 +1822,7 @@ test("environment panel shows runs only for the selected context", async ({ page
   await enterApp(page);
   await selectRemoteContext(page);
   await page.getByRole("button", { name: "Toggle panel" }).click();
-  await page.getByRole("button", { name: "Add panel" }).click();
-  await page.getByRole("button", { name: "Environment" }).click();
+  await page.getByRole("button", { name: "Environment", exact: true }).click();
   await page.locator(".context-card", { hasText: "ssh:gpu-server" }).getByRole("button", { name: "View runs" }).click();
   await expect(page.locator(".run-card", { hasText: "Kinase screen QC" })).toBeVisible();
   await expect(page.locator(".run-card", { hasText: "Local normalization" })).toHaveCount(0);
@@ -3755,6 +3755,7 @@ test("code lives in Notebook instead of Artifacts", async ({ page }) => {
   await expect(page.getByText(/60,675 genes/)).toBeVisible({ timeout: 10_000 });
 
   await page.getByRole("button", { name: "Toggle panel" }).click();
+  await page.getByRole("button", { name: "Add panel" }).click();
   await page.getByRole("button", { name: "Notebook (2)", exact: true }).click();
 
   const cells = page.locator(".notebook-cell");
@@ -3775,6 +3776,7 @@ test("R tool calls project into a highlighted Notebook cell", async ({ page }) =
   await page.getByRole("button", { name: "Send" }).click();
   await expect(page.getByText("R summary complete.")).toBeVisible({ timeout: 10_000 });
   await page.getByRole("button", { name: "Toggle panel" }).click();
+  await page.getByRole("button", { name: "Add panel" }).click();
   await page.getByRole("button", { name: "Notebook (1)", exact: true }).click();
 
   const cell = page.locator(".notebook-cell");
@@ -3791,6 +3793,7 @@ test("an SVG star saves a Notebook cell in the global library", async ({ page })
   await page.getByRole("button", { name: "Send" }).click();
   await expect(page.getByText(/60,675 genes/)).toBeVisible({ timeout: 10_000 });
   await page.getByRole("button", { name: "Toggle panel" }).click();
+  await page.getByRole("button", { name: "Add panel" }).click();
   await page.getByRole("button", { name: "Notebook (2)", exact: true }).click();
 
   const cell = page.locator(".notebook-cell").first();

--- a/ui/src/app_support.rs
+++ b/ui/src/app_support.rs
@@ -4137,6 +4137,9 @@ pub(super) const ALL_RIGHT_TABS: [RightTab; 6] = [
     RightTab::SideChat,
 ];
 
+pub(super) const DEFAULT_RIGHT_TABS: [RightTab; 3] =
+    [RightTab::Artifacts, RightTab::File, RightTab::Hosts];
+
 pub(super) fn ensure_right_tab(
     tab: RightTab,
     show_right: RwSignal<bool>,

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -833,7 +833,7 @@ fn App() -> impl IntoView {
     let collapsed_art_groups = create_rw_signal::<HashSet<String>>(HashSet::new());
     let rp_grid = create_rw_signal(false); // false = detailed/list, true = tiled/grid; shared by Artifacts + Files
     let right_tab = create_rw_signal(RightTab::Artifacts);
-    let open_right_tabs = create_rw_signal(vec![RightTab::Artifacts, RightTab::Notebook]);
+    let open_right_tabs = create_rw_signal(DEFAULT_RIGHT_TABS.to_vec());
     let right_tab_add_menu_open = create_rw_signal(false);
     let file_source = create_rw_signal("local".to_string());
     let file_query = create_rw_signal(String::new());
@@ -4958,7 +4958,7 @@ fn App() -> impl IntoView {
                                 *open = false;
                             } else {
                                 if open_right_tabs.get_untracked().is_empty() {
-                                    open_right_tabs.set(vec![RightTab::Artifacts, RightTab::Notebook]);
+                                    open_right_tabs.set(DEFAULT_RIGHT_TABS.to_vec());
                                     right_tab.set(RightTab::Artifacts);
                                 }
                                 *open = true;
@@ -6742,7 +6742,6 @@ fn App() -> impl IntoView {
                         }
                         RightTab::File => {
                             let loc = locale.get();
-                            let source = file_source.get();
                             let ssh_contexts = execution_contexts
                                 .get()
                                 .into_iter()
@@ -6753,7 +6752,7 @@ fn App() -> impl IntoView {
                                     <label class="fb-source-label">
                                         <span>{t(loc, "files.source")}</span>
                                         <select class="fb-source" aria-label=t(loc, "files.source")
-                                            prop:value=source.clone()
+                                            prop:value=move || file_source.get()
                                             on:change=move |event| {
                                                 let next = dom_value(&event);
                                                 file_source.set(next.clone());
@@ -6783,7 +6782,9 @@ fn App() -> impl IntoView {
                                             }).collect_view()}
                                         </select>
                                     </label>
-                                    {if source == "local" {
+                                    {move || {
+                                        let source = file_source.get();
+                                        if source == "local" {
                                         let cwd = file_cwd.get();
                                         let parent = if cwd == "." { None } else { Some(parent_path(&cwd)) };
                                         view! {
@@ -7018,7 +7019,7 @@ fn App() -> impl IntoView {
                                             </div>
                                             <div class="hint fb-root">{t(loc, "files.remote_read_only")}</div>
                                         }.into_view()
-                                    }}
+                                    }}}
                                 </div>
                             }.into_view()
                         }


### PR DESCRIPTION
## Problem

The Files panel could show remote directory contents while the location selector still displayed the local project. Because the browser considered the local option selected, users could not trigger a change back to local files.

The right sidebar also opened Artifacts and Notebook by default instead of the desired core panels.

## Changes

- Keep the Files source selector mounted and bind its value reactively while local/remote directory content updates independently.
- Add regression coverage for selecting an SSH source and switching back to the local project.
- Define the default right-sidebar tabs as Artifacts, Files, and Environment.
- Reuse the same defaults when reopening a sidebar whose tabs were all closed.
- Keep Notebook available from Add panel and update its tests to open it explicitly.

## User impact

Files now reports the selected location accurately and can always return from SSH browsing to the local project. New or reset right sidebars open with Artifacts, Files, and Environment.

## Validation

- `cargo check --target wasm32-unknown-unknown`
- `cargo test --workspace`
- 10 focused Playwright tests covering Files, default sidebar tabs, Environment, and explicit Notebook opening
- Full Playwright run: 145 passed; three unrelated timing/layout cases failed. The automatic reviewer and figure-modal cases passed on focused rerun.

## Known limitations

The existing `pet navigation opens the project and session that need the user` Playwright test remains timing-sensitive because the synthetic event can fire before its listener is registered. It is unrelated to these Files/sidebar changes and remains a follow-up test-hardening task.