### PR TITLE
fix: migrate pinned sessions for existing databases

### DIFF
--- a/crates/wisp-store/migrations/0000_init.sql
+++ b/crates/wisp-store/migrations/0000_init.sql
@@ -29,6 +29,7 @@ CREATE TABLE IF NOT EXISTS frames (
     status          TEXT NOT NULL,
     project_id      TEXT REFERENCES projects(id) ON DELETE CASCADE,
     folder_id       TEXT REFERENCES folders(id) ON DELETE SET NULL,
+    pinned          INTEGER NOT NULL DEFAULT 0,
     model           TEXT,
     input_tokens    INTEGER,
     output_tokens   INTEGER,

--- a/crates/wisp-store/src/lib.rs
+++ b/crates/wisp-store/src/lib.rs
@@ -76,6 +76,7 @@ const PLUGIN_INSTALLATIONS_MIGRATION: &str = "0021_plugin_installations";
 const PLUGIN_INSTALLATIONS_MIGRATION_SQL: &str =
     include_str!("../migrations/0021_plugin_installations.sql");
 const FRAME_SEEN_MIGRATION: &str = "0022_frame_seen";
+const SESSION_PINNED_MIGRATION: &str = "0023_session_pinned";
 
 #[derive(Clone)]
 pub struct Store {
@@ -299,6 +300,15 @@ impl Store {
             .execute(pool)
             .await;
             Self::record_migration(pool, FRAME_SEEN_MIGRATION).await?;
+        }
+        if !Self::migration_applied(pool, SESSION_PINNED_MIGRATION).await? {
+            Self::add_columns_if_missing(
+                pool,
+                "frames",
+                &[("pinned", "INTEGER NOT NULL DEFAULT 0")],
+            )
+            .await?;
+            Self::record_migration(pool, SESSION_PINNED_MIGRATION).await?;
         }
         Ok(())
     }
@@ -582,11 +592,6 @@ impl Store {
         }
         if !Self::has_column(pool, "frames", "folder_id").await? {
             sqlx::query("ALTER TABLE frames ADD COLUMN folder_id TEXT")
-                .execute(pool)
-                .await?;
-        }
-        if !Self::has_column(pool, "frames", "pinned").await? {
-            sqlx::query("ALTER TABLE frames ADD COLUMN pinned INTEGER NOT NULL DEFAULT 0")
                 .execute(pool)
                 .await?;
         }

--- a/crates/wisp-store/src/store_tests.rs
+++ b/crates/wisp-store/src/store_tests.rs
@@ -1000,6 +1000,37 @@ async fn pinned_sessions_are_listed_separately_and_toggle() {
 }
 
 #[tokio::test]
+async fn existing_database_without_pinned_column_is_repaired() {
+    let tmp = std::env::temp_dir().join(format!(
+        "wisp_pinned_migration_{}.sqlite",
+        uuid::Uuid::new_v4()
+    ));
+    let store = Store::open(&tmp).await.unwrap();
+    store.create_project("p", "proj", "").await.unwrap();
+    store.create_frame("f", "p", "OPERON", "m").await.unwrap();
+    store
+        .append_message("f", 1, &Message::user("saved conversation"))
+        .await
+        .unwrap();
+    sqlx::query("ALTER TABLE frames DROP COLUMN pinned")
+        .execute(&store.pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM wisp_schema_migrations WHERE version=?")
+        .bind(SESSION_PINNED_MIGRATION)
+        .execute(&store.pool)
+        .await
+        .unwrap();
+    store.pool.close().await;
+
+    let reopened = Store::open(&tmp).await.unwrap();
+    reopened.set_session_pinned("f", "p", true).await.unwrap();
+    assert_eq!(reopened.list_pinned_sessions("p").await.unwrap().len(), 1);
+    reopened.pool.close().await;
+    let _ = std::fs::remove_file(&tmp);
+}
+
+#[tokio::test]
 async fn multi_turn_append() {
     // Mirrors the Tauri wiring: a frame is created once, then messages are
     // appended across turns with incrementing seq; load_messages returns
@@ -1862,6 +1893,7 @@ async fn store_open_records_migrations_and_seeds_local_context() {
             AGENT_WORKFLOW_LINEAGE_MIGRATION.to_string(),
             PLUGIN_INSTALLATIONS_MIGRATION.to_string(),
             FRAME_SEEN_MIGRATION.to_string(),
+            SESSION_PINNED_MIGRATION.to_string(),
         ]
     );
 

--- a/crates/wisp-tools/src/lib.rs
+++ b/crates/wisp-tools/src/lib.rs
@@ -131,7 +131,9 @@ impl Registry {
     /// so call and result rows match in the UI transcript.
     pub fn event_name(&self, name: &str, args: &Value) -> String {
         let target = if name == USE_MCP_TOOL {
-            args.get("tool_name").and_then(Value::as_str).unwrap_or(name)
+            args.get("tool_name")
+                .and_then(Value::as_str)
+                .unwrap_or(name)
         } else {
             name
         };


### PR DESCRIPTION
## Problem

The conversation pin feature queried frames.pinned, but that column was added inside the already-existing 0001_control_plane_backfill implementation. Databases that had recorded 0001 before the pin feature shipped skipped the updated function forever, causing list_sessions_page to fail with no such column: f.pinned and leaving the sidebar empty.

The Chromium preload integrity message is unrelated and harmless.

## Changes

- Add the pinned column to the initial frames schema for new databases.
- Add the idempotent 0023_session_pinned migration for existing databases.
- Remove the misplaced pinned-column addition from the old 0001 backfill.
- Add a regression test that removes pinned while retaining the old migration history, then verifies reopening repairs the database and pinning works.
- Keep pre-existing rustfmt drift in a separate formatting-only commit.

## Verification

- cargo fmt --all -- --check
- cargo test -p wisp-store
- cargo test --workspace

All tests passed, including 64 wisp-store tests and 390 wisp-tauri tests.

## Manual smoke

1. Launch the updated app against a database created before the pin feature.
2. Confirm the conversation sidebar loads without editing SQLite manually.
3. Pin and unpin a conversation and restart the app.
4. Confirm the pinned state and full conversation list remain visible.