### PR TITLE
feat(ui): copy artifact provenance code (#409)

### DIFF
--- a/crates/wisp-tools/src/lib.rs
+++ b/crates/wisp-tools/src/lib.rs
@@ -131,7 +131,9 @@ impl Registry {
     /// so call and result rows match in the UI transcript.
     pub fn event_name(&self, name: &str, args: &Value) -> String {
         let target = if name == USE_MCP_TOOL {
-            args.get("tool_name").and_then(Value::as_str).unwrap_or(name)
+            args.get("tool_name")
+                .and_then(Value::as_str)
+                .unwrap_or(name)
         } else {
             name
         };

--- a/docs/global-library.md
+++ b/docs/global-library.md
@@ -6,6 +6,8 @@ projects in the local Wisp installation.
 - Click the SVG star beside a Notebook cell to save its language and source.
 - Click the SVG star in an image artifact header to save the image bytes and,
   when provenance exists, the code that generated it.
+- In an image artifact viewer, open **Code** and use **Copy code** to copy the
+  exact recorded source. Provenance code remains read-only.
 - Open **Library** from the Projects screen or a project sidebar. Items can be
   searched, filtered, removed, or traced back to their source project/session.
 

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -2377,7 +2377,8 @@ test("environment panel shows runs only for the selected context", async ({ page
   await expect(page.locator(".run-card", { hasText: "Local normalization" })).toHaveCount(0);
 });
 
-test("clicking a figure opens the artifact modal with provenance", async ({ page }) => {
+test("clicking a figure opens the artifact modal with provenance", async ({ page, context }) => {
+  await context.grantPermissions(["clipboard-read", "clipboard-write"]);
   await enterApp(page);
   // A file path in the user turn is collected as an artifact; a .png name maps
   // to the "image" kind, which opens directly in the modal viewer on click.
@@ -2488,6 +2489,17 @@ test("clicking a figure opens the artifact modal with provenance", async ({ page
   // Code tab renders the recorded source (from get_artifact_provenance).
   await page.locator(".am-tab", { hasText: "Code" }).click();
   await expect(page.locator(".artifact-modal")).toContainText("savefig");
+  await page.evaluate(() => {
+    Object.defineProperty(navigator.clipboard, "writeText", {
+      configurable: true,
+      value: async (text: string) => { (window as any).__copiedProvenanceCode = text; },
+    });
+  });
+  await artifactModal.getByRole("button", { name: "Copy code" }).click();
+  await expect(page.locator(".copy-toast")).toHaveText("Copied");
+  await expect.poll(() => page.evaluate(() => (window as any).__copiedProvenanceCode)).toBe(
+    "import matplotlib\nplt.savefig('volcano.png')",
+  );
   const codeScrollOwners = await page.locator(".artifact-modal .am-panel").evaluate((panel) => {
     const code = panel.querySelector<HTMLElement>(".rp-code")!;
     code.querySelector("code")!.textContent = Array.from({ length: 200 }, (_, i) => `line ${i + 1}`).join("\n");

--- a/ui/src/app_support.rs
+++ b/ui/src/app_support.rs
@@ -7535,6 +7535,23 @@ pub(super) fn ArtifactModal(
                                 {move || t(locale.get(), &label_key)}</button>
                         }
                     }).collect_view()}
+                    {move || {
+                        (tab.get() == "code")
+                            .then(|| prov.get())
+                            .flatten()
+                            .filter(|p| !p.code.is_empty())
+                            .map(|p| {
+                                let code = p.code;
+                                view! {
+                                    <button type="button" class="icon-btn" style="margin-left: auto"
+                                        title=move || t(locale.get(), "tool.copy_code")
+                                        aria-label=move || t(locale.get(), "tool.copy_code")
+                                        on:click=move |_| copy_text(code.clone())>
+                                        {compose_icon("copy")}
+                                    </button>
+                                }
+                            })
+                    }}
                 </div>
                 <div class="am-panel">
                     {move || {


### PR DESCRIPTION
## Problem

The artifact viewer exposes the source code that produced an image, but users
cannot copy that provenance code directly for reproducible reuse.

## Changes

- Add a localized, accessible **Copy code** action to the artifact viewer's
  **Code** tab when recorded source is available.
- Reuse the existing clipboard helper and **Copied** toast, without adding a
  dependency or a second clipboard path.
- Document that provenance source can be copied and remains read-only.
- Keep pre-existing `cargo fmt` drift in a separate formatting-only commit.

## Tests

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cd ui && cargo check --target wasm32-unknown-unknown`
- Targeted Playwright provenance-modal test
- `cd ui-tests && npm ci && npx playwright test`
  - 190 passed
  - 1 environment-gated Motif test skipped

The Playwright regression verifies both the success toast and the exact source
written to the clipboard.

## Manual smoke

1. Generate or open an image artifact with recorded provenance.
2. Open the artifact viewer and select **Code**.
3. Click **Copy code**.
4. Confirm the **Copied** toast appears and pasting returns the displayed source.

## Known limitations / follow-up

- Provenance code remains read-only in this PR.
- Editable code with immutable history, shared with the Library request in
  #415, is tracked separately in #455.

Closes #409
