### PR TITLE
feat(browser): add web_screenshot tool for real-browser vision

### DIFF
--- a/crates/wisp-core/src/agent.rs
+++ b/crates/wisp-core/src/agent.rs
@@ -341,12 +341,12 @@ async fn agent_loop_inner(
                     Some(vision) => match describe_image(vision, img, &name, &args).await {
                         Ok(text) => (Content::text(text.clone()), text, true),
                         Err(e) => {
-                            let text = format!("view_image error: vision model failed: {e}");
+                            let text = format!("{name} error: vision model failed: {e}");
                             (Content::text(text.clone()), text, false)
                         }
                     },
                     None => {
-                        let text = "view_image error: no vision model is configured. Mark an API model as vision-capable in Settings -> Models and set it for image analysis.".to_string();
+                        let text = format!("{name} error: no vision model is configured. Mark an API model as vision-capable in Settings -> Models and set it for image analysis.");
                         (Content::text(text.clone()), text, false)
                     }
                 }

--- a/docs/real-browser-automation.md
+++ b/docs/real-browser-automation.md
@@ -91,6 +91,12 @@ These settings must be changed manually because internal settings pages such as
 - `web_execute_js`: execute JavaScript in the selected real tab. It also accepts
   a JSON `{ "cmd": "cdp", ... }` request for a single Chrome DevTools Protocol
   method when trusted browser input or another CDP-only action is required.
+- `web_screenshot`: capture the visible viewport of the selected real tab as a
+  JPEG and read it with the configured vision model, for rendered layout,
+  charts, canvas/WebGL pages, QR codes, or a page that looks wrong. It captures
+  the viewport only; scroll with `web_execute_js` to reach content below the
+  fold. It needs a vision-capable model configured in
+  **Settings → Models**, like `view_image`.
 
 Both tools always require at least one Wisp approval. The approval can be
 granted once, for the session, for the project, or globally through the existing

--- a/skills/browser-use/SKILL.md
+++ b/skills/browser-use/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: browser-use
-description: "Use this skill to drive the user's real, persistent Chrome/Chromium session — open pages, read them, click, fill and submit forms, navigate, switch tabs, or scrape content that needs the user's existing cookies and login state. Triggers when the user asks to do something in their browser, log into a site and act inside it, fill out a web form, click through a flow, or extract data from a page that requires being signed in. Tools: browser_setup (check/connect the extension), web_open_tab (open a URL), web_scan (read visible content + actionable elements with ready-made selectors), web_execute_js (click/type/navigate, or a JSON command for tabs/CDP). Not for the built-in read-only web fetch — this is for interacting with a live browser."
+description: "Use this skill to drive the user's real, persistent Chrome/Chromium session — open pages, read them, click, fill and submit forms, navigate, switch tabs, or scrape content that needs the user's existing cookies and login state. Triggers when the user asks to do something in their browser, log into a site and act inside it, fill out a web form, click through a flow, or extract data from a page that requires being signed in. Tools: browser_setup (check/connect the extension), web_open_tab (open a URL), web_scan (read visible content + actionable elements with ready-made selectors), web_execute_js (click/type/navigate, or a JSON command for tabs/CDP), web_screenshot (see what the tab is showing — layout, charts, canvas, QR codes). Not for the built-in read-only web fetch — this is for interacting with a live browser."
 fold_cue: "instead_of=guessing-selectors use=web_scan first — it returns a unique CSS selector and rect for every actionable element; never invent selectors"
 ---
 
@@ -49,12 +49,22 @@ until the popup shows *Connected to Wisp*. Never invent the path.
 | Switch to & focus a tab (so the user sees it) | `{"cmd":"tabs","method":"switch","tabId":<id>}` |
 | List tabs | `{"cmd":"tabs"}` (or just `web_scan tabs_only`) |
 | Trusted click when `.click()` is ignored | `{"cmd":"cdp","method":"Input.dispatchMouseEvent","params":{"type":"mousePressed","x":<x>,"y":<y>,"button":"left","clickCount":1}}` then the same with `"type":"mouseReleased"` — use the element's `rect` centre from `web_scan` |
-| Screenshot | `{"cmd":"cdp","method":"Page.captureScreenshot","params":{"format":"png"}}` |
 
 Prefer plain JS. Reach for `cmd:cdp` only when a page blocks synthetic
