### PR TITLE
fix(ui): don't clip the final answer at 4000 chars

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1903,7 +1903,13 @@ impl Output for TauriOutput {
         });
     }
     fn tool_result(&self, name: &str, ok: bool, content: &str, duration_ms: u64) {
-        let clipped: String = content.chars().take(4000).collect();
+        // ponytail: attempt_completion's "tool result" IS the final answer bubble,
+        // so the 4000-char preview clip must not apply to it.
+        let clipped: String = if name == "attempt_completion" {
+            content.to_string()
+        } else {
+            content.chars().take(4000).collect()
+        };
         self.emit(AgentEvent::ToolResult {
             frame_id: self.frame_id.clone(),
             name: name.into(),


### PR DESCRIPTION
## 问题

长回答在实时聊天界面里被截断（句子中间断掉），但模型输出其实是完整的。

从一份 debug request 快照里对齐验证：被截断的那条最终答案在会话历史中是完整的 4598 字符，而界面上的断点正好落在**第 4000 个字符**。重开会话就能看到全文，所以只是实时渲染这一段掉了。

## 根因

最终答案是 `attempt_completion` 工具的结果，实时 UI 把它的 tool result 提升成 assistant 气泡（`src-tauri/src/lib.rs:1182`）。但 `TauriOutput::tool_result` 会把**所有** tool result 裁到 4000 字符做预览，最终答案顺带中枪。

落盘路径不受影响（`ctx.append_tool` → `budget_stream_result` 只裁 shell/python/r），所以数据没丢。

## 改动

在预览裁剪里豁免 `attempt_completion`，一处修复覆盖所有调用方。

## Reviewer notes

- 其他工具的 4000 字符预览裁剪保持不变。
- 无新增测试：单个分支判断，且现有断言无法观察到 Tauri 事件负载。

🤖 Generated with [Claude Code](https://claude.com/claude-code)