### PR TITLE
fix(ui): report real app version and only inline display mode to MCP Apps

### DIFF
--- a/ui/src/api.js
+++ b/ui/src/api.js
@@ -1214,6 +1214,8 @@ table { max-width: 100%; }
 
 const mcpAppInstances = new Map();
 let mcpAppParkingRoot = null;
+let wispAppVersion = "0.0.0";
+window.__TAURI__?.app?.getVersion?.().then((version) => { wispAppVersion = version; });
 
 function injectMcpAppCsp(html, resourceMeta) {
   const csp = resourceMeta?.ui?.csp || resourceMeta?.csp || {};
@@ -1307,12 +1309,12 @@ function createMcpAppInstance(instanceId, payloadJson) {
   const hostContext = () => ({
     theme: document.documentElement.dataset.theme === "dark" ? "dark" : "light",
     displayMode: "inline",
-    availableDisplayModes: ["inline", "fullscreen"],
+    availableDisplayModes: ["inline"],
     containerDimensions: mcpAppDimensions(instance),
     locale: document.documentElement.lang || navigator.language || "en",
     timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
     platform: "desktop",
-    userAgent: "wisp-science/0.19.0",
+    userAgent: `wisp-science/${wispAppVersion}`,
     toolInfo: { tool: payload.tool || {} },
   });
   const sendHostContext = () => {
@@ -1365,7 +1367,7 @@ function createMcpAppInstance(instanceId, payloadJson) {
             sandbox: { csp: payload?.resource?._meta?.ui?.csp || payload?.resource?._meta?.csp || {} },
             updateModelContext: { text: {} },
           },
-          hostInfo: { name: "wisp-science", version: "0.19.0" },
+          hostInfo: { name: "wisp-science", version: wispAppVersion },
           hostContext: hostContext(),
         },
       });


### PR DESCRIPTION
## What changed

Two small fixes in the MCP App host bridge (`ui/src/api.js`):

- **Stale hardcoded version**: `hostContext.userAgent` and `hostInfo.version` were hardcoded to `0.19.0` while the app is at 0.22.0. The version is now fetched once at module load via `window.__TAURI__.app.getVersion()` (with a `0.0.0` fallback for environments without the Tauri app API, e.g. the Playwright mock).
- **Inconsistent display-mode claim**: `hostContext.availableDisplayModes` advertised `["inline", "fullscreen"]`, but the host never implemented `ui/request-display-mode` — an App requesting fullscreen gets `-32601 Capability is not granted by Wisp`. Narrowed the claim to `["inline"]` so Apps aren't misled.

## Why

Found while auditing our MCP Apps (SEP-1865, `io.modelcontextprotocol/ui`) host support. Both were host-context lies: one factual (wrong version), one capability-level (advertising a mode we reject).

## Notes for review

- MCP Apps only mount after a session exists and a tool call presents a `ui://` resource, so the async version fetch is always resolved by first use.
- Existing tests only assert `hostInfo.name === "wisp-science"`, never the version or display modes, so no test changes needed.
- Verified with `node --check` (ES module syntax); the real version value requires the Tauri runtime, which the mock preview can't exercise.
- If an App ever needs fullscreen, implement `ui/request-display-mode` and re-add `"fullscreen"` then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)