### PR TITLE
feat(artifact): edit provenance code and rerun via composer

### DIFF
--- a/ui/mock-bridge.js
+++ b/ui/mock-bridge.js
@@ -620,6 +620,15 @@
             delete libraryVersions[args?.id];
             return libraryItems.length !== before;
           }
+          case "get_artifact_provenance":
+            return {
+              code: "import pandas as pd\ndf = search_fx_cell()\ndf.to_csv(\"report.csv\", index=False)",
+              language: "python",
+              output: "12 hits written to report.csv",
+              exit_status: "ok",
+              inputs: [],
+              env: null,
+            };
           case "get_library_item": {
             const item = libraryItems.find((entry) => entry.id === args?.id);
             return item ? { ...item, base64: null } : null;

--- a/ui/src/app_support.rs
+++ b/ui/src/app_support.rs
@@ -7487,6 +7487,7 @@ pub(super) fn ArtifactModal(
     on_close: Callback<()>,
     on_open_center: Callback<ModalArtifact>,
     on_open_path: Callback<(String, String)>, // open an input file (path, kind)
+    on_rerun: Callback<String>, // drop a rerun request into the composer (#455)
     library_items: ReadSignal<Vec<LibraryItem>>,
     on_library_changed: Callback<()>,
 ) -> impl IntoView {
@@ -7494,6 +7495,8 @@ pub(super) fn ArtifactModal(
     let prov = create_rw_signal(None::<ArtifactProvenance>);
     let loaded = create_rw_signal(false);
     let tab = create_rw_signal("code");
+    let editing_code = create_rw_signal(false);
+    let code_draft = create_rw_signal(String::new());
     let dom_id = unique_dom_id("amodal");
     {
         let path = path.clone();
@@ -7511,6 +7514,7 @@ pub(super) fn ArtifactModal(
     }
     let path_head = path.clone();
     let path_dl = path.clone();
+    let rerun_name = name.clone();
     let center_artifact = (path.clone(), name.clone(), kind.clone());
     let star_path = path.clone();
     let star_session = session.clone();
@@ -7617,12 +7621,24 @@ pub(super) fn ArtifactModal(
                             .filter(|p| !p.code.is_empty())
                             .map(|p| {
                                 let code = p.code;
+                                let draft_seed = code.clone();
                                 view! {
                                     <button type="button" class="icon-btn" style="margin-left: auto"
                                         title=move || t(locale.get(), "tool.copy_code")
                                         aria-label=move || t(locale.get(), "tool.copy_code")
                                         on:click=move |_| copy_text(code.clone())>
                                         {compose_icon("copy")}
+                                    </button>
+                                    <button type="button" class="icon-btn" class:active=move || editing_code.get()
+                                        title=move || t(locale.get(), "artifact.edit_code")
+                                        aria-label=move || t(locale.get(), "artifact.edit_code")
+                                        on:click=move |_| {
+                                            if !editing_code.get_untracked() {
+                                                code_draft.set(draft_seed.clone());
+                                            }
+                                            editing_code.update(|v| *v = !*v);
+                                        }>
+                                        {compose_icon("edit")}
                                     </button>
                                 }
                             })
@@ -7636,6 +7652,36 @@ pub(super) fn ArtifactModal(
                             return view! { <div class="am-empty">{t(loc,"artifact.none")}</div> }.into_view();
                         };
                         match tab.get() {
+                            "code" if editing_code.get() => {
+                                let lang = p.language.clone();
+                                let send_name = rerun_name.clone();
+                                view! {
+                                    <textarea class="am-edit-area" prop:value=move || code_draft.get()
+                                        on:input=move |ev| code_draft.set(event_target_value(&ev))></textarea>
+                                    <div class="am-edit-actions">
+                                        <button type="button" class="btn-ghost"
+                                            on:click=move |_| editing_code.set(false)>
+                                            {t(loc, "library.cancel")}
+                                        </button>
+                                        <button type="button" class="btn-primary"
+                                            on:click=move |_| {
+                                                let code = code_draft.get_untracked();
+                                                if code.trim().is_empty() {
+                                                    return;
+                                                }
+                                                let message = format!(
+                                                    "{}\n```{}\n{}\n```",
+                                                    tf(loc, "artifact.rerun_prompt", &[("name", &send_name)]),
+                                                    lang,
+                                                    code.trim_end(),
+                                                );
+                                                on_rerun.call(message);
+                                            }>
+                                            {t(loc, "artifact.rerun_send")}
+                                        </button>
+                                    </div>
+                                }.into_view()
+                            }
                             "code" => view! { <RpCodeView lang=p.language.clone() body=p.code.clone() /> }.into_view(),
                             "log" => view! { <pre class="am-log">{p.output.clone()}</pre> }.into_view(),
                             "inputs" => view! {

--- a/ui/src/i18n.rs
+++ b/ui/src/i18n.rs
@@ -109,6 +109,11 @@ fn lookup(locale: Locale, key: &str) -> Option<&'static str> {
         (Locale::En, "library.empty.body") => Some("Use the star on a code cell or figure to keep an immutable copy here."),
         (Locale::En, "library.open_source") => Some("Open source"),
         (Locale::En, "library.generating_code") => Some("Generating code"),
+        (Locale::En, "artifact.edit_code") => Some("Edit code and re-run"),
+        (Locale::En, "artifact.rerun_send") => Some("Insert into chat"),
+        (Locale::En, "artifact.rerun_prompt") => Some(
+            "I edited the code that produced {name}. Please re-run this version and regenerate the artifact:",
+        ),
         (Locale::En, "library.versions") => Some("Versions"),
         (Locale::En, "library.version_original") => Some("Original"),
         (Locale::En, "library.edit") => Some("Edit code"),
@@ -1450,6 +1455,11 @@ Do not leave generated files in the project root.",
         (Locale::Zh, "library.empty.body") => Some("点击代码单元或图片上的星标，在这里保存一份固定快照。"),
         (Locale::Zh, "library.open_source") => Some("打开来源"),
         (Locale::Zh, "library.generating_code") => Some("生成代码"),
+        (Locale::Zh, "artifact.edit_code") => Some("编辑代码重跑"),
+        (Locale::Zh, "artifact.rerun_send") => Some("填入对话框"),
+        (Locale::Zh, "artifact.rerun_prompt") => {
+            Some("我修改了生成 {name} 的代码，请用下面这版重新运行，重新生成产物：")
+        }
         (Locale::Zh, "library.versions") => Some("版本"),
         (Locale::Zh, "library.version_original") => Some("原始"),
         (Locale::Zh, "library.edit") => Some("编辑代码"),

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -10482,6 +10482,11 @@ fn App() -> impl IntoView {
                         reveal_in_files(&p, file_source, file_cwd, file_query, file_entries, show_right, open_right_tabs, right_tab);
                         modal_artifact.set(None);
                     })
+                    on_rerun=Callback::new(move |text: String| {
+                        input.set(text);
+                        focus_composer();
+                        modal_artifact.set(None);
+                    })
                     library_items=library_items.read_only()
                     on_library_changed=refresh_library_items />
             }

--- a/ui/src/styles/modals.css
+++ b/ui/src/styles/modals.css
@@ -298,6 +298,9 @@ textarea.host-input { min-height:64px; resize:vertical; }
 .artifact-modal .am-panel { max-height: 30vh; overflow: auto; flex: 0 0 auto; min-width: 0; }
 .artifact-modal .am-panel > .rp-code { max-height: none; overflow: visible; }
 .artifact-modal .am-log { font-family: var(--font-mono); font-size: 12px; white-space: pre-wrap; margin: 0; }
+.artifact-modal .am-edit-area { width: 100%; min-height: 180px; resize: vertical; padding: 10px; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--bg-sunken); color: var(--text); font-family: var(--font-mono); font-size: 12px; line-height: 1.5; }
+.artifact-modal .am-edit-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 8px; }
+.artifact-modal .am-tabs .icon-btn.active { color: var(--clay-strong); }
 .artifact-modal .am-empty { color: var(--text-faint); font-size: 12.5px; padding: 16px; }
 .artifact-modal .am-inputs { display: flex; flex-direction: column; gap: 4px; }
 .artifact-modal .am-input { text-align: left; background: var(--bg-sunken); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 6px 9px; font: inherit; font-size: 12px; font-family: var(--font-mono); color: var(--text-muted); cursor: default; }


### PR DESCRIPTION
## What

Second slice of #455 — the redraw/rerun ask from #409.

The artifact modal's Code tab gains an edit mode:

- A pencil button (next to the existing copy button) opens the provenance source in a textarea.
- "Insert into chat" builds a localized rerun request — template + fenced code block tagged with the cell's language — and drops it into the composer with focus, reusing the same `input.set + focus_composer` pattern as the Agents panel. The user reviews and sends; nothing is auto-sent.
- Cancel (or closing the modal) discards the draft.

Also adds a mock-bridge `get_artifact_provenance` case so the flow is testable in `?mock=1` preview.

## Why no schema change

The plan originally included binding artifacts to exact code versions (a migration adding `exec_log_id`). Investigating the real flow showed it is unnecessary:

- Session artifact chips are derived by scanning transcript text for paths (`extract_protos`); the modal displays the **current file on disk**, and `find_provenance_by_path` returns the latest writer of that path — file bytes and code always correspond.
- `execution_log` is append-only: every run is already an immutable code version, and library edits (#470) never touch it. A rerun simply produces a new cell whose provenance binds to the regenerated artifact automatically.
- Versioned run artifacts (`artifact_versions`) already carry `producing_run_id`.

So the #455 acceptance points "历史产物不随最新版本漂移" and "删除新版本不让原始溯源失效" hold structurally without a migration.

## Not in this PR

Rerunning directly from a library version — the library screen is app-global and lacks a session context; per-version copy covers it until the in-project library entry (#415) lands.

## Verification

- `cd ui && cargo check --target wasm32-unknown-unknown` clean (UI-only change)
- Manual flow in `?mock=1`: open `report.csv` → Code tab → pencil → edit a line → "Insert into chat" → composer receives the full message (template + ```python fence + edited code), modal closes, composer focused

🤖 Generated with [Claude Code](https://claude.com/claude-code)