### PR TITLE
feat: auto-fill model output limits in the model form

### DIFF
--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -3082,7 +3082,8 @@ test("vision assignment keeps model fields and stored key placeholder untouched"
     useForVision: true,
     profile: {
       provider: "openai_responses",
-      context_window: 128000,
+      // gpt-5.6-* matches the MODEL_LIMITS auto-fill (128K out / 1.05M ctx)
+      context_window: 1050000,
       reasoning_effort: "medium",
       use_for_vision: true,
     },

--- a/ui/src/settings_view.rs
+++ b/ui/src/settings_view.rs
@@ -49,6 +49,46 @@ fn settings_provider_defaults(provider: &str) -> (&'static str, &'static str) {
     }
 }
 
+/// Known model families → (max output tokens, context window), per vendor docs
+/// as of 2026-07. Prefix match, first hit wins — keep longer prefixes above
+/// their shorter siblings ("claude-sonnet-4-5" before "claude-sonnet-4").
+/// ponytail: static table; swap for a live models-API query only if providers
+/// ever expose output limits uniformly (today only Anthropic does).
+const MODEL_LIMITS: [(&str, u64, u64); 18] = [
+    ("claude-opus-4-5", 64_000, 200_000),
+    ("claude-opus-4", 128_000, 1_000_000),
+    ("claude-sonnet-4-5", 64_000, 200_000),
+    ("claude-sonnet-4", 128_000, 1_000_000),
+    ("claude-sonnet-5", 128_000, 1_000_000),
+    ("claude-haiku-4-5", 64_000, 200_000),
+    ("claude-fable-5", 128_000, 1_000_000),
+    ("claude-mythos", 128_000, 1_000_000),
+    ("gpt-5.6", 128_000, 1_050_000),
+    ("gpt-5.5", 128_000, 1_000_000),
+    ("gpt-5", 128_000, 400_000),
+    ("gpt-4.1", 32_768, 1_000_000),
+    ("gpt-4o", 16_384, 128_000),
+    ("deepseek-v4", 384_000, 1_000_000),
+    ("kimi-k3", 131_072, 1_000_000),
+    ("glm-5.2", 131_072, 1_000_000),
+    ("glm-5", 131_072, 200_000),
+    ("glm-4.6", 131_072, 200_000),
+];
+
+/// Auto-fill max_tokens/context_window to the model's documented ceiling when
+/// the model id matches a known family. Runs whenever the model id changes;
+/// unknown models keep whatever is already in the form.
+fn apply_known_model_limits(form: &mut ModelForm) {
+    let model = form.model.trim().to_ascii_lowercase();
+    if let Some(&(_, max_tokens, context_window)) = MODEL_LIMITS
+        .iter()
+        .find(|(prefix, _, _)| model.starts_with(prefix))
+    {
+        form.max_tokens = max_tokens;
+        form.context_window = context_window;
+    }
+}
+
 /// One-click presets for popular OpenAI-compatible providers (#334):
 /// (label, api_url, model). The user only has to paste an API key.
 /// The "Coding" entries are the monthly coding-plan endpoints — those
@@ -953,6 +993,7 @@ pub(super) fn SettingsView(
                                                         o.provider = settings_provider_value(&p).into();
                                                         o.api_url = api_url.into();
                                                         o.model = model.into();
+                                                        apply_known_model_limits(o);
                                                     });
                                                 }
                                                 >
