### PR TITLE
Fix flaky ssh_run_detaches test by gating the fake poller

### DIFF
--- a/src-tauri/src/run_context/tests.rs
+++ b/src-tauri/src/run_context/tests.rs
@@ -358,6 +358,10 @@ async fn ssh_run_detaches_persists_handle_and_finishes_from_poller() {
         .synthesize_launch_ack
         .store(true, std::sync::atomic::Ordering::SeqCst);
     runner.push(ok_output(&poll_response("finished:0", "complete", "")));
+    // Hold the poller until the pre-completion status has been observed, so
+    // the run cannot finish before the assertions below run under load.
+    let poll_gate = Arc::new(tokio::sync::Semaphore::new(0));
+    *runner.poll_gate.lock().unwrap() = Some(poll_gate.clone());
     let command = "printf '%s\\n' '$HOME' && printf '%s\\n' '$(date)'";
     let submitted = manager
         .submit(
@@ -386,6 +390,7 @@ async fn ssh_run_detaches_persists_handle_and_finishes_from_poller() {
         .as_deref()
         .unwrap()
         .starts_with("~/.wisp-science/runs/"));
+    poll_gate.add_permits(1);
     let finished = wait_for_terminal(&store, &submitted.run_id).await;
     assert_eq!(finished.status, wisp_store::RunStatus::Succeeded);
     assert_eq!(finished.exit_code, Some(0));
@@ -758,6 +763,9 @@ struct ScriptedRunRunner {
     commands: StdMutex<Vec<RunCommand>>,
     synthesize_launch_ack: std::sync::atomic::AtomicBool,
     token: StdMutex<Option<String>>,
+    // When set, "poll SSH Run" commands block until the test releases a permit,
+    // so a test can observe pre-completion state without racing the poller.
+    poll_gate: StdMutex<Option<Arc<tokio::sync::Semaphore>>>,
 }
 
 impl ScriptedRunRunner {
@@ -767,6 +775,7 @@ impl ScriptedRunRunner {
             commands: StdMutex::new(Vec::new()),
             synthesize_launch_ack: std::sync::atomic::AtomicBool::new(false),
             token: StdMutex::new(None),
+            poll_gate: StdMutex::new(None),
         }
     }
 
@@ -782,6 +791,12 @@ impl RunCommandRunner for ScriptedRunRunner {
         command: RunCommand,
         _timeout: Duration,
     ) -> Result<RunCommandOutput, String> {
+        if command.script == "poll SSH Run" {
+            let gate = self.poll_gate.lock().unwrap().clone();
+            if let Some(gate) = gate {
+                let _permit = gate.acquire().await.unwrap();
+            }
+        }
         if command.script == "prepare SSH Run" {
             if let Some(payload) = command.stdin.as_deref() {
                 let token = payload


### PR DESCRIPTION
## What changed

`run_context::tests::ssh_run_detaches_persists_handle_and_finishes_from_poller` was flaky under full `cargo test --workspace` load: it asserts `submitted.status` is `Submitted | Running`, but for remote runs `submit()` spawns the lifecycle task first and then re-reads the run from the store (`run_context.rs` submit path), so under load the fake poller could already have driven the run to `Succeeded` before the assertion ran.

The fix is entirely in the test file:

- `ScriptedRunRunner` gains an optional `poll_gate` (`tokio::sync::Semaphore`). When set, `poll SSH Run` commands block until the test releases a permit. Tests that don't set it are unaffected.
- The flaky test sets the gate to 0 permits before `submit()`, so the poller can reach at most prepare → launch and then blocks — the returned status is deterministically `Submitted`/`Running`. After the detach assertions it calls `add_permits(1)` and proceeds with the existing `wait_for_terminal` checks.

## Why

The original assertions are untouched, so the test still verifies everything it did before — the run detaches, persists its handle/workdir, and is finished by the poller — it just no longer races the poller to observe the intermediate state.

## Verification

- `cargo test -p wisp-tauri --lib run_context`: 23/23 pass
- Target test looped 30×: no failures
- Full `cargo test -p wisp-tauri --lib`: 254/254 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)