### PR TITLE
feat(context): progressively disclose MCP tools and skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ wisp-science/
 │  ├─ wisp-core/    ContextManager (3-tier compaction), SystemPrompt, agent_loop, memory
 │  ├─ wisp-tools/   read/write/edit/search/grep/shell/attempt_completion + Windows safety
 │  ├─ wisp-store/   sqlx SQLite (projects/frames/messages/artifacts/settings) + OS keyring
-│  ├─ wisp-skills/  SKILL.md discovery + use_skill tool (bundled catalog at skills/)
+│  ├─ wisp-skills/  SKILL.md discovery + search_skills/use_skill progressive loading
 │  ├─ wisp-runtime/ project-scoped Python/R runtime manager + REPL tools
 │  ├─ wisp-mcp/     stdio JSON-RPC MCP client + McpTool adapter (bundled bio-tools)
 │  ├─ wisp-acp/     ACP v1 stdio client for external coding agents
@@ -343,7 +343,9 @@ uv pip install mcp requests
 # plus any server-specific deps (httpx, xmltodict, etc.) the package imports
 ```
 
-Then the agent can call that server's tools (e.g. PubMed search) directly.
+The agent first discovers matching tools with `search_mcp_tools`, then calls the
+selected tool through `use_mcp_tool`. The full server catalog is never copied
+into every model request.
 
 ### Notion MCP
 
@@ -420,6 +422,8 @@ correctly.
 - **Context compaction** (`wisp-core::context`): three tiers fire before each
   model call at 80% of the context budget — micro-compact oversized tool
   output, drop old turns, then an LLM-driven full summary as a last resort.
+  Skill catalogs and MCP schemas use progressive disclosure instead of living
+  in the baseline prompt.
 - **Providers** (`wisp-llm`): one trait, two wire formats (OpenAI
   `/chat/completions` and Anthropic `/v1/messages`), both with SSE streaming.
   `RoutedProvider` picks a low/medium/high tier per turn from the last user
@@ -438,7 +442,8 @@ correctly.
   with object names, types, shapes/sizes, and bounded metadata. The table can be
   pinned over the conversation and dragged without interrupting the runtime.
 - **MCP** (`wisp-mcp`): a minimal newline-JSON-RPC client launches any stdio
-  MCP server and exposes each remote tool as a first-class agent tool.
+  MCP server. Remote schemas stay behind the fixed `search_mcp_tools` /
+  `use_mcp_tool` pair until a task needs them.
 
 ## Acknowledgements
 

--- a/crates/wisp-core/src/lib.rs
+++ b/crates/wisp-core/src/lib.rs
@@ -47,6 +47,7 @@ pub fn build_registry(
     memory_enabled: bool,
 ) -> Registry {
     let mut reg = Registry::builtins();
+    reg.add(Box::new(wisp_skills::SearchSkillsTool::new(skills.clone())));
     reg.add(Box::new(wisp_skills::UseSkillTool::new(skills)));
     if memory_enabled {
         reg.add(Box::new(SearchMemoryTool::new(memory.clone())));
@@ -94,11 +95,15 @@ impl Agent {
         }
     }
 
-    /// Seed the system prompt once when the session is fresh.
+    /// Seed a fresh system prompt or refresh its catalog-free skills section.
     pub fn seed_system_prompt(&mut self, skills: &SkillIndex, compute_hosts: Option<String>) {
+        let system_prompt = SystemPrompt::new(&self.root, skills, compute_hosts);
         if self.ctx.is_empty() {
-            let prompt = SystemPrompt::new(&self.root, skills, compute_hosts).assemble();
-            self.ctx.append_system(prompt);
+            self.ctx.append_system(system_prompt.assemble());
+        } else if let Some(message) = self.ctx.messages.first_mut() {
+            if let wisp_llm::Content::Text(prompt) = &mut message.content {
+                system_prompt.refresh_skills_guidance(prompt);
+            }
         }
     }
 

--- a/crates/wisp-core/src/system_prompt.rs
+++ b/crates/wisp-core/src/system_prompt.rs
@@ -86,11 +86,33 @@ Before any `pip`, `uv`, `npm`, or `pixi add` download, consider the user's netwo
     }
 
     fn skills_guidance(&self) -> String {
-        let desc = self.skills.descriptions();
-        if desc.is_empty() {
+        let count = self.skills.all().len();
+        if count == 0 {
             return "## Skills Selection Guidelines\n\nNo skills available.\n".into();
         }
-        format!("## Skills Selection Guidelines\n\n{desc}\n\n- If an installed skill is relevant, call `use_skill` first before proceeding.\n- Skills may contain: workflows, best practices, reusable scripts, references\n")
+        let availability = if count == 1 { "skill is" } else { "skills are" };
+        format!(
+            "## Skills Selection Guidelines\n\n\
+{count} installed {availability} available. Their catalog and bodies are not preloaded.\n\n\
+- When a task may match an installed workflow, call `search_skills` with concise task or domain keywords.\n\
+- Then call `use_skill` with the exact returned name before proceeding.\n\
+- If the user already attached a selected skill's guidance to the turn, follow that content without loading it again.\n"
+        )
+    }
+
+    /// Replace only the skills section in a persisted system prompt. Other
+    /// session-specific sections (specialist, delegation, user rules) stay intact.
+    pub fn refresh_skills_guidance(&self, prompt: &mut String) {
+        const HEADER: &str = "## Skills Selection Guidelines";
+        let Some(start) = prompt.find(HEADER) else {
+            return;
+        };
+        let search_from = start + HEADER.len();
+        let end = prompt[search_from..]
+            .find("\n\n## ")
+            .map(|offset| search_from + offset)
+            .unwrap_or(prompt.len());
+        prompt.replace_range(start..end, self.skills_guidance().trim_end());
     }
 
     fn memory(&self) -> String {
@@ -225,5 +247,47 @@ mod tests {
             out.contains("nested-quote one-liners"),
             "ssh quoting guidance missing:\n{out}"
         );
+    }
+
+    #[test]
+    fn prompt_keeps_skill_catalog_out_of_context() {
+        let root = std::env::temp_dir().join(format!(
+            "wisp-system-prompt-skills-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let skill_dir = root.join("secret-skill");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: secret-skill\ndescription: SHOULD_NOT_BE_IN_SYSTEM_PROMPT\n---\nbody",
+        )
+        .unwrap();
+        let skills = SkillIndex::load(&[root.clone()]);
+
+        let out = SystemPrompt::new(std::path::Path::new("/tmp"), &skills, None).assemble();
+        assert!(out.contains("1 installed skill is available"), "{out}");
+        assert!(out.contains("`search_skills`"), "{out}");
+        assert!(!out.contains("secret-skill"), "{out}");
+        assert!(!out.contains("SHOULD_NOT_BE_IN_SYSTEM_PROMPT"), "{out}");
+
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn persisted_prompt_drops_legacy_skill_catalog_only() {
+        let skills = SkillIndex::default();
+        let system = SystemPrompt::new(std::path::Path::new("/tmp"), &skills, None);
+        let mut prompt = "before\n\n## Skills Selection Guidelines\n\n- old: HUGE DESCRIPTION\n\n## User Rules\n\nkeep me\n\n## Specialist: reviewer\n\nkeep this too".to_string();
+
+        system.refresh_skills_guidance(&mut prompt);
+
+        assert!(!prompt.contains("HUGE DESCRIPTION"), "{prompt}");
+        assert!(prompt.contains("No skills available."), "{prompt}");
+        assert!(prompt.contains("## User Rules\n\nkeep me"), "{prompt}");
+        assert!(prompt.contains("## Specialist: reviewer"), "{prompt}");
     }
 }

--- a/crates/wisp-mcp/src/lib.rs
+++ b/crates/wisp-mcp/src/lib.rs
@@ -1,8 +1,10 @@
-//! Minimal stdio JSON-RPC MCP client + `McpTool` adapter.
+//! Minimal stdio JSON-RPC MCP client + deferred `McpTool` adapter.
 //!
 //! Launch a server with [`McpClient::launch`], enumerate its tools with
 //! [`McpClient::tools_list`], and wrap each as an [`McpTool`] to register with
-//! the agent's tool registry. Example (bio-tools):
+//! the agent's tool registry. The registry exposes MCP schemas through a fixed
+//! search/dispatch pair instead of sending the full catalog on every turn.
+//! Example (bio-tools):
 //!
 //! ```ignore
 //! let client = Arc::new(McpClient::launch("python",

