### PR TITLE
fix: 「需要你」只标记未读回复，打开即清除

### DIFF
--- a/crates/wisp-store/src/lib.rs
+++ b/crates/wisp-store/src/lib.rs
@@ -75,6 +75,7 @@ const AGENT_WORKFLOW_LINEAGE_MIGRATION: &str = "0020_agent_workflow_lineage";
 const PLUGIN_INSTALLATIONS_MIGRATION: &str = "0021_plugin_installations";
 const PLUGIN_INSTALLATIONS_MIGRATION_SQL: &str =
     include_str!("../migrations/0021_plugin_installations.sql");
+const FRAME_SEEN_MIGRATION: &str = "0022_frame_seen";
 
 #[derive(Clone)]
 pub struct Store {
@@ -278,6 +279,27 @@ impl Store {
             Self::execute_sql_script(pool, PLUGIN_INSTALLATIONS_MIGRATION_SQL).await?;
             Self::record_migration(pool, PLUGIN_INSTALLATIONS_MIGRATION).await?;
         }
+        if !Self::migration_applied(pool, FRAME_SEEN_MIGRATION).await? {
+            // Last activity the user has viewed, compared against message ts.
+            // 0 = never viewed, so a session flags "needs you" until opened.
+            Self::add_columns_if_missing(
+                pool,
+                "frames",
+                &[("seen_at", "INTEGER NOT NULL DEFAULT 0")],
+            )
+            .await?;
+            // Treat pre-existing history as read — without this, upgrading
+            // flags every old conversation at once and each one would have to
+            // be opened to clear it.
+            let _ = sqlx::query(
+                "UPDATE frames SET seen_at = \
+                    (SELECT COALESCE(MAX(ts), frames.updated_at) FROM messages m \
+                     WHERE m.frame_id = frames.id)",
+            )
+            .execute(pool)
+            .await;
+            Self::record_migration(pool, FRAME_SEEN_MIGRATION).await?;
+        }
         Ok(())
     }
 
