### PR TITLE
fix(run_context): resolve cancel races behind flaky lifecycle tests

### DIFF
--- a/src-tauri/src/run_context.rs
+++ b/src-tauri/src/run_context.rs
@@ -749,6 +749,11 @@ impl RunManager {
             .map_err(|e| e.to_string())?
             .ok_or_else(|| format!("Run not found: {run_id}"))?;
         if refreshed.status.is_terminal() {
+            // The lifecycle task can confirm the cancellation requested above
+            // before this re-read; that is success, not an error.
+            if requested && refreshed.status == wisp_store::RunStatus::Cancelled {
+                return Ok(());
+            }
             return Err(format!("Run is already {}", refreshed.status.as_str()));
         }
         if refreshed.kind == "file_transfer" {

--- a/src-tauri/src/run_context/tests.rs
+++ b/src-tauri/src/run_context/tests.rs
@@ -464,7 +464,7 @@ async fn ssh_run_detaches_persists_handle_and_finishes_from_poller() {
     // Hold the poller until the pre-completion status has been observed, so
     // the run cannot finish before the assertions below run under load.
     let poll_gate = Arc::new(tokio::sync::Semaphore::new(0));
-    *runner.poll_gate.lock().unwrap() = Some(poll_gate.clone());
+    *runner.rpc_gate.lock().unwrap() = Some(poll_gate.clone());
     let command = "printf '%s\\n' '$HOME' && printf '%s\\n' '$(date)'";
     let submitted = manager
         .submit(
@@ -754,6 +754,10 @@ async fn ssh_cancel_stays_cancelling_until_remote_group_confirms() {
     let runner = Arc::new(ScriptedRunRunner::new(vec![ok_output(
         "__WISP_CANCEL__:cancelled\n",
     )]));
+    // Hold the remote cancel RPC so the group has not confirmed yet when the
+    // pre-confirmation status is asserted, even under slow scheduling.
+    let cancel_gate = Arc::new(tokio::sync::Semaphore::new(0));
+    *runner.rpc_gate.lock().unwrap() = Some(cancel_gate.clone());
     let manager = RunManager::with_runner(runner.clone());
 
     manager.cancel(&store, "remote").await.unwrap();
@@ -761,6 +765,7 @@ async fn ssh_cancel_stays_cancelling_until_remote_group_confirms() {
         store.get_run("remote").await.unwrap().unwrap().status,
         wisp_store::RunStatus::Cancelling
     );
+    cancel_gate.add_permits(1);
     assert_eq!(
         wait_for_terminal(&store, "remote").await.status,
         wisp_store::RunStatus::Cancelled
@@ -929,9 +934,10 @@ struct ScriptedRunRunner {
     commands: StdMutex<Vec<RunCommand>>,
     synthesize_launch_ack: std::sync::atomic::AtomicBool,
     token: StdMutex<Option<String>>,
-    // When set, "poll SSH Run" commands block until the test releases a permit,
-    // so a test can observe pre-completion state without racing the poller.
-    poll_gate: StdMutex<Option<Arc<tokio::sync::Semaphore>>>,
+    // When set, poll/cancel SSH RPCs block until the test releases a permit,
+    // so a test can observe pre-confirmation state without racing the
+    // background lifecycle task.
+    rpc_gate: StdMutex<Option<Arc<tokio::sync::Semaphore>>>,
 }
 
 impl ScriptedRunRunner {
@@ -941,7 +947,7 @@ impl ScriptedRunRunner {
             commands: StdMutex::new(Vec::new()),
             synthesize_launch_ack: std::sync::atomic::AtomicBool::new(false),
             token: StdMutex::new(None),
-            poll_gate: StdMutex::new(None),
+            rpc_gate: StdMutex::new(None),
         }
     }
 
@@ -957,8 +963,8 @@ impl RunCommandRunner for ScriptedRunRunner {
         command: RunCommand,
         _timeout: Duration,
     ) -> Result<RunCommandOutput, String> {
-        if command.script == "poll SSH Run" {
-            let gate = self.poll_gate.lock().unwrap().clone();
+        if matches!(command.script.as_str(), "poll SSH Run" | "cancel SSH Run") {
+            let gate = self.rpc_gate.lock().unwrap().clone();
             if let Some(gate) = gate {
                 let _permit = gate.acquire().await.unwrap();
             }


### PR DESCRIPTION
## What

Fixes the timing-flaky tests `run_context::tests::ssh_cancel_stays_cancelling_until_remote_group_confirms` and `background_run_can_be_cancelled_without_waiting_for_the_command` by addressing the two real races behind them — no sleeps added.

- **`RunManager::cancel()` (production race):** after `request_run_cancellation` commits `Cancelling`, the background lifecycle heartbeat can confirm that very cancellation and write `Cancelled` before `cancel()` re-reads the run. `cancel()` then returned `Err("Run is already cancelled")` for a cancellation it had just successfully requested (test `.unwrap()` panic; in production, a spurious error toast for a successful cancel). Now that interleaving returns `Ok` — only when this call initiated the request and the terminal state is `Cancelled`.
- **Scripted runner gate (test race):** `cancel()` spawns the `remote_lifecycle` task and returns; the scripted runner answered the `cancel SSH Run` RPC instantly, so under slow scheduling the run reached `Cancelled` before the test asserted `Cancelling` (`left: Cancelled, right: Cancelling`). The existing `poll_gate` is generalized into `rpc_gate` covering both `poll SSH Run` and `cancel SSH Run`; the ssh_cancel test holds the gate until the pre-confirmation assertion runs, then releases it and waits for `Cancelled`.

## Why

Under 6 test processes × `--test-threads=16` running `cargo test -p wisp-tauri --lib` in parallel, both tests flaked. The test's premise "the remote group has not confirmed yet" was never enforced, and `cancel()` had a genuine self-race with the lifecycle heartbeat.

## Verification

| Binary | Stress (6 procs × 16 threads) | Target-test failures |
|---|---|---|
| Unfixed | 180 targeted `run_context` runs | **9** (8× ssh_cancel assertion, 1× background `"Run is already cancelled"` unwrap panic) |
| Fixed | 180 targeted + 48 full `--lib` runs | **0** |

The pre-fix failure modes match the traced interleavings exactly. Remaining full-suite flakes (`project_sync` "database is locked", `native_delegation`) are pre-existing and out of scope (tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)