--- a/crates/wisp-mcp/src/tool.rs
+++ b/crates/wisp-mcp/src/tool.rs
@@ -32,6 +32,9 @@ impl Tool for McpTool {
     fn schema(&self) -> ToolSchema {
         self.schema.clone()
     }
+    fn defer_schema(&self) -> bool {
+        true
+    }
     fn preview(&self, args: &Value) -> String {
         let s = args.to_string();
         s.chars().take(120).collect()

--- a/crates/wisp-skills/src/index.rs
+++ b/crates/wisp-skills/src/index.rs
@@ -79,15 +79,6 @@ impl SkillIndex {
         }
     }
 
-    /// One `- name: description` line per skill, for the system prompt.
-    pub fn descriptions(&self) -> String {
-        self.skills
-            .iter()
-            .map(|s| format!("- {}: {}", s.name, s.description))
-            .collect::<Vec<_>>()
-            .join("\n")
-    }
-
     pub fn get(&self, name: &str) -> Option<&Skill> {
         self.skills.iter().find(|s| s.name == name)
     }

--- a/crates/wisp-skills/src/lib.rs
+++ b/crates/wisp-skills/src/lib.rs
@@ -4,4 +4,4 @@ pub mod index;
 pub mod tool;
 
 pub use index::{bundled_dir, list_resources, parse_skill_file, Skill, SkillIndex};
-pub use tool::{render_skill, UseSkillTool};
+pub use tool::{render_skill, SearchSkillsTool, UseSkillTool};

--- a/crates/wisp-skills/src/tool.rs
+++ b/crates/wisp-skills/src/tool.rs
@@ -1,4 +1,4 @@
-//! `use_skill` — load an installed skill's guidance, scripts, and references.
+//! Search installed skill metadata, then load one skill's full guidance on demand.
 
 use crate::index::{list_resources, Skill, SkillIndex};
 use async_trait::async_trait;
@@ -6,6 +6,14 @@ use serde_json::json;
 use std::sync::Arc;
 use wisp_llm::ToolSchema;
 use wisp_tools::{Tool, ToolEnv, ToolResult};
+
+const DEFAULT_SEARCH_LIMIT: usize = 5;
+const MAX_SEARCH_LIMIT: usize = 10;
+const MAX_DESCRIPTION_CHARS: usize = 512;
+
+pub struct SearchSkillsTool {
+    skills: Arc<SkillIndex>,
+}
 
 pub struct UseSkillTool {
     skills: Arc<SkillIndex>,
@@ -32,6 +40,117 @@ pub fn render_skill(skill: &Skill) -> String {
         }
     }
     out
+}
+
+impl SearchSkillsTool {
+    pub fn new(skills: Arc<SkillIndex>) -> Self {
+        Self { skills }
+    }
+
+    fn search(&self, args: &serde_json::Value) -> ToolResult {
+        let Some(query) = args
+            .get("query")
+            .and_then(serde_json::Value::as_str)
+            .map(str::trim)
+            .filter(|query| !query.is_empty())
+        else {
+            return ToolResult::fail("missing required argument 'query'");
+        };
+        let limit = args
+            .get("limit")
+            .and_then(serde_json::Value::as_u64)
+            .map(|limit| limit as usize)
+            .unwrap_or(DEFAULT_SEARCH_LIMIT)
+            .clamp(1, MAX_SEARCH_LIMIT);
+        let query = query.to_lowercase();
+        let browse = query == "*";
+        let terms: Vec<_> = query.split_whitespace().collect();
+        let mut matches = vec![];
+        for skill in self.skills.all() {
+            let name = skill.name.to_lowercase();
+            let description = skill.description.to_lowercase();
+            let tags = skill.tags.join(" ").to_lowercase();
+            let mut score = usize::from(browse);
+            if name == query {
+                score += 1_000;
+            } else if name.contains(&query) {
+                score += 100;
+            }
+            if description.contains(&query) || tags.contains(&query) {
+                score += 50;
+            }
+            for term in &terms {
+                if name.contains(term) {
+                    score += 20;
+                }
+                if description.contains(term) {
+                    score += 5;
+                }
+                if tags.contains(term) {
+                    score += 10;
+                }
+            }
+            if score > 0 {
+                matches.push((score, skill));
+            }
+        }
+        matches.sort_by(|(left_score, left), (right_score, right)| {
+            right_score
+                .cmp(left_score)
+                .then_with(|| left.name.cmp(&right.name))
+        });
+        let matched_skills = matches.len();
+        let results: Vec<_> = matches
+            .into_iter()
+            .take(limit)
+            .map(|(_, skill)| {
+                json!({
+                    "name": skill.name,
+                    "description": truncate_chars(&skill.description, MAX_DESCRIPTION_CHARS),
+                    "tags": skill.tags,
+                })
+            })
+            .collect();
+        ToolResult::ok(
+            serde_json::to_string_pretty(&json!({
+                "results": results,
+                "matched_skills": matched_skills,
+                "total_skills": self.skills.all().len(),
+                "next": "Call 'use_skill' with the exact name of the relevant skill. Use query '*' to browse.",
+            }))
+            .unwrap_or_default(),
+        )
+    }
+}
+
+#[async_trait]
+impl Tool for SearchSkillsTool {
+    fn name(&self) -> &str {
+        "search_skills"
+    }
+    fn schema(&self) -> ToolSchema {
+        ToolSchema::new(
+            "search_skills",
+            "Search installed skill names, descriptions, and tags without loading every skill body.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "query": { "type": "string", "description": "Task, workflow, domain keywords, or '*' to browse" },
+                    "limit": { "type": "integer", "description": "Maximum matches to return (default 5, maximum 10)" }
+                },
+                "required": ["query"]
+            }),
+        )
+    }
+    fn preview(&self, args: &serde_json::Value) -> String {
+        args.get("query")
+            .and_then(|value| value.as_str())
+            .unwrap_or_default()
+            .to_string()
+    }
+    async fn run(&self, args: &serde_json::Value, _env: &dyn ToolEnv) -> ToolResult {
+        self.search(args)
+    }
 }
 
 impl UseSkillTool {
@@ -67,5 +186,61 @@ impl Tool for UseSkillTool {
             return ToolResult::fail(format!("skill '{name}' not found"));
         };
         ToolResult::ok(render_skill(skill))
+    }
+}
+
+fn truncate_chars(value: &str, max_chars: usize) -> String {
+    if value.chars().count() <= max_chars {
+        return value.to_string();
+    }
+    let mut truncated: String = value.chars().take(max_chars).collect();
+    truncated.push_str("… [truncated]");
+    truncated
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn skill_search_returns_only_relevant_metadata() {
+        let root = std::env::temp_dir().join(format!(
+            "wisp-skill-search-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        for (name, description, tags) in [
+            (
+                "pubmed-review",
+                "Find biomedical papers and synthesize evidence.",
+                "literature, medicine",
+            ),
+            (
+                "plot-figure",
+                "Create publication-ready charts.",
+                "visualization",
+            ),
+        ] {
+            let dir = root.join(name);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(
+                dir.join("SKILL.md"),
+                format!("---\nname: {name}\ndescription: {description}\ntags: [{tags}]\n---\nbody"),
+            )
+            .unwrap();
+        }
+        let search = SearchSkillsTool::new(Arc::new(SkillIndex::load(&[root.clone()])));
+
+        let result = search.search(&json!({ "query": "biomedical literature" }));
+        assert!(result.success, "search failed: {}", result.content);
+        let output: serde_json::Value = serde_json::from_str(&result.content).unwrap();
+        assert_eq!(output["results"][0]["name"], "pubmed-review");
+        assert_eq!(output["results"].as_array().unwrap().len(), 1);
+        assert!(!result.content.contains("publication-ready charts"));
+
+        std::fs::remove_dir_all(root).ok();
     }
 }

--- a/crates/wisp-tools/src/lib.rs
+++ b/crates/wisp-tools/src/lib.rs
@@ -25,6 +25,12 @@ pub use tool::Tool;
 use serde_json::Value;
 use wisp_llm::ToolSchema;
 
+const SEARCH_MCP_TOOLS: &str = "search_mcp_tools";
+const USE_MCP_TOOL: &str = "use_mcp_tool";
+const DEFAULT_MCP_SEARCH_LIMIT: usize = 5;
+const MAX_MCP_SEARCH_LIMIT: usize = 10;
+const MAX_MCP_DESCRIPTION_CHARS: usize = 2_048;
+
 /// The built-in tool set plus any extras (repl, MCP) registered later.
 pub struct Registry {
     tools: Vec<Box<dyn Tool>>,
@@ -54,7 +60,17 @@ impl Registry {
     }
 
     pub fn schemas(&self) -> Vec<ToolSchema> {
-        self.tools.iter().map(|t| t.schema()).collect()
+        let mut schemas: Vec<_> = self
+            .tools
+            .iter()
+            .filter(|tool| !tool.defer_schema())
+            .map(|tool| tool.schema())
+            .collect();
+        if self.tools.iter().any(|tool| tool.defer_schema()) {
+            schemas.push(search_mcp_tools_schema());
+            schemas.push(use_mcp_tool_schema());
+        }
+        schemas
     }
 
     pub fn names(&self) -> Vec<&str> {
@@ -71,30 +87,207 @@ impl Registry {
     /// Dispatch a tool call: enforce the approval policy, emit the call card,
     /// run `before`, then `run`.
     pub async fn run(&self, name: &str, args: &Value, env: &dyn ToolEnv) -> ToolResult {
+        if name == SEARCH_MCP_TOOLS {
+            return self.run_mcp_search(args, env).await;
+        }
+        if name == USE_MCP_TOOL {
+            let Some(tool_name) = args.get("tool_name").and_then(Value::as_str) else {
+                return ToolResult::fail("missing required argument 'tool_name'");
+            };
+            let Some(tool_input) = args.get("tool_input").filter(|value| value.is_object()) else {
+                return ToolResult::fail("'tool_input' must be a JSON object");
+            };
+            let Some(tool) = self
+                .tools
+                .iter()
+                .find(|tool| tool.defer_schema() && tool.name() == tool_name)
+            else {
+                return ToolResult::fail(format!(
+                    "deferred MCP tool '{tool_name}' not found; call '{SEARCH_MCP_TOOLS}' first"
+                ));
+            };
+            return run_registered_tool(tool.as_ref(), tool_input, env).await;
+        }
         let Some(tool) = self.get(name) else {
             return ToolResult::fail(format!("unknown tool '{name}'"));
         };
-        // Per-tool approval gate. `Deny` blocks before the call card even shows;
-        // `Ask` shows the card then routes through `confirm`; `Allow` runs as before.
-        let approval = env.approval_mode(name).await;
+        run_registered_tool(tool, args, env).await
+    }
+
+    async fn run_mcp_search(&self, args: &Value, env: &dyn ToolEnv) -> ToolResult {
+        let approval = env.approval_mode(SEARCH_MCP_TOOLS).await;
         if approval == env::Approval::Deny {
-            return ToolResult::fail(format!("tool '{name}' is blocked by the approval policy"));
+            return ToolResult::fail(format!(
+                "tool '{SEARCH_MCP_TOOLS}' is blocked by the approval policy"
+            ));
         }
-        let preview = tool.preview(args);
+        let preview = args
+            .get("query")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
         env.emit(ToolEvent::Call {
-            name: name.to_string(),
+            name: SEARCH_MCP_TOOLS.to_string(),
             preview,
         })
         .await;
-        if approval == env::Approval::Ask && !env.confirm(&format!("Run tool '{name}'?")).await {
+        if approval == env::Approval::Ask
+            && !env
+                .confirm(&format!("Run tool '{SEARCH_MCP_TOOLS}'?"))
+                .await
+        {
             env.emit(ToolEvent::Result { ok: false }).await;
-            return ToolResult::fail(format!("tool '{name}' was denied by the user"));
+            return ToolResult::fail(format!("tool '{SEARCH_MCP_TOOLS}' was denied by the user"));
         }
-        tool.before(args, env).await;
-        let result = tool.run(args, env).await;
+        let result = self.search_mcp_tools(args);
         env.emit(ToolEvent::Result { ok: result.success }).await;
         result
     }
+
+    fn search_mcp_tools(&self, args: &Value) -> ToolResult {
+        let Some(query) = args
+            .get("query")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|query| !query.is_empty())
+        else {
+            return ToolResult::fail("missing required argument 'query'");
+        };
+        let limit = args
+            .get("limit")
+            .and_then(Value::as_u64)
+            .map(|limit| limit as usize)
+            .unwrap_or(DEFAULT_MCP_SEARCH_LIMIT)
+            .clamp(1, MAX_MCP_SEARCH_LIMIT);
+        let query = query.to_lowercase();
+        let browse = query == "*";
+        let terms: Vec<_> = query.split_whitespace().collect();
+        let total_hidden_tools = self.tools.iter().filter(|tool| tool.defer_schema()).count();
+        let mut matches = vec![];
+        for tool in self.tools.iter().filter(|tool| tool.defer_schema()) {
+            let schema = tool.schema();
+            let name = schema.function.name.to_lowercase();
+            let description = schema.function.description.to_lowercase();
+            let parameters = schema.function.parameters.to_string().to_lowercase();
+            let mut score = usize::from(browse);
+            if name == query {
+                score += 1_000;
+            } else if name.contains(&query) {
+                score += 100;
+            }
+            if description.contains(&query) {
+                score += 50;
+            }
+            for term in &terms {
+                if name.contains(term) {
+                    score += 20;
+                }
+                if description.contains(term) {
+                    score += 5;
+                }
+                if parameters.contains(term) {
+                    score += 1;
+                }
+            }
+            if score > 0 {
+                matches.push((score, schema));
+            }
+        }
+        matches.sort_by(|(left_score, left), (right_score, right)| {
+            right_score
+                .cmp(left_score)
+                .then_with(|| left.function.name.cmp(&right.function.name))
+        });
+        let matched_tools = matches.len();
+        let results: Vec<_> = matches
+            .into_iter()
+            .take(limit)
+            .map(|(_, schema)| {
+                serde_json::json!({
+                    "tool_name": schema.function.name,
+                    "description": truncate_chars(
+                        &schema.function.description,
+                        MAX_MCP_DESCRIPTION_CHARS,
+                    ),
+                    "input_schema": schema.function.parameters,
+                })
+            })
+            .collect();
+        ToolResult::ok(
+            serde_json::to_string_pretty(&serde_json::json!({
+                "results": results,
+                "matched_tools": matched_tools,
+                "total_hidden_tools": total_hidden_tools,
+                "next": format!(
+                    "Call '{USE_MCP_TOOL}' with a returned tool_name and matching tool_input. Use query '*' to browse."
+                ),
+            }))
+            .unwrap_or_default(),
+        )
+    }
+}
+
+async fn run_registered_tool(tool: &dyn Tool, args: &Value, env: &dyn ToolEnv) -> ToolResult {
+    let name = tool.name();
+    // Per-tool approval gate. `Deny` blocks before the call card even shows;
+    // `Ask` shows the card then routes through `confirm`; `Allow` runs as before.
+    let approval = env.approval_mode(name).await;
+    if approval == env::Approval::Deny {
+        return ToolResult::fail(format!("tool '{name}' is blocked by the approval policy"));
+    }
+    let preview = tool.preview(args);
+    env.emit(ToolEvent::Call {
+        name: name.to_string(),
+        preview,
+    })
+    .await;
+    if approval == env::Approval::Ask && !env.confirm(&format!("Run tool '{name}'?")).await {
+        env.emit(ToolEvent::Result { ok: false }).await;
+        return ToolResult::fail(format!("tool '{name}' was denied by the user"));
+    }
+    tool.before(args, env).await;
+    let result = tool.run(args, env).await;
+    env.emit(ToolEvent::Result { ok: result.success }).await;
+    result
+}
+
+fn truncate_chars(value: &str, max_chars: usize) -> String {
+    if value.chars().count() <= max_chars {
+        return value.to_string();
+    }
+    let mut truncated: String = value.chars().take(max_chars).collect();
+    truncated.push_str("… [truncated]");
+    truncated
+}
+
+fn search_mcp_tools_schema() -> ToolSchema {
+    ToolSchema::new(
+        SEARCH_MCP_TOOLS,
+        "Search deferred MCP tools by name, description, and input fields. Returns only matching schemas so the full MCP catalog does not consume every request.",
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "query": { "type": "string", "description": "Capability, server, action, known tool name, or '*' to browse" },
+                "limit": { "type": "integer", "description": "Maximum matches to return (default 5, maximum 10)" }
+            },
+            "required": ["query"]
+        }),
+    )
+}
+
+fn use_mcp_tool_schema() -> ToolSchema {
+    ToolSchema::new(
+        USE_MCP_TOOL,
+        "Call an MCP tool found by search_mcp_tools. tool_input must match the returned input_schema.",
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "tool_name": { "type": "string", "description": "Exact tool_name returned by search_mcp_tools" },
+                "tool_input": { "type": "object", "description": "Arguments matching the selected tool's input_schema", "additionalProperties": true }
+            },
+            "required": ["tool_name", "tool_input"]
+        }),
+    )
 }
 
 /// A thin `view_image` tool wrapper around the shared image helper.
