### PR TITLE
fix: 消除两个隔离/委派测试的 flaky(SQLite busy_timeout + worktree 清理同步)

### DIFF
--- a/crates/wisp-store/src/lib.rs
+++ b/crates/wisp-store/src/lib.rs
@@ -84,7 +84,13 @@ impl Store {
             std::fs::create_dir_all(parent)?;
         }
         let opts = SqliteConnectOptions::from_str(&format!("sqlite://{}", path.display()))?
-            .create_if_missing(true);
+            .create_if_missing(true)
+            // WAL allows only one writer at a time; with a pool of concurrent
+            // connections a second writer would otherwise get SQLITE_BUSY
+            // immediately (default timeout is 0) and fail. Wait for the lock
+            // instead — concurrent tasks writing the same store (e.g. message +
+            // provenance persistence) must serialize, not error out.
+            .busy_timeout(std::time::Duration::from_secs(5));
         let pool = SqlitePoolOptions::new()
             .max_connections(4)
             .connect_with(opts)

--- a/crates/wisp-store/src/library.rs
+++ b/crates/wisp-store/src/library.rs
@@ -67,7 +67,10 @@ impl LibraryStore {
             std::fs::create_dir_all(parent)?;
         }
         let opts = SqliteConnectOptions::from_str(&format!("sqlite://{}", path.display()))?
-            .create_if_missing(true);
+            .create_if_missing(true)
+            // Wait for the WAL write lock instead of failing a concurrent writer
+            // with SQLITE_BUSY (default timeout is 0). See Store::open.
+            .busy_timeout(std::time::Duration::from_secs(5));
         let pool = SqlitePoolOptions::new()
             .max_connections(4)
             .connect_with(opts)

--- a/src-tauri/src/delegation_runtime.rs
+++ b/src-tauri/src/delegation_runtime.rs
@@ -4202,17 +4202,28 @@ mod tests {
         };
 
         drop(guard);
-        for _ in 0..250 {
-            if !worktree.exists() {
+        // Cleanup runs in a task spawned by Drop: it sleeps ~1.5s, then removes
+        // the worktree, prunes, and *finally* deletes the branch. Waiting only
+        // for the worktree to disappear races the later branch deletion, so poll
+        // until the branch — the last resource cleaned — is gone.
+        let branch_present = || {
+            String::from_utf8_lossy(&git(&["branch", "--list", "wisp-agent/*"]).stdout)
+                .contains("wisp-agent/")
+        };
+        let mut cleaned = false;
+        for _ in 0..500 {
+            if !worktree.exists() && !branch_present() {
+                cleaned = true;
                 break;
             }
             tokio::time::sleep(Duration::from_millis(20)).await;
         }
-        assert!(!worktree.exists());
         assert!(
-            !String::from_utf8_lossy(&git(&["branch", "--list", "wisp-agent/*"]).stdout)
-                .contains("wisp-agent/")
+            cleaned,
+            "isolated worktree and branch were not cleaned up in time"
         );
+        assert!(!worktree.exists());
+        assert!(!branch_present());
         assert_ne!(
             isolated_runtime_scope("p", "request-a"),
             isolated_runtime_scope("p", "request-b")


### PR DESCRIPTION
## 背景

CI 的 `rust (stable)` / `rust (1.88.0)` job 偶发失败,失败集中在 `wisp-tauri` 的两个测试。这是 **main 上早已存在的 flaky**(与近期 UI 改动无关——纯 README 提交的 CI 也红过)。本地并行压测可稳定复现,已定位两处独立根因。

## 根因与修复

### 1. `native_child_file_links_become_durable_artifact_references`(CI 稳挂,本地 ~3/60)

**这是真实的健壮性 bug,不只是测试问题。** `Store::open` 用了 WAL + 连接池(`max_connections(4)`)但**没设 `busy_timeout`**(默认 0 = 立即失败)。WAL 模式只允许一个写者;native 委派运行时 `message_task`(存产物)与 `provenance_task`(存执行日志)通过 sqlx 的阻塞线程池**并发写同一个库**——即便在单线程 tokio 测试运行时下,写也发生在阻塞线程上、墙钟上会重叠。一旦撞上,后写的连接立即拿到 `SQLITE_BUSY` → `bind_resolved` 里的 `save_artifact` 返回 `Err`、错误被上层吞掉 → `list_artifacts` 返回 0(`assert_eq!(len, 1)` 得到 `left: 0, right: 1`)。CI 慢盘/高负载放大重叠窗口,macOS 快盘难复现。

**修复**:给 SQLite 连接设 `busy_timeout(5s)`,并发写者等锁而非立即报错。`crates/wisp-store/src/lib.rs` 与 `crates/wisp-store/src/library.rs` 两个 `Store::open` 同样处理。

### 2. `dropped_isolated_execution_guard_cleans_the_worktree_and_branch`(本地 ~1/7)

`IsolatedExecutionGuard` 的 `Drop` 里 spawn 的清理任务顺序是:`sleep ~1.5s → 删 worktree → prune → 最后删分支`。而测试只轮询 **worktree 消失**就 break,紧接着断言 `wisp-agent/*` 分支已删。负载高时"worktree 没了但分支还没删"的窗口被放大 → 断言挂。

**修复**:**只改测试**——轮询到**分支**(最后清理的资源)消失再断言;生产清理逻辑不动。轮询窗口放宽到 10s 以吸收 CI 抖动。

## 验证

本地并行压测(`--test-threads 8`,全套 lib 测试)各 60 轮:

| | 修复前 | 修复后 |
|---|---|---|
| `native_child_file_links...` | 3 / 60 失败 | 0 |
| `...worktree_and_branch` | 0 / 60(含独立复现 ~1/7) | 0 |

`cargo check -p wisp-store` 通过;`wisp-tauri` 测试二进制正常构建。

## 评审提示

- `busy_timeout` 是生产行为改进(并发写更稳),不是测试专用 hack;5s 上限只在真正撞锁时才等待,正常写路径无影响。
- worktree 那处只动测试断言的同步方式,不改 `delegation_isolation` 的清理顺序/逻辑。
- 与本分支无关的 UI PR(#377 等)之所以 CI 红,正是被这两个 flaky 连累;此 PR 合并后 main 与后续 PR 应恢复绿色。

🤖 Generated with [Claude Code](https://claude.com/claude-code)