### PR TITLE
feat: hand off robot challenges to the user

### DIFF
--- a/docs/real-browser-automation.md
+++ b/docs/real-browser-automation.md
@@ -35,6 +35,20 @@ and browser restarts. It reconnects to `ws://127.0.0.1:18765` when Wisp is
 running. Only loopback connections whose WebSocket origin is a Chrome extension
 with Wisp's bundled, stable extension ID are accepted.
 
+## Human-verification handoff
+
+When `web_scan` detects an **Are you a robot?** page together with a request to
+confirm that the visitor is human or complete a CAPTCHA challenge, it returns
+`human_intervention.required=true`. The Agent must stop browser automation, ask
+the user to complete the challenge manually in the current visible browser tab,
+and wait for confirmation. It then scans the same tab again and continues only
+after the challenge is gone. The persistent browser profile keeps any clearance
+cookie issued after the manual verification.
+
+Wisp does not attempt to click, solve, or bypass CAPTCHA challenges. A page that
+merely mentions the phrase **Are you a robot?** without the accompanying
+human-verification prompt does not trigger the handoff.
+
 ## Downloads and native dialogs
 
 GA Web controls web-page tabs. It cannot operate Chrome/Edge toolbar download

--- a/src-tauri/src/browser_bridge.rs
+++ b/src-tauri/src/browser_bridge.rs
@@ -469,6 +469,23 @@ fn render_json(value: &Value) -> String {
     clipped
 }
 
+fn human_verification_handoff(page: &Value) -> Option<Value> {
+    let title = page.get("title").and_then(Value::as_str).unwrap_or("");
+    let text = page.get("text").and_then(Value::as_str).unwrap_or("");
+    let content = format!("{title}\n{text}").to_ascii_lowercase();
+    if !content.contains("are you a robot")
+        || !(content.contains("confirm you are a human") || content.contains("captcha challenge"))
+    {
+        return None;
+    }
+    Some(json!({
+        "required": true,
+        "reason": "captcha_challenge",
+        "instruction": "Stop browser automation and ask the user to complete the human-verification challenge manually in this current visible browser tab. Wait for the user to confirm completion before scanning the same tab again.",
+        "resume": "After the user confirms, call web_scan on the same tab and continue only when the challenge is no longer detected."
+    }))
+}
+
 const SCAN_SCRIPT: &str = r##"(() => {
   const visible = (el) => {
     const s = getComputedStyle(el), r = el.getBoundingClientRect();
@@ -567,7 +584,7 @@ impl Tool for WebScanTool {
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(
             self.name(),
-            "Read visible content and actionable elements from the user's real, persistent Chrome/Chromium session. The browser keeps its existing cookies, login state, extensions, GPU/WebGL behavior, and normal profile fingerprint. Use tabs_only first when the target tab is unclear.",
+            "Read visible content and actionable elements from the user's real, persistent Chrome/Chromium session. The browser keeps its existing cookies, login state, extensions, GPU/WebGL behavior, and normal profile fingerprint. Use tabs_only first when the target tab is unclear. If the result contains human_intervention.required=true, stop browser automation, ask the user to complete the challenge in the current visible tab, and wait for confirmation before scanning again.",
             json!({
                 "type": "object",
                 "properties": {
@@ -629,10 +646,14 @@ impl Tool for WebScanTool {
             )
             .await
         {
-            Ok(execution) => ToolResult::ok(render_json(&json!({
-                "tab_id": execution.tab_id,
-                "page": execution.value
-            }))),
+            Ok(execution) => {
+                let handoff = human_verification_handoff(&execution.value);
+                ToolResult::ok(render_json(&json!({
+                    "human_intervention": handoff,
+                    "tab_id": execution.tab_id,
+                    "page": execution.value
+                })))
+            }
             Err(error) => ToolResult::fail(error),
         }
     }
@@ -657,7 +678,7 @@ impl Tool for WebExecuteJsTool {
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(
             self.name(),
-            "Execute JavaScript in a tab from the user's real, persistent Chrome/Chromium session. Call web_scan first and do not guess selectors. For a task that will trigger multiple file downloads, first tell the user how to allow automatic multiple downloads for the trusted target site at chrome://settings/content/automaticDownloads or edge://settings/content/automaticDownloads, then wait for confirmation; until confirmed, trigger at most one file download. A JSON script with cmd='cdp' may call one Chrome DevTools Protocol method for trusted input or other advanced browser actions.",
+            "Execute JavaScript in a tab from the user's real, persistent Chrome/Chromium session. Call web_scan first and do not guess selectors. If web_scan reports human_intervention.required=true, do not automate the challenge; wait for the user to complete it and confirm before continuing. For a task that will trigger multiple file downloads, first tell the user how to allow automatic multiple downloads for the trusted target site at chrome://settings/content/automaticDownloads or edge://settings/content/automaticDownloads, then wait for confirmation; until confirmed, trigger at most one file download. A JSON script with cmd='cdp' may call one Chrome DevTools Protocol method for trusted input or other advanced browser actions.",
             json!({
                 "type": "object",
                 "properties": {
@@ -771,6 +792,27 @@ mod tests {
             WebExecuteJsTool::new(bridge).minimum_approval(),
             Approval::Ask
         );
+    }
+
+    #[test]
+    fn are_you_a_robot_page_requires_manual_handoff() {
+        let handoff = human_verification_handoff(&json!({
+            "title": "Are you a robot?",
+            "text": "Please confirm you are a human by completing the captcha challenge below."
+        }))
+        .unwrap();
+
+        assert_eq!(handoff["required"], true);
+        assert_eq!(handoff["reason"], "captcha_challenge");
+        assert!(handoff["instruction"]
+            .as_str()
+            .unwrap()
+            .contains("Wait for the user to confirm"));
+        assert!(human_verification_handoff(&json!({
+            "title": "Browser automation article",
+            "text": "This article asks: Are you a robot?"
+        }))
+        .is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

A real persistent browser can still receive an interactive Are you a robot? challenge. Continuing to click or retry automatically is unreliable; the task needs a deterministic handoff to the user in the same visible browser session.

## Summary

- detect the paired Are you a robot and confirm-human/CAPTCHA text in web_scan results
- return human_intervention.required=true with explicit stop, manual-completion, and resume instructions
- tell web_execute_js not to automate a detected challenge
- avoid false positives when a normal page merely mentions Are you a robot
- document the human-verification handoff and persistent-session resume behavior

## Tests

- cargo fmt --all -- --check
- cargo test -p wisp-tauri browser_bridge
- cargo test --workspace
- cd ui && cargo check --target wasm32-unknown-unknown
- cd ui-tests && npm ci && npx playwright test (186 passed, 1 skipped)
- git diff --check

## Manual smoke

1. Open an HTTP(S) page in the connected real browser containing the Are you a robot challenge shown in the issue.
2. Call web_scan and confirm it returns human_intervention.required=true and reason=captcha_challenge.
3. Confirm the Agent stops and asks the user to complete the challenge in the current visible tab.
4. Complete the challenge manually and tell the Agent it is done.
5. Confirm the Agent scans the same tab again and continues only after the challenge is gone.
6. Open a normal article that merely mentions Are you a robot and confirm no handoff is returned.

## Known limitations

- this intentionally recognizes the concrete challenge wording instead of attempting generic CAPTCHA classification
- Wisp does not click, solve, or bypass CAPTCHA challenges
- repeated challenges caused by site rate limits or network reputation still require the site-defined recovery path