### PR TITLE
fix(ui): scope side chat to the active session

### DIFF
--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -1117,6 +1117,35 @@ fn App() -> impl IntoView {
         center_file.set(selected);
         *previous_session = current_session;
     });
+    // Side chat is per-session, same as the center tabs above: stash the
+    // outgoing session's Q&A and restore the incoming session's, so switching
+    // sessions no longer leaves the previous session's side chat on screen.
+    let side_chat_by_session = create_rw_signal::<HashMap<String, Vec<ChatItem>>>(HashMap::new());
+    let previous_side_chat_session = Rc::new(RefCell::new(None::<String>));
+    create_effect(move |_| {
+        let current_session = active_session.get();
+        let mut previous_session = previous_side_chat_session.borrow_mut();
+        if *previous_session == current_session {
+            return;
+        }
+        if let Some(session_id) = previous_session.as_ref() {
+            side_chat_by_session.update(|states| {
+                states.insert(session_id.clone(), side_chat_items.get_untracked());
+            });
+        }
+        let restored = current_session.as_ref().and_then(|session_id| {
+            side_chat_by_session.with_untracked(|states| states.get(session_id).cloned())
+        });
+        side_chat_items.set(restored.unwrap_or_default());
+        side_chat_input.set(String::new());
+        side_chat_model_menu_open.set(false);
+        // ponytail: busy is a global flag, so we clear it on switch to drop a
+        // stale spinner. Trade-off: returning to a session whose request is
+        // still in flight won't re-show its spinner. Make busy per-session if
+        // that ever matters.
+        side_chat_busy.set(false);
+        *previous_session = current_session;
+    });
     // Dedicated project windows use the same guarded transition as every
     // interactive project-open path. The callback is built after `load_session`.
     let dedicated_project_id = url_project_param();
@@ -2361,36 +2390,37 @@ fn App() -> impl IntoView {
         };
         spawn_local(async move {
             let arg = to_value(&serde_json::json!({
-                "sessionId": sid,
+                "sessionId": sid.clone(),
                 "question": question,
                 "acpAgentId": acp_agent,
             }))
             .unwrap();
-            match invoke_checked("side_chat", arg).await {
-                Ok(v) => {
-                    let text = v.as_string().unwrap_or_default();
-                    side_chat_items.update(|items| {
-                        items.push(ChatItem::Assistant {
-                            text,
-                            model: model.clone(),
-                            resources: Vec::new(),
-                        });
-                    });
-                }
-                Err(err) => {
-                    side_chat_items.update(|items| {
-                        items.push(ChatItem::Assistant {
-                            text: format!(
-                                "Error: {}",
-                                localize_backend(locale.get(), &js_error_text(err))
-                            ),
-                            model: model.clone(),
-                            resources: Vec::new(),
-                        });
-                    });
-                }
+            let reply = match invoke_checked("side_chat", arg).await {
+                Ok(v) => ChatItem::Assistant {
+                    text: v.as_string().unwrap_or_default(),
+                    model: model.clone(),
+                    resources: Vec::new(),
+                },
+                Err(err) => ChatItem::Assistant {
+                    text: format!(
+                        "Error: {}",
+                        localize_backend(locale.get(), &js_error_text(err))
+                    ),
+                    model: model.clone(),
+                    resources: Vec::new(),
+                },
+            };
+            // The user may have switched sessions while this was in flight.
+            // Deliver the answer to the session it was asked about, not whatever
+            // side chat is on screen now.
+            if active_session.get_untracked() == sid {
+                side_chat_items.update(|items| items.push(reply));
+                side_chat_busy.set(false);
+            } else if let Some(id) = sid {
+                side_chat_by_session.update(|states| {
+                    states.entry(id).or_default().push(reply);
+                });
             }
-            side_chat_busy.set(false);
         });
     };
 


### PR DESCRIPTION
## Problem

侧边问答(side chat)本应跟 session 绑定,但切换 session 后面板仍显示上一个 session 的问答。

**根因**:侧边问答历史 `side_chat_items` 是单一全局信号,切换 session 时从未重置——不像主对话有 per-session 的 `transcripts` 缓存、中间文件标签页有 `center_tabs_by_session` 缓存。后端 `side_chat` 命令是无状态一次性的(只读当前 session 的 transcript 作上下文),所以问答历史只活在前端这个全局信号里。

## Fix

照抄旁边已验证的 `center_tabs_by_session` 模式(`ui/src/main.rs`):

- 新增 `side_chat_by_session` 每会话缓存 + 一个监听 `active_session` 的 effect:切走时暂存旧 session 的问答,切入时恢复新 session 的;顺带清空输入框、关闭模型下拉、清 busy。
- `send_side_chat` 的在途请求做会话隔离:回答返回时若用户已切走,回答落到**发起它的那个 session**,而不是当前屏幕上的 session。

现在每个 session 各自保留侧边问答,来回切互不干扰(与主对话一致)。

## Verification

- `cargo check --target wasm32-unknown-unknown` 通过,无警告
- `cargo test -p wisp-ui` 101 tests 全过

## Notes

- 未给该 effect 单独写测试:它镜像的 `center_tabs_by_session` 本身无测试,仓库惯例只测纯函数,这段 reactive 胶水抽不出纯函数。
- `busy` 是全局标志,留了个小 ceiling(切回一个请求仍在途的 session 不会重新显示转圈),已在代码注释,需要时可改成 per-session。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DUXyKqpvshDWN7mXVBoHNm