### PR TITLE
fix(agents): keep workflow panel and cards visible after session take-over

### DIFF
--- a/crates/wisp-store/src/sessions.rs
+++ b/crates/wisp-store/src/sessions.rs
@@ -307,6 +307,16 @@ impl Store {
         Ok(())
     }
 
+    pub async fn root_frame_id(&self, frame_id: &str) -> Result<Option<String>> {
+        Ok(sqlx::query_scalar::<_, Option<String>>(
+            "SELECT COALESCE(root_frame_id, id) FROM frames WHERE id=?",
+        )
+        .bind(frame_id)
+        .fetch_optional(&self.pool)
+        .await?
+        .flatten())
+    }
+
     pub async fn frame_model(&self, frame_id: &str) -> Result<Option<String>> {
         Ok(
             sqlx::query_scalar::<_, Option<String>>("SELECT model FROM frames WHERE id=?")

--- a/src-tauri/src/delegation_runtime.rs
+++ b/src-tauri/src/delegation_runtime.rs
@@ -198,6 +198,15 @@ async fn load_agent_workflow_snapshots(
         .await
         .map_err(|error| error.to_string())?;
     if let Some(session_id) = session_id {
+        // A taken-over delegation child frame must keep showing the workflows
+        // of the conversation that spawned it, which stay bound to the root
+        // frame (#442).
+        let session_id = store
+            .root_frame_id(session_id)
+            .await
+            .map_err(|error| error.to_string())?
+            .unwrap_or_else(|| session_id.to_string());
+        let session_id = session_id.as_str();
         let root_ids = workflows
             .iter()
             .filter(|workflow| workflow.depth == 0)
@@ -6352,6 +6361,43 @@ mod tests {
             .await
             .unwrap());
         (plan, registry, host)
+    }
+
+    #[tokio::test]
+    async fn snapshots_for_a_taken_over_child_frame_resolve_to_the_root_conversation() {
+        let (store, _root) = dynamic_fixture().await;
+        let (registry, host) = test_dynamic_policy();
+        let plan = dynamic_workflow::resolve_proposal(
+            &store,
+            "takeover-workflow".into(),
+            dynamic_proposal(vec![dynamic_task("interpret", &[])]),
+            &registry,
+            &host,
+            None,
+        )
+        .await
+        .unwrap();
+        let (workflow, steps) = workflow_records(
+            &plan,
+            "p",
+            std::path::Path::new("workspace"),
+            Some("f".into()),
+        )
+        .unwrap();
+        store
+            .create_agent_workflow_plan(&workflow, &steps)
+            .await
+            .unwrap();
+        store
+            .create_child_frame("agent-child", "f", "p", "Task agent", "local")
+            .await
+            .unwrap();
+
+        let from_child = load_agent_workflow_snapshots(&store, "p", Some("agent-child"))
+            .await
+            .unwrap();
+        assert_eq!(from_child.len(), 1);
+        assert_eq!(from_child[0].workflow.id, plan.id);
     }
 
     #[tokio::test]

--- a/ui/src/agent_workflows.rs
+++ b/ui/src/agent_workflows.rs
@@ -406,7 +406,21 @@ fn group_workflows(
                 .then_with(|| left.workflow.id.cmp(&right.workflow.id))
         });
     }
-    groups.retain(|group| Some(group.frame_id.as_str()) == session_id);
+    // A taken-over child frame still belongs to the group that spawned it (#442).
+    groups.retain(|group| {
+        let Some(session_id) = session_id else {
+            return false;
+        };
+        group.frame_id == session_id
+            || group.snapshots.iter().any(|snapshot| {
+                snapshot.dynamic.tasks.iter().any(|task| {
+                    task.result
+                        .as_ref()
+                        .and_then(|result| result.child_frame_id.as_deref())
+                        == Some(session_id)
+                })
+            })
+    });
     groups
 }
 
@@ -1380,6 +1394,81 @@ mod tests {
             .tasks
             .iter()
             .all(|task| task.specialist_id.is_none()));
