### PR TITLE
fix(llm): detect mid-stream cuts instead of treating partial text as a finished turn

### DIFF
--- a/crates/wisp-core/src/agent.rs
+++ b/crates/wisp-core/src/agent.rs
@@ -18,6 +18,7 @@ use wisp_tools::{ImageData, Registry, ToolEnv};
 
 const RETRY_DELAYS: [u64; 3] = [1_000, 5_000, 10_000];
 const TRUNCATED_OUTPUT_MESSAGE: &str = "模型输出在达到 max_tokens 上限时被截断，任务可能尚未完成——请在设置中调高该模型的 max_tokens，或直接继续对话让我接着做。(output truncated at max_tokens)";
+const STREAM_CUT_MESSAGE: &str = "模型响应流在中途被断开（未收到结束标记），已生成的部分内容不完整、不会计入上下文。常见原因：网络不稳定、代理/中转站切断连接，或同一 API key 的并发请求达到上限（例如多个会话同时使用同一模型）。可重发消息重试；需要并行会话时建议错开请求或使用不同的 API key。(stream cut mid-response, #437)";
 /// How many byte-identical tool-call batches within the recent window count as
 /// "stuck". Windowed (not consecutive) so alternating A/B/A/B loops also trip it.
 const STUCK_REPEAT_LIMIT: usize = 5;
@@ -247,8 +248,14 @@ async fn agent_loop_inner(
             Some(c) => StreamSinkAdapter::with_cancel(output, c),
             None => StreamSinkAdapter::new(output),
         };
-        let comp =
-            stream_with_retry(provider, &messages, &tools.schemas(), &mut sink, cancel).await?;
+        let comp = match stream_with_retry(provider, &messages, &tools.schemas(), &mut sink, cancel)
+            .await
+        {
+            // ponytail: no auto-retry after a cut — re-streaming would duplicate the
+            // already-emitted deltas in the UI; add a sink reset event if this recurs.
+            Err(LlmError::Incomplete) => anyhow::bail!(STREAM_CUT_MESSAGE),
+            r => r?,
+        };
         if cancel.is_some_and(|c| c.load(Ordering::Relaxed)) {
             anyhow::bail!("stopped by user");
         }

--- a/crates/wisp-llm/src/anthropic.rs
+++ b/crates/wisp-llm/src/anthropic.rs
@@ -302,6 +302,7 @@ impl Provider for AnthropicProvider {
         let mut content = String::new();
         let mut finish_reason: Option<String> = None;
         let mut usage = Usage::default();
+        let mut saw_stop = false;
 
         while let Some(chunk) = stream.next().await {
             // Stop mid-generation: drop the stream and return the partial result
@@ -401,6 +402,9 @@ impl Provider for AnthropicProvider {
                             merge_usage(&mut usage, parse_usage(Some(u)));
                         }
                     }
+                    "message_stop" => {
+                        saw_stop = true;
+                    }
                     _ => {}
                 }
             }