@@ -980,7 +1021,10 @@ pub(super) fn SettingsView(
                                         <label>{move || t(locale.get(), "settings.model")}
                                             <input prop:value=move || model_form.get().map(|f| f.model.clone()).unwrap_or_default()
                                                 placeholder=move || t(locale.get(), "settings.model_ph")
-                                                on:input=move |ev| model_form.update(|o| if let Some(o)=o { o.model = event_target_input(&ev).value(); }) /></label>
+                                                on:input=move |ev| model_form.update(|o| if let Some(o)=o {
+                                                    o.model = event_target_input(&ev).value();
+                                                    apply_known_model_limits(o);
+                                                }) /></label>
                                         <label>{move || t(locale.get(), "settings.max_tokens")}
                                             <input type="number" min="16" step="1"
                                                 on:input=move|ev| model_form.update(|o| if let Some(o)=o {
@@ -1105,7 +1149,11 @@ pub(super) fn SettingsView(
                                         view! {
                                             <button type="button" class="settings-add-btn" on:click=move |_| {
                                                 show_acp_agents.set(false);
-                                                model_form.set(Some(new_model_form()));
+                                                model_form.set(Some({
+                                                    let mut form = new_model_form();
+                                                    apply_known_model_limits(&mut form);
+                                                    form
+                                                }));
                                                 model_form_key.set(String::new());
                                                 model_form_msg.set(None);
                                             }>{move || t(locale.get(), "models.add")}</button>
@@ -1243,7 +1291,7 @@ pub(super) fn SettingsView(
                                             <button type="button" class="model-preset-btn"
                                                 on:click=move |_| {
                                                     show_acp_agents.set(false);
-                                                    model_form.set(Some(ModelForm {
+                                                    let mut form = ModelForm {
                                                         label: label.into(),
                                                         provider: "openai".into(),
                                                         api_url: api_url.into(),
@@ -1251,7 +1299,9 @@ pub(super) fn SettingsView(
                                                         max_tokens: 8192,
                                                         context_window: 128_000,
                                                         ..Default::default()
-                                                    }));
+                                                    };
+                                                    apply_known_model_limits(&mut form);
+                                                    model_form.set(Some(form));
                                                     model_form_key.set(String::new());
                                                     model_form_msg.set(None);
                                                     focus_element_soon("model-form-api-key");
@@ -2778,5 +2828,36 @@ pub(super) fn SettingsView(
             })}
         </div>
 }.into_view())
+    }
+}
+
+#[cfg(test)]
+mod model_limit_tests {
+    use super::*;
+
+    #[test]
+    fn known_models_fill_output_ceiling() {
+        let mut form = ModelForm {
+            model: "claude-sonnet-4-5".into(),
+            ..Default::default()
+        };
+        apply_known_model_limits(&mut form);
+        assert_eq!((form.max_tokens, form.context_window), (64_000, 200_000));
+
+        // Longer prefix must win over "claude-sonnet-4".
+        form.model = "claude-sonnet-4-6".into();
+        apply_known_model_limits(&mut form);
+        assert_eq!((form.max_tokens, form.context_window), (128_000, 1_000_000));
+
+        // Case/whitespace tolerant.
+        form.model = " GPT-5.5 ".into();
+        apply_known_model_limits(&mut form);
+        assert_eq!((form.max_tokens, form.context_window), (128_000, 1_000_000));
+
+        // Unknown models keep whatever the form already has.
+        form.max_tokens = 8_192;
+        form.model = "totally-unknown".into();
+        apply_known_model_limits(&mut form);
+        assert_eq!(form.max_tokens, 8_192);
     }
 }


### PR DESCRIPTION
## What changed

The model config form defaulted **max output tokens** to a conservative 8192 for every model. This PR adds a static `MODEL_LIMITS` table in `ui/src/settings_view.rs` mapping known model-id prefixes to their documented (max output tokens, context window), plus an `apply_known_model_limits()` helper that auto-fills both fields whenever the model id changes:

- typing in the model name input
- switching the provider dropdown
- clicking a quick-add preset (Kimi / GLM / DeepSeek / …)
- opening the new-model form

Unknown models are left untouched, so manual values survive as long as the model id itself isn't re-edited. Matching is longest-prefix-first, case- and whitespace-insensitive.

## Why a static table

Only Anthropic's Models API exposes per-model output limits; OpenAI-compatible endpoints have no uniform way to query them. A small in-UI table covers the app's own presets and mainstream families with zero network calls.

## Limits sourced from vendor docs (2026-07)

- Claude 4.6+/5 family: 128K out / 1M ctx; Haiku 4.5 & Opus/Sonnet 4.5: 64K / 200K (Anthropic docs)
- GPT-5.6 (sol/terra) and GPT-5.5: 128K out / ~1M ctx; GPT-5: 128K / 400K (OpenAI docs)
- DeepSeek V4 Pro: 384K out / 1M ctx
- Kimi K3: 131072 out / 1M ctx; GLM-5.2: 131072 / 1M

Caveat for review: bare `glm-5`'s context window is conservatively set to 200K (no authoritative figure found); `glm-4` is deliberately **not** prefix-matched (only `glm-4.6`) to avoid overfilling glm-4-plus/air, which cap output at 4K.

## Testing

`cargo test model_limit` in `ui/` — new unit test covers longest-prefix ordering, case/whitespace tolerance, and the unknown-model no-op (1 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)