### PR TITLE
feat(core): resolve dynamic agent capabilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6301,6 +6301,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/crates/wisp-core/Cargo.toml
+++ b/crates/wisp-core/Cargo.toml
@@ -18,6 +18,7 @@ regex = { workspace = true }
 glob = { workspace = true }
 chrono = { workspace = true }
 uuid = { workspace = true }
+sha2 = { workspace = true }
 wisp-llm = { workspace = true }
 wisp-tools = { workspace = true }
 wisp-skills = { workspace = true }

--- a/crates/wisp-core/src/delegation.rs
+++ b/crates/wisp-core/src/delegation.rs
@@ -112,6 +112,8 @@ pub struct PermissionSet {
     pub network: bool,
     #[serde(default)]
     pub write: bool,
+    #[serde(default)]
+    pub execute: bool,
 }
 
 impl PermissionSet {
@@ -133,6 +135,7 @@ impl PermissionSet {
                 .collect(),
             network: self.network && granted.network,
             write: self.write && granted.write,
+            execute: self.execute && granted.execute,
         }
     }
 }
@@ -229,6 +232,20 @@ pub struct SpecialistSnapshot {
     pub connectors: Option<Vec<String>>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CapabilityRevision {
+    pub id: String,
+    pub revision: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentAuthorizationSnapshot {
+    pub registry_revision: String,
+    pub policy_revision: String,
+    pub capabilities: Vec<CapabilityRevision>,
+    pub integrity_hash: String,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(tag = "kind", content = "specialist", rename_all = "snake_case")]
 pub enum AgentOrigin {
@@ -315,6 +332,8 @@ pub struct AgentSpec {
     pub output_schema_source: AgentOutputSchemaSource,
     #[serde(default)]
     pub approval_reasons: Vec<String>,
+    #[serde(default)]
+    pub authorization: Option<AgentAuthorizationSnapshot>,
 }
 
 impl AgentSpec {
@@ -322,7 +341,8 @@ impl AgentSpec {
         if self.agent_id.trim().is_empty() {
             anyhow::bail!("agent_id is required");
         }
-        if self.template_id.trim().is_empty() {
+        if matches!(self.origin, AgentOrigin::LegacyTemplate) && self.template_id.trim().is_empty()
+        {
             anyhow::bail!("template_id is required");
         }
         if self.name.trim().is_empty() {
@@ -535,6 +555,15 @@ pub struct ValidatedAgentDelegationRequest {
     inner: AgentDelegationRequest,
 }
 
+#[derive(Clone, Copy)]
+pub enum DelegationRequestValidator<'a> {
+    Legacy(&'a crate::orchestration::AgentTemplateRegistry),
+    Dynamic {
+        registry: &'a crate::delegation_policy::CapabilityRegistry,
+        host: &'a crate::delegation_policy::DelegationHostPolicy,
+    },
+}
+
 impl ValidatedAgentDelegationRequest {
     pub fn as_request(&self) -> &AgentDelegationRequest {
         &self.inner
@@ -543,18 +572,40 @@ impl ValidatedAgentDelegationRequest {
     pub fn into_request(self) -> AgentDelegationRequest {
         self.inner
     }
-}
 
-impl TryFrom<AgentDelegationRequest> for ValidatedAgentDelegationRequest {
-    type Error = anyhow::Error;
+    pub fn authorize(
+        request: AgentDelegationRequest,
+        validator: DelegationRequestValidator<'_>,
+    ) -> anyhow::Result<Self> {
+        match validator {
+            DelegationRequestValidator::Legacy(templates) => {
+                Self::try_from_legacy(request, templates)
+            }
+            DelegationRequestValidator::Dynamic { registry, host } => {
+                Self::try_from_dynamic(request, registry, host)
+            }
+        }
+    }
 
-    fn try_from(request: AgentDelegationRequest) -> Result<Self, Self::Error> {
+    pub fn try_from_legacy(
+        request: AgentDelegationRequest,
+        templates: &crate::orchestration::AgentTemplateRegistry,
+    ) -> anyhow::Result<Self> {
         request.validate()?;
-        let templates = crate::orchestration::AgentTemplateRegistry::builtins();
         let template = templates
             .get(&request.spec.template_id)
             .ok_or_else(|| anyhow::anyhow!("unknown controlled agent template"))?;
         template.validate_spec(&request.spec)?;
+        Ok(Self { inner: request })
+    }
+
+    pub fn try_from_dynamic(
+        request: AgentDelegationRequest,
+        registry: &crate::delegation_policy::CapabilityRegistry,
+        host: &crate::delegation_policy::DelegationHostPolicy,
+    ) -> anyhow::Result<Self> {
+        request.validate()?;
+        registry.validate_resolved_spec(&request.spec, host)?;
         Ok(Self { inner: request })
     }
 }
@@ -608,9 +659,19 @@ pub trait AgentDelegator: Send + Sync {
     async fn delegate(
         &self,
         request: AgentDelegationRequest,
+        validator: DelegationRequestValidator<'_>,
     ) -> anyhow::Result<AgentDelegationResponse> {
-        let request_id = request.request_id.clone();
-        let request = ValidatedAgentDelegationRequest::try_from(request)?;
+        let request = ValidatedAgentDelegationRequest::authorize(request, validator)?;
+        self.delegate_authorized(request).await
+    }
+
+    /// Execute a request that an explicit legacy-template or dynamic-policy
+    /// validator has authorized.
+    async fn delegate_authorized(
+        &self,
+        request: ValidatedAgentDelegationRequest,
+    ) -> anyhow::Result<AgentDelegationResponse> {
+        let request_id = request.as_request().request_id.clone();
         let output_contract = request.as_request().spec.output_contract.clone();
         let budget = request.as_request().spec.budget.clone();
         let mut response = self.delegate_validated(request).await?;
@@ -727,6 +788,7 @@ mod tests {
             workspace_policy: None,
             output_schema_source: AgentOutputSchemaSource::Standard,
             approval_reasons: vec![],
+            authorization: None,
         }
     }
 
@@ -743,6 +805,7 @@ mod tests {
                 paths: vec!["src/**".into()],
                 network: false,
                 write: false,
+                execute: false,
             },
             context_policy: ContextPolicy {
                 include_history: true,
@@ -780,15 +843,18 @@ mod tests {
             paths: vec!["src/**".into(), "tmp/**".into()],
             network: true,
             write: true,
+            execute: true,
         };
         let granted = PermissionSet {
             tools: vec!["read".into()],
             paths: vec!["src/**".into()],
             network: false,
             write: false,
+            execute: false,
         };
         assert_eq!(requested.intersect(&granted).tools, vec!["read"]);
         assert!(!requested.intersect(&granted).network);
+        assert!(!requested.intersect(&granted).execute);
         assert_eq!(
             AgentBudget {
                 max_tokens: Some(2_000),

--- a/crates/wisp-core/src/delegation_policy.rs
+++ b/crates/wisp-core/src/delegation_policy.rs
@@ -1,0 +1,1826 @@
+//! Pure policy resolution for dynamic delegated Agents.
+//!
+//! Model-authored proposals contain capability IDs, never raw permissions.
+//! This module resolves those IDs against host-owned definitions and produces
+//! a versioned, revalidatable execution snapshot.
+
+use crate::orchestration::MAX_PARALLEL_AGENTS;
+use crate::{
+    AgentAuthorizationSnapshot, AgentBackend, AgentBudget, AgentExecutorRef, AgentOrigin,
+    AgentOutputSchemaSource, AgentRole, AgentSessionPolicy, AgentSpec, AgentWorkspacePolicy,
+    CapabilityRevision, ContextPolicy, DelegationMode, DelegationPlan, DelegationPlanStep,
+    PermissionSet, SpecialistSnapshot, DYNAMIC_DELEGATION_SCHEMA_VERSION, MAX_DELEGATION_TASKS,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+use std::collections::{HashMap, HashSet};
+use thiserror::Error;
+
+const ELEVATED_TOKEN_THRESHOLD: u32 = 20_000;
+const ELEVATED_COST_THRESHOLD_MICROUNITS: u64 = 1_000_000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CapabilityRisk {
+    ReadOnly,
+    Write,
+    Execute,
+    Network,
+    External,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecutorFeature {
+    ProjectRead,
+    ProjectWrite,
+    CodeExecution,
+    NetworkAccess,
+    LiteratureAccess,
+    Vision,
+    Isolation,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ModelFeature {
+    Vision,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CapabilityDefinition {
+    pub id: String,
+    pub revision: u32,
+    pub display_name: String,
+    pub description: String,
+    pub risk: CapabilityRisk,
+    pub permissions: PermissionSet,
+    #[serde(default)]
+    pub required_executor_features: Vec<ExecutorFeature>,
+    #[serde(default)]
+    pub required_model_features: Vec<ModelFeature>,
+    #[serde(default)]
+    pub required_skills: Vec<String>,
+    #[serde(default)]
+    pub required_connectors: Vec<String>,
+    pub context_ceiling: ContextPolicy,
+    pub default_budget: AgentBudget,
+    pub budget_ceiling: AgentBudget,
+    pub workspace_policy: AgentWorkspacePolicy,
+    #[serde(default)]
+    pub approval_reason: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CapabilityRegistry {
+    revision: String,
+    definitions: HashMap<String, CapabilityDefinition>,
+    order: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ModelProfilePolicy {
+    pub id: String,
+    #[serde(default)]
+    pub features: Vec<ModelFeature>,
+    #[serde(default)]
+    pub external: bool,
+    #[serde(default = "enabled_by_default")]
+    pub enabled: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExecutorProfilePolicy {
+    pub executor: AgentExecutorRef,
+    #[serde(default)]
+    pub features: Vec<ExecutorFeature>,
+    #[serde(default)]
+    pub model_ids: Vec<String>,
+    #[serde(default = "enabled_by_default")]
+    pub enabled: bool,
+}
+
+const fn enabled_by_default() -> bool {
+    true
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct DelegationHostPolicy {
+    pub revision: String,
+    #[serde(default)]
+    pub enabled_capabilities: Vec<String>,
+    #[serde(default)]
+    pub available_skills: Vec<String>,
+    #[serde(default)]
+    pub available_connectors: Vec<String>,
+    #[serde(default)]
+    pub models: Vec<ModelProfilePolicy>,
+    #[serde(default)]
+    pub executors: Vec<ExecutorProfilePolicy>,
+    #[serde(default)]
+    pub default_model_id: Option<String>,
+    #[serde(default)]
+    pub permission_ceiling: PermissionSet,
+    #[serde(default)]
+    pub context_ceiling: ContextPolicy,
+    #[serde(default)]
+    pub budget_ceiling: AgentBudget,
+    #[serde(default)]
+    pub default_timeout_secs: Option<u64>,
+    #[serde(default)]
+    pub timeout_ceiling_secs: Option<u64>,
+    #[serde(default)]
+    pub auto_safe: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DelegatedTaskProposal {
+    pub id: String,
+    pub instruction: String,
+    #[serde(default)]
+    pub context_summary: String,
+    #[serde(default)]
+    pub depends_on: Vec<String>,
+    pub capabilities: Vec<String>,
+    #[serde(default)]
+    pub specialist: Option<SpecialistSnapshot>,
+    #[serde(default)]
+    pub output_schema: Option<Value>,
+    #[serde(default)]
+    pub isolated: bool,
+    #[serde(default)]
+    pub model_id: Option<String>,
+    #[serde(default)]
+    pub executor: Option<AgentExecutorRef>,
+    #[serde(default)]
+    pub budget: Option<AgentBudget>,
+    #[serde(default = "empty_object")]
+    pub input: Value,
+}
+
+fn empty_object() -> Value {
+    json!({})
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedAgentTask {
+    spec: AgentSpec,
+    input: Value,
+    risk: CapabilityRisk,
+    budget_ceiling: AgentBudget,
+    required_executor_features: Vec<ExecutorFeature>,
+}
+
+impl ResolvedAgentTask {
+    pub fn spec(&self) -> &AgentSpec {
+        &self.spec
+    }
+
+    pub fn input(&self) -> &Value {
+        &self.input
+    }
+
+    pub fn risk(&self) -> CapabilityRisk {
+        self.risk
+    }
+
+    pub fn budget_ceiling(&self) -> &AgentBudget {
+        &self.budget_ceiling
+    }
+
+    pub fn required_executor_features(&self) -> &[ExecutorFeature] {
+        &self.required_executor_features
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedDelegationPlan {
+    plan: DelegationPlan,
+}
+
+impl ResolvedDelegationPlan {
+    pub fn as_plan(&self) -> &DelegationPlan {
+        &self.plan
+    }
+
+    pub fn into_plan(self) -> DelegationPlan {
+        self.plan
+    }
+}
+
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum ResolutionError {
+    #[error("invalid delegation proposal: {0}")]
+    InvalidProposal(String),
+    #[error("unknown capability: {0}")]
+    UnknownCapability(String),
+    #[error("capability is disabled or unavailable: {0}")]
+    UnavailableCapability(String),
+    #[error("Specialist {specialist_id} does not allow {kind}: {value}")]
+    SpecialistRestriction {
+        specialist_id: String,
+        kind: &'static str,
+        value: String,
+    },
+    #[error("unknown or unavailable model profile: {0}")]
+    UnknownModel(String),
+    #[error("unknown or unavailable executor profile: {0}")]
+    UnknownExecutor(String),
+    #[error("no eligible model is configured")]
+    NoEligibleModel,
+    #[error("no eligible executor is configured")]
+    NoEligibleExecutor,
+    #[error("requested task budget exceeds the capability or host ceiling")]
+    BudgetExceeded,
+    #[error("dynamic delegation snapshot is stale: {0}")]
+    StaleSnapshot(String),
+    #[error("dynamic delegation snapshot integrity check failed")]
+    IntegrityMismatch,
+    #[error("dynamic delegation snapshot does not match current policy")]
+    SnapshotMismatch,
+}
+
+impl CapabilityRegistry {
+    pub fn new(
+        revision: impl Into<String>,
+        definitions: Vec<CapabilityDefinition>,
+    ) -> Result<Self, ResolutionError> {
+        let revision = revision.into();
+        if revision.trim().is_empty() {
+            return Err(ResolutionError::InvalidProposal(
+                "capability registry revision is required".into(),
+            ));
+        }
+        let mut by_id = HashMap::new();
+        let mut order = Vec::with_capacity(definitions.len());
+        for definition in definitions {
+            if !valid_id(&definition.id) || definition.revision == 0 {
+                return Err(ResolutionError::InvalidProposal(format!(
+                    "invalid capability definition: {}",
+                    definition.id
+                )));
+            }
+            let id = definition.id.clone();
+            if by_id.insert(id.clone(), definition).is_some() {
+                return Err(ResolutionError::InvalidProposal(format!(
+                    "duplicate capability definition: {id}"
+                )));
+            }
+            order.push(id);
+        }
+        Ok(Self {
+            revision,
+            definitions: by_id,
+            order,
+        })
+    }
+
+    pub fn builtins() -> Self {
+        Self::new("wisp-capabilities-v1", builtin_capabilities())
+            .expect("built-in capability definitions must be valid")
+    }
+
+    pub fn revision(&self) -> &str {
+        &self.revision
+    }
+
+    pub fn get(&self, id: &str) -> Option<&CapabilityDefinition> {
+        self.definitions.get(id)
+    }
+
+    pub fn available_ids(&self, host: &DelegationHostPolicy) -> Vec<String> {
+        self.order
+            .iter()
+            .filter(|id| {
+                self.definitions
+                    .get(*id)
+                    .is_some_and(|definition| definition_available(definition, host))
+            })
+            .cloned()
+            .collect()
+    }
+
+    pub fn resolve_task(
+        &self,
+        proposal: DelegatedTaskProposal,
+        host: &DelegationHostPolicy,
+    ) -> Result<ResolvedAgentTask, ResolutionError> {
+        validate_host(host)?;
+        validate_proposal(&proposal)?;
+
+        let mut definitions = Vec::with_capacity(proposal.capabilities.len());
+        for capability in &proposal.capabilities {
+            let definition = self
+                .get(capability)
+                .ok_or_else(|| ResolutionError::UnknownCapability(capability.clone()))?;
+            if !definition_available(definition, host) {
+                return Err(ResolutionError::UnavailableCapability(capability.clone()));
+            }
+            validate_specialist_restrictions(proposal.specialist.as_ref(), definition)?;
+            definitions.push(definition);
+        }
+
+        let grant = compose_grant(&definitions, host)?;
+        let model = select_model(&proposal, &grant.required_model_features, host)?;
+        let workspace_policy = if proposal.isolated {
+            AgentWorkspacePolicy::Isolated
+        } else {
+            grant.workspace_policy
+        };
+        let mut executor_features = grant.required_executor_features.clone();
+        if workspace_policy == AgentWorkspacePolicy::Isolated {
+            insert_sorted(&mut executor_features, ExecutorFeature::Isolation);
+        }
+        let executor = select_executor(
+            proposal.executor.as_ref(),
+            &executor_features,
+            &model.id,
+            host,
+        )?;
+        let budget = select_budget(
+            &grant.default_budget,
+            proposal.budget.as_ref(),
+            &grant.budget_ceiling,
+        )?;
+        let timeout_secs = select_timeout(host)?;
+        let mut approval_reasons =
+            approval_reasons(&grant, model, &executor, workspace_policy, &budget);
+        approval_reasons.sort();
+        approval_reasons.dedup();
+
+        let origin = proposal
+            .specialist
+            .clone()
+            .map(AgentOrigin::Specialist)
+            .unwrap_or(AgentOrigin::Temporary);
+        let name = proposal
+            .specialist
+            .as_ref()
+            .map(|specialist| specialist.name.clone())
+            .unwrap_or_else(|| proposal.id.clone());
+        let role = if proposal.specialist.is_some() {
+            AgentRole::Custom("specialist".into())
+        } else {
+            AgentRole::Custom("temporary".into())
+        };
+        let output_schema_source = if proposal.output_schema.is_some() {
+            AgentOutputSchemaSource::Task
+        } else {
+            AgentOutputSchemaSource::Standard
+        };
+        let output_contract = proposal.output_schema.clone().unwrap_or_else(|| {
+            json!({
+                "type": "object"
+            })
+        });
+        let mut spec = AgentSpec {
+            template_id: String::new(),
+            agent_id: proposal.id.clone(),
+            name,
+            goal: proposal.instruction.clone(),
+            context_summary: proposal.context_summary.clone(),
+            inputs: vec![],
+            acceptance_criteria: vec![],
+            dependencies: proposal.depends_on.clone(),
+            role,
+            backend: backend_for(&executor),
+            model: Some(model.id.clone()),
+            prompt_template: resolved_prompt(&proposal),
+            input_contract: json!({"type": "object"}),
+            output_contract,
+            permissions: grant.permissions.clone(),
+            context_policy: grant.context_policy.clone(),
+            budget,
+            timeout_secs,
+            requires_review: false,
+            session_policy: AgentSessionPolicy::New,
+            allow_delegation: false,
+            origin,
+            capabilities: proposal.capabilities.clone(),
+            executor: Some(executor),
+            workspace_policy: Some(workspace_policy),
+            output_schema_source,
+            approval_reasons,
+            authorization: Some(AgentAuthorizationSnapshot {
+                registry_revision: self.revision.clone(),
+                policy_revision: host.revision.clone(),
+                capabilities: definitions
+                    .iter()
+                    .map(|definition| CapabilityRevision {
+                        id: definition.id.clone(),
+                        revision: definition.revision,
+                    })
+                    .collect(),
+                integrity_hash: String::new(),
+            }),
+        };
+        spec.validate()
+            .and_then(|_| spec.validate_dynamic_metadata())
+            .map_err(|error| ResolutionError::InvalidProposal(error.to_string()))?;
+        set_integrity_hash(&mut spec)?;
+
+        Ok(ResolvedAgentTask {
+            spec,
+            input: proposal.input,
+            risk: grant.risk,
+            budget_ceiling: grant.budget_ceiling,
+            required_executor_features: executor_features,
+        })
+    }
+
+    pub fn resolve_plan(
+        &self,
+        goal: impl Into<String>,
+        mode: DelegationMode,
+        max_parallel: usize,
+        tasks: Vec<DelegatedTaskProposal>,
+        host: &DelegationHostPolicy,
+    ) -> Result<ResolvedDelegationPlan, ResolutionError> {
+        self.resolve_plan_with_id(
+            uuid::Uuid::new_v4().to_string(),
+            goal.into(),
+            mode,
+            max_parallel,
+            tasks,
+            host,
+        )
+    }
+
+    fn resolve_plan_with_id(
+        &self,
+        id: String,
+        goal: String,
+        mode: DelegationMode,
+        max_parallel: usize,
+        tasks: Vec<DelegatedTaskProposal>,
+        host: &DelegationHostPolicy,
+    ) -> Result<ResolvedDelegationPlan, ResolutionError> {
+        if tasks.is_empty() || tasks.len() > MAX_DELEGATION_TASKS {
+            return Err(ResolutionError::InvalidProposal(format!(
+                "a delegation plan requires 1 to {MAX_DELEGATION_TASKS} tasks"
+            )));
+        }
+        if !(1..=MAX_PARALLEL_AGENTS).contains(&max_parallel) {
+            return Err(ResolutionError::InvalidProposal(format!(
+                "max_parallel must be between 1 and {MAX_PARALLEL_AGENTS}"
+            )));
+        }
+        let resolved = tasks
+            .into_iter()
+            .map(|task| self.resolve_task(task, host))
+            .collect::<Result<Vec<_>, _>>()?;
+        let has_approval_reason = resolved
+            .iter()
+            .any(|task| !task.spec.approval_reasons.is_empty());
+        let requires_confirmation = match mode {
+            DelegationMode::Manual | DelegationMode::Assisted => true,
+            DelegationMode::Automatic => !host.auto_safe || has_approval_reason,
+        };
+        let plan = DelegationPlan {
+            schema_version: DYNAMIC_DELEGATION_SCHEMA_VERSION,
+            id,
+            goal,
+            mode,
+            requires_confirmation,
+            max_parallel,
+            steps: resolved
+                .into_iter()
+                .map(|task| DelegationPlanStep {
+                    id: task.spec.agent_id.clone(),
+                    spec: task.spec,
+                    input: task.input,
+                })
+                .collect(),
+        };
+        plan.validate_structure()
+            .map_err(|error| ResolutionError::InvalidProposal(error.to_string()))?;
+        Ok(ResolvedDelegationPlan { plan })
+    }
+
+    pub fn validate_resolved_spec(
+        &self,
+        spec: &AgentSpec,
+        host: &DelegationHostPolicy,
+    ) -> Result<(), ResolutionError> {
+        spec.validate()
+            .and_then(|_| spec.validate_dynamic_metadata())
+            .map_err(|error| ResolutionError::InvalidProposal(error.to_string()))?;
+        let authorization = spec
+            .authorization
+            .as_ref()
+            .ok_or_else(|| ResolutionError::StaleSnapshot("authorization is missing".into()))?;
+        if authorization.registry_revision != self.revision {
+            return Err(ResolutionError::StaleSnapshot(
+                "capability registry revision changed".into(),
+            ));
+        }
+        if authorization.policy_revision != host.revision {
+            return Err(ResolutionError::StaleSnapshot(
+                "host policy revision changed".into(),
+            ));
+        }
+        let expected_revisions = spec
+            .capabilities
+            .iter()
+            .map(|id| {
+                self.get(id)
+                    .map(|definition| CapabilityRevision {
+                        id: id.clone(),
+                        revision: definition.revision,
+                    })
+                    .ok_or_else(|| ResolutionError::UnknownCapability(id.clone()))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        if authorization.capabilities != expected_revisions {
+            return Err(ResolutionError::StaleSnapshot(
+                "capability definition revision changed".into(),
+            ));
+        }
+        if integrity_hash(spec)? != authorization.integrity_hash {
+            return Err(ResolutionError::IntegrityMismatch);
+        }
+        let expected = self.resolve_task(proposal_from_spec(spec)?, host)?;
+        if expected.spec != *spec {
+            return Err(ResolutionError::SnapshotMismatch);
+        }
+        Ok(())
+    }
+
+    pub fn validate_resolved_plan(
+        &self,
+        plan: &DelegationPlan,
+        host: &DelegationHostPolicy,
+    ) -> Result<(), ResolutionError> {
+        if plan.schema_version != DYNAMIC_DELEGATION_SCHEMA_VERSION {
+            return Err(ResolutionError::InvalidProposal(
+                "resolved policy validation requires a v2 plan".into(),
+            ));
+        }
+        plan.validate_structure()
+            .map_err(|error| ResolutionError::InvalidProposal(error.to_string()))?;
+        for step in &plan.steps {
+            self.validate_resolved_spec(&step.spec, host)?;
+        }
+        let proposals = plan
+            .steps
+            .iter()
+            .map(|step| {
+                let mut proposal = proposal_from_spec(&step.spec)?;
+                proposal.input = step.input.clone();
+                Ok(proposal)
+            })
+            .collect::<Result<Vec<_>, ResolutionError>>()?;
+        let expected = self.resolve_plan_with_id(
+            plan.id.clone(),
+            plan.goal.clone(),
+            plan.mode,
+            plan.max_parallel,
+            proposals,
+            host,
+        )?;
+        if expected.plan != *plan {
+            return Err(ResolutionError::SnapshotMismatch);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ComposedGrant {
+    risk: CapabilityRisk,
+    permissions: PermissionSet,
+    required_executor_features: Vec<ExecutorFeature>,
+    required_model_features: Vec<ModelFeature>,
+    context_policy: ContextPolicy,
+    default_budget: AgentBudget,
+    budget_ceiling: AgentBudget,
+    workspace_policy: AgentWorkspacePolicy,
+    approval_reasons: Vec<String>,
+}
+
+fn compose_grant(
+    definitions: &[&CapabilityDefinition],
+    host: &DelegationHostPolicy,
+) -> Result<ComposedGrant, ResolutionError> {
+    let mut risk = CapabilityRisk::ReadOnly;
+    let mut tools = Vec::new();
+    let mut required_paths = Vec::new();
+    let mut network = false;
+    let mut write = false;
+    let mut execute = false;
+    let mut executor_features = Vec::new();
+    let mut model_features = Vec::new();
+    let mut context = None;
+    let mut default_budget = None;
+    let mut budget_ceiling = None;
+    let mut workspace = AgentWorkspacePolicy::SharedReadOnly;
+    let mut approval_reasons = Vec::new();
+
+    for definition in definitions {
+        risk = risk.max(definition.risk);
+        extend_unique(&mut tools, &definition.permissions.tools);
+        extend_unique(&mut required_paths, &definition.permissions.paths);
+        network |= definition.permissions.network;
+        write |= definition.permissions.write;
+        execute |= definition.permissions.execute;
+        for feature in &definition.required_executor_features {
+            insert_sorted(&mut executor_features, *feature);
+        }
+        for feature in &definition.required_model_features {
+            insert_sorted(&mut model_features, *feature);
+        }
+        context = Some(match context {
+            Some(current) => restrict_context(current, &definition.context_ceiling),
+            None => definition.context_ceiling.clone(),
+        });
+        default_budget = Some(match default_budget {
+            Some(current) => restrict_budget(current, &definition.default_budget),
+            None => definition.default_budget.clone(),
+        });
+        budget_ceiling = Some(match budget_ceiling {
+            Some(current) => restrict_budget(current, &definition.budget_ceiling),
+            None => definition.budget_ceiling.clone(),
+        });
+        workspace = stricter_workspace(workspace, definition.workspace_policy);
+        if let Some(reason) = &definition.approval_reason {
+            approval_reasons.push(reason.clone());
+        }
+    }
+    if write {
+        risk = risk.max(CapabilityRisk::Write);
+    }
+    if execute {
+        risk = risk.max(CapabilityRisk::Execute);
+    }
+    if network {
+        risk = risk.max(CapabilityRisk::Network);
+    }
+
+    if tools
+        .iter()
+        .any(|tool| !host.permission_ceiling.tools.contains(tool))
+        || (network && !host.permission_ceiling.network)
+        || (write && !host.permission_ceiling.write)
+        || (execute && !host.permission_ceiling.execute)
+    {
+        return Err(ResolutionError::UnavailableCapability(
+            "host permission ceiling".into(),
+        ));
+    }
+    let paths = resolve_paths(&required_paths, &host.permission_ceiling.paths);
+    if !required_paths.is_empty() && paths.is_empty() {
+        return Err(ResolutionError::UnavailableCapability(
+            "project path ceiling".into(),
+        ));
+    }
+    let context_policy = restrict_context(context.unwrap_or_default(), &host.context_ceiling);
+    let budget_ceiling = restrict_budget(budget_ceiling.unwrap_or_default(), &host.budget_ceiling);
+    let default_budget = restrict_budget(default_budget.unwrap_or_default(), &budget_ceiling);
+    Ok(ComposedGrant {
+        risk,
+        permissions: PermissionSet {
+            tools,
+            paths,
+            network,
+            write,
+            execute,
+        },
+        required_executor_features: executor_features,
+        required_model_features: model_features,
+        context_policy,
+        default_budget,
+        budget_ceiling,
+        workspace_policy: workspace,
+        approval_reasons,
+    })
+}
+
+fn validate_host(host: &DelegationHostPolicy) -> Result<(), ResolutionError> {
+    if host.revision.trim().is_empty() {
+        return Err(ResolutionError::InvalidProposal(
+            "host policy revision is required".into(),
+        ));
+    }
+    if host.default_timeout_secs == Some(0) || host.timeout_ceiling_secs == Some(0) {
+        return Err(ResolutionError::InvalidProposal(
+            "host timeouts must be positive".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_proposal(proposal: &DelegatedTaskProposal) -> Result<(), ResolutionError> {
+    if !valid_id(&proposal.id) || proposal.instruction.trim().is_empty() {
+        return Err(ResolutionError::InvalidProposal(
+            "task id and instruction are required".into(),
+        ));
+    }
+    if proposal.capabilities.is_empty() {
+        return Err(ResolutionError::InvalidProposal(
+            "at least one capability is required".into(),
+        ));
+    }
+    let mut seen = HashSet::new();
+    if proposal
+        .capabilities
+        .iter()
+        .any(|id| !valid_id(id) || !seen.insert(id))
+    {
+        return Err(ResolutionError::InvalidProposal(
+            "capability IDs must be valid and unique".into(),
+        ));
+    }
+    if !proposal.input.is_object() {
+        return Err(ResolutionError::InvalidProposal(
+            "task input must be an object".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn definition_available(definition: &CapabilityDefinition, host: &DelegationHostPolicy) -> bool {
+    let permissions_available = host.enabled_capabilities.contains(&definition.id)
+        && definition
+            .required_skills
+            .iter()
+            .all(|id| host.available_skills.contains(id))
+        && definition
+            .required_connectors
+            .iter()
+            .all(|id| host.available_connectors.contains(id))
+        && definition
+            .permissions
+            .tools
+            .iter()
+            .all(|id| host.permission_ceiling.tools.contains(id))
+        && (!definition.permissions.network || host.permission_ceiling.network)
+        && (!definition.permissions.write || host.permission_ceiling.write)
+        && (!definition.permissions.execute || host.permission_ceiling.execute)
+        && (definition.permissions.paths.is_empty()
+            || !resolve_paths(
+                &definition.permissions.paths,
+                &host.permission_ceiling.paths,
+            )
+            .is_empty());
+    if !permissions_available {
+        return false;
+    }
+    let mut executor_features = definition.required_executor_features.clone();
+    if definition.workspace_policy == AgentWorkspacePolicy::Isolated {
+        insert_sorted(&mut executor_features, ExecutorFeature::Isolation);
+    }
+    host.models
+        .iter()
+        .filter(|model| model_eligible(model, &definition.required_model_features))
+        .any(|model| {
+            host.executors
+                .iter()
+                .any(|executor| executor_eligible(executor, &executor_features, &model.id))
+        })
+}
+
+fn validate_specialist_restrictions(
+    specialist: Option<&SpecialistSnapshot>,
+    definition: &CapabilityDefinition,
+) -> Result<(), ResolutionError> {
+    let Some(specialist) = specialist else {
+        return Ok(());
+    };
+    if let Some(allowed) = &specialist.skills {
+        if let Some(value) = definition
+            .required_skills
+            .iter()
+            .find(|value| !allowed.contains(value))
+        {
+            return Err(ResolutionError::SpecialistRestriction {
+                specialist_id: specialist.id.clone(),
+                kind: "skill",
+                value: value.clone(),
+            });
+        }
+    }
+    if let Some(allowed) = &specialist.connectors {
+        if let Some(value) = definition
+            .required_connectors
+            .iter()
+            .find(|value| !allowed.contains(value))
+        {
+            return Err(ResolutionError::SpecialistRestriction {
+                specialist_id: specialist.id.clone(),
+                kind: "connector",
+                value: value.clone(),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn select_model<'a>(
+    proposal: &DelegatedTaskProposal,
+    required: &[ModelFeature],
+    host: &'a DelegationHostPolicy,
+) -> Result<&'a ModelProfilePolicy, ResolutionError> {
+    if let Some(id) = &proposal.model_id {
+        return host
+            .models
+            .iter()
+            .find(|model| model.id == *id && model_eligible(model, required))
+            .ok_or_else(|| ResolutionError::UnknownModel(id.clone()));
+    }
+    if let Some(id) = proposal
+        .specialist
+        .as_ref()
+        .and_then(|specialist| specialist.model_id.as_ref())
+    {
+        if let Some(model) = host
+            .models
+            .iter()
+            .find(|model| model.id == *id && model_eligible(model, required))
+        {
+            return Ok(model);
+        }
+    }
+    if let Some(id) = &host.default_model_id {
+        if let Some(model) = host
+            .models
+            .iter()
+            .find(|model| model.id == *id && model_eligible(model, required))
+        {
+            return Ok(model);
+        }
+    }
+    host.models
+        .iter()
+        .find(|model| model_eligible(model, required))
+        .ok_or(ResolutionError::NoEligibleModel)
+}
+
+fn model_eligible(model: &ModelProfilePolicy, required: &[ModelFeature]) -> bool {
+    model.enabled
+        && required
+            .iter()
+            .all(|feature| model.features.contains(feature))
+}
+
+fn select_executor(
+    requested: Option<&AgentExecutorRef>,
+    required: &[ExecutorFeature],
+    model_id: &str,
+    host: &DelegationHostPolicy,
+) -> Result<AgentExecutorRef, ResolutionError> {
+    if let Some(requested) = requested {
+        return host
+            .executors
+            .iter()
+            .find(|profile| {
+                profile.executor == *requested && executor_eligible(profile, required, model_id)
+            })
+            .map(|profile| profile.executor.clone())
+            .ok_or_else(|| ResolutionError::UnknownExecutor(executor_name(requested)));
+    }
+    host.executors
+        .iter()
+        .filter(|profile| executor_eligible(profile, required, model_id))
+        .min_by_key(|profile| {
+            if profile.executor == AgentExecutorRef::Native {
+                0
+            } else {
+                1
+            }
+        })
+        .map(|profile| profile.executor.clone())
+        .ok_or(ResolutionError::NoEligibleExecutor)
+}
+
+fn executor_eligible(
+    profile: &ExecutorProfilePolicy,
+    required: &[ExecutorFeature],
+    model_id: &str,
+) -> bool {
+    profile.enabled
+        && required
+            .iter()
+            .all(|feature| profile.features.contains(feature))
+        && (profile.model_ids.is_empty() || profile.model_ids.iter().any(|id| id == model_id))
+}
+
+fn select_budget(
+    defaults: &AgentBudget,
+    requested: Option<&AgentBudget>,
+    ceiling: &AgentBudget,
+) -> Result<AgentBudget, ResolutionError> {
+    let selected = AgentBudget {
+        max_tokens: requested
+            .and_then(|value| value.max_tokens)
+            .or(defaults.max_tokens),
+        max_tool_calls: requested
+            .and_then(|value| value.max_tool_calls)
+            .or(defaults.max_tool_calls),
+        max_cost_microunits: requested
+            .and_then(|value| value.max_cost_microunits)
+            .or(defaults.max_cost_microunits),
+    };
+    if !limit_within(selected.max_tokens, ceiling.max_tokens)
+        || !limit_within(selected.max_tool_calls, ceiling.max_tool_calls)
+        || !limit_within(selected.max_cost_microunits, ceiling.max_cost_microunits)
+    {
+        return Err(ResolutionError::BudgetExceeded);
+    }
+    Ok(selected)
+}
+
+fn select_timeout(host: &DelegationHostPolicy) -> Result<Option<u64>, ResolutionError> {
+    match (host.default_timeout_secs, host.timeout_ceiling_secs) {
+        (Some(default), Some(ceiling)) if default > ceiling => Err(
+            ResolutionError::InvalidProposal("default timeout exceeds host ceiling".into()),
+        ),
+        (default, _) => Ok(default),
+    }
+}
+
+fn approval_reasons(
+    grant: &ComposedGrant,
+    model: &ModelProfilePolicy,
+    executor: &AgentExecutorRef,
+    workspace: AgentWorkspacePolicy,
+    budget: &AgentBudget,
+) -> Vec<String> {
+    let mut reasons = grant.approval_reasons.clone();
+    if grant.permissions.write {
+        reasons.push("Task can modify project files".into());
+    }
+    if grant.permissions.execute {
+        reasons.push("Task can execute code".into());
+    }
+    if grant.permissions.network {
+        reasons.push("Task can access network services".into());
+    }
+    if grant.risk == CapabilityRisk::External || model.external {
+        reasons.push("Task uses an external service or model".into());
+    }
+    match executor {
+        AgentExecutorRef::Native => {}
+        AgentExecutorRef::Acp { profile_id } => {
+            reasons.push(format!("Task uses ACP executor profile {profile_id}"));
+        }
+        AgentExecutorRef::External { profile_id } => {
+            reasons.push(format!("Task uses external executor profile {profile_id}"));
+        }
+    }
+    if workspace == AgentWorkspacePolicy::Isolated {
+        reasons.push("Task requires an isolated workspace and explicit merge".into());
+    }
+    if budget_is_elevated(budget, &grant.default_budget) {
+        reasons.push("Task requests an elevated resource budget".into());
+    }
+    reasons
+}
+
+fn budget_is_elevated(selected: &AgentBudget, defaults: &AgentBudget) -> bool {
+    limit_greater(selected.max_tokens, defaults.max_tokens)
+        || limit_greater(selected.max_tool_calls, defaults.max_tool_calls)
+        || limit_greater(selected.max_cost_microunits, defaults.max_cost_microunits)
+        || selected
+            .max_tokens
+            .is_some_and(|value| value > ELEVATED_TOKEN_THRESHOLD)
+        || selected
+            .max_cost_microunits
+            .is_some_and(|value| value > ELEVATED_COST_THRESHOLD_MICROUNITS)
+}
+
+fn proposal_from_spec(spec: &AgentSpec) -> Result<DelegatedTaskProposal, ResolutionError> {
+    let specialist = match &spec.origin {
+        AgentOrigin::Temporary => None,
+        AgentOrigin::Specialist(snapshot) => Some(snapshot.clone()),
+        AgentOrigin::LegacyTemplate => {
+            return Err(ResolutionError::InvalidProposal(
+                "legacy templates cannot be revalidated as dynamic tasks".into(),
+            ))
+        }
+    };
+    let output_schema = match spec.output_schema_source {
+        AgentOutputSchemaSource::Standard => None,
+        AgentOutputSchemaSource::Task => Some(spec.output_contract.clone()),
+        AgentOutputSchemaSource::Specialist => {
+            return Err(ResolutionError::SnapshotMismatch);
+        }
+    };
+    Ok(DelegatedTaskProposal {
+        id: spec.agent_id.clone(),
+        instruction: spec.goal.clone(),
+        context_summary: spec.context_summary.clone(),
+        depends_on: spec.dependencies.clone(),
+        capabilities: spec.capabilities.clone(),
+        specialist,
+        output_schema,
+        isolated: spec.workspace_policy == Some(AgentWorkspacePolicy::Isolated),
+        model_id: spec.model.clone(),
+        executor: spec.executor.clone(),
+        budget: Some(spec.budget.clone()),
+        input: json!({}),
+    })
+}
+
+fn resolved_prompt(proposal: &DelegatedTaskProposal) -> String {
+    match &proposal.specialist {
+        Some(specialist) => format!(
+            "You are {} ({}) working as a bounded Wisp sub-Agent.\n\nSpecialist instructions:\n{}\n\nAssigned task:\n{}",
+            specialist.name,
+            specialist.id,
+            specialist.instructions.trim(),
+            proposal.instruction.trim()
+        ),
+        None => format!(
+            "You are a temporary bounded Wisp sub-Agent. Complete only the assigned task and return evidence for the parent Agent.\n\nAssigned task:\n{}",
+            proposal.instruction.trim()
+        ),
+    }
+}
+
+fn backend_for(executor: &AgentExecutorRef) -> AgentBackend {
+    match executor {
+        AgentExecutorRef::Native => AgentBackend::Local,
+        AgentExecutorRef::Acp { .. } => AgentBackend::Acp,
+        AgentExecutorRef::External { .. } => AgentBackend::Custom("external".into()),
+    }
+}
+
+fn executor_name(executor: &AgentExecutorRef) -> String {
+    match executor {
+        AgentExecutorRef::Native => "native".into(),
+        AgentExecutorRef::Acp { profile_id } => format!("acp:{profile_id}"),
+        AgentExecutorRef::External { profile_id } => format!("external:{profile_id}"),
+    }
+}
+
+fn set_integrity_hash(spec: &mut AgentSpec) -> Result<(), ResolutionError> {
+    let hash = integrity_hash(spec)?;
+    spec.authorization
+        .as_mut()
+        .expect("resolver always attaches authorization")
+        .integrity_hash = hash;
+    Ok(())
+}
+
+fn integrity_hash(spec: &AgentSpec) -> Result<String, ResolutionError> {
+    let mut canonical = spec.clone();
+    if let Some(authorization) = canonical.authorization.as_mut() {
+        authorization.integrity_hash.clear();
+    }
+    let bytes = serde_json::to_vec(&canonical)
+        .map_err(|error| ResolutionError::InvalidProposal(error.to_string()))?;
+    let digest = Sha256::digest(bytes);
+    Ok(digest.iter().map(|byte| format!("{byte:02x}")).collect())
+}
+
+fn resolve_paths(required: &[String], host: &[String]) -> Vec<String> {
+    if required.is_empty() {
+        return vec![];
+    }
+    host.iter()
+        .filter(|candidate| {
+            required.iter().any(|ceiling| {
+                ceiling == *candidate
+                    || (ceiling == "project://**" && candidate.starts_with("project://"))
+            })
+        })
+        .cloned()
+        .collect()
+}
+
+fn restrict_context(left: ContextPolicy, right: &ContextPolicy) -> ContextPolicy {
+    left.restrict(right)
+}
+
+fn restrict_budget(left: AgentBudget, right: &AgentBudget) -> AgentBudget {
+    left.restrict(right)
+}
+
+fn stricter_workspace(
+    left: AgentWorkspacePolicy,
+    right: AgentWorkspacePolicy,
+) -> AgentWorkspacePolicy {
+    if workspace_rank(right) > workspace_rank(left) {
+        right
+    } else {
+        left
+    }
+}
+
+const fn workspace_rank(policy: AgentWorkspacePolicy) -> u8 {
+    match policy {
+        AgentWorkspacePolicy::SharedReadOnly => 0,
+        AgentWorkspacePolicy::SerializedMutation => 1,
+        AgentWorkspacePolicy::Isolated => 2,
+    }
+}
+
+fn extend_unique(target: &mut Vec<String>, values: &[String]) {
+    for value in values {
+        if !target.contains(value) {
+            target.push(value.clone());
+        }
+    }
+}
+
+fn insert_sorted<T: Ord + Copy>(target: &mut Vec<T>, value: T) {
+    if !target.contains(&value) {
+        target.push(value);
+        target.sort();
+    }
+}
+
+fn limit_within<T: Ord>(selected: Option<T>, ceiling: Option<T>) -> bool {
+    match (selected, ceiling) {
+        (_, None) => true,
+        (Some(selected), Some(ceiling)) => selected <= ceiling,
+        (None, Some(_)) => false,
+    }
+}
+
+fn limit_greater<T: Ord>(selected: Option<T>, defaults: Option<T>) -> bool {
+    match (selected, defaults) {
+        (Some(selected), Some(default)) => selected > default,
+        (None, Some(_)) => true,
+        _ => false,
+    }
+}
+
+fn valid_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 64
+        && value.bytes().all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'_' | b'-')
+        })
+}
+
+fn builtin_capabilities() -> Vec<CapabilityDefinition> {
+    vec![
+        capability(
+            "reasoning",
+            "Reasoning",
+            "Reason without project tools.",
+            CapabilityRisk::ReadOnly,
+            &[],
+            false,
+            false,
+            false,
+            &[],
+            &[],
+            &[],
+            AgentWorkspacePolicy::SharedReadOnly,
+            8_000,
+            16_000,
+        ),
+        capability(
+            "project_read",
+            "Project read",
+            "Read and search project files.",
+            CapabilityRisk::ReadOnly,
+            &["read", "search", "grep"],
+            false,
+            false,
+            false,
+            &[ExecutorFeature::ProjectRead],
+            &[],
+            &[],
+            AgentWorkspacePolicy::SharedReadOnly,
+            8_000,
+            20_000,
+        ),
+        capability(
+            "project_write",
+            "Project write",
+            "Read and modify project files.",
+            CapabilityRisk::Write,
+            &["read", "search", "grep", "write", "edit"],
+            true,
+            false,
+            false,
+            &[ExecutorFeature::ProjectRead, ExecutorFeature::ProjectWrite],
+            &[],
+            &[],
+            AgentWorkspacePolicy::SerializedMutation,
+            10_000,
+            24_000,
+        ),
+        capability(
+            "code_run",
+            "Code execution",
+            "Run bounded project code.",
+            CapabilityRisk::Execute,
+            &["read", "search", "grep", "shell"],
+            false,
+            false,
+            true,
+            &[ExecutorFeature::ProjectRead, ExecutorFeature::CodeExecution],
+            &[],
+            &[],
+            AgentWorkspacePolicy::SerializedMutation,
+            12_000,
+            32_000,
+        ),
+        capability(
+            "literature_search",
+            "Literature search",
+            "Search configured scholarly sources.",
+            CapabilityRisk::Network,
+            &["literature_search"],
+            false,
+            true,
+            false,
+            &[
+                ExecutorFeature::NetworkAccess,
+                ExecutorFeature::LiteratureAccess,
+            ],
+            &[],
+            &["literature"],
+            AgentWorkspacePolicy::SharedReadOnly,
+            10_000,
+            20_000,
+        ),
+        capability(
+            "external_research",
+            "External research",
+            "Use configured external research sources.",
+            CapabilityRisk::External,
+            &["web_search"],
+            false,
+            true,
+            false,
+            &[ExecutorFeature::NetworkAccess],
+            &[],
+            &["web"],
+            AgentWorkspacePolicy::SharedReadOnly,
+            10_000,
+            20_000,
+        ),
+        capability(
+            "visualization",
+            "Visualization",
+            "Create figures with bounded runtime tools.",
+            CapabilityRisk::Execute,
+            &["read", "search", "grep", "write", "edit", "python", "r"],
+            true,
+            false,
+            true,
+            &[
+                ExecutorFeature::ProjectRead,
+                ExecutorFeature::ProjectWrite,
+                ExecutorFeature::CodeExecution,
+            ],
+            &[],
+            &[],
+            AgentWorkspacePolicy::SerializedMutation,
+            12_000,
+            32_000,
+        ),
+        capability(
+            "review",
+            "Review",
+            "Inspect project evidence without modifying it.",
+            CapabilityRisk::ReadOnly,
+            &["read", "search", "grep"],
+            false,
+            false,
+            false,
+            &[ExecutorFeature::ProjectRead],
+            &[],
+            &[],
+            AgentWorkspacePolicy::SharedReadOnly,
+            8_000,
+            16_000,
+        ),
+        capability_with_model(
+            "image_inspection",
+            "Image inspection",
+            "Inspect local images with a configured vision model.",
+            CapabilityRisk::External,
+            &["read", "view_image"],
+            &[ExecutorFeature::ProjectRead, ExecutorFeature::Vision],
+            &[ModelFeature::Vision],
+            8_000,
+            16_000,
+        ),
+    ]
+}
+
+#[allow(clippy::too_many_arguments)]
+fn capability(
+    id: &str,
+    display_name: &str,
+    description: &str,
+    risk: CapabilityRisk,
+    tools: &[&str],
+    write: bool,
+    network: bool,
+    execute: bool,
+    executor_features: &[ExecutorFeature],
+    skills: &[&str],
+    connectors: &[&str],
+    workspace_policy: AgentWorkspacePolicy,
+    default_tokens: u32,
+    max_tokens: u32,
+) -> CapabilityDefinition {
+    CapabilityDefinition {
+        id: id.into(),
+        revision: 1,
+        display_name: display_name.into(),
+        description: description.into(),
+        risk,
+        permissions: PermissionSet {
+            tools: tools.iter().map(|value| (*value).into()).collect(),
+            paths: if tools.is_empty() {
+                vec![]
+            } else {
+                vec!["project://**".into()]
+            },
+            network,
+            write,
+            execute,
+        },
+        required_executor_features: executor_features.to_vec(),
+        required_model_features: vec![],
+        required_skills: skills.iter().map(|value| (*value).into()).collect(),
+        required_connectors: connectors.iter().map(|value| (*value).into()).collect(),
+        context_ceiling: ContextPolicy {
+            include_history: false,
+            include_artifacts: true,
+            max_tokens: Some(max_tokens),
+        },
+        default_budget: AgentBudget {
+            max_tokens: Some(default_tokens),
+            max_tool_calls: Some(32),
+            max_cost_microunits: Some(500_000),
+        },
+        budget_ceiling: AgentBudget {
+            max_tokens: Some(max_tokens),
+            max_tool_calls: Some(64),
+            max_cost_microunits: Some(1_000_000),
+        },
+        workspace_policy,
+        approval_reason: None,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn capability_with_model(
+    id: &str,
+    display_name: &str,
+    description: &str,
+    risk: CapabilityRisk,
+    tools: &[&str],
+    executor_features: &[ExecutorFeature],
+    model_features: &[ModelFeature],
+    default_tokens: u32,
+    max_tokens: u32,
+) -> CapabilityDefinition {
+    let mut definition = capability(
+        id,
+        display_name,
+        description,
+        risk,
+        tools,
+        false,
+        false,
+        false,
+        executor_features,
+        &[],
+        &[],
+        AgentWorkspacePolicy::SharedReadOnly,
+        default_tokens,
+        max_tokens,
+    );
+    definition.required_model_features = model_features.to_vec();
+    definition
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+
+    fn host_policy() -> DelegationHostPolicy {
+        let registry = CapabilityRegistry::builtins();
+        let tools = registry
+            .order
+            .iter()
+            .flat_map(|id| registry.get(id).unwrap().permissions.tools.clone())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect();
+        DelegationHostPolicy {
+            revision: "test-policy-v1".into(),
+            enabled_capabilities: registry.order.clone(),
+            available_skills: vec![],
+            available_connectors: vec!["literature".into(), "web".into()],
+            models: vec![
+                ModelProfilePolicy {
+                    id: "local".into(),
+                    features: vec![],
+                    external: false,
+                    enabled: true,
+                },
+                ModelProfilePolicy {
+                    id: "vision".into(),
+                    features: vec![ModelFeature::Vision],
+                    external: true,
+                    enabled: true,
+                },
+            ],
+            executors: vec![
+                ExecutorProfilePolicy {
+                    executor: AgentExecutorRef::Native,
+                    features: vec![
+                        ExecutorFeature::ProjectRead,
+                        ExecutorFeature::ProjectWrite,
+                        ExecutorFeature::CodeExecution,
+                        ExecutorFeature::NetworkAccess,
+                        ExecutorFeature::LiteratureAccess,
+                        ExecutorFeature::Vision,
+                        ExecutorFeature::Isolation,
+                    ],
+                    model_ids: vec![],
+                    enabled: true,
+                },
+                ExecutorProfilePolicy {
+                    executor: AgentExecutorRef::Acp {
+                        profile_id: "acp-general".into(),
+                    },
+                    features: vec![
+                        ExecutorFeature::ProjectRead,
+                        ExecutorFeature::ProjectWrite,
+                        ExecutorFeature::CodeExecution,
+                        ExecutorFeature::NetworkAccess,
+                        ExecutorFeature::LiteratureAccess,
+                        ExecutorFeature::Vision,
+                        ExecutorFeature::Isolation,
+                    ],
+                    model_ids: vec!["local".into(), "vision".into()],
+                    enabled: true,
+                },
+            ],
+            default_model_id: Some("local".into()),
+            permission_ceiling: PermissionSet {
+                tools,
+                paths: vec!["project://**".into()],
+                network: true,
+                write: true,
+                execute: true,
+            },
+            context_ceiling: ContextPolicy {
+                include_history: false,
+                include_artifacts: true,
+                max_tokens: Some(32_000),
+            },
+            budget_ceiling: AgentBudget {
+                max_tokens: Some(32_000),
+                max_tool_calls: Some(64),
+                max_cost_microunits: Some(1_000_000),
+            },
+            default_timeout_secs: Some(600),
+            timeout_ceiling_secs: Some(1_800),
+            auto_safe: true,
+        }
+    }
+
+    fn proposal(id: &str, capabilities: &[&str]) -> DelegatedTaskProposal {
+        DelegatedTaskProposal {
+            id: id.into(),
+            instruction: format!("Complete {id}"),
+            context_summary: String::new(),
+            depends_on: vec![],
+            capabilities: capabilities.iter().map(|value| (*value).into()).collect(),
+            specialist: None,
+            output_schema: None,
+            isolated: false,
+            model_id: None,
+            executor: None,
+            budget: None,
+            input: json!({}),
+        }
+    }
+
+    #[test]
+    fn builtins_resolve_to_exact_tool_and_permission_grants() {
+        let registry = CapabilityRegistry::builtins();
+        let host = host_policy();
+        let cases = [
+            ("reasoning", vec![], false, false, false),
+            (
+                "project_read",
+                vec!["read", "search", "grep"],
+                false,
+                false,
+                false,
+            ),
+            (
+                "project_write",
+                vec!["read", "search", "grep", "write", "edit"],
+                true,
+                false,
+                false,
+            ),
+            (
+                "code_run",
+                vec!["read", "search", "grep", "shell"],
+                false,
+                false,
+                true,
+            ),
+            (
+                "literature_search",
+                vec!["literature_search"],
+                false,
+                true,
+                false,
+            ),
+            ("external_research", vec!["web_search"], false, true, false),
+            (
+                "visualization",
+                vec!["read", "search", "grep", "write", "edit", "python", "r"],
+                true,
+                false,
+                true,
+            ),
+            (
+                "review",
+                vec!["read", "search", "grep"],
+                false,
+                false,
+                false,
+            ),
+            (
+                "image_inspection",
+                vec!["read", "view_image"],
+                false,
+                false,
+                false,
+            ),
+        ];
+        for (id, tools, write, network, execute) in cases {
+            let resolved = registry.resolve_task(proposal(id, &[id]), &host).unwrap();
+            assert_eq!(resolved.spec().permissions.tools, tools, "{id}");
+            assert_eq!(resolved.spec().permissions.write, write, "{id}");
+            assert_eq!(resolved.spec().permissions.network, network, "{id}");
+            assert_eq!(resolved.spec().permissions.execute, execute, "{id}");
+            assert_eq!(
+                resolved.spec().permissions.paths.is_empty(),
+                id == "reasoning",
+                "{id}"
+            );
+        }
+    }
+
+    #[test]
+    fn composed_capabilities_use_highest_risk_and_narrowest_budget() {
+        let registry = CapabilityRegistry::builtins();
+        let host = host_policy();
+        let resolved = registry
+            .resolve_task(proposal("work", &["project_read", "code_run"]), &host)
+            .unwrap();
+        assert_eq!(resolved.risk(), CapabilityRisk::Execute);
+        assert_eq!(resolved.budget_ceiling().max_tokens, Some(20_000));
+        assert!(resolved.spec().permissions.tools.contains(&"shell".into()));
+
+        let mut too_large = proposal("work", &["project_read", "code_run"]);
+        too_large.budget = Some(AgentBudget {
+            max_tokens: Some(20_001),
+            ..Default::default()
+        });
+        assert_eq!(
+            registry.resolve_task(too_large, &host).unwrap_err(),
+            ResolutionError::BudgetExceeded
+        );
+    }
+
+    #[test]
+    fn unknown_disabled_and_unavailable_capabilities_fail_closed() {
+        let registry = CapabilityRegistry::builtins();
+        let mut host = host_policy();
+        assert!(matches!(
+            registry.resolve_task(proposal("x", &["missing"]), &host),
+            Err(ResolutionError::UnknownCapability(_))
+        ));
+        host.enabled_capabilities.retain(|id| id != "project_read");
+        assert!(matches!(
+            registry.resolve_task(proposal("x", &["project_read"]), &host),
+            Err(ResolutionError::UnavailableCapability(_))
+        ));
+        host.enabled_capabilities.push("project_read".into());
+        host.permission_ceiling.tools.retain(|tool| tool != "read");
+        assert!(matches!(
+            registry.resolve_task(proposal("x", &["project_read"]), &host),
+            Err(ResolutionError::UnavailableCapability(_))
+        ));
+
+        let mut host = host_policy();
+        host.permission_ceiling.execute = false;
+        assert!(matches!(
+            registry.resolve_task(proposal("x", &["code_run"]), &host),
+            Err(ResolutionError::UnavailableCapability(_))
+        ));
+    }
+
+    #[test]
+    fn advertised_capabilities_follow_runtime_resource_availability() {
+        let registry = CapabilityRegistry::builtins();
+        let mut host = host_policy();
+        assert!(registry
+            .available_ids(&host)
+            .contains(&"literature_search".into()));
+        host.available_connectors
+            .retain(|connector| connector != "literature");
+        assert!(!registry
+            .available_ids(&host)
+            .contains(&"literature_search".into()));
+
+        assert!(registry
+            .available_ids(&host)
+            .contains(&"image_inspection".into()));
+        host.models
+            .iter_mut()
+            .find(|model| model.id == "vision")
+            .unwrap()
+            .enabled = false;
+        assert!(!registry
+            .available_ids(&host)
+            .contains(&"image_inspection".into()));
+    }
+
+    #[test]
+    fn specialist_allowlists_only_narrow_capabilities() {
+        let registry = CapabilityRegistry::builtins();
+        let host = host_policy();
+        let mut restricted = proposal("papers", &["literature_search"]);
+        restricted.specialist = Some(SpecialistSnapshot {
+            id: "bio".into(),
+            name: "Biology".into(),
+            instructions: "Use primary sources".into(),
+            model_id: None,
+            skills: None,
+            connectors: Some(vec![]),
+        });
+        assert!(matches!(
+            registry.resolve_task(restricted.clone(), &host),
+            Err(ResolutionError::SpecialistRestriction { .. })
+        ));
+
+        restricted.specialist.as_mut().unwrap().connectors =
+            Some(vec!["literature".into(), "untrusted-extra".into()]);
+        let resolved = registry.resolve_task(restricted, &host).unwrap();
+        assert_eq!(resolved.spec().permissions.tools, vec!["literature_search"]);
+        assert!(!resolved
+            .spec()
+            .permissions
+            .tools
+            .contains(&"untrusted-extra".into()));
+    }
+
+    #[test]
+    fn model_and_executor_overrides_must_select_configured_eligible_profiles() {
+        let registry = CapabilityRegistry::builtins();
+        let host = host_policy();
+        let mut task = proposal("inspect", &["image_inspection"]);
+        task.model_id = Some("vision".into());
+        task.executor = Some(AgentExecutorRef::Acp {
+            profile_id: "acp-general".into(),
+        });
+        let resolved = registry.resolve_task(task.clone(), &host).unwrap();
+        assert_eq!(resolved.spec().model.as_deref(), Some("vision"));
+        assert_eq!(resolved.spec().executor, task.executor);
+
+        task.model_id = Some("local".into());
+        assert!(matches!(
+            registry.resolve_task(task.clone(), &host),
+            Err(ResolutionError::UnknownModel(_))
+        ));
+        task.model_id = Some("vision".into());
+        task.executor = Some(AgentExecutorRef::Acp {
+            profile_id: "missing".into(),
+        });
+        assert!(matches!(
+            registry.resolve_task(task, &host),
+            Err(ResolutionError::UnknownExecutor(_))
+        ));
+    }
+
+    #[test]
+    fn native_read_only_auto_safe_batch_skips_confirmation() {
+        let registry = CapabilityRegistry::builtins();
+        let host = host_policy();
+        let mut review = proposal("review", &["review"]);
+        review.depends_on = vec!["inspect".into()];
+        let plan = registry
+            .resolve_plan(
+                "inspect and review",
+                DelegationMode::Automatic,
+                2,
+                vec![proposal("inspect", &["project_read"]), review],
+                &host,
+            )
+            .unwrap();
+        assert!(!plan.as_plan().requires_confirmation);
+        registry
+            .validate_resolved_plan(plan.as_plan(), &host)
+            .unwrap();
+    }
+
+    #[test]
+    fn risky_choices_each_produce_an_explicit_confirmation_reason() {
+        let registry = CapabilityRegistry::builtins();
+        let host = host_policy();
+        let cases = [
+            ("project_write", "modify project files"),
+            ("code_run", "execute code"),
+            ("literature_search", "network services"),
+            ("image_inspection", "external service or model"),
+        ];
+        for (capability, fragment) in cases {
+            let resolved = registry
+                .resolve_task(proposal(capability, &[capability]), &host)
+                .unwrap();
+            assert!(resolved
+                .spec()
+                .approval_reasons
+                .iter()
+                .any(|reason| reason.contains(fragment)));
+        }
+
+        let mut acp = proposal("acp", &["reasoning"]);
+        acp.executor = Some(AgentExecutorRef::Acp {
+            profile_id: "acp-general".into(),
+        });
+        assert!(registry
+            .resolve_task(acp, &host)
+            .unwrap()
+            .spec()
+            .approval_reasons
+            .iter()
+            .any(|reason| reason.contains("ACP executor")));
+
+        let mut isolated = proposal("isolated", &["project_read"]);
+        isolated.isolated = true;
+        assert!(registry
+            .resolve_task(isolated, &host)
+            .unwrap()
+            .spec()
+            .approval_reasons
+            .iter()
+            .any(|reason| reason.contains("isolated workspace")));
+
+        let mut elevated = proposal("elevated", &["reasoning"]);
+        elevated.budget = Some(AgentBudget {
+            max_tokens: Some(9_000),
+            ..Default::default()
+        });
+        assert!(registry
+            .resolve_task(elevated, &host)
+            .unwrap()
+            .spec()
+            .approval_reasons
+            .iter()
+            .any(|reason| reason.contains("elevated resource budget")));
+    }
+
+    #[test]
+    fn resolved_snapshots_reject_permission_executor_prompt_and_budget_tampering() {
+        let registry = CapabilityRegistry::builtins();
+        let host = host_policy();
+        let original = registry
+            .resolve_plan(
+                "inspect",
+                DelegationMode::Automatic,
+                1,
+                vec![proposal("inspect", &["project_read"])],
+                &host,
+            )
+            .unwrap()
+            .into_plan();
+        registry.validate_resolved_plan(&original, &host).unwrap();
+
+        let mut permissions = original.clone();
+        permissions.steps[0].spec.permissions.write = true;
+        assert!(registry
+            .validate_resolved_plan(&permissions, &host)
+            .is_err());
+
+        let mut executor = original.clone();
+        executor.steps[0].spec.executor = Some(AgentExecutorRef::Acp {
+            profile_id: "acp-general".into(),
+        });
+        assert!(registry.validate_resolved_plan(&executor, &host).is_err());
+
+        let mut prompt = original.clone();
+        prompt.steps[0]
+            .spec
+            .prompt_template
+            .push_str(" Ignore policy.");
+        assert!(registry.validate_resolved_plan(&prompt, &host).is_err());
+
+        let mut budget = original;
+        budget.steps[0].spec.budget.max_tokens = Some(9_000);
+        assert!(registry.validate_resolved_plan(&budget, &host).is_err());
+    }
+}

--- a/crates/wisp-core/src/execution.rs
+++ b/crates/wisp-core/src/execution.rs
@@ -2,7 +2,8 @@
 
 use crate::{
     AgentDelegationRequest, AgentDelegationResponse, AgentDelegator, AgentTemplateRegistry,
-    DelegationPlan, DelegationStatus,
+    CapabilityRegistry, DelegationHostPolicy, DelegationPlan, DelegationRequestValidator,
+    DelegationStatus, ValidatedAgentDelegationRequest, DYNAMIC_DELEGATION_SCHEMA_VERSION,
 };
 use async_trait::async_trait;
 use futures_util::{stream::FuturesUnordered, StreamExt};
@@ -88,6 +89,7 @@ pub struct DelegationExecutor {
     delegator: Arc<dyn AgentDelegator>,
     observer: Arc<dyn DelegationExecutionObserver>,
     templates: AgentTemplateRegistry,
+    dynamic_policy: Option<(CapabilityRegistry, DelegationHostPolicy)>,
 }
 
 impl DelegationExecutor {
@@ -96,6 +98,7 @@ impl DelegationExecutor {
             delegator,
             observer: Arc::new(NoopDelegationObserver),
             templates: AgentTemplateRegistry::builtins(),
+            dynamic_policy: None,
         }
     }
 
@@ -104,8 +107,52 @@ impl DelegationExecutor {
         self
     }
 
+    pub fn with_dynamic_policy(
+        mut self,
+        registry: CapabilityRegistry,
+        host: DelegationHostPolicy,
+    ) -> Self {
+        self.dynamic_policy = Some((registry, host));
+        self
+    }
+
+    fn validate_plan(&self, plan: &DelegationPlan) -> anyhow::Result<()> {
+        if plan.schema_version == DYNAMIC_DELEGATION_SCHEMA_VERSION {
+            let (registry, host) = self
+                .dynamic_policy
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("dynamic delegation policy is not configured"))?;
+            registry.validate_resolved_plan(plan, host)?;
+            Ok(())
+        } else {
+            plan.validate(&self.templates)
+        }
+    }
+
+    fn validate_request(
+        &self,
+        request: AgentDelegationRequest,
+        schema_version: u32,
+    ) -> anyhow::Result<ValidatedAgentDelegationRequest> {
+        if schema_version == DYNAMIC_DELEGATION_SCHEMA_VERSION {
+            let (registry, host) = self
+                .dynamic_policy
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("dynamic delegation policy is not configured"))?;
+            ValidatedAgentDelegationRequest::authorize(
+                request,
+                DelegationRequestValidator::Dynamic { registry, host },
+            )
+        } else {
+            ValidatedAgentDelegationRequest::authorize(
+                request,
+                DelegationRequestValidator::Legacy(&self.templates),
+            )
+        }
+    }
+
     pub async fn execute(&self, plan: DelegationPlan) -> anyhow::Result<DelegationExecutionResult> {
-        plan.validate(&self.templates)?;
+        self.validate_plan(&plan)?;
         self.observer.workflow_started(&plan).await?;
 
         let requests = plan
@@ -196,8 +243,9 @@ impl DelegationExecutor {
                     &request.spec.dependencies,
                     &responses,
                 );
-                self.observer.step_started(&request).await?;
-                running_requests.insert(step_id.clone(), request.request_id.clone());
+                let request = self.validate_request(request, plan.schema_version)?;
+                self.observer.step_started(request.as_request()).await?;
+                running_requests.insert(step_id.clone(), request.as_request().request_id.clone());
                 running.push(run_request(self.delegator.clone(), step_id, request));
             }
 
@@ -261,21 +309,22 @@ type DelegationFuture = Pin<
 fn run_request(
     delegator: Arc<dyn AgentDelegator>,
     step_id: String,
-    request: AgentDelegationRequest,
+    request: ValidatedAgentDelegationRequest,
 ) -> DelegationFuture {
     Box::pin(async move {
-        let timeout = request.spec.timeout_secs.map(Duration::from_secs);
+        let raw_request = request.as_request().clone();
+        let timeout = raw_request.spec.timeout_secs.map(Duration::from_secs);
         let result = match timeout {
             Some(timeout) => {
-                match tokio::time::timeout(timeout, delegator.delegate(request.clone())).await {
+                match tokio::time::timeout(timeout, delegator.delegate_authorized(request)).await {
                     Ok(result) => result,
                     Err(_) => {
-                        let _ = delegator.cancel(&request.request_id).await;
+                        let _ = delegator.cancel(&raw_request.request_id).await;
                         let message = format!(
                             "delegated Agent timed out after {} seconds",
                             timeout.as_secs()
                         );
-                        match delegator.status(&request.request_id).await {
+                        match delegator.status(&raw_request.request_id).await {
                             Ok(Some(mut response)) => {
                                 response.status = DelegationStatus::Failed;
                                 response.output = Value::Object(Map::new());
@@ -287,7 +336,7 @@ fn run_request(
                     }
                 }
             }
-            None => delegator.delegate(request.clone()).await,
+            None => delegator.delegate_authorized(request).await,
         };
         let response = match result {
             Ok(response)
@@ -302,7 +351,7 @@ fn run_request(
                 response
             }
             Ok(response) => failed_response(
-                &request.request_id,
+                &raw_request.request_id,
                 DelegationStatus::Failed,
                 format!(
                     "backend returned non-terminal status: {:?}",
@@ -310,12 +359,12 @@ fn run_request(
                 ),
             ),
             Err(error) => failed_response(
-                &request.request_id,
+                &raw_request.request_id,
                 DelegationStatus::Failed,
                 error.to_string(),
             ),
         };
-        (step_id, request, response)
+        (step_id, raw_request, response)
     })
 }
 
@@ -367,7 +416,9 @@ fn attach_dependency_results(
 mod tests {
     use super::*;
     use crate::{
-        AgentDelegationResponse, DelegationMode, DelegationPlanner, ValidatedAgentDelegationRequest,
+        AgentBudget, AgentDelegationResponse, AgentExecutorRef, ContextPolicy,
+        DelegatedTaskProposal, DelegationMode, DelegationPlanner, ExecutorProfilePolicy,
+        ModelProfilePolicy, PermissionSet, ValidatedAgentDelegationRequest,
     };
     use std::sync::atomic::{AtomicUsize, Ordering};
     use tokio::sync::Mutex;
@@ -477,6 +528,63 @@ mod tests {
             .unwrap()
     }
 
+    fn dynamic_policy() -> (CapabilityRegistry, DelegationHostPolicy) {
+        (
+            CapabilityRegistry::builtins(),
+            DelegationHostPolicy {
+                revision: "execution-test-v1".into(),
+                enabled_capabilities: vec!["reasoning".into()],
+                models: vec![ModelProfilePolicy {
+                    id: "local".into(),
+                    features: vec![],
+                    external: false,
+                    enabled: true,
+                }],
+                executors: vec![ExecutorProfilePolicy {
+                    executor: AgentExecutorRef::Native,
+                    features: vec![],
+                    model_ids: vec!["local".into()],
+                    enabled: true,
+                }],
+                default_model_id: Some("local".into()),
+                permission_ceiling: PermissionSet::default(),
+                context_ceiling: ContextPolicy::default(),
+                budget_ceiling: AgentBudget::default(),
+                default_timeout_secs: Some(60),
+                timeout_ceiling_secs: Some(60),
+                auto_safe: true,
+                ..DelegationHostPolicy::default()
+            },
+        )
+    }
+
+    fn dynamic_plan() -> DelegationPlan {
+        let (registry, host) = dynamic_policy();
+        registry
+            .resolve_plan(
+                "reason independently",
+                DelegationMode::Automatic,
+                1,
+                vec![DelegatedTaskProposal {
+                    id: "reason".into(),
+                    instruction: "Return a concise independent analysis".into(),
+                    context_summary: String::new(),
+                    depends_on: vec![],
+                    capabilities: vec!["reasoning".into()],
+                    specialist: None,
+                    output_schema: None,
+                    isolated: false,
+                    model_id: None,
+                    executor: None,
+                    budget: None,
+                    input: serde_json::json!({}),
+                }],
+                &host,
+            )
+            .unwrap()
+            .into_plan()
+    }
+
     #[tokio::test]
     async fn scheduler_limits_parallelism_and_runs_reviewer_last() {
         let delegator = Arc::new(RecordingDelegator {
@@ -563,5 +671,32 @@ mod tests {
             .steps
             .iter()
             .all(|step| step.response.status == DelegationStatus::Cancelled));
+    }
+
+    #[tokio::test]
+    async fn dynamic_execution_requires_and_uses_explicit_policy_validation() {
+        let delegator = Arc::new(RecordingDelegator {
+            active: AtomicUsize::new(0),
+            max_active: AtomicUsize::new(0),
+            calls: Mutex::new(vec![]),
+            fail: None,
+        });
+        let error = DelegationExecutor::new(delegator.clone())
+            .execute(dynamic_plan())
+            .await
+            .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("dynamic delegation policy is not configured"));
+        assert!(delegator.calls.lock().await.is_empty());
+
+        let (registry, host) = dynamic_policy();
+        let result = DelegationExecutor::new(delegator.clone())
+            .with_dynamic_policy(registry, host)
+            .execute(dynamic_plan())
+            .await
+            .unwrap();
+        assert_eq!(result.status, DelegationExecutionStatus::Succeeded);
+        assert_eq!(delegator.calls.lock().await.as_slice(), ["reason"]);
     }
 }

--- a/crates/wisp-core/src/lib.rs
+++ b/crates/wisp-core/src/lib.rs
@@ -4,6 +4,7 @@
 pub mod agent;
 pub mod context;
 pub mod delegation;
+pub mod delegation_policy;
 pub mod execution;
 pub mod memory;
 pub mod orchestration;
@@ -14,11 +15,17 @@ pub mod system_prompt;
 pub use agent::{agent_loop, agent_loop_continue};
 pub use context::ContextManager;
 pub use delegation::{
-    AgentArtifact, AgentBackend, AgentBudget, AgentDelegationRequest, AgentDelegationResponse,
-    AgentDelegator, AgentEvidence, AgentExecutorRef, AgentOrigin, AgentOutputSchemaSource,
-    AgentRole, AgentSessionPolicy, AgentSpec, AgentUsage, AgentWorkspacePolicy, ContextPolicy,
+    AgentArtifact, AgentAuthorizationSnapshot, AgentBackend, AgentBudget, AgentDelegationRequest,
+    AgentDelegationResponse, AgentDelegator, AgentEvidence, AgentExecutorRef, AgentOrigin,
+    AgentOutputSchemaSource, AgentRole, AgentSessionPolicy, AgentSpec, AgentUsage,
+    AgentWorkspacePolicy, CapabilityRevision, ContextPolicy, DelegationRequestValidator,
     DelegationStatus, PermissionSet, SpecialistSnapshot, UnconfiguredAgentDelegator,
     ValidatedAgentDelegationRequest, MAX_AGENT_OUTPUT_SCHEMA_BYTES,
+};
+pub use delegation_policy::{
+    CapabilityDefinition, CapabilityRegistry, CapabilityRisk, DelegatedTaskProposal,
+    DelegationHostPolicy, ExecutorFeature, ExecutorProfilePolicy, ModelFeature, ModelProfilePolicy,
+    ResolutionError, ResolvedAgentTask, ResolvedDelegationPlan,
 };
 pub use execution::{
     DelegationExecutionObserver, DelegationExecutionResult, DelegationExecutionStatus,

--- a/crates/wisp-core/src/orchestration.rs
+++ b/crates/wisp-core/src/orchestration.rs
@@ -84,6 +84,7 @@ impl AgentTemplate {
             workspace_policy: None,
             output_schema_source: Default::default(),
             approval_reasons: vec![],
+            authorization: None,
         }
         .constrained_by(
             &self.permission_ceiling,
@@ -103,6 +104,13 @@ impl AgentTemplate {
             || spec.prompt_template != self.prompt_template
             || spec.input_contract != self.input_contract
             || spec.output_contract != self.output_contract
+            || spec.origin != AgentOrigin::LegacyTemplate
+            || !spec.capabilities.is_empty()
+            || spec.executor.is_some()
+            || spec.workspace_policy.is_some()
+            || spec.output_schema_source != Default::default()
+            || !spec.approval_reasons.is_empty()
+            || spec.authorization.is_some()
         {
             anyhow::bail!("agent spec changes fixed template fields");
         }
@@ -483,6 +491,7 @@ fn capabilities_require_automatic_confirmation(
         backend,
         AgentBackend::Acp | AgentBackend::Http | AgentBackend::Custom(_)
     ) || permissions.write
+        || permissions.execute
         || permissions.network
         || budget
             .max_tokens
@@ -619,6 +628,9 @@ fn template(
             paths: vec!["project://**".into()],
             network,
             write,
+            execute: tools
+                .iter()
+                .any(|tool| matches!(*tool, "codex_project_exec" | "shell")),
         },
         context_ceiling: ContextPolicy {
             include_history: true,
@@ -643,8 +655,8 @@ fn template(
 mod tests {
     use super::*;
     use crate::{
-        AgentDelegationRequest, AgentDelegationResponse, AgentDelegator, DelegationStatus,
-        ValidatedAgentDelegationRequest,
+        AgentDelegationRequest, AgentDelegationResponse, AgentDelegator,
+        DelegationRequestValidator, DelegationStatus, ValidatedAgentDelegationRequest,
     };
 
     struct EchoDelegator;
@@ -715,6 +727,7 @@ mod tests {
                     paths: vec!["project://**".into(), "secret://**".into()],
                     network: true,
                     write: true,
+                    execute: true,
                 },
                 context_policy: reviewer.context_ceiling.clone(),
                 budget: AgentBudget {
@@ -906,15 +919,16 @@ mod tests {
             spec,
             input: json!({}),
         };
-        assert!(EchoDelegator.delegate(request).await.is_err());
+        assert!(EchoDelegator
+            .delegate(request, DelegationRequestValidator::Legacy(&templates))
+            .await
+            .is_err());
     }
 
     #[tokio::test]
     async fn delegation_boundary_fails_over_budget_results_without_losing_provenance() {
-        let template = AgentTemplateRegistry::builtins()
-            .get("reviewer")
-            .unwrap()
-            .clone();
+        let templates = AgentTemplateRegistry::builtins();
+        let template = templates.get("reviewer").unwrap().clone();
         let spec = template
             .instantiate(AgentInstanceRequest {
                 agent_id: "review".into(),
@@ -939,13 +953,16 @@ mod tests {
             })
             .unwrap();
         let response = OverBudgetDelegator
-            .delegate(AgentDelegationRequest {
-                request_id: "request".into(),
-                workflow_id: "workflow".into(),
-                step_id: "review".into(),
-                spec,
-                input: json!({}),
-            })
+            .delegate(
+                AgentDelegationRequest {
+                    request_id: "request".into(),
+                    workflow_id: "workflow".into(),
+                    step_id: "review".into(),
+                    spec,
+                    input: json!({}),
+                },
+                DelegationRequestValidator::Legacy(&templates),
+            )
             .await
             .unwrap();
         assert_eq!(response.status, DelegationStatus::Failed);
@@ -985,6 +1002,7 @@ mod tests {
                 workspace_policy: Some(crate::AgentWorkspacePolicy::SharedReadOnly),
                 output_schema_source: Default::default(),
                 approval_reasons: vec![],
+                authorization: None,
             },
             input: json!({}),
         }
@@ -1039,6 +1057,10 @@ mod tests {
         value.as_object_mut().unwrap().remove("schema_version");
         for step in value["steps"].as_array_mut().unwrap() {
             let spec = step["spec"].as_object_mut().unwrap();
+            spec["permissions"]
+                .as_object_mut()
+                .unwrap()
+                .remove("execute");
             for key in [
                 "origin",
                 "capabilities",
@@ -1053,6 +1075,7 @@ mod tests {
         let restored: DelegationPlan = serde_json::from_value(value).unwrap();
         assert_eq!(restored.schema_version, 1);
         assert_eq!(restored.steps[0].spec.origin, AgentOrigin::LegacyTemplate);
+        assert!(!restored.steps[0].spec.permissions.execute);
         restored
             .validate(&AgentTemplateRegistry::builtins())
             .unwrap();

--- a/src-tauri/src/delegation_runtime.rs
+++ b/src-tauri/src/delegation_runtime.rs
@@ -2757,6 +2757,7 @@ mod tests {
                         paths: vec!["project://**".into()],
                         network: true,
                         write: true,
+                        execute: false,
                     },
                     &root,
                 ),


### PR DESCRIPTION
## User-facing problem

Dynamic task JSON must not become authorization by itself. The host needs a model- and executor-neutral policy boundary that converts controlled capability IDs into exact, bounded grants and rejects modified snapshots before execution.

## Changes

- Add a pure CapabilityRegistry with the nine initial built-in capabilities.
- Resolve temporary or Specialist-backed task proposals into immutable v2 AgentSpec snapshots.
- Keep capability definition separate from runtime availability, including connector, model, executor, and path checks.
- Compose exact tool, path, read/write/execute/network, context, budget, workspace, model, and executor grants.
- Prefer Native execution while allowing only configured eligible ACP or external profiles.
- Add explicit approval reasons for mutation, execution, network/external access, ACP, isolation/merge, and elevated budgets.
- Persist capability/policy revisions plus an integrity hash and re-resolve snapshots against current ceilings before execution.
- Replace implicit request authorization with an explicit legacy-or-dynamic validator.
- Make DelegationExecutor reject v2 plans unless a dynamic policy is explicitly configured.
- Add a serde-default execute permission bit; legacy plans without it remain read-compatible.

## Tests

- Exact grants for every built-in capability.
- Capability composition, narrowest ceilings, and highest risk.
- Unknown, disabled, unavailable, and Specialist-restricted capabilities fail closed.
- Runtime capability advertisements follow connector/model/executor availability.
- Model and executor overrides require configured eligible profiles.
- Native read-only auto-safe batches skip confirmation.
- Every elevated operation emits an approval reason.
- Permission, executor, prompt, and budget tampering is rejected.
- Default executors reject v2 plans; explicitly configured dynamic policies execute them.
- cargo fmt --all -- --check
- cargo test --workspace

## Manual smoke

No UI or runtime caller changes in this PR. The policy and execution boundary are exercised with in-memory dynamic plans and a recording backend.

## Known limitations / follow-ups

- The Tauri workflow creator still emits legacy v1 template plans.
- Native child Agent execution and capability-filtered tool registries arrive in the next stacked PR.
- Scientific connector and runtime availability will be wired to real project configuration in later milestone PRs.