### PR TITLE
fix: 消除 SQLite 快照导出与写事务的两类立即 BUSY flaky

### DIFF
--- a/crates/wisp-store/src/agent_workflow_attempts.rs
+++ b/crates/wisp-store/src/agent_workflow_attempts.rs
@@ -381,7 +381,7 @@ impl Store {
         if attempt.status != AgentWorkflowAttemptStatus::Queued {
             anyhow::bail!("new agent workflow attempts must start queued");
         }
-        let mut tx = self.pool.begin().await?;
+        let mut tx = self.begin_write().await?;
         let runnable: i64 = sqlx::query_scalar(
             "SELECT COUNT(*) FROM agent_workflow_steps s JOIN agent_workflows w ON w.id=s.workflow_id WHERE s.id=? AND s.workflow_id=? AND w.status='running'",
         )
@@ -442,7 +442,7 @@ impl Store {
             anyhow::bail!("new agent workflow attempts must start queued");
         }
         let now = chrono::Utc::now().timestamp();
-        let mut tx = self.pool.begin().await?;
+        let mut tx = self.begin_write().await?;
         lock_root_workflow(&mut tx, &attempt.root_workflow_id).await?;
         let workflow = sqlx::query(
             "SELECT w.root_workflow_id,w.parent_attempt_id,w.depth,w.status,\
@@ -675,7 +675,7 @@ impl Store {
         &self,
         attempt_id: &str,
     ) -> Result<bool> {
-        let mut tx = self.pool.begin().await?;
+        let mut tx = self.begin_write().await?;
         let row = sqlx::query(
             "SELECT a.root_workflow_id,a.depth,a.status,a.allow_delegation,a.cancel_requested,\
              r.status AS root_status,r.created_at,r.root_limits_json FROM agent_workflow_attempts a \
@@ -889,7 +889,7 @@ impl Store {
         attempt_id: &str,
         yielded: bool,
     ) -> Result<bool> {
-        let mut tx = self.pool.begin().await?;
+        let mut tx = self.begin_write().await?;
         let row = sqlx::query(
             "SELECT a.root_workflow_id,a.status,a.allow_delegation,a.cancel_requested,\
              r.root_limits_json,r.status AS root_status FROM agent_workflow_attempts a \
@@ -965,7 +965,7 @@ impl Store {
         error: &str,
     ) -> Result<(u64, bool)> {
         let now = chrono::Utc::now().timestamp();
-        let mut tx = self.pool.begin().await?;
+        let mut tx = self.begin_write().await?;
         let attempts = sqlx::query(
             "UPDATE agent_workflow_attempts SET status='failed',error=COALESCE(error,?),\
              delegation_slot_yielded=0,finished_at=COALESCE(finished_at,?),updated_at=? \
@@ -996,7 +996,7 @@ impl Store {
         let now = chrono::Utc::now().timestamp();
         let reason =
             "The application stopped before this Agent execution reached a terminal state.";
-        let mut tx = self.pool.begin().await?;
+        let mut tx = self.begin_write().await?;
         sqlx::query(
             "UPDATE agent_workflow_deliveries SET resume_status='interrupted',\
              resume_error=COALESCE(resume_error,?),updated_at=? WHERE resume_status='running'",

--- a/crates/wisp-store/src/agent_workflow_deliveries.rs
+++ b/crates/wisp-store/src/agent_workflow_deliveries.rs
@@ -165,7 +165,7 @@ impl Store {
         &self,
         frame_id: &str,
     ) -> Result<Vec<AgentWorkflowDelivery>> {
-        let mut tx = self.pool.begin().await?;
+        let mut tx = self.begin_write().await?;
         let rows = sqlx::query(&format!(
             "{SELECT_DELIVERY} WHERE frame_id=? AND result_json IS NOT NULL \
              AND delivered_at IS NULL ORDER BY created_at,id"
@@ -229,7 +229,7 @@ impl Store {
         &self,
         frame_id: &str,
     ) -> Result<Vec<AgentWorkflowDelivery>> {
-        let mut tx = self.pool.begin().await?;
+        let mut tx = self.begin_write().await?;
         let rows = sqlx::query(&format!(
             "{SELECT_DELIVERY} WHERE frame_id=? AND delivered_at IS NOT NULL \
              AND resume_status='pending' ORDER BY created_at,id"
@@ -265,7 +265,7 @@ impl Store {
         let status = if success { "succeeded" } else { "failed" };
         let now = chrono::Utc::now().timestamp();
         let mut changed = 0;
-        let mut tx = self.pool.begin().await?;
+        let mut tx = self.begin_write().await?;
         for id in ids {
             changed += sqlx::query(
                 "UPDATE agent_workflow_deliveries SET resume_status=?,resume_error=?,presented_at=?,updated_at=? \
@@ -301,7 +301,7 @@ impl Store {
     pub async fn mark_agent_workflow_deliveries_presented(&self, ids: &[String]) -> Result<u64> {
         let now = chrono::Utc::now().timestamp();
         let mut changed = 0;
-        let mut tx = self.pool.begin().await?;
+        let mut tx = self.begin_write().await?;
         for id in ids {
             changed += sqlx::query(
                 "UPDATE agent_workflow_deliveries SET presented_at=?,updated_at=? \

--- a/crates/wisp-store/src/agent_workflows.rs
+++ b/crates/wisp-store/src/agent_workflows.rs
@@ -630,7 +630,7 @@ impl super::Store {
             anyhow::bail!("new agent workflow plans must start as draft");
         }
         validate_plan_steps(&workflow.id, steps)?;
-        let mut tx = self.pool.begin().await?;
+        let mut tx = self.begin_write().await?;
         let limits: AgentDelegationRootLimits = serde_json::from_str(&workflow.root_limits_json)?;
         if workflow.depth == 0 {
             if u32::try_from(steps.len()).unwrap_or(u32::MAX) > limits.max_tasks {
@@ -699,7 +699,7 @@ impl super::Store {
         }
         validate_plan_steps(&workflow.id, steps)?;
         let now = chrono::Utc::now().timestamp();
-        let mut tx = self.pool.begin().await?;
+        let mut tx = self.begin_write().await?;
         let updated = sqlx::query(
             "UPDATE agent_workflows SET frame_id=?,name=?,description=?,goal=?,mode=?,max_parallel=?,requires_confirmation=?,plan_json=?,version=version+1,enabled=?,updated_at=? WHERE id=? AND version=? AND status='draft'",
         )
@@ -789,7 +789,7 @@ impl super::Store {
             }
         }
         let now = chrono::Utc::now().timestamp();
-        let mut tx = self.pool.begin().await?;
+        let mut tx = self.begin_write().await?;
         let updated = sqlx::query(
             "UPDATE agent_workflows SET status=?,version=version+1,approved_at=CASE WHEN ?='approved' THEN ? ELSE approved_at END,updated_at=? WHERE id=? AND status=?",
         )
@@ -914,7 +914,7 @@ impl super::Store {
     }
 
     pub async fn delete_agent_workflow(&self, id: &str) -> Result<bool> {
-        let mut tx = self.pool.begin().await?;
+        let mut tx = self.begin_write().await?;
         sqlx::query("UPDATE agent_workflows SET status='draft' WHERE id=?")
             .bind(id)
             .execute(&mut *tx)
@@ -937,7 +937,7 @@ impl super::Store {
 
     pub async fn create_agent_workflow_step(&self, step: &AgentWorkflowStep) -> Result<()> {
         step.validate()?;
-        let mut tx = self.pool.begin().await?;
+        let mut tx = self.begin_write().await?;
         bump_draft_workflow_version(&mut tx, &step.workflow_id).await?;
         sqlx::query(
             "INSERT INTO agent_workflow_steps(id,workflow_id,position,agent_id,template_id,role,backend,model,prompt_template,input_schema_json,output_schema_json,input_contract_json,output_contract_json,permissions_json,context_policy_json,budget_json,spec_json,timeout_secs,created_at,updated_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
@@ -991,7 +991,7 @@ impl super::Store {
 
     pub async fn update_agent_workflow_step(&self, step: &AgentWorkflowStep) -> Result<bool> {
         step.validate()?;
-        let mut tx = self.pool.begin().await?;
+        let mut tx = self.begin_write().await?;
         let current_workflow_id = sqlx::query_scalar::<_, String>(
             "SELECT workflow_id FROM agent_workflow_steps WHERE id=?",
         )
@@ -1021,7 +1021,7 @@ impl super::Store {
     }
 
     pub async fn delete_agent_workflow_step(&self, id: &str) -> Result<bool> {
-        let mut tx = self.pool.begin().await?;
+        let mut tx = self.begin_write().await?;
         let workflow_id = sqlx::query_scalar::<_, String>(
             "SELECT workflow_id FROM agent_workflow_steps WHERE id=?",
         )

--- a/crates/wisp-store/src/artifacts.rs
+++ b/crates/wisp-store/src/artifacts.rs
@@ -16,7 +16,7 @@ impl Store {
         storage_path: &str,
     ) -> Result<String> {
         let now = chrono::Utc::now().timestamp();
-        let mut tx = self.pool.begin().await?;
+        let mut tx = self.begin_write().await?;
         let parent_version_id: Option<String> =
             sqlx::query_scalar("SELECT latest_version_id FROM artifacts WHERE id=?")
                 .bind(id)
@@ -80,7 +80,7 @@ impl Store {
     /// version. This is used when an isolated Agent workspace is removed after
     /// its immutable artifact bytes have been copied to durable app storage.
     pub async fn relocate_artifact_storage(&self, id: &str, storage_path: &str) -> Result<bool> {
-        let mut tx = self.pool.begin().await?;
+        let mut tx = self.begin_write().await?;
         let latest_version_id: Option<String> =
             sqlx::query_scalar("SELECT latest_version_id FROM artifacts WHERE id=?")
                 .bind(id)

--- a/crates/wisp-store/src/lib.rs
+++ b/crates/wisp-store/src/lib.rs
@@ -80,6 +80,18 @@ pub struct Store {
 impl Store {
     /// Open (or create) the SQLite database at `path` and run migrations.
     pub async fn open(path: &Path) -> Result<Self> {
+        Self::open_with_journal(path, true).await
+    }
+
+    /// Open a throwaway snapshot/transfer database in the default rollback
+    /// journal mode. Switching a database out of WAL needs an exclusive lock
+    /// that ignores `busy_timeout` and fails with SQLITE_BUSY immediately, so
+    /// portable single-file snapshots must never enter WAL to begin with.
+    pub(crate) async fn open_snapshot(path: &Path) -> Result<Self> {
+        Self::open_with_journal(path, false).await
+    }
+
+    async fn open_with_journal(path: &Path, wal: bool) -> Result<Self> {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
@@ -97,15 +109,27 @@ impl Store {
             .await?;
         // WAL journaling so a crash mid-turn can't corrupt the DB and committed
         // messages survive (pairs with incremental message persistence).
-        sqlx::query("PRAGMA journal_mode=WAL")
-            .execute(&pool)
-            .await?;
+        if wal {
+            sqlx::query("PRAGMA journal_mode=WAL")
+                .execute(&pool)
+                .await?;
+        }
         Self::migrate(&pool).await?;
         let store = Self { pool };
         store
             .upsert_execution_context(&ExecutionContext::new("local", "Local")?)
             .await?;
         Ok(store)
+    }
+
+    /// Every multi-statement transaction in this store writes. Take the write
+    /// lock at BEGIN so a concurrent writer queues on `busy_timeout` instead
+    /// of failing immediately with SQLITE_BUSY_SNAPSHOT when a deferred
+    /// transaction that read first upgrades to a write mid-flight.
+    pub(crate) async fn begin_write(
+        &self,
+    ) -> sqlx::Result<sqlx::Transaction<'static, sqlx::Sqlite>> {
+        self.pool.begin_with("BEGIN IMMEDIATE").await
     }
 
     async fn migrate(pool: &SqlitePool) -> Result<()> {

--- a/crates/wisp-store/src/project_transfer.rs
+++ b/crates/wisp-store/src/project_transfer.rs
@@ -3,7 +3,7 @@ use anyhow::{Context, Result};
 use futures_util::TryStreamExt;
 use sha2::{Digest, Sha256};
 use sqlx::{
-    sqlite::{SqliteConnectOptions, SqliteConnection, SqlitePoolOptions},
+    sqlite::{SqliteConnectOptions, SqlitePoolOptions},
     Column, Connection, Row, Sqlite, Transaction, TypeInfo, ValueRef,
 };
 use std::collections::HashSet;
@@ -727,7 +727,10 @@ impl Store {
             std::fs::remove_file(destination)?;
         }
         let source_db = self.database_path().await?;
-        let transfer = Store::open(destination).await?;
+        // Rollback-journal mode: the snapshot must end up as one standalone
+        // file, and leaving WAL later would need an exclusive lock that
+        // ignores `busy_timeout` and flakes with SQLITE_BUSY.
+        let transfer = Store::open_snapshot(destination).await?;
         let mut connection = transfer.pool.acquire().await?;
         sqlx::query("ATTACH DATABASE ? AS transfer")
             .bind(source_db.to_string_lossy().as_ref())
@@ -778,21 +781,8 @@ impl Store {
         .bind(project_id)
         .fetch_one(&transfer.pool)
         .await?;
+        sqlx::query("VACUUM").execute(&transfer.pool).await?;
         transfer.pool.close().await;
-        // Reopen with exactly one connection before leaving WAL mode. A pool
-        // can keep idle readers alive and make journal_mode changes fail with
-        // SQLITE_BUSY; the resulting snapshot must be one standalone file.
-        let options =
-            SqliteConnectOptions::from_str(&format!("sqlite://{}", destination.display()))?;
-        let mut standalone = SqliteConnection::connect_with(&options).await?;
-        sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)")
-            .execute(&mut standalone)
-            .await?;
-        sqlx::query("PRAGMA journal_mode=DELETE")
-            .execute(&mut standalone)
-            .await?;
-        sqlx::query("VACUUM").execute(&mut standalone).await?;
-        standalone.close().await?;
         Ok(ProjectTransferStats {
             frames: counts.0,
             messages: counts.1,
@@ -1093,6 +1083,11 @@ mod tests {
         assert_eq!(stats.artifacts, 1);
         assert_eq!(stats.runs, 1);
         assert_eq!(stats.path_warnings, 0);
+        // The snapshot must be one standalone rollback-journal file: header
+        // bytes 18/19 are the file format versions (1 = legacy, 2 = WAL).
+        let header = std::fs::read(&archive_path).unwrap();
+        assert_eq!(&header[18..20], &[1, 1]);
+        assert!(!archive_path.with_extension("sqlite-wal").exists());
 
         let target = Store::open(&target_path).await.unwrap();
         let workspace = Path::new("/Users/alice/Study");

--- a/crates/wisp-store/src/projects.rs
+++ b/crates/wisp-store/src/projects.rs
@@ -81,7 +81,7 @@ impl Store {
     /// ponytail: explicit cascade of known child tables; switch to
     /// `PRAGMA foreign_keys=ON` if more child tables appear.
     pub async fn delete_project(&self, id: &str) -> Result<()> {
-        let mut tx = self.pool.begin().await?;
+        let mut tx = self.begin_write().await?;
         super::project_transfer::delete_project_children(&mut tx, id).await?;
         sqlx::query("DELETE FROM project_sync_state WHERE project_id=?")
             .bind(id)

--- a/crates/wisp-store/src/resources.rs
+++ b/crates/wisp-store/src/resources.rs
@@ -9,7 +9,7 @@ impl Store {
         message_seq: i64,
         links: &[MessageResourceLink],
     ) -> Result<()> {
-        let mut tx = self.pool.begin().await?;
+        let mut tx = self.begin_write().await?;
         sqlx::query("DELETE FROM message_resource_links WHERE frame_id=? AND message_seq=?")
             .bind(frame_id)
             .bind(message_seq)

--- a/crates/wisp-store/src/sessions.rs
+++ b/crates/wisp-store/src/sessions.rs
@@ -721,7 +721,7 @@ impl Store {
         if exists.is_none() {
             anyhow::bail!("Session not found");
         }
-        let mut tx = self.pool.begin().await?;
+        let mut tx = self.begin_write().await?;
         delete_session_rows(&mut tx, frame_id).await?;
         tx.commit().await?;
         Ok(())
@@ -782,7 +782,7 @@ impl Store {
             anyhow::bail!("New session id cannot be empty");
         }
 
-        let mut tx = self.pool.begin().await?;
+        let mut tx = self.begin_write().await?;
         let target_exists: Option<(String,)> = sqlx::query_as("SELECT id FROM projects WHERE id=?")
             .bind(target_project_id)
             .fetch_optional(&mut *tx)
@@ -983,7 +983,7 @@ impl Store {
 
     /// Delete a folder; sessions inside are kept (folder_id cleared).
     pub async fn delete_folder(&self, id: &str, project_id: &str) -> Result<()> {
-        let mut tx = self.pool.begin().await?;
+        let mut tx = self.begin_write().await?;
         sqlx::query("UPDATE frames SET folder_id=NULL WHERE folder_id=? AND project_id=?")
             .bind(id)
             .bind(project_id)


### PR DESCRIPTION
## 问题

`cargo test --workspace` 在 CI 上偶发失败(PR #389 连续两次 attempt 被迫重跑),失败测试与被改代码无关:

1. `project_sync::tests::two_devices_push_pull_and_refuse_divergent_changes` — `Err("error returned from database: (code: 5) database is locked")`
2. `native_delegation::tests::native_child_file_links_become_durable_artifact_references` — `assertion left == right failed, left: 0, right: 1`

本地单跑全绿,只在 CI 并行 + 慢 I/O 下暴露。用 6 进程 × `--test-threads=16` 的并行压测在本地稳定复现,并通过分步标注拿到了两处确切的失败语句。

## 根因(均为产品代码问题,非测试隔离问题)

各测试的 DB 路径本就是 UUID 唯一;真正的根因是 wisp-store 里两类**不经过 busy_timeout、立即失败**的 SQLite 锁错误:

1. **WAL 退出切换**:`export_project_database` 先用 `Store::open` 打开快照库(强制进 WAL),末尾用 `PRAGMA journal_mode=DELETE` 切回单文件。WAL 进出需要的排他锁不走 busy handler(sqlx 源码注释明确说明),连接池任何一个连接晚关几毫秒即立即 code 5。压测中 9/9 次失败全部落在这条 PRAGMA 上。
2. **deferred 事务先读后写**:`save_artifact` 先 SELECT 再 INSERT;原生委派运行时中消息持久化与溯源持久化并发写同一个池,读→写升级时对方已提交即立即返回 SQLITE_BUSY_SNAPSHOT(code 517),该错误在 `bind_resolved` 被吞成 failed_link,artifacts 计数变 0。压测抓到确切的 517。

此前 d061523 单加 `busy_timeout(5s)` 无效:5s 本就是 sqlx 默认值,且这两类错误都不进 busy handler(该分支 CI 也确实再次失败)。

## 改动

- `Store::open_snapshot`(新):快照/导出临时库从一开始就用回滚日志模式,永不进 WAL;`export_project_database` 末尾整段 checkpoint / `journal_mode=DELETE` / standalone 连接删除,只保留池上的 `VACUUM`。附带收益:快照主文件始终完整,不再依赖 WAL checkpoint。
- `Store::begin_write`(新):`BEGIN IMMEDIATE`,写锁在 BEGIN 时获取并由 busy_timeout 正常排队;wisp-store 全部 24 处多语句写事务统一改用。`project_transfer` 中 3 处 `connection.begin()` 保持不变(均为写语句开头,不存在 517 窗口)。
- 测试:在既有导出/导入 round-trip 测试中新增断言——导出快照必须是单文件、非 WAL(文件头 18/19 字节 = 1,且无 `-wal` 伴生文件)。

未改动 PR #389 的排序功能代码,也未改动两个失败测试本身。

## 验证

- 修复前:48 次全量并行压测中约半数实例失败(两测试均复现,含 CI 同款错误码)。
- 修复后:同强度 48 次全量运行,这两个测试零失败;`cargo test --workspace`、`cargo fmt --all -- --check` 全绿。

## 已知限制 / 后续

- 压测另暴露一个无关的预存时序 flaky:`run_context::tests::ssh_cancel_stays_cancelling_until_remote_group_confirms`(高负载下状态提前变为 Cancelled),已另立任务单独处理,不混入本 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)