### PR TITLE
feat: add persistent real-browser bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,11 @@ valuable suggestions:
 
 - **Claude Science (Operon)** is referenced in product comparison and
   compatibility research.
+- Real-browser automation is inspired by
+  [GenericAgent's GA Web / TMWebDriver](https://github.com/lsdefine/GenericAgent)
+  architecture (MIT, Copyright 2025 lsdefine). Wisp's Rust bridge and Manifest
+  V3 extension are an independent implementation; see
+  [`browser-extension/NOTICE.md`](browser-extension/NOTICE.md).
 - The agent core is based on
   [`w4n9H/mangopi-cli`](https://github.com/w4n9H/mangopi-cli) (Apache-2.0).
 - `skills/` and `mcp-servers/bio-tools/` vendored from the upstream

--- a/README_zh.md
+++ b/README_zh.md
@@ -325,6 +325,11 @@ Assistant 对话形式打开。打开时会把内置的 `assets_*.tar.gz` 解压
 ## 致谢
 
 - **Claude Science (Operon)** 用于产品对比与兼容性研究。
+- 真实浏览器自动化受
+  [GenericAgent 的 GA Web / TMWebDriver](https://github.com/lsdefine/GenericAgent)
+  架构启发（MIT，Copyright 2025 lsdefine）。Wisp 的 Rust 桥接器与 Manifest V3
+  扩展为独立实现；详细出处见
+  [`browser-extension/NOTICE.md`](browser-extension/NOTICE.md)。
 - Agent 核心基于
   [`w4n9H/mangopi-cli`](https://github.com/w4n9H/mangopi-cli)（Apache-2.0）。
 - `skills/` 与 `mcp-servers/bio-tools/` 来自上游 `wisp-science` 资源包

--- a/browser-extension/NOTICE.md
+++ b/browser-extension/NOTICE.md
@@ -1,0 +1,22 @@
+# Acknowledgement and provenance
+
+Wisp's real-browser bridge is inspired by the **GA Web / TMWebDriver** design
+in [lsdefine/GenericAgent](https://github.com/lsdefine/GenericAgent): an agent
+connects to a real, persistent Chrome/Chromium profile through a loopback
+bridge and a browser extension instead of launching a temporary headless
+profile.
+
+GenericAgent is distributed under the MIT License:
+
+> Copyright (c) 2025 lsdefine
+
+The Rust bridge and Manifest V3 extension in Wisp are an independent
+implementation. No GenericAgent source files are redistributed here. The
+connection model and compatible message shapes were informed by GenericAgent's
+public implementation. Wisp is not affiliated with or endorsed by the
+GenericAgent project.
+
+Upstream project and license:
+
+- <https://github.com/lsdefine/GenericAgent>
+- <https://github.com/lsdefine/GenericAgent/blob/main/LICENSE>

--- a/browser-extension/background.js
+++ b/browser-extension/background.js
@@ -1,0 +1,268 @@
+// Inspired by GenericAgent's GA Web / TMWebDriver real-browser bridge.
+// Independent Wisp implementation; attribution: https://github.com/lsdefine/GenericAgent
+// GenericAgent is MIT-licensed, Copyright (c) 2025 lsdefine. See NOTICE.md.
+
+const BRIDGE_URL = "ws://127.0.0.1:18765";
+const RECONNECT_ALARM = "wisp-browser-reconnect";
+
+let socket = null;
+let keepAliveTimer = null;
+let lastError = "";
+
+const isScriptable = (url) => /^https?:/i.test(url || "");
+
+async function browserTabs() {
+  return (await chrome.tabs.query({}))
+    .filter((tab) => isScriptable(tab.url))
+    .map((tab) => ({
+      id: tab.id,
+      url: tab.url || "",
+      title: tab.title || "",
+      active: !!tab.active,
+      windowId: tab.windowId,
+    }));
+}
+
+function send(message) {
+  if (socket?.readyState === WebSocket.OPEN) {
+    socket.send(JSON.stringify(message));
+  }
+}
+
+async function sendTabs(type = "tabs_update") {
+  send({ type, tabs: await browserTabs() });
+}
+
+function startKeepAlive() {
+  clearInterval(keepAliveTimer);
+  keepAliveTimer = setInterval(() => {
+    if (socket?.readyState === WebSocket.OPEN) {
+      send({ type: "ping" });
+    }
+  }, 20_000);
+}
+
+function connect() {
+  if (socket && socket.readyState <= WebSocket.OPEN) return;
+  try {
+    socket = new WebSocket(BRIDGE_URL);
+  } catch (error) {
+    lastError = error.message;
+    socket = null;
+    return;
+  }
+  socket.onopen = async () => {
+    lastError = "";
+    startKeepAlive();
+    await sendTabs("ext_ready");
+  };
+  socket.onmessage = async (event) => {
+    try {
+      const request = JSON.parse(event.data);
+      if (request.id && request.code !== undefined) await handleRequest(request);
+    } catch (error) {
+      lastError = error.message;
+    }
+  };
+  socket.onerror = () => {
+    lastError = "Cannot connect to Wisp on 127.0.0.1:18765";
+  };
+  socket.onclose = () => {
+    clearInterval(keepAliveTimer);
+    keepAliveTimer = null;
+    socket = null;
+  };
+}
+
+async function runPageCode(code) {
+  const clean = (value) => {
+    if (value === undefined) return null;
+    if (value === window) return `[Window: ${location.href}]`;
+    if (value === document) return "[Document]";
+    if (value instanceof Element) return value.outerHTML;
+    if (value instanceof NodeList || value instanceof HTMLCollection) {
+      return [...value].slice(0, 200).map((node) =>
+        node instanceof Element ? node.outerHTML : String(node)
+      );
+    }
+    try {
+      const seen = new WeakSet();
+      return JSON.parse(JSON.stringify(value, (_key, item) => {
+        if (item instanceof Element) return item.outerHTML;
+        if (typeof item === "object" && item !== null) {
+          if (seen.has(item)) return "[Circular]";
+          seen.add(item);
+        }
+        return item;
+      }));
+    } catch (error) {
+      return `[Unserializable: ${error.message}]`;
+    }
+  };
+  try {
+    let value;
+    try {
+      value = (0, eval)(code);
+      if (value instanceof Promise) value = await value;
+    } catch (error) {
+      if (!(error instanceof SyntaxError)) throw error;
+      const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+      value = await new AsyncFunction(code)();
+    }
+    return { ok: true, data: clean(value) };
+  } catch (error) {
+    const message = error.message || String(error);
+    return {
+      ok: false,
+      error: { name: error.name || "Error", message, stack: error.stack || "" },
+      csp: /content security policy|unsafe-eval|refused to evaluate/i.test(message),
+    };
+  }
+}
+
+function cdpExpression(code) {
+  return `(async () => {
+    const code = ${JSON.stringify(code)};
+    const clean = (value) => {
+      if (value === undefined) return null;
+      if (value instanceof Element) return value.outerHTML;
+      if (value instanceof NodeList || value instanceof HTMLCollection) return [...value].slice(0, 200).map(x => x instanceof Element ? x.outerHTML : String(x));
+      try { const seen = new WeakSet(); return JSON.parse(JSON.stringify(value, (_k, x) => { if (x instanceof Element) return x.outerHTML; if (typeof x === 'object' && x !== null) { if (seen.has(x)) return '[Circular]'; seen.add(x); } return x; })); }
+      catch (e) { return '[Unserializable: ' + e.message + ']'; }
+    };
+    try {
+      let value;
+      try { value = (0, eval)(code); if (value instanceof Promise) value = await value; }
+      catch (e) { if (!(e instanceof SyntaxError)) throw e; const AsyncFunction = Object.getPrototypeOf(async function(){}).constructor; value = await new AsyncFunction(code)(); }
+      return { ok: true, data: clean(value) };
+    } catch (e) { return { ok: false, error: { name: e.name || 'Error', message: e.message || String(e), stack: e.stack || '' } }; }
+  })()`;
+}
+
+async function runWithCdp(tabId, method, params = {}) {
+  await chrome.debugger.attach({ tabId }, "1.3");
+  try {
+    return await chrome.debugger.sendCommand({ tabId }, method, params);
+  } finally {
+    await chrome.debugger.detach({ tabId }).catch(() => {});
+  }
+}
+
+async function executeJavaScript(tabId, code) {
+  let result;
+  try {
+    const injected = await chrome.scripting.executeScript({
+      target: { tabId },
+      world: "MAIN",
+      func: runPageCode,
+      args: [code],
+    });
+    result = injected[0]?.result;
+  } catch (error) {
+    result = {
+      ok: false,
+      error: { name: error.name || "Error", message: error.message || String(error) },
+      csp: true,
+    };
+  }
+  if (result?.ok) return result.data;
+  if (!result?.csp) throw result?.error || new Error("Page execution failed");
+
+  const cdp = await runWithCdp(tabId, "Runtime.evaluate", {
+    expression: cdpExpression(code),
+    awaitPromise: true,
+    returnByValue: true,
+  });
+  if (cdp.exceptionDetails) {
+    throw new Error(cdp.exceptionDetails.exception?.description || "CDP execution failed");
+  }
+  const value = cdp.result?.value;
+  if (!value?.ok) throw value?.error || new Error("CDP execution failed");
+  return value.data;
+}
+
+async function runCommand(tabId, command) {
+  switch (command.cmd) {
+    case "cdp":
+      return await runWithCdp(command.tabId || tabId, command.method, command.params || {});
+    case "tabs": {
+      if (command.method === "create") {
+        const tab = await chrome.tabs.create({
+          url: command.url,
+          active: command.active ?? false,
+        });
+        return { id: tab.id, url: tab.url, title: tab.title };
+      }
+      if (command.method === "switch") {
+        const tab = await chrome.tabs.update(command.tabId || tabId, { active: true });
+        await chrome.windows.update(tab.windowId, { focused: true });
+        return { ok: true };
+      }
+      return await browserTabs();
+    }
+    default:
+      throw new Error(`Unknown browser command: ${command.cmd}`);
+  }
+}
+
+async function handleRequest(request) {
+  const created = new Set();
+  const onCreated = (tab) => created.add(tab.id);
+  chrome.tabs.onCreated.addListener(onCreated);
+  try {
+    let command = request.code;
+    if (typeof command === "string") {
+      try {
+        const parsed = JSON.parse(command);
+        if (parsed && typeof parsed === "object" && parsed.cmd) command = parsed;
+      } catch (_) {}
+    }
+    const result = typeof command === "string"
+      ? await executeJavaScript(request.tabId, command)
+      : await runCommand(request.tabId, command);
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    const newTabs = [];
+    for (const id of created) {
+      try {
+        const tab = await chrome.tabs.get(id);
+        newTabs.push({ id: tab.id, url: tab.url, title: tab.title });
+      } catch (_) {}
+    }
+    send({ type: "result", id: request.id, result, newTabs });
+  } catch (error) {
+    send({
+      type: "error",
+      id: request.id,
+      error: error?.message ? { name: error.name || "Error", message: error.message, stack: error.stack || "" } : error,
+    });
+  } finally {
+    chrome.tabs.onCreated.removeListener(onCreated);
+  }
+}
+
+chrome.alarms.create(RECONNECT_ALARM, { periodInMinutes: 1 });
+chrome.alarms.onAlarm.addListener((alarm) => {
+  if (alarm.name === RECONNECT_ALARM) connect();
+});
+chrome.runtime.onStartup.addListener(connect);
+chrome.runtime.onInstalled.addListener(connect);
+chrome.tabs.onCreated.addListener(() => sendTabs());
+chrome.tabs.onRemoved.addListener(() => sendTabs());
+chrome.tabs.onActivated.addListener(() => sendTabs());
+chrome.tabs.onUpdated.addListener((_id, change) => {
+  if (change.status === "complete" || change.url) sendTabs();
+});
+chrome.runtime.onMessage.addListener((message, _sender, reply) => {
+  if (message?.type === "wisp_bridge_status") {
+    reply({
+      connected: socket?.readyState === WebSocket.OPEN,
+      endpoint: BRIDGE_URL,
+      error: lastError,
+    });
+  } else if (message?.type === "wisp_bridge_connect") {
+    connect();
+    reply({ ok: true });
+  }
+});
+
+connect();

--- a/browser-extension/manifest.json
+++ b/browser-extension/manifest.json
@@ -1,0 +1,17 @@
+{
+  "manifest_version": 3,
+  "name": "Wisp Real Browser Bridge",
+  "version": "0.1.0",
+  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAp+1W8tqVOLPTzYkx6AXoi5r6bSpmgA1obuaybI31/TKE0xhPbIrDARTZ5FhyUPJubSZKYBijaVEmLdeo74T1UQVNr1RVPYMgy1SqW/877SYj7vsw9KDYnWlQ0kWaMg7pif8y/zk+17RepOJru4b2nfoeHeiVf6K64FPHWPknH9RdR1r4WbGNsIYYyXOI0PB7gzRkj0HfzyonTA9ut2cQ79EB+1Z2OYLqH6i6znWTPjyP4W2u+UENnPRLr4wQZthpD31X5NL1r7FAqQvIRU5J/OXyYd9YORnmxdhojBn3BbNRwzjTgpL6uWEMHHvX8UG+g7Vj7m7MtlxueoF8sLAJRQIDAQAB",
+  "minimum_chrome_version": "116",
+  "description": "Connects Wisp to tabs in this persistent Chrome/Chromium profile.",
+  "permissions": ["alarms", "debugger", "scripting", "tabs"],
+  "host_permissions": ["<all_urls>", "http://127.0.0.1/*"],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "Wisp Real Browser Bridge"
+  }
+}

--- a/browser-extension/popup.html
+++ b/browser-extension/popup.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Wisp Browser Bridge</title>
+    <style>
+      body { font: 13px system-ui, sans-serif; margin: 14px; min-width: 250px; color: #202124; }
+      h1 { font-size: 15px; margin: 0 0 10px; }
+      #status { margin-bottom: 8px; }
+      .ok { color: #137333; }
+      .bad { color: #b3261e; }
+      small { color: #5f6368; }
+      button { margin-top: 12px; }
+    </style>
+  </head>
+  <body>
+    <h1>Wisp Real Browser Bridge</h1>
+    <div id="status">Checking…</div>
+    <small>Uses tabs in this Chrome profile. Wisp must be running.</small>
+    <br />
+    <button id="reconnect" type="button">Reconnect</button>
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/browser-extension/popup.js
+++ b/browser-extension/popup.js
@@ -1,0 +1,16 @@
+const status = document.getElementById("status");
+
+async function refresh() {
+  const result = await chrome.runtime.sendMessage({ type: "wisp_bridge_status" });
+  status.className = result?.connected ? "ok" : "bad";
+  status.textContent = result?.connected
+    ? "Connected to Wisp"
+    : (result?.error || "Wisp is not connected");
+}
+
+document.getElementById("reconnect").addEventListener("click", async () => {
+  await chrome.runtime.sendMessage({ type: "wisp_bridge_connect" });
+  setTimeout(refresh, 250);
+});
+
+refresh();

--- a/crates/wisp-paths/src/lib.rs
+++ b/crates/wisp-paths/src/lib.rs
@@ -65,6 +65,10 @@ pub fn seed_dir() -> Option<PathBuf> {
     existing_dir(&resource_root(), "seed")
 }
 
+pub fn browser_extension_dir() -> Option<PathBuf> {
+    existing_dir(&resource_root(), "browser-extension")
+}
+
 pub fn kernel_worker_path() -> Option<PathBuf> {
     python_dir()
         .map(|d| d.join("kernel_worker.py"))
@@ -95,6 +99,7 @@ mod tests {
         assert!(r_kernel_worker_path().is_some());
         assert!(bio_tools_dir().is_some());
         assert!(seed_dir().is_some());
+        assert!(browser_extension_dir().is_some());
     }
 
     #[test]

--- a/docs/real-browser-automation.md
+++ b/docs/real-browser-automation.md
@@ -1,0 +1,66 @@
+# Real-browser automation
+
+> **Acknowledgement:** this feature is inspired by GenericAgent's
+> [GA Web / TMWebDriver](https://github.com/lsdefine/GenericAgent) architecture.
+> Wisp's Rust bridge and Manifest V3 extension are an independent
+> implementation. Detailed provenance is bundled in
+> `browser-extension/NOTICE.md`.
+
+Wisp exposes `web_scan` and `web_execute_js` against tabs in the user's existing
+Chrome/Chromium profile. It does not start Playwright, Selenium, a headless
+browser, or a temporary profile. The controlled pages therefore keep the
+profile's cookies and login state, installed extensions, GPU/WebGL behavior,
+and normal browser fingerprint.
+
+## Install the bridge extension
+
+The user can ask Wisp to **configure the browser**. The Agent calls the
+read-only `browser_setup` tool and reports the current connection status, the
+exact extension directory on that installation, and the following steps.
+
+1. Start Wisp Science.
+2. Open `chrome://extensions` in the Chrome/Chromium profile Wisp should use.
+3. Enable **Developer mode**.
+4. Choose **Load unpacked** and select the bundled `browser-extension/`
+   directory. In a source checkout this is the repository's
+   `browser-extension/` directory. An installed build reports its exact bundled
+   path through `browser_setup`. Select the directory itself, not an individual
+   file or archive inside it.
+5. Open the extension popup and confirm that it says **Connected to Wisp**.
+
+The unpacked extension remains installed in that browser profile across Wisp
+and browser restarts. It reconnects to `ws://127.0.0.1:18765` when Wisp is
+running. Only loopback connections whose WebSocket origin is a Chrome extension
+with Wisp's bundled, stable extension ID are accepted.
+
+## Agent tools
+
+- `browser_setup`: report bridge status, the exact bundled extension directory,
+  and one-time installation steps. It does not read browser page content and
+  does not require approval.
+- `web_scan`: list real browser tabs, extract page text, or return a compact
+  snapshot of visible actionable elements and selectors.
+- `web_execute_js`: execute JavaScript in the selected real tab. It also accepts
+  a JSON `{ "cmd": "cdp", ... }` request for a single Chrome DevTools Protocol
+  method when trusted browser input or another CDP-only action is required.
+
+Both tools always require at least one Wisp approval. The approval can be
+granted once, for the session, for the project, or globally through the existing
+approval card. Treat broad grants carefully: the extension has access to every
+HTTP(S) tab in that Chrome profile.
+
+## Security and limits
+
+- The extension asks only for `tabs`, `scripting`, `debugger`, and the alarm used
+  to reconnect. It has no dedicated cookie-export API, does not remove page CSP,
+  disable dialogs, or change content settings. Approved page JavaScript or raw
+  CDP commands are still powerful and should be treated as access to the tab.
+- Ordinary execution uses Chrome's scripting API. Wisp falls back to a temporary
+  CDP attachment only when page CSP prevents that execution, or when the caller
+  explicitly requests a CDP method.
+- Chrome internal pages such as `chrome://settings` cannot be scripted. Only
+  HTTP(S) tabs are advertised.
+- JavaScript-created DOM events are not trusted events. Use an explicitly
+  approved CDP `Input.*` command when a site requires trusted input.
+- Wisp and GenericAgent's TMWebDriver use the same default port. Run only one
+  bridge server on port `18765` at a time.

--- a/src-tauri/src/browser_bridge.rs
+++ b/src-tauri/src/browser_bridge.rs
@@ -1,0 +1,815 @@
+//! Loopback bridge to a user-installed Chrome/Chromium extension.
+//!
+//! The extension runs inside the user's existing browser profile, so page
+//! execution keeps that profile's cookies, login state, extensions, GPU, and
+//! browser fingerprint. Wisp never launches a separate automation browser.
+//!
+//! Design acknowledgement: this bridge is inspired by GenericAgent's GA Web /
+//! TMWebDriver real-browser architecture and compatible loopback protocol:
+//! https://github.com/lsdefine/GenericAgent (MIT, Copyright 2025 lsdefine).
+//! This module is Wisp's independent Rust implementation; see
+//! `browser-extension/NOTICE.md` for provenance details.
+
+use async_trait::async_trait;
+use futures_util::{SinkExt, StreamExt};
+use serde::Serialize;
+use serde_json::{json, Value};
+use std::collections::{BTreeMap, HashMap};
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::{mpsc, oneshot, Mutex};
+use tokio_tungstenite::tungstenite::handshake::server::{ErrorResponse, Request, Response};
+use tokio_tungstenite::tungstenite::http::StatusCode;
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::{accept_hdr_async, WebSocketStream};
+use uuid::Uuid;
+use wisp_llm::ToolSchema;
+use wisp_tools::{Approval, Tool, ToolEnv, ToolResult};
+
+const BRIDGE_ADDR: &str = "127.0.0.1:18765";
+const EXTENSION_ORIGIN: &str = "chrome-extension://gnkjgagleagkgdlkkcianolobfdoocnp";
+const DEFAULT_TIMEOUT_MS: u64 = 15_000;
+const MAX_TIMEOUT_MS: u64 = 60_000;
+const MAX_SCRIPT_BYTES: usize = 64 * 1024;
+const MAX_RESULT_CHARS: usize = 200_000;
+
+#[derive(Clone, Debug, Serialize)]
+pub struct BrowserTab {
+    id: i64,
+    url: String,
+    title: String,
+    active: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    window_id: Option<i64>,
+}
+
+#[derive(Clone)]
+struct BridgeClient {
+    connection_id: u64,
+    tx: mpsc::UnboundedSender<Message>,
+}
+
+#[derive(Default)]
+struct BridgeState {
+    client: Option<BridgeClient>,
+    tabs: BTreeMap<i64, BrowserTab>,
+    selected_tab: Option<i64>,
+    pending: HashMap<String, oneshot::Sender<Result<Value, String>>>,
+    startup_error: Option<String>,
+}
+
+pub struct BrowserBridge {
+    state: Mutex<BridgeState>,
+    next_connection_id: AtomicU64,
+    extension_dir: PathBuf,
+}
+
+struct BrowserExecution {
+    tab_id: i64,
+    value: Value,
+}
+
+impl BrowserBridge {
+    fn new(extension_dir: PathBuf) -> Self {
+        Self {
+            state: Mutex::new(BridgeState::default()),
+            next_connection_id: AtomicU64::new(1),
+            extension_dir,
+        }
+    }
+
+    pub async fn start(extension_dir: PathBuf) -> Arc<Self> {
+        let bridge = Arc::new(Self::new(extension_dir));
+        match TcpListener::bind(BRIDGE_ADDR).await {
+            Ok(listener) => {
+                let task_bridge = bridge.clone();
+                tokio::spawn(async move { task_bridge.accept_loop(listener).await });
+            }
+            Err(error) => {
+                bridge.state.lock().await.startup_error = Some(format!(
+                    "cannot listen on {BRIDGE_ADDR}: {error}; stop any other TMWebDriver/Wisp browser bridge using this port"
+                ));
+            }
+        }
+        bridge
+    }
+
+    async fn setup_info(&self) -> Value {
+        let state = self.state.lock().await;
+        let extension_dir = std::fs::canonicalize(&self.extension_dir)
+            .unwrap_or_else(|_| self.extension_dir.clone());
+        let extension_path_exists = extension_dir.is_dir();
+        let status = if state.startup_error.is_some() {
+            "error"
+        } else if !extension_path_exists {
+            "extension_missing"
+        } else if state.client.is_some() {
+            "connected"
+        } else {
+            "disconnected"
+        };
+        let extension_path = extension_dir.display().to_string();
+
+        json!({
+            "status": status,
+            "connected_tabs": state.tabs.len(),
+            "extension_path": extension_path,
+            "extension_path_exists": extension_path_exists,
+            "extension_id": EXTENSION_ORIGIN.trim_start_matches("chrome-extension://"),
+            "bridge_endpoint": format!("ws://{BRIDGE_ADDR}"),
+            "install_scope": "once_per_browser_profile",
+            "steps": [
+                "Start Wisp Science and keep it running.",
+                "Open chrome://extensions in the Chrome/Chromium profile Wisp should control.",
+                "Enable Developer mode.",
+                format!("Click Load unpacked and select this folder: {extension_path}"),
+                "Open the Wisp Real Browser Bridge extension popup and confirm Connected to Wisp."
+            ],
+            "error": state.startup_error
+        })
+    }
+
+    async fn accept_loop(self: Arc<Self>, listener: TcpListener) {
+        loop {
+            match listener.accept().await {
+                Ok((stream, _)) => {
+                    let bridge = self.clone();
+                    tokio::spawn(async move {
+                        if let Err(error) = bridge.accept_connection(stream).await {
+                            tracing::warn!(target: "wisp", "browser bridge connection rejected: {error}");
+                        }
+                    });
+                }
+                Err(error) => {
+                    tracing::warn!(target: "wisp", "browser bridge accept failed: {error}");
+                }
+            }
+        }
+    }
+
+    async fn accept_connection(
+        self: Arc<Self>,
+        stream: TcpStream,
+    ) -> Result<(), tokio_tungstenite::tungstenite::Error> {
+        let socket = accept_hdr_async(stream, |request: &Request, response: Response| {
+            let origin = request
+                .headers()
+                .get("origin")
+                .and_then(|value| value.to_str().ok());
+            if allowed_extension_origin(origin) {
+                Ok(response)
+            } else {
+                Err(forbidden_response())
+            }
+        })
+        .await?;
+        self.serve_connection(socket).await;
+        Ok(())
+    }
+
+    async fn serve_connection(self: Arc<Self>, socket: WebSocketStream<TcpStream>) {
+        let connection_id = self.next_connection_id.fetch_add(1, Ordering::Relaxed);
+        let (mut writer, mut reader) = socket.split();
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        self.install_client(connection_id, tx.clone()).await;
+        let writer_task = tokio::spawn(async move {
+            while let Some(message) = rx.recv().await {
+                if writer.send(message).await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        while let Some(message) = reader.next().await {
+            match message {
+                Ok(Message::Text(text)) => self.handle_text(connection_id, text.as_str()).await,
+                Ok(Message::Ping(payload)) => {
+                    let _ = tx.send(Message::Pong(payload));
+                }
+                Ok(Message::Close(_)) | Err(_) => break,
+                _ => {}
+            }
+        }
+        writer_task.abort();
+        self.disconnect_client(connection_id).await;
+    }
+
+    async fn install_client(&self, connection_id: u64, tx: mpsc::UnboundedSender<Message>) {
+        let mut state = self.state.lock().await;
+        fail_pending(&mut state, "browser extension connection was replaced");
+        state.client = Some(BridgeClient { connection_id, tx });
+        state.tabs.clear();
+        state.selected_tab = None;
+    }
+
+    async fn disconnect_client(&self, connection_id: u64) {
+        let mut state = self.state.lock().await;
+        if state
+            .client
+            .as_ref()
+            .is_some_and(|client| client.connection_id == connection_id)
+        {
+            state.client = None;
+            state.tabs.clear();
+            state.selected_tab = None;
+            fail_pending(&mut state, "browser extension disconnected");
+        }
+    }
+
+    async fn handle_text(&self, connection_id: u64, text: &str) {
+        let Ok(message) = serde_json::from_str::<Value>(text) else {
+            return;
+        };
+        let message_type = message.get("type").and_then(Value::as_str).unwrap_or("");
+        let mut state = self.state.lock().await;
+        if !state
+            .client
+            .as_ref()
+            .is_some_and(|client| client.connection_id == connection_id)
+        {
+            return;
+        }
+        match message_type {
+            "ext_ready" | "tabs_update" => replace_tabs(&mut state, &message),
+            "result" | "error" => {
+                let Some(id) = message.get("id").and_then(Value::as_str) else {
+                    return;
+                };
+                let Some(sender) = state.pending.remove(id) else {
+                    return;
+                };
+                let result = if message_type == "result" {
+                    Ok(message
+                        .get("result")
+                        .or_else(|| message.get("data"))
+                        .cloned()
+                        .unwrap_or(Value::Null))
+                } else {
+                    Err(render_bridge_error(message.get("error")))
+                };
+                let _ = sender.send(result);
+            }
+            _ => {}
+        }
+    }
+
+    async fn execute(
+        &self,
+        requested_tab: Option<i64>,
+        code: &str,
+        timeout: Duration,
+    ) -> Result<BrowserExecution, String> {
+        let id = Uuid::new_v4().to_string();
+        let (response_tx, response_rx) = oneshot::channel();
+        let tab_id = {
+            let mut state = self.state.lock().await;
+            if let Some(error) = &state.startup_error {
+                return Err(self.unavailable_message(error));
+            }
+            let Some(client) = state.client.clone() else {
+                return Err(self.unavailable_message("browser extension is not connected"));
+            };
+            let tab_id = select_tab(&state, requested_tab)?;
+            state.selected_tab = Some(tab_id);
+            state.pending.insert(id.clone(), response_tx);
+            let payload = json!({ "id": id, "tabId": tab_id, "code": code }).to_string();
+            if client.tx.send(Message::Text(payload.into())).is_err() {
+                state.pending.remove(&id);
+                return Err("browser extension disconnected before the request was sent".into());
+            }
+            tab_id
+        };
+
+        match tokio::time::timeout(timeout, response_rx).await {
+            Ok(Ok(Ok(value))) => Ok(BrowserExecution { tab_id, value }),
+            Ok(Ok(Err(error))) => Err(error),
+            Ok(Err(_)) => Err("browser extension disconnected before returning a result".into()),
+            Err(_) => {
+                self.state.lock().await.pending.remove(&id);
+                Err(format!(
+                    "browser execution timed out after {} ms",
+                    timeout.as_millis()
+                ))
+            }
+        }
+    }
+
+    async fn tabs(&self) -> Result<Vec<BrowserTab>, String> {
+        let state = self.state.lock().await;
+        if let Some(error) = &state.startup_error {
+            return Err(self.unavailable_message(error));
+        }
+        if state.client.is_none() {
+            return Err(self.unavailable_message("browser extension is not connected"));
+        }
+        Ok(state.tabs.values().cloned().collect())
+    }
+
+    fn unavailable_message(&self, reason: &str) -> String {
+        format!(
+            "real-browser bridge unavailable: {reason}. In Chrome/Chromium open chrome://extensions, enable Developer mode, and Load unpacked from '{}'. Keep Wisp running; the extension connects only to {BRIDGE_ADDR}.",
+            self.extension_dir.display()
+        )
+    }
+}
+
+fn allowed_extension_origin(origin: Option<&str>) -> bool {
+    origin == Some(EXTENSION_ORIGIN)
+}
+
+fn forbidden_response() -> ErrorResponse {
+    tokio_tungstenite::tungstenite::http::Response::builder()
+        .status(StatusCode::FORBIDDEN)
+        .body(Some(
+            "Wisp browser bridge accepts Chrome extensions only".into(),
+        ))
+        .expect("static browser bridge rejection response")
+}
+
+fn fail_pending(state: &mut BridgeState, reason: &str) {
+    for (_, sender) in state.pending.drain() {
+        let _ = sender.send(Err(reason.to_string()));
+    }
+}
+
+fn replace_tabs(state: &mut BridgeState, message: &Value) {
+    let Some(tabs) = message.get("tabs").and_then(Value::as_array) else {
+        return;
+    };
+    state.tabs = tabs
+        .iter()
+        .filter_map(parse_tab)
+        .map(|tab| (tab.id, tab))
+        .collect();
+    if !state
+        .selected_tab
+        .is_some_and(|tab_id| state.tabs.contains_key(&tab_id))
+    {
+        state.selected_tab = state
+            .tabs
+            .values()
+            .find(|tab| tab.active)
+            .or_else(|| state.tabs.values().next())
+            .map(|tab| tab.id);
+    }
+}
+
+fn parse_tab(value: &Value) -> Option<BrowserTab> {
+    let id = value.get("id").and_then(|id| {
+        id.as_i64()
+            .or_else(|| id.as_str().and_then(|id| id.parse().ok()))
+    })?;
+    Some(BrowserTab {
+        id,
+        url: value
+            .get("url")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        title: value
+            .get("title")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        active: value
+            .get("active")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        window_id: value.get("windowId").and_then(Value::as_i64),
+    })
+}
+
+fn select_tab(state: &BridgeState, requested: Option<i64>) -> Result<i64, String> {
+    if state.tabs.is_empty() {
+        return Err("browser extension is connected, but no HTTP(S) tabs are available".into());
+    }
+    if let Some(tab_id) = requested {
+        return state
+            .tabs
+            .contains_key(&tab_id)
+            .then_some(tab_id)
+            .ok_or_else(|| {
+                format!("browser tab {tab_id} is not available; call web_scan with tabs_only=true")
+            });
+    }
+    state
+        .selected_tab
+        .filter(|tab_id| state.tabs.contains_key(tab_id))
+        .or_else(|| state.tabs.values().find(|tab| tab.active).map(|tab| tab.id))
+        .or_else(|| state.tabs.keys().next().copied())
+        .ok_or_else(|| "no browser tab is selected".into())
+}
+
+fn render_bridge_error(error: Option<&Value>) -> String {
+    match error {
+        Some(Value::String(error)) => error.clone(),
+        Some(error) => serde_json::to_string_pretty(error).unwrap_or_else(|_| error.to_string()),
+        None => "browser extension returned an unknown error".into(),
+    }
+}
+
+fn tab_id_arg(args: &Value) -> Result<Option<i64>, String> {
+    let Some(value) = args.get("switch_tab_id") else {
+        return Ok(None);
+    };
+    value
+        .as_i64()
+        .or_else(|| value.as_str().and_then(|value| value.parse().ok()))
+        .map(Some)
+        .ok_or_else(|| "switch_tab_id must be an integer tab id returned by web_scan".into())
+}
+
+fn render_json(value: &Value) -> String {
+    let rendered = serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string());
+    if rendered.chars().count() <= MAX_RESULT_CHARS {
+        return rendered;
+    }
+    let mut clipped: String = rendered.chars().take(MAX_RESULT_CHARS).collect();
+    clipped.push_str("\n... browser result truncated");
+    clipped
+}
+
+const SCAN_SCRIPT: &str = r##"(() => {
+  const visible = (el) => {
+    const s = getComputedStyle(el), r = el.getBoundingClientRect();
+    return s.display !== 'none' && s.visibility !== 'hidden' && Number(s.opacity) > 0 && r.width > 0 && r.height > 0;
+  };
+  const selector = (el) => {
+    if (el.id) {
+      const id = '#' + CSS.escape(el.id);
+      if (document.querySelectorAll(id).length === 1) return id;
+    }
+    const parts = [];
+    for (let node = el; node && node.nodeType === 1 && parts.length < 6; node = node.parentElement) {
+      let part = node.tagName.toLowerCase();
+      const siblings = node.parentElement ? [...node.parentElement.children].filter(x => x.tagName === node.tagName) : [];
+      if (siblings.length > 1) part += `:nth-of-type(${siblings.indexOf(node) + 1})`;
+      parts.unshift(part);
+      const candidate = parts.join(' > ');
+      if (document.querySelectorAll(candidate).length === 1) return candidate;
+    }
+    return parts.join(' > ');
+  };
+  const query = 'a,button,input,textarea,select,summary,[role],[contenteditable=true],h1,h2,h3,label';
+  const elements = [...document.querySelectorAll(query)].filter(visible).slice(0, 400).map((el) => {
+    const r = el.getBoundingClientRect(), type = el.getAttribute('type') || '';
+    return {
+      selector: selector(el), tag: el.tagName.toLowerCase(), role: el.getAttribute('role') || undefined,
+      text: (el.innerText || el.textContent || '').trim().replace(/\s+/g, ' ').slice(0, 500) || undefined,
+      aria_label: el.getAttribute('aria-label') || undefined, href: el.href || undefined, type: type || undefined,
+      value: type.toLowerCase() === 'password' ? undefined : (el.value || undefined), disabled: !!el.disabled,
+      rect: [Math.round(r.x), Math.round(r.y), Math.round(r.width), Math.round(r.height)]
+    };
+  });
+  return { url: location.href, title: document.title, viewport: [innerWidth, innerHeight],
+    text: (document.body?.innerText || '').slice(0, 30000), elements };
+})()"##;
+
+const TEXT_SCAN_SCRIPT: &str = r#"(() => ({
+  url: location.href,
+  title: document.title,
+  text: (document.body?.innerText || '').slice(0, 50000)
+}))()"#;
+
+pub struct BrowserSetupTool {
+    bridge: Arc<BrowserBridge>,
+}
+
+impl BrowserSetupTool {
+    pub fn new(bridge: Arc<BrowserBridge>) -> Self {
+        Self { bridge }
+    }
+}
+
+#[async_trait]
+impl Tool for BrowserSetupTool {
+    fn name(&self) -> &str {
+        "browser_setup"
+    }
+
+    fn schema(&self) -> ToolSchema {
+        ToolSchema::new(
+            self.name(),
+            "Call when the user asks to configure, install, set up, or connect the real browser. Returns the current bridge status, the exact local browser-extension folder to choose with Chrome's Load unpacked button, and complete installation steps. The extension is installed once per browser profile.",
+            json!({
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+            }),
+        )
+    }
+
+    fn preview(&self, _args: &Value) -> String {
+        "show real-browser setup status and extension path".into()
+    }
+
+    async fn run(&self, _args: &Value, _env: &dyn ToolEnv) -> ToolResult {
+        ToolResult::ok(render_json(&self.bridge.setup_info().await))
+    }
+}
+
+pub struct WebScanTool {
+    bridge: Arc<BrowserBridge>,
+}
+
+impl WebScanTool {
+    pub fn new(bridge: Arc<BrowserBridge>) -> Self {
+        Self { bridge }
+    }
+}
+
+#[async_trait]
+impl Tool for WebScanTool {
+    fn name(&self) -> &str {
+        "web_scan"
+    }
+
+    fn schema(&self) -> ToolSchema {
+        ToolSchema::new(
+            self.name(),
+            "Read visible content and actionable elements from the user's real, persistent Chrome/Chromium session. The browser keeps its existing cookies, login state, extensions, GPU/WebGL behavior, and normal profile fingerprint. Use tabs_only first when the target tab is unclear.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "tabs_only": { "type": "boolean", "description": "List connected HTTP(S) tabs without reading page content" },
+                    "switch_tab_id": { "type": ["integer", "string"], "description": "Tab id returned by this tool; selects that tab for this and later calls" },
+                    "text_only": { "type": "boolean", "description": "Return page text without the actionable-element snapshot" }
+                }
+            }),
+        )
+    }
+
+    fn minimum_approval(&self) -> Approval {
+        Approval::Ask
+    }
+
+    fn preview(&self, args: &Value) -> String {
+        if args
+            .get("tabs_only")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+        {
+            "list real-browser tabs".into()
+        } else {
+            args.get("switch_tab_id")
+                .map(|tab| format!("scan real-browser tab {tab}"))
+                .unwrap_or_else(|| "scan selected real-browser tab".into())
+        }
+    }
+
+    async fn run(&self, args: &Value, _env: &dyn ToolEnv) -> ToolResult {
+        if args
+            .get("tabs_only")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+        {
+            return match self.bridge.tabs().await {
+                Ok(tabs) => ToolResult::ok(render_json(&json!({ "tabs": tabs }))),
+                Err(error) => ToolResult::fail(error),
+            };
+        }
+        let tab_id = match tab_id_arg(args) {
+            Ok(tab_id) => tab_id,
+            Err(error) => return ToolResult::fail(error),
+        };
+        let text_only = args
+            .get("text_only")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        match self
+            .bridge
+            .execute(
+                tab_id,
+                if text_only {
+                    TEXT_SCAN_SCRIPT
+                } else {
+                    SCAN_SCRIPT
+                },
+                Duration::from_millis(DEFAULT_TIMEOUT_MS),
+            )
+            .await
+        {
+            Ok(execution) => ToolResult::ok(render_json(&json!({
+                "tab_id": execution.tab_id,
+                "page": execution.value
+            }))),
+            Err(error) => ToolResult::fail(error),
+        }
+    }
+}
+
+pub struct WebExecuteJsTool {
+    bridge: Arc<BrowserBridge>,
+}
+
+impl WebExecuteJsTool {
+    pub fn new(bridge: Arc<BrowserBridge>) -> Self {
+        Self { bridge }
+    }
+}
+
+#[async_trait]
+impl Tool for WebExecuteJsTool {
+    fn name(&self) -> &str {
+        "web_execute_js"
+    }
+
+    fn schema(&self) -> ToolSchema {
+        ToolSchema::new(
+            self.name(),
+            "Execute JavaScript in a tab from the user's real, persistent Chrome/Chromium session. Call web_scan first and do not guess selectors. A JSON script with cmd='cdp' may call one Chrome DevTools Protocol method for trusted input or other advanced browser actions.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "script": { "type": "string", "description": "JavaScript, or a JSON command such as {\"cmd\":\"cdp\",\"method\":\"Input.dispatchMouseEvent\",\"params\":{...}}" },
+                    "switch_tab_id": { "type": ["integer", "string"], "description": "Tab id returned by web_scan" },
+                    "timeout_ms": { "type": "integer", "minimum": 1, "maximum": 60000, "description": "Execution timeout in milliseconds (default 15000)" }
+                },
+                "required": ["script"]
+            }),
+        )
+    }
+
+    fn minimum_approval(&self) -> Approval {
+        Approval::Ask
+    }
+
+    fn preview(&self, args: &Value) -> String {
+        let script = args.get("script").and_then(Value::as_str).unwrap_or("");
+        let mut preview: String = script.chars().take(240).collect();
+        if script.chars().count() > 240 {
+            preview.push('…');
+        }
+        preview
+    }
+
+    async fn run(&self, args: &Value, _env: &dyn ToolEnv) -> ToolResult {
+        let Some(script) = args
+            .get("script")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|script| !script.is_empty())
+        else {
+            return ToolResult::fail("missing required argument 'script'");
+        };
+        if script.len() > MAX_SCRIPT_BYTES {
+            return ToolResult::fail(format!(
+                "browser script is {} bytes (maximum {MAX_SCRIPT_BYTES})",
+                script.len()
+            ));
+        }
+        let tab_id = match tab_id_arg(args) {
+            Ok(tab_id) => tab_id,
+            Err(error) => return ToolResult::fail(error),
+        };
+        let timeout_ms = args
+            .get("timeout_ms")
+            .and_then(Value::as_u64)
+            .unwrap_or(DEFAULT_TIMEOUT_MS)
+            .clamp(1, MAX_TIMEOUT_MS);
+        match self
+            .bridge
+            .execute(tab_id, script, Duration::from_millis(timeout_ms))
+            .await
+        {
+            Ok(execution) => ToolResult::ok(render_json(&json!({
+                "tab_id": execution.tab_id,
+                "result": execution.value
+            }))),
+            Err(error) => ToolResult::fail(error),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::Engine;
+    use sha2::{Digest, Sha256};
+
+    #[test]
+    fn manifest_key_matches_the_only_accepted_extension_origin() {
+        let manifest_path = wisp_paths::browser_extension_dir()
+            .unwrap()
+            .join("manifest.json");
+        let manifest: Value =
+            serde_json::from_slice(&std::fs::read(manifest_path).unwrap()).unwrap();
+        let key = manifest["key"].as_str().unwrap();
+        let der = base64::engine::general_purpose::STANDARD
+            .decode(key)
+            .unwrap();
+        let digest = Sha256::digest(der);
+        let id: String = digest[..16]
+            .iter()
+            .flat_map(|byte| [byte >> 4, byte & 0x0f])
+            .map(|nibble| char::from(b'a' + nibble))
+            .collect();
+        assert_eq!(EXTENSION_ORIGIN, format!("chrome-extension://{id}"));
+    }
+
+    #[test]
+    fn bridge_accepts_extension_origins_only() {
+        assert!(allowed_extension_origin(Some(
+            "chrome-extension://gnkjgagleagkgdlkkcianolobfdoocnp"
+        )));
+        assert!(!allowed_extension_origin(Some(
+            "chrome-extension://abcdefghijklmnop"
+        )));
+        assert!(!allowed_extension_origin(Some("https://example.com")));
+        assert!(!allowed_extension_origin(Some("null")));
+        assert!(!allowed_extension_origin(None));
+    }
+
+    #[test]
+    fn page_access_tools_always_require_approval() {
+        let bridge = Arc::new(BrowserBridge::new(PathBuf::from("extension")));
+        assert_eq!(
+            WebScanTool::new(bridge.clone()).minimum_approval(),
+            Approval::Ask
+        );
+        assert_eq!(
+            WebExecuteJsTool::new(bridge).minimum_approval(),
+            Approval::Ask
+        );
+    }
+
+    #[tokio::test]
+    async fn setup_reports_the_extension_folder_without_requiring_approval() {
+        let extension_dir = wisp_paths::browser_extension_dir().unwrap();
+        let bridge = Arc::new(BrowserBridge::new(extension_dir.clone()));
+        let info = bridge.setup_info().await;
+        let expected_path = std::fs::canonicalize(extension_dir).unwrap();
+
+        assert_eq!(info["status"], "disconnected");
+        assert_eq!(info["extension_path"], expected_path.display().to_string());
+        assert_eq!(info["extension_path_exists"], true);
+        assert_eq!(info["install_scope"], "once_per_browser_profile");
+        assert!(info["steps"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|step| step.as_str().unwrap().contains("Load unpacked")));
+        assert_eq!(
+            BrowserSetupTool::new(bridge).minimum_approval(),
+            Approval::Allow
+        );
+    }
+
+    #[test]
+    fn tab_parser_accepts_generic_agent_numeric_and_string_ids() {
+        let numeric =
+            parse_tab(&json!({ "id": 7, "url": "https://a", "title": "A", "active": true }))
+                .unwrap();
+        let string = parse_tab(&json!({ "id": "8", "url": "https://b", "title": "B" })).unwrap();
+        assert_eq!(numeric.id, 7);
+        assert!(numeric.active);
+        assert_eq!(string.id, 8);
+    }
+
+    #[tokio::test]
+    async fn routes_execution_to_the_live_extension_and_correlates_result() {
+        let bridge = Arc::new(BrowserBridge::new(PathBuf::from("extension")));
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        bridge.install_client(1, tx).await;
+        bridge
+            .handle_text(
+                1,
+                r#"{"type":"ext_ready","tabs":[{"id":42,"url":"https://example.com","title":"Example","active":true}]}"#,
+            )
+            .await;
+
+        let running = {
+            let bridge = bridge.clone();
+            tokio::spawn(async move {
+                bridge
+                    .execute(None, "document.title", Duration::from_secs(1))
+                    .await
+            })
+        };
+        let outbound = rx.recv().await.unwrap().into_text().unwrap();
+        let outbound: Value = serde_json::from_str(&outbound).unwrap();
+        assert_eq!(outbound["tabId"], 42);
+        assert_eq!(outbound["code"], "document.title");
+        let id = outbound["id"].as_str().unwrap();
+        bridge
+            .handle_text(
+                1,
+                &json!({ "type": "result", "id": id, "result": "Example" }).to_string(),
+            )
+            .await;
+
+        let result = running.await.unwrap().unwrap();
+        assert_eq!(result.tab_id, 42);
+        assert_eq!(result.value, "Example");
+    }
+
+    #[test]
+    fn browser_results_are_bounded_before_entering_model_context() {
+        let rendered = render_json(&json!({ "text": "x".repeat(MAX_RESULT_CHARS * 2) }));
+        assert!(rendered.chars().count() <= MAX_RESULT_CHARS + 40);
+        assert!(rendered.ends_with("browser result truncated"));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -20,6 +20,7 @@ use wisp_store::{LibraryStore, Store};
 mod acp;
 mod approval_commands;
 mod artifact_commands;
+mod browser_bridge;
 mod channels;
 mod connector_commands;
 mod context_probe;
@@ -1490,6 +1491,7 @@ struct AppState {
     library: LibraryStore,
     run_manager: run_context::RunManager,
     runtime_manager: wisp_runtime::RuntimeManager,
+    browser_bridge: Arc<browser_bridge::BrowserBridge>,
     active: std::sync::RwLock<HashMap<String, ActiveProject>>,
     /// One runtime per conversation frame id. Locked only briefly to clone the
     /// `Arc`; the per-session `agent` mutex is what serializes turns *within*
@@ -3913,6 +3915,15 @@ async fn send_message_inner(
             load_memory_enabled(&state.store).await,
             vision_cfg.clone(),
         );
+        agent.add_tool(Box::new(browser_bridge::BrowserSetupTool::new(
+            state.browser_bridge.clone(),
+        )));
+        agent.add_tool(Box::new(browser_bridge::WebScanTool::new(
+            state.browser_bridge.clone(),
+        )));
+        agent.add_tool(Box::new(browser_bridge::WebExecuteJsTool::new(
+            state.browser_bridge.clone(),
+        )));
         agent.add_tool(Box::new(run_context::RunInContextTool::new(
             state.store.clone(),
             state.run_manager.clone(),
@@ -7075,6 +7086,11 @@ pub fn run() {
             let approval_grants = Arc::new(StdMutex::new(tauri::async_runtime::block_on(
                 load_approval_grants(&store),
             )));
+            let browser_extension_dir = wisp_paths::browser_extension_dir()
+                .unwrap_or_else(|| wisp_paths::resource_root().join("browser-extension"));
+            let browser_bridge = tauri::async_runtime::block_on(
+                browser_bridge::BrowserBridge::start(browser_extension_dir),
+            );
             if let Ok((attempts, workflows)) = tauri::async_runtime::block_on(
                 store.recover_interrupted_agent_workflows(),
             ) {
@@ -7088,6 +7104,7 @@ pub fn run() {
                 library,
                 run_manager,
                 runtime_manager,
+                browser_bridge,
                 active: std::sync::RwLock::new(HashMap::from([(
                     "main".to_string(),
                     ActiveProject {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -25,6 +25,7 @@
       "../python/": "python/",
       "../r/": "r/",
       "../mcp-servers/bio-tools/": "mcp-servers/bio-tools/",
+      "../browser-extension/": "browser-extension/",
       "../seed/": "seed/"
     },
     "icon": [


### PR DESCRIPTION
## Problem

Browser automation previously lacked a path to the user’s real Chrome/Chromium profile, so it could not preserve cookies, login state, installed extensions, GPU/WebGL behavior, or the normal profile fingerprint.

## Summary

- add a loopback WebSocket bridge restricted to the bundled extension ID
- add a persistent Manifest V3 Chrome/Chromium extension
- expose browser_setup, web_scan, and web_execute_js to the main Agent
- keep page scanning and execution behind Wisp approval while setup remains read-only
- bundle the extension in development and release resource layouts
- document installation, security boundaries, limitations, and GenericAgent attribution

## Tests

- cargo fmt --all -- --check
- cargo test -p wisp-tauri browser_bridge
- cargo test --workspace
- node --check browser-extension/background.js
- git diff --check

## Manual smoke

1. Start Wisp Science.
2. Ask Wisp to configure the browser and copy the returned extension directory.
3. Open chrome://extensions, enable Developer mode, choose Load unpacked, and select that directory.
4. Confirm the extension popup reports Connected to Wisp.
5. Open an HTTP(S) tab, approve web_scan, and verify the real tab content is returned.
6. Approve a harmless web_execute_js call and verify it runs in the same profile.

## Known limitations

- installation is manual once per Chrome/Chromium profile
- Chrome internal pages cannot be scripted
- Wisp and GenericAgent TMWebDriver cannot both bind loopback port 18765
- the bridge currently supports one connected browser extension instance

## Attribution

The real-browser architecture and compatible message protocol are inspired by GenericAgent GA Web / TMWebDriver (MIT, Copyright 2025 lsdefine). The Wisp Rust bridge and Manifest V3 extension are an independent implementation.