@@ -159,6 +352,31 @@ mod approval_tests {
         async fn run(&self, _args: &Value, _env: &dyn ToolEnv) -> ToolResult {
             self.0.store(true, Ordering::SeqCst);
             ToolResult::ok("ran")
+        }
+    }
+
+    struct DeferredTool;
+    #[async_trait::async_trait]
+    impl Tool for DeferredTool {
+        fn name(&self) -> &str {
+            "pubmed_search_articles"
+        }
+        fn schema(&self) -> ToolSchema {
+            ToolSchema::new(
+                self.name(),
+                "Search PubMed articles by biomedical keywords.",
+                serde_json::json!({
+                    "type": "object",
+                    "properties": { "query": { "type": "string" } },
+                    "required": ["query"]
+                }),
+            )
+        }
+        fn defer_schema(&self) -> bool {
+            true
+        }
+        async fn run(&self, args: &Value, _env: &dyn ToolEnv) -> ToolResult {
+            ToolResult::ok(format!("searched {}", args["query"]))
         }
     }
 
@@ -255,5 +473,65 @@ mod approval_tests {
             .filter(|ev| matches!(ev, ToolEvent::Call { .. }))
             .count();
         assert_eq!(calls, 1, "registry should emit the only tool call card");
+    }
+
+    #[test]
+    fn deferred_schemas_are_replaced_by_search_and_dispatch_tools() {
+        let mut reg = Registry { tools: vec![] };
+        reg.add(Box::new(SpyTool(&SPY_FOR_SCHEMA_TEST)));
+        reg.add(Box::new(DeferredTool));
+
+        let names: Vec<_> = reg
+            .schemas()
+            .into_iter()
+            .map(|schema| schema.function.name)
+            .collect();
+
+        assert_eq!(names, ["spy", SEARCH_MCP_TOOLS, USE_MCP_TOOL]);
+        assert!(!names.contains(&"pubmed_search_articles".to_string()));
+    }
+
+    static SPY_FOR_SCHEMA_TEST: AtomicBool = AtomicBool::new(false);
+
+    #[tokio::test]
+    async fn deferred_tool_is_searched_then_dispatched() {
+        let mut reg = Registry { tools: vec![] };
+        reg.add(Box::new(DeferredTool));
+        let env = EventEnv {
+            root: PathBuf::from("."),
+            events: Mutex::new(vec![]),
+        };
+
+        let found = reg
+            .run(
+                SEARCH_MCP_TOOLS,
+                &serde_json::json!({ "query": "biomedical articles" }),
+                &env,
+            )
+            .await;
+        assert!(found.success, "search failed: {}", found.content);
+        let catalog: Value = serde_json::from_str(&found.content).unwrap();
+        assert_eq!(catalog["results"][0]["tool_name"], "pubmed_search_articles");
+        assert_eq!(
+            catalog["results"][0]["input_schema"]["required"][0],
+            "query"
+        );
+
+        let called = reg
+            .run(
+                USE_MCP_TOOL,
+                &serde_json::json!({
+                    "tool_name": "pubmed_search_articles",
+                    "tool_input": { "query": "cancer" }
+                }),
+                &env,
+            )
+            .await;
+        assert!(called.success, "dispatch failed: {}", called.content);
+        assert_eq!(called.content, "searched \"cancer\"");
+        assert!(env.events.lock().unwrap().iter().any(|event| matches!(
+            event,
+            ToolEvent::Call { name, .. } if name == "pubmed_search_articles"
+        )));
     }
 }

