### PR TITLE
fix(ui): don't highlight the active HTTP model while an ACP agent is selected

### DIFF
--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -8308,11 +8308,13 @@ fn App() -> impl IntoView {
                                                 let selected = active_session.get().and_then(|session_id| {
                                                     session_model_ids.with(|models| models.get(&session_id).cloned())
                                                 });
-                                                let acp_locked = active_acp_agent_id.get().is_some() && items.with(|rows| !rows.is_empty());
+                                                let acp_selected = active_acp_agent_id.get().is_some();
+                                                let acp_locked = acp_selected && items.with(|rows| !rows.is_empty());
                                                 list.into_iter().map(|m| {
                                                     let pick_id = m.id.clone();
                                                     let pick_label = m.label.clone();
-                                                    let is_active = selected.as_deref().map_or(m.active, |id| id == m.id);
+                                                    let is_active = !acp_selected
+                                                        && selected.as_deref().map_or(m.active, |id| id == m.id);
                                                     let show_sub = !m.model.is_empty() && m.model != m.label;
                                                     view! {
                                                         <div class="model-menu-row" class:active=is_active>


### PR DESCRIPTION
## Summary
- The composer model menu could show ✓ on both the selected ACP agent and the last-active HTTP model at the same time.
- Root cause: the HTTP row's `is_active` only looked at `m.active` / the session model and ignored `active_acp_agent_id`. The underlying state is already exclusive (`switch_http_model` clears the ACP selection) — display-only bug.
- Fix: gate HTTP-row highlight on no ACP agent being active, same pattern the side-chat picker already uses (`main.rs:9553`).

## Test plan
- `cargo check` in `ui/` passes.
- Manual: open the composer model menu, pick an ACP agent → only the agent row shows ✓; pick an HTTP model → only that model shows ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NCVoyrVHJcdvcKvKNQCwvh