### PR TITLE
fix(ui): send on Enter when WKWebView tags it keyCode 229 after IME commit

### DIFF
--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -48,8 +48,8 @@ use std::rc::Rc;
 use text::{
     dom_value, event_target_checked, event_target_value, file_kind, format_bytes,
     format_duration_ms, group_artifact_indices, ime_composing, join_path, md_to_html,
-    opens_in_system_browser, parent_path, provider_defaults, provider_value, runtime_language,
-    tool_card_label, unique_dom_id, user_message_presentation,
+    note_composition_end, opens_in_system_browser, parent_path, provider_defaults, provider_value,
+    runtime_language, tool_card_label, unique_dom_id, user_message_presentation,
 };
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
@@ -5242,6 +5242,12 @@ fn App() -> impl IntoView {
             ev.prevent_default();
         }
     };
+
+    // Feed ime_composing: a keyCode-229 keydown right after this is the IME
+    // confirm key; a 229 keydown far from it is a real key (see text.rs).
+    window_event_listener(ev::compositionend, |ev| {
+        note_composition_end(ev.time_stamp());
+    });
 
     // Escape stack: topmost overlay → menus → drag cancel → right pane →
     // approval reject last. Composer @-mention and plan-feedback collapse

--- a/ui/src/text.rs
+++ b/ui/src/text.rs
@@ -6,6 +6,7 @@
 //! module in the UI that is trivially unit-testable and freely reusable; keep
 //! new coupling-free utilities here instead of growing `main.rs`.
 
+use std::cell::Cell;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
@@ -17,12 +18,44 @@ pub(crate) fn unique_dom_id(prefix: &str) -> String {
     format!("{prefix}-{}", NEXT_DOM_ID.fetch_add(1, Ordering::Relaxed))
 }
 
+thread_local! {
+    /// Timestamp of the last `compositionend`, consumed by `ime_composing`.
+    static COMPOSITION_ENDED_AT: Cell<f64> = const { Cell::new(f64::NEG_INFINITY) };
+    /// Timestamp of the keydown already judged IME-owned, so every guard
+    /// inspecting the same event agrees even after the marker is consumed.
+    static IME_SWALLOWED_AT: Cell<f64> = const { Cell::new(f64::NEG_INFINITY) };
+}
+
+/// Record a `compositionend` timestamp (one window-level listener in `App`).
+pub(crate) fn note_composition_end(time_stamp_ms: f64) {
+    COMPOSITION_ENDED_AT.with(|t| t.set(time_stamp_ms));
+}
+
 /// True while an IME is composing. WebKit (macOS WKWebView) fires the Enter
 /// keydown that confirms a candidate *after* `compositionend`, so
 /// `isComposing` is already false there — but `keyCode` is still 229, the
-/// IME-processed sentinel. Check both or that Enter sends the message.
+/// IME-processed sentinel. Only a 229 keydown *near* a compositionend is the
+/// confirm key, and it is swallowed once: with a CJK input source active
+/// WKWebView keeps tagging later standalone Enters 229 too, and those must
+/// send instead of inserting a newline (same 500ms-window + consume-once
+/// approach ProseMirror uses for this WebKit quirk).
 pub(crate) fn ime_composing(ev: &web_sys::KeyboardEvent) -> bool {
-    ev.is_composing() || ev.key_code() == 229
+    if ev.is_composing() {
+        return true;
+    }
+    if ev.key_code() != 229 {
+        return false;
+    }
+    let ts = ev.time_stamp();
+    if IME_SWALLOWED_AT.with(|t| t.get()) == ts {
+        return true;
+    }
+    let near = COMPOSITION_ENDED_AT.with(|t| (ts - t.get()).abs() < 500.0);
+    if near {
+        COMPOSITION_ENDED_AT.with(|t| t.set(f64::NEG_INFINITY));
+        IME_SWALLOWED_AT.with(|t| t.set(ts));
+    }
+    near
 }
 
 pub(crate) fn dom_value(ev: &web_sys::Event) -> String {


### PR DESCRIPTION
## What

With "Enter 发送" configured, pressing Enter in the composer still inserted a newline when a Chinese IME was the active input source.

## Why

b23c986 (fix for #108) made `ime_composing()` treat every keyCode-229 keydown as IME-owned. That correctly suppresses the Enter that confirms an IME candidate — WKWebView fires it after `compositionend` with `isComposing` already false — but with a CJK input source active WKWebView keeps tagging later standalone Enters 229 too. Those fell through the send guard to the default action: a newline.

## How

- `text.rs`: record the last `compositionend` timestamp; a 229 keydown only counts as IME-owned within 500ms of it, and the marker is consumed so it's swallowed exactly once (same window + consume-once approach ProseMirror uses for this WebKit quirk). A same-event memo keeps multiple guards inspecting one keydown consistent.
- `main.rs`: one window-level `compositionend` listener feeds the timestamp.

All eleven keydown guards route through `ime_composing()`, so composer send, side chat, pickers, palettes, and Escape handlers all inherit the fix.

## Verification

Simulated the event sequences against the running trunk preview (Chromium; real WKWebView+IME can't be driven synthetically):

- standalone Enter tagged 229 → sends (the reported bug)
- `compositionend` + immediate 229 Enter → swallowed (#108 stays fixed)
- another 229 Enter 150ms later → sends
- plain Enter (13) → sends; Shift+Enter → newline

`cargo check --target wasm32-unknown-unknown` passes. Worth a hands-on pass with a Chinese IME on the desktop app before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)