### PR TITLE
fix(openai): stop replaying historical reasoning_content

### DIFF
--- a/crates/wisp-llm/src/openai.rs
+++ b/crates/wisp-llm/src/openai.rs
@@ -83,6 +83,16 @@ impl OpenAiProvider {
                 _ => {}
             }
         }
+        // Never replay chain-of-thought. Re-sending historical `reasoning_content`
+        // bloats the request (~37% of an 86K kimi-k3 session) and feeds a
+        // "thinking" model its own past flailing, reinforcing repeat loops.
+        // Chat-completions models regenerate reasoning each turn and don't require
+        // prior reasoning (unlike the encrypted-reasoning Responses API). Dropping
+        // it uniformly — not per-turn — is also what keeps the prefix cacheable:
+        // every assistant message serializes identically on every turn, so the
+        // provider's prompt cache keeps hitting. (Keeping "only the last turn's"
+        // would mutate a message once it's no longer last, breaking the prefix.)
+        // Same stance as pi / grok-build, which never bulk-replay raw CoT.
         messages
             .iter()
             .filter_map(|m| match m.role {
@@ -99,9 +109,6 @@ impl OpenAiProvider {
                     let mut o = json!({ "role": "assistant", "content": m.content.as_text() });
                     if !kept.is_empty() {
                         o["tool_calls"] = serde_json::to_value(&kept).unwrap_or(Value::Null);
-                    }
-                    if let Some(r) = &m.reasoning {
-                        o["reasoning_content"] = json!(r);
                     }
                     Some(o)
                 }
@@ -538,6 +545,25 @@ mod tests {
         let out = OpenAiProvider::sanitize(&msgs);
         assert_eq!(out[0]["tool_calls"].as_array().unwrap().len(), 1);
         assert_eq!(out[1]["tool_call_id"], "a");
+    }
+
+    // reasoning_content is never replayed — not even for the most recent turn.
+    // Bulk-replaying past CoT bloats context and reinforces repeat loops; keeping
+    // it off *every* assistant message keeps each one byte-stable across turns so
+    // the provider's prefix cache keeps hitting.
+    #[test]
+    fn never_replays_reasoning() {
+        let mut old = Message::assistant("first");
+        old.reasoning = Some("old thinking".into());
+        let mut recent = Message::assistant("second");
+        recent.reasoning = Some("fresh thinking".into());
+        let msgs = vec![old, Message::user("more"), recent];
+        let out = OpenAiProvider::sanitize(&msgs);
+        assert!(out[0].get("reasoning_content").is_none());
+        assert!(
+            out[2].get("reasoning_content").is_none(),
+            "even the last turn's reasoning is dropped for cache stability"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`OpenAiProvider::sanitize` re-sent `reasoning_content` for **every** historical assistant message (`openai.rs:103`). In the captured degenerate `kimi-k3` session that was **~32K tokens = 37%** of an 86K request — past chain-of-thought that is worse than dead weight:

- **Bloat**: 37% of every request is stale CoT.
- **Loop fuel**: replaying a "thinking" model its own prior flailing ("let me probe pypdf again…") reinforces the exact repeat loop it's stuck in — the degradation behind #393 / PR #395 / #401.

## Fix

Never replay `reasoning_content` in the chat-completions request. Chat-completions models regenerate reasoning each turn and don't require prior reasoning (unlike the encrypted-reasoning Responses API), so nothing is lost. Reasoning is still parsed and stored for UI/transcript display — only the outbound request drops it.

### Why drop it for *every* turn, not just keep the last one

Prompt-cache consistency. Providers cache on a stable request **prefix**. If we kept "only the most recent turn's" reasoning, that message would carry reasoning on turn N and lose it on turn N+1 (once a newer assistant turn arrives) — mutating the prefix and breaking the cache from that point every turn. Dropping it uniformly keeps **every** assistant message byte-stable across turns, so the prefix cache keeps hitting. One-time miss on first deploy, leaner cached prefixes thereafter.

Same stance as `earendil-works/pi` (`transform-messages.ts` + `openai-completions.ts`: only signature-gated reasoning is replayed, never raw CoT) and `xai-org/grok-build` (signed/summarized thinking, LLM-summarization compaction).

## Impact

On the captured session: **86K → ~54K tokens (−37%)**, and removes a self-reinforcing loop input.

## Test

New `never_replays_reasoning`: asserts no assistant message — including the most recent — carries `reasoning_content`. `cargo test -p wisp-llm --lib` → **14 passed**.

Companion to #401 (loop guard stops repeats; this stops feeding the model its own repeats).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SgHqSh9BzyP48VL6vYd5pZ