### PR TITLE
feat(tauri): edit dynamic agent workflows

### DIFF
--- a/docs/agent-delegation.md
+++ b/docs/agent-delegation.md
@@ -57,6 +57,11 @@ requires approval is denied instead of silently escalating.
 - Wisp persists the resolved v2 plan before execution. Stored steps contain the
   immutable Specialist, capability revisions, permissions, model, executor,
   contracts, budgets, and policy integrity hash used for revalidation.
+- Before approval, a v2 draft exposes both its editable proposal and the
+  resolved authority that will actually run. Each edit checks the draft's
+  version, reruns dependency and policy resolution, and replaces the plan
+  atomically. Approval makes the snapshot immutable; run and retry reuse that
+  exact snapshot instead of asking a planner to recreate it.
 - Read-only tasks may share the project workspace. Until isolated workspaces
   are implemented, all writable or executable tasks use one mutation lane and
   cannot edit the same checkout concurrently. An isolation request is rejected

--- a/src-tauri/src/delegation_runtime.rs
+++ b/src-tauri/src/delegation_runtime.rs
@@ -1,4 +1,4 @@
-use crate::{acp, build_provider_config, load_settings, models, ActiveProject};
+use crate::{acp, build_provider_config, dynamic_workflow, load_settings, models, ActiveProject};
 use async_trait::async_trait;
 use serde_json::{json, Map, Value};
 use std::{
@@ -45,6 +45,10 @@ pub(crate) struct AgentWorkflowSnapshot {
     pub(crate) steps: Vec<AgentWorkflowStep>,
     pub(crate) attempts: Vec<AgentWorkflowAttempt>,
     delegation_enabled: bool,
+    pub(crate) plan_schema_version: u32,
+    pub(crate) approval_policy: dynamic_workflow::AgentApprovalPolicy,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) dynamic: Option<dynamic_workflow::DynamicAgentWorkflowSummary>,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -265,6 +269,30 @@ pub(crate) async fn persist_dynamic_agent_workflow(
     registry: &CapabilityRegistry,
     host: &DelegationHostPolicy,
 ) -> Result<AgentWorkflowSnapshot, String> {
+    persist_resolved_dynamic_workflow(
+        store,
+        project_id,
+        project_root,
+        frame_id,
+        plan,
+        registry,
+        host,
+        "Inline dynamic Agent batch",
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn persist_resolved_dynamic_workflow(
+    store: &Store,
+    project_id: &str,
+    project_root: &std::path::Path,
+    frame_id: String,
+    plan: &DelegationPlan,
+    registry: &CapabilityRegistry,
+    host: &DelegationHostPolicy,
+    description: &str,
+) -> Result<AgentWorkflowSnapshot, String> {
     require_session_delegation(store, project_id, &frame_id).await?;
     if plan.schema_version != DYNAMIC_DELEGATION_SCHEMA_VERSION {
         return Err("Inline delegation requires a v2 Agent plan.".into());
@@ -273,12 +301,234 @@ pub(crate) async fn persist_dynamic_agent_workflow(
         .validate_resolved_plan(plan, host)
         .map_err(|error| error.to_string())?;
     let (mut workflow, steps) = workflow_records(plan, project_id, project_root, Some(frame_id))?;
-    workflow.description = "Inline dynamic Agent batch".into();
+    workflow.description = description.into();
     store
         .create_agent_workflow_plan(&workflow, &steps)
         .await
         .map_err(|error| error.to_string())?;
     load_workflow_snapshot(store, workflow).await
+}
+
+pub(crate) async fn create_dynamic_agent_workflow_draft(
+    store: &Store,
+    project_id: &str,
+    project_root: &std::path::Path,
+    frame_id: String,
+    proposal: dynamic_workflow::DynamicAgentWorkflowProposal,
+    policy: &(CapabilityRegistry, DelegationHostPolicy),
+) -> Result<AgentWorkflowSnapshot, String> {
+    require_session_delegation(store, project_id, &frame_id).await?;
+    let workflow_id = uuid::Uuid::new_v4().to_string();
+    let plan =
+        dynamic_workflow::resolve_proposal(store, workflow_id, proposal, &policy.0, &policy.1)
+            .await?;
+    persist_resolved_dynamic_workflow(
+        store,
+        project_id,
+        project_root,
+        frame_id,
+        &plan,
+        &policy.0,
+        &policy.1,
+        "Dynamic Agent workflow",
+    )
+    .await
+}
+
+#[tauri::command]
+pub(crate) async fn create_dynamic_agent_workflow(
+    state: State<'_, crate::AppState>,
+    window: tauri::WebviewWindow,
+    proposal: dynamic_workflow::DynamicAgentWorkflowProposal,
+) -> Result<AgentWorkflowSnapshot, dynamic_workflow::DynamicWorkflowCommandError> {
+    let project = state.active(window.label());
+    let frame_id = state.active_frame(window.label()).ok_or_else(|| {
+        dynamic_workflow::DynamicWorkflowCommandError::new(
+            "conversation_required",
+            "Open a conversation before creating an Agent workflow.",
+        )
+    })?;
+    let auto_safe = proposal.approval_policy == dynamic_workflow::AgentApprovalPolicy::AutoSafe;
+    let policy = dynamic_delegation_policy(&state.store)
+        .await
+        .map_err(|error| {
+            dynamic_workflow::DynamicWorkflowCommandError::new("policy_unavailable", error)
+        })?;
+    let mut snapshot = create_dynamic_agent_workflow_draft(
+        &state.store,
+        &project.id,
+        &project.root,
+        frame_id,
+        proposal,
+        &policy,
+    )
+    .await
+    .map_err(|error| {
+        dynamic_workflow::DynamicWorkflowCommandError::new("invalid_proposal", error)
+    })?;
+    if auto_safe && !snapshot.workflow.requires_confirmation {
+        snapshot = approve_created_automatic_workflow(&state.store, snapshot)
+            .await
+            .map_err(|error| {
+                dynamic_workflow::DynamicWorkflowCommandError::new("approval_failed", error)
+            })?;
+        spawn_agent_workflow(&state, project, snapshot.workflow.id.clone()).map_err(|error| {
+            dynamic_workflow::DynamicWorkflowCommandError::new("execution_failed", error)
+        })?;
+    }
+    Ok(snapshot)
+}
+
+pub(crate) async fn revise_dynamic_agent_workflow_draft(
+    store: &Store,
+    project_id: &str,
+    project_root: &std::path::Path,
+    workflow_id: &str,
+    proposal: dynamic_workflow::DynamicAgentWorkflowProposal,
+    expected_version: i64,
+    policy: &(CapabilityRegistry, DelegationHostPolicy),
+) -> Result<AgentWorkflowSnapshot, dynamic_workflow::DynamicWorkflowCommandError> {
+    let current = project_workflow(store, project_id, workflow_id)
+        .await
+        .map_err(|error| dynamic_workflow::DynamicWorkflowCommandError::new("not_found", error))?;
+    require_workflow_delegation(store, &current)
+        .await
+        .map_err(|error| {
+            dynamic_workflow::DynamicWorkflowCommandError::new("delegation_disabled", error)
+        })?;
+    if current.status != AgentWorkflowStatus::Draft {
+        return Err(dynamic_workflow::DynamicWorkflowCommandError::new(
+            "immutable_plan",
+            "Only draft Agent plans can be revised.",
+        ));
+    }
+    let current_plan =
+        serde_json::from_str::<DelegationPlan>(&current.plan_json).map_err(|error| {
+            dynamic_workflow::DynamicWorkflowCommandError::new(
+                "invalid_stored_plan",
+                format!("Agent workflow plan is invalid: {error}"),
+            )
+        })?;
+    if current_plan.schema_version != DYNAMIC_DELEGATION_SCHEMA_VERSION {
+        return Err(dynamic_workflow::DynamicWorkflowCommandError::new(
+            "legacy_plan",
+            "Use the legacy workflow editor for a v1 Agent plan.",
+        ));
+    }
+    if current.version != expected_version {
+        return Err(dynamic_workflow::DynamicWorkflowCommandError::conflict(
+            workflow_id,
+            expected_version,
+            current.version,
+        ));
+    }
+    let plan = dynamic_workflow::resolve_proposal(
+        store,
+        workflow_id.into(),
+        proposal,
+        &policy.0,
+        &policy.1,
+    )
+    .await
+    .map_err(|error| {
+        dynamic_workflow::DynamicWorkflowCommandError::new("invalid_proposal", error)
+    })?;
+    policy
+        .0
+        .validate_resolved_plan(&plan, &policy.1)
+        .map_err(|error| {
+            dynamic_workflow::DynamicWorkflowCommandError::new(
+                "authorization_failed",
+                error.to_string(),
+            )
+        })?;
+    let (mut workflow, steps) =
+        workflow_records(&plan, project_id, project_root, current.frame_id.clone()).map_err(
+            |error| dynamic_workflow::DynamicWorkflowCommandError::new("invalid_plan", error),
+        )?;
+    workflow.description = "Dynamic Agent workflow".into();
+    workflow.created_at = current.created_at;
+    workflow.version = current.version;
+    if !store
+        .replace_agent_workflow_plan(&workflow, &steps, expected_version)
+        .await
+        .map_err(|error| {
+            dynamic_workflow::DynamicWorkflowCommandError::new(
+                "persistence_failed",
+                error.to_string(),
+            )
+        })?
+    {
+        let actual_version = store
+            .get_agent_workflow(workflow_id)
+            .await
+            .ok()
+            .flatten()
+            .map_or(-1, |workflow| workflow.version);
+        return Err(dynamic_workflow::DynamicWorkflowCommandError::conflict(
+            workflow_id,
+            expected_version,
+            actual_version,
+        ));
+    }
+    let updated = store
+        .get_agent_workflow(workflow_id)
+        .await
+        .map_err(|error| {
+            dynamic_workflow::DynamicWorkflowCommandError::new(
+                "persistence_failed",
+                error.to_string(),
+            )
+        })?
+        .ok_or_else(|| {
+            dynamic_workflow::DynamicWorkflowCommandError::new(
+                "not_found",
+                "Agent workflow disappeared after revision.",
+            )
+        })?;
+    load_workflow_snapshot(store, updated)
+        .await
+        .map_err(|error| {
+            dynamic_workflow::DynamicWorkflowCommandError::new("snapshot_failed", error)
+        })
+}
+
+#[tauri::command]
+pub(crate) async fn revise_dynamic_agent_workflow(
+    state: State<'_, crate::AppState>,
+    window: tauri::WebviewWindow,
+    workflow_id: String,
+    proposal: dynamic_workflow::DynamicAgentWorkflowProposal,
+    expected_version: i64,
+) -> Result<AgentWorkflowSnapshot, dynamic_workflow::DynamicWorkflowCommandError> {
+    let project = state.active(window.label());
+    let auto_safe = proposal.approval_policy == dynamic_workflow::AgentApprovalPolicy::AutoSafe;
+    let policy = dynamic_delegation_policy(&state.store)
+        .await
+        .map_err(|error| {
+            dynamic_workflow::DynamicWorkflowCommandError::new("policy_unavailable", error)
+        })?;
+    let mut snapshot = revise_dynamic_agent_workflow_draft(
+        &state.store,
+        &project.id,
+        &project.root,
+        &workflow_id,
+        proposal,
+        expected_version,
+        &policy,
+    )
+    .await?;
+    if auto_safe && !snapshot.workflow.requires_confirmation {
+        snapshot = approve_created_automatic_workflow(&state.store, snapshot)
+            .await
+            .map_err(|error| {
+                dynamic_workflow::DynamicWorkflowCommandError::new("approval_failed", error)
+            })?;
+        spawn_agent_workflow(&state, project, workflow_id).map_err(|error| {
+            dynamic_workflow::DynamicWorkflowCommandError::new("execution_failed", error)
+        })?;
+    }
+    Ok(snapshot)
 }
 
 #[tauri::command]
@@ -632,11 +882,24 @@ async fn load_workflow_snapshot(
         .list_agent_workflow_attempts(&workflow.id)
         .await
         .map_err(|error| error.to_string())?;
+    let parsed_plan = serde_json::from_str::<DelegationPlan>(&workflow.plan_json).ok();
+    let plan_schema_version = parsed_plan.as_ref().map_or(1, |plan| plan.schema_version);
+    let approval_policy = parsed_plan.as_ref().map_or_else(
+        || dynamic_workflow::AgentApprovalPolicy::from_workflow_mode(&workflow.mode),
+        |plan| dynamic_workflow::AgentApprovalPolicy::from_mode(plan.mode),
+    );
+    let dynamic = parsed_plan
+        .as_ref()
+        .filter(|plan| plan.schema_version == DYNAMIC_DELEGATION_SCHEMA_VERSION)
+        .and_then(|plan| dynamic_workflow::summarize(plan, &attempts).ok());
     Ok(AgentWorkflowSnapshot {
         workflow,
         steps,
         attempts,
         delegation_enabled,
+        plan_schema_version,
+        approval_policy,
+        dynamic,
     })
 }
 
@@ -737,18 +1000,30 @@ pub(crate) async fn retry_agent_workflow(
     workflow_id: String,
 ) -> Result<AgentWorkflowSnapshot, String> {
     let project = state.active(window.label());
-    let workflow = project_workflow(&state.store, &project.id, &workflow_id).await?;
-    require_workflow_delegation(&state.store, &workflow).await?;
+    let snapshot = prepare_agent_workflow_retry(&state.store, &project.id, &workflow_id).await?;
+    let automatic = snapshot.workflow.mode == "automatic";
+    if automatic {
+        spawn_agent_workflow(&state, project, workflow_id)?;
+    }
+    Ok(snapshot)
+}
+
+pub(crate) async fn prepare_agent_workflow_retry(
+    store: &Store,
+    project_id: &str,
+    workflow_id: &str,
+) -> Result<AgentWorkflowSnapshot, String> {
+    let workflow = project_workflow(store, project_id, workflow_id).await?;
+    require_workflow_delegation(store, &workflow).await?;
     if !matches!(
         workflow.status,
         AgentWorkflowStatus::Failed | AgentWorkflowStatus::Cancelled
     ) {
         return Err("Only a failed or cancelled Agent workflow can be retried.".into());
     }
-    if !state
-        .store
+    if !store
         .transition_agent_workflow_status(
-            &workflow_id,
+            workflow_id,
             workflow.status,
             AgentWorkflowStatus::Approved,
         )
@@ -757,13 +1032,8 @@ pub(crate) async fn retry_agent_workflow(
     {
         return Err("Agent workflow changed in another window; refresh and try again.".into());
     }
-    let updated = project_workflow(&state.store, &project.id, &workflow_id).await?;
-    let automatic = updated.mode == "automatic";
-    let snapshot = load_workflow_snapshot(&state.store, updated).await?;
-    if automatic {
-        spawn_agent_workflow(&state, project, workflow_id)?;
-    }
-    Ok(snapshot)
+    let updated = project_workflow(store, project_id, workflow_id).await?;
+    load_workflow_snapshot(store, updated).await
 }
 
 #[tauri::command]
@@ -967,7 +1237,7 @@ pub(crate) async fn execute_agent_workflow_with_delegator(
     dynamic_policy: Option<(CapabilityRegistry, DelegationHostPolicy)>,
 ) -> Result<DelegationExecutionResult, String> {
     let workflow = store
-        .get_agent_workflow(&workflow_id)
+        .get_agent_workflow(workflow_id)
         .await
         .map_err(|error| error.to_string())?
         .ok_or_else(|| "Agent workflow does not exist".to_string())?;
@@ -2601,10 +2871,140 @@ fn bounded_json(value: &Value, limit: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::dynamic_workflow::{
+        AgentApprovalPolicy, AgentExecutorSelection, DynamicAgentTaskProposal,
+        DynamicAgentWorkflowProposal,
+    };
+    use std::sync::atomic::AtomicUsize;
     use wisp_core::{
-        AgentTemplateRegistry, DelegationMode, DelegationPlanner, ValidatedAgentDelegationRequest,
+        AgentSpec, AgentTemplateRegistry, DelegationMode, DelegationPlanner,
+        ValidatedAgentDelegationRequest,
     };
     use wisp_store::{AgentWorkflow, AgentWorkflowStep};
+
+    async fn dynamic_fixture() -> (Store, std::path::PathBuf) {
+        let root =
+            std::env::temp_dir().join(format!("wisp_dynamic_workflow_{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&root).unwrap();
+        let store = Store::open(&root.join("store.sqlite")).await.unwrap();
+        store
+            .create_project("p", "Project", &root.to_string_lossy())
+            .await
+            .unwrap();
+        store
+            .create_frame("f", "p", "Agent", "local")
+            .await
+            .unwrap();
+        save_session_delegation_enabled(&store, "p", "f", true)
+            .await
+            .unwrap();
+        (store, root)
+    }
+
+    fn test_dynamic_policy() -> (CapabilityRegistry, DelegationHostPolicy) {
+        (
+            CapabilityRegistry::builtins(),
+            DelegationHostPolicy {
+                revision: "dynamic-command-test-v1".into(),
+                enabled_capabilities: vec![
+                    "reasoning".into(),
+                    "project_read".into(),
+                    "project_write".into(),
+                    "review".into(),
+                ],
+                models: vec![
+                    ModelProfilePolicy {
+                        id: "local".into(),
+                        features: vec![],
+                        external: false,
+                        enabled: true,
+                    },
+                    ModelProfilePolicy {
+                        id: "remote".into(),
+                        features: vec![],
+                        external: true,
+                        enabled: true,
+                    },
+                ],
+                executors: vec![
+                    ExecutorProfilePolicy {
+                        executor: AgentExecutorRef::Native,
+                        features: vec![
+                            ExecutorFeature::ProjectRead,
+                            ExecutorFeature::ProjectWrite,
+                            ExecutorFeature::CodeExecution,
+                        ],
+                        model_ids: vec!["local".into(), "remote".into()],
+                        enabled: true,
+                    },
+                    ExecutorProfilePolicy {
+                        executor: AgentExecutorRef::Acp {
+                            profile_id: "acp-test".into(),
+                        },
+                        features: vec![
+                            ExecutorFeature::ProjectRead,
+                            ExecutorFeature::ProjectWrite,
+                            ExecutorFeature::CodeExecution,
+                        ],
+                        model_ids: vec!["local".into(), "remote".into()],
+                        enabled: true,
+                    },
+                ],
+                default_model_id: Some("local".into()),
+                permission_ceiling: PermissionSet {
+                    tools: vec![
+                        "read".into(),
+                        "search".into(),
+                        "grep".into(),
+                        "write".into(),
+                        "edit".into(),
+                    ],
+                    paths: vec!["project://**".into()],
+                    network: false,
+                    write: true,
+                    execute: true,
+                },
+                context_ceiling: ContextPolicy {
+                    include_history: false,
+                    include_artifacts: true,
+                    max_tokens: Some(32_000),
+                },
+                budget_ceiling: AgentBudget {
+                    max_tokens: Some(32_000),
+                    max_tool_calls: Some(64),
+                    max_cost_microunits: Some(1_000_000),
+                },
+                default_timeout_secs: Some(30),
+                timeout_ceiling_secs: Some(30),
+                auto_safe: true,
+                ..DelegationHostPolicy::default()
+            },
+        )
+    }
+
+    fn dynamic_task(id: &str, dependencies: &[&str]) -> DynamicAgentTaskProposal {
+        DynamicAgentTaskProposal {
+            id: id.into(),
+            instruction: format!("Complete task {id}"),
+            depends_on: dependencies.iter().map(|value| (*value).into()).collect(),
+            capabilities: vec!["reasoning".into()],
+            specialist_id: None,
+            output_schema: None,
+            isolated: false,
+            model_id: None,
+            executor: None,
+            budget: None,
+        }
+    }
+
+    fn dynamic_proposal(tasks: Vec<DynamicAgentTaskProposal>) -> DynamicAgentWorkflowProposal {
+        DynamicAgentWorkflowProposal {
+            goal: "Complete a dynamic workflow".into(),
+            context: "Shared test context".into(),
+            approval_policy: AgentApprovalPolicy::ReviewAll,
+            tasks,
+        }
+    }
 
     #[test]
     fn structured_result_parser_rejects_prose_and_incomplete_results() {
@@ -2758,6 +3158,402 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn dynamic_draft_revision_is_atomic_and_revalidates_dependencies() {
+        let (store, root) = dynamic_fixture().await;
+        let policy = test_dynamic_policy();
+        let created = create_dynamic_agent_workflow_draft(
+            &store,
+            "p",
+            &root,
+            "f".into(),
+            dynamic_proposal(vec![
+                dynamic_task("first", &[]),
+                dynamic_task("second", &["first"]),
+            ]),
+            &policy,
+        )
+        .await
+        .unwrap();
+        assert_eq!(created.workflow.version, 1);
+        assert_eq!(
+            created.plan_schema_version,
+            DYNAMIC_DELEGATION_SCHEMA_VERSION
+        );
+        assert_eq!(created.approval_policy, AgentApprovalPolicy::ReviewAll);
+        let dynamic = created.dynamic.as_ref().unwrap();
+        assert_eq!(dynamic.tasks[1].depends_on, ["first"]);
+        assert_eq!(dynamic.approval_policy, AgentApprovalPolicy::ReviewAll);
+
+        let mut without_dependency = dynamic.editable_proposal.clone();
+        without_dependency.tasks[1].depends_on.clear();
+        let revised = revise_dynamic_agent_workflow_draft(
+            &store,
+            "p",
+            &root,
+            &created.workflow.id,
+            without_dependency,
+            1,
+            &policy,
+        )
+        .await
+        .unwrap();
+        assert_eq!(revised.workflow.version, 2);
+        assert!(revised.dynamic.as_ref().unwrap().tasks[1]
+            .depends_on
+            .is_empty());
+
+        let stale = revise_dynamic_agent_workflow_draft(
+            &store,
+            "p",
+            &root,
+            &created.workflow.id,
+            revised.dynamic.as_ref().unwrap().editable_proposal.clone(),
+            1,
+            &policy,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(stale.code, "version_conflict");
+        assert_eq!(
+            stale.version_conflict.unwrap(),
+            dynamic_workflow::AgentWorkflowVersionConflict {
+                workflow_id: created.workflow.id.clone(),
+                expected_version: 1,
+                actual_version: 2,
+            }
+        );
+
+        let mut cycle = revised.dynamic.unwrap().editable_proposal;
+        cycle.tasks[0].depends_on = vec!["second".into()];
+        cycle.tasks[1].depends_on = vec!["first".into()];
+        let rejected = revise_dynamic_agent_workflow_draft(
+            &store,
+            "p",
+            &root,
+            &created.workflow.id,
+            cycle,
+            2,
+            &policy,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(rejected.code, "invalid_proposal");
+        assert!(rejected.message.contains("cycle"));
+        assert_eq!(
+            store
+                .get_agent_workflow(&created.workflow.id)
+                .await
+                .unwrap()
+                .unwrap()
+                .version,
+            2
+        );
+
+        drop(store);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn dynamic_revision_recalculates_model_executor_and_capability_approval_reasons() {
+        let (store, root) = dynamic_fixture().await;
+        let policy = test_dynamic_policy();
+        let created = create_dynamic_agent_workflow_draft(
+            &store,
+            "p",
+            &root,
+            "f".into(),
+            dynamic_proposal(vec![dynamic_task("edit", &[])]),
+            &policy,
+        )
+        .await
+        .unwrap();
+        assert!(created
+            .dynamic
+            .as_ref()
+            .unwrap()
+            .approval_reasons
+            .is_empty());
+
+        let mut proposal = created.dynamic.as_ref().unwrap().editable_proposal.clone();
+        proposal.tasks[0].capabilities = vec!["project_write".into()];
+        proposal.tasks[0].model_id = Some("remote".into());
+        proposal.tasks[0].executor = Some(AgentExecutorSelection {
+            kind: "acp".into(),
+            profile_id: Some("acp-test".into()),
+        });
+        proposal.tasks[0].budget.as_mut().unwrap().max_tokens = Some(4_000);
+        let revised = revise_dynamic_agent_workflow_draft(
+            &store,
+            "p",
+            &root,
+            &created.workflow.id,
+            proposal,
+            created.workflow.version,
+            &policy,
+        )
+        .await
+        .unwrap();
+        let dynamic = revised.dynamic.unwrap();
+        let messages = dynamic
+            .approval_reasons
+            .iter()
+            .map(|reason| reason.message.as_str())
+            .collect::<Vec<_>>();
+        assert!(messages
+            .iter()
+            .any(|reason| reason.contains("modify project")));
+        assert!(messages.iter().any(|reason| reason.contains("external")));
+        assert!(messages
+            .iter()
+            .any(|reason| reason.contains("ACP executor")));
+        assert_eq!(dynamic.tasks[0].executor.kind, "acp");
+        assert_eq!(
+            dynamic.tasks[0].executor.model_id.as_deref(),
+            Some("remote")
+        );
+        assert!(dynamic.tasks[0].can_write);
+        assert_eq!(dynamic.tasks[0].budget.max_tokens, Some(4_000));
+
+        drop(store);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn approved_dynamic_plan_keeps_its_specialist_snapshot_immutable() {
+        let (store, root) = dynamic_fixture().await;
+        let policy = test_dynamic_policy();
+        let saved = crate::specialists::upsert(
+            &store,
+            crate::specialists::Specialist {
+                id: String::new(),
+                name: "Domain expert".into(),
+                icon: String::new(),
+                color: String::new(),
+                description: "test".into(),
+                instructions: "Original immutable instructions".into(),
+                model_id: String::new(),
+                review_backend: None,
+                skills: None,
+                connectors: None,
+                builtin: false,
+            },
+        )
+        .await
+        .unwrap();
+        let mut specialist = saved.into_iter().find(|item| !item.builtin).unwrap();
+        let specialist_id = specialist.id.clone();
+        let mut task = dynamic_task("expert", &[]);
+        task.specialist_id = Some(specialist_id.clone());
+        let created = create_dynamic_agent_workflow_draft(
+            &store,
+            "p",
+            &root,
+            "f".into(),
+            dynamic_proposal(vec![task]),
+            &policy,
+        )
+        .await
+        .unwrap();
+        let editable = created.dynamic.as_ref().unwrap().editable_proposal.clone();
+        assert!(store
+            .approve_agent_workflow_plan(&created.workflow.id, created.workflow.version)
+            .await
+            .unwrap());
+
+        specialist.instructions = "Changed after approval".into();
+        crate::specialists::upsert(&store, specialist)
+            .await
+            .unwrap();
+        let stored = store
+            .get_agent_workflow(&created.workflow.id)
+            .await
+            .unwrap()
+            .unwrap();
+        let plan: DelegationPlan = serde_json::from_str(&stored.plan_json).unwrap();
+        let AgentOrigin::Specialist(snapshot) = &plan.steps[0].spec.origin else {
+            panic!("expected Specialist snapshot");
+        };
+        assert_eq!(snapshot.id, specialist_id);
+        assert_eq!(snapshot.instructions, "Original immutable instructions");
+        let immutable = revise_dynamic_agent_workflow_draft(
+            &store,
+            "p",
+            &root,
+            &created.workflow.id,
+            editable,
+            stored.version,
+            &policy,
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(immutable.code, "immutable_plan");
+
+        drop(store);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    struct RetrySnapshotDelegator {
+        calls: AtomicUsize,
+        specs: StdMutex<Vec<AgentSpec>>,
+    }
+
+    #[async_trait]
+    impl AgentDelegator for RetrySnapshotDelegator {
+        async fn delegate_validated(
+            &self,
+            request: ValidatedAgentDelegationRequest,
+        ) -> anyhow::Result<AgentDelegationResponse> {
+            let request = request.into_request();
+            self.specs.lock().unwrap().push(request.spec);
+            let call = self.calls.fetch_add(1, Ordering::SeqCst);
+            if call == 0 {
+                return Ok(AgentDelegationResponse {
+                    request_id: request.request_id,
+                    status: DelegationStatus::Failed,
+                    output: json!({}),
+                    artifact_ids: vec![],
+                    artifacts: vec![],
+                    evidence: vec![],
+                    usage: AgentUsage::default(),
+                    agent_session_id: None,
+                    child_frame_id: Some("first-child".into()),
+                    error: Some("first attempt failed".into()),
+                });
+            }
+            Ok(AgentDelegationResponse {
+                request_id: request.request_id,
+                status: DelegationStatus::Succeeded,
+                output: json!({"summary": "retried without replanning"}),
+                artifact_ids: vec![],
+                artifacts: vec![],
+                evidence: vec![],
+                usage: AgentUsage::default(),
+                agent_session_id: None,
+                child_frame_id: Some("second-child".into()),
+                error: None,
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn retry_executes_the_same_approved_dynamic_snapshot() {
+        let (store, root) = dynamic_fixture().await;
+        let policy = test_dynamic_policy();
+        let created = create_dynamic_agent_workflow_draft(
+            &store,
+            "p",
+            &root,
+            "f".into(),
+            dynamic_proposal(vec![dynamic_task("retry", &[])]),
+            &policy,
+        )
+        .await
+        .unwrap();
+        assert!(store
+            .approve_agent_workflow_plan(&created.workflow.id, created.workflow.version)
+            .await
+            .unwrap());
+        let delegator = Arc::new(RetrySnapshotDelegator {
+            calls: AtomicUsize::new(0),
+            specs: StdMutex::new(vec![]),
+        });
+        let first = execute_agent_workflow_with_delegator(
+            &store,
+            "p",
+            &created.workflow.id,
+            delegator.clone(),
+            Some(policy.clone()),
+        )
+        .await
+        .unwrap();
+        assert_eq!(first.status, DelegationExecutionStatus::Failed);
+
+        let retried = prepare_agent_workflow_retry(&store, "p", &created.workflow.id)
+            .await
+            .unwrap();
+        assert_eq!(retried.workflow.status, AgentWorkflowStatus::Approved);
+        let second = execute_agent_workflow_with_delegator(
+            &store,
+            "p",
+            &created.workflow.id,
+            delegator.clone(),
+            Some(policy),
+        )
+        .await
+        .unwrap();
+        assert_eq!(second.status, DelegationExecutionStatus::Succeeded);
+        let specs = delegator.specs.lock().unwrap();
+        assert_eq!(specs.len(), 2);
+        assert_eq!(specs[0], specs[1]);
+
+        drop(specs);
+        drop(store);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn interrupted_v2_workflow_recovers_to_explicit_failed_state() {
+        let (store, root) = dynamic_fixture().await;
+        let policy = test_dynamic_policy();
+        let created = create_dynamic_agent_workflow_draft(
+            &store,
+            "p",
+            &root,
+            "f".into(),
+            dynamic_proposal(vec![dynamic_task("recover", &[])]),
+            &policy,
+        )
+        .await
+        .unwrap();
+        assert!(store
+            .approve_agent_workflow_plan(&created.workflow.id, created.workflow.version)
+            .await
+            .unwrap());
+        assert!(store
+            .transition_agent_workflow_status(
+                &created.workflow.id,
+                AgentWorkflowStatus::Approved,
+                AgentWorkflowStatus::Running,
+            )
+            .await
+            .unwrap());
+        let step = &created.steps[0];
+        let attempt = AgentWorkflowAttempt::queued(
+            uuid::Uuid::new_v4().to_string(),
+            &created.workflow.id,
+            &step.id,
+            1,
+            "interrupted-request",
+            &step.backend,
+            r#"{}"#,
+        )
+        .unwrap();
+        store.create_agent_workflow_attempt(&attempt).await.unwrap();
+
+        assert_eq!(
+            store.recover_interrupted_agent_workflows().await.unwrap(),
+            (1, 1)
+        );
+        let workflow = store
+            .get_agent_workflow(&created.workflow.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(workflow.status, AgentWorkflowStatus::Failed);
+        let snapshot = load_workflow_snapshot(&store, workflow).await.unwrap();
+        let result = snapshot.dynamic.unwrap().tasks[0].result.clone().unwrap();
+        assert_eq!(result.status, "failed");
+        assert!(result.error.unwrap().contains("stopped"));
+        assert_eq!(
+            store.recover_interrupted_agent_workflows().await.unwrap(),
+            (0, 0)
+        );
+
+        drop(store);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
     async fn low_risk_automatic_plan_is_approved_before_background_start() {
         let root =
             std::env::temp_dir().join(format!("wisp_automatic_plan_{}", uuid::Uuid::new_v4()));
@@ -2794,6 +3590,9 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(approved.workflow.status, AgentWorkflowStatus::Approved);
+        assert_eq!(approved.plan_schema_version, 1);
+        assert_eq!(approved.approval_policy, AgentApprovalPolicy::AutoSafe);
+        assert!(approved.dynamic.is_none());
         drop(store);
         let _ = std::fs::remove_dir_all(root);
     }

--- a/src-tauri/src/delegation_tool.rs
+++ b/src-tauri/src/delegation_tool.rs
@@ -1,25 +1,27 @@
 //! Parent-facing delegation tools. `delegate_tasks` resolves and runs a
 //! dynamic batch inline; `propose_delegation` remains for v1 UI compatibility.
 
-use crate::{delegation_runtime, run_context::RunManager, specialists, ActiveProject};
+use crate::{
+    delegation_runtime,
+    dynamic_workflow::{
+        self, AgentApprovalPolicy, DynamicAgentTaskProposal, DynamicAgentWorkflowProposal,
+        MAX_CONTEXT_CHARS, MAX_GOAL_CHARS, MAX_INSTRUCTION_CHARS,
+    },
+    run_context::RunManager,
+    specialists, ActiveProject,
+};
 use async_trait::async_trait;
 use serde::Deserialize;
 use serde_json::{json, Value};
 use std::{collections::HashMap, sync::Arc};
 use wisp_core::{
-    AgentDelegator, CapabilityRegistry, DelegatedTaskProposal, DelegationExecutionResult,
-    DelegationHostPolicy, DelegationMode, SpecialistSnapshot, MAX_AGENT_OUTPUT_SCHEMA_BYTES,
+    AgentDelegator, CapabilityRegistry, DelegationExecutionResult, DelegationHostPolicy,
     MAX_DELEGATION_TASKS,
 };
 use wisp_llm::ToolSchema;
 use wisp_store::Store;
 use wisp_tools::{ConfirmDecision, Tool, ToolEnv, ToolResult};
 
-const DEFAULT_INLINE_PARALLELISM: usize = 2;
-const MAX_MODEL_TASK_ID_BYTES: usize = 31;
-const MAX_GOAL_CHARS: usize = 2_000;
-const MAX_CONTEXT_CHARS: usize = 12_000;
-const MAX_INSTRUCTION_CHARS: usize = 8_000;
 const INLINE_DATA_BYTES: usize = 4_000;
 const INLINE_TEXT_CHARS: usize = 1_000;
 
@@ -261,74 +263,47 @@ impl DelegateTasksTool {
         .await?;
         let parsed: DelegateTasksArgs = serde_json::from_value(args.clone())
             .map_err(|error| format!("invalid task batch: {error}"))?;
-        validate_batch(&parsed)?;
         let workflow_id = uuid::Uuid::new_v4().to_string();
-        let mut display_ids = HashMap::with_capacity(parsed.tasks.len());
-        let mut proposals = Vec::with_capacity(parsed.tasks.len());
-        for task in parsed.tasks {
-            let stored_id = stored_task_id(&workflow_id, &task.id);
-            display_ids.insert(stored_id.clone(), task.id.clone());
-            let specialist = match task.specialist_id.as_deref() {
-                Some(id) => {
-                    let specialist = specialists::get(&self.store, id)
-                        .await
-                        .ok_or_else(|| format!("unknown Specialist: {id}"))?;
-                    if specialist.id == "reviewer"
-                        && (task.capabilities.iter().any(|capability| {
-                            !matches!(capability.as_str(), "reasoning" | "project_read" | "review")
-                        }) || !task
-                            .capabilities
-                            .iter()
-                            .any(|capability| capability == "review"))
-                    {
-                        return Err(
-                            "the built-in Reviewer requires the review capability and cannot receive write or execute capabilities"
-                                .into(),
-                        );
-                    }
-                    Some(SpecialistSnapshot {
-                        id: specialist.id,
-                        name: specialist.name,
-                        instructions: specialist.instructions,
-                        model_id: (!specialist.model_id.trim().is_empty())
-                            .then_some(specialist.model_id),
-                        skills: specialist.skills,
-                        connectors: specialist.connectors,
-                    })
-                }
-                None => None,
-            };
-            proposals.push(DelegatedTaskProposal {
-                id: stored_id,
-                instruction: task.instruction.trim().to_string(),
-                context_summary: parsed.context.trim().to_string(),
-                depends_on: task
-                    .depends_on
-                    .iter()
-                    .map(|dependency| stored_task_id(&workflow_id, dependency))
-                    .collect(),
-                capabilities: task.capabilities,
-                specialist,
-                output_schema: task.output_schema,
-                isolated: task.isolated,
-                model_id: None,
-                executor: None,
-                budget: None,
-                input: json!({"task_id": task.id}),
-            });
-        }
         let (registry, host) = self.policy().await?;
-        let plan = registry
-            .resolve_plan_with_id(
-                workflow_id.clone(),
-                parsed.goal.trim().to_string(),
-                DelegationMode::Automatic,
-                DEFAULT_INLINE_PARALLELISM,
-                proposals,
-                &host,
-            )
-            .map_err(|error| error.to_string())?
-            .into_plan();
+        let proposal = DynamicAgentWorkflowProposal {
+            goal: parsed.goal,
+            context: parsed.context,
+            approval_policy: AgentApprovalPolicy::AutoSafe,
+            tasks: parsed
+                .tasks
+                .into_iter()
+                .map(|task| DynamicAgentTaskProposal {
+                    id: task.id,
+                    instruction: task.instruction,
+                    depends_on: task.depends_on,
+                    capabilities: task.capabilities,
+                    specialist_id: task.specialist_id,
+                    output_schema: task.output_schema,
+                    isolated: task.isolated,
+                    model_id: None,
+                    executor: None,
+                    budget: None,
+                })
+                .collect(),
+        };
+        let plan = dynamic_workflow::resolve_proposal(
+            &self.store,
+            workflow_id.clone(),
+            proposal,
+            &registry,
+            &host,
+        )
+        .await?;
+        let display_ids = plan
+            .steps
+            .iter()
+            .filter_map(|step| {
+                step.input
+                    .get("task_id")
+                    .and_then(Value::as_str)
+                    .map(|id| (step.id.clone(), id.to_string()))
+            })
+            .collect::<HashMap<_, _>>();
         let snapshot = delegation_runtime::persist_dynamic_agent_workflow(
             &self.store,
             &self.project.id,
@@ -384,109 +359,6 @@ impl DelegateTasksTool {
         };
         Ok(compact_execution_result(&execution, &display_ids))
     }
-}
-
-fn validate_batch(args: &DelegateTasksArgs) -> Result<(), String> {
-    let goal = args.goal.trim();
-    if goal.is_empty() || goal.chars().count() > MAX_GOAL_CHARS {
-        return Err(format!(
-            "goal must contain 1 to {MAX_GOAL_CHARS} characters"
-        ));
-    }
-    if args.context.chars().count() > MAX_CONTEXT_CHARS {
-        return Err(format!(
-            "shared context cannot exceed {MAX_CONTEXT_CHARS} characters"
-        ));
-    }
-    if args.tasks.is_empty() || args.tasks.len() > MAX_DELEGATION_TASKS {
-        return Err(format!(
-            "a batch requires 1 to {MAX_DELEGATION_TASKS} tasks"
-        ));
-    }
-    let mut ids = std::collections::HashSet::new();
-    for task in &args.tasks {
-        if !valid_model_task_id(&task.id) {
-            return Err(format!(
-                "invalid task id '{}'; use a lowercase letter followed by at most 30 lowercase letters, digits, '_' or '-'",
-                task.id
-            ));
-        }
-        if !ids.insert(task.id.as_str()) {
-            return Err(format!("duplicate task id: {}", task.id));
-        }
-        let instruction = task.instruction.trim();
-        if instruction.is_empty() || instruction.chars().count() > MAX_INSTRUCTION_CHARS {
-            return Err(format!(
-                "task {} instruction must contain 1 to {MAX_INSTRUCTION_CHARS} characters",
-                task.id
-            ));
-        }
-        if task.capabilities.is_empty() {
-            return Err(format!("task {} requires at least one capability", task.id));
-        }
-        if task.output_schema.as_ref().is_some_and(|schema| {
-            !schema.is_object()
-                || serde_json::to_vec(schema)
-                    .is_ok_and(|bytes| bytes.len() > MAX_AGENT_OUTPUT_SCHEMA_BYTES)
-        }) {
-            return Err(format!(
-                "task {} output_schema must be an object no larger than {MAX_AGENT_OUTPUT_SCHEMA_BYTES} bytes",
-                task.id
-            ));
-        }
-    }
-    for task in &args.tasks {
-        let mut dependencies = std::collections::HashSet::new();
-        for dependency in &task.depends_on {
-            if !dependencies.insert(dependency.as_str()) {
-                return Err(format!(
-                    "task {} contains duplicate dependency {dependency}",
-                    task.id
-                ));
-            }
-            if dependency == &task.id {
-                return Err(format!("task {} cannot depend on itself", task.id));
-            }
-            if !ids.contains(dependency.as_str()) {
-                return Err(format!(
-                    "task {} depends on unknown task {dependency}",
-                    task.id
-                ));
-            }
-        }
-    }
-    let mut completed = std::collections::HashSet::new();
-    while completed.len() < args.tasks.len() {
-        let before = completed.len();
-        for task in &args.tasks {
-            if !completed.contains(task.id.as_str())
-                && task
-                    .depends_on
-                    .iter()
-                    .all(|dependency| completed.contains(dependency.as_str()))
-            {
-                completed.insert(task.id.as_str());
-            }
-        }
-        if completed.len() == before {
-            return Err("task dependencies contain a cycle".into());
-        }
-    }
-    Ok(())
-}
-
-fn valid_model_task_id(value: &str) -> bool {
-    let bytes = value.as_bytes();
-    !bytes.is_empty()
-        && bytes.len() <= MAX_MODEL_TASK_ID_BYTES
-        && bytes[0].is_ascii_lowercase()
-        && bytes.iter().all(|byte| {
-            byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'_' | b'-')
-        })
-}
-
-fn stored_task_id(workflow_id: &str, task_id: &str) -> String {
-    format!("{workflow_id}:{task_id}")
 }
 
 fn approval_prompt(
@@ -1212,34 +1084,6 @@ mod tests {
     }
 
     #[test]
-    fn batch_validation_rejects_unknown_duplicate_and_cyclic_dependencies() {
-        let parse = |tasks: Value| DelegateTasksArgs {
-            goal: "test dependencies".into(),
-            context: String::new(),
-            tasks: serde_json::from_value(tasks).unwrap(),
-        };
-        let task = |id: &str, dependencies: &[&str]| {
-            json!({
-                "id": id,
-                "instruction": format!("Run {id}"),
-                "depends_on": dependencies,
-                "capabilities": ["reasoning"]
-            })
-        };
-
-        let unknown = parse(json!([task("a", &["missing"])]));
-        assert!(validate_batch(&unknown)
-            .unwrap_err()
-            .contains("unknown task"));
-        let duplicate = parse(json!([task("a", &[]), task("b", &["a", "a"])]));
-        assert!(validate_batch(&duplicate)
-            .unwrap_err()
-            .contains("duplicate dependency"));
-        let cycle = parse(json!([task("a", &["b"]), task("b", &["a"])]));
-        assert!(validate_batch(&cycle).unwrap_err().contains("cycle"));
-    }
-
-    #[test]
     fn compact_preview_respects_utf8_byte_limit() {
         let compact = compact_value(&json!({"text": "界界界界界界"}), 10, "workflow", "task");
         let preview = compact["preview"].as_str().unwrap();
@@ -1421,15 +1265,16 @@ mod tests {
         assert_eq!(value["feedback"], "keep this read-only");
         assert!(value["results"].as_array().unwrap().is_empty());
         assert!(delegator.calls().is_empty());
-        let prompts = env.prompts.lock().unwrap();
-        assert_eq!(prompts.len(), 1);
-        assert!(prompts[0].contains(wisp_tools::plan::PLAN_APPROVAL_PREFIX));
-        assert!(prompts[0].contains("project_write"));
-        assert!(prompts[0].contains("native"));
+        {
+            let prompts = env.prompts.lock().unwrap();
+            assert_eq!(prompts.len(), 1);
+            assert!(prompts[0].contains(wisp_tools::plan::PLAN_APPROVAL_PREFIX));
+            assert!(prompts[0].contains("project_write"));
+            assert!(prompts[0].contains("native"));
+        }
         let workflow = store.list_agent_workflows("p").await.unwrap().remove(0);
         assert_eq!(workflow.status, wisp_store::AgentWorkflowStatus::Draft);
 
-        drop(prompts);
         drop(store);
         let _ = std::fs::remove_dir_all(root);
     }

--- a/src-tauri/src/dynamic_workflow.rs
+++ b/src-tauri/src/dynamic_workflow.rs
@@ -1,0 +1,708 @@
+//! Stable proposal and inspection DTOs for v2 dynamic Agent workflows.
+//!
+//! Both model-authored inline batches and UI-authored drafts resolve through
+//! this module. Callers submit capability IDs and optional policy choices;
+//! only the host resolver can produce executable permissions.
+
+use crate::specialists;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::collections::{HashMap, HashSet};
+use wisp_core::{
+    AgentBudget, AgentExecutorRef, AgentOrigin, AgentOutputSchemaSource, AgentWorkspacePolicy,
+    CapabilityRegistry, DelegatedTaskProposal, DelegationHostPolicy, DelegationMode,
+    DelegationPlan, SpecialistSnapshot, MAX_AGENT_OUTPUT_SCHEMA_BYTES, MAX_DELEGATION_TASKS,
+};
+use wisp_store::{AgentWorkflowAttempt, Store};
+
+pub(crate) const DEFAULT_DYNAMIC_PARALLELISM: usize = 2;
+const MAX_TASK_ID_BYTES: usize = 31;
+pub(crate) const MAX_GOAL_CHARS: usize = 2_000;
+pub(crate) const MAX_CONTEXT_CHARS: usize = 12_000;
+pub(crate) const MAX_INSTRUCTION_CHARS: usize = 8_000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum AgentApprovalPolicy {
+    ReviewAll,
+    AutoSafe,
+}
+
+impl AgentApprovalPolicy {
+    pub(crate) fn from_mode(mode: DelegationMode) -> Self {
+        match mode {
+            DelegationMode::Automatic => Self::AutoSafe,
+            DelegationMode::Manual | DelegationMode::Assisted => Self::ReviewAll,
+        }
+    }
+
+    fn mode(self) -> DelegationMode {
+        match self {
+            Self::ReviewAll => DelegationMode::Manual,
+            Self::AutoSafe => DelegationMode::Automatic,
+        }
+    }
+
+    pub(crate) fn from_workflow_mode(mode: &str) -> Self {
+        if mode == "automatic" {
+            Self::AutoSafe
+        } else {
+            Self::ReviewAll
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct AgentExecutorSelection {
+    pub(crate) kind: String,
+    #[serde(default)]
+    pub(crate) profile_id: Option<String>,
+}
+
+impl AgentExecutorSelection {
+    fn into_ref(self) -> Result<AgentExecutorRef, String> {
+        let profile_id = || {
+            self.profile_id
+                .clone()
+                .filter(|value| !value.trim().is_empty())
+                .ok_or_else(|| format!("{} executor requires profile_id", self.kind))
+        };
+        match self.kind.as_str() {
+            "native" if self.profile_id.is_none() => Ok(AgentExecutorRef::Native),
+            "native" => Err("native executor cannot include profile_id".into()),
+            "acp" => Ok(AgentExecutorRef::Acp {
+                profile_id: profile_id()?,
+            }),
+            "external" => Ok(AgentExecutorRef::External {
+                profile_id: profile_id()?,
+            }),
+            _ => Err(format!("unknown executor kind: {}", self.kind)),
+        }
+    }
+
+    fn from_ref(executor: &AgentExecutorRef) -> Self {
+        match executor {
+            AgentExecutorRef::Native => Self {
+                kind: "native".into(),
+                profile_id: None,
+            },
+            AgentExecutorRef::Acp { profile_id } => Self {
+                kind: "acp".into(),
+                profile_id: Some(profile_id.clone()),
+            },
+            AgentExecutorRef::External { profile_id } => Self {
+                kind: "external".into(),
+                profile_id: Some(profile_id.clone()),
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct AgentBudgetProposal {
+    #[serde(default)]
+    pub(crate) max_tokens: Option<u32>,
+    #[serde(default)]
+    pub(crate) max_tool_calls: Option<u32>,
+    #[serde(default)]
+    pub(crate) max_cost_microunits: Option<u64>,
+}
+
+impl From<AgentBudgetProposal> for AgentBudget {
+    fn from(value: AgentBudgetProposal) -> Self {
+        Self {
+            max_tokens: value.max_tokens,
+            max_tool_calls: value.max_tool_calls,
+            max_cost_microunits: value.max_cost_microunits,
+        }
+    }
+}
+
+impl From<&AgentBudget> for AgentBudgetProposal {
+    fn from(value: &AgentBudget) -> Self {
+        Self {
+            max_tokens: value.max_tokens,
+            max_tool_calls: value.max_tool_calls,
+            max_cost_microunits: value.max_cost_microunits,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct DynamicAgentTaskProposal {
+    pub(crate) id: String,
+    pub(crate) instruction: String,
+    #[serde(default)]
+    pub(crate) depends_on: Vec<String>,
+    pub(crate) capabilities: Vec<String>,
+    #[serde(default)]
+    pub(crate) specialist_id: Option<String>,
+    #[serde(default)]
+    pub(crate) output_schema: Option<Value>,
+    #[serde(default)]
+    pub(crate) isolated: bool,
+    #[serde(default)]
+    pub(crate) model_id: Option<String>,
+    #[serde(default)]
+    pub(crate) executor: Option<AgentExecutorSelection>,
+    #[serde(default)]
+    pub(crate) budget: Option<AgentBudgetProposal>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct DynamicAgentWorkflowProposal {
+    pub(crate) goal: String,
+    #[serde(default)]
+    pub(crate) context: String,
+    pub(crate) approval_policy: AgentApprovalPolicy,
+    pub(crate) tasks: Vec<DynamicAgentTaskProposal>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct AgentExecutorSummary {
+    pub(crate) kind: String,
+    pub(crate) profile_id: Option<String>,
+    pub(crate) model_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct AgentApprovalReasonSummary {
+    pub(crate) task_id: String,
+    pub(crate) message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct AgentResultSummary {
+    pub(crate) status: String,
+    pub(crate) summary: Option<String>,
+    pub(crate) error: Option<String>,
+    pub(crate) child_frame_id: Option<String>,
+    pub(crate) input_tokens: i64,
+    pub(crate) output_tokens: i64,
+    pub(crate) tool_calls: i64,
+    pub(crate) cost_microunits: i64,
+    pub(crate) duration_secs: Option<i64>,
+    pub(crate) full_result_available: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub(crate) struct ResolvedAgentTaskSummary {
+    pub(crate) id: String,
+    pub(crate) stored_step_id: String,
+    pub(crate) instruction: String,
+    pub(crate) depends_on: Vec<String>,
+    pub(crate) capabilities: Vec<String>,
+    pub(crate) specialist_id: Option<String>,
+    pub(crate) specialist_name: Option<String>,
+    pub(crate) executor: AgentExecutorSummary,
+    pub(crate) workspace_policy: String,
+    pub(crate) tools: Vec<String>,
+    pub(crate) can_write: bool,
+    pub(crate) can_execute: bool,
+    pub(crate) can_access_network: bool,
+    pub(crate) budget: AgentBudgetProposal,
+    pub(crate) timeout_secs: Option<u64>,
+    pub(crate) approval_reasons: Vec<String>,
+    pub(crate) output_schema: Option<Value>,
+    pub(crate) result: Option<AgentResultSummary>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub(crate) struct DynamicAgentWorkflowSummary {
+    pub(crate) schema_version: u32,
+    pub(crate) approval_policy: AgentApprovalPolicy,
+    pub(crate) editable_proposal: DynamicAgentWorkflowProposal,
+    pub(crate) tasks: Vec<ResolvedAgentTaskSummary>,
+    pub(crate) approval_reasons: Vec<AgentApprovalReasonSummary>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct AgentWorkflowVersionConflict {
+    pub(crate) workflow_id: String,
+    pub(crate) expected_version: i64,
+    pub(crate) actual_version: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct DynamicWorkflowCommandError {
+    pub(crate) code: String,
+    pub(crate) message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) version_conflict: Option<AgentWorkflowVersionConflict>,
+}
+
+impl DynamicWorkflowCommandError {
+    pub(crate) fn new(code: &str, message: impl Into<String>) -> Self {
+        Self {
+            code: code.into(),
+            message: message.into(),
+            version_conflict: None,
+        }
+    }
+
+    pub(crate) fn conflict(
+        workflow_id: impl Into<String>,
+        expected_version: i64,
+        actual_version: i64,
+    ) -> Self {
+        let workflow_id = workflow_id.into();
+        Self {
+            code: "version_conflict".into(),
+            message: "Agent plan changed in another window; refresh and try again.".into(),
+            version_conflict: Some(AgentWorkflowVersionConflict {
+                workflow_id,
+                expected_version,
+                actual_version,
+            }),
+        }
+    }
+}
+
+pub(crate) async fn resolve_proposal(
+    store: &Store,
+    workflow_id: String,
+    proposal: DynamicAgentWorkflowProposal,
+    registry: &CapabilityRegistry,
+    host: &DelegationHostPolicy,
+) -> Result<DelegationPlan, String> {
+    validate_proposal(&proposal)?;
+    let mut tasks = Vec::with_capacity(proposal.tasks.len());
+    for task in proposal.tasks {
+        let specialist = specialist_snapshot(store, task.specialist_id.as_deref()).await?;
+        if specialist
+            .as_ref()
+            .is_some_and(|value| value.id == "reviewer")
+            && (task.capabilities.iter().any(|capability| {
+                !matches!(capability.as_str(), "reasoning" | "project_read" | "review")
+            }) || !task
+                .capabilities
+                .iter()
+                .any(|capability| capability == "review"))
+        {
+            return Err(
+                "the built-in Reviewer requires the review capability and cannot receive write or execute capabilities"
+                    .into(),
+            );
+        }
+        let display_id = task.id;
+        tasks.push(DelegatedTaskProposal {
+            id: stored_task_id(&workflow_id, &display_id),
+            instruction: task.instruction.trim().into(),
+            context_summary: proposal.context.trim().into(),
+            depends_on: task
+                .depends_on
+                .iter()
+                .map(|dependency| stored_task_id(&workflow_id, dependency))
+                .collect(),
+            capabilities: task.capabilities,
+            specialist,
+            output_schema: task.output_schema,
+            isolated: task.isolated,
+            model_id: task.model_id.filter(|value| !value.trim().is_empty()),
+            executor: task
+                .executor
+                .map(AgentExecutorSelection::into_ref)
+                .transpose()?,
+            budget: task.budget.map(AgentBudget::from),
+            input: json!({"task_id": display_id}),
+        });
+    }
+    registry
+        .resolve_plan_with_id(
+            workflow_id,
+            proposal.goal.trim().into(),
+            proposal.approval_policy.mode(),
+            DEFAULT_DYNAMIC_PARALLELISM,
+            tasks,
+            host,
+        )
+        .map(|resolved| resolved.into_plan())
+        .map_err(|error| error.to_string())
+}
+
+pub(crate) fn summarize(
+    plan: &DelegationPlan,
+    attempts: &[AgentWorkflowAttempt],
+) -> Result<DynamicAgentWorkflowSummary, String> {
+    if plan.schema_version != wisp_core::DYNAMIC_DELEGATION_SCHEMA_VERSION {
+        return Err("dynamic workflow summary requires a v2 plan".into());
+    }
+    let ids = plan
+        .steps
+        .iter()
+        .map(|step| (step.id.as_str(), display_task_id(plan, step)))
+        .collect::<HashMap<_, _>>();
+    let approval_policy = AgentApprovalPolicy::from_mode(plan.mode);
+    let context = plan
+        .steps
+        .first()
+        .map(|step| step.spec.context_summary.clone())
+        .unwrap_or_default();
+    let mut proposal_tasks = Vec::with_capacity(plan.steps.len());
+    let mut tasks = Vec::with_capacity(plan.steps.len());
+    let mut approval_reasons = Vec::new();
+    for step in &plan.steps {
+        let id = ids
+            .get(step.id.as_str())
+            .cloned()
+            .unwrap_or_else(|| step.id.clone());
+        let depends_on = step
+            .spec
+            .dependencies
+            .iter()
+            .map(|dependency| {
+                ids.get(dependency.as_str())
+                    .cloned()
+                    .unwrap_or_else(|| dependency.clone())
+            })
+            .collect::<Vec<_>>();
+        let specialist = match &step.spec.origin {
+            AgentOrigin::Specialist(specialist) => Some(specialist),
+            AgentOrigin::LegacyTemplate | AgentOrigin::Temporary => None,
+        };
+        let output_schema = (step.spec.output_schema_source == AgentOutputSchemaSource::Task)
+            .then(|| step.spec.output_contract.clone());
+        let executor = step
+            .spec
+            .executor
+            .as_ref()
+            .map(AgentExecutorSelection::from_ref);
+        proposal_tasks.push(DynamicAgentTaskProposal {
+            id: id.clone(),
+            instruction: step.spec.goal.clone(),
+            depends_on: depends_on.clone(),
+            capabilities: step.spec.capabilities.clone(),
+            specialist_id: specialist.map(|value| value.id.clone()),
+            output_schema: output_schema.clone(),
+            isolated: step.spec.workspace_policy == Some(AgentWorkspacePolicy::Isolated),
+            model_id: step.spec.model.clone(),
+            executor: executor.clone(),
+            budget: Some(AgentBudgetProposal::from(&step.spec.budget)),
+        });
+        approval_reasons.extend(step.spec.approval_reasons.iter().map(|message| {
+            AgentApprovalReasonSummary {
+                task_id: id.clone(),
+                message: message.clone(),
+            }
+        }));
+        let latest_attempt = attempts
+            .iter()
+            .filter(|attempt| attempt.step_id == step.id)
+            .max_by_key(|attempt| attempt.attempt);
+        let executor_summary = match step.spec.executor.as_ref() {
+            Some(executor) => {
+                let selected = AgentExecutorSelection::from_ref(executor);
+                AgentExecutorSummary {
+                    kind: selected.kind,
+                    profile_id: selected.profile_id,
+                    model_id: step.spec.model.clone(),
+                }
+            }
+            None => AgentExecutorSummary {
+                kind: "unresolved".into(),
+                profile_id: None,
+                model_id: step.spec.model.clone(),
+            },
+        };
+        tasks.push(ResolvedAgentTaskSummary {
+            id,
+            stored_step_id: step.id.clone(),
+            instruction: step.spec.goal.clone(),
+            depends_on,
+            capabilities: step.spec.capabilities.clone(),
+            specialist_id: specialist.map(|value| value.id.clone()),
+            specialist_name: specialist.map(|value| value.name.clone()),
+            executor: executor_summary,
+            workspace_policy: workspace_policy_name(step.spec.workspace_policy),
+            tools: step.spec.permissions.tools.clone(),
+            can_write: step.spec.permissions.write,
+            can_execute: step.spec.permissions.execute,
+            can_access_network: step.spec.permissions.network,
+            budget: AgentBudgetProposal::from(&step.spec.budget),
+            timeout_secs: step.spec.timeout_secs,
+            approval_reasons: step.spec.approval_reasons.clone(),
+            output_schema,
+            result: latest_attempt.map(result_summary),
+        });
+    }
+    Ok(DynamicAgentWorkflowSummary {
+        schema_version: plan.schema_version,
+        approval_policy,
+        editable_proposal: DynamicAgentWorkflowProposal {
+            goal: plan.goal.clone(),
+            context,
+            approval_policy,
+            tasks: proposal_tasks,
+        },
+        tasks,
+        approval_reasons,
+    })
+}
+
+fn result_summary(attempt: &AgentWorkflowAttempt) -> AgentResultSummary {
+    let summary = serde_json::from_str::<Value>(&attempt.output_json)
+        .ok()
+        .and_then(|value| value.get("summary")?.as_str().map(str::to_string));
+    AgentResultSummary {
+        status: serde_json::to_value(attempt.status)
+            .ok()
+            .and_then(|value| value.as_str().map(str::to_string))
+            .unwrap_or_else(|| "unknown".into()),
+        summary,
+        error: attempt.error.clone(),
+        child_frame_id: attempt.child_frame_id.clone(),
+        input_tokens: attempt.input_tokens,
+        output_tokens: attempt.output_tokens,
+        tool_calls: attempt.tool_calls,
+        cost_microunits: attempt.cost_microunits,
+        duration_secs: attempt
+            .started_at
+            .zip(attempt.finished_at)
+            .map(|(started, finished)| finished.saturating_sub(started)),
+        full_result_available: attempt.response_json.is_some(),
+    }
+}
+
+fn display_task_id(plan: &DelegationPlan, step: &wisp_core::DelegationPlanStep) -> String {
+    step.input
+        .get("task_id")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .map(str::to_string)
+        .or_else(|| {
+            step.id
+                .strip_prefix(&format!("{}:", plan.id))
+                .map(str::to_string)
+        })
+        .unwrap_or_else(|| step.id.clone())
+}
+
+fn workspace_policy_name(policy: Option<AgentWorkspacePolicy>) -> String {
+    match policy {
+        Some(AgentWorkspacePolicy::SharedReadOnly) => "shared_read_only",
+        Some(AgentWorkspacePolicy::SerializedMutation) => "serialized_mutation",
+        Some(AgentWorkspacePolicy::Isolated) => "isolated",
+        None => "unresolved",
+    }
+    .into()
+}
+
+async fn specialist_snapshot(
+    store: &Store,
+    specialist_id: Option<&str>,
+) -> Result<Option<SpecialistSnapshot>, String> {
+    let Some(id) = specialist_id else {
+        return Ok(None);
+    };
+    let specialist = specialists::get(store, id)
+        .await
+        .ok_or_else(|| format!("unknown Specialist: {id}"))?;
+    Ok(Some(SpecialistSnapshot {
+        id: specialist.id,
+        name: specialist.name,
+        instructions: specialist.instructions,
+        model_id: (!specialist.model_id.trim().is_empty()).then_some(specialist.model_id),
+        skills: specialist.skills,
+        connectors: specialist.connectors,
+    }))
+}
+
+fn validate_proposal(proposal: &DynamicAgentWorkflowProposal) -> Result<(), String> {
+    let goal = proposal.goal.trim();
+    if goal.is_empty() || goal.chars().count() > MAX_GOAL_CHARS {
+        return Err(format!(
+            "goal must contain 1 to {MAX_GOAL_CHARS} characters"
+        ));
+    }
+    if proposal.context.chars().count() > MAX_CONTEXT_CHARS {
+        return Err(format!(
+            "shared context cannot exceed {MAX_CONTEXT_CHARS} characters"
+        ));
+    }
+    if proposal.tasks.is_empty() || proposal.tasks.len() > MAX_DELEGATION_TASKS {
+        return Err(format!(
+            "a batch requires 1 to {MAX_DELEGATION_TASKS} tasks"
+        ));
+    }
+    let mut ids = HashSet::new();
+    for task in &proposal.tasks {
+        if !valid_task_id(&task.id) {
+            return Err(format!(
+                "invalid task id '{}'; use a lowercase letter followed by at most 30 lowercase letters, digits, '_' or '-'",
+                task.id
+            ));
+        }
+        if !ids.insert(task.id.as_str()) {
+            return Err(format!("duplicate task id: {}", task.id));
+        }
+        let instruction = task.instruction.trim();
+        if instruction.is_empty() || instruction.chars().count() > MAX_INSTRUCTION_CHARS {
+            return Err(format!(
+                "task {} instruction must contain 1 to {MAX_INSTRUCTION_CHARS} characters",
+                task.id
+            ));
+        }
+        if task.capabilities.is_empty() {
+            return Err(format!("task {} requires at least one capability", task.id));
+        }
+        if task.output_schema.as_ref().is_some_and(|schema| {
+            !schema.is_object()
+                || serde_json::to_vec(schema)
+                    .is_ok_and(|bytes| bytes.len() > MAX_AGENT_OUTPUT_SCHEMA_BYTES)
+        }) {
+            return Err(format!(
+                "task {} output_schema must be an object no larger than {MAX_AGENT_OUTPUT_SCHEMA_BYTES} bytes",
+                task.id
+            ));
+        }
+        if let Some(budget) = &task.budget {
+            if budget.max_tokens == Some(0)
+                || budget.max_tool_calls == Some(0)
+                || budget.max_cost_microunits == Some(0)
+            {
+                return Err(format!("task {} budget limits must be positive", task.id));
+            }
+        }
+    }
+    for task in &proposal.tasks {
+        let mut dependencies = HashSet::new();
+        for dependency in &task.depends_on {
+            if !dependencies.insert(dependency.as_str()) {
+                return Err(format!(
+                    "task {} contains duplicate dependency {dependency}",
+                    task.id
+                ));
+            }
+            if dependency == &task.id {
+                return Err(format!("task {} cannot depend on itself", task.id));
+            }
+            if !ids.contains(dependency.as_str()) {
+                return Err(format!(
+                    "task {} depends on unknown task {dependency}",
+                    task.id
+                ));
+            }
+        }
+    }
+    let mut completed = HashSet::new();
+    while completed.len() < proposal.tasks.len() {
+        let before = completed.len();
+        for task in &proposal.tasks {
+            if !completed.contains(task.id.as_str())
+                && task
+                    .depends_on
+                    .iter()
+                    .all(|dependency| completed.contains(dependency.as_str()))
+            {
+                completed.insert(task.id.as_str());
+            }
+        }
+        if completed.len() == before {
+            return Err("task dependencies contain a cycle".into());
+        }
+    }
+    Ok(())
+}
+
+fn valid_task_id(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    !bytes.is_empty()
+        && bytes.len() <= MAX_TASK_ID_BYTES
+        && bytes[0].is_ascii_lowercase()
+        && bytes.iter().all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'_' | b'-')
+        })
+}
+
+fn stored_task_id(workflow_id: &str, task_id: &str) -> String {
+    format!("{workflow_id}:{task_id}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn task(id: &str, depends_on: &[&str]) -> DynamicAgentTaskProposal {
+        DynamicAgentTaskProposal {
+            id: id.into(),
+            instruction: format!("Run {id}"),
+            depends_on: depends_on.iter().map(|value| (*value).into()).collect(),
+            capabilities: vec!["reasoning".into()],
+            specialist_id: None,
+            output_schema: None,
+            isolated: false,
+            model_id: None,
+            executor: None,
+            budget: None,
+        }
+    }
+
+    #[test]
+    fn proposal_validation_rejects_unknown_duplicate_and_cyclic_dependencies() {
+        let proposal = |tasks| DynamicAgentWorkflowProposal {
+            goal: "test".into(),
+            context: String::new(),
+            approval_policy: AgentApprovalPolicy::ReviewAll,
+            tasks,
+        };
+        assert!(validate_proposal(&proposal(vec![task("a", &["missing"])]))
+            .unwrap_err()
+            .contains("unknown task"));
+        assert!(
+            validate_proposal(&proposal(vec![task("a", &[]), task("b", &["a", "a"])]))
+                .unwrap_err()
+                .contains("duplicate dependency")
+        );
+        assert!(
+            validate_proposal(&proposal(vec![task("a", &["b"]), task("b", &["a"])]))
+                .unwrap_err()
+                .contains("cycle")
+        );
+    }
+
+    #[test]
+    fn executor_selection_is_strict_and_round_trips() {
+        for executor in [
+            AgentExecutorRef::Native,
+            AgentExecutorRef::Acp {
+                profile_id: "acp-1".into(),
+            },
+            AgentExecutorRef::External {
+                profile_id: "external-1".into(),
+            },
+        ] {
+            assert_eq!(
+                AgentExecutorSelection::from_ref(&executor)
+                    .into_ref()
+                    .unwrap(),
+                executor
+            );
+        }
+        assert!(AgentExecutorSelection {
+            kind: "native".into(),
+            profile_id: Some("unexpected".into()),
+        }
+        .into_ref()
+        .is_err());
+    }
+
+    #[test]
+    fn legacy_modes_map_to_the_two_display_approval_policies() {
+        assert_eq!(
+            AgentApprovalPolicy::from_workflow_mode("manual"),
+            AgentApprovalPolicy::ReviewAll
+        );
+        assert_eq!(
+            AgentApprovalPolicy::from_workflow_mode("assisted"),
+            AgentApprovalPolicy::ReviewAll
+        );
+        assert_eq!(
+            AgentApprovalPolicy::from_workflow_mode("automatic"),
+            AgentApprovalPolicy::AutoSafe
+        );
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,6 +27,7 @@ mod debug_request;
 mod delegation_runtime;
 mod delegation_tool;
 mod desktop_lifecycle;
+mod dynamic_workflow;
 mod file_browser;
 mod harvest;
 mod library_commands;
@@ -6661,6 +6662,8 @@ pub fn run() {
             delegation_runtime::set_session_delegation_enabled,
             delegation_runtime::create_agent_workflow,
             delegation_runtime::revise_agent_workflow,
+            delegation_runtime::create_dynamic_agent_workflow,
+            delegation_runtime::revise_dynamic_agent_workflow,
             delegation_runtime::approve_agent_workflow,
             delegation_runtime::run_agent_workflow,
             delegation_runtime::cancel_agent_workflow,

--- a/ui/src/dto.rs
+++ b/ui/src/dto.rs
@@ -1283,6 +1283,138 @@ pub(crate) struct AgentWorkflowSnapshot {
     pub(crate) steps: Vec<AgentWorkflowStep>,
     pub(crate) attempts: Vec<AgentWorkflowAttempt>,
     pub(crate) delegation_enabled: bool,
+    #[serde(default = "legacy_agent_plan_schema_version")]
+    pub(crate) plan_schema_version: u32,
+    #[serde(default)]
+    pub(crate) approval_policy: AgentApprovalPolicy,
+    #[serde(default)]
+    pub(crate) dynamic: Option<DynamicAgentWorkflowSummary>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum AgentApprovalPolicy {
+    ReviewAll,
+    AutoSafe,
+}
+
+impl Default for AgentApprovalPolicy {
+    fn default() -> Self {
+        Self::ReviewAll
+    }
+}
+
+fn legacy_agent_plan_schema_version() -> u32 {
+    1
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub(crate) struct AgentExecutorSelection {
+    pub(crate) kind: String,
+    pub(crate) profile_id: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default)]
+pub(crate) struct AgentBudgetProposal {
+    pub(crate) max_tokens: Option<u32>,
+    pub(crate) max_tool_calls: Option<u32>,
+    pub(crate) max_cost_microunits: Option<u64>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub(crate) struct DynamicAgentTaskProposal {
+    pub(crate) id: String,
+    pub(crate) instruction: String,
+    pub(crate) depends_on: Vec<String>,
+    pub(crate) capabilities: Vec<String>,
+    pub(crate) specialist_id: Option<String>,
+    pub(crate) output_schema: Option<serde_json::Value>,
+    pub(crate) isolated: bool,
+    pub(crate) model_id: Option<String>,
+    pub(crate) executor: Option<AgentExecutorSelection>,
+    pub(crate) budget: Option<AgentBudgetProposal>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub(crate) struct DynamicAgentWorkflowProposal {
+    pub(crate) goal: String,
+    pub(crate) context: String,
+    pub(crate) approval_policy: AgentApprovalPolicy,
+    pub(crate) tasks: Vec<DynamicAgentTaskProposal>,
+}
+
+#[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
+pub(crate) struct AgentExecutorSummary {
+    pub(crate) kind: String,
+    pub(crate) profile_id: Option<String>,
+    pub(crate) model_id: Option<String>,
+}
+
+#[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
+pub(crate) struct AgentApprovalReasonSummary {
+    pub(crate) task_id: String,
+    pub(crate) message: String,
+}
+
+#[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
+pub(crate) struct AgentResultSummary {
+    pub(crate) status: String,
+    pub(crate) summary: Option<String>,
+    pub(crate) error: Option<String>,
+    pub(crate) child_frame_id: Option<String>,
+    pub(crate) input_tokens: i64,
+    pub(crate) output_tokens: i64,
+    pub(crate) tool_calls: i64,
+    pub(crate) cost_microunits: i64,
+    pub(crate) duration_secs: Option<i64>,
+    pub(crate) full_result_available: bool,
+}
+
+#[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ResolvedAgentTaskSummary {
+    pub(crate) id: String,
+    pub(crate) stored_step_id: String,
+    pub(crate) instruction: String,
+    pub(crate) depends_on: Vec<String>,
+    pub(crate) capabilities: Vec<String>,
+    pub(crate) specialist_id: Option<String>,
+    pub(crate) specialist_name: Option<String>,
+    pub(crate) executor: AgentExecutorSummary,
+    pub(crate) workspace_policy: String,
+    pub(crate) tools: Vec<String>,
+    pub(crate) can_write: bool,
+    pub(crate) can_execute: bool,
+    pub(crate) can_access_network: bool,
+    pub(crate) budget: AgentBudgetProposal,
+    pub(crate) timeout_secs: Option<u64>,
+    pub(crate) approval_reasons: Vec<String>,
+    pub(crate) output_schema: Option<serde_json::Value>,
+    pub(crate) result: Option<AgentResultSummary>,
+}
+
+#[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
+pub(crate) struct DynamicAgentWorkflowSummary {
+    pub(crate) schema_version: u32,
+    pub(crate) approval_policy: AgentApprovalPolicy,
+    pub(crate) editable_proposal: DynamicAgentWorkflowProposal,
+    pub(crate) tasks: Vec<ResolvedAgentTaskSummary>,
+    pub(crate) approval_reasons: Vec<AgentApprovalReasonSummary>,
+}
+
+#[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
+#[allow(dead_code)]
+pub(crate) struct AgentWorkflowVersionConflict {
+    pub(crate) workflow_id: String,
+    pub(crate) expected_version: i64,
+    pub(crate) actual_version: i64,
+}
+
+#[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
+#[allow(dead_code)]
+pub(crate) struct DynamicWorkflowCommandError {
+    pub(crate) code: String,
+    pub(crate) message: String,
+    pub(crate) version_conflict: Option<AgentWorkflowVersionConflict>,
 }
 
 #[derive(Deserialize, Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
## Problem

Inline v2 Agent batches could already execute and persist, but there was no stable backend contract for inspecting and safely editing an arbitrary dynamic draft. The existing workflow commands also did not expose resolved authority, approval reasons, executor selection, or typed optimistic-version conflicts to the upcoming dynamic Agents UI.

## Changes

- Add shared v2 proposal and summary DTOs for arbitrary temporary tasks, Specialists, dependencies, capabilities, model/executor overrides, isolation, budgets, approval reasons, and latest results.
- Add `create_dynamic_agent_workflow` and `revise_dynamic_agent_workflow` commands with `review_all` and `auto_safe` policies.
- Re-resolve structure and authorization on every draft revision, replace plans atomically with the existing version CAS, and return a structured version conflict.
- Keep approved plans immutable and make retry execute the same stored resolved snapshot without replanning.
- Reuse the same resolver for model-authored `delegate_tasks` batches and UI-authored drafts.
- Extend workflow snapshots and UI DTOs while preserving v1 mock and legacy workflow compatibility.
- Document draft immutability and snapshot retry semantics.

This keeps the useful oh-my-pi idea of a thin dynamic task contract while retaining Wisp-specific persisted approval and authorization snapshots.

## Tests

- `cargo fmt --all -- --check`
- `cargo test --workspace` (including 297 Tauri tests)
- `cd ui && cargo check --target wasm32-unknown-unknown`
- `cd ui-tests && npm ci && npx playwright test` (169 passed)
- Targeted tests cover optimistic conflicts, dependency removal and cycles, capability/model/executor re-resolution, immutable Specialist snapshots, retry without replanning, and interrupted v2 recovery.

## Manual smoke steps

1. Enable Delegation for a conversation.
2. Create a v2 dynamic draft with two independent tasks and one dependent task; inspect the resolved model, executor, permissions, budget, and approval reasons.
3. Revise a dependency or capability with the current version and confirm the version increments; retry the old version and confirm a typed conflict.
4. Approve and run the stored draft, then retry a failed/cancelled workflow and confirm the task snapshot is unchanged.

## Known limitations / follow-ups

- The fixed-team panel is still rendered; the next stacked PR replaces it with the dynamic draft/activity UI.
- Production dynamic policy advertises Native execution in this PR. Generic configured ACP profiles are added by the later executor-profile PR.
- Isolated workspaces, background completion, and bounded nested delegation remain later roadmap PRs.
- Legacy v1 workflows and commands remain available during migration.