-events or you truly need trusted input. **Screenshots return base64 that
-floods context and is truncated at ~200k chars — prefer `web_scan`'s
-structured output; screenshot only when structure isn't enough.**
+events or you truly need trusted input.
+
+## Seeing the page — `web_screenshot`
+
+`web_scan` gives text and elements; **`web_screenshot`** gives sight. Use it
+when structure isn't enough: rendered layout, a chart or diagram, a
+canvas/WebGL page, a QR code, a PDF or image viewer, or a page that looks
+broken. It captures the **visible viewport** of the tab — to see below the
+fold, scroll first (`web_execute_js` `scrollTo(0, 1200)`) and capture again.
+Pass `question` to say what to read out of it, e.g.
+`{"question":"is the login QR code visible and not expired?"}`.
+
+It goes through the configured vision model, so `web_scan` stays the cheaper
+default — screenshot when you need eyes, not for every step.
 
 ## Stop conditions (do not automate through these)
 

--- a/src-tauri/src/browser_bridge.rs
+++ b/src-tauri/src/browser_bridge.rs
@@ -27,7 +27,7 @@ use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::{accept_hdr_async, WebSocketStream};
 use uuid::Uuid;
 use wisp_llm::ToolSchema;
-use wisp_tools::{Approval, Tool, ToolEnv, ToolResult};
+use wisp_tools::{Approval, ImageData, Tool, ToolEnv, ToolResult};
 
 const BRIDGE_ADDR: &str = "127.0.0.1:18765";
 const EXTENSION_ORIGIN: &str = "chrome-extension://gnkjgagleagkgdlkkcianolobfdoocnp";
@@ -35,6 +35,9 @@ const DEFAULT_TIMEOUT_MS: u64 = 15_000;
 const MAX_TIMEOUT_MS: u64 = 60_000;
 const MAX_SCRIPT_BYTES: usize = 64 * 1024;
 const MAX_RESULT_CHARS: usize = 200_000;
+/// Base64 payload ceiling for one screenshot, matching the shared image path's
+/// 5 MB decoded limit (base64 inflates by 4/3).
+const MAX_SCREENSHOT_B64: usize = 7 * 1024 * 1024;
 
 #[derive(Clone, Debug, Serialize)]
 pub struct BrowserTab {
@@ -845,6 +848,94 @@ impl Tool for WebOpenTabTool {
     }
 }
 
