### PR TITLE
fix: report verified native browser extension path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6428,6 +6428,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "dirs 5.0.1",
+ "dunce",
  "flate2",
  "futures-util",
  "glob",

--- a/docs/real-browser-automation.md
+++ b/docs/real-browser-automation.md
@@ -51,7 +51,17 @@ For unattended browser downloads, make this one-time browser-profile change:
    without opening a native location prompt. An authorized Wisp filesystem tool
    can process or move the saved file afterward.
 
-This setting must be changed manually because internal settings pages such as
+For unattended batches that download more than one file from the same site:
+
+1. Open `chrome://settings/content/automaticDownloads` in Chrome, or
+   `edge://settings/content/automaticDownloads` in Edge.
+2. Add only the trusted target site to **Allowed to automatically download
+   multiple files**. If the browser asks on that site's first batch, choose
+   **Allow**.
+3. Do not grant this permission to untrusted sites; it allows that site to
+   trigger multiple successive downloads without a user gesture for each file.
+
+These settings must be changed manually because internal settings pages such as
 `chrome://settings` and `edge://settings` are not scriptable by the bridge.
 
 ## Agent tools

--- a/docs/real-browser-automation.md
+++ b/docs/real-browser-automation.md
@@ -53,12 +53,15 @@ For unattended browser downloads, make this one-time browser-profile change:
 
 For unattended batches that download more than one file from the same site:
 
-1. Open `chrome://settings/content/automaticDownloads` in Chrome, or
+1. Before triggering the batch, Wisp explains the following browser settings
+   and waits for the user to confirm that configuration is complete. Until the
+   user confirms, Wisp downloads at most one file.
+2. Open `chrome://settings/content/automaticDownloads` in Chrome, or
    `edge://settings/content/automaticDownloads` in Edge.
-2. Add only the trusted target site to **Allowed to automatically download
+3. Add only the trusted target site to **Allowed to automatically download
    multiple files**. If the browser asks on that site's first batch, choose
    **Allow**.
-3. Do not grant this permission to untrusted sites; it allows that site to
+4. Do not grant this permission to untrusted sites; it allows that site to
    trigger multiple successive downloads without a user gesture for each file.
 
 These settings must be changed manually because internal settings pages such as

--- a/docs/real-browser-automation.md
+++ b/docs/real-browser-automation.md
@@ -35,6 +35,25 @@ and browser restarts. It reconnects to `ws://127.0.0.1:18765` when Wisp is
 running. Only loopback connections whose WebSocket origin is a Chrome extension
 with Wisp's bundled, stable extension ID are accepted.
 
+## Downloads and native dialogs
+
+GA Web controls web-page tabs. It cannot operate Chrome/Edge toolbar download
+bubbles or native operating-system **Open**, **Save**, and **Save As** dialogs.
+Page JavaScript and the Wisp extension cannot access those browser or operating
+system surfaces.
+
+For unattended browser downloads, make this one-time browser-profile change:
+
+1. Open `chrome://settings/downloads` in Chrome, or
+   `edge://settings/downloads` in Edge.
+2. Turn off **Ask where to save each file before downloading**.
+3. Downloads will then use the browser's configured default download directory
+   without opening a native location prompt. An authorized Wisp filesystem tool
+   can process or move the saved file afterward.
+
+This setting must be changed manually because internal settings pages such as
+`chrome://settings` and `edge://settings` are not scriptable by the bridge.
+
 ## Agent tools
 
 - `browser_setup`: report bridge status, the exact bundled extension directory,

--- a/docs/real-browser-automation.md
+++ b/docs/real-browser-automation.md
@@ -25,7 +25,9 @@ exact extension directory on that installation, and the following steps.
    directory. In a source checkout this is the repository's
    `browser-extension/` directory. An installed build reports its exact bundled
    path through `browser_setup`. Select the directory itself, not an individual
