### PR TITLE
feat(notify): 点击任务完成通知跳转到对应会话 (#434)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2808,20 +2808,59 @@ fn app_has_focus() -> bool {
     !focused_windows().lock().unwrap().is_empty()
 }
 
+/// The `open-session` payload a window's most recent desktop notification was
+/// about, held until that window next gains focus — the user returning, usually
+/// by clicking the notification. Consumed once, then the window navigates to the
+/// session (#434). The desktop notification plugin has no click callback, so the
+/// focus that a click triggers is the signal we hang the navigation off of.
+fn pending_notify_targets() -> &'static StdMutex<HashMap<String, serde_json::Value>> {
+    static PENDING: std::sync::OnceLock<StdMutex<HashMap<String, serde_json::Value>>> =
+        std::sync::OnceLock::new();
+    PENDING.get_or_init(Default::default)
+}
+
+/// Remove and return a window's queued notification target, if any. Consuming it
+/// disarms the navigation so a later, unrelated focus does not re-trigger it.
+fn take_pending_notify_target(label: &str) -> Option<serde_json::Value> {
+    pending_notify_targets().lock().unwrap().remove(label)
+}
+
+/// If the focused window has a session queued from an earlier notification,
+/// navigate to it (once). Called on every `Focused(true)`.
+fn drain_pending_notify_target(window: &tauri::Window) {
+    if let Some(target) = take_pending_notify_target(window.label()) {
+        let _ = window.emit_to(window.label(), "open-session", target);
+    }
+}
+
 /// Desktop notification for task status (#327). No-op while any app window is
 /// focused (the in-app UI already shows the state) or when disabled in settings.
+/// Clicking the notification navigates to the session it was about (#434) —
+/// see `pending_notify_targets`.
 #[tauri::command]
 async fn notify_user(
-    app: tauri::AppHandle,
+    window: tauri::Window,
     state: State<'_, AppState>,
     title: String,
     body: String,
+    session_id: String,
 ) -> Result<(), String> {
     if app_has_focus() || !load_notifications_enabled(&state.store).await {
         return Ok(());
     }
+    // Arm click-to-open before showing: on this window's next focus it jumps to
+    // the session. Skipped if the session's project can't be resolved (the
+    // notification still shows, just without navigation).
+    if let Ok(Some(project_id)) = state.store.frame_project_id(&session_id).await {
+        pending_notify_targets().lock().unwrap().insert(
+            window.label().to_string(),
+            serde_json::json!({ "projectId": project_id, "sessionId": session_id }),
+        );
+    }
     use tauri_plugin_notification::NotificationExt;
-    app.notification()
+    window
+        .app_handle()
+        .notification()
         .builder()
         .title(title)
         .body(body)
@@ -7362,6 +7401,9 @@ pub fn run() {
         .on_window_event(|window, event| match event {
             tauri::WindowEvent::Focused(focused) => {
                 record_window_focus(window.label(), *focused);
+                if *focused {
+                    drain_pending_notify_target(window);
+                }
             }
             tauri::WindowEvent::Destroyed => record_window_focus(window.label(), false),
             _ => {}

--- a/src-tauri/src/lib_tests.rs
+++ b/src-tauri/src/lib_tests.rs
@@ -1132,6 +1132,18 @@ fn window_focus_tracking_survives_unordered_focus_handoff() {
     assert_reset();
 }
 
+// Click-to-open (#434): a notification arms one navigation for its window, and
+// the first focus consumes it — a second focus must not re-trigger.
+#[test]
+fn pending_notify_target_fires_once_per_window() {
+    super::pending_notify_targets()
+        .lock()
+        .unwrap()
+        .insert("proj-434".into(), serde_json::json!({ "sessionId": "s1" }));
+    assert!(super::take_pending_notify_target("proj-434").is_some());
+    assert!(super::take_pending_notify_target("proj-434").is_none());
+}
+
 // Queue (#433): the enqueue/driver protocol must (a) claim exactly one driver,
 // (b) drain FIFO, and (c) let a later enqueue re-claim after the queue empties —
 // otherwise an item enqueued just as the driver exits would strand with no runner.

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -1566,8 +1566,12 @@ fn App() -> impl IntoView {
         } else {
             format!("{session} · {detail}")
         };
+        let session_id = frame_id.to_string();
         spawn_local(async move {
-            let arg = to_value(&serde_json::json!({ "title": title, "body": body })).unwrap();
+            let arg = to_value(
+                &serde_json::json!({ "title": title, "body": body, "sessionId": session_id }),
+            )
+            .unwrap();
             let _ = invoke("notify_user", arg).await;
         });
     };


### PR DESCRIPTION
Closes #434

## 问题

后台会话跑完时会弹桌面通知，但点击通知只是让它消失——用户仍停留在当前打开的会话，不会跳到刚完成的那个会话。

## 方案

Tauri v2 桌面通知插件没有点击回调（用 `notify-rust` 同步捕获点击会阻塞主线程冻结 UI），所以改为挂在"点击通知 → 应用窗口重新获得焦点"这个信号上：

- `notify_user` 在弹通知前，用 `frame_project_id` 解析出会话所属项目，把 `open-session` 载荷按触发窗口的 label 暂存（`pending_notify_targets`）。
- 该窗口下次 `Focused(true)` 时消费一次，复用已有的 `open-session` 事件 `emit_to` 导航到会话，然后清除。
- 前端 `notify_desktop` 调用时多传一个 `sessionId`（即 `frame_id`）。

**消费一次**：暂存目标在首次聚焦后即清除，之后无关的聚焦不会再触发跳转。

## 复用的既有设施

- `open-session` 事件（#423 / 桌宠 `open_pet_session` 已在用的导航通道）
- `Focused` 窗口事件（原本只用来记录焦点状态）

## 测试

- 新增单测 `pending_notify_target_fires_once_per_window`：验证"武装一次、消费一次"语义。
- `cargo check -p wisp-tauri` 与 ui 的 `cargo check --target wasm32-unknown-unknown` 均通过。

## Reviewer 须知（已知取舍）

- **没有时间窗限制**：若用户忽略通知、稍后因别的原因点回该窗口，仍会跳一次到那个已完成会话。若有"跳到过期会话"的反馈再加时间窗。
- **多窗口边角**：通知只对触发它的窗口武装；若点击后聚焦的是另一个窗口则不跳（fail-safe，不会误跳）。单窗口场景正常。

🤖 Generated with [Claude Code](https://claude.com/claude-code)