### PR TITLE
feat(ui): show in-flight step in collapsed steps header

### DIFF
--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -9686,6 +9686,11 @@ fn render_steps_group(
     };
     let total_label =
         (total_ms > 0 && (!live || n_tools > 0)).then(|| format_duration_ms(total_ms));
+    // The group re-renders on every streaming delta (fingerprint-keyed row),
+    // so this static line tracks the in-flight step while collapsed.
+    let now_line = live
+        .then(|| steps_now_line(&items, &t(locale.get(), "chat.thinking")))
+        .flatten();
     let open = disclosure_signal(disclosure_state, &group_id, live);
     let rows = items.into_iter().enumerate().map(|(position, it)| match it {
         ChatItem::Assistant { text, .. } => {
@@ -9820,10 +9825,89 @@ fn render_steps_group(
             }>
                 <span class="steps-chevron"></span>
                 <span class="steps-title">{title}</span>
+                {now_line.map(|text| view! { <span class="steps-now">{text}</span> })}
                 {total_label.map(|label| view! { <span class="steps-meta">{label}</span> })}
             </div>
             <div class="steps-body">{rows}</div>
         </div>
+    }
+}
+
+/// Latest step of a live run as "name · detail", shown in the collapsed
+/// steps header so folding the panel hides detail, not progress.
+fn steps_now_line(items: &[ChatItem], thinking_label: &str) -> Option<String> {
+    let first_line = |s: &str| -> String {
+        s.lines()
+            .find(|l| !l.trim().is_empty())
+            .unwrap_or("")
+            .trim()
+            .chars()
+            .take(80)
+            .collect()
+    };
+    items.iter().rev().find_map(|item| match item {
+        ChatItem::Tool { name, input, .. } => {
+            let detail = first_line(input);
+            Some(if detail.is_empty() {
+                name.clone()
+            } else {
+                format!("{name} · {detail}")
+            })
+        }
+        ChatItem::AcpTool {
+            title,
+            kind,
+            content,
+            locations,
+            ..
+        } => {
+            let detail = acp_tool_step_detail(kind, content, locations);
+            Some(if detail.is_empty() {
+                title.clone()
+            } else {
+                format!("{title} · {detail}")
+            })
+        }
+        ChatItem::Assistant { text, .. } => {
+            let line = first_line(text);
+            (!line.is_empty()).then_some(line)
+        }
+        ChatItem::Reasoning(_) => Some(thinking_label.to_string()),
+        _ => None,
+    })
+}
+
+#[cfg(test)]
+mod steps_now_line_tests {
+    use super::steps_now_line;
+    use crate::dto::ChatItem;
+
+    fn tool(name: &str, input: &str) -> ChatItem {
+        ChatItem::Tool {
+            name: name.into(),
+            ok: None,
+            input: input.into(),
+            output: String::new(),
+            started_at_ms: None,
+            duration_ms: None,
+        }
+    }
+
+    #[test]
+    fn shows_latest_step() {
+        let items = vec![
+            ChatItem::Reasoning("hmm".into()),
+            tool("python", "\nfrom pypdf import PdfReader\nmore"),
+        ];
+        assert_eq!(
+            steps_now_line(&items, "thinking"),
+            Some("python · from pypdf import PdfReader".into())
+        );
+        assert_eq!(
+            steps_now_line(&[ChatItem::Reasoning("hmm".into())], "thinking"),
+            Some("thinking".into())
+        );
+        assert_eq!(steps_now_line(&[], "thinking"), None);
     }
 }
 

--- a/ui/src/styles/chat.css
+++ b/ui/src/styles/chat.css
@@ -1072,7 +1072,9 @@ button.stop:disabled { opacity: .6; cursor: default; }
 .steps-chevron { flex: 0 0 auto; width: 9px; height: 9px; color: var(--text-faint); transition: transform .15s ease; background: currentColor;
   clip-path: polygon(30% 0, 55% 50%, 30% 100%, 20% 90%, 38% 50%, 20% 10%); }
 .steps.open > .steps-head .steps-chevron { transform: rotate(90deg); }
-.steps-title { flex: 1 1 auto; font-size: 12.5px; font-weight: 600; color: var(--text-muted); }
+.steps-title { flex: 0 0 auto; font-size: 12.5px; font-weight: 600; color: var(--text-muted); }
+.steps-now { flex: 1 1 auto; min-width: 0; font-size: 12px; color: var(--text-faint); font-family: var(--font-mono); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.steps.open > .steps-head .steps-now { display: none; }
 .steps-meta { flex: 0 0 auto; margin-left: auto; font-size: 11.5px; color: var(--text-faint); font-variant-numeric: tabular-nums; }
 .steps-body { padding: 2px 6px 6px; display: none; flex-direction: column; }
 .steps.open > .steps-body { display: flex; }


### PR DESCRIPTION
## Summary
- While a live run's steps panel is collapsed, the header showed only "执行中…" with no progress indication
- Now the collapsed header shows the latest in-flight step as `name · detail` (tool name + first input line, progress text first line, or the thinking label), updating live via the existing fingerprint-keyed re-render on each streaming delta
- The line is hidden when the panel is expanded, since the step rows already show the same detail

## Test plan
- [x] `cargo test steps_now_line` — new unit test covering tool/reasoning/empty cases
- [x] `cargo check --target wasm32-unknown-unknown`
- [x] `cargo fmt`
- [ ] Manual: start a long-running turn, collapse the steps panel, verify the current step streams in the header and disappears on expand

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018KpnTZc6hq1W4bewpGFibb