+    }
+
+    #[test]
+    fn taken_over_child_frame_keeps_its_root_group() {
+        let snapshot: AgentWorkflowSnapshot = serde_json::from_value(serde_json::json!({
+            "workflow": {
+                "id": "wf-1",
+                "frame_id": "parent-frame",
+                "root_workflow_id": "",
+                "depth": 0,
+                "name": "Workflow",
+                "goal": "g",
+                "mode": "manual",
+                "status": "running",
+                "max_parallel": 1,
+                "requires_confirmation": true,
+                "version": 1,
+                "updated_at": 0
+            },
+            "delegation_enabled": true,
+            "dynamic": {
+                "schema_version": 1,
+                "approval_policy": "review_all",
+                "editable_proposal": {
+                    "goal": "g",
+                    "context": "",
+                    "approval_policy": "review_all",
+                    "tasks": []
+                },
+                "approval_reasons": [],
+                "tasks": [{
+                    "id": "task_1",
+                    "stored_step_id": "step-1",
+                    "instruction": "do",
+                    "depends_on": [],
+                    "capabilities": [],
+                    "specialist_id": null,
+                    "specialist_name": null,
+                    "executor": {"kind": "native", "profile_id": null, "model_id": null},
+                    "workspace_policy": "shared",
+                    "merge_policy": "manual",
+                    "tools": [],
+                    "can_write": false,
+                    "can_execute": false,
+                    "can_access_network": false,
+                    "budget": {
+                        "max_tokens": null,
+                        "max_tool_calls": null,
+                        "max_cost_microunits": null
+                    },
+                    "timeout_secs": null,
+                    "approval_reasons": [],
+                    "output_schema": null,
+                    "result": {
+                        "status": "running",
+                        "summary": null,
+                        "error": null,
+                        "child_frame_id": "agent-child",
+                        "input_tokens": 0,
+                        "output_tokens": 0,
+                        "tool_calls": 0,
+                        "cost_microunits": 0,
+                        "duration_secs": null,
+                        "full_result_available": false
+                    }
+                }]
+            }
+        }))
+        .expect("snapshot fixture deserializes");
+
+        let parent = group_workflows(vec![snapshot.clone()], &[], Some("parent-frame"));
+        assert_eq!(parent.len(), 1);
+        let taken_over = group_workflows(vec![snapshot.clone()], &[], Some("agent-child"));
+        assert_eq!(taken_over.len(), 1);
+        assert!(group_workflows(vec![snapshot], &[], Some("unrelated")).is_empty());
     }
 
     #[test]

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -3958,6 +3958,14 @@ fn App() -> impl IntoView {
     });
     let refresh_agent_sessions = Callback::new(move |_: ()| refresh_session_history());
 
+    // Take-over from the Agents panel: load_session flips the right pane to
+    // Artifacts for the generic session-switch path, which made the panel (and
+    // the workflow being inspected) vanish mid-click (#442).
+    let takeover_session = Callback::new(move |id: String| {
+        load_session.call(id);
+        right_tab.set(RightTab::Agents);
+    });
+
     let load_earlier_messages = Callback::new(move |_: ()| {
         let Some(id) = active_session.get_untracked() else {
             return;
@@ -8914,7 +8922,7 @@ fn App() -> impl IntoView {
                             sessions,
                             delegation_enabled,
                             locale,
-                            load_session.clone(),
+                            takeover_session.clone(),
                             refresh_agent_sessions.clone(),
                         ).into_view(),
                         RightTab::Notebook => {


### PR DESCRIPTION
## Summary

Fixes #442 (the bug half: "接管会话后 agent 内容全部消失、会话内容截断").

Taking over a delegated child frame made the Agents panel appear to lose everything. Three causes, one per change:

- **Backend filter**: `list_agent_workflows` matched workflows against the viewed session id exactly, but workflows stay bound to the root conversation frame — so viewing a taken-over child frame (`agent-*`) returned an empty list. Now the session id is resolved to its root frame first (new `Store::root_frame_id`; child frames record `root_frame_id` at creation).
- **Frontend group filter**: `group_workflows` had the same exact-match retain as a stale-state guard. It now also keeps a group when any task result's `child_frame_id` equals the viewed session.
- **Take-over button**: it reused the generic session-switch callback, which flips the right pane to Artifacts — the panel (and the workflow being inspected) vanished the moment you clicked. Take-over now restores the Agents tab after switching.

No session content was ever lost or truncated: take-over only retargets the viewed transcript to the child frame and never cancels a running turn; the parent conversation remains reachable from the session list.

## Test plan

- New backend test `snapshots_for_a_taken_over_child_frame_resolve_to_the_root_conversation`: workflow bound to parent frame is returned when listing by the child frame id.
- New UI test `taken_over_child_frame_keeps_its_root_group`: group retained for both parent and child frame ids, dropped for unrelated ids.
- `cargo test -p wisp-tauri delegation` (71 passed), `cargo test -p wisp-store` (62 passed), `cargo test` in `ui/` (103 passed), `cargo check --target wasm32-unknown-unknown` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lu3ptQKSTKNKPq8SfGABbo