### PR TITLE
fix(ui): keep right-pane tab menu and docx pages inside their panes

### DIFF
--- a/ui/src/styles/right-pane.css
+++ b/ui/src/styles/right-pane.css
@@ -21,7 +21,7 @@
 .rp-tab-add { display: inline-flex; align-items: center; justify-content: center; width: 28px; height: 28px; border: 1px solid var(--border-strong); border-radius: var(--radius-xs); background: var(--bg-elev); color: var(--text-muted); font: inherit; font-size: 18px; line-height: 1; cursor: pointer; }
 .rp-tab-add:hover, .rp-tab-add.active { background: var(--bg-sunken); color: var(--text); }
 .rp-tab-add-backdrop { position: fixed; inset: 0; z-index: 71; }
-.rp-tab-add-menu { position: absolute; z-index: 72; left: 0; top: calc(100% + 6px); min-width: 200px; max-height: 280px; overflow-y: auto; padding: 6px; background: var(--bg-elev); border: 1px solid var(--border-strong); border-radius: var(--radius-sm); box-shadow: var(--shadow); transform-origin: top left; animation: motion-surface-in-soft var(--motion-duration-fast) var(--motion-ease-decelerate) both; }
+.rp-tab-add-menu { position: absolute; z-index: 72; right: 0; top: calc(100% + 6px); min-width: 200px; max-height: 280px; overflow-y: auto; padding: 6px; background: var(--bg-elev); border: 1px solid var(--border-strong); border-radius: var(--radius-sm); box-shadow: var(--shadow); transform-origin: top right; animation: motion-surface-in-soft var(--motion-duration-fast) var(--motion-ease-decelerate) both; }
 .rp-tab-add-item { display: flex; align-items: center; justify-content: space-between; gap: 12px; width: 100%; padding: 8px 10px; border: none; border-radius: 7px; background: transparent; color: var(--text); font: inherit; font-size: 12.5px; text-align: left; cursor: pointer; }
 .rp-tab-add-item:hover { background: var(--bg-sunken); }
 .rp-tab-add-item.open { color: var(--text-muted); }
@@ -384,7 +384,11 @@
    none) so it can be added to chat like md/pdf. */
 .rp-docx, .rp-docx .docx-wrapper { user-select: text; -webkit-user-select: text; }
 .rp-docx .docx-wrapper { background: transparent; padding: 16px 0; display: flex; flex-direction: column; align-items: center; gap: 16px; }
-.rp-docx .docx-wrapper > section.docx { box-shadow: 0 1px 6px rgba(0, 0, 0, .2); margin: 0 !important; }
+/* `margin: 0 auto` centers each fixed-width A4 page but collapses to 0 when the
+   page is wider than the pane, so it falls to flex-start instead of overflowing
+   into unreachable scroll space (which clipped the page's left edge). Auto
+   inline margins override align-items:center and work on every webview. */
+.rp-docx .docx-wrapper > section.docx { box-shadow: 0 1px 6px rgba(0, 0, 0, .2); margin: 0 auto !important; }
 .rp-docx-loading { display: flex; min-height: 120px; align-items: center; justify-content: center; padding: 16px; text-align: center; }
 .rp-xlsx { display: flex; width: 100%; min-width: 0; min-height: 240px; height: 100%; flex-direction: column; overflow: hidden; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--bg-elev); }
 .rp-xlsx-warning { flex: 0 0 auto; padding: 7px 10px; border-bottom: 1px solid color-mix(in srgb, var(--warn) 35%, var(--border)); background: color-mix(in srgb, var(--warn) 10%, var(--bg-elev)); color: var(--text-muted); font-size: 11px; }


### PR DESCRIPTION
## 问题

右侧面板有两个溢出问题（见对话中的两张截图）：

1. **"添加标签页"下拉菜单被截断** —「+」按钮的菜单锚定在 `left: 0`，从按钮向右展开。由于「+」位于面板右半区，200px 宽的菜单会溢出窗口右边缘，导致菜单项文字被截断（`Noteb...`、`侧边问...`）。

2. **docx 预览左边缘被裁掉 + 出现横向滚动条** — docx 预览用 `align-items: center` 居中固定宽度的 A4/Letter 页面。当分栏后面板比页面窄时，flex 居中会把左侧溢出推入**无法滚动到达**的区域，于是页面左边缘被裁掉（看起来像被侧边栏盖住），右侧溢出则生成横向滚动条。

## 改动

`ui/src/styles/right-pane.css`，纯 CSS：

- `.rp-tab-add-menu`：`left: 0` → `right: 0`（`transform-origin: top right`），菜单改为向左展开，留在面板内。
- `.rp-docx .docx-wrapper > section.docx`：`margin: 0` → `margin: 0 auto`。auto 内联外边距在页面放得下时居中、放不下时收缩为 0 落到 flex-start，任何内容都不会被裁掉。选用 `margin: auto` 而非 `align-items: safe center` 关键字，是因为它在旧版 WebView2 上也能工作（见 #279）。改在共享的 `.rp-docx` 规则里，中央预览与 artifact 弹窗预览一并修复。

## 给 reviewer

- 侧边栏本身没问题，是正常的 in-flow flex 项；docx 只是因为被裁掉的左边缘正好贴在侧边栏边界，看起来像重叠。
- 未能跑浏览器截图验证：本次会话的预览面板无法承载本地 `file://` 渲染（CSP 剥离脚本、截图报 no site）。改动是符合 CSS 规范的 `margin: auto` flex 行为，建议本地 `trunk build` 后打开一个 docx 分栏查看。

🤖 Generated with [Claude Code](https://claude.com/claude-code)