### PR TITLE
feat(projects): make the standard research layout opt-in (#405)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6272,6 +6272,7 @@ async fn create_project(
     workspace_dir: String,
     description: String,
     agent_context: String,
+    standard_layout: bool,
 ) -> Result<ProjectSummary, String> {
     if name.trim().is_empty() {
         return Err("Project name is required".into());
@@ -6289,7 +6290,11 @@ async fn create_project(
     let _ = std::fs::remove_file(&marker);
 
     let id = Uuid::new_v4().to_string();
-    workspace_manifest::init_workspace_layout(&path, &id, name.trim())?;
+    // #405: opt-in. Unchecked means the user keeps their own structure, so we
+    // create nothing — the convention lives in .wisp/WISP.md instead (below).
+    if standard_layout {
+        workspace_manifest::init_workspace_layout(&path, &id, name.trim())?;
+    }
     state
         .store
         .create_project(&id, name.trim(), dir)

--- a/src-tauri/src/workspace_manifest.rs
+++ b/src-tauri/src/workspace_manifest.rs
@@ -6,6 +6,9 @@ pub const WORKSPACE_DIRS: &[&str] = &[
     "data/raw",
     "data/external",
     "data/processed",
+    // Landing zone for files pulled off a compute host; one subdirectory per
+    // execution-context label, created on demand by the transfer.
+    "remote",
     "analysis/scripts",
     "analysis/notebooks",
     "analysis/workflows",

--- a/ui/src/app_support.rs
+++ b/ui/src/app_support.rs
@@ -8459,6 +8459,45 @@ pub(super) fn ApprovalCard(
     }
 }
 
+#[cfg(test)]
+mod layout_block_tests {
+    use super::apply_layout_block;
+
+    const BLOCK: &str = "Write outputs to figures/, results/tables/.";
+
+    #[test]
+    fn toggling_is_idempotent_and_preserves_user_text() {
+        // Checking twice must not duplicate the block, and unchecking must
+        // leave the user's own notes untouched.
+        let on = apply_layout_block("", BLOCK, true);
+        assert_eq!(on, BLOCK);
+        assert_eq!(apply_layout_block(&on, BLOCK, true), BLOCK);
+
+        let mixed = apply_layout_block("Counts are in GEO.", BLOCK, true);
+        assert_eq!(mixed, format!("Counts are in GEO.\n\n{BLOCK}"));
+        assert_eq!(apply_layout_block(&mixed, BLOCK, true), mixed);
+        assert_eq!(
+            apply_layout_block(&mixed, BLOCK, false),
+            "Counts are in GEO."
+        );
+        assert_eq!(apply_layout_block("", BLOCK, false), "");
+    }
+}
+
+/// Add or remove the standard-layout convention block in the new-project Agent
+/// Context field (#405). The block is plain editable text, not hidden state:
+/// whatever ends up in the textarea is what gets written to `.wisp/WISP.md`.
+/// Strip-then-append keeps repeated toggles idempotent.
+pub(super) fn apply_layout_block(ctx: &str, block: &str, on: bool) -> String {
+    let rest = ctx.replace(block, "");
+    let rest = rest.trim();
+    match (on, rest.is_empty()) {
+        (false, _) => rest.to_string(),
+        (true, true) => block.to_string(),
+        (true, false) => format!("{rest}\n\n{block}"),
+    }
+}
+
 #[component]
 pub(super) fn ProjectsScreen(
     locale: RwSignal<Locale>,
@@ -8485,6 +8524,10 @@ pub(super) fn ProjectsScreen(
     let new_dir = create_rw_signal(String::new());
     let new_desc = create_rw_signal(String::new());
     let new_ctx = create_rw_signal(String::new());
+    // Off by default: pointing at an existing repo must not litter it. Checking
+    // the box reveals the convention text, which doubles as a worked example of
+    // what Agent Context is for.
+    let new_layout = create_rw_signal(false);
     let importing = create_rw_signal(false);
     let syncing_projects = create_rw_signal(HashSet::<String>::new());
     let sync_notice = create_rw_signal(None::<(bool, String)>);
@@ -8633,14 +8676,25 @@ pub(super) fn ProjectsScreen(
         })
     };
 
+    // Seed the convention text on open so the checkbox's default is visible and
+    // editable rather than applied behind the user's back.
+    create_effect(move |_| {
+        if creating.get() {
+            let block = t(locale.get(), "projects.layout_context");
+            new_ctx.update(|c| *c = apply_layout_block(c, &block, new_layout.get()));
+        }
+    });
+
     let submit = move |_| {
         let (n, d, desc, ctx) = (new_name.get(), new_dir.get(), new_desc.get(), new_ctx.get());
+        let layout = new_layout.get();
         if n.trim().is_empty() || d.trim().is_empty() {
             return;
         }
         spawn_local(async move {
             let arg = to_value(&serde_json::json!({
                 "name": n, "workspaceDir": d, "description": desc, "agentContext": ctx,
+                "standardLayout": layout,
             }))
             .unwrap();
             let v = invoke("create_project", arg).await;
@@ -8649,6 +8703,7 @@ pub(super) fn ProjectsScreen(
                 new_dir.set(String::new());
                 new_desc.set(String::new());
                 new_ctx.set(String::new());
+                new_layout.set(false);
                 creating.set(false);
                 on_open.call(p.id);
             }
@@ -8999,6 +9054,17 @@ pub(super) fn ProjectsScreen(
                             <textarea class="ps-textarea" rows="2"
                                 prop:value=move || new_desc.get()
                                 on:input=move |ev| new_desc.set(event_target_value(&ev))></textarea>
+                        </label>
+                        <label class="pn-layout">
+                            <span class="toggle">
+                                <input type="checkbox" prop:checked=move || new_layout.get()
+                                    on:change=move |ev| new_layout.set(event_target_checked(&ev)) />
+                                <span class="toggle-track" aria-hidden="true"></span>
+                            </span>
+                            <span>
+                                {move || t(locale.get(), "projects.standard_layout")}
+                                <span class="ps-hint">{move || t(locale.get(), "projects.standard_layout_hint")}</span>
+                            </span>
                         </label>
                         <label>
                             {move || t(locale.get(), "proj_settings.agent_context")}

--- a/ui/src/i18n.rs
+++ b/ui/src/i18n.rs
@@ -1301,6 +1301,20 @@ fn lookup(locale: Locale, key: &str) -> Option<&'static str> {
         (Locale::En, "projects.name_ph") => Some("Project name"),
         (Locale::En, "projects.choose_dir") => Some("Choose folder"),
         (Locale::En, "projects.directory") => Some("Project directory"),
+        (Locale::En, "projects.standard_layout") => Some("Use the standard research layout"),
+        (Locale::En, "projects.standard_layout_hint") => Some("Creates the folders below. Turn it off to keep your own structure and describe it instead."),
+        (Locale::En, "projects.layout_context") => Some(
+            "This project uses the standard research layout. Write outputs to these paths, relative to the project root:\n\
+- figures -> figures/\n\
+- tables -> results/tables/\n\
+- fitted models -> results/models/\n\
+- reports -> results/reports/\n\
+- scripts and notebooks -> analysis/scripts/, analysis/notebooks/\n\
+- data -> data/raw/ (untouched inputs), data/processed/ (derived)\n\
+- files pulled off a compute host -> remote/<server>/, one folder per server, named after that execution context's label\n\
+- papers and PDFs -> literature/\n\
+Do not leave generated files in the project root.",
+        ),
         (Locale::En, "projects.create") => Some("Create"),
         (Locale::En, "projects.cancel") => Some("Cancel"),
         (Locale::En, "projects.sessions_n") => Some("{n} sessions"),
@@ -2569,6 +2583,20 @@ fn lookup(locale: Locale, key: &str) -> Option<&'static str> {
         (Locale::Zh, "projects.name_ph") => Some("项目名称"),
         (Locale::Zh, "projects.choose_dir") => Some("选择文件夹"),
         (Locale::Zh, "projects.directory") => Some("项目目录"),
+        (Locale::Zh, "projects.standard_layout") => Some("使用标准科研目录结构"),
+        (Locale::Zh, "projects.standard_layout_hint") => Some("创建下方列出的目录。关闭则保留你自己的结构，改为在下方描述它。"),
+        (Locale::Zh, "projects.layout_context") => Some(
+            "本项目采用标准科研目录结构。产物请写入以下路径（相对项目根目录）：\n\
+- 图表 -> figures/\n\
+- 表格 -> results/tables/\n\
+- 拟合模型 -> results/models/\n\
+- 报告 -> results/reports/\n\
+- 脚本与 notebook -> analysis/scripts/、analysis/notebooks/\n\
+- 数据 -> data/raw/（原始输入，不修改）、data/processed/（衍生数据）\n\
+- 从远程主机拉取的文件 -> remote/<服务器>/，每台服务器一个子目录，用该执行上下文的名称命名\n\
+- 文献与 PDF -> literature/\n\
+不要把生成的文件留在项目根目录。",
+        ),
         (Locale::Zh, "projects.create") => Some("创建"),
         (Locale::Zh, "projects.cancel") => Some("取消"),
         (Locale::Zh, "projects.sessions_n") => Some("{n} 个会话"),

--- a/ui/src/styles/alignment.css
+++ b/ui/src/styles/alignment.css
@@ -72,6 +72,10 @@
 }
 .proj-settings-modal .ps-close:hover { color: var(--text); background: var(--bg-sunken); }
 .proj-settings-modal .ps-hint { font-size: 11.5px; line-height: 1.4; font-weight: 400; color: var(--text-faint); }
+/* Toggle sits beside its label instead of stacking (`.modal label` is a column). */
+.proj-settings-modal .pn-layout { flex-direction: row; align-items: flex-start; gap: 10px; cursor: pointer; }
+.proj-settings-modal .pn-layout .toggle { flex: 0 0 auto; margin-top: 1px; }
+.proj-settings-modal .pn-layout .ps-hint { display: block; margin-top: 3px; }
 .proj-settings-modal .ps-textarea {
   width: 100%; box-sizing: border-box; background: var(--bg-input); color: var(--text);
   border: 1px solid var(--border-strong); border-radius: var(--radius-sm); padding: 9px 11px;


### PR DESCRIPTION
Closes #405.

## The bug, and what actually caused it

Figures were landing in the project root instead of `figures/`. The issue reads like an archiving step that misfires "sometimes", but there was never an archiving step at all:

- `figures/` and its siblings are created at project creation ([workspace_manifest.rs](https://github.com/xuzhougeng/wisp-science/blob/main/src-tauri/src/workspace_manifest.rs)) and then **never referenced again**.
- The system prompt never mentions the layout — `system_prompt.rs` has no workspace-layout section, and the word `figures` does not appear in it.
- Every code tool runs with `cwd = project root` (`tool.rs:100`, `shell.rs:108`), so `ggsave("heatmap.png")` necessarily lands in the root.
- The post-execution scan (`agent.rs:308-341`) records new file paths but never moves anything.
- `save_workspace_file_by_kind` — the only API that knows `Figure -> figures` — is a Tauri command with no callers.

So a plot reached `figures/` only when the model happened to guess the prefix. "Sometimes" was the guessing.

It was never figures-only, either: `.rds`, `.py` and `.txt` outputs sprawl the same way.

## Approach

The obvious fix is a hardcoded layout line in the system prompt. That was rejected as too rigid — it would impose one structure on every project, including existing repos with their own conventions.

Instead this reuses the mechanism already wired up for exactly this purpose: the **Agent Context** field writes to `.wisp/WISP.md`, which `system_prompt.rs:22` injects as `## User Rules`. No new config schema, no settings editor, no changes to the system prompt.

## Changes

- `create_project` takes `standard_layout: bool`. Unchecked creates nothing, so pointing Wisp at an existing repository no longer litters it with 14 empty folders. (It is a non-`Option` bool on purpose: if the UI ever stops sending `standardLayout`, Tauri rejects the call loudly instead of silently defaulting to `false` and quietly disabling the layout for everyone.)
- The new-project dialog gets a checkbox, **off by default**. Checking it drops the convention text into Agent Context, where it is visible and editable before submit. It doubles as a worked example of what that field is for — users who keep their own structure just describe it there instead.
- Adds `remote/<server>/` for data pulled off a compute host, one folder per execution-context label. `transfer_between_contexts` currently instructs the agent to *"do not guess it — ask the user when unspecified"* for local destinations ([transfer.rs:183](https://github.com/xuzhougeng/wisp-science/blob/main/src-tauri/src/run_context/transfer.rs#L183)); the convention supplies a default so it stops asking, and where the data came from stays visible.

## Reviewer notes

- `apply_layout_block` is a pure function with a test for the case that would actually bite: repeated toggling must not duplicate the block or eat text the user typed themselves.
- Adding the row pushed the dialog past the fold at 1280x720, hiding Create behind a scroll. The hint copy was cut to one line to win it back — verified Create/Cancel are visible again at that size.
- The existing Playwright assertion `modal.top >= 20` is unaffected: 20px is the `max-height: calc(100vh - 40px)` clamp, not a coincidence, so added content can't push it below.
- Skipping `init_workspace_layout` also skips writing `.wisp/project.toml`. Checked — nothing reads that file except its own test.

## Verification

- Drove the whole flow in trunk + the mock bridge: default off with an empty field; three on/off cycles leave exactly one copy of the block and preserve user-typed text; `standardLayout` reaches the bridge as camelCase alongside the composed `agentContext`.
- `cargo test` — 105 UI tests and the 3 `workspace_manifest` tests pass; wasm target and the Tauri backend both `cargo check` clean.
- `cargo fmt` run on `src-tauri` only, per this repo's convention of never fmt-ing the `ui` crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)