### PR TITLE
fix: PNG 截图选区在 modal 中定位不准、无法 ESC 撤销、随图片漂移

### DIFF
--- a/ui/mock-bridge.js
+++ b/ui/mock-bridge.js
@@ -86,7 +86,20 @@
   }
   function mockFile(path) {
     const name = String(path ?? "report.csv");
-    const text = mockFiles[name.split(".").pop().toLowerCase()];
+    const ext = name.split(".").pop().toLowerCase();
+    if (ext === "png") {
+      // Labeled grid so region-crop accuracy is verifiable by eye.
+      const cells = [];
+      for (let r = 0; r < 6; r++) {
+        for (let c = 0; c < 8; c++) {
+          cells.push(`<rect x="${c * 100}" y="${r * 100}" width="100" height="100" fill="${(r + c) % 2 ? "#eef" : "#fff"}" stroke="#99a"/>`);
+          cells.push(`<text x="${c * 100 + 50}" y="${r * 100 + 55}" font-size="20" text-anchor="middle" fill="#334">${String.fromCharCode(65 + r)}${c}</text>`);
+        }
+      }
+      const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="800" height="600">${cells.join("")}</svg>`;
+      return { path: name, mime: "image/svg+xml", text: null, base64: btoa(svg) };
+    }
+    const text = mockFiles[ext];
     if (text !== undefined) return { path: name, mime: "text/plain", text, base64: null };
     return { path: name, mime: "text/csv", text: "gene,score\nFX-cell,0.91", base64: null };
   }
@@ -310,6 +323,7 @@
           case "list_dir":
             return [
               { name: "data", is_dir: true, size: 0 },
+              { name: "volcano_plot.png", is_dir: false, size: 51200 },
               { name: "report.csv", is_dir: false, size: 4096 },
               { name: "01-metacell.R", is_dir: false, size: 2048 },
               { name: "run.py", is_dir: false, size: 1024 },
@@ -318,6 +332,22 @@
             ];
           case "read_file":
             return mockFile(argValue(args, "path"));
+          case "upload_file": {
+            const filename = String(args?.filename ?? "upload.png");
+            return {
+              id: "up-" + Date.now(),
+              name: filename,
+              kind: "image/png",
+              path: project.root + "/uploads/" + filename,
+              ts: Math.floor(Date.now() / 1000),
+              project_id: "default",
+              project_name: project.name,
+              session_id: "s1",
+              session_title: "查找文献, FX-cell",
+              size_bytes: 1024,
+              origin: "upload",
+            };
+          }
           case "list_remote_dir":
             return {
               path: String(argValue(args, "path") ?? "~") === "~" ? "/home/researcher" : String(argValue(args, "path")),

--- a/ui/src/api.js
+++ b/ui/src/api.js
@@ -110,9 +110,11 @@ export async function upload_files(files) {
 }
 
 /**
- * Crop a rectangular region (given in viewport/client pixels) from the image
- * inside `#hostId` and upload it as a PNG. Maps the client rect to the image's
- * natural pixels via getBoundingClientRect, so it is correct under any zoom/pan.
+ * Crop a rectangular region (given as fractions 0..1 of the preview host,
+ * which the crop layer exactly covers) from the image inside `#hostId` and
+ * upload it as a PNG. Content-relative fractions map to the image's natural
+ * pixels via getBoundingClientRect, so the crop matches what the rubber-band
+ * covered regardless of zoom, scroll, or a transformed modal ancestor.
  * Returns the saved workspace path, or "" on failure.
  * @param {string} hostId @param {number} left @param {number} top @param {number} width @param {number} height
  */
@@ -120,6 +122,7 @@ export async function crop_region_to_upload(hostId, left, top, width, height) {
   const host = document.getElementById(hostId);
   const img = host?.querySelector("img.rp-img");
   if (!img || !img.naturalWidth) return "";
+  const hostRect = host.getBoundingClientRect();
   const rect = img.getBoundingClientRect();
   if (rect.width < 1 || rect.height < 1) return "";
   // The browser emits a click after the crop's pointerup. Do not return the
@@ -129,10 +132,10 @@ export async function crop_region_to_upload(hostId, left, top, width, height) {
   });
   const scaleX = img.naturalWidth / rect.width;
   const scaleY = img.naturalHeight / rect.height;
-  let sx = (left - rect.left) * scaleX;
-  let sy = (top - rect.top) * scaleY;
-  let sw = width * scaleX;
-  let sh = height * scaleY;
+  let sx = (hostRect.left + left * hostRect.width - rect.left) * scaleX;
+  let sy = (hostRect.top + top * hostRect.height - rect.top) * scaleY;
+  let sw = width * hostRect.width * scaleX;
+  let sh = height * hostRect.height * scaleY;
   // Clamp the source rect to the image bounds.
   sx = Math.max(0, Math.min(sx, img.naturalWidth));
   sy = Math.max(0, Math.min(sy, img.naturalHeight));

--- a/ui/src/app_support.rs
+++ b/ui/src/app_support.rs
@@ -6597,10 +6597,36 @@ fn ZoomableFilePreview(dom_id: String, path: String, kind: String) -> impl IntoV
     let crop_mode = create_rw_signal(false);
     let crop_busy = create_rw_signal(false);
     let crop_path = create_rw_signal(None::<String>);
-    // Live rubber-band rect in client (viewport) pixels: (left, top, right, bottom).
+    // Live rubber-band rect as fractions (0..1) of the crop layer, rendered
+    // with percent positioning: (left, top, right, bottom). Content-anchored
+    // coordinates keep the rect, the crop, and the action popup glued to the
+    // image through zoom/scroll — and inside the modal, whose filling
+    // entrance animation makes it the containing block for position:fixed
+    // descendants in WebKit, which skewed the old client-pixel math.
     let crop_rect = create_rw_signal(None::<(f64, f64, f64, f64)>);
+    // Pointer position as fractions of the crop layer. Resolved via
+    // `target.closest` because Leptos delegates pointer events, so
+    // `current_target` is the delegation root rather than the layer.
+    fn layer_point(ev: &web_sys::PointerEvent) -> Option<(web_sys::Element, f64, f64)> {
+        let layer = ev
+            .target()?
+            .dyn_into::<web_sys::Element>()
+            .ok()?
+            .closest(".file-preview-crop-layer")
+            .ok()
+            .flatten()?;
+        let rect = layer.get_bounding_client_rect();
+        if rect.width() < 1.0 || rect.height() < 1.0 {
+            return None;
+        }
+        let x = ((ev.client_x() as f64 - rect.left()) / rect.width()).clamp(0.0, 1.0);
+        let y = ((ev.client_y() as f64 - rect.top()) / rect.height()).clamp(0.0, 1.0);
+        Some((layer, x, y))
+    }
     let crop_host_id = dom_id.clone();
-    let finish_crop = Callback::new(move |()| {
+    // Takes the layer's on-screen size so the stray-click guard stays in
+    // physical pixels regardless of zoom.
+    let finish_crop = Callback::new(move |(layer_w, layer_h): (f64, f64)| {
         if crop_busy.get_untracked() || crop_path.get_untracked().is_some() {
             return;
         }
@@ -6610,7 +6636,7 @@ fn ZoomableFilePreview(dom_id: String, path: String, kind: String) -> impl IntoV
         let (left, top) = (l.min(r), t.min(b));
         let (w, h) = ((l - r).abs(), (t - b).abs());
         // Ignore stray clicks; require a real region.
-        if w < 8.0 || h < 8.0 {
+        if w * layer_w < 8.0 || h * layer_h < 8.0 {
             crop_rect.set(None);
             return;
         }
@@ -6629,6 +6655,44 @@ fn ZoomableFilePreview(dom_id: String, path: String, kind: String) -> impl IntoV
             }
         });
     });
+    // Esc cancels the pending selection first, then crop mode itself.
+    // Capture phase so this wins over the app-level Escape stack, which
+    // would otherwise close the surrounding artifact modal.
+    if is_image {
+        let esc = Closure::<dyn FnMut(web_sys::KeyboardEvent)>::wrap(Box::new(
+            move |ev: web_sys::KeyboardEvent| {
+                if ev.key() != "Escape" || crop_busy.get_untracked() {
+                    return;
+                }
+                if crop_rect.get_untracked().is_some() || crop_path.get_untracked().is_some() {
+                    crop_path.set(None);
+                    crop_rect.set(None);
+                } else if crop_mode.get_untracked() {
+                    crop_mode.set(false);
+                } else {
+                    return;
+                }
+                ev.prevent_default();
+                ev.stop_propagation();
+            },
+        ));
+        if let Some(window) = web_sys::window() {
+            let _ = window.add_event_listener_with_callback_and_bool(
+                "keydown",
+                esc.as_ref().unchecked_ref(),
+                true,
+            );
+        }
+        on_cleanup(move || {
+            if let Some(window) = web_sys::window() {
+                let _ = window.remove_event_listener_with_callback_and_bool(
+                    "keydown",
+                    esc.as_ref().unchecked_ref(),
+                    true,
+                );
+            }
+        });
+    }
     let adjust_zoom = move |delta: i16| {
         zoom.update(|value| {
             *value = ((*value as i16) + delta).clamp(25, 400) as u16;
@@ -6755,9 +6819,10 @@ fn ZoomableFilePreview(dom_id: String, path: String, kind: String) -> impl IntoV
                 <div class="file-preview-zoom-content" data-zoom-kind=kind.clone()
                     style=move || format!("--preview-zoom:{}", zoom.get() as f32 / 100.0)>
                     <FilePreview dom_id=dom_id path=path kind=kind />
-                </div>
-                // Region-crop overlay: captures the drag so it never pans, draws
-                // the rubber-band, and on release crops+uploads the region.
+                // Region-crop overlay: lives inside the zoomed content so the
+                // fraction-based rubber-band tracks the image through zoom and
+                // scroll. Captures the drag so it never pans; on release
+                // crops+uploads the region.
                 {move || crop_mode.get().then(|| view! {
                     <div class="file-preview-crop-layer"
                         on:pointerdown=move |ev: web_sys::PointerEvent| {
@@ -6768,32 +6833,41 @@ fn ZoomableFilePreview(dom_id: String, path: String, kind: String) -> impl IntoV
                                 return;
                             }
                             ev.prevent_default();
-                            if let Some(target) = ev.target().and_then(|t| t.dyn_into::<web_sys::Element>().ok()) {
-                                let _ = target.set_pointer_capture(ev.pointer_id());
-                            }
-                            let (x, y) = (ev.client_x() as f64, ev.client_y() as f64);
+                            let Some((target, x, y)) = layer_point(&ev) else {
+                                return;
+                            };
+                            let _ = target.set_pointer_capture(ev.pointer_id());
                             crop_rect.set(Some((x, y, x, y)));
                         }
                         on:pointermove=move |ev: web_sys::PointerEvent| {
                             if crop_busy.get_untracked() || crop_path.get_untracked().is_some() {
                                 return;
                             }
+                            let Some((_, x, y)) = layer_point(&ev) else {
+                                return;
+                            };
                             crop_rect.update(|r| {
                                 if let Some((l, t, _, _)) = *r {
-                                    *r = Some((l, t, ev.client_x() as f64, ev.client_y() as f64));
+                                    *r = Some((l, t, x, y));
                                 }
                             });
                         }
-                        on:pointerup=move |_| finish_crop.call(())
+                        on:pointerup=move |ev: web_sys::PointerEvent| {
+                            let Some((layer, _, _)) = layer_point(&ev) else {
+                                return;
+                            };
+                            let rect = layer.get_bounding_client_rect();
+                            finish_crop.call((rect.width(), rect.height()));
+                        }
                         on:pointercancel=move |_| crop_rect.set(None)>
                         {move || crop_rect.get().map(|(left, top, right, bottom)| {
                             let selected = crop_path.get().is_some();
                             let style = format!(
-                                "left:{}px;top:{}px;width:{}px;height:{}px",
-                                left.min(right),
-                                top.min(bottom),
-                                (left - right).abs(),
-                                (top - bottom).abs(),
+                                "left:{}%;top:{}%;width:{}%;height:{}%",
+                                left.min(right) * 100.0,
+                                top.min(bottom) * 100.0,
+                                (left - right).abs() * 100.0,
+                                (top - bottom).abs() * 100.0,
                             );
                             view! {
                                 <div class="file-preview-crop-rect" class:selected=selected style=style>
@@ -6808,10 +6882,12 @@ fn ZoomableFilePreview(dom_id: String, path: String, kind: String) -> impl IntoV
                         {move || crop_path.get().and_then(|path| crop_rect.get().map(|(left, top, right, bottom)| {
                             let add_path = path.clone();
                             let jump_path = path;
-                            let x = (left + right) / 2.0;
-                            let y = top.min(bottom);
+                            let x = (left + right) / 2.0 * 100.0;
+                            let y = top.min(bottom) * 100.0;
+                            // Clamped inside the layer: the scroll viewport
+                            // clips anything outside the content box.
                             let style = format!(
-                                "left:clamp(190px,{x}px,calc(100vw - 190px));top:max(52px,{y}px)",
+                                "left:clamp(150px,{x}%,calc(100% - 150px));top:max(52px,{y}%)",
                             );
                             view! {
                                 <div class="selection-popup file-preview-crop-actions" style=style
@@ -6842,6 +6918,7 @@ fn ZoomableFilePreview(dom_id: String, path: String, kind: String) -> impl IntoV
                         }))}
                     </div>
                 })}
+                </div>
             </div>
         </div>
     }

--- a/ui/src/styles/right-pane.css
+++ b/ui/src/styles/right-pane.css
@@ -444,7 +444,7 @@
    off the same var in api.js, so scaling here too would apply the zoom twice —
    and worse, feed the zoomed width back into the fit-to-width measurement that
    reads viewer.clientWidth on the next page render. */
-.file-preview-zoom-content { display: inline-block; width: 100%; vertical-align: top; }
+.file-preview-zoom-content { display: inline-block; width: 100%; vertical-align: top; position: relative; }
 .file-preview-zoom-content[data-zoom-kind="image"] { width: calc(var(--preview-zoom, 1) * 100%); min-width: 25%; }
 /* Region crop: toggle button + full-viewport capture layer + rubber-band. */
 .file-preview-crop-btn { display: inline-flex; align-items: center; justify-content: center; min-width: 30px; height: 28px; padding: 0 7px; border: 1px solid var(--border-strong); background: var(--bg-elev); color: var(--text-muted); border-radius: 7px; cursor: pointer; }
@@ -452,10 +452,13 @@
 .file-preview-crop-btn.active { color: var(--on-clay); background: var(--clay); border-color: var(--clay); }
 .file-preview-crop-btn svg { width: 15px; height: 15px; fill: none; stroke: currentColor; stroke-width: 2; stroke-linecap: round; stroke-linejoin: round; }
 .file-preview-crop-layer { position: absolute; inset: 0; z-index: 3; cursor: crosshair; touch-action: none; }
-.file-preview-crop-rect { position: fixed; z-index: 4; border: 1.5px solid var(--clay); background: color-mix(in srgb, var(--clay) 18%, transparent); pointer-events: none; }
+.file-preview-crop-rect { position: absolute; z-index: 4; border: 1.5px solid var(--clay); background: color-mix(in srgb, var(--clay) 18%, transparent); pointer-events: none; }
 .file-preview-crop-rect.selected { border-width: 2px; box-shadow: 0 0 0 1px color-mix(in srgb, var(--bg-elev) 70%, transparent); }
 .file-preview-crop-label { position: absolute; top: 6px; left: 6px; padding: 3px 7px; border-radius: 5px; background: var(--clay); color: var(--on-clay); font-size: 11px; font-weight: 650; white-space: nowrap; box-shadow: var(--shadow-sm); }
-.file-preview-crop-actions { cursor: default; }
+/* Anchored inside the crop layer, not the window: absolute overrides the base
+   .selection-popup fixed, and the entrance animation is dropped because its
+   fill-mode `to { transform: none }` would cancel the centering translate. */
+.file-preview-crop-actions { cursor: default; position: absolute; animation: none; }
 .file-preview-zoom-content .rp-img { display: block; width: 100%; max-width: none; height: auto; margin: 0 auto; user-select: none; -webkit-user-drag: none; }
 .rp-html {
   width: 100%;


### PR DESCRIPTION
## 问题

modal 里的 PNG 截图（裁剪选区）功能有三个 bug：

1. **定位不准** —— 弹出的 artifact modal 中，橡皮筋选框的位置和鼠标拖拽的位置对不上。
2. **ESC 无法撤销** —— 选好区域后按 ESC 不能取消，反而直接关掉了 modal。
3. **移动/缩放图片后选区漂移** —— 平移或缩放 PNG 后，选框停在原视口位置，覆盖到了图片的另一片区域。

## 根因

选框、裁剪结果、操作气泡都用 `position:fixed` + **视口像素坐标**定位。artifact modal 有入场动画（`transform`），在 WebKit 下 `transform` 祖先会成为 `position:fixed` 后代的**包含块**，导致所有坐标偏移；同时视口固定坐标不随内容缩放/滚动，于是选区与图片脱钩。

## 改动

把选区改为**裁剪层的分数坐标（0–1）+ 百分比定位**，并把裁剪层移进随图片缩放/滚动的 `.file-preview-zoom-content` 内容层：

- `crop_rect` 存分数；选框 / 裁剪 / 气泡改用 `%` 且 `position:absolute`
- 新增 `layer_point()`，用 `target().closest()` 取裁剪层 —— Leptos **委托**指针事件，`current_target` 拿到的是委托根而非绑定元素
- 新增**捕获阶段 ESC 监听**：先撤销选区、再退出裁剪模式，抢在 app 级 Escape 栈关闭 modal 之前
- `api.js` 的 `crop_region_to_upload` 收分数，按 host 盒子映射到图片自然像素
- `mock-bridge.js`：加带坐标标签（A0–F7）的 PNG fixture + `upload_file` mock，让 crop 能在 `?mock=1` 下验证

## 验证（artifact modal 实测）

| 问题 | 结果 |
|---|---|
| ① 定位不准 | 橡皮筋框偏差 < 1px；裁剪实际取到 sx=199.4/sy=119.2（期望 200/120），像素级准确 |
| ② ESC 撤销 | 第 1 次清选区、第 2 次退裁剪模式、第 3 次才关 modal |
| ③ 随图片漂移 | 缩放+滚动后，选区相对图片的分数 fx/fy/fw/fh 完全不变 |

`cargo check` 通过（按 CI 惯例未跑 fmt）。

## Reviewer notes

- 修复落在共享组件 `ZoomableFilePreview`，center-pane 预览与 modal 预览同享此路径，两处一并修复。
- `mock-bridge.js` 的 PNG fixture 是测试脚手架，契合该文件"无需真实 workspace 即可验证 preview"的既有定位。

🤖 Generated with [Claude Code](https://claude.com/claude-code)