### PR TITLE
fix(notify): stop finished sessions from hijacking other windows

### DIFF
--- a/src-tauri/src/app_commands.rs
+++ b/src-tauri/src/app_commands.rs
@@ -17,10 +17,22 @@ pub(super) async fn notify_user(
     if app_has_focus() || !load_notifications_enabled(&state.store).await {
         return Ok(());
     }
+    // The done/attention agent events are broadcast to every window, so every
+    // window calls this command for every session. Only the window whose active
+    // project owns the session may notify and arm click-to-open — otherwise
+    // each unrelated window queues this session and navigates to it on its next
+    // focus, hijacking windows that were viewing other sessions, and N windows
+    // show N duplicate notifications.
+    let project_id = state.store.frame_project_id(&session_id).await.ok().flatten();
+    if let Some(project_id) = &project_id {
+        if state.active(window.label()).id != *project_id {
+            return Ok(());
+        }
+    }
     // Arm click-to-open before showing: on this window's next focus it jumps to
     // the session. Skipped if the session's project can't be resolved (the
     // notification still shows, just without navigation).
-    if let Ok(Some(project_id)) = state.store.frame_project_id(&session_id).await {
+    if let Some(project_id) = project_id {
         pending_notify_targets().lock().unwrap().insert(
             window.label().to_string(),
             serde_json::json!({ "projectId": project_id, "sessionId": session_id }),


### PR DESCRIPTION
## What

With multiple windows open (e.g. window A running task A, window B running task B), whichever session finished first would take over **every** window: after refocusing, both windows displayed session B's content.

## Why

The done/attention agent events are broadcast to all windows (`app.emit` in `lib.rs`), and every window's frontend calls `notify_user` for every such event. With the app unfocused, `notify_user` armed a pending `open-session` target keyed by the **calling** window's label but pointing at the finished session — so window A got queued to open session B. On each window's next `Focused(true)`, `drain_pending_notify_target` navigated it there (#434 click-to-open), hijacking windows that were viewing other sessions. It also produced N duplicate desktop notifications for N windows.

## Fix

Guard `notify_user` (the single function all windows route through): only the window whose active project owns the session may show the notification and arm the click-to-open target; other windows return early. This fixes both the hijack and the duplicate notifications.

## Notes for review

- Minor behavior change: if no open window has the session's project active when it finishes (e.g. that window was switched to another project mid-turn), the notification is skipped instead of shown. Previously it was shown from every window, each armed to navigate on focus.
- Sessions whose project can't be resolved keep the old behavior (notification shows, no navigation).
- `cargo check` and the existing notify test pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)