### PR TITLE
fix: bind model selection to conversations

### DIFF
--- a/crates/wisp-store/src/sessions.rs
+++ b/crates/wisp-store/src/sessions.rs
@@ -281,6 +281,36 @@ impl Store {
         Ok(())
     }
 
+    pub async fn frame_model(&self, frame_id: &str) -> Result<Option<String>> {
+        Ok(
+            sqlx::query_scalar::<_, Option<String>>("SELECT model FROM frames WHERE id=?")
+                .bind(frame_id)
+                .fetch_optional(&self.pool)
+                .await?
+                .flatten(),
+        )
+    }
+
+    pub async fn set_frame_model(
+        &self,
+        frame_id: &str,
+        project_id: &str,
+        model: &str,
+    ) -> Result<()> {
+        let updated =
+            sqlx::query("UPDATE frames SET model=?,updated_at=? WHERE id=? AND project_id=?")
+                .bind(model)
+                .bind(chrono::Utc::now().timestamp())
+                .bind(frame_id)
+                .bind(project_id)
+                .execute(&self.pool)
+                .await?;
+        if updated.rows_affected() != 1 {
+            anyhow::bail!("Session not found");
+        }
+        Ok(())
+    }
+
     pub async fn append_message(&self, frame_id: &str, seq: i64, msg: &Message) -> Result<()> {
         let id = uuid::Uuid::new_v4().to_string();
         let role = if msg.role == wisp_llm::Role::User

--- a/crates/wisp-store/src/store_tests.rs
+++ b/crates/wisp-store/src/store_tests.rs
@@ -202,6 +202,38 @@ async fn child_agent_frames_stay_out_of_top_level_session_history() {
 }
 
 #[tokio::test]
+async fn frame_models_are_session_scoped() {
+    let tmp = std::env::temp_dir().join(format!(
+        "wisp_store_frame_models_{}.sqlite",
+        uuid::Uuid::new_v4()
+    ));
+    let store = Store::open(&tmp).await.unwrap();
+    store.create_project("p", "proj", "").await.unwrap();
+    store
+        .create_frame("first", "p", "OPERON", "m1")
+        .await
+        .unwrap();
+    store
+        .create_frame("second", "p", "OPERON", "m1")
+        .await
+        .unwrap();
+
+    store.set_frame_model("first", "p", "m2").await.unwrap();
+
+    assert_eq!(
+        store.frame_model("first").await.unwrap().as_deref(),
+        Some("m2")
+    );
+    assert_eq!(
+        store.frame_model("second").await.unwrap().as_deref(),
+        Some("m1")
+    );
+    assert!(store.set_frame_model("first", "other", "m3").await.is_err());
+    store.pool.close().await;
+    let _ = std::fs::remove_file(tmp);
+}
+
+#[tokio::test]
 async fn agent_workflow_and_steps_roundtrip() {
     let tmp = std::env::temp_dir().join(format!(
         "wisp_agent_workflow_{}.sqlite",

--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -4,6 +4,12 @@ wisp-science calls remote LLM APIs through model profiles. Desktop users
 configure these in **Settings -> Models**. Each row is a model profile with its
 own display name, provider, API URL, model ID, advanced options, and API key.
 
+The composer model picker binds the selected HTTP model to the current
+conversation. Switching one populated conversation asks for confirmation and
+does not change any other conversation. Empty conversations switch immediately
+without a warning. The active profile in Settings remains the default for new
+conversations.
+
 Model profiles describe model access and capabilities for the **built-in Wisp
 agent**. External coding agents (Codex / Claude via ACP) are configured under
 **Settings → Models → ACP Agents** — see [ACP Agents](acp-agents.md). Do not put

--- a/src-tauri/src/delegation_runtime.rs
+++ b/src-tauri/src/delegation_runtime.rs
@@ -1028,8 +1028,17 @@ pub(crate) async fn dynamic_delegation_policy_for_project(
     .await?;
     let isolation_available =
         crate::delegation_isolation::git_worktree_available(&project.root).await;
-    let (registry, host) =
-        build_dynamic_delegation_policy(store, Some(&resources), isolation_available).await?;
+    let preferred_model_id = match frame_id {
+        Some(frame_id) => Some(models::session_profile_id(store, frame_id).await),
+        None => None,
+    };
+    let (registry, host) = build_dynamic_delegation_policy(
+        store,
+        Some(&resources),
+        isolation_available,
+        preferred_model_id.as_deref(),
+    )
+    .await?;
     Ok(ProjectDelegationPolicy {
         registry,
         host,
@@ -1040,21 +1049,51 @@ pub(crate) async fn dynamic_delegation_policy_for_project(
 pub(crate) async fn dynamic_delegation_policy(
     store: &Store,
 ) -> Result<(CapabilityRegistry, DelegationHostPolicy), String> {
-    build_dynamic_delegation_policy(store, None, false).await
+    build_dynamic_delegation_policy(store, None, false, None).await
+}
+
+fn select_default_model_id(
+    model_policies: &[ModelProfilePolicy],
+    preferred_model_id: Option<&str>,
+    active_model_id: Option<&str>,
+) -> Option<String> {
+    preferred_model_id
+        .filter(|id| {
+            model_policies
+                .iter()
+                .any(|profile| profile.enabled && profile.id == *id)
+        })
+        .map(str::to_string)
+        .or_else(|| {
+            active_model_id
+                .filter(|id| {
+                    model_policies
+                        .iter()
+                        .any(|profile| profile.enabled && profile.id == *id)
+                })
+                .map(str::to_string)
+        })
+        .or_else(|| {
+            model_policies
+                .iter()
+                .find(|profile| profile.enabled)
+                .map(|profile| profile.id.clone())
+        })
 }
 
 async fn build_dynamic_delegation_policy(
     store: &Store,
     resources: Option<&crate::delegation_resources::ScientificResourceCatalog>,
     isolation_available: bool,
+    preferred_model_id: Option<&str>,
 ) -> Result<(CapabilityRegistry, DelegationHostPolicy), String> {
     let model_profiles = models::delegation_profiles(store).await;
     let (active_provider, active_url, active_model, active_key) = load_settings(store).await;
-    let mut default_model_id = None;
+    let mut active_model_id = None;
     let mut model_policies = Vec::new();
     for profile in model_profiles {
         let (provider, api_url, model, has_key) = if profile.active {
-            default_model_id = Some(profile.id.clone());
+            active_model_id = Some(profile.id.clone());
             (
                 active_provider.clone(),
                 active_url.clone(),
@@ -1087,12 +1126,11 @@ async fn build_dynamic_delegation_policy(
                 && !model.trim().is_empty(),
         });
     }
-    if default_model_id.is_none() {
-        default_model_id = model_policies
-            .iter()
-            .find(|profile| profile.enabled)
-            .map(|profile| profile.id.clone());
-    }
+    let default_model_id = select_default_model_id(
+        &model_policies,
+        preferred_model_id,
+        active_model_id.as_deref(),
+    );
     let enabled_model_ids = model_policies
         .iter()
         .filter(|profile| profile.enabled)
@@ -4387,6 +4425,29 @@ mod tests {
         }
     }
 
+    #[test]
+    fn session_model_is_the_dynamic_delegation_default() {
+        let models = vec![
+            ModelProfilePolicy {
+                id: "global".into(),
+                features: vec![],
+                external: false,
+                enabled: true,
+            },
+            ModelProfilePolicy {
+                id: "session".into(),
+                features: vec![],
+                external: false,
+                enabled: true,
+            },
+        ];
+
+        assert_eq!(
+            select_default_model_id(&models, Some("session"), Some("global")).as_deref(),
+            Some("session")
+        );
+    }
+
     #[tokio::test]
     async fn dynamic_policy_registers_native_and_each_available_acp_profile() {
         let (store, root) = dynamic_fixture().await;
@@ -4480,9 +4541,10 @@ mod tests {
             &["web"],
             &["python"],
         );
-        let (registry, host) = build_dynamic_delegation_policy(&store, Some(&resources), true)
-            .await
-            .unwrap();
+        let (registry, host) =
+            build_dynamic_delegation_policy(&store, Some(&resources), true, None)
+                .await
+                .unwrap();
 
         for capability in ["literature_search", "external_research", "visualization"] {
             assert!(host.enabled_capabilities.contains(&capability.into()));
@@ -4513,9 +4575,10 @@ mod tests {
 
         let offline =
             crate::delegation_resources::ScientificResourceCatalog::fake(&[], &[], &[], &[], &[]);
-        let (_, offline_host) = build_dynamic_delegation_policy(&store, Some(&offline), false)
-            .await
-            .unwrap();
+        let (_, offline_host) =
+            build_dynamic_delegation_policy(&store, Some(&offline), false, None)
+                .await
+                .unwrap();
         assert!(!offline_host
             .enabled_capabilities
             .contains(&"literature_search".into()));

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1294,6 +1294,15 @@ async fn clear_idle_agents(state: &AppState) {
     }
 }
 
+async fn clear_session_agent(state: &AppState, frame_id: &str) {
+    let runtime = state.sessions.lock().await.get(frame_id).cloned();
+    if let Some(runtime) = runtime {
+        if let Ok(mut guard) = runtime.agent.try_lock() {
+            *guard = None;
+        }
+    }
+}
+
 #[cfg(debug_assertions)]
 fn llm_model_mismatch(configured_model: &str, actual_model: &str) -> bool {
     !configured_model
@@ -2192,11 +2201,12 @@ fn apply_llm_advanced(
     cfg.reasoning_effort = effective_reasoning_effort(reasoning_effort);
 }
 
-pub(crate) async fn load_settings(store: &Store) -> (String, String, String, String) {
-    // Resolve through the active model profile (migrates legacy single-model
-    // installs on first read), then apply env/default fallbacks so a blank
-    // field still produces a usable config.
-    let (provider, api_url, model, api_key) = models::active_config(store).await;
+fn resolve_model_settings(
+    provider: String,
+    api_url: String,
+    model: String,
+    api_key: String,
+) -> (String, String, String, String) {
     let provider = normalized_provider(&non_empty_setting(Some(provider), || {
         env_or("WISP_PROVIDER", "openai")
     }));
@@ -2212,6 +2222,47 @@ pub(crate) async fn load_settings(store: &Store) -> (String, String, String, Str
         api_key
     };
     (provider, api_url, model, api_key)
+}
+
+pub(crate) async fn load_settings(store: &Store) -> (String, String, String, String) {
+    // Resolve through the active model profile (migrates legacy single-model
+    // installs on first read), then apply env/default fallbacks so a blank
+    // field still produces a usable config.
+    let (provider, api_url, model, api_key) = models::active_config(store).await;
+    resolve_model_settings(provider, api_url, model, api_key)
+}
+
+async fn load_session_settings(
+    store: &Store,
+    frame_id: &str,
+) -> (String, String, String, String, u64, String) {
+    let profile_id = models::session_profile_id(store, frame_id).await;
+    let (provider, api_url, model, api_key, max_tokens, reasoning_effort) =
+        match models::profile_llm(store, &profile_id).await {
+            Some(config) => config,
+            None => {
+                let (provider, api_url, model, api_key) = load_settings(store).await;
+                let (max_tokens, reasoning_effort) = models::active_llm_advanced(store).await;
+                return (
+                    provider,
+                    api_url,
+                    model,
+                    api_key,
+                    max_tokens,
+                    reasoning_effort,
+                );
+            }
+        };
+    let (provider, api_url, model, api_key) =
+        resolve_model_settings(provider, api_url, model, api_key);
+    (
+        provider,
+        api_url,
+        model,
+        api_key,
+        max_tokens,
+        reasoning_effort,
+    )
 }
 
 fn parse_disabled_skills(raw: Option<&str>) -> HashSet<String> {
@@ -3008,8 +3059,9 @@ async fn register_mcp_filtered(
 /// concrete session id before streaming starts.
 async fn create_session_frame(store: &Store, project_id: &str) -> Result<String, String> {
     let id = Uuid::new_v4().to_string();
+    let model_id = models::active_profile_id(store).await;
     store
-        .create_frame(&id, project_id, "OPERON", "wisp")
+        .create_frame(&id, project_id, "OPERON", &model_id)
         .await
         .map_err(|e| format!("{e}"))?;
     Ok(id)
@@ -3503,7 +3555,6 @@ async fn send_message_inner(
             }
         }
     }
-    let model_label = models::active_label(&state.store).await;
     let vision_cfg = build_vision_provider_config(&state.store).await;
 
     let max_context = state
@@ -3546,16 +3597,16 @@ async fn send_message_inner(
     // Deliberately no set_active_frame here: see the `AppState::active_frame`
     // doc — a turn writing view state races the user's session/project switch.
 
+    let session_profile_id = models::session_profile_id(&state.store, &frame_id).await;
+    let model_label = models::session_label(&state.store, &frame_id).await;
     let specialist = specialists::session_specialist(&state.store, &frame_id).await;
     let delegation_enabled =
         delegation_runtime::session_delegation_enabled(&state.store, &frame_id).await;
     let (provider, api_url, model, api_key, max_tokens, reasoning_effort) = match &specialist {
-        Some(spec) => specialists::specialist_llm(&state.store, spec).await,
-        None => {
-            let (p, u, m, k) = load_settings(&state.store).await;
-            let (mt, re) = models::active_llm_advanced(&state.store).await;
-            (p, u, m, k, mt, re)
+        Some(spec) if !spec.model_id.trim().is_empty() => {
+            specialists::specialist_llm(&state.store, spec).await
         }
+        _ => load_session_settings(&state.store, &frame_id).await,
     };
     let cfg = build_provider_config(
         &provider,
@@ -3570,7 +3621,8 @@ async fn send_message_inner(
         specialist
             .as_ref()
             .map(|specialist| specialist.model_id.as_str())
-            .filter(|id| !id.trim().is_empty()),
+            .filter(|id| !id.trim().is_empty())
+            .or(Some(session_profile_id.as_str())),
     )
     .await;
     let attached_images = if resume {
@@ -4659,6 +4711,12 @@ async fn branch_session(
     let _project_activity = state.begin_project_activity(&ap.id)?;
     let id = create_session_frame(&state.store, &ap.id).await?;
     if let Some(source) = session_id.as_deref().filter(|s| !s.is_empty()) {
+        let model_id = models::session_profile_id(&state.store, source).await;
+        state
+            .store
+            .set_frame_model(&id, &ap.id, &model_id)
+            .await
+            .map_err(|error| error.to_string())?;
         let msgs = state
             .store
             .load_messages(source)
@@ -7001,6 +7059,7 @@ pub fn run() {
             pet_commands::open_pet_session,
             desktop_lifecycle::set_pet_window_visible,
             models::list_models,
+            models::get_session_model,
             models::save_model,
             models::remove_model,
             models::set_active_model,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -499,6 +499,36 @@ async fn active_id(store: &wisp_store::Store, profiles: &[ModelProfile]) -> Stri
     }
 }
 
+pub async fn active_profile_id(store: &wisp_store::Store) -> String {
+    let profiles = ensure(store).await;
+    active_id(store, &profiles).await
+}
+
+pub async fn session_profile_id(store: &wisp_store::Store, frame_id: &str) -> String {
+    let profiles = ensure(store).await;
+    let bound = store
+        .frame_model(frame_id)
+        .await
+        .ok()
+        .flatten()
+        .unwrap_or_default();
+    if profiles.iter().any(|profile| profile.id == bound) {
+        bound
+    } else {
+        active_id(store, &profiles).await
+    }
+}
+
+pub async fn session_label(store: &wisp_store::Store, frame_id: &str) -> String {
+    let profiles = ensure(store).await;
+    let id = session_profile_id(store, frame_id).await;
+    profiles
+        .iter()
+        .find(|profile| profile.id == id)
+        .map(|profile| profile.label.clone())
+        .unwrap_or_default()
+}
+
 /// Key for a profile, falling back to the legacy `api_key` secret for the
 /// migrated "default" profile (so a not-yet-re-saved default still works).
 fn key_for(id: &str) -> String {
@@ -761,6 +791,26 @@ pub async fn list_models(state: State<'_, crate::AppState>) -> Result<Vec<ModelP
     Ok(decorated(&state.store).await)
 }
 
+#[tauri::command]
+pub async fn get_session_model(
+    state: State<'_, crate::AppState>,
+    window: tauri::WebviewWindow,
+    session_id: String,
+) -> Result<String, String> {
+    let project = state.active(window.label());
+    if state
+        .store
+        .frame_project_id(&session_id)
+        .await
+        .map_err(|error| error.to_string())?
+        .as_deref()
+        != Some(project.id.as_str())
+    {
+        return Err("Session not found".into());
+    }
+    Ok(session_profile_id(&state.store, &session_id).await)
+}
+
 /// Upsert a profile. An empty `id` creates a new one; a non-empty `key` updates
 /// the keyring (a blank key leaves the stored one untouched).
 #[tauri::command]
@@ -863,18 +913,29 @@ pub async fn remove_model(
 #[tauri::command]
 pub async fn set_active_model(
     state: State<'_, crate::AppState>,
+    window: tauri::WebviewWindow,
     id: String,
+    session_id: Option<String>,
 ) -> Result<Vec<ModelProfile>, String> {
     let profiles = ensure(&state.store).await;
     if !profiles.iter().any(|p| p.id == id) {
         return Err("Unknown model.".into());
     }
-    state
-        .store
-        .set_setting(ACTIVE_KEY, &id)
-        .await
-        .map_err(|e| e.to_string())?;
-    crate::clear_idle_agents(&state).await;
+    if let Some(session_id) = session_id.filter(|value| !value.is_empty()) {
+        let project = state.active(window.label());
+        state
+            .store
+            .set_frame_model(&session_id, &project.id, &id)
+            .await
+            .map_err(|error| error.to_string())?;
+        crate::clear_session_agent(&state, &session_id).await;
+    } else {
+        state
+            .store
+            .set_setting(ACTIVE_KEY, &id)
+            .await
+            .map_err(|e| e.to_string())?;
+    }
     Ok(decorated(&state.store).await)
 }
 
@@ -921,6 +982,35 @@ mod tests {
             json[1]["use_for_vision"], true,
             "IPC response lost vision assignment"
         );
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    #[tokio::test]
+    async fn session_profile_binding_does_not_change_other_sessions() {
+        let tmp = std::env::temp_dir().join(format!(
+            "wisp_session_models_{}.sqlite",
+            uuid::Uuid::new_v4()
+        ));
+        let store = wisp_store::Store::open(&tmp).await.unwrap();
+        store.create_project("p", "project", "").await.unwrap();
+        save_raw(
+            &store,
+            &[
+                test_profile("m1", "first", "model-1"),
+                test_profile("m2", "second", "model-2"),
+            ],
+        )
+        .await
+        .unwrap();
+        store.set_setting(ACTIVE_KEY, "m1").await.unwrap();
+        store.create_frame("a", "p", "OPERON", "m1").await.unwrap();
+        store.create_frame("b", "p", "OPERON", "m1").await.unwrap();
+
+        store.set_frame_model("a", "p", "m2").await.unwrap();
+
+        assert_eq!(session_profile_id(&store, "a").await, "m2");
+        assert_eq!(session_profile_id(&store, "b").await, "m1");
+        drop(store);
         let _ = std::fs::remove_file(&tmp);
     }
 

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -68,7 +68,12 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
       ? [{ id: "long-session", title: "Long transcript", ts: 2000, running: false }]
       : query.has("mockAgentWorkflow")
         ? [{ id: "s-current", title: "Agent workflow conversation", ts: 2000, running: false }]
-        : [];
+        : query.get("mockSessionModels") === "1"
+          ? [
+              { id: "s-model-a", title: "First model session", ts: 2000, running: false },
+              { id: "s-model-b", title: "Second model session", ts: 1900, running: false },
+            ]
+          : [];
   let activeProjectId = "default";
   let terminalCounter = 0;
   let mockUpdateCheck = {
@@ -176,6 +181,10 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
       use_for_vision: false,
     },
   ];
+  const activeHttpModelId = () => mockModels.find((model) => model.active)?.id ?? mockModels[0]?.id ?? "";
+  const sessionModels: Record<string, string> = query.get("mockSessionModels") === "1"
+    ? { "s-model-a": "default", "s-model-b": "default" }
+    : {};
   let mockAcpAgents = [
     { id: "acp-test", label: "Test ACP Agent", command: "fake-acp", args: ["--stdio"] },
   ];
@@ -725,6 +734,17 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
           case "load_demo":
             return demo;
           case "load_session":
+            if (query.get("mockSessionModels") === "1") {
+              const id = String(arg("id") ?? "");
+              return {
+                items: [
+                  { role: "user", text: `Question in ${id}`, tool_name: null, ok: null },
+                  { role: "assistant", text: `Answer in ${id}`, tool_name: null, ok: null },
+                ],
+                next_before_seq: null,
+                user_offset: 0,
+              };
+            }
             if (mockResourceSession) {
               return {
                 items: [{
@@ -942,6 +962,10 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
             return null;
           case "list_models":
             return mockModels;
+          case "get_session_model": {
+            const sessionId = String(arg("sessionId") ?? "");
+            return sessionModels[sessionId] ?? activeHttpModelId();
+          }
           case "list_acp_agents":
             return mockAcpAgents;
           case "get_dynamic_agent_options":
@@ -1358,7 +1382,12 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
           }
           case "set_active_model": {
             const id = arg("id") ?? "";
-            mockModels = mockModels.map((m) => ({ ...m, active: m.id === id }));
+            const sessionId = String(arg("sessionId") ?? "");
+            if (sessionId) {
+              sessionModels[sessionId] = id;
+            } else {
+              mockModels = mockModels.map((m) => ({ ...m, active: m.id === id }));
+            }
             return mockModels;
           }
           case "get_project_info":
@@ -1806,10 +1835,17 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
             return memoryFiles;
           case "read_memory_file":
             return "User prefers DeepSeek.\n";
-          case "new_session":
-            return `s-${Math.random().toString(36).slice(2)}`;
-          case "branch_session":
-            return `branch-${Math.random().toString(36).slice(2)}`;
+          case "new_session": {
+            const id = `s-${Math.random().toString(36).slice(2)}`;
+            sessionModels[id] = activeHttpModelId();
+            return id;
+          }
+          case "branch_session": {
+            const id = `branch-${Math.random().toString(36).slice(2)}`;
+            const source = String(arg("sessionId") ?? "");
+            sessionModels[id] = sessionModels[source] ?? activeHttpModelId();
+            return id;
+          }
           case "side_chat": {
             const question = String(arg("question") ?? "");
             if (question === "SIDESCROLLTEST") {
@@ -1835,6 +1871,7 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
           case "send_message": {
             const fid = (args && (args.sessionId ?? args.session_id)) || "t1";
             const msg = (args && args.message) || "";
+            sessionModels[fid] ??= activeHttpModelId();
             const acpAgentId = args?.acpAgentId ?? acpBindings[fid];
             if (acpAgentId && String(msg).includes("ACPTHINK")) {
               // Codex-style ordering: a short reply streams first, THEN thinking,

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -211,6 +211,9 @@ test("background Agent completion appears in its owning conversation", async ({ 
 
 test("switching HTTP models confirms cache invalidation", async ({ page }) => {
   await enterApp(page);
+  await composer(page).fill("bind this conversation model");
+  await page.getByRole("button", { name: "Send" }).click();
+  await expect(page.getByText("Hello from mock wisp-science.")).toBeVisible();
 
   await page.locator(".model-picker-btn").click();
   const opusOption = page.getByRole("button", { name: /opus-4\.8/ });
@@ -236,6 +239,9 @@ test("switching HTTP models confirms cache invalidation", async ({ page }) => {
 
 test("model switch warning can be permanently dismissed", async ({ page }) => {
   await enterApp(page);
+  await composer(page).fill("bind this conversation model");
+  await page.getByRole("button", { name: "Send" }).click();
+  await expect(page.getByText("Hello from mock wisp-science.")).toBeVisible();
 
   await page.locator(".model-picker-btn").click();
   await page.getByRole("button", { name: /opus-4\.8/ }).click();
@@ -250,6 +256,38 @@ test("model switch warning can be permanently dismissed", async ({ page }) => {
   await page.getByRole("button", { name: /deepseek-v4-pro/ }).click();
   await expect(page.getByTestId("model-switch-confirm")).toHaveCount(0);
   await expect.poll(() => lastInvokeArgs(page, "set_active_model")).toMatchObject({ id: "default" });
+});
+
+test("empty conversations switch models without warning", async ({ page }) => {
+  await enterApp(page);
+  await newSessionButton(page).click();
+
+  await page.locator(".model-picker-btn").click();
+  await page.getByRole("button", { name: /opus-4\.8/ }).click();
+
+  await expect(page.getByTestId("model-switch-confirm")).toHaveCount(0);
+  await expect.poll(() => lastInvokeArgs(page, "set_active_model")).toMatchObject({
+    id: "opus",
+    sessionId: expect.any(String),
+  });
+  await expect(page.locator(".model-picker-label")).toHaveText("opus-4.8");
+});
+
+test("model selection stays bound to its conversation", async ({ page }) => {
+  await enterApp(page, "/?mockSessionModels=1");
+  await page.locator('[data-session-id="s-model-a"]').click();
+  await expect(page.locator(".model-picker-label")).toHaveText("deepseek-v4-pro");
+
+  await page.locator(".model-picker-btn").click();
+  await page.getByRole("button", { name: /opus-4\.8/ }).click();
+  await page.getByTestId("model-switch-confirm")
+    .getByRole("button", { name: "Yes, switch" }).click();
+  await expect(page.locator(".model-picker-label")).toHaveText("opus-4.8");
+
+  await page.locator('[data-session-id="s-model-b"]').click();
+  await expect(page.locator(".model-picker-label")).toHaveText("deepseek-v4-pro");
+  await page.locator('[data-session-id="s-model-a"]').click();
+  await expect(page.locator(".model-picker-label")).toHaveText("opus-4.8");
 });
 
 test("Settings Models page can open ACP Agents dialog", async ({ page }) => {

--- a/ui/src/app_support.rs
+++ b/ui/src/app_support.rs
@@ -4221,14 +4221,16 @@ pub(super) fn flush_delta_buf(
     items: RwSignal<Vec<ChatItem>>,
     transcripts: RwSignal<HashMap<String, Vec<ChatItem>>>,
     models: RwSignal<Vec<ModelProfile>>,
+    session_models: RwSignal<HashMap<String, String>>,
 ) {
     let drained: Vec<_> = buf.borrow_mut().drain().collect();
     if drained.is_empty() {
         return;
     }
-    let fallback_model = active_model_label(&models.get_untracked());
+    let profiles = models.get_untracked();
+    let bindings = session_models.get_untracked();
     for (fid, deltas) in drained {
-        let model = fallback_model.clone();
+        let model = session_model_label(&profiles, &bindings, Some(&fid));
         route_items(active, items, transcripts, &fid, move |v| {
             for d in deltas {
                 match d {
@@ -4248,6 +4250,7 @@ pub(super) fn schedule_delta_flush(
     items: RwSignal<Vec<ChatItem>>,
     transcripts: RwSignal<HashMap<String, Vec<ChatItem>>>,
     models: RwSignal<Vec<ModelProfile>>,
+    session_models: RwSignal<HashMap<String, String>>,
 ) {
     if scheduled.get() {
         return;
@@ -4258,7 +4261,7 @@ pub(super) fn schedule_delta_flush(
     set_timeout(
         move || {
             scheduled.set(false);
-            flush_delta_buf(&buf, active, items, transcripts, models);
+            flush_delta_buf(&buf, active, items, transcripts, models, session_models);
         },
         std::time::Duration::from_millis(50),
     );

--- a/ui/src/dto.rs
+++ b/ui/src/dto.rs
@@ -9,6 +9,7 @@
 
 use crate::i18n::Locale;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -288,12 +289,28 @@ pub(crate) struct PlanCard {
 }
 
 pub(crate) fn active_model_label(models: &[ModelProfile]) -> Option<String> {
+    model_label(models, None)
+}
+
+pub(crate) fn model_label(models: &[ModelProfile], model_id: Option<&str>) -> Option<String> {
     models
         .iter()
-        .find(|m| m.active)
+        .find(|model| model_id == Some(model.id.as_str()))
+        .or_else(|| models.iter().find(|model| model.active))
         .or_else(|| models.first())
         .map(|m| m.label.clone())
         .filter(|s| !s.is_empty())
+}
+
+pub(crate) fn session_model_label(
+    models: &[ModelProfile],
+    session_models: &HashMap<String, String>,
+    session_id: Option<&str>,
+) -> Option<String> {
+    model_label(
+        models,
+        session_id.and_then(|session_id| session_models.get(session_id).map(String::as_str)),
+    )
 }
 
 /// Selection captured from a file preview by `api.js`'s `preview_selection`.

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -653,6 +653,8 @@ fn App() -> impl IntoView {
     let pet_status = create_rw_signal(PetStatus::default());
     // Configured model profiles + the composer's bottom-right picker state.
     let models = create_rw_signal::<Vec<ModelProfile>>(vec![]);
+    let active_session = create_rw_signal::<Option<String>>(None);
+    let session_model_ids = create_rw_signal::<HashMap<String, String>>(HashMap::new());
     let acp_agents = create_rw_signal::<Vec<AcpAgentProfile>>(vec![]);
     let active_acp_agent_id = create_rw_signal::<Option<String>>(None);
     // An ACP Agent can only bind an empty frame. When the picker creates that
@@ -685,12 +687,22 @@ fn App() -> impl IntoView {
     let switch_http_model = Callback::new(move |(id, dont_ask_again): (String, bool)| {
         provisional_acp_selection.set(None);
         active_acp_agent_id.set(None);
+        let session_id = active_session.get_untracked();
         spawn_local(async move {
-            let arg = to_value(&serde_json::json!({ "id": id })).unwrap();
+            let arg = to_value(&serde_json::json!({
+                "id": id.clone(),
+                "sessionId": session_id.clone(),
+            }))
+            .unwrap();
             match invoke_checked("set_active_model", arg).await {
                 Ok(v) => {
                     if let Ok(list) = serde_wasm_bindgen::from_value::<Vec<ModelProfile>>(v) {
                         models.set(list);
+                    }
+                    if let Some(session_id) = session_id {
+                        session_model_ids.update(|models| {
+                            models.insert(session_id, id);
+                        });
                     }
                     if dont_ask_again {
                         disable_model_switch_warning();
@@ -815,8 +827,27 @@ fn App() -> impl IntoView {
     let collapsed_folders = create_rw_signal::<HashSet<String>>(HashSet::new());
     let drag_session = create_rw_signal::<Option<String>>(None);
     let drop_target = create_rw_signal::<Option<String>>(None);
-    let active_session = create_rw_signal::<Option<String>>(None);
     let session_execution_contexts = create_rw_signal::<HashSet<String>>(HashSet::new());
+    create_effect(move |_| {
+        let Some(session_id) = active_session.get() else {
+            return;
+        };
+        spawn_local(async move {
+            let args =
+                to_value(&serde_json::json!({ "sessionId": session_id.clone() })).unwrap();
+            let Ok(value) = invoke_checked("get_session_model", args).await else {
+                return;
+            };
+            let Some(model_id) = value.as_string() else {
+                return;
+            };
+            if active_session.get_untracked().as_deref() == Some(session_id.as_str()) {
+                session_model_ids.update(|models| {
+                    models.insert(session_id, model_id);
+                });
+            }
+        });
+    });
     create_effect(move |_| {
         let Some(session_id) = active_session.get() else {
             session_execution_contexts.set(HashSet::new());
@@ -1462,6 +1493,7 @@ fn App() -> impl IntoView {
     let status_cb = status;
     let locale_cb = locale;
     let models_cb = models;
+    let session_models_cb = session_model_ids;
     let center_file_revisions_cb = center_file_revisions;
     let project_info_cb = project_info;
     // Streaming deltas are buffered and flushed on a timer (~20 fps) instead of
@@ -1480,7 +1512,16 @@ fn App() -> impl IntoView {
         };
         // Ordered, non-delta events (tool calls, results, done…) must observe
         // every delta buffered before them, so drain the buffer first.
-        let flush_now = || flush_delta_buf(&cb_buf, active_cb, items_cb, transcripts_cb, models_cb);
+        let flush_now = || {
+            flush_delta_buf(
+                &cb_buf,
+                active_cb,
+                items_cb,
+                transcripts_cb,
+                models_cb,
+                session_models_cb,
+            )
+        };
         let queue = |fid: String, d: PendingDelta| {
             queue_delta(&cb_buf, fid, d);
             schedule_delta_flush(
@@ -1490,6 +1531,7 @@ fn App() -> impl IntoView {
                 items_cb,
                 transcripts_cb,
                 models_cb,
+                session_models_cb,
             );
         };
         let set_pet_activity = |frame_id: &str, state: &str| {
@@ -1504,9 +1546,13 @@ fn App() -> impl IntoView {
             AgentEvent::User { frame_id, text } => {
                 set_pet_activity(&frame_id, "running");
                 flush_now();
+                let model = session_model_label(
+                    &models_cb.get_untracked(),
+                    &session_models_cb.get_untracked(),
+                    Some(&frame_id),
+                );
                 route_items(active_cb, items_cb, transcripts_cb, &frame_id, |v| {
-                    let model = active_model_label(&models_cb.get());
-                    start_user_turn(v, text, model);
+                    start_user_turn(v, text, model.clone());
                 })
             }
             AgentEvent::MessageBoundary { .. } => {}
@@ -1674,7 +1720,11 @@ fn App() -> impl IntoView {
             AgentEvent::Error { frame_id, message } => {
                 flush_now();
                 notify_desktop(&frame_id, "error", &message);
-                let model = active_model_label(&models_cb.get());
+                let model = session_model_label(
+                    &models_cb.get_untracked(),
+                    &session_models_cb.get_untracked(),
+                    Some(&frame_id),
+                );
                 route_items(active_cb, items_cb, transcripts_cb, &frame_id, |v| {
                     strip_approval_pending(v);
                     v.push(ChatItem::Assistant {
@@ -2163,7 +2213,11 @@ fn App() -> impl IntoView {
                 .map(|agent| agent.label)
                 .or_else(|| Some("ACP Agent".into()))
         } else {
-            active_model_label(&models.get())
+            session_model_label(
+                &models.get(),
+                &session_model_ids.get(),
+                active.as_deref(),
+            )
         };
         input.set(String::new());
         attachments.set(vec![]);
@@ -2523,7 +2577,11 @@ fn App() -> impl IntoView {
                 status.set("ACP protocol v1 cannot replay a Wisp transcript.".into());
                 return;
             }
-            let model = active_model_label(&models.get());
+            let model = session_model_label(
+                &models.get(),
+                &session_model_ids.get(),
+                Some(&id),
+            );
             items.update(|v| {
                 strip_error_at(v, error_idx);
                 ensure_streaming_assistant(v, model.clone());
@@ -7446,7 +7504,10 @@ fn App() -> impl IntoView {
                                                 acp_agents.get().into_iter().find(|agent| agent.id == id).map(|agent| agent.label).unwrap_or_else(|| "ACP Agent".into())
                                             } else {
                                                 let l = models.get();
-                                                l.iter().find(|m| m.active).or_else(|| l.first()).map(|m| m.label.clone()).unwrap_or_default()
+                                                let selected = active_session.get().and_then(|session_id| {
+                                                    session_model_ids.with(|models| models.get(&session_id).cloned())
+                                                });
+                                                model_label(&l, selected.as_deref()).unwrap_or_default()
                                             }
                                         }}</span>
                                         <span class="model-picker-chev">"▾"</span>
@@ -7456,11 +7517,14 @@ fn App() -> impl IntoView {
                                         <div class="model-menu">
                                             {move || {
                                                 let list = models.get();
+                                                let selected = active_session.get().and_then(|session_id| {
+                                                    session_model_ids.with(|models| models.get(&session_id).cloned())
+                                                });
                                                 let acp_locked = active_acp_agent_id.get().is_some() && items.with(|rows| !rows.is_empty());
                                                 list.into_iter().map(|m| {
                                                     let pick_id = m.id.clone();
                                                     let pick_label = m.label.clone();
-                                                    let is_active = m.active;
+                                                    let is_active = selected.as_deref().map_or(m.active, |id| id == m.id);
                                                     let show_sub = !m.model.is_empty() && m.model != m.label;
                                                     view! {
                                                         <div class="model-menu-row" class:active=is_active>
@@ -7476,7 +7540,7 @@ fn App() -> impl IntoView {
                                                                     return;
                                                                 }
                                                                 let id = pick_id.clone();
-                                                                if model_switch_warning_disabled() {
+                                                                if model_switch_warning_disabled() || items.with(|rows| rows.is_empty()) {
                                                                     switch_http_model.call((id, false));
                                                                 } else {
                                                                     model_switch_confirm.set(Some((id, pick_label.clone())));


### PR DESCRIPTION
## Problem

Model selection was global even when changed from a conversation, so switching one conversation also changed every other conversation. The switch warning also appeared for a brand-new empty conversation, where there is no context to invalidate.

## Summary

- Persist the selected model on each conversation using the existing frames.model field.
- Resolve model configuration, delegation defaults, labels, and streamed events from the owning conversation.
- Change the global active model only when selecting the default outside a conversation.
- Skip the model-switch warning for empty conversations; keep it for conversations with messages.
- Copy the source conversation model when branching.
- Document the conversation-scoped behavior and the Settings default for new conversations.

## Tests

- Added store coverage proving two conversations keep independent model bindings.
- Added Tauri coverage for per-session model resolution and dynamic delegation defaults.
- Added Playwright coverage for empty-conversation switching, populated-conversation confirmation, and cross-conversation isolation.
- cargo fmt --all -- --check
- cargo test --workspace
- cd ui && cargo check --target wasm32-unknown-unknown
- cd ui-tests && npm ci && npx playwright test (183 passed)

## Manual smoke

1. Create an empty conversation and switch models; verify no warning appears.
2. Send a message, switch models again, and verify the warning appears.
3. Open another conversation, select a different model, then switch between both conversations and verify each retains its model.
4. Create a new conversation and verify it starts with the active model configured in Settings.

## Known limitations / follow-up

Existing conversations whose stored model does not match a current profile fall back to the Settings default until explicitly switched. No migration or backfill is included because this feature has not been broadly released. No follow-up is required for the current scope.