### PR TITLE
Allow Specialists to back dynamic Agent tasks

### DIFF
--- a/crates/wisp-core/src/delegation_policy.rs
+++ b/crates/wisp-core/src/delegation_policy.rs
@@ -283,7 +283,7 @@ impl CapabilityRegistry {
             .find(|definition| definition.id == "code_run")
             .expect("code_run capability")
             .revision = 2;
-        Self::new("wisp-capabilities-v2", definitions)
+        Self::new("wisp-capabilities-v3", definitions)
             .expect("built-in capability definitions must be valid")
     }
 
@@ -1088,18 +1088,15 @@ fn proposal_from_spec(spec: &AgentSpec) -> Result<DelegatedTaskProposal, Resolut
 }
 
 fn resolved_prompt(proposal: &DelegatedTaskProposal) -> String {
+    let base = "You are a bounded Wisp sub-Agent. Complete only the assigned task, return evidence to the parent Agent, and do not delegate further.";
     match &proposal.specialist {
         Some(specialist) => format!(
-            "You are {} ({}) working as a bounded Wisp sub-Agent.\n\nSpecialist instructions:\n{}\n\nAssigned task:\n{}",
+            "{base}\n\nSpecialist identity: {} ({})\nSpecialist instructions:\n{}",
             specialist.name,
             specialist.id,
-            specialist.instructions.trim(),
-            proposal.instruction.trim()
+            specialist.instructions.trim()
         ),
-        None => format!(
-            "You are a temporary bounded Wisp sub-Agent. Complete only the assigned task and return evidence for the parent Agent.\n\nAssigned task:\n{}",
-            proposal.instruction.trim()
-        ),
+        None => format!("{base}\n\nRole: temporary generic Agent."),
     }
 }
 
@@ -1769,6 +1766,56 @@ mod tests {
             .permissions
             .tools
             .contains(&"untrusted-extra".into()));
+    }
+
+    #[test]
+    fn specialist_identity_model_and_prompt_are_snapshotted_without_a_fixed_team() {
+        let registry = CapabilityRegistry::builtins();
+        let host = host_policy();
+        let mut task = proposal("expert", &["project_read"]);
+        task.specialist = Some(SpecialistSnapshot {
+            id: "domain-expert".into(),
+            name: "Domain expert".into(),
+            instructions: "Use the saved domain rubric.".into(),
+            model_id: Some("vision".into()),
+            skills: None,
+            connectors: None,
+        });
+
+        let resolved = registry.resolve_task(task, &host).unwrap();
+        assert_eq!(resolved.spec().model.as_deref(), Some("vision"));
+        assert!(resolved
+            .spec()
+            .prompt_template
+            .contains("Specialist identity: Domain expert (domain-expert)"));
+        assert!(resolved
+            .spec()
+            .prompt_template
+            .contains("Use the saved domain rubric."));
+        assert!(!resolved.spec().prompt_template.contains("Complete expert"));
+
+        let AgentOrigin::Specialist(snapshot) = &resolved.spec().origin else {
+            panic!("expected Specialist snapshot");
+        };
+        let mut dangling = proposal("fallback", &["reasoning"]);
+        dangling.specialist = Some(SpecialistSnapshot {
+            model_id: Some("deleted-model".into()),
+            ..snapshot.clone()
+        });
+        let fallback = registry.resolve_task(dangling, &host).unwrap();
+        assert_eq!(fallback.spec().model.as_deref(), Some("local"));
+
+        let plan = registry
+            .resolve_plan(
+                "one temporary task",
+                DelegationMode::Manual,
+                2,
+                vec![proposal("generic", &["reasoning"])],
+                &host,
+            )
+            .unwrap();
+        assert_eq!(plan.as_plan().steps.len(), 1);
+        assert_eq!(plan.as_plan().steps[0].spec.origin, AgentOrigin::Temporary);
     }
 
     #[test]

--- a/docs/agent-delegation.md
+++ b/docs/agent-delegation.md
@@ -35,7 +35,19 @@ of the meaning of a code-capable Agent.
 Omitting `specialist_id` creates a generic temporary Agent. Selecting a
 Specialist reuses its persona, model preference, skills, and connector
 restrictions as an immutable snapshot for that run. A Specialist is therefore