-   file or archive inside it.
+   file or archive inside it. The reported path comes from the running Wisp
+   binary's native Tauri resource directory and must be copied verbatim; Wisp
+   never translates it between Windows, WSL, macOS, or Linux path formats.
 5. Open the extension popup and confirm that it says **Connected to Wisp**.
 
 The unpacked extension remains installed in that browser profile across Wisp

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,6 +28,7 @@ tracing-subscriber = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 dirs = "5"
+dunce = { workspace = true }
 reqwest = { workspace = true }
 regex = { workspace = true }
 url = { workspace = true }

--- a/src-tauri/src/browser_bridge.rs
+++ b/src-tauri/src/browser_bridge.rs
@@ -144,6 +144,12 @@ impl BrowserBridge {
                 "chrome_settings_url": "chrome://settings/downloads",
                 "edge_settings_url": "edge://settings/downloads",
                 "setting_to_disable": "Ask where to save each file before downloading",
+                "multiple_downloads": {
+                    "chrome_settings_url": "chrome://settings/content/automaticDownloads",
+                    "edge_settings_url": "edge://settings/content/automaticDownloads",
+                    "recommended_action": "Add only the trusted target site to Allowed to automatically download multiple files. If the browser asks on the site's first batch, choose Allow.",
+                    "security_note": "Do not allow automatic multiple downloads for untrusted sites."
+                },
                 "effect": "Downloads save to the browser's configured default download directory without opening a native location prompt. Authorized filesystem tools may process the saved file afterward."
             },
             "error": state.startup_error
