### PR TITLE
fix(preview): pin office preview width to stop PPTX render loop

### DIFF
--- a/ui-tests/tests/pptx-preview-width.spec.ts
+++ b/ui-tests/tests/pptx-preview-width.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect, type Page } from "@playwright/test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { tauriMock } from "./mock-tauri";
+const officeFixtures = {
+  xlsxBase64: readFileSync(resolve(__dirname, "../fixtures/office-preview.xlsx")).toString("base64"),
+  pptxBase64: readFileSync(resolve(__dirname, "../fixtures/office-preview.pptx")).toString("base64"),
+};
+// Regression for the PPTX preview feedback loop: the renderer sizes each slide to
+// the container's width, so if the mount host isn't width-pinned the container grows
+// (twitch) or collapses to a sliver (blank until resize). The container must stay
+// pinned to the figure and stable over time. Run narrow, where the bug is worst.
+test("PPTX preview width stays pinned in a narrow modal", async ({ page }) => {
+  await page.setViewportSize({ width: 380, height: 800 });
+  await page.addInitScript(tauriMock, officeFixtures);
+  await page.goto("/");
+  await page.locator(".proj-card-main").first().click();
+  await page.getByRole("button", { name: "Files" }).click();
+  await page.locator('.fb-row[data-workspace-path="office-preview.pptx"]').click();
+  await expect(page.locator(".artifact-modal .rp-pptx")).toBeVisible();
+
+  const measure = (page: Page) => page.evaluate(() => {
+    const c = document.querySelector(".rp-pptx") as HTMLElement;
+    const fig = document.querySelector(".am-figure.office-preview") as HTMLElement;
+    const content = document.querySelector('.rp-pptx [data-slide-index="0"] > div > *') as HTMLElement | null;
+    const m = (content?.style.transform || "").match(/scale\(([\d.]+)\)/);
+    return { cw: c.clientWidth, figW: fig.offsetWidth, scale: m ? parseFloat(m[1]) : null };
+  });
+  await page.waitForTimeout(500);
+  const a = await measure(page);
+  await page.waitForTimeout(700);
+  const b = await measure(page);
+
+  // Container pinned to the figure (not runaway, not collapsed).
+  expect(Math.abs(a.cw - a.figW)).toBeLessThan(30);
+  // Stable over time — no feedback loop.
+  expect(Math.abs(a.cw - b.cw)).toBeLessThan(5);
+  // Slide actually rendered, not scaled to a near-zero sliver.
+  expect(a.scale).not.toBeNull();
+  expect(a.scale!).toBeGreaterThan(0.1);
+});

--- a/ui/src/styles/modals.css
+++ b/ui/src/styles/modals.css
@@ -269,7 +269,14 @@ textarea.host-input { min-height:64px; resize:vertical; }
 .artifact-modal .am-figure.docx-preview > .rp-heavy { display: flex; flex: 1 1 auto; min-height: 0; flex-direction: column; }
 .artifact-modal .am-figure.docx-preview .rp-docx { flex: 1 1 auto; min-height: 0; overflow: auto; }
 .artifact-modal .am-figure.office-preview { height: 66vh; max-height: 66vh; overflow: hidden; padding: 0; flex-direction: column; }
-.artifact-modal .am-figure.office-preview > .rp-heavy { display: flex; flex: 1 1 auto; min-height: 0; flex-direction: column; }
+/* width:100% pins the mount host to the figure width. Without it the host (a flex
+   item under .am-figure's inherited align-items:flex-start) shrink-wraps to its
+   content — and the PPTX renderer sizes every slide to container.clientWidth, so
+   container width <- content width <- container width feeds back: the panel runs
+   away wider each frame (the visible twitch) or collapses to a sliver that renders
+   slides at ~scale 0.05, i.e. blank until you resize. Pinning the width keeps
+   clientWidth content-independent and breaks the loop (fixes xlsx too). */
+.artifact-modal .am-figure.office-preview > .rp-heavy { display: flex; flex: 1 1 auto; min-height: 0; flex-direction: column; width: 100%; }
 .artifact-modal .am-figure.office-preview :is(.rp-xlsx, .rp-pptx) { flex: 1 1 auto; min-height: 0; }
 .artifact-modal.html-preview .am-figure { overflow: auto; }
 .artifact-modal .am-figure > * { flex: 1 1 auto; min-width: 0; min-height: 0; }


### PR DESCRIPTION
## Problem

The PPTX preview in the artifact modal **twitched (抽搐) and rendered blank** — slides showed as white boxes with only "Slide N" labels — until the window was enlarged.

## Root cause

A CSS **width feedback loop**, not a rendering timing bug:

1. `.am-figure` sets `align-items: flex-start` (to left-align image/PDF previews). The office preview is a flex column, so this leaves the mount host `.rp-heavy` **shrink-wrapped to its content** instead of pinned to the modal width.
2. The PPTX renderer (`@aiden0z/pptx-renderer`) sizes every slide box to `container.clientWidth` on each render.
3. So container width ← content width ← container width. Unstable: it either **runs away** (container grows every frame → the twitch, content clipped) or **collapses to a sliver** (slides render at `scale(0.05)` → blank).
4. The renderer only re-renders on **width changes**, so once stuck it stays stuck — which is why enlarging the panel ("必须放大才行") was the only thing that recovered it.

## Fix

One property — `width: 100%` on `.artifact-modal .am-figure.office-preview > .rp-heavy` — pins the container to the figure width (already pinned by the modal), making `clientWidth` content-independent and breaking the loop. Also fixes XLSX previews, which were overflowing the figure.

## Verification

Reproduced and fixed against the real app (Playwright + the fixture pptx), measuring the container over time:

| case | before | after |
|---|---|---|
| pptx, narrow (380px) | 1244 → 2684px, runaway | **284px, stable** |
| pptx, wide (1280px) | 764 → 1684px, runaway | **824px, stable** |
| xlsx, narrow | overflowing 482px | **292px, pinned** |

New regression test `ui-tests/tests/pptx-preview-width.spec.ts` plus the existing PPTX and XLSX tests all pass against a real `trunk` rebuild of the fixed CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)