### PR TITLE
fix(windows): close project windows independently of the main window

### DIFF
--- a/src-tauri/src/desktop_lifecycle.rs
+++ b/src-tauri/src/desktop_lifecycle.rs
@@ -34,15 +34,6 @@ pub(crate) fn activate_workspace(app: &AppHandle) {
 }
 
 #[cfg(target_os = "windows")]
-fn hide_workspace_windows(app: &AppHandle) {
-    for (label, window) in app.webview_windows() {
-        if label != PET_WINDOW_LABEL {
-            let _ = window.hide();
-        }
-    }
-}
-
-#[cfg(target_os = "windows")]
 fn default_pet_position(app: &AppHandle) -> Option<(f64, f64)> {
     let monitor = app.primary_monitor().ok().flatten()?;
     let origin = monitor.position();
@@ -157,8 +148,12 @@ pub(crate) fn install_windows_shell(app: &mut App) -> tauri::Result<()> {
         main.on_window_event(move |event| {
             if let tauri::WindowEvent::CloseRequested { api, .. } = event {
                 if should_hide_workspace_on_close("main") {
+                    // Hide only the main window (it lives on in the tray).
+                    // Per-project windows close independently (#420).
                     api.prevent_close();
-                    hide_workspace_windows(&app_handle);
+                    if let Some(main) = app_handle.get_webview_window("main") {
+                        let _ = main.hide();
+                    }
                 }
             }
         });


### PR DESCRIPTION
## 问题

#420：Windows 上打开多窗口后，关闭一个窗口会把所有窗口一起"关闭"。

## 根因

`install_windows_shell` 里主窗口的 `CloseRequested` 处理调用 `hide_workspace_windows`，把除 pet 之外的**所有**窗口一起隐藏进托盘。这是 #52 引入多项目窗口之前"单窗口关闭即收进托盘"的设计残留——多窗口下关主窗口就把项目窗口全部藏掉了。项目窗口自身的关闭路径（`getCurrentWindow().close()`）本来就只关自己，不受影响。

## 修复

主窗口关闭时只隐藏主窗口本身（托盘行为保持不变），删除 `hide_workspace_windows`。项目窗口的生命周期完全独立。

## 验证

- `cargo test`：368 通过。
- Windows 专属代码路径无法在 Linux 上交叉编译验证（C 依赖 build script 需要 MSVC），改动 API 用法与同文件既有模式一致，请在 Windows 上手工验证：主窗口 + 项目窗口同开，关主窗口 → 项目窗口保留；托盘"Open"恢复主窗口；关项目窗口 → 只关自己。

Fixes #420

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VUPEWivFtLAFjZMLmvCsw