### PR TITLE
fix: register demo commands and compact task removal

### DIFF
--- a/src-tauri/src/seed.rs
+++ b/src-tauri/src/seed.rs
@@ -33,12 +33,12 @@ pub struct Demo {
     pub thinking: Option<String>,
 }
 
-#[tauri::command]
+#[tauri::command(rename = "list_demos")]
 pub(super) fn list_demos_cmd() -> Vec<DemoInfo> {
     list_demos()
 }
 
-#[tauri::command]
+#[tauri::command(rename = "load_demo")]
 pub(super) fn load_demo_cmd(
     state: State<'_, AppState>,
     window: tauri::WebviewWindow,

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -4486,6 +4486,24 @@ test("manual dynamic drafts accept arbitrary tasks", async ({ page }) => {
   await expect(card.locator('[data-step-id$=":compare"] .agent-chip.dependency')).toHaveText("inspect");
 });
 
+test("dynamic task removal uses a compact enabled control when multiple tasks exist", async ({ page }) => {
+  await enterApp(page);
+  await enableDelegation(page);
+  await page.getByRole("button", { name: "Toggle panel" }).click();
+  await page.locator(".rightpane").getByRole("button", { name: "Agents", exact: true }).click();
+  const panel = page.getByTestId("agent-workflows");
+
+  const firstRemove = panel.locator(".dynamic-agent-task").first()
+    .getByRole("button", { name: "Remove task" });
+  await expect(firstRemove).toBeDisabled();
+  await panel.getByTestId("dynamic-add-task").click();
+  await expect(firstRemove).toBeEnabled();
+  await expect(firstRemove).toHaveCSS("width", "27px");
+  await firstRemove.click();
+  await expect(panel.locator(".dynamic-agent-task")).toHaveCount(1);
+  await expect(firstRemove).toBeDisabled();
+});
+
 test("dynamic ACP selection uses a profile and clears the Native-only model", async ({ page }) => {
   await enterApp(page);
   await enableDelegation(page);

--- a/ui/src/styles/right-pane.css
+++ b/ui/src/styles/right-pane.css
@@ -552,7 +552,7 @@
 .dynamic-agent-task { min-width: 0; margin: 0; padding: 9px; border: 1px solid var(--border); border-radius: 8px; background: var(--bg-sunken); }
 .dynamic-agent-task-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
 .dynamic-agent-task-head legend { padding: 0; color: var(--text); font-size: 11.5px; font-weight: 700; }
-.dynamic-task-remove { min-width: 27px; padding: 3px 7px; }
+.dynamic-task-remove { box-sizing: border-box; flex: 0 0 27px; width: 27px; height: 27px; padding: 3px; }
 .dynamic-agent-task-grid { display: grid; grid-template-columns: minmax(84px, .38fr) minmax(150px, 1fr); gap: 8px; margin-top: 7px; }
 .dynamic-agent-task-grid label, .dynamic-agent-advanced-grid label { display: grid; align-content: start; gap: 4px; }
 .dynamic-agent-task-grid textarea { min-height: 58px; }


### PR DESCRIPTION
## Problem
The UI invoked list_demos, but Tauri registered the Rust handler as list_demos_cmd, causing the demo list command to fail. The temporary-Agent task remove button also expanded beyond its intended compact size.

## Changes
- Register demo handlers as list_demos and load_demo to match UI invocations.
- Make the dynamic task removal control a fixed 27 by 27 px button.
- Add a Playwright regression test for the remove-control state, dimensions, and behavior.

## Verification
- cargo fmt --all -- --check
- cargo test --workspace
- cd ui and cargo check --target wasm32-unknown-unknown
- cd ui-tests and npx playwright test

## Manual smoke
1. Open the projects screen; demo listing no longer reports an unknown Tauri command.
2. In Agents, add a second temporary task; the first task's compact x control becomes enabled and removes it.

## Limitations / follow-up
None.