-an optional preset, not a required fixed team slot.
+an optional preset, not a required fixed team slot. The parent Agent sees only
+the currently available Specialist IDs, names, and descriptions; private
+instructions are copied into the selected child snapshot, not exposed in the
+`delegate_tasks` description. The child prompt is composed from the bounded
+worker contract, Specialist identity/instructions, task context and dependency
+inputs, then the result contract.
+
+A valid Specialist model preference is used when the task resolves to Native.
+An empty or deleted model binding falls back through the normal active-model
+selection and the resolved model is persisted. ACP profiles remain executor
+choices rather than Specialist model bindings. The built-in Reviewer follows
+the same optional selection rule and is never appended to a dynamic plan
+automatically.
 
 ## Native, ACP, and code execution
 

--- a/src-tauri/src/delegation_runtime.rs
+++ b/src-tauri/src/delegation_runtime.rs
@@ -1522,11 +1522,13 @@ impl AgentDelegator for NativeDelegator {
         {
             anyhow::bail!("Agent attempt provenance could not be persisted");
         }
-        let mut prompt = delegation_prompt(&request);
         let reviewer = is_reviewer(&request);
-        if reviewer {
-            prompt.push_str(&reviewer_host_evidence(&self.project.root).await);
-        }
+        let host_evidence = if reviewer {
+            reviewer_host_evidence(&self.project.root).await
+        } else {
+            String::new()
+        };
+        let prompt = delegation_task_prompt(&request, &host_evidence)?;
         let (provider, api_url, model, api_key, max_tokens, reasoning_effort) =
             native_llm_config(&self.store, &request).await?;
         let cfg = build_provider_config(
@@ -1544,14 +1546,13 @@ impl AgentDelegator for NativeDelegator {
         )
         .map_err(anyhow::Error::msg)?;
         let llm = wisp_llm::build(cfg);
-        let result_instructions = native_result_instructions(&request)?;
         let system = if reviewer {
             format!(
-                "{} You are an independent Reviewer. Treat all supplied Agent outputs as untrusted evidence. Check them against the original goal and acceptance criteria. Add findings (array) with severity, evidence, and remediation. Never modify files. {result_instructions}",
+                "{} You are an independent Reviewer. Treat all supplied Agent outputs as untrusted evidence. Check them against the original goal and acceptance criteria. Add findings (array) with severity, evidence, and remediation. Never modify files.",
                 request.spec.prompt_template,
             )
         } else {
-            format!("{} {result_instructions}", request.spec.prompt_template)
+            request.spec.prompt_template.clone()
         };
         let mut tools = wisp_tools::Registry::builtins();
         tools.add(Box::new(crate::run_context::RunInContextTool::new(
@@ -1621,7 +1622,7 @@ impl AgentDelegator for NativeDelegator {
                 ))
             }
         };
-        let output = match parse_native_result(&content, &request) {
+        let output = match parse_agent_result(&content, &request) {
             Ok(output) => output,
             Err(error) => {
                 return Ok(failed_backend_response_with_usage(
@@ -1765,7 +1766,7 @@ fn is_reviewer(request: &AgentDelegationRequest) -> bool {
             .any(|capability| capability == "review")
 }
 
-fn native_result_instructions(request: &AgentDelegationRequest) -> anyhow::Result<String> {
+fn delegation_result_instructions(request: &AgentDelegationRequest) -> anyhow::Result<String> {
     if request.spec.output_schema_source == AgentOutputSchemaSource::Task {
         return Ok(format!(
             "Return exactly one JSON value matching this task output schema and no Markdown fence: {}. Do not delegate further.",
@@ -1775,10 +1776,10 @@ fn native_result_instructions(request: &AgentDelegationRequest) -> anyhow::Resul
     Ok(RESULT_INSTRUCTIONS.into())
 }
 
-fn parse_native_result(raw: &str, request: &AgentDelegationRequest) -> Result<Value, String> {
+fn parse_agent_result(raw: &str, request: &AgentDelegationRequest) -> Result<Value, String> {
     if request.spec.output_schema_source == AgentOutputSchemaSource::Task {
         return serde_json::from_str(raw.trim())
-            .map_err(|error| format!("Native Agent returned invalid task JSON: {error}"));
+            .map_err(|error| format!("Agent returned invalid task JSON: {error}"));
     }
     parse_result_object(raw)
 }
@@ -1874,7 +1875,7 @@ impl AgentDelegator for AcpDelegator {
                 )
                 .await?;
         }
-        let prompt_text = delegation_prompt(&request);
+        let prompt_text = delegation_prompt(&request)?;
         let next_seq = self.store.load_messages(&child_frame_id).await?.len() as i64 + 1;
         self.store
             .append_message(&child_frame_id, next_seq, &Message::user(&prompt_text))
@@ -2255,7 +2256,7 @@ async fn run_acp_request(
             usage.value,
         ));
     }
-    let output = match parse_result_object(&answer) {
+    let output = match parse_agent_result(&answer, request) {
         Ok(output) => output,
         Err(error) => {
             return Ok(failed_acp_response(
@@ -2770,9 +2771,15 @@ impl DelegationExecutionObserver for StoreDelegationObserver {
     }
 }
 
-fn delegation_prompt(request: &AgentDelegationRequest) -> String {
-    format!(
-        "Controlled Agent task\nName: {}\nGoal: {}\nContext: {}\nAcceptance criteria:\n{}\nInput JSON:\n{}\n\n{}",
+fn delegation_task_prompt(
+    request: &AgentDelegationRequest,
+    supplemental_context: &str,
+) -> anyhow::Result<String> {
+    let supplemental_context = (!supplemental_context.trim().is_empty())
+        .then(|| format!("\n\n{}", supplemental_context.trim()))
+        .unwrap_or_default();
+    Ok(format!(
+        "Controlled Agent task\nName: {}\nTask: {}\nContext: {}\nAcceptance criteria:\n{}\nDependency/input JSON:\n{}{}\n\nResult contract:\n{}",
         request.spec.name,
         request.spec.goal,
         request.spec.context_summary,
@@ -2784,8 +2791,17 @@ fn delegation_prompt(request: &AgentDelegationRequest) -> String {
             .collect::<Vec<_>>()
             .join("\n"),
         serde_json::to_string_pretty(&request.input).unwrap_or_else(|_| "{}".into()),
-        RESULT_INSTRUCTIONS,
-    )
+        supplemental_context,
+        delegation_result_instructions(request)?,
+    ))
+}
+
+fn delegation_prompt(request: &AgentDelegationRequest) -> anyhow::Result<String> {
+    Ok(format!(
+        "{}\n\n{}",
+        request.spec.prompt_template.trim(),
+        delegation_task_prompt(request, "")?
+    ))
 }
 
 fn parse_result_object(raw: &str) -> Result<Value, String> {
@@ -3050,6 +3066,7 @@ mod tests {
                     "reasoning".into(),
                     "project_read".into(),
                     "project_write".into(),
+                    "code_run".into(),
                     "review".into(),
                 ],
                 models: vec![
@@ -3098,6 +3115,9 @@ mod tests {
                         "grep".into(),
                         "write".into(),
                         "edit".into(),
+                        "run_in_context".into(),
+                        "get_run".into(),
+                        "cancel_run".into(),
                     ],
                     paths: vec!["project://**".into()],
                     network: false,
@@ -3234,6 +3254,29 @@ mod tests {
         assert!(parse_result_object(r#"{"summary":"done"}"#).is_err());
         assert!(parse_result_object(r#"{"summary":"done","files_changed":[],"diff_summary":"","artifacts":[],"evidence":[],"tests":[],"risks":[]}"#)
         .is_ok());
+
+        let request = AgentDelegationRequest {
+            request_id: "request".into(),
+            workflow_id: "workflow".into(),
+            step_id: "step".into(),
+            spec: serde_json::from_value(json!({
+                "agent_id": "structured",
+                "name": "Structured Agent",
+                "goal": "Return rows",
+                "role": "temporary",
+                "backend": "local",
+                "prompt_template": "Return structured data.",
+                "output_contract": {"type": "array"},
+                "output_schema_source": "task"
+            }))
+            .unwrap(),
+            input: json!({}),
+        };
+        assert_eq!(
+            parse_agent_result("[1,2]", &request).unwrap(),
+            json!([1, 2])
+        );
+        assert!(parse_agent_result("not JSON", &request).is_err());
     }
 
     #[test]
@@ -3540,6 +3583,172 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn custom_specialist_model_prompt_and_code_grant_reach_one_native_child() {
+        let (store, root) = dynamic_fixture().await;
+        let (registry, mut host) = test_dynamic_policy();
+        host.executors
+            .retain(|profile| profile.executor == AgentExecutorRef::Native);
+        let saved = crate::specialists::upsert(
+            &store,
+            crate::specialists::Specialist {
+                id: String::new(),
+                name: "Code scientist".into(),
+                icon: String::new(),
+                color: String::new(),
+                description: "Checks scientific code".into(),
+                instructions: "Apply the saved scientific coding rubric.".into(),
+                model_id: "remote".into(),
+                review_backend: None,
+                skills: None,
+                connectors: None,
+                builtin: false,
+            },
+        )
+        .await
+        .unwrap();
+        let specialist_id = saved
+            .iter()
+            .find(|specialist| !specialist.builtin)
+            .unwrap()
+            .id
+            .clone();
+        let mut task = dynamic_task("code", &[]);
+        task.capabilities = vec!["code_run".into()];
+        task.specialist_id = Some(specialist_id.clone());
+
+        let plan = dynamic_workflow::resolve_proposal(
+            &store,
+            "specialist-workflow".into(),
+            dynamic_proposal(vec![task]),
+            &registry,
+            &host,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(plan.steps.len(), 1, "Reviewer must not be appended");
+        let spec = plan.steps[0].spec.clone();
+        assert_eq!(spec.executor, Some(AgentExecutorRef::Native));
+        assert_eq!(spec.model.as_deref(), Some("remote"));
+        assert!(spec.permissions.execute);
+        assert!(spec.permissions.tools.contains(&"run_in_context".into()));
+        let AgentOrigin::Specialist(snapshot) = &spec.origin else {
+            panic!("expected Specialist snapshot");
+        };
+        assert_eq!(snapshot.id, specialist_id);
+        assert_eq!(
+            snapshot.instructions,
+            "Apply the saved scientific coding rubric."
+        );
+
+        let request = AgentDelegationRequest {
+            request_id: "request".into(),
+            workflow_id: plan.id.clone(),
+            step_id: plan.steps[0].id.clone(),
+            spec,
+            input: json!({"dependency_results":{"inspect":{"summary":"checked"}}}),
+        };
+        let prompt = delegation_prompt(&request).unwrap();
+        let markers = [
+            "bounded Wisp sub-Agent",
+            "Specialist identity: Code scientist",
+            "Apply the saved scientific coding rubric.",
+            "Controlled Agent task",
+            "Task: Complete task code",
+            "Context: Shared test context",
+            "Dependency/input JSON",
+            "Result contract",
+        ];
+        let positions = markers
+            .iter()
+            .map(|marker| {
+                prompt
+                    .find(marker)
+                    .unwrap_or_else(|| panic!("missing {marker}"))
+            })
+            .collect::<Vec<_>>();
+        assert!(positions.windows(2).all(|pair| pair[0] < pair[1]));
+
+        drop(store);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn missing_or_deleted_specialist_fails_before_a_plan_exists() {
+        let (store, root) = dynamic_fixture().await;
+        let (registry, host) = test_dynamic_policy();
+        let saved = crate::specialists::upsert(
+            &store,
+            crate::specialists::Specialist {
+                id: String::new(),
+                name: "Temporary expert".into(),
+                icon: String::new(),
+                color: String::new(),
+                description: String::new(),
+                instructions: String::new(),
+                model_id: String::new(),
+                review_backend: None,
+                skills: None,
+                connectors: None,
+                builtin: false,
+            },
+        )
+        .await
+        .unwrap();
+        let deleted_id = saved
+            .iter()
+            .find(|specialist| !specialist.builtin)
+            .unwrap()
+            .id
+            .clone();
+        crate::specialists::remove(&store, &deleted_id)
+            .await
+            .unwrap();
+        let mut task = dynamic_task("expert", &[]);
+        task.specialist_id = Some(deleted_id);
+        let error = dynamic_workflow::resolve_proposal(
+            &store,
+            "missing-workflow".into(),
+            dynamic_proposal(vec![task]),
+            &registry,
+            &host,
+        )
+        .await
+        .unwrap_err();
+        assert!(error.contains("unknown Specialist"));
+
+        drop(store);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn reviewer_is_spawned_only_when_explicitly_selected() {
+        let (store, root) = dynamic_fixture().await;
+        let (registry, host) = test_dynamic_policy();
+        let mut task = dynamic_task("review", &[]);
+        task.capabilities = vec!["review".into()];
+        task.specialist_id = Some("reviewer".into());
+
+        let plan = dynamic_workflow::resolve_proposal(
+            &store,
+            "review-workflow".into(),
+            dynamic_proposal(vec![task]),
+            &registry,
+            &host,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(plan.steps.len(), 1);
+        assert!(matches!(
+            &plan.steps[0].spec.origin,
+            AgentOrigin::Specialist(snapshot) if snapshot.id == "reviewer"
+        ));
+        drop(store);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
     async fn approved_dynamic_plan_keeps_its_specialist_snapshot_immutable() {
         let (store, root) = dynamic_fixture().await;
         let policy = test_dynamic_policy();
@@ -3585,6 +3794,12 @@ mod tests {
         crate::specialists::upsert(&store, specialist)
             .await
             .unwrap();
+        crate::specialists::remove(&store, &specialist_id)
+            .await
+            .unwrap();
+        assert!(crate::specialists::get(&store, &specialist_id)
+            .await
+            .is_none());
         let stored = store
             .get_agent_workflow(&created.workflow.id)
             .await

--- a/src-tauri/src/delegation_tool.rs
+++ b/src-tauri/src/delegation_tool.rs
@@ -1097,6 +1097,33 @@ mod tests {
         assert_eq!(compact["lookup"]["mcp_tool"], "wisp_get_delegated_result");
     }
 
+    #[test]
+    fn delegation_schema_lists_spawnable_specialists_without_private_prompts() {
+        let (registry, host) = test_policy();
+        let schema = build_delegate_tasks_schema(
+            &registry,
+            &host,
+            &[specialists::Specialist {
+                id: "paper-expert".into(),
+                name: "Paper expert".into(),
+                icon: String::new(),
+                color: String::new(),
+                description: "Finds primary literature".into(),
+                instructions: "PRIVATE SPECIALIST RUBRIC".into(),
+                model_id: "private-model-binding".into(),
+                review_backend: None,
+                skills: None,
+                connectors: None,
+                builtin: false,
+            }],
+        );
+        let parameters = schema.function.parameters.to_string();
+        assert!(parameters.contains("paper-expert"));
+        assert!(parameters.contains("Finds primary literature"));
+        assert!(!parameters.contains("PRIVATE SPECIALIST RUBRIC"));
+        assert!(!parameters.contains("private-model-binding"));
+    }
+
     #[tokio::test]
     async fn parent_agent_delegates_parallel_tasks_and_synthesizes_inline() {
         let (store, project, root) = fixture().await;

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -4467,6 +4467,34 @@ test("dynamic ACP selection uses a profile and clears the Native-only model", as
   expect(args.proposal.tasks[0].model_id).toBeUndefined();
 });
 
+test("dynamic tasks can select a newly saved custom Specialist", async ({ page }) => {
+  await enterApp(page);
+  await openSettingsSection(page, "Specialists");
+  await page.getByText("Add specialist").click();
+  await page.getByText("Write from scratch").click();
+  await page.getByLabel("Name").fill("Paper hunter");
+  await page.getByLabel("Instructions").fill("Prefer primary literature.");
+  await page.getByRole("button", { name: "Save" }).click();
+  await expect(page.getByText("Paper hunter")).toBeVisible();
+  await page.locator(".settings-head-close").click();
+
+  await enableDelegation(page);
+  await page.getByRole("button", { name: "Toggle panel" }).click();
+  await page.locator(".rightpane").getByRole("button", { name: "Agents", exact: true }).click();
+  const panel = page.getByTestId("agent-workflows");
+  const task = panel.locator(".dynamic-agent-task").first();
+  await panel.getByTestId("agent-goal").fill("Find relevant evidence");
+  await task.getByTestId("dynamic-task-instruction").fill("Inspect the available evidence");
+  await task.getByTestId("dynamic-task-specialist").selectOption({ label: "Paper hunter" });
+  await panel.getByTestId("agent-create").click();
+
+  await expect.poll(() => lastInvokeArgs(page, "create_dynamic_agent_workflow")).toMatchObject({
+    proposal: {
+      tasks: [{ specialist_id: "sp1" }],
+    },
+  });
+});
+
 test("risky dynamic drafts expose resolved authority and can be revised before approval", async ({ page }) => {
   await enterApp(page);
   await enableDelegation(page);

--- a/ui/src/agent_workflows.rs
+++ b/ui/src/agent_workflows.rs
@@ -296,8 +296,16 @@ fn parse_executor_key(value: &str) -> Option<AgentExecutorSelection> {
     })
 }
 
-pub(super) fn refresh_agent_resources(state: AgentPanelState) {
+pub(super) fn refresh_agent_resources(
+    state: AgentPanelState,
+    specialists: RwSignal<Vec<Specialist>>,
+) {
     spawn_local(async move {
+        if let Ok(value) = invoke_checked("list_specialists", JsValue::UNDEFINED).await {
+            if let Ok(items) = serde_wasm_bindgen::from_value::<Vec<Specialist>>(value) {
+                specialists.set(items);
+            }
+        }
         if let Ok(value) = invoke_checked("list_agent_templates", JsValue::UNDEFINED).await {
             if let Ok(items) = serde_wasm_bindgen::from_value::<Vec<AgentTemplateSummary>>(value) {
                 state.templates.set(items);
@@ -813,7 +821,7 @@ fn dynamic_editor(
                 <button type="button" class="icon-btn" title=move || t(locale.get(), "agents.refresh")
                     aria-label=move || t(locale.get(), "agents.refresh")
                     on:click=move |_| {
-                        refresh_agent_resources(state);
+                        refresh_agent_resources(state, specialists);
                         refresh_agent_workflows(state.workflows, state.error);
                     }>{"↻"}</button>
             </div>

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -1028,7 +1028,7 @@ fn App() -> impl IntoView {
     let agent_panel = AgentPanelState::new();
     let agent_workflows = agent_panel.workflows;
     let agent_workflow_error = agent_panel.error;
-    refresh_agent_resources(agent_panel);
+    refresh_agent_resources(agent_panel, specialists);
     let file_source = create_rw_signal("local".to_string());
     let file_query = create_rw_signal(String::new());
     let file_cwd = create_rw_signal(".".to_string());


### PR DESCRIPTION
## Problem

Dynamic tasks already carried an optional Specialist snapshot, but the execution paths were not fully equivalent: Native saw the saved persona while ACP received only the task envelope, and the Agents panel could render before its live Specialist list had loaded. This made custom Specialist selection inconsistent across executors and entry points.

## Changes

- Compose delegated prompts in one stable order: bounded worker contract, optional Specialist identity and private instructions, task/context/dependency input, then result contract.
- Send the complete composed prompt to ACP while keeping Native identity in its system message and task/result data in the user message.
- Use one result parser for Native and ACP so task-specific JSON output contracts work on either executor.
- Keep valid Specialist model preferences on Native, fall back to the active eligible model for dangling bindings, and persist the resolved model.
- Refresh saved Specialists with the Agents panel resources so newly created custom Specialists are selectable immediately.
- Keep Specialist instructions and model bindings out of the parent delegate_tasks schema; only IDs, names, and descriptions are advertised.
- Bump the dynamic capability registry revision for the changed prompt contract and document Reviewer, model fallback, snapshot, and privacy behavior.

## Tests

- cargo fmt --all -- --check
- cargo test --workspace
- cd ui && cargo check --target wasm32-unknown-unknown
- cd ui && cargo test (94 passed)
- cd ui-tests && npm ci --no-audit --prefer-offline && npx playwright test (173 passed)

Coverage includes generic tasks without a fixed team, custom instructions/model propagation, dangling model fallback, skill/connector restriction, deleted Specialist rejection, immutable approved snapshots after edit/removal, explicit-only Reviewer spawning, Native code execution with no ACP executor, prompt order, private prompt redaction, shared Native/ACP structured results, and custom Specialist selection in the dynamic editor.

## Manual smoke

1. Save a custom Specialist with instructions and a non-default model.
2. Create one read-only dynamic task, select that Specialist, and inspect the resolved model and Specialist name before approval.
3. Edit or remove the Specialist after approval and confirm the stored task still uses the approved snapshot.
4. Repeat with an explicit ACP profile and confirm the child receives the Specialist persona while the panel reports the ACP executor.
5. Confirm Reviewer appears only when explicitly selected with the review capability.

## Known limitations and follow-ups

- Specialist allowlists currently narrow only capabilities registered by the host. PR9 adds the Native scientific skill and connector adapters that make those resource-backed capabilities available.
- The Reviewer-specific one-shot review_backend setting is not a dynamic-task backend special case; dynamic Reviewer tasks use the same generic executor selector as every other Specialist.
- Drafts created against the earlier preview registry revision must be regenerated before approval so the new prompt contract is reviewed explicitly.