### PR TITLE
fix: hide auto-resume for inline Agent completion

### DIFF
--- a/docs/agent-delegation.md
+++ b/docs/agent-delegation.md
@@ -72,10 +72,12 @@ turn's incremental message sequence. Retrying a failed or cancelled workflow
 creates a new generation, so the retry can deliver once without redelivering
 the earlier result.
 
-Enable **Auto-resume parent** to let an idle parent Agent synthesize newly
-delivered results without another user message. Several completions that become
-ready together may be combined into one synthesis turn, but each generation's
-resume claim is made only once. If the app stops after claiming that turn, the
+When **Background** is selected, enable **Auto-resume parent** to let an idle
+parent Agent synthesize newly delivered results without another user message;
+the option is hidden for inline completion, where it does not apply. Several
+completions that become ready together may be combined into one synthesis
+turn, but each generation's resume claim is made only once. If the app stops
+after claiming that turn, the
 claim is recorded as interrupted instead of being silently replayed on restart.
 Without auto-resume, the completion card remains in the owning conversation
 and enters the Native parent's context on its next turn. ACP parents receive

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -1773,12 +1773,19 @@ test("agent menu updates review, reviewer model, and memory preferences", async 
 
   const completion = page.getByTestId("agent-completion-policy");
   await expect(completion).toHaveValue("inline");
+  await expect(menu.locator("label.agent-menu-row", { hasText: "Auto-resume parent" })).toHaveCount(0);
   await completion.selectOption("background");
   await expect.poll(() => lastInvokeArgs(page, "set_session_agent_completion"))
     .toMatchObject({ policy: "background", autoResume: false });
-  await menu.locator("label.agent-menu-row", { hasText: "Auto-resume parent" }).click();
+  const autoResume = menu.locator("label.agent-menu-row", { hasText: "Auto-resume parent" });
+  await expect(autoResume).toBeVisible();
+  await autoResume.click();
   await expect.poll(() => lastInvokeArgs(page, "set_session_agent_completion"))
     .toMatchObject({ policy: "background", autoResume: true });
+  await completion.selectOption("inline");
+  await expect.poll(() => lastInvokeArgs(page, "set_session_agent_completion"))
+    .toMatchObject({ policy: "inline", autoResume: false });
+  await expect(autoResume).toHaveCount(0);
 
   await menu.locator("label.agent-menu-row", { hasText: "Auto-review" }).click();
   await expect.poll(() => lastInvokeArgs(page, "set_auto_review_enabled")).toMatchObject({ enabled: true });

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -7166,23 +7166,23 @@ fn App() -> impl IntoView {
                                             </option>
                                         </select>
                                     </label>
-                                    <label class="agent-menu-row">
-                                        <span>{move || t(locale.get(), "composer.agent_auto_resume")}</span>
-                                        <span class="toggle agent-menu-toggle">
-                                            <input type="checkbox"
-                                                data-testid="agent-auto-resume"
-                                                prop:checked=move || agent_completion.get().auto_resume
-                                                disabled=move || !delegation_enabled.get()
-                                                    || agent_completion.get().policy != AgentCompletionPolicy::Background
-                                                    || agent_completion_busy.get()
-                                                on:change=move |event| {
-                                                    let mut next = agent_completion.get_untracked();
-                                                    next.auto_resume = event_target_checked(&event);
-                                                    save_agent_completion.call(next);
-                                                } />
-                                            <span class="toggle-track" aria-hidden="true"></span>
-                                        </span>
-                                    </label>
+                                    {move || (agent_completion.get().policy == AgentCompletionPolicy::Background).then(|| view! {
+                                        <label class="agent-menu-row">
+                                            <span>{move || t(locale.get(), "composer.agent_auto_resume")}</span>
+                                            <span class="toggle agent-menu-toggle">
+                                                <input type="checkbox"
+                                                    data-testid="agent-auto-resume"
+                                                    prop:checked=move || agent_completion.get().auto_resume
+                                                    disabled=move || !delegation_enabled.get() || agent_completion_busy.get()
+                                                    on:change=move |event| {
+                                                        let mut next = agent_completion.get_untracked();
+                                                        next.auto_resume = event_target_checked(&event);
+                                                        save_agent_completion.call(next);
+                                                    } />
+                                                <span class="toggle-track" aria-hidden="true"></span>
+                                            </span>
+                                        </label>
+                                    })}
                                     <label class="agent-menu-row">
                                         <span>{move || t(locale.get(), "composer.auto_review")}</span>
                                         <span class="toggle agent-menu-toggle">


### PR DESCRIPTION
## User-facing problem

Auto-resume only applies to background Agent completion. Showing its disabled toggle while inline completion is selected adds a control the user cannot act on.

## Changes

- Render Auto-resume parent only when Background completion is selected.
- Preserve the existing reset to false when switching back to inline completion.
- Extend the Agent menu Playwright test for hidden, visible, and hidden-again states.
- Document when the option is available.

## Verification

- cargo fmt --all -- --check
- cargo test --workspace
- cd ui && cargo check --target wasm32-unknown-unknown
- targeted Agent menu Playwright test
- full Playwright suite: 180 passed

## Manual smoke

1. Enable Delegation and open Agent options.
2. Confirm Auto-resume parent is absent for inline completion.
3. Select Background and confirm the option appears and can be enabled.
4. Select inline completion again and confirm the option disappears.

## Known limitations and follow-up

None for this scoped UI behavior.