### PR TITLE
fix: make SSH exploration and local downloads reliable

### DIFF
--- a/crates/wisp-core/src/context.rs
+++ b/crates/wisp-core/src/context.rs
@@ -56,6 +56,11 @@ pub struct ContextManager {
     /// Set once the warning fired; reset when back under the threshold.
     warned: bool,
     pub runtime_injections: Vec<Message>,
+    /// Persisted prefix and ephemeral messages used by the latest model call.
+    /// Keeping only the prefix length avoids cloning the full conversation on
+    /// every agent-loop iteration.
+    last_request_message_count: Option<usize>,
+    last_request_runtime_injections: Vec<Message>,
 }
 
 impl ContextManager {
@@ -66,6 +71,8 @@ impl ContextManager {
             warn_threshold: (max_context as f64 * 0.8) as usize,
             warned: false,
             runtime_injections: vec![],
+            last_request_message_count: None,
+            last_request_runtime_injections: vec![],
         }
     }
 
@@ -77,6 +84,7 @@ impl ContextManager {
     }
     pub fn clear(&mut self) {
         self.messages.clear();
+        self.invalidate_last_request();
     }
 
     pub fn append_system(&mut self, content: impl Into<String>) {
@@ -95,6 +103,24 @@ impl ContextManager {
     }
     pub fn clear_runtime_injections(&mut self) {
         self.runtime_injections.clear();
+    }
+
+    fn invalidate_last_request(&mut self) {
+        self.last_request_message_count = None;
+        self.last_request_runtime_injections.clear();
+    }
+
+    /// Reconstruct the provider-agnostic messages prepared for the latest
+    /// model call, even after runtime injections were cleared and the model
+    /// response was appended to persisted history.
+    pub fn last_request(&self) -> Option<Vec<Message>> {
+        let count = self.last_request_message_count?;
+        if count > self.messages.len() {
+            return None;
+        }
+        let mut messages = self.messages[..count].to_vec();
+        messages.extend(self.last_request_runtime_injections.iter().cloned());
+        Some(messages)
     }
 
     pub fn append_assistant(
@@ -129,6 +155,7 @@ impl ContextManager {
     }
 
     pub fn load(&mut self, path: &Path) {
+        self.invalidate_last_request();
         match std::fs::read_to_string(path) {
             Ok(s) => match serde_json::from_str::<Vec<Message>>(&s) {
                 Ok(v) => self.messages = v,
@@ -462,6 +489,7 @@ work in progress. Use this structure:
         provider: &dyn Provider,
         archive_path: &Path,
     ) -> Result<(usize, usize), String> {
+        self.invalidate_last_request();
         let before = self.total_tokens();
         self.save(archive_path);
         if !archive_path.is_file() {
@@ -512,6 +540,9 @@ work in progress. Use this structure:
             self.warned = true;
             output.context_warning(total, self.max_context);
         }
+        self.last_request_message_count = Some(self.messages.len());
+        self.last_request_runtime_injections
+            .clone_from(&self.runtime_injections);
         if self.runtime_injections.is_empty() {
             std::borrow::Cow::Borrowed(&self.messages)
         } else {
@@ -762,6 +793,30 @@ mod tests {
         ctx.append_user("y".repeat(4_000));
         ctx.prepare_for_api(&counter);
         assert_eq!(counter.0.load(std::sync::atomic::Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn last_request_preserves_cleared_injections_and_excludes_the_response() {
+        let counter = WarnCounter(std::sync::atomic::AtomicUsize::new(0));
+        let mut ctx = ContextManager::new(100_000);
+        ctx.append_system("system");
+        ctx.append_user("question");
+        ctx.inject_user("runtime compute context");
+
+        let prepared = ctx.prepare_for_api(&counter).into_owned();
+        ctx.append_assistant("answer".into(), vec![], None);
+        ctx.clear_runtime_injections();
+
+        let captured = ctx.last_request().expect("last request");
+        assert_eq!(
+            serde_json::to_string(&captured).unwrap(),
+            serde_json::to_string(&prepared).unwrap()
+        );
+        assert_eq!(captured.len(), 3);
+        assert_eq!(captured[2].content.as_text(), "runtime compute context");
+        assert!(!captured
+            .iter()
+            .any(|message| message.content.as_text() == "answer"));
     }
 
     #[test]

--- a/crates/wisp-store/src/sessions.rs
+++ b/crates/wisp-store/src/sessions.rs
@@ -796,7 +796,12 @@ impl Store {
             let folder_id: Option<String> = row.try_get("folder_id")?;
             let custom_title: Option<String> = row.try_get("custom_title")?;
             let first_user: Option<String> = row.try_get("first_user")?;
-            out.push((id, session_display_title(custom_title, first_user), created, folder_id));
+            out.push((
+                id,
+                session_display_title(custom_title, first_user),
+                created,
+                folder_id,
+            ));
         }
         Ok(out)
     }

--- a/crates/wisp-store/src/store_tests.rs
+++ b/crates/wisp-store/src/store_tests.rs
@@ -981,7 +981,10 @@ async fn pinned_sessions_are_listed_separately_and_toggle() {
 
     store.set_session_pinned("a", "p", true).await.unwrap();
     let pinned = store.list_pinned_sessions("p").await.unwrap();
-    assert_eq!(pinned.iter().map(|r| r.0.as_str()).collect::<Vec<_>>(), ["a"]);
+    assert_eq!(
+        pinned.iter().map(|r| r.0.as_str()).collect::<Vec<_>>(),
+        ["a"]
+    );
     // The full listing still contains every session, pinned or not.
     assert_eq!(store.list_sessions("p").await.unwrap().len(), 3);
 
@@ -989,7 +992,10 @@ async fn pinned_sessions_are_listed_separately_and_toggle() {
     assert!(store.list_pinned_sessions("p").await.unwrap().is_empty());
 
     // Pinning a missing session is an error, not a silent no-op.
-    assert!(store.set_session_pinned("missing", "p", true).await.is_err());
+    assert!(store
+        .set_session_pinned("missing", "p", true)
+        .await
+        .is_err());
     let _ = std::fs::remove_file(&tmp);
 }
 

--- a/crates/wisp-tools/src/plan.rs
+++ b/crates/wisp-tools/src/plan.rs
@@ -131,7 +131,8 @@ impl Tool for UpdatePlanTool {
              every call — it replaces the previous plan, it is not a delta. Reach for it only when the \
              work is genuinely multi-stage (several analyses to sequence, long compute, a pipeline worth \
              showing the user); skip it for lookups, a single computation, or reading one file. Keep at \
-             most one step 'in_progress' at a time.",
+             most one step 'in_progress' at a time. A failed or cancelled tool call does not complete its \
+             related step; keep that step in_progress/pending or revise the plan.",
             json!({
                 "type": "object",
                 "properties": {

--- a/docs/server-transfers.md
+++ b/docs/server-transfers.md
@@ -1,8 +1,9 @@
-# Transfers between SSH contexts
+# Transfers from SSH contexts
 
-Wisp transfers one exact file or directory between two registered, probed SSH
-execution contexts. Agent-generated free-form `ssh`, `scp`, and
-`rsync -e ssh` commands remain disabled.
+Wisp transfers one exact file or directory from a registered, probed SSH
+execution context either to another SSH context or to the local machine.
+Agent-generated free-form `ssh`, `scp`, and `rsync -e ssh` commands remain
+disabled.
 
 ## Routes
 
@@ -15,8 +16,22 @@ execution contexts. Agent-generated free-form `ssh`, `scp`, and
   then uploads with B's separately configured credentials. The temporary
   directory is removed after success, failure, or cancellation.
 
-The source and destination paths must be exact absolute or `~/` paths. Globs
-and filesystem/home roots are rejected. Neither route adds `--delete`.
+For SSH-to-SSH transfers, the source and destination paths must be exact
+absolute or `~/` paths. Globs and filesystem/home roots are rejected. Neither
+route adds `--delete`.
+
+## Download to the local machine
+
+Set `destination_context_id` to `local` and provide the exact new absolute
+local file or directory path. If the user has not chosen that path, ask before
+calling the tool. Local downloads accept `route=auto|relay` and
+`transport=auto|scp`.
+
+Wisp authenticates through the selected source context once and downloads with
+scp into a private staging directory beside the destination. After a complete
+download, it renames the staged item to the requested path. Existing
+destinations are rejected and partial downloads are removed after failure,
+cancellation, or timeout.
 
 ## User-approved trust
 
@@ -40,6 +55,7 @@ themselves; it does not generate or copy a key.
 ## Current limitations
 
 - Direct rsync is resumable at rsync's file-transfer level; scp relay is not.
+- SSH-to-local downloads use scp and are not resumable yet.
 - Relay temporarily needs local free space approximately equal to the source.
 - scp recursive copies follow symlinks according to the installed OpenSSH
   implementation.

--- a/skills/remote-compute-ssh/SKILL.md
+++ b/skills/remote-compute-ssh/SKILL.md
@@ -16,7 +16,8 @@ or Wisp restarts.
 
 1. Use short `run_in_context` calls for read-only discovery such as
    `nvidia-smi -L`, `which python3`, or `module avail`. Free-form shell SSH is
-   disabled.
+   disabled. Use the interpreter path reported by the context probe; do not
+   assume a `python` alias exists when the probe found `python3`.
 2. Put the real command in one `run_in_context` call. Include environment
    activation in the command so the Run is reproducible.
 3. To watch the Run or wait for later work, call `monitor_run` exactly once with
@@ -59,6 +60,11 @@ script by basename. Upload progress, throughput, and ETA appear in the Run card.
 the server, reference its absolute remote path in `command`; do not copy it
 back to the laptop just to send it out again.
 
+A remote command or application exiting non-zero is normal exploration after a
+successful login. Read stderr, correct the command from the probed
+capabilities, and continue. Stop only when SSH rejects authentication or host
+trust; do not repeat a rejected login with guessed credentials or SSH options.
+
 The control directory is `~/.wisp-science/runs/<run-id>` and the command starts
 in its `inputs/` subdirectory. stdout and stderr are
 tailed into the Run record. The SSH supervisor requires `setsid`, GNU-compatible
@@ -89,10 +95,17 @@ For a small result that must become local, wait until the Run is terminal,
 then transfer it as a separate quick operation and register the local file.
 Large outputs should remain remote references.
 
-## Transfers between SSH contexts
+## Transfers from SSH contexts
 
-Use `transfer_between_contexts` for one exact remote file or directory. Never
-compose nested `ssh`, `scp`, or `rsync -e ssh` inside `run_in_context`.
+Use `transfer_between_contexts` for one exact remote file or directory. The
+destination may be another selected SSH context or `local`. Never compose
+nested `ssh`, `scp`, or `rsync -e ssh` inside `run_in_context`.
+
+For a local download, set `destination_context_id` to `local` and provide the
+exact new absolute local path. Ask the user when that path is unspecified.
+Wisp stages the item beside the destination, never overwrites an existing
+path, and removes partial staging data after failure or cancellation. Call
+`monitor_run` once with the returned Run id.
 
 When the user approves persistent A→B trust, call `configure_ssh_trust` first.
 It creates a dedicated key on A, carries only the public key through Wisp,

--- a/src-tauri/src/debug_request.rs
+++ b/src-tauri/src/debug_request.rs
@@ -3,11 +3,12 @@
 //! Answers two transparency questions users can't otherwise see: how large the
 //! built-in system prompt is, and whether an uploaded file's contents were
 //! inlined into the request (vs. read by a tool). It serializes the exact
-//! provider-agnostic request — system prompt + full message history + runtime
-//! injections + tool schemas — with a per-section token/char breakdown.
+//! provider-agnostic request — the persisted prefix and runtime injections used
+//! by the latest model call, plus tool schemas — with a per-section token/char
+//! breakdown. The subsequent assistant response is intentionally excluded.
 //!
 //! Preferred source is the live `Agent` cached in `SessionRuntime` (highest
-//! fidelity: tools + provider/model + post-compaction context). When no agent
+//! fidelity: tools + provider/model + latest prepared request). When no agent
 //! is resident (never run this launch) or a turn holds the lock, it falls back
 //! to the persisted messages, which still carry the system prompt (message[0])
 //! and any inlined file content.
@@ -166,15 +167,18 @@ pub(super) async fn export_debug_request(
 
     let captured_at = chrono::Utc::now().to_rfc3339();
 
-    // Prefer the live agent (tools + provider + post-compaction context). Use a
+    // Prefer the live agent (tools + provider + latest prepared request). Use a
     // non-blocking try_lock so an in-flight turn falls back to persisted
     // messages instead of stalling the export behind a long turn.
     let rt = { state.sessions.lock().await.get(&session_id).cloned() };
     let live = rt.as_ref().and_then(|rt| {
         rt.agent.try_lock().ok().and_then(|guard| {
             guard.as_ref().map(|agent| {
-                let mut msgs: Vec<Message> = agent.ctx.messages.clone();
-                msgs.extend(agent.ctx.runtime_injections.iter().cloned());
+                let msgs = agent.ctx.last_request().unwrap_or_else(|| {
+                    let mut messages: Vec<Message> = agent.ctx.messages.clone();
+                    messages.extend(agent.ctx.runtime_injections.iter().cloned());
+                    messages
+                });
                 build_snapshot(
                     &session_id,
                     captured_at.clone(),

--- a/src-tauri/src/file_browser.rs
+++ b/src-tauri/src/file_browser.rs
@@ -658,7 +658,7 @@ fn list_remote_dir_with_runner(
     let output = match runner.run(&command) {
         Ok(output) => output,
         Err(error) => {
-            if crate::ssh_guard::is_connectivity_failure(&error) {
+            if crate::ssh_guard::is_authentication_failure(&error) {
                 crate::ssh_guard::record_failure(&context.id, &error);
             }
             return Err(error);
@@ -674,7 +674,7 @@ fn list_remote_dir_with_runner(
             "Remote directory request failed (exit {}): {detail}",
             output.status
         );
-        if crate::ssh_guard::is_connectivity_failure(&error) {
+        if crate::ssh_guard::is_authentication_failure(&error) {
             crate::ssh_guard::record_failure(&context.id, &error);
         }
         return Err(error);
@@ -736,7 +736,7 @@ fn read_remote_file_bytes_with_runner(
     let output = match runner.run(&command) {
         Ok(output) => output,
         Err(error) => {
-            if crate::ssh_guard::is_connectivity_failure(&error) {
+            if crate::ssh_guard::is_authentication_failure(&error) {
                 crate::ssh_guard::record_failure(&context.id, &error);
             }
             return Err(error);
@@ -752,7 +752,7 @@ fn read_remote_file_bytes_with_runner(
             "Remote file request failed (exit {}): {detail}",
             output.status
         );
-        if crate::ssh_guard::is_connectivity_failure(&error) {
+        if crate::ssh_guard::is_authentication_failure(&error) {
             crate::ssh_guard::record_failure(&context.id, &error);
         }
         return Err(error);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5610,14 +5610,17 @@ async fn list_sessions_page(
             folder_id,
         })
         .collect();
-    items.extend(rows.into_iter().map(|(id, title, ts, folder_id)| SessionInfo {
-        running: running.contains(&id),
-        pinned: pinned_ids.contains(&id),
-        id,
-        title,
-        ts,
-        folder_id,
-    }));
+    items.extend(
+        rows.into_iter()
+            .map(|(id, title, ts, folder_id)| SessionInfo {
+                running: running.contains(&id),
+                pinned: pinned_ids.contains(&id),
+                id,
+                title,
+                ts,
+                folder_id,
+            }),
+    );
     Ok(SessionPage {
         items,
         next_cursor,

--- a/src-tauri/src/run_context.rs
+++ b/src-tauri/src/run_context.rs
@@ -168,12 +168,12 @@ fn record_ssh_runner_outcome(context_id: &str, result: &Result<RunCommandOutput,
             } else {
                 output.stderr.trim()
             };
-            if crate::ssh_guard::is_connectivity_failure(detail) {
+            if crate::ssh_guard::is_authentication_failure(detail) {
                 crate::ssh_guard::record_failure(context_id, detail);
             }
         }
         Err(error) => {
-            if crate::ssh_guard::is_connectivity_failure(error) {
+            if crate::ssh_guard::is_authentication_failure(error) {
                 crate::ssh_guard::record_failure(context_id, error);
             }
         }

--- a/src-tauri/src/run_context/remote.rs
+++ b/src-tauri/src/run_context/remote.rs
@@ -868,6 +868,7 @@ pub(super) fn permanent_remote_start_error(error: &str) -> bool {
         "no route to host",
         "network is unreachable",
         "kex_exchange_identification",
+        "ssh authentication gate blocked",
         "ssh connectivity gate blocked",
     ]
     .iter()

--- a/src-tauri/src/run_context/tests.rs
+++ b/src-tauri/src/run_context/tests.rs
@@ -147,6 +147,47 @@ async fn run_in_context_can_suspend_until_terminal_without_get_run_calls() {
 }
 
 #[tokio::test]
+async fn run_in_context_wait_reports_a_failed_run_as_a_failed_tool_call() {
+    use wisp_tools::Tool;
+    let tmp = std::env::temp_dir().join(format!("wisp_run_wait_fail_{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&tmp).unwrap();
+    let store = wisp_store::Store::open(&tmp.join("wisp.sqlite"))
+        .await
+        .unwrap();
+    store
+        .create_project("p", "project", &tmp.to_string_lossy())
+        .await
+        .unwrap();
+    let manager = RunManager::with_runner(Arc::new(FakeRunRunner {
+        output: Ok(RunCommandOutput {
+            exit_code: 127,
+            stdout: String::new(),
+            stderr: "python: command not found".into(),
+        }),
+    }));
+    let tool = RunInContextTool::new(store, manager, "p".into(), None);
+    let result = tool
+        .run(
+            &serde_json::json!({
+                "context_id": "local",
+                "command": "python -c pass",
+                "wait_for_completion": true
+            }),
+            &RunToolTestEnv(tmp.clone()),
+        )
+        .await;
+
+    assert!(
+        !result.success,
+        "failed Run must not render as a green tool call"
+    );
+    let run: wisp_store::RunRecord = serde_json::from_str(&result.content).unwrap();
+    assert_eq!(run.status, wisp_store::RunStatus::Failed);
+    assert_eq!(run.exit_code, Some(127));
+    let _ = std::fs::remove_dir_all(tmp);
+}
+
+#[tokio::test]
 async fn run_in_context_rejects_nested_ssh_transfer_commands() {
     use wisp_tools::Tool;
     let tmp = std::env::temp_dir().join(format!("wisp_run_ssh_guard_{}", uuid::Uuid::new_v4()));
@@ -1198,7 +1239,7 @@ fn permanent_remote_start_errors_require_user_intervention() {
         "SSH launch failed: connection timed out"
     ));
     assert!(permanent_remote_start_error(
-        "SSH connectivity gate blocked for `ssh:gpu` after a previous failure"
+        "SSH authentication gate blocked for `ssh:gpu` after a previous failure"
     ));
 }
 

--- a/src-tauri/src/run_context/tools.rs
+++ b/src-tauri/src/run_context/tools.rs
@@ -275,11 +275,17 @@ async fn wait_for_terminal(
 }
 
 fn run_wait_result(run: wisp_store::RunRecord, detached: bool) -> ToolResult {
+    let succeeded = run.status == wisp_store::RunStatus::Succeeded;
     let mut value = serde_json::to_value(run).unwrap_or_default();
     if detached {
         value["wait_detached"] = serde_json::Value::Bool(true);
     }
-    ToolResult::ok(value.to_string())
+    let content = value.to_string();
+    if detached || succeeded {
+        ToolResult::ok(content)
+    } else {
+        ToolResult::fail(content)
+    }
 }
 
 pub struct CancelRunTool {

--- a/src-tauri/src/run_context/transfer.rs
+++ b/src-tauri/src/run_context/transfer.rs
@@ -173,16 +173,16 @@ impl Tool for TransferBetweenContextsTool {
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(
             self.name(),
-            "Transfer one exact file or directory between two selected SSH contexts as a persisted Run. `auto` uses a verified direct edge when available (rsync with scp fallback), otherwise it relays through a private local temporary directory using each context's configured credentials. Never use shell ssh/scp/rsync for this.",
+            "Transfer one exact file or directory from a selected SSH context to another selected SSH context or to `local` as a persisted Run. SSH-to-SSH `auto` uses a verified direct edge when available (rsync with scp fallback), otherwise it relays through a private local temporary directory. SSH-to-local downloads with the source context's configured credentials to an exact new absolute local path and never overwrites an existing item. Never use shell ssh/scp/rsync for this.",
             serde_json::json!({
                 "type": "object",
                 "properties": {
-                    "source_context_id": { "type": "string" },
+                    "source_context_id": { "type": "string", "description": "Selected SSH context id" },
                     "source_path": { "type": "string", "description": "Exact absolute or ~/ source path; globs are rejected" },
-                    "destination_context_id": { "type": "string" },
-                    "destination_path": { "type": "string", "description": "Exact absolute or ~/ destination path; globs are rejected" },
-                    "route": { "type": "string", "enum": ["auto", "direct", "relay"], "default": "auto" },
-                    "transport": { "type": "string", "enum": ["auto", "rsync", "scp"], "default": "auto" },
+                    "destination_context_id": { "type": "string", "description": "Selected SSH context id, or `local` for a download" },
+                    "destination_path": { "type": "string", "description": "SSH: exact absolute or ~/ path. Local: exact new absolute file/directory path; do not guess it—ask the user when unspecified. Globs are rejected." },
+                    "route": { "type": "string", "enum": ["auto", "direct", "relay"], "default": "auto", "description": "direct/relay apply to SSH-to-SSH; local accepts auto or relay" },
+                    "transport": { "type": "string", "enum": ["auto", "rsync", "scp"], "default": "auto", "description": "SSH-to-local accepts auto or scp" },
                     "timeout_secs": { "type": "integer", "description": "Wall timeout, 1 second to 7 days" }
                 },
                 "required": ["source_context_id", "source_path", "destination_context_id", "destination_path"]
@@ -532,6 +532,39 @@ fn validate_remote_path(label: &str, path: &str) -> Result<(), String> {
     Ok(())
 }
 
+fn validate_local_destination(path: &str) -> Result<PathBuf, String> {
+    if path.is_empty()
+        || path.contains(['\0', '\n', '\r'])
+        || path.contains(['*', '?', '[', ']', '{', '}'])
+    {
+        return Err(
+            "destination_path must be one exact local path without control characters or globs"
+                .into(),
+        );
+    }
+    let destination = PathBuf::from(path);
+    if !destination.is_absolute() || destination.file_name().is_none() {
+        return Err("local destination_path must be an absolute non-root path".into());
+    }
+    if destination.exists() {
+        return Err(format!(
+            "local destination_path already exists: {}",
+            destination.display()
+        ));
+    }
+    Ok(destination)
+}
+
+fn remote_item_name(path: &str) -> Result<&str, String> {
+    let name = path
+        .trim_end_matches('/')
+        .rsplit('/')
+        .next()
+        .filter(|name| !name.is_empty() && !matches!(*name, "." | ".."))
+        .ok_or_else(|| "source_path must name one file or directory".to_string())?;
+    Ok(name)
+}
+
 async fn submit_transfer(
     store: &wisp_store::Store,
     manager: &RunManager,
@@ -540,11 +573,7 @@ async fn submit_transfer(
     project_root: &Path,
     request: TransferRequest,
 ) -> Result<serde_json::Value, String> {
-    if request.source_context_id == request.destination_context_id {
-        return Err("Source and destination SSH contexts must be different".into());
-    }
     validate_remote_path("source_path", &request.source_path)?;
-    validate_remote_path("destination_path", &request.destination_path)?;
     if !matches!(request.route.as_str(), "auto" | "direct" | "relay") {
         return Err("route must be 'auto', 'direct', or 'relay'".into());
     }
@@ -552,6 +581,44 @@ async fn submit_transfer(
         return Err("transport must be 'auto', 'rsync', or 'scp'".into());
     }
     let source = selected_ssh_context(store, frame_id, &request.source_context_id).await?;
+    let timeout_secs = request
+        .timeout_secs
+        .unwrap_or(4 * 60 * 60)
+        .clamp(1, 7 * 24 * 60 * 60);
+
+    if request.destination_context_id == "local" {
+        if request.route == "direct" {
+            return Err("SSH-to-local transfers use route=auto or route=relay".into());
+        }
+        if request.transport == "rsync" {
+            return Err("SSH-to-local transfers use transport=auto or transport=scp".into());
+        }
+        let destination = validate_local_destination(&request.destination_path)?;
+        let response = manager
+            .submit_ssh_download_to_local(
+                store.clone(),
+                project_id,
+                frame_id,
+                &source,
+                &request.source_path,
+                &destination,
+                Duration::from_secs(timeout_secs),
+            )
+            .await?;
+        return Ok(serde_json::json!({
+            "run_id": response.run_id,
+            "status": response.status,
+            "route": "local",
+            "transport": "scp",
+            "destination_path": destination,
+            "next_action": "Call monitor_run exactly once to wait for completion."
+        }));
+    }
+
+    if request.source_context_id == request.destination_context_id {
+        return Err("Source and destination SSH contexts must be different".into());
+    }
+    validate_remote_path("destination_path", &request.destination_path)?;
     let destination =
         selected_ssh_context(store, frame_id, &request.destination_context_id).await?;
     let destination_connection =
@@ -604,11 +671,6 @@ async fn submit_transfer(
         _ if edge.is_some() => "direct",
         _ => "relay",
     };
-    let timeout_secs = request
-        .timeout_secs
-        .unwrap_or(4 * 60 * 60)
-        .clamp(1, 7 * 24 * 60 * 60);
-
     let response = if route == "direct" {
         let edge = edge.expect("direct route requires edge");
         let command = direct_transfer_script(
@@ -731,6 +793,131 @@ fi
 
 impl RunManager {
     #[allow(clippy::too_many_arguments)]
+    async fn submit_ssh_download_to_local(
+        &self,
+        store: wisp_store::Store,
+        project_id: &str,
+        frame_id: Option<&str>,
+        source: &wisp_store::ExecutionContext,
+        source_path: &str,
+        destination_path: &Path,
+        timeout: Duration,
+    ) -> Result<SubmitRunResponse, String> {
+        if destination_path.exists() {
+            return Err(format!(
+                "local destination_path already exists: {}",
+                destination_path.display()
+            ));
+        }
+        let destination_parent = destination_path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+            .ok_or_else(|| "local destination_path must have a parent directory".to_string())?;
+        std::fs::create_dir_all(destination_parent)
+            .map_err(|error| format!("create local destination directory: {error}"))?;
+
+        let source_connection = crate::ssh_hosts::SshConnection::from_execution_context(source)?;
+        let item_name = remote_item_name(source_path)?.to_string();
+        let run_id = uuid::Uuid::new_v4().to_string();
+        let staging_dir = RelayTempDir::new_in(destination_parent, &run_id)?;
+        let started = Instant::now();
+        let mut run = wisp_store::RunRecord::new(
+            &run_id,
+            project_id,
+            &source.id,
+            format!("Download {item_name} from {}", source.label),
+            "file_transfer",
+        );
+        run.frame_id = frame_id.map(Into::into);
+        run.command = Some(format!(
+            "download {}:{} -> local:{}",
+            source.id,
+            source_path,
+            destination_path.display()
+        ));
+        run.timeout_secs = Some(timeout.as_secs() as i64);
+        run.progress_json = serde_json::to_string(&transfer_progress(
+            "download",
+            "downloading",
+            0,
+            0,
+            0,
+            0,
+            Some(item_name),
+            started,
+        ))
+        .map_err(|error| error.to_string())?;
+        run.env_snapshot_json = serde_json::json!({
+            "route": "local",
+            "transport": "scp",
+            "source_context_id": source.id,
+            "destination_context_id": "local",
+            "destination_path": destination_path
+        })
+        .to_string();
+        store
+            .create_run(&run)
+            .await
+            .map_err(|error| error.to_string())?;
+        if !store
+            .activate_run_lifecycle(
+                &run_id,
+                wisp_store::RunStatus::Submitted,
+                &self.owner_id,
+                ACTIVE_LEASE_SECS,
+            )
+            .await
+            .map_err(|error| error.to_string())?
+        {
+            return Err("Download Run changed state before it could start".into());
+        }
+
+        let runner = self.runner.clone();
+        let owner_id = self.owner_id.clone();
+        let active = self.active.clone();
+        let cleanup_id = run_id.clone();
+        let task_run_id = run_id.clone();
+        let source_path = source_path.trim_end_matches('/').to_string();
+        let destination_path = destination_path.to_path_buf();
+        let task_store = store.clone();
+        let task = tokio::spawn(async move {
+            let result = local_download_lifecycle(
+                &task_store,
+                &owner_id,
+                &task_run_id,
+                runner,
+                staging_dir,
+                source_connection,
+                source_path,
+                destination_path,
+                timeout,
+                started,
+            )
+            .await;
+            if let Err(error) = result {
+                tracing::warn!(run_id = %task_run_id, "local download lifecycle failed: {error}");
+            }
+        });
+        let abort = task.abort_handle();
+        self.active
+            .lock()
+            .await
+            .insert(run_id.clone(), ActiveRun { abort });
+        tokio::spawn(async move {
+            let _ = task.await;
+            active.lock().await.remove(&cleanup_id);
+        });
+        Ok(SubmitRunResponse {
+            run_id,
+            status: wisp_store::RunStatus::Submitted,
+            exit_code: None,
+            stdout_tail: None,
+            stderr_tail: None,
+            remote_workdir: None,
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
     async fn submit_ssh_relay(
         &self,
         store: wisp_store::Store,
@@ -848,6 +1035,14 @@ struct RelayTempDir(PathBuf);
 impl RelayTempDir {
     fn new(run_id: &str) -> Result<Self, String> {
         let path = std::env::temp_dir().join(format!("wisp-relay-{run_id}"));
+        Self::create(path)
+    }
+
+    fn new_in(parent: &Path, run_id: &str) -> Result<Self, String> {
+        Self::create(parent.join(format!(".wisp-transfer-{run_id}")))
+    }
+
+    fn create(path: PathBuf) -> Result<Self, String> {
         std::fs::create_dir(&path).map_err(|error| format!("create relay directory: {error}"))?;
         #[cfg(unix)]
         {
@@ -863,6 +1058,147 @@ impl Drop for RelayTempDir {
     fn drop(&mut self) {
         let _ = std::fs::remove_dir_all(&self.0);
     }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn download_remote_item(
+    store: &wisp_store::Store,
+    owner_id: &str,
+    run_id: &str,
+    runner: &dyn super::RunCommandRunner,
+    staging_dir: &Path,
+    source: &crate::ssh_hosts::SshConnection,
+    source_path: &str,
+    timeout: Duration,
+    script: &str,
+) -> Result<(super::RunCommandOutput, PathBuf, u64, u64), String> {
+    let mut download_args = source.scp_option_args()?;
+    download_args.push("-r".into());
+    download_args.push(format!("{}:{source_path}", source.target()?));
+    download_args.push(scp_local_path(staging_dir));
+    let download = checked_output(
+        "SSH download",
+        run_with_lifecycle_lease(
+            store,
+            run_id,
+            owner_id,
+            runner,
+            RunCommand {
+                context_id: format!("ssh:{}", source.alias),
+                program: "scp".into(),
+                args: download_args,
+                script: script.into(),
+                cwd: Some(staging_dir.to_path_buf()),
+                stdin: None,
+                envs: crate::ssh_hosts::auth_envs_for_connection(source)?,
+            },
+            timeout,
+        )
+        .await,
+    )?;
+    let local_item = single_relay_item(staging_dir)?;
+    let (total_bytes, files_total) = relay_item_stats(&local_item)?;
+    Ok((download, local_item, total_bytes, files_total))
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn local_download_lifecycle(
+    store: &wisp_store::Store,
+    owner_id: &str,
+    run_id: &str,
+    runner: Arc<dyn super::RunCommandRunner>,
+    staging_dir: RelayTempDir,
+    source: crate::ssh_hosts::SshConnection,
+    source_path: String,
+    destination_path: PathBuf,
+    timeout: Duration,
+    started: Instant,
+) -> Result<(), String> {
+    if !store
+        .transition_run_to_running_owned(run_id, owner_id)
+        .await
+        .map_err(|error| error.to_string())?
+    {
+        return Ok(());
+    }
+    let result = async {
+        let (download, local_item, total_bytes, files_total) = download_remote_item(
+            store,
+            owner_id,
+            run_id,
+            runner.as_ref(),
+            &staging_dir.0,
+            &source,
+            &source_path,
+            timeout,
+            "local download",
+        )
+        .await?;
+        if destination_path.exists() {
+            return Err(format!(
+                "local destination_path appeared during transfer and was not overwritten: {}",
+                destination_path.display()
+            ));
+        }
+        std::fs::rename(&local_item, &destination_path)
+            .map_err(|error| format!("finalize local download: {error}"))?;
+        Ok::<_, String>((download, total_bytes, files_total))
+    }
+    .await;
+
+    let (status, exit_code, stdout, stderr, progress) = match result {
+        Ok((download, total_bytes, files_total)) => (
+            wisp_store::RunStatus::Succeeded,
+            Some(0),
+            download.stdout,
+            download.stderr,
+            transfer_progress(
+                "download",
+                "downloaded",
+                total_bytes,
+                total_bytes,
+                files_total,
+                files_total,
+                destination_path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .map(Into::into),
+                started,
+            ),
+        ),
+        Err(error) if error == "run_in_context cancelled" => (
+            wisp_store::RunStatus::Cancelled,
+            None,
+            String::new(),
+            error,
+            transfer_progress("download", "cancelled", 0, 0, 0, 0, None, started),
+        ),
+        Err(error) if error.starts_with("run_in_context timed out after ") => (
+            wisp_store::RunStatus::TimedOut,
+            Some(124),
+            String::new(),
+            error,
+            transfer_progress("download", "failed", 0, 0, 0, 0, None, started),
+        ),
+        Err(error) => (
+            wisp_store::RunStatus::Failed,
+            Some(-1),
+            String::new(),
+            error,
+            transfer_progress("download", "failed", 0, 0, 0, 0, None, started),
+        ),
+    };
+    let _ = store
+        .update_run_progress_owned(run_id, owner_id, &progress)
+        .await;
+    let _ = store
+        .update_run_output_owned(run_id, owner_id, Some(&tail(&stdout)), Some(&tail(&stderr)))
+        .await;
+    let _ = store
+        .finish_active_run_owned(run_id, owner_id, status, exit_code)
+        .await
+        .map_err(|error| error.to_string())?;
+    Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -887,32 +1223,18 @@ async fn relay_lifecycle(
         return Ok(());
     }
     let result = async {
-        let mut download_args = source.scp_option_args()?;
-        download_args.push("-r".into());
-        download_args.push(format!("{}:{source_path}", source.target()?));
-        download_args.push(scp_local_path(&relay_dir.0));
-        let download = checked_output(
-            "Relay download",
-            run_with_lifecycle_lease(
-                store,
-                run_id,
-                owner_id,
-                runner.as_ref(),
-                RunCommand {
-                    context_id: format!("ssh:{}", source.alias),
-                    program: "scp".into(),
-                    args: download_args,
-                    script: "relay download".into(),
-                    cwd: Some(relay_dir.0.clone()),
-                    stdin: None,
-                    envs: crate::ssh_hosts::auth_envs_for_connection(&source)?,
-                },
-                timeout,
-            )
-            .await,
-        )?;
-        let local_item = single_relay_item(&relay_dir.0)?;
-        let (total_bytes, files_total) = relay_item_stats(&local_item)?;
+        let (download, local_item, total_bytes, files_total) = download_remote_item(
+            store,
+            owner_id,
+            run_id,
+            runner.as_ref(),
+            &relay_dir.0,
+            &source,
+            &source_path,
+            timeout,
+            "relay download",
+        )
+        .await?;
         let uploading = transfer_progress(
             "relay",
             "uploading",
@@ -1121,6 +1443,16 @@ mod tests {
         for path in ["", "/", "~", "relative", "/data/*.csv", "/tmp/a\nb"] {
             assert!(validate_remote_path("source", path).is_err(), "{path:?}");
         }
+
+        let root = std::env::temp_dir().join(format!("wisp_local_path_{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&root).unwrap();
+        assert!(validate_local_destination(&root.join("new.bam").to_string_lossy()).is_ok());
+        assert!(validate_local_destination("relative.bam").is_err());
+        assert!(validate_local_destination(&root.to_string_lossy()).is_err());
+        let existing = root.join("existing.bam");
+        std::fs::write(&existing, b"keep").unwrap();
+        assert!(validate_local_destination(&existing.to_string_lossy()).is_err());
+        let _ = std::fs::remove_dir_all(root);
     }
 
     struct RecordingRunner {
@@ -1155,7 +1487,7 @@ mod tests {
             command: RunCommand,
             _timeout: Duration,
         ) -> Result<RunCommandOutput, String> {
-            if command.script == "relay download" {
+            if command.script.ends_with("download") {
                 let directory = PathBuf::from(command.args.last().unwrap());
                 std::fs::write(directory.join("result.txt"), b"relay bytes").unwrap();
             }
@@ -1320,6 +1652,137 @@ mod tests {
             .iter()
             .any(|arg| arg == "bob@b.example:/results/"));
         drop(commands);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn ssh_source_downloads_to_exact_new_local_path() {
+        let (root, store) = test_store().await;
+        let runner = Arc::new(RelayRunner {
+            commands: StdMutex::new(Vec::new()),
+        });
+        let manager = RunManager::with_runner(runner.clone());
+        let destination = root.join("igv").join("sample.bam");
+        let response = submit_transfer(
+            &store,
+            &manager,
+            "p",
+            Some("f"),
+            &root,
+            TransferRequest {
+                source_context_id: "ssh:a".into(),
+                source_path: "/data/result.txt".into(),
+                destination_context_id: "local".into(),
+                destination_path: destination.to_string_lossy().into_owned(),
+                route: "auto".into(),
+                transport: "auto".into(),
+                timeout_secs: Some(30),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(response["route"], "local");
+        assert_eq!(response["transport"], "scp");
+        let run_id = response["run_id"].as_str().unwrap();
+        let run = loop {
+            let run = store.get_run(run_id).await.unwrap().unwrap();
+            if run.status.is_terminal() {
+                break run;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        };
+        assert_eq!(run.status, wisp_store::RunStatus::Succeeded);
+        assert_eq!(run.kind, "file_transfer");
+        assert_eq!(std::fs::read(&destination).unwrap(), b"relay bytes");
+        let progress: wisp_store::RunProgress = serde_json::from_str(&run.progress_json).unwrap();
+        assert_eq!(progress.phase, "downloaded");
+        assert_eq!(progress.completed_bytes, 11);
+        assert_eq!(progress.files_completed, 1);
+
+        let commands = runner.commands.lock().unwrap();
+        assert_eq!(commands.len(), 1);
+        assert_eq!(commands[0].context_id, "ssh:a");
+        assert_eq!(commands[0].script, "local download");
+        assert!(commands[0]
+            .args
+            .iter()
+            .any(|arg| arg == "alice@a.example:/data/result.txt"));
+        drop(commands);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn failed_local_download_leaves_no_destination_or_staging_item() {
+        let (root, store) = test_store().await;
+        let runner = Arc::new(RecordingRunner {
+            outputs: StdMutex::new(
+                vec![Ok(RunCommandOutput {
+                    exit_code: 1,
+                    stdout: String::new(),
+                    stderr: "scp: /missing: No such file or directory".into(),
+                })]
+                .into(),
+            ),
+            commands: StdMutex::new(Vec::new()),
+        });
+        let manager = RunManager::with_runner(runner.clone());
+        let destination = root.join("failed").join("sample.bam");
+        let response = submit_transfer(
+            &store,
+            &manager,
+            "p",
+            Some("f"),
+            &root,
+            TransferRequest {
+                source_context_id: "ssh:a".into(),
+                source_path: "/missing".into(),
+                destination_context_id: "local".into(),
+                destination_path: destination.to_string_lossy().into_owned(),
+                route: "auto".into(),
+                transport: "scp".into(),
+                timeout_secs: Some(30),
+            },
+        )
+        .await
+        .unwrap();
+
+        let run_id = response["run_id"].as_str().unwrap();
+        let run = loop {
+            let run = store.get_run(run_id).await.unwrap().unwrap();
+            if run.status.is_terminal() {
+                break run;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        };
+        assert_eq!(run.status, wisp_store::RunStatus::Failed);
+        assert!(!destination.exists());
+        for _ in 0..20 {
+            let staging_exists = std::fs::read_dir(destination.parent().unwrap())
+                .unwrap()
+                .flatten()
+                .any(|entry| {
+                    entry
+                        .file_name()
+                        .to_string_lossy()
+                        .starts_with(".wisp-transfer-")
+                });
+            if !staging_exists {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        assert!(
+            std::fs::read_dir(destination.parent().unwrap())
+                .unwrap()
+                .flatten()
+                .all(|entry| !entry
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with(".wisp-transfer-")),
+            "failed transfer staging directory was not cleaned"
+        );
+        assert_eq!(runner.commands.lock().unwrap().len(), 1);
         let _ = std::fs::remove_dir_all(root);
     }
 }

--- a/src-tauri/src/runtime_launcher.rs
+++ b/src-tauri/src/runtime_launcher.rs
@@ -208,7 +208,7 @@ impl RuntimeLauncher for TauriRuntimeLauncher {
                     .await
                     .map_err(|error| {
                         if context.kind == wisp_store::ExecutionContextKind::Ssh
-                            && crate::ssh_guard::is_connectivity_failure(&error)
+                            && crate::ssh_guard::is_authentication_failure(&error)
                         {
                             crate::ssh_guard::record_failure(&context.id, &error);
                         }
@@ -271,7 +271,7 @@ impl RuntimeLauncher for TauriRuntimeLauncher {
                 crate::ssh_hosts::cleanup_password_auth_env(&ssh_auth_envs);
                 if context.kind == wisp_store::ExecutionContextKind::Ssh {
                     let detail = error.to_string();
-                    if crate::ssh_guard::is_connectivity_failure(&detail) {
+                    if crate::ssh_guard::is_authentication_failure(&detail) {
                         crate::ssh_guard::record_failure(&context.id, &detail);
                     }
                 }

--- a/src-tauri/src/ssh_guard.rs
+++ b/src-tauri/src/ssh_guard.rs
@@ -1,19 +1,19 @@
-//! Process-wide SSH connectivity gate.
+//! Process-wide SSH authentication gate.
 //!
-//! After a hard connectivity/auth failure, further managed SSH attempts for the
-//! same context fail immediately without contacting the server. This protects
-//! remote hosts (and the caller's IP) from AI tool loops that look like SSH
-//! brute-force probes. A successful connection or a user-driven probe clears
-//! the block.
+//! After an authentication/trust failure, further managed SSH attempts for the
+//! same context fail immediately without contacting the server. Remote command
+//! and transport failures do not open the gate: correcting failed commands is
+//! normal exploration, while only repeated login attempts resemble brute force.
+//! A successful connection or a user-driven probe clears the block.
 
 use std::collections::HashMap;
 use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
-/// How long a host stays blocked after a connectivity failure.
+/// How long a host stays blocked after an authentication failure.
 const COOLDOWN: Duration = Duration::from_secs(15 * 60);
 
-const BLOCKED_MARKER: &str = "SSH connectivity gate blocked";
+const BLOCKED_MARKER: &str = "SSH authentication gate blocked";
 
 #[derive(Debug, Clone)]
 struct Block {
@@ -38,35 +38,20 @@ fn normalize_key(context_id: &str) -> String {
     }
 }
 
-/// True when the error indicates SSH transport/auth failure rather than a
-/// remote command that simply returned non-zero after a successful login.
-pub fn is_connectivity_failure(error: &str) -> bool {
+/// True only when another connection would repeat rejected credentials or an
+/// untrusted host key. Remote command and ordinary transport failures are not
+/// authentication failures.
+pub fn is_authentication_failure(error: &str) -> bool {
     let error = error.to_ascii_lowercase();
     [
-        "connection timed out",
-        "connect timed out",
-        "operation timed out",
-        "connection refused",
-        "connection reset",
-        "connection closed by remote host",
-        "no route to host",
-        "network is unreachable",
-        "could not resolve hostname",
-        "could not resolve host",
-        "name or service not known",
         "permission denied (publickey",
         "permission denied (keyboard-interactive",
         "permission denied (password",
         "too many authentication failures",
+        "ssh key authentication failed",
+        "ssh password authentication failed",
         "host key verification failed",
-        "no such identity",
-        "identity file",
-        "not accessible: no such file or directory",
-        "kex_exchange_identification",
-        "banner exchange",
-        "ssh: connect to host",
-        "ssh_dispatch_run_fatal",
-        "ssh connectivity gate blocked",
+        "ssh authentication gate blocked",
     ]
     .iter()
     .any(|needle| error.contains(needle))
@@ -78,8 +63,8 @@ pub fn blocked_message(context_id: &str, reason: &str) -> String {
          from repeated login attempts (which remote hosts treat as SSH brute force). \
          Do NOT retry with shell `ssh`, alternate `-i` keys, StrictHostKeyChecking changes, \
          `python`/`r` on this context_id, or additional `run_in_context` calls. \
-         Report the failure once and ask the user to fix connectivity (unlock IP, fix key, \
-         re-probe the environment) then retry manually. Previous error: {reason}"
+         Report the failure once and ask the user to fix the saved credentials, user/key, \
+         or host trust, then re-probe before retrying. Previous error: {reason}"
     )
 }
 
@@ -103,7 +88,7 @@ pub fn assert_allowed(context_id: &str) -> Result<(), String> {
 
 pub fn record_failure(context_id: &str, error: &str) {
     let key = normalize_key(context_id);
-    if key.is_empty() || !is_connectivity_failure(error) {
+    if key.is_empty() || !is_authentication_failure(error) {
         return;
     }
     // Avoid nesting the gate message as the "previous" reason.
@@ -267,7 +252,7 @@ pub fn preflight_shell(cmd: &str) -> Result<(), String> {
 
 /// After a shell command finishes, open the gate for targets it failed to reach.
 pub fn note_shell_outcome(cmd: &str, success: bool, detail: &str) {
-    if success || !shell_looks_like_ssh(cmd) || !is_connectivity_failure(detail) {
+    if success || !shell_looks_like_ssh(cmd) || !is_authentication_failure(detail) {
         return;
     }
     let targets = shell_ssh_targets(cmd);
@@ -290,13 +275,10 @@ mod tests {
     }
 
     #[test]
-    fn gate_blocks_after_connectivity_failure_and_clears_on_success() {
+    fn gate_blocks_after_authentication_failure_and_clears_on_success() {
         let id = unique_id("block");
         assert!(assert_allowed(&id).is_ok());
-        record_failure(
-            &id,
-            "ssh: connect to host example port 22: Connection timed out",
-        );
+        record_failure(&id, "Permission denied (publickey,password).");
         let err = assert_allowed(&id).unwrap_err();
         assert!(err.contains(BLOCKED_MARKER), "{err}");
         assert!(err.contains("Do NOT retry"), "{err}");
@@ -305,13 +287,16 @@ mod tests {
     }
 
     #[test]
-    fn non_connectivity_errors_do_not_open_the_gate() {
+    fn command_and_transport_errors_do_not_open_the_authentication_gate() {
         let id = unique_id("cmdfail");
-        record_failure(
-            &id,
+        for error in [
             "ls: cannot access '/missing': No such file or directory",
-        );
-        assert!(assert_allowed(&id).is_ok());
+            "ssh: connect to host example port 22: Connection timed out",
+            "Connection refused",
+        ] {
+            record_failure(&id, error);
+            assert!(assert_allowed(&id).is_ok(), "{error}");
+        }
     }
 
     #[test]
@@ -335,14 +320,10 @@ mod tests {
     }
 
     #[test]
-    fn note_shell_outcome_opens_gate_for_parsed_target() {
+    fn note_shell_authentication_failure_opens_gate_for_parsed_target() {
         let alias = format!("host-{}", uuid::Uuid::new_v4());
         let cmd = format!("ssh -o ConnectTimeout=10 {alias} true");
-        note_shell_outcome(
-            &cmd,
-            false,
-            &format!("ssh: connect to host {alias} port 22: Connection timed out"),
-        );
+        note_shell_outcome(&cmd, false, "Permission denied (publickey).");
         let err = assert_allowed(&alias).unwrap_err();
         assert!(err.contains(BLOCKED_MARKER), "{err}");
         clear(&alias);

--- a/src-tauri/src/ssh_hosts.rs
+++ b/src-tauri/src/ssh_hosts.rs
@@ -633,16 +633,20 @@ paths. To watch a submitted Run or wait for its result, call `monitor_run` \
 exactly once instead of repeatedly calling `get_run`. For persistent interactive analysis, call `python` or `r` with the \
 matching `context_id`; omitting it selects `local`. Interpreter paths come from \
 the execution context's saved settings or probe result, not shell environment \
-changes. Use `set_runtime_interpreter` when the user provides a different \
-Python or R executable.\n\
-**SSH connectivity policy:** remote work is only allowed after a successful Probe \
+changes. For one-off `run_in_context` scripts, use the exact probed interpreter \
+path shown in capabilities; do not guess `python` when the probe found `python3`. \
+Use `set_runtime_interpreter` when the user provides a different Python or R executable.\n\
+**SSH authentication policy:** remote work is only allowed after a successful Probe \
 on the registered environment. Always use `run_in_context`, `python`, `r`, \
 `configure_ssh_trust`, or `transfer_between_contexts` with \
 the matching `context_id` so Wisp uses the configured alias/user/port/identity \
-exactly. Free-form shell `ssh`/`scp` is disabled. If connectivity is unknown or \
-failed: STOP, tell the user to check the SSH server and Probe again — do not invent \
-`ssh -i`, ports, or `StrictHostKeyChecking` options. After one failure, do not \
-retry; repeated attempts look like SSH brute force and can ban the user's IP.\n\n",
+exactly. Free-form shell `ssh`/`scp` is disabled. If SSH authentication or host-key \
+verification fails: STOP, report it once, and ask the user to fix the saved credentials \
+or trust and Probe again — do not invent `ssh -i`, ports, or `StrictHostKeyChecking` \
+options. Do not retry a rejected login because repeated authentication attempts can ban \
+the user's IP. A successful SSH connection followed by any remote command/application \
+failure—including exit 127—is normal exploration: inspect stderr, correct the command \
+using the probed capabilities, and continue.\n\n",
     );
     for ctx in contexts {
         let cfg: serde_json::Value = serde_json::from_str(&ctx.config_json).unwrap_or_default();
@@ -714,7 +718,7 @@ retry; repeated attempts look like SSH brute force and can ban the user's IP.\n\
             .find(|(id, _)| id == &ctx.id)
         {
             s.push_str(&format!(
-                " — CONNECTIVITY GATE OPEN: blocked after prior failure ({reason}). Do not attempt any SSH to this host"
+                " — AUTHENTICATION GATE OPEN: blocked after a rejected login or host trust failure ({reason}). Do not attempt another SSH login to this host"
             ));
         }
         s.push('\n');
@@ -766,12 +770,22 @@ fn capability_summary(capabilities_json: &str) -> Option<String> {
     {
         parts.push(format!("scheduler: {scheduler}"));
     }
-    if let Some(python) = caps
-        .get("python")
-        .and_then(|v| v.as_str())
-        .filter(|s| !s.trim().is_empty())
-    {
-        parts.push(python.into());
+    let python_executable = caps
+        .get("python_executable")
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.trim().is_empty());
+    let python_version = caps
+        .get("python_version")
+        .or_else(|| caps.get("python"))
+        .and_then(|value| value.as_str())
+        .filter(|value| !value.trim().is_empty());
+    match (python_executable, python_version) {
+        (Some(executable), Some(version)) => {
+            parts.push(format!("python: {executable} ({version})"));
+        }
+        (Some(executable), None) => parts.push(format!("python: {executable}")),
+        (None, Some(version)) => parts.push(version.into()),
+        (None, None) => {}
     }
     if parts.is_empty() {
         None
@@ -1436,8 +1450,8 @@ Host -unsafe bad/name !negated
             "remote path warning missing:\n{s}"
         );
         assert!(
-            s.contains("SSH connectivity policy"),
-            "connectivity policy missing:\n{s}"
+            s.contains("SSH authentication policy"),
+            "authentication policy missing:\n{s}"
         );
         assert!(
             s.contains("Free-form shell `ssh`/`scp` is disabled"),
@@ -1450,6 +1464,10 @@ Host -unsafe bad/name !negated
         assert!(
             s.contains("successful Probe"),
             "probe-first guidance missing:\n{s}"
+        );
+        assert!(
+            s.contains("including exit 127") && s.contains("correct the command"),
+            "ordinary command failure recovery guidance missing:\n{s}"
         );
         assert!(s.contains("slurm; sbatch"), "notes missing:\n{s}");
     }
@@ -1692,7 +1710,9 @@ Host -unsafe bad/name !negated
             "arch": "x86_64",
             "gpu_summary": "GPU 0: NVIDIA A100",
             "scheduler": "slurm",
-            "python": "Python 3.11.8"
+            "python": "Python 3.11.8",
+            "python_executable": "/usr/bin/python3",
+            "python_version": "Python 3.11.8"
         })
         .to_string();
 
@@ -1700,6 +1720,9 @@ Host -unsafe bad/name !negated
         assert!(s.contains("Linux/x86_64"), "os/arch missing:\n{s}");
         assert!(s.contains("GPU 0: NVIDIA A100"), "gpu missing:\n{s}");
         assert!(s.contains("scheduler: slurm"), "scheduler missing:\n{s}");
-        assert!(s.contains("Python 3.11.8"), "python missing:\n{s}");
+        assert!(
+            s.contains("python: /usr/bin/python3 (Python 3.11.8)"),
+            "python executable missing:\n{s}"
+        );
     }
 }


### PR DESCRIPTION
## Problem

A successful SSH login could still stop the workflow when a remote command failed. In the reported CPU3 case, the probe found /usr/bin/python3, but the generated command used python and exited 127. The failed Run was then exposed as a successful tool call, allowing the plan to be marked complete. Structured transfers also supported SSH-to-SSH only, so the agent could not safely download BAM and reference files to a chosen local path.

## Changes

- Return waited failed, timed-out, cancelled, and lost Runs as failed tool results.
- Keep plan steps open after a failed or cancelled tool call.
- Narrow the process-wide SSH gate to rejected authentication and host-key trust failures. Remote command and transport failures remain correctable exploration.
- Show the exact probed interpreter path and tell one-off Run commands to use it.
- Add SSH-to-local support to transfer_between_contexts with one managed scp process, a persisted file-transfer Run, sibling staging, existing-destination rejection, and partial-data cleanup.
- Preserve the exact latest provider-agnostic model request, including runtime injections, for debug export.
- Update the bundled SSH skill and transfer documentation.
- Apply pre-existing rustfmt drift in a separate formatting-only commit, as required by AGENTS.md.

## Tests

- cargo fmt --all -- --check
- cargo test --workspace
- cd ui && cargo check --target wasm32-unknown-unknown
- cd ui-tests && npm ci && npx playwright test

Playwright result: 190 passed, 1 skipped.

## Manual smoke

1. Select and successfully probe an SSH execution context.
2. Ask Wisp to locate a file with a one-off Run and verify it uses the probed interpreter path.
3. Choose an exact new absolute local destination and approve transfer_between_contexts with destination_context_id=local.
4. Call monitor_run once and verify the completed file appears only after the transfer succeeds.
5. Verify an ordinary remote command failure can be corrected, while rejected SSH authentication blocks another automatic login attempt.

## Known limitations

- SSH-to-local uses scp and is not resumable yet.
- Automated tests use fake runners and do not require a real SSH host, in accordance with project policy.