@@ -421,6 +425,10 @@ impl Provider for AnthropicProvider {
             .collect();
 
         if content.is_empty() && tool_calls.is_empty() && finish_reason.is_none() {
+            return Err(LlmError::Incomplete);
+        }
+        if crate::provider::stream_was_cut(finish_reason.is_some() || saw_stop, sink.is_cancelled())
+        {
             return Err(LlmError::Incomplete);
         }
         Ok(Completion {

--- a/crates/wisp-llm/src/openai.rs
+++ b/crates/wisp-llm/src/openai.rs
@@ -369,6 +369,7 @@ impl Provider for OpenAiProvider {
             std::collections::BTreeMap::new();
         let mut finish_reason: Option<String> = None;
         let mut usage = Usage::default();
+        let mut saw_done = false;
 
         while let Some(chunk) = stream.next().await {
             // Stop mid-generation: drop the stream and return the partial result
@@ -383,7 +384,11 @@ impl Provider for OpenAiProvider {
                 buf.drain(..idx + 2);
                 for line in event.lines() {
                     let line = line.strip_prefix("data:").unwrap_or(line).trim();
-                    if line.is_empty() || line == "[DONE]" {
+                    if line == "[DONE]" {
+                        saw_done = true;
+                        continue;
+                    }
+                    if line.is_empty() {
                         continue;
                     }
                     let Ok(val) = serde_json::from_str::<Value>(line) else {
@@ -445,6 +450,10 @@ impl Provider for OpenAiProvider {
         ensure_named_tool_calls(&tool_calls_v)?;
 
         if content.is_empty() && tool_calls_v.is_empty() && finish_reason.is_none() {
+            return Err(LlmError::Incomplete);
+        }
+        if crate::provider::stream_was_cut(finish_reason.is_some() || saw_done, sink.is_cancelled())
+        {
             return Err(LlmError::Incomplete);
         }
 

--- a/crates/wisp-llm/src/provider.rs
+++ b/crates/wisp-llm/src/provider.rs
@@ -66,6 +66,15 @@ pub fn is_retriable(err: &LlmError) -> bool {
     }
 }
 
+/// A healthy SSE stream always delivers a terminal marker before closing: a
+/// `finish_reason`/`stop_reason` chunk, or at least OpenAI's `[DONE]` line. A
+/// stream that closes with neither — and was not cancelled by the user — was
+/// cut mid-response (network drop, proxy kill, per-key concurrency limit), so
+/// the partial text must not be mistaken for a finished answer (#437).
+pub fn stream_was_cut(saw_terminal: bool, cancelled: bool) -> bool {
+    !saw_terminal && !cancelled
+}
+
 /// Which provider family to build.
 #[derive(Debug, Clone)]
 pub enum ProviderKind {
@@ -257,5 +266,18 @@ mod tests {
     fn utf8_stream_matches_whole_input_for_ascii() {
         let mut s = Utf8Stream::default();
         assert_eq!(s.push(b"data: {\"x\":1}\n\n"), "data: {\"x\":1}\n\n");
+    }
+
+    // #437: a stream that closes without a terminal marker is a cut, EXCEPT
+    // when the user hit Stop — that must keep returning the partial (#58).
+    #[test]
+    fn stream_cut_detection_spares_user_cancel() {
+        assert!(stream_was_cut(false, false), "silent EOF is a cut");
+        assert!(
+            !stream_was_cut(true, false),
+            "finish_reason/[DONE] is a clean end"
+        );
+        assert!(!stream_was_cut(false, true), "user Stop is not a cut");
+        assert!(!stream_was_cut(true, true));
     }
 }


### PR DESCRIPTION
## Summary

Fixes #437 — 同一模型开两个会话时，其中一个输出半句话（如"我已经收集到完整的信息。让我为你整理一个清晰的回答。"）后直接终止，必须手动说"继续"。

Root cause: a stream that closed **without any terminal marker** (`finish_reason` / `stop_reason` / `[DONE]`) — e.g. a relay/proxy dropping the connection, or the provider's per-key concurrency limit killing one of two parallel streams — was returned as `Ok` with the partial text. The agent loop then hit its no-tool-call `break` and silently ended the turn mid-sentence, presenting the truncated text as a finished answer.

## Changes

- `wisp-llm/provider.rs`: new `stream_was_cut()` — no terminal marker + not user-cancelled ⇒ the stream was cut, not finished.
- `wisp-llm/openai.rs`: track `[DONE]`; a cut stream now returns `LlmError::Incomplete` instead of a bogus completion (this is the GLM path from the issue).
- `wisp-llm/anthropic.rs`: same, with `stop_reason` / `message_stop` as the terminal markers. (`responses.rs` delegates to the non-streaming call and is unaffected.)
- `wisp-core/agent.rs`: the loop maps `Incomplete` to a clear Chinese error naming the likely causes (network drop, relay cut, same-key concurrency limit) and the remedy, instead of stopping silently.

User Stop mid-stream keeps returning the partial result (#58 behavior unchanged, guarded by a unit test).

Deliberately **no auto-retry** after a cut: re-streaming would duplicate the already-emitted (and persisted) text deltas in the UI bubble; a sink-reset event is the prerequisite, left as a `ponytail:` note.

## Test plan

- `cargo test -p wisp-llm -p wisp-core` — 83 passed, including the new `stream_cut_detection_spares_user_cancel` truth-table test.
- Manual repro of the issue needs two concurrent sessions on a concurrency-limited GLM key; the cut now surfaces as an explicit error instead of a silent half-sentence stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7whhnDYAUoiiMC9ohLMZT