### PR TITLE
fix(ui): keep side chat pinned to latest message

### DIFF
--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -1620,8 +1620,16 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
             return `s-${Math.random().toString(36).slice(2)}`;
           case "branch_session":
             return `branch-${Math.random().toString(36).slice(2)}`;
-          case "side_chat":
-            return `Side answer: ${arg("question") ?? ""}`;
+          case "side_chat": {
+            const question = String(arg("question") ?? "");
+            if (question === "SIDESCROLLTEST") {
+              return Array.from(
+                { length: 40 },
+                (_, index) => `Side answer line ${index + 1}`,
+              ).join("\n\n");
+            }
+            return `Side answer: ${question}`;
+          }
           case "confirm_response":
           case "dismiss_onboarding":
             return null;

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -856,6 +856,33 @@ test("side chat answers in a temporary side panel and can switch model", async (
   });
 });
 
+test("side chat stays at the latest message after sending and switching tabs", async ({ page }) => {
+  await enterApp(page);
+  await composer(page).fill("SIDESCROLLTEST");
+  await page.getByRole("button", { name: "Message options" }).click();
+  await page.getByRole("button", { name: "Side chat" }).click();
+
+  const panel = page.locator(".rightpane");
+  const log = panel.locator(".sidechat-log");
+  await expect(panel.getByText("Side answer line 40")).toBeVisible();
+  await expect.poll(() => log.evaluate((element) =>
+    element.scrollHeight > element.clientHeight,
+  )).toBe(true);
+  const bottomGap = () => log.evaluate((element) =>
+    element.scrollHeight - element.clientHeight - element.scrollTop,
+  );
+  await expect.poll(bottomGap).toBeLessThan(8);
+
+  await panel.locator(".rp-tab", { hasText: "Artifacts" }).click();
+  await panel.getByRole("button", { name: "Side chat", exact: true }).click();
+  await expect.poll(bottomGap).toBeLessThan(8);
+
+  await panel.getByPlaceholder("Follow up…").fill("latest side follow-up");
+  await panel.getByRole("button", { name: "Send" }).click();
+  await expect(panel.getByText("Side answer: latest side follow-up")).toBeVisible();
+  await expect.poll(bottomGap).toBeLessThan(8);
+});
+
 test("branch in new session starts a new frame from the current session", async ({ page }) => {
   await enterApp(page);
   await composer(page).fill("seed context");

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -64,6 +64,7 @@ const RIGHT_PANE_MAX_WIDTH: f64 = 900.0;
 const PANE_RESIZER_WIDTH: f64 = 5.0;
 const SIDEBAR_RESIZER_WIDTH: f64 = 10.0;
 const THEME_STORAGE_KEY: &str = "wisp-theme";
+const SIDE_CHAT_SCROLLER_ID: &str = "side-chat-scroller";
 /// Reserved `acp_config_menu_open` key for the session-mode dropdown, kept
 /// distinct from any agent-supplied config option id.
 const ACP_MODE_MENU: &str = "__acp_session_mode";
@@ -988,6 +989,22 @@ fn App() -> impl IntoView {
     let right_tab_add_menu_open = create_rw_signal(false);
     let rp_tab_drag = create_rw_signal(None::<RightTab>);
     let rp_tab_drop = create_rw_signal(None::<RightTab>);
+    create_effect(move |_| {
+        side_chat_items.with(|items| items.len());
+        if !show_right.get() || right_tab.get() != RightTab::SideChat {
+            return;
+        }
+        request_animation_frame(|| {
+            let Some(scroller) = web_sys::window()
+                .and_then(|window| window.document())
+                .and_then(|document| document.get_element_by_id(SIDE_CHAT_SCROLLER_ID))
+                .and_then(|element| element.dyn_into::<web_sys::HtmlElement>().ok())
+            else {
+                return;
+            };
+            scroller.set_scroll_top(scroller.scroll_height());
+        });
+    });
     create_effect(move |_| {
         if show_right.get() {
             let _ = right_tab.get();
@@ -8243,7 +8260,7 @@ fn App() -> impl IntoView {
                         RightTab::SideChat => {
                             view! {
                                 <div class="sidechat-in-pane">
-                                    <div class="sidechat-log">
+                                    <div class="sidechat-log" id=SIDE_CHAT_SCROLLER_ID>
                                         {move || {
                                             let rows = side_chat_items.get();
                                             if rows.is_empty() && !side_chat_busy.get() {


### PR DESCRIPTION
## Problem

Sending a side-chat message or switching away from and back to the Side chat tab rebuilt its scroll container at scrollTop 0, hiding the newest answer.

## Changes

- Give the side-chat log a stable DOM id and follow message, pane, and tab changes after the next render frame.
- Scroll the side chat to the newest message after an answer, a follow-up, or a right-pane tab remount.
- Add a long mocked side-chat response and a Playwright regression covering initial rendering, tab switching, and follow-up sends.

## Tests

- cargo fmt --all -- --check
- cargo test --workspace
- cd ui && cargo check --target wasm32-unknown-unknown
- cd ui-tests && npm ci
- cd ui-tests && npx playwright test (170 passed)

## Manual smoke

1. Open Side chat and produce enough messages to overflow the panel.
2. Send a follow-up and confirm the latest message stays visible.
3. Switch to Artifacts, return to Side chat, and confirm the latest message remains visible.

## Known limitations and follow-up

This scoped fix restores the latest side-chat message after a remount; it does not preserve an intentionally scrolled historical position. No follow-up is required for the reported behavior.