### PR TITLE
fix(ssh): 常驻连接失败时保留 OpenSSH 的真实报错 (#478)

### DIFF
--- a/src-tauri/src/ssh_hosts.rs
+++ b/src-tauri/src/ssh_hosts.rs
@@ -640,7 +640,10 @@ Use `set_runtime_interpreter` when the user provides a different Python or R exe
 on the registered environment. Always use `run_in_context`, `python`, `r`, \
 `configure_ssh_trust`, or `transfer_between_contexts` with \
 the matching `context_id` so Wisp uses the configured alias/user/port/identity \
-exactly. Free-form shell `ssh`/`scp` is disabled. If SSH authentication or host-key \
+exactly. Free-form shell `ssh`/`scp` is disabled, and so is reaching the same host through \
+an SSH client library (`paramiko`, `fabric`, `ssh2`, …) from `python`/`r`/shell: that bypasses \
+the user's saved credentials and this policy, so never offer it as a fallback. \
+If SSH authentication or host-key \
 verification fails: STOP, report it once, and ask the user to fix the saved credentials \
 or trust and Probe again — do not invent `ssh -i`, ports, or `StrictHostKeyChecking` \
 options. Do not retry a rejected login because repeated authentication attempts can ban \

--- a/src-tauri/src/ssh_master.rs
+++ b/src-tauri/src/ssh_master.rs
@@ -84,12 +84,17 @@ fn frame(payload: &SshPayload, nonce: &str) -> String {
     }
 }
 
