### PR TITLE
feat: delegate temporary agent tasks inline

### DIFF
--- a/crates/wisp-core/src/delegation.rs
+++ b/crates/wisp-core/src/delegation.rs
@@ -630,7 +630,57 @@ impl AgentDelegationResponse {
 }
 
 fn matches_json_contract(value: &Value, contract: &Value) -> bool {
-    match contract.get("type").and_then(Value::as_str) {
+    matches_json_contract_at_depth(value, contract, 0)
+}
+
+fn matches_json_contract_at_depth(value: &Value, contract: &Value, depth: usize) -> bool {
+    if depth > 32 || !contract.is_object() {
+        return false;
+    }
+    if contract
+        .get("const")
+        .is_some_and(|expected| expected != value)
+        || contract
+            .get("enum")
+            .and_then(Value::as_array)
+            .is_some_and(|values| !values.contains(value))
+    {
+        return false;
+    }
+    if contract
+        .get("allOf")
+        .and_then(Value::as_array)
+        .is_some_and(|schemas| {
+            !schemas
+                .iter()
+                .all(|schema| matches_json_contract_at_depth(value, schema, depth + 1))
+        })
+        || contract
+            .get("anyOf")
+            .and_then(Value::as_array)
+            .is_some_and(|schemas| {
+                !schemas
+                    .iter()
+                    .any(|schema| matches_json_contract_at_depth(value, schema, depth + 1))
+            })
+        || contract
+            .get("oneOf")
+            .and_then(Value::as_array)
+            .is_some_and(|schemas| {
+                schemas
+                    .iter()
+                    .filter(|schema| matches_json_contract_at_depth(value, schema, depth + 1))
+                    .count()
+                    != 1
+            })
+        || contract
+            .get("not")
+            .is_some_and(|schema| matches_json_contract_at_depth(value, schema, depth + 1))
+    {
+        return false;
+    }
+
+    let type_matches = match contract.get("type").and_then(Value::as_str) {
         None => true,
         Some("object") => value.is_object(),
         Some("array") => value.is_array(),
@@ -640,7 +690,151 @@ fn matches_json_contract(value: &Value, contract: &Value) -> bool {
         Some("boolean") => value.is_boolean(),
         Some("null") => value.is_null(),
         Some(_) => false,
+    };
+    if !type_matches {
+        return false;
     }
+
+    if let Some(object) = value.as_object() {
+        if contract
+            .get("minProperties")
+            .and_then(Value::as_u64)
+            .is_some_and(|minimum| object.len() < minimum as usize)
+            || contract
+                .get("maxProperties")
+                .and_then(Value::as_u64)
+                .is_some_and(|maximum| object.len() > maximum as usize)
+        {
+            return false;
+        }
+        if contract
+            .get("required")
+            .and_then(Value::as_array)
+            .is_some_and(|required| {
+                required
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .any(|key| !object.contains_key(key))
+            })
+        {
+            return false;
+        }
+        let properties = contract.get("properties").and_then(Value::as_object);
+        if properties.is_some_and(|properties| {
+            properties.iter().any(|(key, schema)| {
+                object
+                    .get(key)
+                    .is_some_and(|value| !matches_json_contract_at_depth(value, schema, depth + 1))
+            })
+        }) {
+            return false;
+        }
+        if let Some(additional) = contract.get("additionalProperties") {
+            for (key, value) in object {
+                if properties.is_some_and(|properties| properties.contains_key(key)) {
+                    continue;
+                }
+                match additional {
+                    Value::Bool(true) => {}
+                    Value::Bool(false) => return false,
+                    Value::Object(_) => {
+                        if !matches_json_contract_at_depth(value, additional, depth + 1) {
+                            return false;
+                        }
+                    }
+                    _ => return false,
+                }
+            }
+        }
+    }
+
+    if let Some(array) = value.as_array() {
+        if contract
+            .get("minItems")
+            .and_then(Value::as_u64)
+            .is_some_and(|minimum| array.len() < minimum as usize)
+            || contract
+                .get("maxItems")
+                .and_then(Value::as_u64)
+                .is_some_and(|maximum| array.len() > maximum as usize)
+            || contract.get("uniqueItems") == Some(&Value::Bool(true))
+                && array
+                    .iter()
+                    .enumerate()
+                    .any(|(index, item)| array[..index].contains(item))
+        {
+            return false;
+        }
+        if let Some(items) = contract.get("items") {
+            if !array
+                .iter()
+                .all(|item| matches_json_contract_at_depth(item, items, depth + 1))
+            {
+                return false;
+            }
+        }
+    }
+
+    if let Some(text) = value.as_str() {
+        let chars = text.chars().count();
+        if contract
+            .get("minLength")
+            .and_then(Value::as_u64)
+            .is_some_and(|minimum| chars < minimum as usize)
+            || contract
+                .get("maxLength")
+                .and_then(Value::as_u64)
+                .is_some_and(|maximum| chars > maximum as usize)
+            || contract
+                .get("pattern")
+                .and_then(Value::as_str)
+                .is_some_and(|pattern| {
+                    regex::Regex::new(pattern).map_or(true, |regex| !regex.is_match(text))
+                })
+        {
+            return false;
+        }
+    }
+
+    if let Some(number) = value.as_f64() {
+        if contract
+            .get("minimum")
+            .and_then(Value::as_f64)
+            .is_some_and(|minimum| number < minimum)
+            || contract
+                .get("maximum")
+                .and_then(Value::as_f64)
+                .is_some_and(|maximum| number > maximum)
+            || contract
+                .get("exclusiveMinimum")
+                .and_then(Value::as_f64)
+                .is_some_and(|minimum| number <= minimum)
+            || contract
+                .get("exclusiveMaximum")
+                .and_then(Value::as_f64)
+                .is_some_and(|maximum| number >= maximum)
+        {
+            return false;
+        }
+    }
+    true
+}
+
+fn task_output_envelope(data: Value, response: &AgentDelegationResponse) -> Value {
+    let summary = data
+        .get("summary")
+        .and_then(Value::as_str)
+        .filter(|summary| !summary.trim().is_empty())
+        .unwrap_or("Structured task output is available in data.")
+        .to_string();
+    serde_json::json!({
+        "summary": summary,
+        "data": data,
+        "artifacts": response.artifacts.clone(),
+        "evidence": response.evidence.clone(),
+        "tests": [],
+        "risks": [],
+    })
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -673,6 +867,8 @@ pub trait AgentDelegator: Send + Sync {
     ) -> anyhow::Result<AgentDelegationResponse> {
         let request_id = request.as_request().request_id.clone();
         let output_contract = request.as_request().spec.output_contract.clone();
+        let task_output =
+            request.as_request().spec.output_schema_source == AgentOutputSchemaSource::Task;
         let budget = request.as_request().spec.budget.clone();
         let mut response = self.delegate_validated(request).await?;
         response.validate()?;
@@ -687,7 +883,12 @@ pub trait AgentDelegator: Send + Sync {
         if response.status == DelegationStatus::Succeeded
             && !matches_json_contract(&response.output, &output_contract)
         {
-            anyhow::bail!("delegation output does not satisfy output_contract");
+            response.status = DelegationStatus::Failed;
+            response.output = Value::Object(Default::default());
+            response.error = Some("delegation output does not satisfy output_contract".into());
+        } else if response.status == DelegationStatus::Succeeded && task_output {
+            let data = std::mem::take(&mut response.output);
+            response.output = task_output_envelope(data, &response);
         }
         response.validate()?;
         Ok(response)
@@ -930,6 +1131,68 @@ mod tests {
         assert!(spec.validate().is_err());
         spec.input_contract = serde_json::json!({"type":"object"});
         assert!(spec.validate().is_ok());
+    }
+
+    #[test]
+    fn json_contract_checks_nested_required_properties_and_arrays() {
+        let contract = serde_json::json!({
+            "type": "object",
+            "required": ["label", "scores"],
+            "properties": {
+                "label": {"type": "string", "minLength": 2},
+                "scores": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {"type": "number", "minimum": 0.0, "maximum": 1.0}
+                }
+            },
+            "additionalProperties": false
+        });
+        assert!(matches_json_contract(
+            &serde_json::json!({"label": "ok", "scores": [0.2, 1.0]}),
+            &contract
+        ));
+        assert!(!matches_json_contract(
+            &serde_json::json!({"label": "x", "scores": [1.2]}),
+            &contract
+        ));
+        assert!(!matches_json_contract(
+            &serde_json::json!({"label": "ok", "scores": [], "extra": true}),
+            &contract
+        ));
+    }
+
+    #[test]
+    fn task_data_is_wrapped_in_the_standard_parent_envelope() {
+        let response = AgentDelegationResponse {
+            request_id: "request".into(),
+            status: DelegationStatus::Succeeded,
+            output: serde_json::json!({}),
+            artifact_ids: vec![],
+            artifacts: vec![AgentArtifact {
+                id: "artifact".into(),
+                ..Default::default()
+            }],
+            evidence: vec![AgentEvidence {
+                kind: "test".into(),
+                summary: "verified".into(),
+                reference: None,
+            }],
+            usage: AgentUsage::default(),
+            agent_session_id: None,
+            child_frame_id: None,
+            error: None,
+        };
+
+        let envelope = task_output_envelope(
+            serde_json::json!({"summary": "measured", "value": 3}),
+            &response,
+        );
+
+        assert_eq!(envelope["summary"], "measured");
+        assert_eq!(envelope["data"]["value"], 3);
+        assert_eq!(envelope["artifacts"][0]["id"], "artifact");
+        assert_eq!(envelope["evidence"][0]["summary"], "verified");
     }
 
     #[test]

--- a/crates/wisp-core/src/delegation_policy.rs
+++ b/crates/wisp-core/src/delegation_policy.rs
@@ -453,7 +453,7 @@ impl CapabilityRegistry {
         )
     }
 
-    fn resolve_plan_with_id(
+    pub fn resolve_plan_with_id(
         &self,
         id: String,
         goal: String,
@@ -717,7 +717,7 @@ fn validate_host(host: &DelegationHostPolicy) -> Result<(), ResolutionError> {
 }
 
 fn validate_proposal(proposal: &DelegatedTaskProposal) -> Result<(), ResolutionError> {
-    if !valid_id(&proposal.id) || proposal.instruction.trim().is_empty() {
+    if !valid_task_id(&proposal.id) || proposal.instruction.trim().is_empty() {
         return Err(ResolutionError::InvalidProposal(
             "task id and instruction are required".into(),
         ));
@@ -743,6 +743,14 @@ fn validate_proposal(proposal: &DelegatedTaskProposal) -> Result<(), ResolutionE
         ));
     }
     Ok(())
+}
+
+fn valid_task_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 128
+        && value.bytes().all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'_' | b'-' | b':')
+        })
 }
 
 fn definition_available(definition: &CapabilityDefinition, host: &DelegationHostPolicy) -> bool {

--- a/crates/wisp-core/src/execution.rs
+++ b/crates/wisp-core/src/execution.rs
@@ -9,7 +9,13 @@ use async_trait::async_trait;
 use futures_util::{stream::FuturesUnordered, StreamExt};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
-use std::{collections::HashMap, future::Future, pin::Pin, sync::Arc, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    time::Duration,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -179,6 +185,7 @@ impl DelegationExecutor {
         let mut responses = HashMap::<String, AgentDelegationResponse>::new();
         let mut running = FuturesUnordered::new();
         let mut running_requests = HashMap::<String, String>::new();
+        let mut running_mutations = HashSet::<String>::new();
         let mut cancellation_applied = false;
 
         while !pending.is_empty() || !running.is_empty() {
@@ -224,15 +231,12 @@ impl DelegationExecutor {
 
             while running.len() < plan.max_parallel {
                 let Some(index) = pending.iter().position(|step_id| {
-                    requests[step_id]
-                        .spec
-                        .dependencies
-                        .iter()
-                        .all(|dependency| {
-                            responses.get(dependency).is_some_and(|response| {
-                                response.status == DelegationStatus::Succeeded
-                            })
-                        })
+                    let request = &requests[step_id];
+                    request.spec.dependencies.iter().all(|dependency| {
+                        responses
+                            .get(dependency)
+                            .is_some_and(|response| response.status == DelegationStatus::Succeeded)
+                    }) && (!uses_mutation_lane(request) || running_mutations.is_empty())
                 }) else {
                     break;
                 };
@@ -246,6 +250,9 @@ impl DelegationExecutor {
                 let request = self.validate_request(request, plan.schema_version)?;
                 self.observer.step_started(request.as_request()).await?;
                 running_requests.insert(step_id.clone(), request.as_request().request_id.clone());
+                if uses_mutation_lane(request.as_request()) {
+                    running_mutations.insert(step_id.clone());
+                }
                 running.push(run_request(self.delegator.clone(), step_id, request));
             }
 
@@ -262,6 +269,7 @@ impl DelegationExecutor {
             };
             if let Some((step_id, request, response)) = next {
                 running_requests.remove(&step_id);
+                running_mutations.remove(&step_id);
                 self.observer.step_finished(&request, &response).await?;
                 responses.insert(step_id, response);
             }
@@ -296,6 +304,15 @@ impl DelegationExecutor {
                 .collect(),
         })
     }
+}
+
+fn uses_mutation_lane(request: &AgentDelegationRequest) -> bool {
+    request.spec.permissions.write
+        || request.spec.permissions.execute
+        || matches!(
+            request.spec.workspace_policy,
+            Some(crate::AgentWorkspacePolicy::SerializedMutation)
+        )
 }
 
 type DelegationFuture = Pin<
@@ -603,6 +620,39 @@ mod tests {
         assert_eq!(calls.last().map(String::as_str), Some("reviewer"));
         let reviewer = result.steps.last().unwrap();
         assert!(reviewer.response.output.is_object());
+    }
+
+    #[tokio::test]
+    async fn scheduler_serializes_shared_workspace_mutations() {
+        let mut plan = DelegationPlanner
+            .from_template_ids(
+                "implement and visualize the result",
+                DelegationMode::Automatic,
+                "",
+                &[],
+                &[],
+                &["code_execution".into(), "visualization".into()],
+                &AgentTemplateRegistry::builtins(),
+            )
+            .unwrap();
+        plan.steps.truncate(2);
+        for step in &mut plan.steps {
+            step.spec.dependencies.clear();
+        }
+        let delegator = Arc::new(RecordingDelegator {
+            active: AtomicUsize::new(0),
+            max_active: AtomicUsize::new(0),
+            calls: Mutex::new(vec![]),
+            fail: None,
+        });
+
+        let result = DelegationExecutor::new(delegator.clone())
+            .execute(plan)
+            .await
+            .unwrap();
+
+        assert_eq!(result.status, DelegationExecutionStatus::Succeeded);
+        assert_eq!(delegator.max_active.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]

--- a/docs/agent-delegation.md
+++ b/docs/agent-delegation.md
@@ -1,60 +1,96 @@
-# Controlled Agent delegation
+# Agent delegation
 
-The **Agents** tab in the right panel turns a project goal into a persisted,
-reviewable multi-Agent workflow. It is separate from choosing an ACP Agent as
-the model for a normal conversation.
+Delegation lets the main Agent create a bounded set of temporary sub-Agents,
+run independent work in parallel, and synthesize their evidence in the same
+conversation turn. Codex and ACP are optional executor choices; neither is part
+of the meaning of a code-capable Agent.
 
-## Workflow
+## Inline temporary Agents
 
 1. Open the composer Agent menu and enable **Delegation** for the current
    conversation. New conversations start with delegation off.
-2. Open the right panel and choose **Agents**, or ask the main Agent to propose
-   a delegated plan. The main Agent can only create a persisted draft; it
-   cannot approve or run the plan on the user's behalf.
-3. Describe a code, analysis, biology, or visualization goal and choose a mode:
-   - **Manual** requires an explicit ordered Agent team. The selected steps run
-     sequentially, and Reviewer is optional but must be last.
-   - **Assisted** asks the active model to select the smallest useful team from
-     the controlled templates using the recent conversation as context. It
-     persists a draft for review and never starts work automatically.
-   - **Automatic** uses the same model-backed planning step, then approves and
-     starts a low-risk local read-only plan in the background. Plans involving
-     ACP, file writes, network access, or a larger budget pause as a draft and
-     require **Approve and run**.
-4. A generated card is a plan, not an Agent result. Review each step's backend,
-   tools, token budget, and timeout. A draft can be edited and regenerated
-   without changing an approved plan behind the user's back.
-5. In Manual or Assisted mode, approve the immutable plan and run it. Automatic
-   mode starts as described above.
-6. Follow persisted step attempts and usage in the panel. Cancel requests are
-   stored in SQLite, so the scheduler and both local and ACP backends observe
-   the same state.
-7. Failed or cancelled workflows can be returned to Approved with **Retry**.
-   Completed step sessions can be opened with **Take over** for ordinary chat.
+2. Ask the main Agent for an outcome that materially benefits from independent
+   or parallel work. The main Agent decides whether delegation is useful and,
+   when it is, calls `delegate_tasks` itself.
+3. The call describes an overall goal, bounded shared context, and up to eight
+   tasks. Each task has its own instruction, dependency IDs, capability IDs,
+   optional Specialist, optional JSON output schema, and optional isolation
+   request.
+4. Wisp resolves every capability through host policy into an exact model,
+   executor, tool set, project scope, workspace policy, budget, and timeout.
+   The model cannot grant raw tools or permissions to a child.
+5. Safe read-only tasks run immediately. A batch that can write, execute code,
+   use an external service, request isolation, or exceed normal budgets uses
+   the existing approval prompt. Rejecting it starts no child and returns the
+   feedback to the main Agent so it can revise the batch.
+6. Independent tasks run concurrently up to the batch limit. A dependent task
+   starts only after its direct dependencies succeed and receives their
+   structured results. An unrelated branch continues after another branch
+   fails; only descendants of the failed branch are blocked.
+7. Ordered, compact results return as tool output. The main Agent must combine
+   them into its final response rather than sending the user elsewhere. If a
+   result was truncated, `get_delegated_result` reads that task's full persisted
+   result for the same conversation.
 
-## Safety and current limits
+Omitting `specialist_id` creates a generic temporary Agent. Selecting a
+Specialist reuses its persona, model preference, skills, and connector
+restrictions as an immutable snapshot for that run. A Specialist is therefore
+an optional preset, not a required fixed team slot.
 
-- Assisted and Automatic workflows run at most two delegated steps concurrently.
-  Manual workflows run their explicit order sequentially. Dependencies are
-  respected and a generated final Reviewer runs only after its inputs succeed.
-- Templates cap tools, project paths, context, time, tokens, tool calls, and
-  cost. Delegated Agents cannot delegate again.
-- Code-capable ACP steps require a configured Codex ACP profile. Codex runs in
-  workspace-write mode with command network access disabled. Its effective
-  approval policy is `on-request`; Wisp rejects command, process, MCP, network,
-  and unscoped file escalations at the ACP boundary.
-- Wisp stores attempts, structured results, evidence, artifacts, usage, child
-  conversation IDs, and ACP session IDs. API keys and private keys remain in
-  their existing credential stores and are not copied into workflow records.
-- Application shutdown marks interrupted workflows failed. Use **Retry** after
-  inspecting the recorded error; Wisp does not silently resume an unknown
-  external process.
-- Turning Delegation off blocks new drafts, approvals, runs, and retries for
-  that conversation. It does not hide history or cancel an already running
-  workflow; cancellation remains an explicit action in the Agents panel.
+## Native, ACP, and code execution
 
-Model-backed planning can only select the built-in code execution, biology
-interpretation, and visualization templates; Wisp constructs and validates the
-actual Agent specs and appends Reviewer. The model cannot invent tools,
-permissions, backends, or nested delegation. Unrelated simple goals can remain
-in the main conversation.
+Native execution runs the ordinary Wisp Agent loop in a separate child
+conversation with only the resolved tools. It supports project reading,
+project writing, and bounded Run Manager execution without starting an ACP
+client. This is the default eligible executor and is enough for a code task.
+
+ACP profiles remain available to workflows that explicitly resolve to an ACP
+executor. A profile may use Codex or another compatible Agent, but the task is
+still defined by capabilities and contracts, not by an ACP or Codex template.
+The same inline delegation surface is exposed through the Wisp MCP bridge as
+`wisp_delegate_tasks` and `wisp_get_delegated_result` when the owning
+conversation opted in. Because that bridge is non-interactive, a batch that
+requires approval is denied instead of silently escalating.
+
+## Persistence and safety
+
+- Wisp persists the resolved v2 plan before execution. Stored steps contain the
+  immutable Specialist, capability revisions, permissions, model, executor,
+  contracts, budgets, and policy integrity hash used for revalidation.
+- Read-only tasks may share the project workspace. Until isolated workspaces
+  are implemented, all writable or executable tasks use one mutation lane and
+  cannot edit the same checkout concurrently. An isolation request is rejected
+  when no eligible isolated executor exists.
+- Children receive only their instruction, bounded shared context, applicable
+  project instructions, explicit inputs, and direct dependency results. They
+  do not receive the full parent transcript.
+- Delegated Agents cannot call `delegate_tasks`; nesting remains disabled until
+  depth, breadth, and total-budget limits are implemented.
+- Output contracts are checked before results reach the parent. Attempts,
+  structured results, artifacts, evidence, usage, child conversation IDs, and
+  backend session IDs remain auditable in SQLite. Secrets stay in the existing
+  credential stores.
+- Turning Delegation off prevents the main conversation and its MCP bridge from
+  listing or invoking delegation tools. It does not erase workflow history or
+  implicitly cancel a workflow that is already running.
+
+## Legacy Agents panel
+
+The right-panel workflow remains available during migration. Manual mode runs
+an explicitly ordered built-in team; Assisted and Automatic modes use the old
+model-selected templates and persisted draft/approval flow. The legacy
+`propose_delegation` tool creates only such a draft and never starts work.
+
+This compatibility path is useful for reviewing and retrying existing v1
+workflows, but it is no longer the normal main-Agent path. Dynamic inline
+delegation does not call the legacy template selector and does not require the
+user to assemble a permanent Biology, Code Execution, Visualization, and
+Reviewer team before each task.
+
+## Manual smoke check
+
+Enable Delegation and ask the main Agent to compare two project files using two
+independent temporary Agents. Confirm that two child tasks overlap, the
+workflow is persisted, and the final chat response contains one synthesized
+comparison. Repeat with a write capability: Wisp should show the exact plan and
+start zero children if approval is denied.

--- a/src-tauri/src/delegation_runtime.rs
+++ b/src-tauri/src/delegation_runtime.rs
@@ -37,7 +37,7 @@ const PLANNER_TIMEOUT: Duration = Duration::from_secs(90);
 const PLANNER_CONTEXT_CHARS: usize = 6_000;
 const DELEGATION_PROMPT_START: &str = "\n\n<delegation_capability>";
 const DELEGATION_PROMPT_END: &str = "</delegation_capability>";
-const DELEGATION_PROMPT_SECTION: &str = "\n\n<delegation_capability>\nThe user enabled controlled sub-Agent delegation for this conversation. When a task materially benefits from parallel code, biology, visualization, or independent review, use propose_delegation to create a persisted draft plan. This tool never approves or runs the plan. Tell the user to review it in the Agents panel; do not claim that delegated work has started.\n</delegation_capability>";
+const DELEGATION_PROMPT_SECTION: &str = "\n\n<delegation_capability>\nThe user enabled controlled sub-Agent delegation for this conversation. When a task materially benefits from independent or parallel work, decompose it yourself and call delegate_tasks with the smallest useful temporary task DAG. Results return as tool output in this same turn: inspect partial failures and synthesize the evidence into your final answer. Use capability IDs from the tool schema; omit specialist_id for generic temporary Agents. Do not delegate trivial work, do not claim work started before the tool returns, and do not ask the user to visit the Agents panel merely to receive results. propose_delegation remains a legacy draft-only tool and is not the normal execution path.\n</delegation_capability>";
 
 #[derive(Debug, Clone, serde::Serialize)]
 pub(crate) struct AgentWorkflowSnapshot {
@@ -249,6 +249,31 @@ pub(crate) async fn create_agent_workflow_draft(
         return Err("This goal does not need a controlled multi-Agent plan.".into());
     }
     let (workflow, steps) = workflow_records(&plan, project_id, project_root, Some(frame_id))?;
+    store
+        .create_agent_workflow_plan(&workflow, &steps)
+        .await
+        .map_err(|error| error.to_string())?;
+    load_workflow_snapshot(store, workflow).await
+}
+
+pub(crate) async fn persist_dynamic_agent_workflow(
+    store: &Store,
+    project_id: &str,
+    project_root: &std::path::Path,
+    frame_id: String,
+    plan: &DelegationPlan,
+    registry: &CapabilityRegistry,
+    host: &DelegationHostPolicy,
+) -> Result<AgentWorkflowSnapshot, String> {
+    require_session_delegation(store, project_id, &frame_id).await?;
+    if plan.schema_version != DYNAMIC_DELEGATION_SCHEMA_VERSION {
+        return Err("Inline delegation requires a v2 Agent plan.".into());
+    }
+    registry
+        .validate_resolved_plan(plan, host)
+        .map_err(|error| error.to_string())?;
+    let (mut workflow, steps) = workflow_records(plan, project_id, project_root, Some(frame_id))?;
+    workflow.description = "Inline dynamic Agent batch".into();
     store
         .create_agent_workflow_plan(&workflow, &steps)
         .await
@@ -549,7 +574,11 @@ fn workflow_records(
                 spec.backend.as_str(),
                 &spec.prompt_template,
             )?;
-            stored.template_id.clone_from(&spec.template_id);
+            stored.template_id = if spec.template_id.trim().is_empty() {
+                "dynamic".into()
+            } else {
+                spec.template_id.clone()
+            };
             stored.model.clone_from(&spec.model);
             stored.input_schema_json = serde_json::to_string(&spec.input_contract)?;
             stored.output_schema_json = serde_json::to_string(&spec.output_contract)?;
@@ -611,7 +640,7 @@ async fn load_workflow_snapshot(
     })
 }
 
-async fn approve_created_automatic_workflow(
+pub(crate) async fn approve_created_automatic_workflow(
     store: &Store,
     snapshot: AgentWorkflowSnapshot,
 ) -> Result<AgentWorkflowSnapshot, String> {
@@ -902,12 +931,47 @@ async fn execute_agent_workflow(
     run_manager: crate::run_context::RunManager,
     workflow_id: &str,
 ) -> Result<DelegationExecutionResult, String> {
+    let delegator = Arc::new(TauriDelegator::new(
+        store.clone(),
+        project.clone(),
+        run_manager,
+    ));
+    let result = execute_agent_workflow_with_delegator(
+        store,
+        &project.id,
+        workflow_id,
+        delegator.clone(),
+        None,
+    )
+    .await;
+    if result.is_err() {
+        delegator.cancel_all().await;
+    }
+    result
+}
+
+pub(crate) async fn execute_inline_agent_workflow(
+    store: &Store,
+    project: ActiveProject,
+    run_manager: crate::run_context::RunManager,
+    workflow_id: &str,
+) -> Result<DelegationExecutionResult, String> {
+    execute_agent_workflow(store, project, run_manager, workflow_id).await
+}
+
+pub(crate) async fn execute_agent_workflow_with_delegator(
+    store: &Store,
+    project_id: &str,
+    workflow_id: &str,
+    delegator: Arc<dyn AgentDelegator>,
+    dynamic_policy: Option<(CapabilityRegistry, DelegationHostPolicy)>,
+) -> Result<DelegationExecutionResult, String> {
     let workflow = store
         .get_agent_workflow(&workflow_id)
         .await
         .map_err(|error| error.to_string())?
         .ok_or_else(|| "Agent workflow does not exist".to_string())?;
-    if workflow.project_id != project.id {
+    if workflow.project_id != project_id {
         return Err("Agent workflow does not belong to the active project".into());
     }
     require_workflow_delegation(store, &workflow).await?;
@@ -916,16 +980,17 @@ async fn execute_agent_workflow(
     if plan.id != workflow.id {
         return Err("Agent workflow plan identity does not match its persisted record".into());
     }
-    let delegator = Arc::new(TauriDelegator::new(store.clone(), project, run_manager));
     let observer = Arc::new(StoreDelegationObserver::new(store.clone()));
     let mut executor = DelegationExecutor::new(delegator.clone()).with_observer(observer.clone());
     if plan.schema_version == DYNAMIC_DELEGATION_SCHEMA_VERSION {
-        let (registry, host) = dynamic_delegation_policy(store).await?;
+        let (registry, host) = match dynamic_policy {
+            Some(policy) => policy,
+            None => dynamic_delegation_policy(store).await?,
+        };
         executor = executor.with_dynamic_policy(registry, host);
     }
     let result = executor.execute(plan).await;
     if result.is_err() {
-        delegator.cancel_all().await;
         let _ = fail_owned_agent_workflow_execution(
             store,
             &observer,
@@ -2556,7 +2621,9 @@ mod tests {
         prompt.push_str("\n\n## Specialist\nKeep this section.");
         sync_delegation_prompt(&mut prompt, true);
         assert_eq!(prompt.matches("<delegation_capability>").count(), 1);
-        assert!(prompt.contains("never approves or runs"));
+        assert!(prompt.contains("call delegate_tasks"));
+        assert!(prompt.contains("synthesize the evidence"));
+        assert!(prompt.contains("legacy draft-only"));
         assert!(prompt.contains("## Specialist\nKeep this section."));
         sync_delegation_prompt(&mut prompt, false);
         assert_eq!(prompt, "Base prompt\n\n## Specialist\nKeep this section.");

--- a/src-tauri/src/delegation_tool.rs
+++ b/src-tauri/src/delegation_tool.rs
@@ -1,12 +1,753 @@
-//! `propose_delegation` — an opt-in main-Agent tool that creates a persisted
-//! draft workflow. Approval and execution remain explicit UI actions.
+//! Parent-facing delegation tools. `delegate_tasks` resolves and runs a
+//! dynamic batch inline; `propose_delegation` remains for v1 UI compatibility.
 
-use crate::{delegation_runtime, ActiveProject};
+use crate::{delegation_runtime, run_context::RunManager, specialists, ActiveProject};
 use async_trait::async_trait;
+use serde::Deserialize;
 use serde_json::{json, Value};
+use std::{collections::HashMap, sync::Arc};
+use wisp_core::{
+    AgentDelegator, CapabilityRegistry, DelegatedTaskProposal, DelegationExecutionResult,
+    DelegationHostPolicy, DelegationMode, SpecialistSnapshot, MAX_AGENT_OUTPUT_SCHEMA_BYTES,
+    MAX_DELEGATION_TASKS,
+};
 use wisp_llm::ToolSchema;
 use wisp_store::Store;
-use wisp_tools::{Tool, ToolEnv, ToolResult};
+use wisp_tools::{ConfirmDecision, Tool, ToolEnv, ToolResult};
+
+const DEFAULT_INLINE_PARALLELISM: usize = 2;
+const MAX_MODEL_TASK_ID_BYTES: usize = 31;
+const MAX_GOAL_CHARS: usize = 2_000;
+const MAX_CONTEXT_CHARS: usize = 12_000;
+const MAX_INSTRUCTION_CHARS: usize = 8_000;
+const INLINE_DATA_BYTES: usize = 4_000;
+const INLINE_TEXT_CHARS: usize = 1_000;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct DelegateTasksArgs {
+    goal: String,
+    #[serde(default)]
+    context: String,
+    tasks: Vec<DelegateTaskInput>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct DelegateTaskInput {
+    id: String,
+    instruction: String,
+    #[serde(default)]
+    depends_on: Vec<String>,
+    capabilities: Vec<String>,
+    #[serde(default)]
+    specialist_id: Option<String>,
+    #[serde(default)]
+    output_schema: Option<Value>,
+    #[serde(default)]
+    isolated: bool,
+}
+
+pub(crate) async fn delegate_tasks_schema(store: &Store) -> Result<ToolSchema, String> {
+    let (registry, host) = delegation_runtime::dynamic_delegation_policy(store).await?;
+    let specialists = specialists::ensure(store).await;
+    Ok(build_delegate_tasks_schema(&registry, &host, &specialists))
+}
+
+fn build_delegate_tasks_schema(
+    registry: &CapabilityRegistry,
+    host: &DelegationHostPolicy,
+    specialists: &[specialists::Specialist],
+) -> ToolSchema {
+    let capabilities = registry.available_ids(host);
+    let capability_help = capabilities
+        .iter()
+        .filter_map(|id| {
+            registry
+                .get(id)
+                .map(|definition| format!("{id}: {}", definition.description))
+        })
+        .collect::<Vec<_>>()
+        .join("; ");
+    let specialist_ids = specialists
+        .iter()
+        .map(|specialist| specialist.id.clone())
+        .collect::<Vec<_>>();
+    let specialist_help = specialists
+        .iter()
+        .map(|specialist| {
+            let description = specialist.description.trim();
+            if description.is_empty() {
+                format!("{}: {}", specialist.id, specialist.name)
+            } else {
+                format!("{}: {} — {description}", specialist.id, specialist.name)
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("; ");
+    ToolSchema::new(
+        "delegate_tasks",
+        "Run a bounded batch of temporary Wisp sub-Agents and return their results to this turn. Decompose the work yourself; independent tasks run in parallel, dependencies run after their prerequisites, and you must synthesize the returned evidence into your final answer. Use the smallest useful batch. Do not delegate trivial work or delegate again from a child.",
+        json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "goal": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": MAX_GOAL_CHARS,
+                    "description": "Overall delegated outcome that the parent Agent will synthesize"
+                },
+                "context": {
+                    "type": "string",
+                    "maxLength": MAX_CONTEXT_CHARS,
+                    "description": "Bounded shared constraints and project state needed by every child; do not paste the full transcript"
+                },
+                "tasks": {
+                    "type": "array",
+                    "minItems": 1,
+                    "maxItems": MAX_DELEGATION_TASKS,
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "pattern": "^[a-z][a-z0-9_-]{0,30}$",
+                                "description": "Unique stable task id used by dependencies and results"
+                            },
+                            "instruction": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": MAX_INSTRUCTION_CHARS,
+                                "description": "Self-contained assignment with concrete output and acceptance criteria"
+                            },
+                            "depends_on": {
+                                "type": "array",
+                                "uniqueItems": true,
+                                "items": {
+                                    "type": "string",
+                                    "pattern": "^[a-z][a-z0-9_-]{0,30}$"
+                                },
+                                "description": "Task ids from this same batch that must succeed first"
+                            },
+                            "capabilities": {
+                                "type": "array",
+                                "minItems": 1,
+                                "uniqueItems": true,
+                                "items": {"type": "string", "enum": capabilities},
+                                "description": capability_help
+                            },
+                            "specialist_id": {
+                                "type": "string",
+                                "enum": specialist_ids,
+                                "description": format!("Optional reusable persona. Omit for a temporary generic Agent. {specialist_help}")
+                            },
+                            "output_schema": {
+                                "type": "object",
+                                "description": "Optional bounded JSON Schema for this task's data result"
+                            },
+                            "isolated": {
+                                "type": "boolean",
+                                "description": "Request an isolated writable workspace; rejected when no eligible isolated executor exists"
+                            }
+                        },
+                        "required": ["id", "instruction", "capabilities"]
+                    }
+                }
+            },
+            "required": ["goal", "tasks"]
+        }),
+    )
+}
+
+pub(crate) struct DelegateTasksTool {
+    store: Store,
+    project: ActiveProject,
+    frame_id: String,
+    run_manager: RunManager,
+    schema: ToolSchema,
+    policy_override: Option<(CapabilityRegistry, DelegationHostPolicy)>,
+    delegator_override: Option<Arc<dyn AgentDelegator>>,
+}
+
+impl DelegateTasksTool {
+    pub(crate) async fn new(
+        store: Store,
+        project: ActiveProject,
+        frame_id: impl Into<String>,
+        run_manager: RunManager,
+    ) -> Result<Self, String> {
+        let schema = delegate_tasks_schema(&store).await?;
+        Ok(Self {
+            store,
+            project,
+            frame_id: frame_id.into(),
+            run_manager,
+            schema,
+            policy_override: None,
+            delegator_override: None,
+        })
+    }
+
+    #[cfg(test)]
+    fn with_runtime(
+        store: Store,
+        project: ActiveProject,
+        frame_id: impl Into<String>,
+        policy: (CapabilityRegistry, DelegationHostPolicy),
+        delegator: Arc<dyn AgentDelegator>,
+    ) -> Self {
+        let schema = build_delegate_tasks_schema(&policy.0, &policy.1, &[]);
+        Self {
+            store,
+            project,
+            frame_id: frame_id.into(),
+            run_manager: RunManager::new(),
+            schema,
+            policy_override: Some(policy),
+            delegator_override: Some(delegator),
+        }
+    }
+
+    async fn policy(&self) -> Result<(CapabilityRegistry, DelegationHostPolicy), String> {
+        match &self.policy_override {
+            Some(policy) => Ok(policy.clone()),
+            None => delegation_runtime::dynamic_delegation_policy(&self.store).await,
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for DelegateTasksTool {
+    fn name(&self) -> &str {
+        "delegate_tasks"
+    }
+
+    fn schema(&self) -> ToolSchema {
+        self.schema.clone()
+    }
+
+    fn preview(&self, args: &Value) -> String {
+        let goal = args
+            .get("goal")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .trim();
+        let count = args
+            .get("tasks")
+            .and_then(Value::as_array)
+            .map_or(0, Vec::len);
+        format!("{count} tasks · {goal}")
+    }
+
+    async fn run(&self, args: &Value, env: &dyn ToolEnv) -> ToolResult {
+        match self.run_batch(args, env).await {
+            Ok(value) => ToolResult::ok(serde_json::to_string(&value).unwrap_or_else(|_| {
+                r#"{"status":"failed","error":"result serialization failed"}"#.into()
+            })),
+            Err(error) => ToolResult::fail(format!("delegate_tasks error: {error}")),
+        }
+    }
+}
+
+impl DelegateTasksTool {
+    async fn run_batch(&self, args: &Value, env: &dyn ToolEnv) -> Result<Value, String> {
+        delegation_runtime::require_session_delegation(
+            &self.store,
+            &self.project.id,
+            &self.frame_id,
+        )
+        .await?;
+        let parsed: DelegateTasksArgs = serde_json::from_value(args.clone())
+            .map_err(|error| format!("invalid task batch: {error}"))?;
+        validate_batch(&parsed)?;
+        let workflow_id = uuid::Uuid::new_v4().to_string();
+        let mut display_ids = HashMap::with_capacity(parsed.tasks.len());
+        let mut proposals = Vec::with_capacity(parsed.tasks.len());
+        for task in parsed.tasks {
+            let stored_id = stored_task_id(&workflow_id, &task.id);
+            display_ids.insert(stored_id.clone(), task.id.clone());
+            let specialist = match task.specialist_id.as_deref() {
+                Some(id) => {
+                    let specialist = specialists::get(&self.store, id)
+                        .await
+                        .ok_or_else(|| format!("unknown Specialist: {id}"))?;
+                    if specialist.id == "reviewer"
+                        && (task.capabilities.iter().any(|capability| {
+                            !matches!(capability.as_str(), "reasoning" | "project_read" | "review")
+                        }) || !task
+                            .capabilities
+                            .iter()
+                            .any(|capability| capability == "review"))
+                    {
+                        return Err(
+                            "the built-in Reviewer requires the review capability and cannot receive write or execute capabilities"
+                                .into(),
+                        );
+                    }
+                    Some(SpecialistSnapshot {
+                        id: specialist.id,
+                        name: specialist.name,
+                        instructions: specialist.instructions,
+                        model_id: (!specialist.model_id.trim().is_empty())
+                            .then_some(specialist.model_id),
+                        skills: specialist.skills,
+                        connectors: specialist.connectors,
+                    })
+                }
+                None => None,
+            };
+            proposals.push(DelegatedTaskProposal {
+                id: stored_id,
+                instruction: task.instruction.trim().to_string(),
+                context_summary: parsed.context.trim().to_string(),
+                depends_on: task
+                    .depends_on
+                    .iter()
+                    .map(|dependency| stored_task_id(&workflow_id, dependency))
+                    .collect(),
+                capabilities: task.capabilities,
+                specialist,
+                output_schema: task.output_schema,
+                isolated: task.isolated,
+                model_id: None,
+                executor: None,
+                budget: None,
+                input: json!({"task_id": task.id}),
+            });
+        }
+        let (registry, host) = self.policy().await?;
+        let plan = registry
+            .resolve_plan_with_id(
+                workflow_id.clone(),
+                parsed.goal.trim().to_string(),
+                DelegationMode::Automatic,
+                DEFAULT_INLINE_PARALLELISM,
+                proposals,
+                &host,
+            )
+            .map_err(|error| error.to_string())?
+            .into_plan();
+        let snapshot = delegation_runtime::persist_dynamic_agent_workflow(
+            &self.store,
+            &self.project.id,
+            &self.project.root,
+            self.frame_id.clone(),
+            &plan,
+            &registry,
+            &host,
+        )
+        .await?;
+
+        if plan.requires_confirmation {
+            match env
+                .confirm_decision(&approval_prompt(&plan, &display_ids))
+                .await
+            {
+                ConfirmDecision::Approved => {}
+                ConfirmDecision::Denied { feedback } => {
+                    return Ok(json!({
+                        "workflow_id": workflow_id,
+                        "status": "denied",
+                        "feedback": feedback,
+                        "results": [],
+                        "message": "No delegated Agent was started. Revise the batch using the user's feedback before trying again."
+                    }));
+                }
+            }
+        }
+        if env.is_cancelled() {
+            return Err("parent turn was cancelled before delegated execution began".into());
+        }
+        delegation_runtime::approve_created_automatic_workflow(&self.store, snapshot).await?;
+        let execution = match &self.delegator_override {
+            Some(delegator) => {
+                delegation_runtime::execute_agent_workflow_with_delegator(
+                    &self.store,
+                    &self.project.id,
+                    &workflow_id,
+                    delegator.clone(),
+                    Some((registry, host)),
+                )
+                .await?
+            }
+            None => {
+                delegation_runtime::execute_inline_agent_workflow(
+                    &self.store,
+                    self.project.clone(),
+                    self.run_manager.clone(),
+                    &workflow_id,
+                )
+                .await?
+            }
+        };
+        Ok(compact_execution_result(&execution, &display_ids))
+    }
+}
+
+fn validate_batch(args: &DelegateTasksArgs) -> Result<(), String> {
+    let goal = args.goal.trim();
+    if goal.is_empty() || goal.chars().count() > MAX_GOAL_CHARS {
+        return Err(format!(
+            "goal must contain 1 to {MAX_GOAL_CHARS} characters"
+        ));
+    }
+    if args.context.chars().count() > MAX_CONTEXT_CHARS {
+        return Err(format!(
+            "shared context cannot exceed {MAX_CONTEXT_CHARS} characters"
+        ));
+    }
+    if args.tasks.is_empty() || args.tasks.len() > MAX_DELEGATION_TASKS {
+        return Err(format!(
+            "a batch requires 1 to {MAX_DELEGATION_TASKS} tasks"
+        ));
+    }
+    let mut ids = std::collections::HashSet::new();
+    for task in &args.tasks {
+        if !valid_model_task_id(&task.id) {
+            return Err(format!(
+                "invalid task id '{}'; use a lowercase letter followed by at most 30 lowercase letters, digits, '_' or '-'",
+                task.id
+            ));
+        }
+        if !ids.insert(task.id.as_str()) {
+            return Err(format!("duplicate task id: {}", task.id));
+        }
+        let instruction = task.instruction.trim();
+        if instruction.is_empty() || instruction.chars().count() > MAX_INSTRUCTION_CHARS {
+            return Err(format!(
+                "task {} instruction must contain 1 to {MAX_INSTRUCTION_CHARS} characters",
+                task.id
+            ));
+        }
+        if task.capabilities.is_empty() {
+            return Err(format!("task {} requires at least one capability", task.id));
+        }
+        if task.output_schema.as_ref().is_some_and(|schema| {
+            !schema.is_object()
+                || serde_json::to_vec(schema)
+                    .is_ok_and(|bytes| bytes.len() > MAX_AGENT_OUTPUT_SCHEMA_BYTES)
+        }) {
+            return Err(format!(
+                "task {} output_schema must be an object no larger than {MAX_AGENT_OUTPUT_SCHEMA_BYTES} bytes",
+                task.id
+            ));
+        }
+    }
+    for task in &args.tasks {
+        let mut dependencies = std::collections::HashSet::new();
+        for dependency in &task.depends_on {
+            if !dependencies.insert(dependency.as_str()) {
+                return Err(format!(
+                    "task {} contains duplicate dependency {dependency}",
+                    task.id
+                ));
+            }
+            if dependency == &task.id {
+                return Err(format!("task {} cannot depend on itself", task.id));
+            }
+            if !ids.contains(dependency.as_str()) {
+                return Err(format!(
+                    "task {} depends on unknown task {dependency}",
+                    task.id
+                ));
+            }
+        }
+    }
+    let mut completed = std::collections::HashSet::new();
+    while completed.len() < args.tasks.len() {
+        let before = completed.len();
+        for task in &args.tasks {
+            if !completed.contains(task.id.as_str())
+                && task
+                    .depends_on
+                    .iter()
+                    .all(|dependency| completed.contains(dependency.as_str()))
+            {
+                completed.insert(task.id.as_str());
+            }
+        }
+        if completed.len() == before {
+            return Err("task dependencies contain a cycle".into());
+        }
+    }
+    Ok(())
+}
+
+fn valid_model_task_id(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    !bytes.is_empty()
+        && bytes.len() <= MAX_MODEL_TASK_ID_BYTES
+        && bytes[0].is_ascii_lowercase()
+        && bytes.iter().all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'_' | b'-')
+        })
+}
+
+fn stored_task_id(workflow_id: &str, task_id: &str) -> String {
+    format!("{workflow_id}:{task_id}")
+}
+
+fn approval_prompt(
+    plan: &wisp_core::DelegationPlan,
+    display_ids: &HashMap<String, String>,
+) -> String {
+    let tasks = plan
+        .steps
+        .iter()
+        .map(|step| {
+            let id = display_ids
+                .get(&step.id)
+                .map(String::as_str)
+                .unwrap_or(&step.id);
+            let reasons = if step.spec.approval_reasons.is_empty() {
+                "native read-only".into()
+            } else {
+                step.spec.approval_reasons.join("; ")
+            };
+            format!(
+                "[ ] {id}: {}\n    capabilities={} · model={} · executor={} · {reasons}",
+                step.spec.goal,
+                step.spec.capabilities.join(","),
+                step.spec.model.as_deref().unwrap_or("active"),
+                step.spec
+                    .executor
+                    .as_ref()
+                    .map(|executor| serde_json::to_string(executor).unwrap_or_default())
+                    .unwrap_or_else(|| "native".into()),
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        "{}Delegated Agent batch: {}\n{}",
+        wisp_tools::plan::PLAN_APPROVAL_PREFIX,
+        plan.goal,
+        tasks
+    )
+}
+
+fn compact_execution_result(
+    execution: &DelegationExecutionResult,
+    display_ids: &HashMap<String, String>,
+) -> Value {
+    let results = execution
+        .steps
+        .iter()
+        .map(|step| {
+            let response = &step.response;
+            let id = display_ids
+                .get(&step.step_id)
+                .cloned()
+                .unwrap_or_else(|| step.step_id.clone());
+            let summary = response
+                .output
+                .get("summary")
+                .and_then(Value::as_str)
+                .map(|value| bounded_chars(value, INLINE_TEXT_CHARS))
+                .or_else(|| {
+                    response
+                        .error
+                        .as_deref()
+                        .map(|value| bounded_chars(value, INLINE_TEXT_CHARS))
+                })
+                .unwrap_or_default();
+            let data = response
+                .output
+                .get("data")
+                .unwrap_or(&response.output);
+            json!({
+                "id": id,
+                "status": response.status,
+                "summary": summary,
+                "data": compact_value(data, INLINE_DATA_BYTES, &execution.workflow_id, &id),
+                "artifacts": response.artifacts,
+                "evidence": response.evidence,
+                "tests": response.output.get("tests").cloned().unwrap_or_else(|| json!([])),
+                "risks": response.output.get("risks").cloned().unwrap_or_else(|| json!([])),
+                "usage": response.usage,
+                "child_frame_id": response.child_frame_id,
+                "error": response.error.as_deref().map(|value| bounded_chars(value, INLINE_TEXT_CHARS)),
+                "lookup": {
+                    "tool": "get_delegated_result",
+                    "mcp_tool": "wisp_get_delegated_result",
+                    "workflow_id": execution.workflow_id,
+                    "task_id": id,
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+    json!({
+        "workflow_id": execution.workflow_id,
+        "status": execution.status,
+        "results": results,
+        "message": "Synthesize these ordered delegated results into the final answer. Independent failures are partial evidence; do not hide them."
+    })
+}
+
+fn compact_value(value: &Value, limit: usize, workflow_id: &str, task_id: &str) -> Value {
+    let raw = serde_json::to_string(value).unwrap_or_default();
+    if raw.len() <= limit {
+        return value.clone();
+    }
+    json!({
+        "truncated": true,
+        "preview": bounded_bytes(&raw, limit),
+        "lookup": {
+            "tool": "get_delegated_result",
+            "mcp_tool": "wisp_get_delegated_result",
+            "workflow_id": workflow_id,
+            "task_id": task_id,
+        }
+    })
+}
+
+fn bounded_bytes(value: &str, limit: usize) -> String {
+    if value.len() <= limit {
+        return value.into();
+    }
+    let mut end = limit.min(value.len());
+    while end > 0 && !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}…", &value[..end])
+}
+
+fn bounded_chars(value: &str, limit: usize) -> String {
+    let mut chars = value.chars();
+    let kept = chars.by_ref().take(limit).collect::<String>();
+    if chars.next().is_some() {
+        format!("{kept}…")
+    } else {
+        kept
+    }
+}
+
+pub(crate) fn get_delegated_result_schema() -> ToolSchema {
+    ToolSchema::new(
+        "get_delegated_result",
+        "Read the latest persisted full result for one task from an earlier delegate_tasks batch. Use only when the compact inline result says it was truncated or lacks needed detail.",
+        json!({
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "workflow_id": {"type": "string"},
+                "task_id": {"type": "string"}
+            },
+            "required": ["workflow_id", "task_id"]
+        }),
+    )
+}
+
+pub(crate) struct GetDelegatedResultTool {
+    store: Store,
+    project_id: String,
+    frame_id: String,
+}
+
+impl GetDelegatedResultTool {
+    pub(crate) fn new(
+        store: Store,
+        project_id: impl Into<String>,
+        frame_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            store,
+            project_id: project_id.into(),
+            frame_id: frame_id.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for GetDelegatedResultTool {
+    fn name(&self) -> &str {
+        "get_delegated_result"
+    }
+
+    fn schema(&self) -> ToolSchema {
+        get_delegated_result_schema()
+    }
+
+    fn preview(&self, args: &Value) -> String {
+        args.get("task_id")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string()
+    }
+
+    async fn run(&self, args: &Value, _env: &dyn ToolEnv) -> ToolResult {
+        match self.read_result(args).await {
+            Ok(value) => ToolResult::ok(serde_json::to_string(&value).unwrap_or_default()),
+            Err(error) => ToolResult::fail(format!("get_delegated_result error: {error}")),
+        }
+    }
+}
+
+impl GetDelegatedResultTool {
+    async fn read_result(&self, args: &Value) -> Result<Value, String> {
+        delegation_runtime::require_session_delegation(
+            &self.store,
+            &self.project_id,
+            &self.frame_id,
+        )
+        .await?;
+        let workflow_id = required_arg(args, "workflow_id")?;
+        let task_id = required_arg(args, "task_id")?;
+        let workflow = self
+            .store
+            .get_agent_workflow(workflow_id)
+            .await
+            .map_err(|error| error.to_string())?
+            .ok_or_else(|| "workflow does not exist".to_string())?;
+        if workflow.project_id != self.project_id
+            || workflow.frame_id.as_deref() != Some(self.frame_id.as_str())
+        {
+            return Err("workflow does not belong to this conversation".into());
+        }
+        let steps = self
+            .store
+            .list_agent_workflow_steps(workflow_id)
+            .await
+            .map_err(|error| error.to_string())?;
+        let suffix = format!(":{task_id}");
+        let step = steps
+            .iter()
+            .find(|step| step.id == task_id || step.id.ends_with(&suffix))
+            .ok_or_else(|| "task does not exist in this workflow".to_string())?;
+        let attempt = self
+            .store
+            .list_agent_workflow_attempts(workflow_id)
+            .await
+            .map_err(|error| error.to_string())?
+            .into_iter()
+            .filter(|attempt| attempt.step_id == step.id)
+            .max_by_key(|attempt| attempt.attempt)
+            .ok_or_else(|| "task has no execution attempt".to_string())?;
+        let response = attempt
+            .response_json
+            .as_deref()
+            .and_then(|raw| serde_json::from_str::<Value>(raw).ok());
+        Ok(json!({
+            "workflow_id": workflow_id,
+            "task_id": task_id,
+            "stored_step_id": step.id,
+            "attempt": attempt.attempt,
+            "status": attempt.status,
+            "response": response,
+            "error": attempt.error,
+        }))
+    }
+}
+
+fn required_arg<'a>(args: &'a Value, name: &str) -> Result<&'a str, String> {
+    args.get(name)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| format!("'{name}' is required"))
+}
 
 pub(crate) fn propose_delegation_schema() -> ToolSchema {
     ToolSchema::new(
@@ -132,12 +873,28 @@ impl Tool for ProposeDelegationTool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::{
+        collections::{HashSet, VecDeque},
+        path::{Path, PathBuf},
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Mutex,
+        },
+    };
+    use wisp_core::{
+        AgentBudget, AgentDelegationResponse, AgentExecutorRef, AgentOutputSchemaSource,
+        AgentUsage, ContextPolicy, DelegationStatus, ExecutorFeature, ExecutorProfilePolicy,
+        ModelProfilePolicy, NullOutput, PermissionSet, ValidatedAgentDelegationRequest,
+    };
+    use wisp_llm::{
+        Completion, FunctionCall, LlmError, Message, Provider, Role, StreamSink, ToolCall, Usage,
+    };
 
-    struct NoEnv(std::path::PathBuf);
+    struct NoEnv(PathBuf);
 
     #[async_trait]
     impl ToolEnv for NoEnv {
-        fn project_root(&self) -> &std::path::Path {
+        fn project_root(&self) -> &Path {
             &self.0
         }
 
@@ -146,6 +903,278 @@ mod tests {
         }
 
         async fn emit(&self, _event: wisp_tools::ToolEvent) {}
+    }
+
+    struct DecisionEnv {
+        root: PathBuf,
+        decision: ConfirmDecision,
+        prompts: Mutex<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl ToolEnv for DecisionEnv {
+        fn project_root(&self) -> &Path {
+            &self.root
+        }
+
+        async fn confirm(&self, _message: &str) -> bool {
+            self.decision.approved()
+        }
+
+        async fn confirm_decision(&self, message: &str) -> ConfirmDecision {
+            self.prompts.lock().unwrap().push(message.into());
+            self.decision.clone()
+        }
+
+        async fn emit(&self, _event: wisp_tools::ToolEvent) {}
+    }
+
+    #[derive(Debug, Clone)]
+    struct DelegatorCall {
+        task_id: String,
+        input: Value,
+    }
+
+    struct FakeDelegator {
+        active: AtomicUsize,
+        max_active: AtomicUsize,
+        calls: Mutex<Vec<DelegatorCall>>,
+        failed_tasks: HashSet<String>,
+        invalid_schema_tasks: HashSet<String>,
+    }
+
+    impl FakeDelegator {
+        fn new(failed_tasks: &[&str], invalid_schema_tasks: &[&str]) -> Self {
+            Self {
+                active: AtomicUsize::new(0),
+                max_active: AtomicUsize::new(0),
+                calls: Mutex::new(vec![]),
+                failed_tasks: failed_tasks.iter().map(|value| (*value).into()).collect(),
+                invalid_schema_tasks: invalid_schema_tasks
+                    .iter()
+                    .map(|value| (*value).into())
+                    .collect(),
+            }
+        }
+
+        fn calls(&self) -> Vec<DelegatorCall> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl AgentDelegator for FakeDelegator {
+        async fn delegate_validated(
+            &self,
+            request: ValidatedAgentDelegationRequest,
+        ) -> anyhow::Result<AgentDelegationResponse> {
+            let request = request.into_request();
+            let task_id = request
+                .input
+                .get("task_id")
+                .and_then(Value::as_str)
+                .unwrap_or(&request.step_id)
+                .to_string();
+            let active = self.active.fetch_add(1, Ordering::SeqCst) + 1;
+            self.max_active.fetch_max(active, Ordering::SeqCst);
+            self.calls.lock().unwrap().push(DelegatorCall {
+                task_id: task_id.clone(),
+                input: request.input.clone(),
+            });
+            tokio::time::sleep(std::time::Duration::from_millis(35)).await;
+            self.active.fetch_sub(1, Ordering::SeqCst);
+
+            if self.failed_tasks.contains(&task_id) {
+                return Ok(AgentDelegationResponse {
+                    request_id: request.request_id,
+                    status: DelegationStatus::Failed,
+                    output: json!({}),
+                    artifact_ids: vec![],
+                    artifacts: vec![],
+                    evidence: vec![],
+                    usage: AgentUsage::default(),
+                    agent_session_id: None,
+                    child_frame_id: Some(format!("child-{task_id}")),
+                    error: Some(format!("{task_id} failed intentionally")),
+                });
+            }
+            let output = if request.spec.output_schema_source == AgentOutputSchemaSource::Task {
+                if self.invalid_schema_tasks.contains(&task_id) {
+                    json!({"score": "invalid"})
+                } else {
+                    json!({"score": 7})
+                }
+            } else {
+                json!({
+                    "summary": format!("{task_id} complete"),
+                    "data": {"task": task_id},
+                    "tests": [],
+                    "risks": []
+                })
+            };
+            Ok(AgentDelegationResponse {
+                request_id: request.request_id,
+                status: DelegationStatus::Succeeded,
+                output,
+                artifact_ids: vec![],
+                artifacts: vec![],
+                evidence: vec![],
+                usage: AgentUsage {
+                    input_tokens: 1,
+                    output_tokens: 2,
+                    ..AgentUsage::default()
+                },
+                agent_session_id: None,
+                child_frame_id: Some(format!("child-{task_id}")),
+                error: None,
+            })
+        }
+    }
+
+    struct SequenceProvider {
+        completions: Mutex<VecDeque<Completion>>,
+        messages: Mutex<Vec<Vec<Message>>>,
+        schemas: Mutex<Vec<Vec<String>>>,
+    }
+
+    impl SequenceProvider {
+        fn new(completions: Vec<Completion>) -> Self {
+            Self {
+                completions: Mutex::new(completions.into()),
+                messages: Mutex::new(vec![]),
+                schemas: Mutex::new(vec![]),
+            }
+        }
+
+        fn pop(&self, messages: &[Message], tools: &[ToolSchema]) -> wisp_llm::Result<Completion> {
+            self.messages.lock().unwrap().push(messages.to_vec());
+            self.schemas.lock().unwrap().push(
+                tools
+                    .iter()
+                    .map(|schema| schema.function.name.clone())
+                    .collect(),
+            );
+            self.completions
+                .lock()
+                .unwrap()
+                .pop_front()
+                .ok_or_else(|| LlmError::Config("fake parent ran out of completions".into()))
+        }
+    }
+
+    #[async_trait]
+    impl Provider for SequenceProvider {
+        fn name(&self) -> &str {
+            "sequence-parent"
+        }
+
+        fn model(&self) -> &str {
+            "sequence-parent-model"
+        }
+
+        async fn complete(
+            &self,
+            messages: &[Message],
+            tools: &[ToolSchema],
+        ) -> wisp_llm::Result<Completion> {
+            self.pop(messages, tools)
+        }
+
+        async fn stream(
+            &self,
+            messages: &[Message],
+            tools: &[ToolSchema],
+            _sink: &mut dyn StreamSink,
+        ) -> wisp_llm::Result<Completion> {
+            self.pop(messages, tools)
+        }
+    }
+
+    fn completion(content: &str, tool_calls: Vec<ToolCall>) -> Completion {
+        Completion {
+            content: content.into(),
+            reasoning: None,
+            finish_reason: Some(if tool_calls.is_empty() {
+                "stop".into()
+            } else {
+                "tool_calls".into()
+            }),
+            tool_calls,
+            usage: Usage {
+                input_tokens: 3,
+                output_tokens: 2,
+            },
+        }
+    }
+
+    fn tool_call(args: Value) -> ToolCall {
+        ToolCall {
+            id: "delegate-call".into(),
+            kind: "function".into(),
+            function: FunctionCall {
+                name: "delegate_tasks".into(),
+                arguments: args.to_string(),
+            },
+        }
+    }
+
+    fn test_policy() -> (CapabilityRegistry, DelegationHostPolicy) {
+        (
+            CapabilityRegistry::builtins(),
+            DelegationHostPolicy {
+                revision: "delegate-tool-test-v1".into(),
+                enabled_capabilities: vec![
+                    "reasoning".into(),
+                    "project_read".into(),
+                    "project_write".into(),
+                    "review".into(),
+                ],
+                models: vec![ModelProfilePolicy {
+                    id: "local".into(),
+                    features: vec![],
+                    external: false,
+                    enabled: true,
+                }],
+                executors: vec![ExecutorProfilePolicy {
+                    executor: AgentExecutorRef::Native,
+                    features: vec![
+                        ExecutorFeature::ProjectRead,
+                        ExecutorFeature::ProjectWrite,
+                        ExecutorFeature::CodeExecution,
+                    ],
+                    model_ids: vec!["local".into()],
+                    enabled: true,
+                }],
+                default_model_id: Some("local".into()),
+                permission_ceiling: PermissionSet {
+                    tools: vec![
+                        "read".into(),
+                        "search".into(),
+                        "grep".into(),
+                        "write".into(),
+                        "edit".into(),
+                    ],
+                    paths: vec!["project://**".into()],
+                    network: false,
+                    write: true,
+                    execute: true,
+                },
+                context_ceiling: ContextPolicy {
+                    include_history: false,
+                    include_artifacts: true,
+                    max_tokens: Some(32_000),
+                },
+                budget_ceiling: AgentBudget {
+                    max_tokens: Some(32_000),
+                    max_tool_calls: Some(64),
+                    max_cost_microunits: Some(1_000_000),
+                },
+                default_timeout_secs: Some(5),
+                timeout_ceiling_secs: Some(5),
+                auto_safe: true,
+                ..DelegationHostPolicy::default()
+            },
+        )
     }
 
     async fn fixture() -> (Store, ActiveProject, std::path::PathBuf) {
@@ -169,6 +1198,398 @@ mod tests {
             memory: std::sync::Arc::new(wisp_core::MemoryManager::new(&root)),
         };
         (store, project, root)
+    }
+
+    async fn enable_delegation(store: &Store) {
+        delegation_runtime::save_session_delegation_enabled(store, "p", "f", true)
+            .await
+            .unwrap();
+    }
+
+    fn parse_tool_result(result: &ToolResult) -> Value {
+        assert!(result.success, "{}", result.content);
+        serde_json::from_str(&result.content).unwrap()
+    }
+
+    #[test]
+    fn batch_validation_rejects_unknown_duplicate_and_cyclic_dependencies() {
+        let parse = |tasks: Value| DelegateTasksArgs {
+            goal: "test dependencies".into(),
+            context: String::new(),
+            tasks: serde_json::from_value(tasks).unwrap(),
+        };
+        let task = |id: &str, dependencies: &[&str]| {
+            json!({
+                "id": id,
+                "instruction": format!("Run {id}"),
+                "depends_on": dependencies,
+                "capabilities": ["reasoning"]
+            })
+        };
+
+        let unknown = parse(json!([task("a", &["missing"])]));
+        assert!(validate_batch(&unknown)
+            .unwrap_err()
+            .contains("unknown task"));
+        let duplicate = parse(json!([task("a", &[]), task("b", &["a", "a"])]));
+        assert!(validate_batch(&duplicate)
+            .unwrap_err()
+            .contains("duplicate dependency"));
+        let cycle = parse(json!([task("a", &["b"]), task("b", &["a"])]));
+        assert!(validate_batch(&cycle).unwrap_err().contains("cycle"));
+    }
+
+    #[test]
+    fn compact_preview_respects_utf8_byte_limit() {
+        let compact = compact_value(&json!({"text": "界界界界界界"}), 10, "workflow", "task");
+        let preview = compact["preview"].as_str().unwrap();
+        assert!(preview.len() <= 13, "preview was {} bytes", preview.len());
+        assert_eq!(compact["lookup"]["mcp_tool"], "wisp_get_delegated_result");
+    }
+
+    #[tokio::test]
+    async fn parent_agent_delegates_parallel_tasks_and_synthesizes_inline() {
+        let (store, project, root) = fixture().await;
+        enable_delegation(&store).await;
+        let delegator = Arc::new(FakeDelegator::new(&[], &[]));
+        let args = json!({
+            "goal": "Compare two independent inputs",
+            "context": "Return concise evidence for the parent.",
+            "tasks": [
+                {
+                    "id": "left",
+                    "instruction": "Analyze the left input.",
+                    "capabilities": ["reasoning"]
+                },
+                {
+                    "id": "right",
+                    "instruction": "Analyze the right input.",
+                    "capabilities": ["reasoning"]
+                }
+            ]
+        });
+        let provider = SequenceProvider::new(vec![
+            completion("", vec![tool_call(args)]),
+            completion("Synthesized left and right evidence.", vec![]),
+        ]);
+        let tool = DelegateTasksTool::with_runtime(
+            store.clone(),
+            project,
+            "f",
+            test_policy(),
+            delegator.clone(),
+        );
+        let mut tools = wisp_tools::Registry::builtins().filtered(&[]);
+        tools.add(Box::new(tool));
+        let mut context = wisp_core::ContextManager::new(32_000);
+
+        wisp_core::agent_loop(
+            &mut context,
+            &provider,
+            None,
+            &tools,
+            &root,
+            &NullOutput,
+            "Compare these inputs and report one conclusion.",
+            4,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(delegator.max_active.load(Ordering::SeqCst), 2);
+        let provider_messages = provider.messages.lock().unwrap();
+        assert_eq!(provider_messages.len(), 2);
+        let tool_message = provider_messages[1]
+            .iter()
+            .find(|message| message.role == Role::Tool)
+            .expect("delegation result should be returned to the parent model");
+        let inline: Value = serde_json::from_str(&tool_message.content.as_text()).unwrap();
+        assert_eq!(inline["status"], "succeeded");
+        assert_eq!(inline["results"].as_array().unwrap().len(), 2);
+        assert!(inline["message"].as_str().unwrap().contains("Synthesize"));
+        assert_eq!(
+            context.messages.last().unwrap().content.as_text(),
+            "Synthesized left and right evidence."
+        );
+        assert!(provider
+            .schemas
+            .lock()
+            .unwrap()
+            .iter()
+            .all(|schemas| schemas == &["delegate_tasks"]));
+
+        drop(tools);
+        drop(store);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn inline_batch_runs_two_tasks_in_parallel_then_supplies_fan_in_results() {
+        let (store, project, root) = fixture().await;
+        enable_delegation(&store).await;
+        let delegator = Arc::new(FakeDelegator::new(&[], &[]));
+        let tool = DelegateTasksTool::with_runtime(
+            store.clone(),
+            project,
+            "f",
+            test_policy(),
+            delegator.clone(),
+        );
+
+        let result = tool
+            .run(
+                &json!({
+                    "goal": "Analyze both sources and combine the evidence",
+                    "tasks": [
+                        {
+                            "id": "source_a",
+                            "instruction": "Analyze source A.",
+                            "capabilities": ["reasoning"]
+                        },
+                        {
+                            "id": "source_b",
+                            "instruction": "Analyze source B.",
+                            "capabilities": ["reasoning"]
+                        },
+                        {
+                            "id": "combine",
+                            "instruction": "Combine both source results.",
+                            "depends_on": ["source_a", "source_b"],
+                            "capabilities": ["reasoning"]
+                        }
+                    ]
+                }),
+                &NoEnv(root.clone()),
+            )
+            .await;
+        let value = parse_tool_result(&result);
+
+        assert_eq!(value["status"], "succeeded");
+        assert_eq!(delegator.max_active.load(Ordering::SeqCst), 2);
+        let calls = delegator.calls();
+        let combine = calls.iter().find(|call| call.task_id == "combine").unwrap();
+        let dependencies = combine.input["dependency_results"].as_object().unwrap();
+        assert_eq!(dependencies.len(), 2);
+        assert!(dependencies
+            .values()
+            .all(|output| output["summary"].as_str().is_some()));
+        let workflow = store.list_agent_workflows("p").await.unwrap().remove(0);
+        assert_eq!(workflow.max_parallel, 2);
+        assert_eq!(workflow.status, wisp_store::AgentWorkflowStatus::Succeeded);
+
+        drop(store);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn approval_denial_starts_no_children_and_returns_feedback_to_parent() {
+        let (store, project, root) = fixture().await;
+        enable_delegation(&store).await;
+        let delegator = Arc::new(FakeDelegator::new(&[], &[]));
+        let tool = DelegateTasksTool::with_runtime(
+            store.clone(),
+            project,
+            "f",
+            test_policy(),
+            delegator.clone(),
+        );
+        let env = DecisionEnv {
+            root: root.clone(),
+            decision: ConfirmDecision::Denied {
+                feedback: Some("keep this read-only".into()),
+            },
+            prompts: Mutex::new(vec![]),
+        };
+
+        let result = tool
+            .run(
+                &json!({
+                    "goal": "Edit the report",
+                    "tasks": [{
+                        "id": "edit_report",
+                        "instruction": "Edit report.md.",
+                        "capabilities": ["project_write"]
+                    }]
+                }),
+                &env,
+            )
+            .await;
+        let value = parse_tool_result(&result);
+
+        assert_eq!(value["status"], "denied");
+        assert_eq!(value["feedback"], "keep this read-only");
+        assert!(value["results"].as_array().unwrap().is_empty());
+        assert!(delegator.calls().is_empty());
+        let prompts = env.prompts.lock().unwrap();
+        assert_eq!(prompts.len(), 1);
+        assert!(prompts[0].contains(wisp_tools::plan::PLAN_APPROVAL_PREFIX));
+        assert!(prompts[0].contains("project_write"));
+        assert!(prompts[0].contains("native"));
+        let workflow = store.list_agent_workflows("p").await.unwrap().remove(0);
+        assert_eq!(workflow.status, wisp_store::AgentWorkflowStatus::Draft);
+
+        drop(prompts);
+        drop(store);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn independent_success_survives_failure_while_only_descendants_are_blocked() {
+        let (store, project, root) = fixture().await;
+        enable_delegation(&store).await;
+        let delegator = Arc::new(FakeDelegator::new(&["bad"], &[]));
+        let tool = DelegateTasksTool::with_runtime(
+            store.clone(),
+            project,
+            "f",
+            test_policy(),
+            delegator.clone(),
+        );
+
+        let result = tool
+            .run(
+                &json!({
+                    "goal": "Collect as much independent evidence as possible",
+                    "tasks": [
+                        {
+                            "id": "bad",
+                            "instruction": "Run the failing analysis.",
+                            "capabilities": ["reasoning"]
+                        },
+                        {
+                            "id": "independent",
+                            "instruction": "Run an independent analysis.",
+                            "capabilities": ["reasoning"]
+                        },
+                        {
+                            "id": "downstream",
+                            "instruction": "Use the failing analysis.",
+                            "depends_on": ["bad"],
+                            "capabilities": ["reasoning"]
+                        }
+                    ]
+                }),
+                &NoEnv(root.clone()),
+            )
+            .await;
+        let value = parse_tool_result(&result);
+        let results = value["results"].as_array().unwrap();
+        let status = |id: &str| {
+            results.iter().find(|item| item["id"] == id).unwrap()["status"]
+                .as_str()
+                .unwrap()
+        };
+
+        assert_eq!(value["status"], "failed");
+        assert_eq!(status("bad"), "failed");
+        assert_eq!(status("independent"), "succeeded");
+        assert_eq!(status("downstream"), "blocked");
+        let called = delegator
+            .calls()
+            .into_iter()
+            .map(|call| call.task_id)
+            .collect::<HashSet<_>>();
+        assert_eq!(called, HashSet::from(["bad".into(), "independent".into()]));
+
+        drop(store);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn task_output_schema_is_enforced_and_full_result_can_be_loaded() {
+        let (store, project, root) = fixture().await;
+        enable_delegation(&store).await;
+        let delegator = Arc::new(FakeDelegator::new(&[], &["invalid"]));
+        let tool =
+            DelegateTasksTool::with_runtime(store.clone(), project, "f", test_policy(), delegator);
+        let score_schema = json!({
+            "type": "object",
+            "properties": {"score": {"type": "integer", "minimum": 0}},
+            "required": ["score"],
+            "additionalProperties": false
+        });
+
+        let result = tool
+            .run(
+                &json!({
+                    "goal": "Return validated scores",
+                    "tasks": [
+                        {
+                            "id": "valid",
+                            "instruction": "Return a valid score.",
+                            "capabilities": ["reasoning"],
+                            "output_schema": score_schema
+                        },
+                        {
+                            "id": "invalid",
+                            "instruction": "Return an invalid score for validation testing.",
+                            "capabilities": ["reasoning"],
+                            "output_schema": score_schema
+                        }
+                    ]
+                }),
+                &NoEnv(root.clone()),
+            )
+            .await;
+        let value = parse_tool_result(&result);
+        let workflow_id = value["workflow_id"].as_str().unwrap();
+        let results = value["results"].as_array().unwrap();
+        assert_eq!(results[0]["status"], "succeeded");
+        assert_eq!(results[0]["data"]["score"], 7);
+        assert_eq!(results[1]["status"], "failed");
+        assert!(results[1]["error"]
+            .as_str()
+            .unwrap()
+            .contains("output_contract"));
+        assert_eq!(results[1]["usage"]["input_tokens"], 1);
+
+        let lookup = GetDelegatedResultTool::new(store.clone(), "p", "f")
+            .run(
+                &json!({"workflow_id": workflow_id, "task_id": "valid"}),
+                &NoEnv(root.clone()),
+            )
+            .await;
+        let full = parse_tool_result(&lookup);
+        assert_eq!(full["response"]["output"]["data"]["score"], 7);
+        assert_eq!(full["response"]["child_frame_id"], "child-valid");
+
+        drop(store);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn disabled_session_cannot_invoke_inline_delegation() {
+        let (store, project, root) = fixture().await;
+        let delegator = Arc::new(FakeDelegator::new(&[], &[]));
+        let tool = DelegateTasksTool::with_runtime(
+            store.clone(),
+            project,
+            "f",
+            test_policy(),
+            delegator.clone(),
+        );
+
+        let result = tool
+            .run(
+                &json!({
+                    "goal": "Analyze one input",
+                    "tasks": [{
+                        "id": "analysis",
+                        "instruction": "Analyze it.",
+                        "capabilities": ["reasoning"]
+                    }]
+                }),
+                &NoEnv(root.clone()),
+            )
+            .await;
+
+        assert!(!result.success);
+        assert!(result.content.contains("delegation is off"));
+        assert!(delegator.calls().is_empty());
+        assert!(store.list_agent_workflows("p").await.unwrap().is_empty());
+        drop(store);
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[tokio::test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3423,7 +3423,7 @@ async fn send_message(
     }
     if guard
         .as_ref()
-        .is_some_and(|agent| agent.tools.get("propose_delegation").is_some() != delegation_enabled)
+        .is_some_and(|agent| agent.tools.get("delegate_tasks").is_some() != delegation_enabled)
     {
         // Delegation is a live per-session capability. Rebuild from persisted
         // messages when the toggle changed so the next turn sees the exact
@@ -3477,6 +3477,20 @@ async fn send_message(
             store: state.store.clone(),
         }));
         if delegation_enabled {
+            agent.add_tool(Box::new(
+                delegation_tool::DelegateTasksTool::new(
+                    state.store.clone(),
+                    ap.clone(),
+                    frame_id.clone(),
+                    state.run_manager.clone(),
+                )
+                .await?,
+            ));
+            agent.add_tool(Box::new(delegation_tool::GetDelegatedResultTool::new(
+                state.store.clone(),
+                ap.id.clone(),
+                frame_id.clone(),
+            )));
             agent.add_tool(Box::new(delegation_tool::ProposeDelegationTool::new(
                 state.store.clone(),
                 ap.clone(),

--- a/src-tauri/src/mcp_bridge.rs
+++ b/src-tauri/src/mcp_bridge.rs
@@ -7,7 +7,7 @@
 
 use crate::{
     bio_domains, connect_mcp, load_disabled_connectors, load_disabled_skills,
-    load_enabled_skill_names, load_mcp_connections, run_context, skill_paths,
+    load_enabled_skill_names, load_mcp_connections, run_context, skill_paths, ActiveProject,
 };
 use anyhow::{anyhow, Context, Result};
 use serde::Deserialize;
@@ -149,6 +149,8 @@ impl BridgeServer {
         ];
         if let Some(frame_id) = self.cfg.frame_id.as_deref() {
             if crate::delegation_runtime::session_delegation_enabled(&self.store, frame_id).await {
+                tools.push(delegate_tasks_tool_schema(&self.store).await?);
+                tools.push(get_delegated_result_tool_schema());
                 tools.push(propose_delegation_tool_schema());
             }
         }
@@ -221,6 +223,53 @@ impl BridgeServer {
             }
             "wisp_cancel_run" => {
                 let result = self.cancel_run(&args).await;
+                (result.content, !result.success)
+            }
+            "wisp_delegate_tasks" => {
+                let Some(frame_id) = self.cfg.frame_id.as_deref() else {
+                    return Err(anyhow!("delegation requires a conversation frame"));
+                };
+                let project = ActiveProject {
+                    id: self.cfg.project_id.clone(),
+                    root: self.cfg.project_root.clone(),
+                    skills: self.skills.clone(),
+                    memory: Arc::new(wisp_core::MemoryManager::new(&self.cfg.project_root)),
+                };
+                let tool = crate::delegation_tool::DelegateTasksTool::new(
+                    self.store.clone(),
+                    project,
+                    frame_id,
+                    self.run_manager.clone(),
+                )
+                .await
+                .map_err(anyhow::Error::msg)?;
+                let result = tool
+                    .run(
+                        &args,
+                        &BridgeToolEnv {
+                            project_root: self.cfg.project_root.clone(),
+                        },
+                    )
+                    .await;
+                (result.content, !result.success)
+            }
+            "wisp_get_delegated_result" => {
+                let Some(frame_id) = self.cfg.frame_id.as_deref() else {
+                    return Err(anyhow!("delegation requires a conversation frame"));
+                };
+                let tool = crate::delegation_tool::GetDelegatedResultTool::new(
+                    self.store.clone(),
+                    self.cfg.project_id.clone(),
+                    frame_id,
+                );
+                let result = tool
+                    .run(
+                        &args,
+                        &BridgeToolEnv {
+                            project_root: self.cfg.project_root.clone(),
+                        },
+                    )
+                    .await;
                 (result.content, !result.success)
             }
             "wisp_propose_delegation" => {
@@ -493,10 +542,16 @@ impl BridgeServer {
                     "reason": "Memory, artifact, graph, and persistent runtime writes require an approval broker and are not exposed by this bridge."
                 },
                 {
+                    "name": "delegation.inline",
+                    "allowed": delegation_enabled,
+                    "tools": if delegation_enabled { vec!["wisp_delegate_tasks", "wisp_get_delegated_result"] } else { vec![] },
+                    "policy": "bounded Native child Agents; read-only batches run inline; any requested approval is denied by this non-interactive bridge"
+                },
+                {
                     "name": "delegation.propose",
                     "allowed": delegation_enabled,
                     "tools": if delegation_enabled { vec!["wisp_propose_delegation"] } else { vec![] },
-                    "policy": "draft_only; explicit UI approval and run remain required"
+                    "policy": "legacy draft-only compatibility path; explicit UI approval and run remain required"
                 }
             ]
         }))
@@ -908,6 +963,26 @@ fn propose_delegation_tool_schema() -> Value {
     })
 }
 
+async fn delegate_tasks_tool_schema(store: &Store) -> Result<Value> {
+    let schema = crate::delegation_tool::delegate_tasks_schema(store)
+        .await
+        .map_err(anyhow::Error::msg)?;
+    Ok(json!({
+        "name": "wisp_delegate_tasks",
+        "description": schema.function.description,
+        "inputSchema": schema.function.parameters,
+    }))
+}
+
+fn get_delegated_result_tool_schema() -> Value {
+    let schema = crate::delegation_tool::get_delegated_result_schema();
+    json!({
+        "name": "wisp_get_delegated_result",
+        "description": schema.function.description,
+        "inputSchema": schema.function.parameters,
+    })
+}
+
 fn is_builtin_tool(name: &str) -> bool {
     matches!(
         name,
@@ -924,6 +999,8 @@ fn is_builtin_tool(name: &str) -> bool {
             | "wisp_get_run"
             | "wisp_monitor_run"
             | "wisp_cancel_run"
+            | "wisp_delegate_tasks"
+            | "wisp_get_delegated_result"
             | "wisp_propose_delegation"
     )
 }
@@ -1111,6 +1188,12 @@ mod tests {
         assert_eq!(get_run_tool_schema()["name"], "wisp_get_run");
         assert_eq!(monitor_run_tool_schema()["name"], "wisp_monitor_run");
         assert_eq!(cancel_run_tool_schema()["name"], "wisp_cancel_run");
+        let delegated_result = get_delegated_result_tool_schema();
+        assert_eq!(delegated_result["name"], "wisp_get_delegated_result");
+        assert_eq!(
+            delegated_result["inputSchema"]["required"],
+            json!(["workflow_id", "task_id"])
+        );
         let delegation = propose_delegation_tool_schema();
         assert_eq!(delegation["name"], "wisp_propose_delegation");
         assert_eq!(delegation["inputSchema"]["required"], json!(["goal"]));
@@ -1132,6 +1215,8 @@ mod tests {
             "wisp_get_run",
             "wisp_monitor_run",
             "wisp_cancel_run",
+            "wisp_delegate_tasks",
+            "wisp_get_delegated_result",
             "wisp_propose_delegation",
         ] {
             assert!(is_builtin_tool(name), "{name} must be reserved");
@@ -1198,6 +1283,8 @@ mod tests {
 
         let disabled = server.tools_list().await.unwrap();
         assert!(!disabled.to_string().contains("wisp_propose_delegation"));
+        assert!(!disabled.to_string().contains("wisp_delegate_tasks"));
+        assert!(!disabled.to_string().contains("wisp_get_delegated_result"));
         crate::delegation_runtime::save_session_delegation_enabled(
             &server.store,
             "project-a",
@@ -1208,8 +1295,31 @@ mod tests {
         .unwrap();
         let enabled = server.tools_list().await.unwrap();
         assert!(enabled.to_string().contains("wisp_propose_delegation"));
+        assert!(enabled.to_string().contains("wisp_delegate_tasks"));
+        assert!(enabled.to_string().contains("wisp_get_delegated_result"));
+        let inline_schema = enabled["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|tool| tool["name"] == "wisp_delegate_tasks")
+            .unwrap();
+        assert_eq!(
+            inline_schema["inputSchema"]["required"],
+            json!(["goal", "tasks"])
+        );
         let capabilities: Value =
             serde_json::from_str(&server.capabilities_text().await.unwrap()).unwrap();
+        let inline = capabilities["capabilities"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|entry| entry["name"] == "delegation.inline")
+            .unwrap();
+        assert_eq!(inline["allowed"], true);
+        assert!(inline["tools"]
+            .as_array()
+            .unwrap()
+            .contains(&json!("wisp_delegate_tasks")));
         let delegation = capabilities["capabilities"]
             .as_array()
             .unwrap()
@@ -1217,6 +1327,16 @@ mod tests {
             .find(|entry| entry["name"] == "delegation.propose")
             .unwrap();
         assert_eq!(delegation["allowed"], true);
+
+        let malformed_inline = server
+            .tools_call(json!({
+                "name": "wisp_delegate_tasks",
+                "arguments": {}
+            }))
+            .await
+            .unwrap();
+        assert_eq!(malformed_inline["isError"], true);
+        assert!(malformed_inline.to_string().contains("invalid task batch"));
 
         let result = server
             .tools_call(json!({


### PR DESCRIPTION
## Problem

The existing main-Agent tool can only create a fixed-template draft and send the user to the Agents panel. It cannot create temporary task-specific Agents, run independent work in parallel, or return results for automatic parent synthesis.

This stacked PR builds on #352 and makes the capability-driven Native path usable end to end without requiring ACP or Codex.

## Changes

- add an opt-in `delegate_tasks` tool with goal, bounded context, task IDs, DAG dependencies, capability IDs, optional Specialist snapshots, task output schemas, and isolation requests
- resolve and persist immutable v2 Agent plans, route risky batches through the existing approval channel, and execute safe batches inline
- return compact ordered partial results to the parent turn and add conversation-scoped `get_delegated_result` lookup for full persisted output
- run independent branches concurrently with `max_parallel=2`, attach direct dependency results at fan-in, block only failed descendants, and serialize shared-workspace mutation tasks
- validate nested task output contracts and preserve usage/provenance when output validation fails
- register equivalent `wisp_delegate_tasks` and `wisp_get_delegated_result` MCP bridge tools behind the same conversation opt-in
- update the parent prompt to decompose and synthesize in the same turn; keep `propose_delegation` only as a legacy draft compatibility path
- rewrite the delegation guide around temporary Native Agents and make ACP/Codex explicitly optional

## Tests

- fake parent model calls `delegate_tasks`, receives two child results as a tool message, and produces a final synthesis
- independent child overlap and fan-in dependency input
- approval denial with feedback and zero child starts
- partial failure with independent success and descendant blocking
- valid and invalid task output schemas plus full-result lookup
- delegation-off invocation and MCP listing/dispatch gates
- shared mutation lane and recursive JSON-contract validation

Validation completed:

- `cargo fmt --all -- --check`
- `cargo test --workspace` (including 290 Tauri tests and 52 core tests)
- `cd ui && cargo check --target wasm32-unknown-unknown`
- `cd ui-tests && npm ci && npx playwright test` (169 passed)

## Manual smoke

1. Enable Delegation for a conversation.
2. Ask the main Agent to compare two project files with independent temporary Agents.
3. Verify two child steps overlap and the final chat response includes one synthesized comparison.
4. Request a write-capable task, deny the exact plan, and verify no child starts and the feedback returns to the parent.

## Known limitations / follow-ups

- dynamic policy selects Native execution in this milestone; generic ACP/external executor profiles follow in later stacked PRs
- inline work is foreground-only; background delivery follows later
- writable tasks share one serialized mutation lane; isolated worktrees and patch merge follow later
- nested delegation remains disabled until explicit depth, breadth, and aggregate-budget limits exist
- the fixed-template Agents panel remains for v1 workflow compatibility and will be retired after dynamic UI parity