### PR TITLE
fix(ui): clear stale send-failed hint when a new turn is committed

### DIFF
--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -2388,6 +2388,10 @@ fn App() -> impl IntoView {
         {
             return;
         }
+        // Any prior send-failed hint (e.g. the max_tokens truncation notice) is
+        // stale once a new turn is committed; the Ok path never cleared it, so it
+        // lingered forever. Clear it here so continuing the conversation dismisses it.
+        status.set(String::new());
         if active_acp_agent_id.get().is_some() && action == ComposerSendAction::BranchNew {
             status.set("ACP protocol v1 does not support branching a bound session.".into());
             return;


### PR DESCRIPTION
## 问题

底部输入框的错误提示（例如「发送失败：模型输出在达到 max_tokens 上限时被截断……」）一旦出现就无法消除，会一直挂在那里。

## 根因

该提示由共享的 `status` 信号驱动（`ui/src/main.rs:6799` 渲染）。发送失败时它被写入，但：

- `send` 回调的 `Ok(_)` 分支从不清空它 —— 即使下一条消息发送成功，旧的错误也还在；
- 切换会话也不清空。

所以这条错误会永久停留，用户没有任何办法把它去掉。

## 改动

在真正提交一次新发送时（通过空输入校验之后）清空 `status`，同时覆盖排队发送和普通发送两条路径。截断提示本身就建议用户「直接继续对话让我接着做」——现在继续对话即可让提示消失。

一行改动：`ui/src/main.rs`。

## 验证

`cargo check --target wasm32-unknown-unknown` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)