@@ -450,6 +472,11 @@ impl Store {
         let rows = sqlx::query(&format!("PRAGMA table_info({table})"))
             .fetch_all(pool)
             .await?;
+        if rows.is_empty() {
+            // Table absent (legacy fixtures skip tables their test never
+            // touches) — nothing to add columns to.
+            return Ok(());
+        }
         let columns = rows
             .iter()
             .map(|row| row.try_get::<String, _>("name"))

--- a/crates/wisp-store/src/models.rs
+++ b/crates/wisp-store/src/models.rs
@@ -87,6 +87,8 @@ pub struct RecentSessionDetail {
     pub created_at: i64,
     pub activity_at: i64,
     pub last_role: Option<String>,
+    /// Activity newer than the last time the user viewed the session.
+    pub unseen: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -114,6 +116,8 @@ pub struct SessionSearchResult {
     pub created_at: i64,
     pub activity_at: i64,
     pub last_role: Option<String>,
+    /// Activity newer than the last time the user viewed the session.
+    pub unseen: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/wisp-store/src/sessions.rs
+++ b/crates/wisp-store/src/sessions.rs
@@ -173,7 +173,8 @@ impl Store {
             "SELECT f.id AS id, f.project_id AS pid, f.created_at AS created_at, f.title AS custom_title, \
                 (SELECT content FROM messages m WHERE m.frame_id = f.id AND m.role='user' ORDER BY m.seq ASC LIMIT 1) AS first_user, \
                 (SELECT role FROM messages m WHERE m.frame_id = f.id ORDER BY m.seq DESC LIMIT 1) AS last_role, \
-                (SELECT COALESCE(MAX(ts), f.updated_at) FROM messages m WHERE m.frame_id = f.id) AS activity_at \
+                (SELECT COALESCE(MAX(ts), f.updated_at) FROM messages m WHERE m.frame_id = f.id) AS activity_at, \
+                (SELECT COALESCE(MAX(ts), f.updated_at) FROM messages m WHERE m.frame_id = f.id) > f.seen_at AS unseen \
              FROM frames f \
              WHERE f.parent_frame_id = f.id \
                AND EXISTS (SELECT 1 FROM messages mm WHERE mm.frame_id = f.id AND mm.role='user') \
@@ -191,6 +192,7 @@ impl Store {
             let custom_title: Option<String> = row.try_get("custom_title")?;
             let first_user: Option<String> = row.try_get("first_user")?;
             let last_role: Option<String> = row.try_get("last_role")?;
+            let unseen: bool = row.try_get("unseen")?;
             let title = session_display_title(custom_title, first_user);
             out.push(RecentSessionDetail {
                 id,
@@ -199,19 +201,22 @@ impl Store {
                 created_at: created,
                 activity_at,
                 last_role,
+                unseen,
             });
         }
         Ok(out)
     }
 
-    /// Last message role per saved session in a project (for dashboard counts).
+    /// Last message role and unseen flag per saved session in a project (for
+    /// dashboard counts).
     pub async fn list_session_last_roles(
         &self,
         project_id: &str,
-    ) -> Result<Vec<(String, Option<String>)>> {
+    ) -> Result<Vec<(String, Option<String>, bool)>> {
         let rows = sqlx::query(
             "SELECT f.id AS id, \
-                (SELECT role FROM messages m WHERE m.frame_id = f.id ORDER BY m.seq DESC LIMIT 1) AS last_role \
+                (SELECT role FROM messages m WHERE m.frame_id = f.id ORDER BY m.seq DESC LIMIT 1) AS last_role, \
+                (SELECT COALESCE(MAX(ts), f.updated_at) FROM messages m WHERE m.frame_id = f.id) > f.seen_at AS unseen \
              FROM frames f \
              WHERE f.project_id = ? AND f.parent_frame_id = f.id \
                AND EXISTS (SELECT 1 FROM messages mm WHERE mm.frame_id = f.id AND mm.role='user')",
@@ -220,8 +225,29 @@ impl Store {
         .fetch_all(&self.pool)
         .await?;
         rows.into_iter()
-            .map(|r| Ok((r.try_get("id")?, r.try_get("last_role")?)))
+            .map(|r| {
+                Ok((
+                    r.try_get("id")?,
+                    r.try_get("last_role")?,
+                    r.try_get("unseen")?,
+                ))
+            })
             .collect()
+    }
+
+    /// Record that the user has viewed this session's current transcript:
+    /// snapshot `seen_at` to the latest activity so status checks can treat
+    /// anything newer as unseen. Unit-agnostic — no wall clock involved.
+    pub async fn mark_frame_seen(&self, id: &str) -> Result<()> {
+        sqlx::query(
+            "UPDATE frames SET seen_at = \
+                (SELECT COALESCE(MAX(ts), frames.updated_at) FROM messages m WHERE m.frame_id = frames.id) \
+             WHERE id = ?",
+        )
+        .bind(id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
     }
 
     pub async fn create_frame(
@@ -1083,7 +1109,8 @@ impl Store {
                     f.created_at AS created_at, COALESCE(f.title,'') AS custom_title, \
                     (SELECT content FROM messages m WHERE m.frame_id=f.id AND m.role='user' ORDER BY m.seq ASC LIMIT 1) AS first_user, \
                     (SELECT role FROM messages m WHERE m.frame_id=f.id ORDER BY m.seq DESC LIMIT 1) AS last_role, \
-                    (SELECT COALESCE(MAX(ts), f.updated_at) FROM messages m WHERE m.frame_id=f.id) AS activity_at \
+                    (SELECT COALESCE(MAX(ts), f.updated_at) FROM messages m WHERE m.frame_id=f.id) AS activity_at, \
+                    (SELECT COALESCE(MAX(ts), f.updated_at) FROM messages m WHERE m.frame_id=f.id) > f.seen_at AS unseen \
              FROM frames f JOIN projects p ON p.id=f.project_id \
              WHERE f.parent_frame_id=f.id \
                AND EXISTS (SELECT 1 FROM messages mm WHERE mm.frame_id=f.id AND mm.role='user') \
@@ -1115,6 +1142,7 @@ impl Store {
                     created_at: row.try_get("created_at")?,
                     activity_at: row.try_get("activity_at")?,
                     last_role: row.try_get("last_role")?,
+                    unseen: row.try_get("unseen")?,
                 })
             })
             .collect()

--- a/crates/wisp-store/src/store_tests.rs
+++ b/crates/wisp-store/src/store_tests.rs
@@ -1332,6 +1332,47 @@ async fn recent_sessions_detail_last_role() {
 }
 
 #[tokio::test]
+async fn mark_frame_seen_clears_unseen_until_new_activity() {
+    let tmp = std::env::temp_dir().join(format!("wisp_store_seen_{}.sqlite", uuid::Uuid::new_v4()));
+    let store = Store::open(&tmp).await.unwrap();
+    store.create_project("p", "proj", "").await.unwrap();
+    store.create_frame("f1", "p", "OPERON", "m").await.unwrap();
+    store
+        .append_message("f1", 1, &Message::user("q"))
+        .await
+        .unwrap();
+    store
+        .append_message("f1", 2, &Message::assistant("done"))
+        .await
+        .unwrap();
+
+    let unseen_of = |rows: Vec<(String, Option<String>, bool)>| {
+        rows.into_iter().find(|r| r.0 == "f1").unwrap().2
+    };
+    assert!(unseen_of(store.list_session_last_roles("p").await.unwrap()));
+
+    store.mark_frame_seen("f1").await.unwrap();
+    assert!(!unseen_of(
+        store.list_session_last_roles("p").await.unwrap()
+    ));
+    let found = store.search_sessions(None, "", 10, None).await.unwrap();
+    assert!(!found.iter().find(|s| s.id == "f1").unwrap().unseen);
+
+    // New activity after the seen snapshot flips it back. Message ts comes
+    // from the wall clock at whole-second resolution, so nudge it forward.
+    store
+        .append_message("f1", 3, &Message::assistant("more"))
+        .await
+        .unwrap();
+    sqlx::query("UPDATE messages SET ts = ts + 10 WHERE frame_id='f1' AND seq=3")
+        .execute(&store.pool)
+        .await
+        .unwrap();
+    assert!(unseen_of(store.list_session_last_roles("p").await.unwrap()));
+    let _ = std::fs::remove_file(&tmp);
+}
+
+#[tokio::test]
 async fn recent_sessions_detail_respects_limit() {
     let tmp = std::env::temp_dir().join(format!(
         "wisp_store_recent_lim_{}.sqlite",
@@ -1774,6 +1815,7 @@ async fn store_open_records_migrations_and_seeds_local_context() {
             AGENT_WORKFLOW_DELIVERIES_MIGRATION.to_string(),
             AGENT_WORKFLOW_LINEAGE_MIGRATION.to_string(),
             PLUGIN_INSTALLATIONS_MIGRATION.to_string(),
+            FRAME_SEEN_MIGRATION.to_string(),
         ]
     );
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -788,6 +788,7 @@ async fn build_project_summary(state: &AppState, id: &str) -> ProjectSummary {
 fn session_runtime_status(
     id: &str,
     last_role: Option<&str>,
+    unseen: bool,
     running: &HashSet<String>,
     awaiting: &HashSet<String>,
 ) -> &'static str {
@@ -795,7 +796,9 @@ fn session_runtime_status(
         "needs_you"
     } else if running.contains(id) {
         "running"
-    } else if last_role_needs_you(last_role) {
+    } else if last_role_needs_you(last_role) && unseen {
+        // An assistant reply only "needs you" until you've viewed it —
+        // otherwise every finished conversation stays flagged forever.
         "needs_you"
     } else {
         "complete"
@@ -804,6 +807,20 @@ fn session_runtime_status(
 
 fn last_role_needs_you(role: Option<&str>) -> bool {
     matches!(role, Some("assistant" | "internal"))
+}
+
+/// A finished turn counts as viewed when some window is showing the session,
+/// so live-watched replies don't flag "needs you" on other surfaces.
+async fn mark_seen_if_viewed(state: &AppState, frame_id: &str) {
+    let viewed = state
+        .active_frame
+        .read()
+        .unwrap()
+        .values()
+        .any(|f| f == frame_id);
+    if viewed {
+        let _ = state.store.mark_frame_seen(frame_id).await;
+    }
 }
 
 async fn project_status_counts(
@@ -817,12 +834,12 @@ async fn project_status_counts(
     };
     let mut running_count = 0i64;
     let mut needs_you_count = 0i64;
-    for (id, role) in rows {
+    for (id, role, unseen) in rows {
         if awaiting.contains(&id) {
             needs_you_count += 1;
         } else if running.contains(&id) {
             running_count += 1;
-        } else if last_role_needs_you(role.as_deref()) {
+        } else if last_role_needs_you(role.as_deref()) && unseen {
             needs_you_count += 1;
         }
     }
@@ -3770,6 +3787,7 @@ async fn send_message_inner(
                         .await;
                 }
                 state.running_turns.lock().await.remove(&frame_id);
+                mark_seen_if_viewed(state, &frame_id).await;
                 let _ = app.emit(
                     "agent",
                     AgentEvent::Done {
@@ -3781,6 +3799,7 @@ async fn send_message_inner(
             }
             Err(error) => {
                 state.running_turns.lock().await.remove(&frame_id);
+                mark_seen_if_viewed(state, &frame_id).await;
                 let _ = app.emit(
                     "agent",
                     AgentEvent::Error {
@@ -4395,6 +4414,8 @@ async fn send_message_inner(
     }
     let _ = tokio::time::timeout(std::time::Duration::from_secs(10), prov_handle).await;
     drop(guard);
+    // After the persist flush so the seen snapshot covers the final messages.
+    mark_seen_if_viewed(&state, &frame_id).await;
 
     match result {
         Ok(_) => {
@@ -5633,7 +5654,13 @@ async fn list_recent_sessions(
     Ok(rows
         .into_iter()
         .map(|r| {
-            let status = session_runtime_status(&r.id, r.last_role.as_deref(), &running, &awaiting);
+            let status = session_runtime_status(
+                &r.id,
+                r.last_role.as_deref(),
+                r.unseen,
+                &running,
+                &awaiting,
+            );
             serde_json::json!({
                 "id": r.id,
                 "project_id": r.project_id,
@@ -6317,6 +6344,7 @@ async fn load_session(
         .map_err(|e| format!("{e}"))?;
     if before_seq.is_none() {
         state.set_active_frame(window.label(), Some(id.clone()));
+        let _ = state.store.mark_frame_seen(&id).await;
         if let Some(rt) = state.sessions.lock().await.get(&id).cloned() {
             rt.set_last_seq(page.latest_seq);
         }
@@ -6335,8 +6363,14 @@ async fn load_session(
 /// viewed session (#194) — `load_session` would clobber the runtime's
 /// `last_seq` with the DB snapshot mid-stream.
 #[tauri::command]
-fn set_viewed_session(state: State<'_, AppState>, window: tauri::WebviewWindow, id: String) {
-    state.set_active_frame(window.label(), Some(id));
+async fn set_viewed_session(
+    state: State<'_, AppState>,
+    window: tauri::WebviewWindow,
+    id: String,
+) -> Result<(), String> {
+    state.set_active_frame(window.label(), Some(id.clone()));
+    let _ = state.store.mark_frame_seen(&id).await;
+    Ok(())
 }
 
 #[tauri::command]
@@ -6440,8 +6474,14 @@ async fn search_sessions(
     Ok(rows
         .into_iter()
         .map(|s| SessionSearchInfo {
-            status: session_runtime_status(&s.id, s.last_role.as_deref(), &running, &awaiting)
-                .into(),
+            status: session_runtime_status(
+                &s.id,
+                s.last_role.as_deref(),
+                s.unseen,
+                &running,
+                &awaiting,
+            )
+            .into(),
             id: s.id,
             project_id: s.project_id,
             project_name: s.project_name,

--- a/src-tauri/src/lib_tests.rs
+++ b/src-tauri/src/lib_tests.rs
@@ -616,25 +616,35 @@ fn session_runtime_status_labels() {
     running.insert("s1".into());
     let awaiting = HashSet::new();
     assert_eq!(
-        session_runtime_status("s1", Some("user"), &running, &awaiting),
+        session_runtime_status("s1", Some("user"), true, &running, &awaiting),
         "running"
     );
     assert_eq!(
-        session_runtime_status("s2", Some("assistant"), &running, &awaiting),
+        session_runtime_status("s2", Some("assistant"), true, &running, &awaiting),
         "needs_you"
     );
     assert_eq!(
-        session_runtime_status("s4", Some("internal"), &running, &awaiting),
+        session_runtime_status("s4", Some("internal"), true, &running, &awaiting),
         "needs_you"
     );
     assert_eq!(
-        session_runtime_status("s3", Some("user"), &running, &awaiting),
+        session_runtime_status("s3", Some("user"), true, &running, &awaiting),
+        "complete"
+    );
+    // A viewed assistant reply no longer needs you — only unseen ones do.
+    assert_eq!(
+        session_runtime_status("s2", Some("assistant"), false, &running, &awaiting),
         "complete"
     );
     let mut awaiting = HashSet::new();
     awaiting.insert("s1".into());
     assert_eq!(
-        session_runtime_status("s1", Some("user"), &running, &awaiting),
+        session_runtime_status("s1", Some("user"), true, &running, &awaiting),
+        "needs_you"
+    );
+    // Blocked sessions stay flagged even after being viewed.
+    assert_eq!(
+        session_runtime_status("s1", Some("user"), false, &running, &awaiting),
         "needs_you"
     );
 }

--- a/src-tauri/src/project_reader.rs
+++ b/src-tauri/src/project_reader.rs
@@ -150,6 +150,7 @@ pub async fn read_references(
                 created_at: 0,
                 activity_at: 0,
                 last_role: None,
+                unseen: false,
             });
         }
     }
@@ -850,6 +851,7 @@ mod tests {
                     created_at: 0,
                     activity_at: 0,
                     last_role: None,
+                    unseen: false,
                 },
                 chunk: SessionChunk {
                     transcript: "[message seq=1 USER]\nevidence".into(),


### PR DESCRIPTION
## 问题

「需要你」的判定是：会话最后一条消息是 assistant 就永久算 needs_you，没有任何已读状态。于是每个正常聊完的对话（包括一句 "hi"）都被永久标记，收件箱徽标涨到 20 且点不掉。

## 修复

给会话引入已读水位 `seen_at`（迁移 0022）：

- **判定**：assistant 回复只在 `activity_at > seen_at`（未读）时才算 needs_you；被确认/提问**阻塞**的会话不受已读影响，处理前一直标记（这是正确的）。
- **标记已读**：打开会话（`load_session` / `set_viewed_session`）即标记；回合结束时若该会话正被任一窗口查看，也自动标记——你盯着它跑完就不会再被其他入口标记。
- **存量回填**：迁移时把历史会话全部置为已读，升级后徽标立刻归零，只有此后真正的新回复才会标记。
- 附带加固：`add_columns_if_missing` 在目标表不存在时 no-op（兼容只建了部分表的遗留测试夹具）。

`seen_at` 快照取自消息 `MAX(ts)`，与时间单位无关，不引入时钟比较。

## 影响面

三个消费方统一生效：收件箱/Ctrl+K（`search_sessions`）、主页最近会话、项目卡片 needs_you 计数。

## 验证

- wisp-store：62 通过（新增 `mark_frame_seen_clears_unseen_until_new_activity`，覆盖 已读→清除→新活动→再标记）。
- src-tauri：370 通过（状态判定测试扩展：已读回复不再标记、阻塞会话无视已读）。
- 前端零改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VUPEWivFtLAFjZMLmvCsw