+pub struct WebScreenshotTool {
+    bridge: Arc<BrowserBridge>,
+}
+
+impl WebScreenshotTool {
+    pub fn new(bridge: Arc<BrowserBridge>) -> Self {
+        Self { bridge }
+    }
+}
+
+#[async_trait]
+impl Tool for WebScreenshotTool {
+    fn name(&self) -> &str {
+        "web_screenshot"
+    }
+
+    fn schema(&self) -> ToolSchema {
+        ToolSchema::new(
+            self.name(),
+            "Look at what a tab in the user's real Chrome/Chromium session is showing. Use it when web_scan's text and element snapshot is not enough: rendered layout, a chart or diagram, a canvas/WebGL page, a QR code, a PDF or image viewer, or a page that looks wrong and needs eyes. Captures the visible viewport of the tab; to reach content below the fold, scroll with web_execute_js first and capture again. Pass 'question' to say what should be read out of the screenshot.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "switch_tab_id": { "type": ["integer", "string"], "description": "Tab id returned by web_scan; selects that tab for this and later calls" },
+                    "question": { "type": "string", "description": "What to look for in the screenshot, e.g. 'is the login QR code visible and not expired?'" }
+                }
+            }),
+        )
+    }
+
+    fn minimum_approval(&self) -> Approval {
+        Approval::Ask
+    }
+
+    fn preview(&self, args: &Value) -> String {
+        args.get("switch_tab_id")
+            .map(|tab| format!("screenshot real-browser tab {tab}"))
+            .unwrap_or_else(|| "screenshot selected real-browser tab".into())
+    }
+
+    async fn run(&self, args: &Value, _env: &dyn ToolEnv) -> ToolResult {
+        let tab_id = match tab_id_arg(args) {
+            Ok(tab_id) => tab_id,
+            Err(error) => return ToolResult::fail(error),
+        };
+        // ponytail: reuses the extension's existing CDP path, so no new
+        // permission and no extension change. JPEG q80 keeps a viewport well
+        // under the image limit and still resolves QR codes and small text.
+        let code = json!({
+            "cmd": "cdp",
+            "method": "Page.captureScreenshot",
+            "params": { "format": "jpeg", "quality": 80 }
+        })
+        .to_string();
+        let execution = match self
+            .bridge
+            .execute(tab_id, &code, Duration::from_millis(DEFAULT_TIMEOUT_MS))
+            .await
+        {
+            Ok(execution) => execution,
+            Err(error) => return ToolResult::fail(error),
+        };
+        let Some(data) = execution
+            .value
+            .get("data")
+            .and_then(Value::as_str)
+            .filter(|data| !data.is_empty())
+        else {
+            return ToolResult::fail("browser screenshot returned no image data");
+        };
+        if data.len() > MAX_SCREENSHOT_B64 {
+            return ToolResult::fail(format!(
+                "browser screenshot is too large ({} bytes of base64); reduce the browser window size and retry",
+                data.len()
+            ));
+        }
+        ToolResult::image(ImageData {
+            mime: "image/jpeg".into(),
+            data_url: format!("data:image/jpeg;base64,{data}"),
+            label: format!(
+                "Screenshot of real browser tab {} ({} KB)",
+                execution.tab_id,
+                data.len() / 1024
+            ),
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -892,7 +983,11 @@ mod tests {
             Approval::Ask
         );
         assert_eq!(
-            WebExecuteJsTool::new(bridge).minimum_approval(),
+            WebExecuteJsTool::new(bridge.clone()).minimum_approval(),
+            Approval::Ask
+        );
+        assert_eq!(
+            WebScreenshotTool::new(bridge).minimum_approval(),
             Approval::Ask
         );
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4258,6 +4258,9 @@ async fn send_message_inner(
         agent.add_tool(Box::new(browser_bridge::WebOpenTabTool::new(
             state.browser_bridge.clone(),
         )));
+        agent.add_tool(Box::new(browser_bridge::WebScreenshotTool::new(
+            state.browser_bridge.clone(),
+        )));
         agent.add_tool(Box::new(run_context::RunInContextTool::new(
             state.store.clone(),
             state.run_manager.clone(),


### PR DESCRIPTION
## 背景

`web_scan` 返回页面文本和可交互元素，但 Agent 看不到**渲染结果**：布局、图表、canvas/WebGL 页面、二维码、PDF/图片查看器，以及"页面看起来不对劲"这类只能用眼睛判断的情况。

原来的绕法是通过 `web_execute_js` 发一条裸 CDP `Page.captureScreenshot` —— 返回的 base64 直接灌进模型上下文，还会在 200k 字符处被截断，基本不可用。

## 改动

- **新增 `web_screenshot` 工具** (`src-tauri/src/browser_bridge.rs`)：抓取选中标签页的**可视视口**，JPEG q80，返回 `ToolResult::image`，接入与 `view_image` 相同的 vision 管线。
  - 参数：`switch_tab_id`（可选，沿用 `web_scan` 的标签页选择逻辑）、`question`（可选，指定要从截图里读什么，例如"登录二维码在不在、是否过期"）。
  - 走扩展**已有的 CDP 通道**——浏览器扩展零改动、无新权限申请。
  - `Approval::Ask`，与其他页面访问工具一致（已加断言覆盖）。
  - base64 体积上限 7 MB，对齐共享图片路径 5 MB 解码后的限制。
- **修掉一处根因** (`crates/wisp-core/src/agent.rs`)：vision 失败 / 未配置 vision 模型的报错文案写死了 `view_image error:`，但这两条路径是所有返回图片的工具共用的。改成用实际工具名，否则截图失败会报成 `view_image` 的错。
- 同步文档 `docs/real-browser-automation.md` 与 `skills/browser-use/SKILL.md`（删掉旧的 CDP 截图配方及其上下文告警）。

## Reviewer 需要知道的

- **依赖 vision 模型**：需要在 设置 → 模型 里标记一个 API 模型为 vision-capable，否则工具返回未配置错误（与 `view_image` 行为一致）。截图**不会**直接进主模型上下文，而是先由 vision 模型转成文字描述。
- **只截视口**：整页长截图和按选择器裁剪都刻意没做。要看首屏以下，先 `web_execute_js` 滚动再截。真出现"二维码太小认不出 / 需要整页存档"再加 clip 参数。
- CDP 路径会短暂 attach debugger，浏览器顶部出现调试提示条——这是既有 `cmd:cdp` 路径的固有行为，非本次引入。
- `cargo check` / `cargo fmt --check` / `cargo test -p wisp-tauri browser` / `cargo test -p wisp-core agent` 均通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)