### PR TITLE
fix: 右键结构化行不再被文本选区菜单劫持,并加"复制文件名"

### DIFF
--- a/ui/src/context_menu.rs
+++ b/ui/src/context_menu.rs
@@ -290,7 +290,13 @@ pub fn build(
     }
 
     let text_entry = editable_text_entry(&target);
-    if text_entry.is_none() {
+    // A stray text selection (e.g. an accidentally selected file name) must not
+    // hijack the context menu of a structural row — file rows, artifact tiles,
+    // sessions and folders have their own menus below and should win when
+    // right-clicked, regardless of what happens to be selected on the page.
+    let on_structural_row =
+        closest(&target, ".fb-row, .rp-tile, .side-item.ses, .side-folder").is_some();
+    if text_entry.is_none() && !on_structural_row {
         if let Some(text) = selection_text() {
             // Mirror the selection popup's quote/explain actions so right-click
             // offers everything in one menu instead of stacking popups.
@@ -452,10 +458,12 @@ pub fn build(
             .get_attribute("data-workspace-path")
             .unwrap_or_default();
         if !path.is_empty() {
+            let file_name = path.rsplit('/').next().unwrap_or(path.as_str()).to_string();
             return Some(CtxMenu {
                 x,
                 y,
                 items: vec![
+                    item("copyName", i18n::t(locale, "ctx.copy_name"), file_name),
                     item(
                         "openWorkspaceFileCenter",
                         i18n::t(locale, "center.open_file"),


### PR DESCRIPTION
## 问题

右键一个文件行时,菜单会因"文件名是否被选中"而变成两套:

- 文件名被选中(点/双击/拖一下就会选中)→ 弹出**文本选区菜单**(复制 / 在右侧对话中交给 AI / 侧边问答解释)
- 没有选中 → 弹出预期的**文件操作菜单**(在中间打开 / 附加到对话 / 下载 / 重命名 / 删除)

根因在 `context_menu.rs` 的 `build()`:全局文本选区判定(第 292 行附近)早于文件行判定(第 445 行附近)返回,而 `selection_text()` 读的是**全局选区**、不校验是否落在右键目标上。于是任意一段选中文本(尤其是顺手选中的文件名)都会劫持文件行的右键菜单。

## 改动

- **修复**:在选区分支加守卫——当右键目标落在结构化行(`.fb-row` / `.rp-tile` / `.side-item.ses` / `.side-folder`)时跳过文本选区菜单,交由各自的行菜单处理。文档正文里的"选中文字→交给 AI/解释"(`.msg .body` / `[data-file-path]`)不受影响。
- **顺带**:工作区文件行菜单新增"复制文件名"(置于首位,从 `data-workspace-path` 取 basename)。原先复制文件名要靠"选中名字再复制",这条路正好被上面的修复堵掉,故补一个正式入口。复用已有的 `ctx.copy_name`,`copyName` 动作本就通过 `run_action` 接好复制逻辑,无需新增。

## 评审提示

- 只动 `ui/src/context_menu.rs` 一个文件,无后端改动。
- `cargo check` + `context_menu` 单测通过。
- `build()` 依赖 DOM,未加单测(与现状一致,该函数原本就只有纯函数部分被测);守卫逻辑简单、确定。
- 未做浏览器预览验证:需在运行中的应用里"选中文件名 + 右键文件行"才能复现,WASM 预览无法有效触发。

🤖 Generated with [Claude Code](https://claude.com/claude-code)