### PR TITLE
feat(browser): add web_open_tab tool for the real-browser bridge

### DIFF
--- a/skills/browser-use/SKILL.md
+++ b/skills/browser-use/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: browser-use
+description: "Use this skill to drive the user's real, persistent Chrome/Chromium session — open pages, read them, click, fill and submit forms, navigate, switch tabs, or scrape content that needs the user's existing cookies and login state. Triggers when the user asks to do something in their browser, log into a site and act inside it, fill out a web form, click through a flow, or extract data from a page that requires being signed in. Tools: browser_setup (check/connect the extension), web_open_tab (open a URL), web_scan (read visible content + actionable elements with ready-made selectors), web_execute_js (click/type/navigate, or a JSON command for tabs/CDP). Not for the built-in read-only web fetch — this is for interacting with a live browser."
+fold_cue: "instead_of=guessing-selectors use=web_scan first — it returns a unique CSS selector and rect for every actionable element; never invent selectors"
+---
+
+# Browser Use — act inside the user's real Chrome
+
+Wisp does **not** launch an automation browser. It talks to a small
+extension inside the user's own Chrome/Chromium, so every action runs in
+their real profile — existing cookies, logins, extensions, and normal
+fingerprint all apply. That is the whole point: you can operate pages the
+user is already signed into.
+
+Every `web_scan` and `web_execute_js` call needs the user's approval by
+design. Do not treat that as a bug to route around.
+
+## Before anything: confirm the bridge is live
+
+Call `browser_setup`. If `status` is not `connected`, relay its `steps`
+(load the unpacked extension from `extension_path`, verbatim) and stop
+until the popup shows *Connected to Wisp*. Never invent the path.
+
+## The loop
+
+1. **`web_open_tab`** `{url}` — open the page (works even with no tab
+   open yet). Returns the new tab id.
+2. **`web_scan`** — read the page. Returns `page.text`, `page.title`, and
+   `page.elements[]`, where each element carries a **unique `selector`**,
+   its visible `text`/`aria_label`, and a `rect` `[x,y,w,h]`. Use these
+   selectors directly — do not guess. Use `tabs_only:true` first when you
+   are unsure which tab to target; pass `switch_tab_id:<id>` to pin one.
+3. **`web_execute_js`** — act, then re-scan to confirm the effect.
+
+## Recipes (`web_execute_js` `script`)
+
+| Goal | script |
+|---|---|
+| Click | `document.querySelector('<selector>').click()` |
+| Type into a field | `const e=document.querySelector('<sel>'); e.value='text'; e.dispatchEvent(new Event('input',{bubbles:true})); e.dispatchEvent(new Event('change',{bubbles:true}))` |
+| Submit a form | click the submit control by its selector, then re-scan |
+| Navigate current tab | `location.href='https://example.com'` |
+| Read a value | `document.querySelector('<sel>').textContent` |
+
+`script` may instead be a **JSON command**:
+
+| Goal | JSON command |
+|---|---|
+| Switch to & focus a tab (so the user sees it) | `{"cmd":"tabs","method":"switch","tabId":<id>}` |
+| List tabs | `{"cmd":"tabs"}` (or just `web_scan tabs_only`) |
+| Trusted click when `.click()` is ignored | `{"cmd":"cdp","method":"Input.dispatchMouseEvent","params":{"type":"mousePressed","x":<x>,"y":<y>,"button":"left","clickCount":1}}` then the same with `"type":"mouseReleased"` — use the element's `rect` centre from `web_scan` |
+| Screenshot | `{"cmd":"cdp","method":"Page.captureScreenshot","params":{"format":"png"}}` |
+
+Prefer plain JS. Reach for `cmd:cdp` only when a page blocks synthetic
+events or you truly need trusted input. **Screenshots return base64 that
+floods context and is truncated at ~200k chars — prefer `web_scan`'s
+structured output; screenshot only when structure isn't enough.**
+
+## Stop conditions (do not automate through these)
+
+- **Human verification / CAPTCHA:** if `web_scan` returns
+  `human_intervention.required=true`, stop, ask the user to complete the
+  challenge in the visible tab, and wait for their confirmation before
+  scanning again.
+- **Credentials:** never type passwords, card numbers, or one-time codes
+  yourself. If a step needs a password, have the user sign in directly in
+  the browser and continue once they confirm.
+- **Irreversible / outward actions** (send, pay, post, delete): confirm
+  with the user before clicking the control.
+- **Downloads:** for multiple-file downloads, first surface the browser
+  settings from `browser_setup` (`download_automation`) and wait for the
+  user to confirm; until then trigger at most one download.

