### PR TITLE
fix: R/py preview code body misaligned with line-number gutter

### DIFF
--- a/ui/src/styles/alignment.css
+++ b/ui/src/styles/alignment.css
@@ -140,7 +140,10 @@ button.rp-icon .gi { width: 15px; height: 15px; opacity: .9; }
   position: sticky; left: 0;
 }
 .rp-code-body { flex: 1 1 auto; margin: 0; padding: 12px 14px; font-family: var(--font-mono); font-size: 12px; line-height: 1.6; }
-.rp-code-body code { display: block; white-space: pre; background: none; border: none; padding: 0; }
+/* .rp-code (not just .rp-code-body) so this outranks the lazily-loaded
+   highlight.js theme's `pre code.hljs { padding: 1em }`, which otherwise wins
+   once highlighting lands and shifts the body 1em off the line-number gutter. */
+.rp-code .rp-code-body code { display: block; white-space: pre; background: none; border: none; padding: 0; }
 .rp-code-body .hljs { background: none; }
 
 /* --- Chat: tool/step summary chip (compact collapsible) --- */


### PR DESCRIPTION
## What

One-selector CSS fix: `.rp-code-body code` → `.rp-code .rp-code-body code` in `ui/src/styles/alignment.css`.

## Why

In the center R/py file preview (and every other `RpCodeView` — right-pane code, notebook cells), the code body sat 12px below/right of the line-number gutter, so line numbers didn't line up with lines.

Root cause: the highlight.js theme stylesheet is lazily appended to `<head>` when highlighting first runs, and it ships a layout rule `pre code.hljs { display: block; overflow-x: auto; padding: 1em }`. With specificity (0,1,2) it beat the app's `.rp-code-body code { padding: 0 }` (0,1,1) — and it loads after app CSS anyway — so the moment highlighting landed, the code element gained 1em (12px) top/left padding and drifted off the gutter. Raising the app rule to (0,2,1) makes it win regardless of load order, the same pattern chat.css already uses to override the theme's colors.

## Verification

Reproduced in a browser against the real vendored highlight.js + theme css with the exact `RpCodeView` DOM: old selector → `padding: 12px` on the code element after `highlightElement` (gutter offset reproduced); new selector → `padding: 0`, gutter and code aligned line-for-line (1 ↔ `library(Seurat)`, 3 ↔ `library(dplyr)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)