@@ -523,7 +529,7 @@ impl Tool for BrowserSetupTool {
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(
             self.name(),
-            "Call when the user asks to configure, install, set up, or connect the real browser. The result is derived from the running Wisp binary's native Tauri resource directory and includes the manual setting required for unattended downloads. Copy extension_path character-for-character and never convert it between Windows, WSL, macOS, or Linux. If extension_path_verified is false, report the missing bundled extension and never invent a path.",
+            "Call when the user asks to configure, install, set up, or connect the real browser. The result is derived from the running Wisp binary's native Tauri resource directory and includes the manual settings required for unattended single and multiple downloads. Copy extension_path character-for-character and never convert it between Windows, WSL, macOS, or Linux. If extension_path_verified is false, report the missing bundled extension and never invent a path.",
             json!({
                 "type": "object",
                 "properties": {},
@@ -786,6 +792,16 @@ mod tests {
         assert_eq!(
             info["download_automation"]["setting_to_disable"],
             "Ask where to save each file before downloading"
+        );
+        assert_eq!(
+            info["download_automation"]["multiple_downloads"]["chrome_settings_url"],
+            "chrome://settings/content/automaticDownloads"
+        );
+        assert!(
+            info["download_automation"]["multiple_downloads"]["recommended_action"]
+                .as_str()
+                .unwrap()
+                .contains("trusted target site")
         );
         assert!(info["steps"].as_array().unwrap().iter().any(|step| step
             .as_str()

--- a/src-tauri/src/browser_bridge.rs
+++ b/src-tauri/src/browser_bridge.rs
@@ -147,6 +147,7 @@ impl BrowserBridge {
                 "multiple_downloads": {
                     "chrome_settings_url": "chrome://settings/content/automaticDownloads",
                     "edge_settings_url": "edge://settings/content/automaticDownloads",
+                    "agent_gate": "Before triggering multiple file downloads, show these browser settings and wait for the user to confirm configuration. Until confirmed, download at most one file.",
                     "recommended_action": "Add only the trusted target site to Allowed to automatically download multiple files. If the browser asks on the site's first batch, choose Allow.",
                     "security_note": "Do not allow automatic multiple downloads for untrusted sites."
                 },
@@ -656,7 +657,7 @@ impl Tool for WebExecuteJsTool {
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(
             self.name(),
-            "Execute JavaScript in a tab from the user's real, persistent Chrome/Chromium session. Call web_scan first and do not guess selectors. A JSON script with cmd='cdp' may call one Chrome DevTools Protocol method for trusted input or other advanced browser actions.",
+            "Execute JavaScript in a tab from the user's real, persistent Chrome/Chromium session. Call web_scan first and do not guess selectors. For a task that will trigger multiple file downloads, first tell the user how to allow automatic multiple downloads for the trusted target site at chrome://settings/content/automaticDownloads or edge://settings/content/automaticDownloads, then wait for confirmation; until confirmed, trigger at most one file download. A JSON script with cmd='cdp' may call one Chrome DevTools Protocol method for trusted input or other advanced browser actions.",
             json!({
                 "type": "object",
                 "properties": {
@@ -803,6 +804,17 @@ mod tests {
                 .unwrap()
                 .contains("trusted target site")
         );
+        assert!(
+            info["download_automation"]["multiple_downloads"]["agent_gate"]
+                .as_str()
+                .unwrap()
+                .contains("wait for the user to confirm")
+        );
+        assert!(WebExecuteJsTool::new(bridge.clone())
+            .schema()
+            .function
+            .description
+            .contains("until confirmed, trigger at most one file download"));
         assert!(info["steps"].as_array().unwrap().iter().any(|step| step
             .as_str()
             .unwrap()

--- a/src-tauri/src/browser_bridge.rs
+++ b/src-tauri/src/browser_bridge.rs
@@ -138,6 +138,14 @@ impl BrowserBridge {
                 "The running Wisp build has no verified bundled extension path. Do not invent a path or claim the extension exists."
             },
             "steps": steps,
+            "download_automation": {
+                "limitation": "GA Web controls web-page tabs. It cannot operate Chrome/Edge toolbar download bubbles or native operating-system Open, Save, and Save As dialogs.",
+                "manual_setup_required": true,
+                "chrome_settings_url": "chrome://settings/downloads",
+                "edge_settings_url": "edge://settings/downloads",
+                "setting_to_disable": "Ask where to save each file before downloading",
+                "effect": "Downloads save to the browser's configured default download directory without opening a native location prompt. Authorized filesystem tools may process the saved file afterward."
+            },
             "error": state.startup_error
         })
     }
@@ -515,7 +523,7 @@ impl Tool for BrowserSetupTool {
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(
             self.name(),
-            "Call when the user asks to configure, install, set up, or connect the real browser. The result is derived from the running Wisp binary's native Tauri resource directory. Copy extension_path character-for-character and never convert it between Windows, WSL, macOS, or Linux. If extension_path_verified is false, report the missing bundled extension and never invent a path.",
+            "Call when the user asks to configure, install, set up, or connect the real browser. The result is derived from the running Wisp binary's native Tauri resource directory and includes the manual setting required for unattended downloads. Copy extension_path character-for-character and never convert it between Windows, WSL, macOS, or Linux. If extension_path_verified is false, report the missing bundled extension and never invent a path.",
             json!({
                 "type": "object",
                 "properties": {},
@@ -771,6 +779,14 @@ mod tests {
         assert_eq!(info["extension_path"], expected_path.display().to_string());
         assert_eq!(info["extension_path_verified"], true);
         assert_eq!(info["install_scope"], "once_per_browser_profile");
+        assert_eq!(
+            info["download_automation"]["chrome_settings_url"],
+            "chrome://settings/downloads"
+        );
+        assert_eq!(
+            info["download_automation"]["setting_to_disable"],
+            "Ask where to save each file before downloading"
+        );
         assert!(info["steps"].as_array().unwrap().iter().any(|step| step
             .as_str()
             .unwrap()

--- a/src-tauri/src/browser_bridge.rs
+++ b/src-tauri/src/browser_bridge.rs
@@ -99,35 +99,45 @@ impl BrowserBridge {
 
     async fn setup_info(&self) -> Value {
         let state = self.state.lock().await;
-        let extension_dir = std::fs::canonicalize(&self.extension_dir)
-            .unwrap_or_else(|_| self.extension_dir.clone());
-        let extension_path_exists = extension_dir.is_dir();
+        let extension_path = self.verified_extension_path();
+        let extension_ready = extension_path.is_some();
         let status = if state.startup_error.is_some() {
             "error"
-        } else if !extension_path_exists {
+        } else if !extension_ready {
             "extension_missing"
         } else if state.client.is_some() {
             "connected"
         } else {
             "disconnected"
         };
-        let extension_path = extension_dir.display().to_string();
+        let steps = extension_path.as_ref().map_or_else(Vec::new, |path| {
+            vec![
+                "Start Wisp Science and keep it running.".to_string(),
+                "Open chrome://extensions in the Chrome/Chromium profile Wisp should control."
+                    .to_string(),
+                "Enable Developer mode.".to_string(),
+                format!("Click Load unpacked and select this exact folder: {path}"),
+                "Open the Wisp Real Browser Bridge extension popup and confirm Connected to Wisp."
+                    .to_string(),
+            ]
+        });
 
         json!({
             "status": status,
             "connected_tabs": state.tabs.len(),
+            "runtime_os": std::env::consts::OS,
+            "path_source": "wisp_tauri_resource_dir",
             "extension_path": extension_path,
-            "extension_path_exists": extension_path_exists,
+            "extension_path_verified": extension_ready,
             "extension_id": EXTENSION_ORIGIN.trim_start_matches("chrome-extension://"),
             "bridge_endpoint": format!("ws://{BRIDGE_ADDR}"),
             "install_scope": "once_per_browser_profile",
-            "steps": [
-                "Start Wisp Science and keep it running.",
-                "Open chrome://extensions in the Chrome/Chromium profile Wisp should control.",
-                "Enable Developer mode.",
-                format!("Click Load unpacked and select this folder: {extension_path}"),
-                "Open the Wisp Real Browser Bridge extension popup and confirm Connected to Wisp."
-            ],
+            "assistant_instruction": if extension_ready {
+                "Copy extension_path character-for-character. Never translate, infer, normalize, or replace any path segment."
+            } else {
+                "The running Wisp build has no verified bundled extension path. Do not invent a path or claim the extension exists."
+            },
+            "steps": steps,
             "error": state.startup_error
         })
     }
@@ -309,10 +319,22 @@ impl BrowserBridge {
     }
 
     fn unavailable_message(&self, reason: &str) -> String {
-        format!(
-            "real-browser bridge unavailable: {reason}. In Chrome/Chromium open chrome://extensions, enable Developer mode, and Load unpacked from '{}'. Keep Wisp running; the extension connects only to {BRIDGE_ADDR}.",
-            self.extension_dir.display()
-        )
+        match self.verified_extension_path() {
+            Some(path) => format!(
+                "real-browser bridge unavailable: {reason}. In Chrome/Chromium open chrome://extensions, enable Developer mode, and Load unpacked from this exact native {} path: '{path}'. Keep Wisp running; the extension connects only to {BRIDGE_ADDR}.",
+                std::env::consts::OS
+            ),
+            None => format!(
+                "real-browser bridge unavailable: {reason}. This Wisp build has no verified bundled browser extension; do not infer an installation path."
+            ),
+        }
+    }
+
+    fn verified_extension_path(&self) -> Option<String> {
+        let dir = dunce::canonicalize(&self.extension_dir).ok()?;
+        dir.join("manifest.json")
+            .is_file()
+            .then(|| dir.display().to_string())
     }
 }
 
@@ -493,7 +515,7 @@ impl Tool for BrowserSetupTool {
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(
             self.name(),
-            "Call when the user asks to configure, install, set up, or connect the real browser. Returns the current bridge status, the exact local browser-extension folder to choose with Chrome's Load unpacked button, and complete installation steps. The extension is installed once per browser profile.",
+            "Call when the user asks to configure, install, set up, or connect the real browser. The result is derived from the running Wisp binary's native Tauri resource directory. Copy extension_path character-for-character and never convert it between Windows, WSL, macOS, or Linux. If extension_path_verified is false, report the missing bundled extension and never invent a path.",
             json!({
                 "type": "object",
                 "properties": {},
@@ -741,21 +763,43 @@ mod tests {
         let extension_dir = wisp_paths::browser_extension_dir().unwrap();
         let bridge = Arc::new(BrowserBridge::new(extension_dir.clone()));
         let info = bridge.setup_info().await;
-        let expected_path = std::fs::canonicalize(extension_dir).unwrap();
+        let expected_path = dunce::canonicalize(extension_dir).unwrap();
 
         assert_eq!(info["status"], "disconnected");
+        assert_eq!(info["runtime_os"], std::env::consts::OS);
+        assert_eq!(info["path_source"], "wisp_tauri_resource_dir");
         assert_eq!(info["extension_path"], expected_path.display().to_string());
-        assert_eq!(info["extension_path_exists"], true);
+        assert_eq!(info["extension_path_verified"], true);
         assert_eq!(info["install_scope"], "once_per_browser_profile");
-        assert!(info["steps"]
-            .as_array()
+        assert!(info["steps"].as_array().unwrap().iter().any(|step| step
+            .as_str()
             .unwrap()
-            .iter()
-            .any(|step| step.as_str().unwrap().contains("Load unpacked")));
+            .contains(info["extension_path"].as_str().unwrap())));
+        assert!(bridge
+            .unavailable_message("not connected")
+            .contains(info["extension_path"].as_str().unwrap()));
         assert_eq!(
             BrowserSetupTool::new(bridge).minimum_approval(),
             Approval::Allow
         );
+    }
+
+    #[tokio::test]
+    async fn setup_never_offers_an_unverified_extension_path() {
+        let missing = std::env::temp_dir().join(format!(
+            "wisp-browser-extension-missing-{}",
+            std::process::id()
+        ));
+        let bridge = BrowserBridge::new(missing.clone());
+        let info = bridge.setup_info().await;
+
+        assert_eq!(info["status"], "extension_missing");
+        assert_eq!(info["extension_path_verified"], false);
+        assert!(info["extension_path"].is_null());
+        assert!(info["steps"].as_array().unwrap().is_empty());
+        assert!(!bridge
+            .unavailable_message("not connected")
+            .contains(&missing.display().to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The browser setup response could present or rewrite an unverified extension path. On Windows this could produce a nonexistent path, leaving Chrome unable to load the extension.

## Summary

- resolve the extension only from the running Wisp binary native Tauri resource directory
- canonicalize it with platform-native path semantics and require manifest.json to exist
- return runtime_os, path_source, and extension_path_verified with an explicit verbatim-copy contract
- return no path and no installation steps when the bundled extension cannot be verified
- make browser_setup and web_scan connection errors use the same verified path
- never translate paths between Windows, WSL, macOS, or Linux
- explain that GA Web cannot control browser download bubbles or native Open/Save/Save As dialogs
- provide the one-time Chrome/Edge settings required for unattended downloads
- gate batch downloads on browser setup: Wisp presents the trusted-site automatic-download settings and waits for user confirmation; until confirmed it triggers at most one file download

## Tests

- cargo fmt --all -- --check
- cargo test -p wisp-tauri browser_bridge
- cargo test --workspace
- git diff --check

## Manual smoke

1. Install and start a Windows Wisp build containing the bundled extension.
2. Ask Wisp to configure the browser.
3. Confirm runtime_os is windows and the reported extension path is an existing native Windows directory containing manifest.json.
4. Paste that exact path into Chrome Load unpacked and confirm the extension connects.
5. Temporarily remove the bundled extension and confirm Wisp reports extension_missing without inventing a path.
6. Confirm the guide points Chrome and Edge to their Downloads pages and instructs the user to turn off Ask where to save each file before downloading.
7. Ask for a task that will trigger multiple file downloads. Confirm Wisp presents the Chrome/Edge automatic-download setup and waits for confirmation instead of immediately starting the batch.
8. Confirm that after the user says configuration is complete, Wisp may proceed with the requested batch.

## Known limitations

- existing installations must update to a build that bundles browser-extension before a verified path can be returned
- extension installation remains a one-time manual Chrome action per browser profile
- GA Web cannot operate browser toolbar download UI or native operating-system file dialogs; unattended downloads require the documented one-time browser settings
- multiple-download permission is intentionally site-scoped and must not be granted to untrusted sites
- the batch-download gate is an agent instruction and user-confirmation flow; it does not attempt unreliable static analysis of arbitrary page JavaScript