--- a/src-tauri/src/browser_bridge.rs
+++ b/src-tauri/src/browser_bridge.rs
@@ -322,6 +322,49 @@ impl BrowserBridge {
         }
     }
 
+    /// Send a control command that does not target an existing tab (e.g. open a
+    /// new tab). Unlike `execute`, this never requires an HTTP(S) tab to exist,
+    /// so it can bootstrap browsing from an empty profile.
+    async fn send_command(&self, code: String, timeout: Duration) -> Result<Value, String> {
+        let id = Uuid::new_v4().to_string();
+        let (response_tx, response_rx) = oneshot::channel();
+        {
+            let mut state = self.state.lock().await;
+            if let Some(error) = &state.startup_error {
+                return Err(self.unavailable_message(error));
+            }
+            let Some(client) = state.client.clone() else {
+                return Err(self.unavailable_message("browser extension is not connected"));
+            };
+            state.pending.insert(id.clone(), response_tx);
+            let payload = json!({ "id": id, "code": code }).to_string();
+            if client.tx.send(Message::Text(payload.into())).is_err() {
+                state.pending.remove(&id);
+                return Err("browser extension disconnected before the request was sent".into());
+            }
+        }
+
+        match tokio::time::timeout(timeout, response_rx).await {
+            Ok(Ok(Ok(value))) => Ok(value),
+            Ok(Ok(Err(error))) => Err(error),
+            Ok(Err(_)) => Err("browser extension disconnected before returning a result".into()),
+            Err(_) => {
+                self.state.lock().await.pending.remove(&id);
+                Err(format!(
+                    "browser command timed out after {} ms",
+                    timeout.as_millis()
+                ))
+            }
+        }
+    }
+
+    async fn open_tab(&self, url: &str, active: bool) -> Result<Value, String> {
+        let code =
+            json!({ "cmd": "tabs", "method": "create", "url": url, "active": active }).to_string();
+        self.send_command(code, Duration::from_millis(DEFAULT_TIMEOUT_MS))
+            .await
+    }
+
     async fn tabs(&self) -> Result<Vec<BrowserTab>, String> {
         let state = self.state.lock().await;
         if let Some(error) = &state.startup_error {
@@ -742,6 +785,66 @@ impl Tool for WebExecuteJsTool {
     }
 }
 
+pub struct WebOpenTabTool {
+    bridge: Arc<BrowserBridge>,
+}
+
+impl WebOpenTabTool {
+    pub fn new(bridge: Arc<BrowserBridge>) -> Self {
+        Self { bridge }
+    }
+}
+
+#[async_trait]
+impl Tool for WebOpenTabTool {
+    fn name(&self) -> &str {
+        "web_open_tab"
+    }
+
+    fn schema(&self) -> ToolSchema {
+        ToolSchema::new(
+            self.name(),
+            "Open a new tab at an http(s) URL in the user's real, persistent Chrome/Chromium session. Works even when no tab is open yet, so use this to start browsing. The result includes the new tab id; pass it as switch_tab_id to web_scan or web_execute_js to act on the new tab.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "url": { "type": "string", "description": "Absolute http:// or https:// URL to open" },
+                    "active": { "type": "boolean", "description": "Focus the new tab (default false)" }
+                },
+                "required": ["url"]
+            }),
+        )
+    }
+
+    fn minimum_approval(&self) -> Approval {
+        Approval::Ask
+    }
+
+    fn preview(&self, args: &Value) -> String {
+        let url = args.get("url").and_then(Value::as_str).unwrap_or("");
+        format!("open real-browser tab at {url}")
+    }
+
+    async fn run(&self, args: &Value, _env: &dyn ToolEnv) -> ToolResult {
+        let Some(url) = args
+            .get("url")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|url| !url.is_empty())
+        else {
+            return ToolResult::fail("missing required argument 'url'");
+        };
+        if !(url.starts_with("http://") || url.starts_with("https://")) {
+            return ToolResult::fail("url must be an absolute http:// or https:// address");
+        }
+        let active = args.get("active").and_then(Value::as_bool).unwrap_or(false);
+        match self.bridge.open_tab(url, active).await {
+            Ok(tab) => ToolResult::ok(render_json(&json!({ "tab": tab }))),
+            Err(error) => ToolResult::fail(error),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -934,6 +1037,39 @@ mod tests {
         let result = running.await.unwrap().unwrap();
         assert_eq!(result.tab_id, 42);
         assert_eq!(result.value, "Example");
+    }
+
+    #[tokio::test]
+    async fn open_tab_creates_a_tab_without_any_existing_tab() {
+        let bridge = Arc::new(BrowserBridge::new(PathBuf::from("extension")));
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        bridge.install_client(1, tx).await;
+        // No tabs_update sent: state.tabs is empty, yet open_tab must still work.
+
+        let running = {
+            let bridge = bridge.clone();
+            tokio::spawn(async move { bridge.open_tab("https://example.com", true).await })
+        };
+        let outbound = rx.recv().await.unwrap().into_text().unwrap();
+        let outbound: Value = serde_json::from_str(&outbound).unwrap();
+        assert!(outbound.get("tabId").is_none());
+        let command: Value = serde_json::from_str(outbound["code"].as_str().unwrap()).unwrap();
+        assert_eq!(command["cmd"], "tabs");
+        assert_eq!(command["method"], "create");
+        assert_eq!(command["url"], "https://example.com");
+        assert_eq!(command["active"], true);
+
+        let id = outbound["id"].as_str().unwrap();
+        bridge
+            .handle_text(
+                1,
+                &json!({ "type": "result", "id": id, "result": { "id": 99, "url": "https://example.com" } })
+                    .to_string(),
+            )
+            .await;
+
+        let tab = running.await.unwrap().unwrap();
+        assert_eq!(tab["id"], 99);
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4015,6 +4015,9 @@ async fn send_message_inner(
         agent.add_tool(Box::new(browser_bridge::WebExecuteJsTool::new(
             state.browser_bridge.clone(),
         )));
+        agent.add_tool(Box::new(browser_bridge::WebOpenTabTool::new(
+            state.browser_bridge.clone(),
+        )));
         agent.add_tool(Box::new(run_context::RunInContextTool::new(
             state.store.clone(),
             state.run_manager.clone(),


### PR DESCRIPTION
## Problem

The real-browser bridge (#411) exposes `browser_setup`, `web_scan`, and `web_execute_js`, but the Agent has no way to open a new tab. The Manifest V3 extension already implements a `tabs create` command — nothing on the Rust side reaches it:

- no tool advertises tab creation, so the model never knows it can do it (`web_execute_js`'s schema only documents `cmd='cdp'`);
- `web_scan` / `web_execute_js` both go through `select_tab`, which errors with *"no HTTP(S) tabs are available"* when the profile has none open. A freshly opened Chrome (only `chrome://newtab`, filtered out) can therefore never open its first scriptable tab.

## Summary

- add `web_open_tab` (url, optional active) that returns the new tab id
- add `BrowserBridge::send_command` — a request channel that does **not** require or select an existing tab, so tab creation works from an empty profile
- validate the URL is absolute http(s); the tool is gated behind Wisp approval (`Approval::Ask`), like the other page tools
- returned tab id feeds `switch_tab_id` on later `web_scan` / `web_execute_js` calls

No changes to the browser extension — `tabs create` was already there.

## Tests

- `cargo fmt -p wisp-tauri -- --check`
- `cargo test -p wisp-tauri browser` — adds `open_tab_creates_a_tab_without_any_existing_tab`, which asserts the create command is sent with **no** `tabId` (the bootstrap case) and the new tab id is returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)