### PR TITLE
fix(settings): confirm ACP agent delete and keep Escape scoped to the dialog

### DIFF
--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -4750,6 +4750,10 @@ test("a deleted ACP reviewer remains visibly selected as missing", async ({ page
   await page.getByTestId("open-acp-agents-from-settings").click();
   const row = page.getByTestId("acp-agent-row").filter({ hasText: "Test ACP Agent" });
   await row.locator(".settings-list-remove").click();
+  await page
+    .getByTestId("model-delete-confirm")
+    .getByRole("button", { name: "Remove model" })
+    .click();
   await expect(row).toHaveCount(0);
 
   await nav.getByRole("button", { name: "Specialists", exact: true }).click();

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -34,7 +34,7 @@ use overlays::{AddHostOverlay, CapabilitiesOverlay, OnboardingOverlay, RuntimeIn
 use pet::{PetDesktop, PetOverlay};
 use project_landing::{ProjectLanding, ProjectLandingState};
 use serde_wasm_bindgen::to_value;
-use settings_view::{SettingsView, SettingsViewState};
+use settings_view::{DeleteConfirm, SettingsView, SettingsViewState};
 use sidebar::{Sidebar, SidebarState};
 use std::cell::{Cell, RefCell};
 use std::collections::VecDeque;
@@ -706,6 +706,9 @@ fn App() -> impl IntoView {
     // Side chat routes through this ACP Agent when set; None = the active model.
     let side_chat_acp_agent = create_rw_signal::<Option<String>>(None);
     let settings_busy = create_rw_signal(false);
+    // Owned here so the window-level Escape stack can close the confirm before
+    // it falls through to closing the whole settings page.
+    let delete_confirm = create_rw_signal(None::<DeleteConfirm>);
     let settings_message = create_rw_signal::<Option<(bool, String)>>(None);
     let update_check_busy = create_rw_signal(false);
     let update_check_modal = create_rw_signal::<Option<UpdateCheckModal>>(None);
@@ -4370,6 +4373,12 @@ fn App() -> impl IntoView {
         if context_details_modal.get().is_some() {
             ev.prevent_default();
             context_details_modal.set(None);
+            return;
+        }
+        // Confirm dialog sits on top of settings — close it first, not the page.
+        if delete_confirm.get().is_some() {
+            ev.prevent_default();
+            delete_confirm.set(None);
             return;
         }
         if show_settings.get() && !settings_busy.get() {
@@ -9099,7 +9108,7 @@ fn App() -> impl IntoView {
                 custom_credentials, cred_msg, approval_grants, conns_view, conn_form_open,
                 conn_form_kind, conn_test_msg, custom_conn_tools, custom_conn_tools_loading,
                 custom_conn_tool_errors, pet_status, ssh_hosts, execution_contexts,
-                runtime_interpreter_form, probing_context_id,
+                runtime_interpreter_form, probing_context_id, delete_confirm,
             }
             open_project=switch_project
             go_settings_section=Callback::new(move |section: String| go_settings_section(&section))

--- a/ui/src/settings_view.rs
+++ b/ui/src/settings_view.rs
@@ -16,6 +16,23 @@ use serde_wasm_bindgen::to_value;
 use std::collections::{BTreeSet, HashMap, HashSet};
 use wasm_bindgen::JsValue;
 
+/// Pending "确定删除?" confirmation. Both models and ACP agents route through
+/// one overlay so the confirm gate lives in a single place. The signal is owned
+/// by the app so the window-level Escape stack can close it before settings.
+#[derive(Clone)]
+pub(super) enum DeleteConfirm {
+    Model { id: String, label: String },
+    Acp { id: String, label: String },
+}
+
+impl DeleteConfirm {
+    fn label(&self) -> &str {
+        match self {
+            DeleteConfirm::Model { label, .. } | DeleteConfirm::Acp { label, .. } => label,
+        }
+    }
+}
+
 fn settings_provider_value(provider: &str) -> &'static str {
     match provider.trim() {
         "anthropic" => "anthropic",
@@ -142,6 +159,7 @@ pub(super) struct SettingsViewState {
     pub(super) execution_contexts: RwSignal<Vec<ExecutionContext>>,
     pub(super) runtime_interpreter_form: RwSignal<Option<RuntimeInterpreterForm>>,
     pub(super) probing_context_id: RwSignal<Option<String>>,
+    pub(super) delete_confirm: RwSignal<Option<DeleteConfirm>>,
 }
 
 #[component]
@@ -232,9 +250,9 @@ pub(super) fn SettingsView(
         execution_contexts,
         runtime_interpreter_form,
         probing_context_id,
+        delete_confirm,
     } = state;
     let acp_form_open = create_memo(move |_| acp_form.get().is_some());
-    let model_delete_confirm = create_rw_signal(None::<(String, String)>);
     let joining = create_rw_signal(false);
     let join_code = create_rw_signal(String::new());
     let join_busy = create_rw_signal(false);
@@ -1101,6 +1119,7 @@ pub(super) fn SettingsView(
                                                     let edit = agent.clone();
                                                     let id_for_test = agent.id.clone();
                                                     let id_for_delete = agent.id.clone();
+                                                    let label_for_delete = agent.label.clone();
                                                     let is_active = active_acp_agent_id.get().as_deref() == Some(agent.id.as_str());
                                                     view! {
                                                         <div class="settings-list-row settings-list-row-link"
@@ -1146,26 +1165,10 @@ pub(super) fn SettingsView(
                                                                 <button class="settings-list-remove" type="button" title=move || t(locale.get(), "models.remove")
                                                                     on:click=move |ev| {
                                                                         ev.stop_propagation();
-                                                                        let id = id_for_delete.clone();
-                                                                        spawn_local(async move {
-                                                                            settings_busy.set(true);
-                                                                            let args = to_value(&serde_json::json!({ "id": id.clone() })).unwrap();
-                                                                            match invoke_checked("remove_acp_agent", args).await {
-                                                                                Ok(value) => {
-                                                                                    if let Ok(list) = serde_wasm_bindgen::from_value::<Vec<AcpAgentProfile>>(value) {
-                                                                                        acp_agents.set(list);
-                                                                                        acp_infos.update(|infos| {
-                                                                                            infos.remove(&id);
-                                                                                        });
-                                                                                        if active_acp_agent_id.get().as_deref() == Some(id.as_str()) {
-                                                                                            active_acp_agent_id.set(None);
-                                                                                        }
-                                                                                    }
-                                                                                }
-                                                                                Err(error) => acp_form_msg.set(Some((false, js_error_text(error)))),
-                                                                            }
-                                                                            settings_busy.set(false);
-                                                                        });
+                                                                        delete_confirm.set(Some(DeleteConfirm::Acp {
+                                                                            id: id_for_delete.clone(),
+                                                                            label: label_for_delete.clone(),
+                                                                        }));
                                                                     }>{compose_icon("close")}</button>
                                                                 <span class="settings-list-chevron" aria-hidden="true">"›"</span>
                                                             </div>
@@ -1284,7 +1287,10 @@ pub(super) fn SettingsView(
                                                                 <button class="settings-list-remove" type="button" title=move || t(locale.get(), "models.remove")
                                                                     on:click=move |ev| {
                                                                         ev.stop_propagation();
-                                                                        model_delete_confirm.set(Some((id.clone(), del_label.clone())));
+                                                                        delete_confirm.set(Some(DeleteConfirm::Model {
+                                                                            id: id.clone(),
+                                                                            label: del_label.clone(),
+                                                                        }));
                                                                     }>{compose_icon("close")}</button>
                                                             }})}
                                                             {(!is_active).then(|| { let id = pick_id.clone(); view! {
@@ -2707,8 +2713,8 @@ pub(super) fn SettingsView(
                     }
                 })}
             </div>
-            {move || model_delete_confirm.get().map(|(id, label)| {
-                let remove_id = id.clone();
+            {move || delete_confirm.get().map(|target| {
+                let label = target.label().to_string();
                 view! {
                     <div class="overlay" data-testid="model-delete-confirm">
                         <div class="modal confirm-modal">
@@ -2719,17 +2725,40 @@ pub(super) fn SettingsView(
                                 &[("model", &label)],
                             )}</div>
                             <div class="row">
-                                <button on:click=move |_| model_delete_confirm.set(None)>
+                                <button on:click=move |_| delete_confirm.set(None)>
                                     {move || t(locale.get(), "settings.cancel")}
                                 </button>
                                 <button class="primary" on:click=move |_| {
-                                    model_delete_confirm.set(None);
-                                    let id = remove_id.clone();
+                                    let target = target.clone();
+                                    delete_confirm.set(None);
                                     spawn_local(async move {
-                                        let arg = to_value(&serde_json::json!({ "id": id })).unwrap();
-                                        if let Ok(value) = invoke_checked("remove_model", arg).await {
-                                            if let Ok(list) = serde_wasm_bindgen::from_value::<Vec<ModelProfile>>(value) {
-                                                models.set(list);
+                                        match target {
+                                            DeleteConfirm::Model { id, .. } => {
+                                                let arg = to_value(&serde_json::json!({ "id": id })).unwrap();
+                                                if let Ok(value) = invoke_checked("remove_model", arg).await {
+                                                    if let Ok(list) = serde_wasm_bindgen::from_value::<Vec<ModelProfile>>(value) {
+                                                        models.set(list);
+                                                    }
+                                                }
+                                            }
+                                            DeleteConfirm::Acp { id, .. } => {
+                                                settings_busy.set(true);
+                                                let args = to_value(&serde_json::json!({ "id": id.clone() })).unwrap();
+                                                match invoke_checked("remove_acp_agent", args).await {
+                                                    Ok(value) => {
+                                                        if let Ok(list) = serde_wasm_bindgen::from_value::<Vec<AcpAgentProfile>>(value) {
+                                                            acp_agents.set(list);
+                                                            acp_infos.update(|infos| {
+                                                                infos.remove(&id);
+                                                            });
+                                                            if active_acp_agent_id.get().as_deref() == Some(id.as_str()) {
+                                                                active_acp_agent_id.set(None);
+                                                            }
+                                                        }
+                                                    }
+                                                    Err(error) => acp_form_msg.set(Some((false, js_error_text(error)))),
+                                                }
+                                                settings_busy.set(false);
                                             }
                                         }
                                     });

--- a/ui/src/styles/modals.css
+++ b/ui/src/styles/modals.css
@@ -122,8 +122,10 @@ textarea.host-input { min-height:64px; resize:vertical; }
   font-size: 12px;
   color: var(--text-faint);
 }
-.acp-agents-pane .settings-list-actions button,
-.acp-agents-settings .settings-list-actions button,
+/* The delete (×) button keeps its base .settings-list-remove look; only the
+   pill-shaped test/auth buttons get styled here. */
+.acp-agents-pane .settings-list-actions button:not(.settings-list-remove),
+.acp-agents-settings .settings-list-actions button:not(.settings-list-remove),
 .acp-agent-info button {
   font: inherit;
   font-size: 12px;
@@ -137,8 +139,8 @@ textarea.host-input { min-height:64px; resize:vertical; }
   white-space: nowrap;
   transition: border-color .12s ease, color .12s ease, background .12s ease;
 }
-.acp-agents-pane .settings-list-actions button:hover,
-.acp-agents-settings .settings-list-actions button:hover,
+.acp-agents-pane .settings-list-actions button:not(.settings-list-remove):hover,
+.acp-agents-settings .settings-list-actions button:not(.settings-list-remove):hover,
 .acp-agent-info button:hover {
   border-color: var(--clay);
   color: var(--clay);


### PR DESCRIPTION
## What

Fixes two bugs on the settings → Models / ACP Agents page.

### 1. ACP agent deletion
- **No confirmation.** Clicking the ACP delete button fired `remove_acp_agent` immediately, unlike model deletion which shows a "确定删除?" confirm dialog.
- **Wrong icon.** The delete button rendered as a green ×-in-a-circle (bordered pill) instead of a clean borderless × like the model list, because the ACP pane CSS styled *every* action button as a pill and overrode the base `.settings-list-remove` look.

### 2. Escape closed the whole settings page
The delete-confirm overlay let `Escape` bubble up to the window-level Escape stack, which hit the `show_settings` branch and closed the entire settings page (bouncing back to the home screen) instead of just dismissing the dialog.

## How

- Route both model and ACP deletes through a single `DeleteConfirm` overlay, so ACP deletion now gets the same confirmation gate.
- Own the `delete_confirm` signal in the app and close it in the window `Escape` handler **before** the settings-close branch — the exact pattern already used for `runtime_interpreter_form` / `context_details_modal`. A window listener fires regardless of focus, unlike the earlier modal-local `keydown` handler, which never triggered in the webview because focus wasn't inside the overlay.
- Exclude `.settings-list-remove` from the ACP pane's pill button styling (`:not(.settings-list-remove)`) so the delete × falls back to the borderless base style, matching the model list.

## Notes for reviewers

- `cargo check` passes for the `ui` crate.
- Not browser-verified: this is a Tauri app and the settings ACP/model lists come from the backend via `invoke`, so a WASM-only dev server can't exercise them. The Escape fix reuses an already-proven code path in the same window handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)