--- a/crates/wisp-tools/src/tool.rs
+++ b/crates/wisp-tools/src/tool.rs
@@ -9,6 +9,11 @@ use wisp_llm::ToolSchema;
 pub trait Tool: Send + Sync {
     fn name(&self) -> &str;
     fn schema(&self) -> ToolSchema;
+    /// Keep this tool callable but omit its schema from ordinary model requests.
+    /// Deferred tools are discovered through the registry's MCP search/dispatch pair.
+    fn defer_schema(&self) -> bool {
+        false
+    }
     /// One-line preview shown in the tool-call card (e.g. the file path).
     fn preview(&self, _args: &Value) -> String {
         String::new()

--- a/docs/acp-agents.md
+++ b/docs/acp-agents.md
@@ -126,12 +126,13 @@ bridge exposes the following project-scoped Wisp Harness gateway:
 
 - `wisp_get_capabilities` — inspect the exact grant and current limitations
 - `wisp_list_skills` / `wisp_use_skill` — discover and load enabled skills
+- `wisp_search_tools` / `wisp_use_tool` — discover and call scientific or custom MCP tools without loading the full schema catalog
 - `wisp_search_memory` — read durable project memory
 - `wisp_list_artifacts` — list artifacts owned by the active project
 - `wisp_get_research_graph` — read project research nodes and edges
 - `wisp_list_execution_contexts` — read context capabilities and probe status
 - `wisp_run_in_context`, `wisp_get_run`, `wisp_monitor_run`, and `wisp_cancel_run` — persisted Run controls; `wisp_monitor_run` waits without repeated model polling
-- enabled scientific tools and enabled custom MCP connections
+- enabled scientific tools and custom MCP connections, available through the search/use pair above
 
 This is deliberately a capability gateway, not an unrestricted export of every
 internal Rust object or UI command. Memory/artifact/graph writes and persistent

--- a/src-tauri/src/debug_request.rs
+++ b/src-tauri/src/debug_request.rs
@@ -213,7 +213,10 @@ pub(super) async fn export_debug_request(
     }
 
     let json = serde_json::to_string_pretty(&snapshot).map_err(|e| format!("{e}"))?;
-    let default_name = format!("wisp-debug-request-{}.json", sanitize_component(&session_id));
+    let default_name = format!(
+        "wisp-debug-request-{}.json",
+        sanitize_component(&session_id)
+    );
     let (tx, rx) = tokio::sync::oneshot::channel();
     app.dialog()
         .file()
@@ -261,9 +264,7 @@ mod tests {
         // (rather than read by a tool), it must be visible in the export.
         let msgs = vec![
             Message::system("sys"),
-            Message::user(
-                "Selected excerpt from workspace file data.xls:\ncol_a,col_b\n1,2\n3,4",
-            ),
+            Message::user("Selected excerpt from workspace file data.xls:\ncol_a,col_b\n1,2\n3,4"),
         ];
         let snap = build_snapshot("s1", "t".into(), &msgs, &[], None, None, "stored-messages");
         assert!(snap.messages[1].text.contains("data.xls"));

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3494,9 +3494,7 @@ async fn send_message(
             Err(e) => tracing::warn!("load session from sqlite failed: {e}"),
         }
         rt.set_last_seq(agent.ctx.messages.len() as i64);
-        if agent.ctx.is_empty() {
-            agent.seed_system_prompt(&skills, None);
-        }
+        agent.seed_system_prompt(&skills, None);
         if let Some(message) = agent.ctx.messages.first_mut() {
             if let wisp_llm::Content::Text(prompt) = &mut message.content {
                 delegation_runtime::sync_delegation_prompt(prompt, delegation_enabled);

--- a/src-tauri/src/mcp_bridge.rs
+++ b/src-tauri/src/mcp_bridge.rs
@@ -20,6 +20,10 @@ use wisp_skills::{list_resources, SkillIndex};
 use wisp_store::Store;
 use wisp_tools::{Approval, Tool, ToolEnv, ToolEvent, ToolResult};
 
+const DEFAULT_TOOL_SEARCH_LIMIT: usize = 5;
+const MAX_TOOL_SEARCH_LIMIT: usize = 10;
+const MAX_TOOL_DESCRIPTION_CHARS: usize = 2_048;
+
 #[derive(Debug, Clone)]
 pub(crate) struct BridgeConfig {
     pub(crate) app_data: PathBuf,
@@ -132,6 +136,8 @@ impl BridgeServer {
                     "required": ["name"]
                 }
             }),
+            search_tools_tool_schema(),
+            use_tool_tool_schema(),
             search_memory_tool_schema(),
             list_artifacts_tool_schema(),
             get_research_graph_tool_schema(),
@@ -146,8 +152,6 @@ impl BridgeServer {
                 tools.push(propose_delegation_tool_schema());
             }
         }
-        let remote = self.ensure_remote_tools().await?;
-        tools.extend(remote);
         Ok(json!({ "tools": tools }))
     }
 
@@ -167,6 +171,26 @@ impl BridgeServer {
                 Ok(s) => (s, false),
                 Err(e) => (e.to_string(), true),
             },
+            "wisp_search_tools" => match self.search_tools_text(&args).await {
+                Ok(s) => (s, false),
+                Err(e) => (e.to_string(), true),
+            },
+            "wisp_use_tool" => {
+                let Some(tool_name) = args.get("tool_name").and_then(Value::as_str) else {
+                    return Ok(tool_call_result(
+                        "missing required argument 'tool_name'",
+                        true,
+                    ));
+                };
+                let Some(tool_input) = args.get("tool_input").filter(|value| value.is_object())
+                else {
+                    return Ok(tool_call_result("'tool_input' must be a JSON object", true));
+                };
+                match self.call_remote_tool(tool_name, tool_input).await {
+                    Ok(result) => result,
+                    Err(error) => (error.to_string(), true),
+                }
+            }
             "wisp_search_memory" => match self.search_memory_text(&args) {
                 Ok(s) => (s, false),
                 Err(e) => (e.to_string(), true),
@@ -219,35 +243,12 @@ impl BridgeServer {
                     .await;
                 (result.content, !result.success)
             }
-            other => {
-                self.ensure_remote_tools().await?;
-                let Some(route) = self.routes.get(other).cloned() else {
-                    return Err(anyhow!("unknown Wisp bridge tool '{other}'"));
-                };
-                match route {
-                    Route::Bio {
-                        client,
-                        remote_name,
-                        ..
-                    }
-                    | Route::Custom {
-                        client,
-                        remote_name,
-                        ..
-                    } => match client.tool_call(&remote_name, &args).await {
-                        Ok(s) => (s, false),
-                        Err(e) => (e.to_string(), true),
-                    },
-                }
-            }
+            other => self.call_remote_tool(other, &args).await?,
         };
-        Ok(json!({
-            "content": [{ "type": "text", "text": text }],
-            "isError": is_error
-        }))
+        Ok(tool_call_result(text, is_error))
     }
 
-    async fn ensure_remote_tools(&mut self) -> Result<Vec<Value>> {
+    async fn ensure_remote_tools(&mut self) -> Result<()> {
         if !self.bundled_bio_tools_loaded {
             self.bundled_bio_tools_loaded = true;
             self.register_bundled_bio_tools().await;
@@ -256,7 +257,7 @@ impl BridgeServer {
             self.custom_mcp_tools_loaded = true;
             self.register_custom_mcp_tools().await;
         }
-        Ok(self.route_tools())
+        Ok(())
     }
 
     async fn register_bundled_bio_tools(&mut self) {
@@ -381,6 +382,36 @@ impl BridgeServer {
             .collect()
     }
 
+    async fn search_tools_text(&mut self, args: &Value) -> Result<String> {
+        self.ensure_remote_tools().await?;
+        search_tool_catalog(self.route_tools(), args)
+    }
+
+    async fn call_remote_tool(&mut self, name: &str, args: &Value) -> Result<(String, bool)> {
+        self.ensure_remote_tools().await?;
+        let route = self
+            .routes
+            .get(name)
+            .cloned()
+            .ok_or_else(|| anyhow!("unknown Wisp bridge tool '{name}'"))?;
+        let (client, remote_name) = match route {
+            Route::Bio {
+                client,
+                remote_name,
+                ..
+            }
+            | Route::Custom {
+                client,
+                remote_name,
+                ..
+            } => (client, remote_name),
+        };
+        Ok(match client.tool_call(&remote_name, args).await {
+            Ok(text) => (text, false),
+            Err(error) => (error.to_string(), true),
+        })
+    }
+
     fn is_reserved(&self, name: &str) -> bool {
         is_builtin_tool(name) || self.routes.contains_key(name)
     }
@@ -450,7 +481,12 @@ impl BridgeServer {
                     "tools": ["wisp_run_in_context", "wisp_cancel_run"],
                     "policy": "non_interactive; dangerous commands requiring confirmation are denied"
                 },
-                { "name": "scientific_mcp", "allowed": true, "discovery": "tools/list" },
+                {
+                    "name": "scientific_mcp",
+                    "allowed": true,
+                    "tools": ["wisp_search_tools", "wisp_use_tool"],
+                    "discovery": "wisp_search_tools"
+                },
                 {
                     "name": "harness.write",
                     "allowed": false,
@@ -610,6 +646,127 @@ fn parse_json_or_string(raw: &str) -> Value {
     serde_json::from_str(raw).unwrap_or_else(|_| Value::String(raw.to_string()))
 }
 
+fn tool_call_result(text: impl Into<String>, is_error: bool) -> Value {
+    json!({
+        "content": [{ "type": "text", "text": text.into() }],
+        "isError": is_error
+    })
+}
+
+fn search_tool_catalog(tools: Vec<Value>, args: &Value) -> Result<String> {
+    let query = args
+        .get("query")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|query| !query.is_empty())
+        .ok_or_else(|| anyhow!("missing required argument 'query'"))?
+        .to_lowercase();
+    let limit = args
+        .get("limit")
+        .and_then(Value::as_u64)
+        .map(|limit| limit as usize)
+        .unwrap_or(DEFAULT_TOOL_SEARCH_LIMIT)
+        .clamp(1, MAX_TOOL_SEARCH_LIMIT);
+    let browse = query == "*";
+    let terms: Vec<_> = query.split_whitespace().collect();
+    let total_hidden_tools = tools.len();
+    let mut matches = vec![];
+    for mut tool in tools {
+        let name = tool["name"].as_str().unwrap_or_default().to_lowercase();
+        let description = tool["description"]
+            .as_str()
+            .unwrap_or_default()
+            .to_lowercase();
+        let parameters = tool["inputSchema"].to_string().to_lowercase();
+        let mut score = usize::from(browse);
+        if name == query {
+            score += 1_000;
+        } else if name.contains(&query) {
+            score += 100;
+        }
+        if description.contains(&query) {
+            score += 50;
+        }
+        for term in &terms {
+            if name.contains(term) {
+                score += 20;
+            }
+            if description.contains(term) {
+                score += 5;
+            }
+            if parameters.contains(term) {
+                score += 1;
+            }
+        }
+        if score > 0 {
+            tool["description"] = Value::String(truncate_catalog_description(
+                tool["description"].as_str().unwrap_or_default(),
+            ));
+            matches.push((score, name, tool));
+        }
+    }
+    matches.sort_by(|left, right| right.0.cmp(&left.0).then_with(|| left.1.cmp(&right.1)));
+    let matched_tools = matches.len();
+    let results: Vec<_> = matches
+        .into_iter()
+        .take(limit)
+        .map(|(_, _, tool)| {
+            json!({
+                "tool_name": tool["name"],
+                "description": tool["description"],
+                "input_schema": tool["inputSchema"],
+            })
+        })
+        .collect();
+    Ok(serde_json::to_string_pretty(&json!({
+        "results": results,
+        "matched_tools": matched_tools,
+        "total_hidden_tools": total_hidden_tools,
+        "next": "Call 'wisp_use_tool' with a returned tool_name and matching tool_input. Use query '*' to browse.",
+    }))?)
+}
+
+fn truncate_catalog_description(value: &str) -> String {
+    if value.chars().count() <= MAX_TOOL_DESCRIPTION_CHARS {
+        return value.to_string();
+    }
+    let mut truncated: String = value.chars().take(MAX_TOOL_DESCRIPTION_CHARS).collect();
+    truncated.push_str("… [truncated]");
+    truncated
+}
+
+fn search_tools_tool_schema() -> Value {
+    json!({
+        "name": "wisp_search_tools",
+        "description": "Search enabled Wisp scientific and custom MCP tools. Returns only matching input schemas instead of exposing the full catalog on every request.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "query": { "type": "string", "description": "Capability, connector, action, known tool name, or '*' to browse" },
+                "limit": { "type": "integer", "description": "Maximum matches to return (default 5, maximum 10)" }
+            },
+            "required": ["query"],
+            "additionalProperties": false
+        }
+    })
+}
+
+fn use_tool_tool_schema() -> Value {
+    json!({
+        "name": "wisp_use_tool",
+        "description": "Call a Wisp MCP tool found by wisp_search_tools. tool_input must match the returned input_schema.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "tool_name": { "type": "string", "description": "Exact tool_name returned by wisp_search_tools" },
+                "tool_input": { "type": "object", "description": "Arguments matching the selected tool's input_schema", "additionalProperties": true }
+            },
+            "required": ["tool_name", "tool_input"],
+            "additionalProperties": false
+        }
+    })
+}
+
 fn get_capabilities_tool_schema() -> Value {
     json!({
         "name": "wisp_get_capabilities",
@@ -757,6 +914,8 @@ fn is_builtin_tool(name: &str) -> bool {
         "wisp_get_capabilities"
             | "wisp_list_skills"
             | "wisp_use_skill"
+            | "wisp_search_tools"
+            | "wisp_use_tool"
             | "wisp_search_memory"
             | "wisp_list_artifacts"
             | "wisp_get_research_graph"
@@ -920,6 +1079,8 @@ mod tests {
             "wisp_get_capabilities"
         );
         assert_eq!(search_memory_tool_schema()["name"], "wisp_search_memory");
+        assert_eq!(search_tools_tool_schema()["name"], "wisp_search_tools");
+        assert_eq!(use_tool_tool_schema()["name"], "wisp_use_tool");
         assert_eq!(list_artifacts_tool_schema()["name"], "wisp_list_artifacts");
         assert_eq!(
             get_research_graph_tool_schema()["name"],
@@ -961,6 +1122,8 @@ mod tests {
             "wisp_get_capabilities",
             "wisp_list_skills",
             "wisp_use_skill",
+            "wisp_search_tools",
+            "wisp_use_tool",
             "wisp_search_memory",
             "wisp_list_artifacts",
             "wisp_get_research_graph",
@@ -974,6 +1137,35 @@ mod tests {
             assert!(is_builtin_tool(name), "{name} must be reserved");
         }
         assert!(!is_builtin_tool("third_party_run"));
+    }
+
+    #[test]
+    fn bridge_mcp_catalog_is_searched_on_demand() {
+        let catalog = vec![
+            json!({
+                "name": "pubmed_search",
+                "description": "Search biomedical literature.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": { "query": { "type": "string" } }
+                }
+            }),
+            json!({
+                "name": "notion_create_page",
+                "description": "Create a Notion page.",
+                "inputSchema": { "type": "object", "properties": {} }
+            }),
+        ];
+
+        let result = search_tool_catalog(catalog, &json!({ "query": "biomedical" })).unwrap();
+        let result: Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(result["total_hidden_tools"], 2);
+        assert_eq!(result["results"].as_array().unwrap().len(), 1);
+        assert_eq!(result["results"][0]["tool_name"], "pubmed_search");
+        assert_eq!(
+            result["results"][0]["input_schema"]["properties"]["query"]["type"],
+            "string"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

Wisp sent the installed skill catalog in the system prompt and advertised every MCP schema on each model request. Context cost therefore grew with configured skills and connectors, even when most capabilities were irrelevant to the current task.

## Summary

- Add search_skills and keep use_skill as the on-demand full guidance loader.
- Remove skill names and descriptions from new system prompts and refresh the skills section in persisted sessions.
- Mark MCP adapters as deferred and expose a fixed search_mcp_tools / use_mcp_tool pair while preserving per-tool approval and legacy direct dispatch.
- Apply the same search/use pattern to the ACP bridge and delay remote MCP startup until first search or use.
- Document progressive disclosure and add unit and bridge coverage.

## Verification

- cargo fmt --all -- --check
- cargo test --workspace
- cd ui && cargo check --target wasm32-unknown-unknown
- cargo run -p wisp-mcp --example smoke
- Playwright targeted rerun: composer context references, Skill manager, and custom MCP tests all passed.

The full Playwright run reached 147 passing tests before the local preview server exited; the remaining 22 failures were page.goto ERR_CONNECTION_REFUSED errors. A second single-worker run reproduced the preview-server exit. The relevant tests and the one preceding assertion failure passed when rerun in isolation.

## Manual smoke

1. Open a new or existing conversation and request a workflow backed by a skill; confirm the agent calls search_skills and then use_skill, with no full catalog in the system prompt.
2. Enable an MCP connector and request one of its capabilities; confirm search_mcp_tools returns matching schemas and use_mcp_tool executes the selected tool.
3. Start an ACP session; confirm tools/list exposes wisp_search_tools and wisp_use_tool instead of each remote MCP schema.

## Known limitations

Search uses deterministic lexical scoring over names, descriptions, tags, and schema fields. BM25 or semantic retrieval can be added later if measured recall is insufficient.