### PR TITLE
fix: 语言在重新打开设置/管理模型时回退为英文 (#431)

### DIFF
--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -3247,10 +3247,11 @@ fn App() -> impl IntoView {
         spawn_local(async move {
             let v = invoke("get_settings", JsValue::UNDEFINED).await;
             if let Ok(cfg) = serde_wasm_bindgen::from_value::<Settings>(v) {
-                let cfg = normalized_settings(cfg);
-                let l = Locale::from_code(&cfg.locale);
-                loc.set(l);
-                set_document_lang(l);
+                let mut cfg = normalized_settings(cfg);
+                // Keep the live locale authoritative: reloading the settings form
+                // must not clobber an unsaved language change (#431). Sync the form
+                // field to the live signal instead of the other way around.
+                cfg.locale = loc.get_untracked().code().into();
                 s.set(cfg);
             } else {
                 msg.set(Some((


### PR DESCRIPTION
## 问题

Fixes #431

设置语言为中文并"返回应用"后，点击 **设置** 或 **管理模型**，界面又变回英文，每次都能复现（Windows v0.20.0 报告）。

## 根因

切换语言只更新了内存中的 `locale` 信号（界面立即生效），"返回应用"不会落盘。而 **设置** 按钮与 **管理模型** 按钮都走同一个 `open_settings_fn`——它在打开面板时重新 `get_settings` 从磁盘读回旧值，用磁盘上的旧 locale 覆盖了 live 的 `locale` 信号，于是未保存的语言选择被丢弃。两个入口同一个 bug 点。

## 改动

`ui/src/main.rs` 的 `open_settings_fn`：重载设置表单时不再回写 `locale` 信号和 document lang，改为让表单字段跟随 live 信号。live `locale` 始终是唯一真相源（启动时从磁盘初始化 + 下拉框改动）。

```diff
- let l = Locale::from_code(&cfg.locale);
- loc.set(l);
- set_document_lang(l);
+ cfg.locale = loc.get_untracked().code().into();
```

保存路径 `cfg.locale = locale.get().code()` 仍取 live 值，无回归。

## 未覆盖 / 评审须知

- 语言改动仍需点"保存"才能**跨重启**持久化（`set_settings` 要求已配置模型，不宜在切语言时静默全量落盘）。issue 只涉及会话内回退，本 PR 不改这条路径。
- 已 `cargo check` 通过（ui 独立 workspace）。