+/// How long a dying master gets to exit and flush its stderr before we give up
+/// on quoting OpenSSH's own diagnostic.
+const DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
+
 struct Master {
     // Held for kill_on_drop: dropping a Master tears the connection down.
-    _child: Child,
+    child: Child,
     stdin: ChildStdin,
     stdout: ChildStdout,
     stderr_buf: Arc<StdMutex<Vec<u8>>>,
+    stderr_task: Option<tokio::task::JoinHandle<()>>,
 }
 
 impl Master {
@@ -121,7 +126,7 @@ impl Master {
             .ok_or_else(|| "failed to open ssh master stderr".to_string())?;
         let stderr_buf = Arc::new(StdMutex::new(Vec::new()));
         let buf = stderr_buf.clone();
-        tokio::spawn(async move {
+        let stderr_task = tokio::spawn(async move {
             let mut chunk = [0_u8; 4096];
             while let Ok(read) = stderr.read(&mut chunk).await {
                 if read == 0 {
@@ -136,10 +141,11 @@ impl Master {
             }
         });
         Ok(Self {
-            _child: child,
+            child,
             stdin,
             stdout,
             stderr_buf,
+            stderr_task: Some(stderr_task),
         })
     }
 
@@ -150,12 +156,28 @@ impl Master {
             .to_string()
     }
 
-    fn transport_error(&self, action: &str, detail: String) -> String {
+    /// A failing `ssh` writes its diagnostic ("Permission denied (publickey)",
+    /// "Host key verification failed", …) to stderr and exits; we notice the
+    /// stdout EOF first, so reporting immediately loses the only line that says
+    /// what went wrong — and hides auth failures from `ssh_guard`. Wait for the
+    /// child and its stderr reader before formatting.
+    async fn transport_error(&mut self, action: &str, detail: String) -> String {
+        let status = match tokio::time::timeout(DRAIN_TIMEOUT, self.child.wait()).await {
+            Ok(Ok(status)) => status.code(),
+            _ => None,
+        };
+        if let Some(task) = self.stderr_task.take() {
+            let _ = tokio::time::timeout(DRAIN_TIMEOUT, task).await;
+        }
         let stderr = self.take_stderr();
+        let exit = match status {
+            Some(code) => format!(" (ssh exited with status {code})"),
+            None => String::new(),
+        };
         if stderr.is_empty() {
-            format!("ssh master {action}: {detail}")
+            format!("ssh master {action}: {detail}{exit}")
         } else {
-            format!("ssh master {action}: {detail}: {stderr}")
+            format!("ssh master {action}: {detail}{exit}: {stderr}")
         }
     }
 
@@ -163,14 +185,16 @@ impl Master {
         let nonce = uuid::Uuid::new_v4().simple().to_string();
         let marker = exit_marker(&nonce);
         let marker = marker.as_bytes();
-        self.stdin
+        if let Err(e) = self
+            .stdin
             .write_all(frame(payload, &nonce).as_bytes())
             .await
-            .map_err(|e| self.transport_error("write failed", e.to_string()))?;
-        self.stdin
-            .flush()
-            .await
-            .map_err(|e| self.transport_error("write failed", e.to_string()))?;
+        {
+            return Err(self.transport_error("write failed", e.to_string()).await);
+        }
+        if let Err(e) = self.stdin.flush().await {
+            return Err(self.transport_error("write failed", e.to_string()).await);
+        }
         let mut buf: Vec<u8> = Vec::new();
         let mut chunk = [0_u8; 8192];
         loop {
@@ -196,13 +220,14 @@ impl Master {
                     "ssh command output exceeded {MAX_RPC_OUTPUT_BYTES} bytes"
                 ));
             }
-            let read = self
-                .stdout
-                .read(&mut chunk)
-                .await
-                .map_err(|e| self.transport_error("read failed", e.to_string()))?;
+            let read = match self.stdout.read(&mut chunk).await {
+                Ok(read) => read,
+                Err(e) => return Err(self.transport_error("read failed", e.to_string()).await),
+            };
             if read == 0 {
-                return Err(self.transport_error("connection closed", "unexpected EOF".into()));
+                return Err(self
+                    .transport_error("connection closed", "unexpected EOF".into())
+                    .await);
             }
             buf.extend_from_slice(&chunk[..read]);
         }
@@ -329,6 +354,32 @@ mod tests {
         let framed = frame(&SshPayload::Script(script.into()), "abc");
         assert!(framed.starts_with("sh -s <<'__WISP_MASTER_abc__X' 2>&1\n"));
         assert!(framed.contains("\n__WISP_MASTER_abc__X\nprintf"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn dying_master_reports_stderr_and_exit_status() {
+        // Stands in for `ssh` refusing to connect: a diagnostic on stderr, then
+        // exit. The error must quote it instead of a bare "unexpected EOF".
+        let mut master = Master::spawn(
+            "sh",
+            &[
+                "-c".into(),
+                "echo 'Permission denied (publickey).' >&2; exit 255".into(),
+            ],
+            &[],
+        )
+        .unwrap();
+        let error = tokio::time::timeout(
+            Duration::from_secs(10),
+            master.rpc(&SshPayload::Command("true".into())),
+        )
+        .await
+        .expect("rpc timed out")
+        .err()
+        .expect("master exited, rpc must fail");
+        assert!(error.contains("Permission denied (publickey)"), "{error}");
+        assert!(error.contains("status 255"), "{error}");
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
Fixes #478

## 问题

`ssh` 连不上时会把原因（`Permission denied (publickey)`、`Host key verification failed`、超时…）写到 stderr 然后退出。而 `ssh_master` 先看到的是 stdout 的 EOF，此时后台读 stderr 的任务通常还没读完，错误就被立刻格式化成一句：

```
ssh master connection closed: unexpected EOF
```

用户（和模型）拿不到任何线索。#478 里模型因此脑补了一个「Wisp Rust SSH 库与 OpenSSH_8.7 兼容性问题」——Wisp 根本没有 Rust SSH 库，全部走系统 OpenSSH 客户端——然后改用 paramiko 绕过。

副作用：`ssh_guard` 靠错误文本里的 `Permission denied` 等关键词识别认证失败；文本被吞掉后，防止反复登录被服务器封 IP 的冷却闸门形同虚设。

## 改动

- `ssh_master.rs`：保留 `Child` 和 stderr 读取任务的句柄；出错时先 `child.wait()`、再 await stderr 任务（各 5s 上限），然后把退出码和 OpenSSH 原话拼进错误：
  ```
  ssh master connection closed: unexpected EOF (ssh exited with status 255): Permission denied (publickey).
  ```
  `transport_error` 因此变成 `async fn(&mut self)`，`rpc()` 里三处 `map_err` 改成 match。
- `ssh_hosts.rs`：compute-context 策略里明确禁止用 `paramiko`/`fabric`/`ssh2` 之类的 SSH 库当备用通道——绕过保存的凭据、host key 校验和上面的闸门。

## 测试

新增 `dying_master_reports_stderr_and_exit_status`：用「写 stderr 后 exit 255」的 `sh` 冒充失败的 ssh，断言错误里同时含 `Permission denied (publickey)` 与 `status 255`（改之前必挂，因为退出码根本没被采集）。

`cargo test --lib ssh_` → 55 passed。

## Reviewer 注意

- 未做「首连失败自动降级到一次性 ssh 会话」：会掩盖真实错误并翻倍登录尝试，与 ssh_guard 的目的冲突。
- 5s 的 `DRAIN_TIMEOUT` 只在失败路径上生效，成功路径不受影响。
- #478 用户的实际连接失败原因仍未知（正因为日志被吞）；本 PR 修的是让它可诊断，已在 issue 下给出自查命令。

🤖 Generated with [Claude Code](https://claude.com/claude-code)