### PR TITLE
fix: 重复环境变量的自定义凭据改为原位覆盖

### DIFF
--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -271,13 +271,28 @@ pub async fn add_custom_credential(
     if CREDENTIALS
         .iter()
         .any(|credential| credential.env.eq_ignore_ascii_case(env_var))
-        || credentials
-            .iter()
-            .any(|credential| credential.env_var.eq_ignore_ascii_case(env_var))
     {
         return Err(format!(
             "A credential already uses environment variable {env_var}."
         ));
+    }
+
+    // Re-adding an env var that already has a row overwrites it in place, so a
+    // cleared or lost value never blocks reconfiguration (#335).
+    if let Some(existing) = credentials
+        .iter_mut()
+        .find(|credential| credential.env_var.eq_ignore_ascii_case(env_var))
+    {
+        existing.name = name.to_string();
+        let credential = existing.clone();
+        secret_set(&custom_secret_name(&credential.id), value)?;
+        save_custom_credentials(store, &credentials).await?;
+        return Ok(CustomCredentialStatus {
+            id: credential.id,
+            name: credential.name,
+            env_var: credential.env_var,
+            present: true,
+        });
     }
 
     let credential = CustomCredential {
@@ -993,6 +1008,21 @@ mod tests {
         assert!(service_env()
             .iter()
             .any(|(name, value)| name == &env_var && value == "replacement"));
+
+        // Re-adding the same env var upserts the existing row instead of
+        // erroring, even after its value was cleared (#335).
+        store_credential(&saved.id, "").unwrap();
+        let updated = add_custom_credential(&store, "MetaSo v2", &env_var, "second")
+            .await
+            .unwrap();
+        assert_eq!(updated.id, saved.id);
+        assert_eq!(updated.name, "MetaSo v2");
+        assert!(updated.present);
+        assert!(service_env()
+            .iter()
+            .any(|(name, value)| name == &env_var && value == "second"));
+        assert_eq!(custom_credential_status(&store).await.unwrap().len(), 1);
+
         remove_custom_credential(&store, &saved.id).await.unwrap();
         assert!(custom_credential_status(&store).await.unwrap().is_empty());
         assert!(!service_env().iter().any(|(name, _)| name == &env_var));

--- a/ui/src/settings_view.rs
+++ b/ui/src/settings_view.rs
@@ -1916,7 +1916,7 @@ pub(super) fn SettingsView(
                         <p class="settings-note">{move || t(locale.get(), "cred.custom.hint")}</p>
                         <For
                             each=move || custom_credentials.get()
-                            key=|credential| credential.id.clone()
+                            key=|credential| (credential.id.clone(), credential.name.clone())
                             let:credential
                         >
                             {
@@ -2043,7 +2043,13 @@ pub(super) fn SettingsView(
                                                         cred_status.update(|status| {
                                                             status.insert(credential.id.clone(), credential.present);
                                                         });
-                                                        custom_credentials.update(|items| items.push(credential));
+                                                        custom_credentials.update(|items| {
+                                                            // Backend upserts by env var, so replace a matching row instead of duplicating it.
+                                                            match items.iter_mut().find(|item| item.id == credential.id) {
+                                                                Some(existing) => *existing = credential,
+                                                                None => items.push(credential),
+                                                            }
+                                                        });
                                                         custom_cred_name.set(String::new());
                                                         custom_cred_env.set(String::new());
                                                         custom_cred_value.set(String::new());


### PR DESCRIPTION
## 问题

Fixes #335

自定义凭据的值被清除(或密钥环丢失)后,凭据行仍占用其环境变量名。此时重新"添加凭据"填同一个环境变量会报 **"环境变量 X 已被其他凭据使用"**,用户被卡住,只能先手动删除旧行再重新添加(issue 截图中助手正是在指导用户做这套操作)。

## 修复

- `add_custom_credential`:环境变量命中已有**自定义**凭据行时,原位覆盖该行(更新名称 + 写入新密钥值)并返回 `present: true`,不再报错;与**内置**凭据的环境变量冲突仍然报错。
- 设置页 UI:添加成功后按 id 替换已有行(避免 `<For>` 出现重复 key),并将行 key 改为 `(id, name)`,改名后行内文本能正确刷新。
- 测试:`custom_credentials_keep_values_out_of_sqlite_and_join_service_env` 新增覆盖——清空值后重新添加同名环境变量应复用同一行、更新名称与值,且不会产生第二条记录。

## 验证

- `cargo test -p wisp-tauri --lib models::` 9 项全部通过
- `ui/` 独立 workspace `cargo check` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)