### PR TITLE
feat(library): 按版本重跑收藏、figure 代码可编辑 (#474)

### DIFF
--- a/docs/global-library.md
+++ b/docs/global-library.md
@@ -7,9 +7,18 @@ projects in the local Wisp installation.
 - Click the SVG star in an image artifact header to save the image bytes and,
   when provenance exists, the code that generated it.
 - In an image artifact viewer, open **Code** and use **Copy code** to copy the
-  exact recorded source. Provenance code remains read-only.
+  exact recorded source, or the pencil to edit it and drop a re-run request into
+  the composer. The recorded source in `execution_log` is never rewritten.
 - Open **Library** from the Projects screen or a project sidebar. Items can be
   searched, filtered, removed, or traced back to their source project/session.
+
+A saved item's code is versioned: the starred snapshot is the immutable v1, and
+each edit appends a new version (`library_item_versions`) instead of rewriting
+it. This applies to `code` items and to a figure's generating code; text
+excerpts stay verbatim because they anchor highlights back to the transcript.
+From a project (not the Projects screen), **Insert into chat** pre-fills the
+composer with the selected version — the request names the item id and version
+number, and the user still sends it.
 
 Library data lives in `library.sqlite` beside the main `wisp.sqlite` app
 database. Project and session IDs/names are stored as source snapshots without

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -671,6 +671,7 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
     { id: "art-markdown", name: "analysis-report.md", kind: "text/markdown", path: "analysis-report.md", ts: Math.floor(Date.now() / 1000), project_id: "default", project_name: "wisp-science", session_id: "s-current", session_title: "Current analysis", origin: "output" },
   ];
   let libraryItems: any[] = [];
+  const libraryVersions: Record<string, any[]> = {};
 
   (window as any).__TAURI__ = {
     core: {
@@ -765,9 +766,44 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
             if (!item) throw new Error("Library item not found");
             return item;
           }
+          case "list_library_item_versions": {
+            const item = libraryItems.find((entry) => entry.id === arg("id"));
+            if (!item) return [];
+            const original = {
+              id: item.id,
+              item_id: item.id,
+              version_number: 1,
+              parent_version_id: null,
+              language: item.language,
+              code: item.code,
+              origin: "original",
+              created_at: item.created_at,
+            };
+            return [original, ...(libraryVersions[item.id] ?? [])];
+          }
+          case "update_library_code": {
+            const item = libraryItems.find((entry) => entry.id === arg("id"));
+            if (!item) throw new Error("Library item not found");
+            if (item.kind === "text") throw new Error("Text excerpts cannot be edited");
+            const edits = (libraryVersions[item.id] ??= []);
+            const head = edits[edits.length - 1];
+            const version = {
+              id: `library-version-${item.id}-${edits.length + 2}`,
+              item_id: item.id,
+              version_number: (head?.version_number ?? 1) + 1,
+              parent_version_id: head?.id ?? item.id,
+              language: arg("language") ?? head?.language ?? item.language,
+              code: String(arg("code") ?? ""),
+              origin: "edit",
+              created_at: Math.floor(Date.now() / 1000),
+            };
+            edits.push(version);
+            return version;
+          }
           case "delete_library_item": {
             const before = libraryItems.length;
             libraryItems = libraryItems.filter((entry) => entry.id !== arg("id"));
+            delete libraryVersions[String(arg("id"))];
             return libraryItems.length !== before;
           }
           case "list_demos":

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -5263,6 +5263,85 @@ test("a starred figure keeps its image and generating code", async ({ page }) =>
   await expect(page.locator('.library-card[data-library-kind="figure"]')).toHaveCount(0);
 });
 
+test("a starred code item edits into a new version and re-runs from the composer (#474)", async ({ page }) => {
+  await enterApp(page);
+  await composer(page).fill("STEPSDEMO");
+  await page.getByRole("button", { name: "Send" }).click();
+  await expect(page.getByText(/60,675 genes/)).toBeVisible({ timeout: 10_000 });
+  await page.getByRole("button", { name: "Toggle panel" }).click();
+  await page.getByRole("button", { name: "Add panel" }).click();
+  await page.getByRole("button", { name: "Notebook (2)", exact: true }).click();
+  await page.locator(".notebook-cell").first().getByRole("button", { name: "Add to library" }).click();
+
+  await page.getByRole("button", { name: "Library", exact: true }).click();
+  await page.locator('.library-card[data-library-kind="code"] .library-card-main').click();
+  const detail = page.locator(".library-detail");
+  await expect(detail.locator(".library-code-head h3")).toHaveText("v1");
+
+  await detail.getByRole("button", { name: "Edit code" }).click();
+  await detail.locator(".library-edit-area").fill("zcat counts.txt.gz | head -20");
+  await detail.getByRole("button", { name: "Save as new version" }).click();
+
+  // The edit appends v2; v1 keeps the starred snapshot verbatim.
+  await expect(detail.locator(".library-code-head h3")).toHaveText("v2");
+  await expect(detail.locator(".rp-code")).toContainText("head -20");
+  await detail.locator(".library-versions button", { hasText: "Original" }).click();
+  await expect(detail.locator(".library-code-head h3")).toHaveText("v1");
+  await expect(detail.locator(".rp-code")).toContainText("zcat counts.txt.gz");
+  await expect(detail.locator(".rp-code")).not.toContainText("head -20");
+
+  // "Insert into chat" pre-fills the composer with the chosen version — the
+  // request carries the item id + version number and is never auto-sent.
+  await detail.locator(".library-versions button", { hasText: "v2" }).click();
+  await detail.getByRole("button", { name: "Insert into chat" }).click();
+  await expect(page.getByTestId("library-screen")).toHaveCount(0);
+  await expect(composer(page)).toHaveValue(/v2/);
+  await expect(composer(page)).toHaveValue(/library item library-1/);
+  await expect(composer(page)).toHaveValue(/head -20/);
+});
+
+test("a starred figure's generating code is editable as a new version (#474)", async ({ page }) => {
+  await enterApp(page);
+  await composer(page).fill("make a volcano plot volcano.png");
+  await page.getByRole("button", { name: "Send" }).click();
+  await page.getByRole("button", { name: "Toggle panel" }).click();
+  await page.locator('.rp-tile[data-artifact-name="volcano.png"] .rp-tile-main').click();
+  const modal = page.locator(".artifact-modal");
+  await modal.getByRole("button", { name: "Add to library" }).click();
+  await modal.getByRole("button", { name: "Close panel" }).click();
+
+  await page.getByRole("button", { name: "Library", exact: true }).click();
+  await page.locator('.library-card[data-library-kind="figure"] .library-card-main').click();
+  const code = page.locator(".library-generating-code");
+  await code.getByRole("button", { name: "Edit code" }).click();
+  await code.locator(".library-edit-area").fill("plt.savefig('volcano.svg')");
+  await code.getByRole("button", { name: "Save as new version" }).click();
+
+  await expect(code.locator(".library-code-head h3")).toHaveText("v2");
+  await expect(code.locator(".rp-code")).toContainText("volcano.svg");
+  // The starred image itself is untouched by a code edit.
+  await expect(page.locator(".library-detail .library-figure img")).toBeVisible();
+  await code.locator(".library-versions button", { hasText: "Original" }).click();
+  await expect(code.locator(".rp-code")).toContainText("import matplotlib");
+});
+
+test("the artifact modal edits provenance code into a composer re-run (#474)", async ({ page }) => {
+  await enterApp(page);
+  await composer(page).fill("make a volcano plot volcano.png");
+  await page.getByRole("button", { name: "Send" }).click();
+  await page.getByRole("button", { name: "Toggle panel" }).click();
+  await page.locator('.rp-tile[data-artifact-name="volcano.png"] .rp-tile-main').click();
+  const modal = page.locator(".artifact-modal");
+  await page.locator(".am-tab", { hasText: "Code" }).click();
+  await modal.getByRole("button", { name: "Edit code and re-run" }).click();
+  await modal.locator(".am-edit-area").fill("plt.savefig('volcano.png', dpi=300)");
+  await modal.getByRole("button", { name: "Insert into chat" }).click();
+
+  await expect(page.locator(".artifact-modal")).toHaveCount(0);
+  await expect(composer(page)).toHaveValue(/dpi=300/);
+  await expect(composer(page)).toHaveValue(/volcano\.png/);
+});
+
 test("the selection popup saves a highlight into the right pane and library", async ({ page }) => {
   await enterApp(page);
   await composer(page).fill("STEPSDEMO");

--- a/ui/src/i18n.rs
+++ b/ui/src/i18n.rs
@@ -120,6 +120,10 @@ fn lookup(locale: Locale, key: &str) -> Option<&'static str> {
         (Locale::En, "library.save") => Some("Save as new version"),
         (Locale::En, "library.cancel") => Some("Cancel"),
         (Locale::En, "library.edit_failed") => Some("Could not save the new version"),
+        (Locale::En, "library.insert") => Some("Insert into chat"),
+        (Locale::En, "library.insert_prompt") => Some(
+            "Please re-run version v{version} of the starred item \"{title}\" (library item {id}):",
+        ),
         (Locale::En, "library.add") => Some("Add to library"),
         (Locale::En, "library.remove") => Some("Remove from library"),
         (Locale::En, "library.read_failed") => Some("Unable to read this library item."),
@@ -1468,6 +1472,10 @@ Do not leave generated files in the project root.",
         (Locale::Zh, "library.save") => Some("保存为新版本"),
         (Locale::Zh, "library.cancel") => Some("取消"),
         (Locale::Zh, "library.edit_failed") => Some("保存新版本失败"),
+        (Locale::Zh, "library.insert") => Some("填入对话框"),
+        (Locale::Zh, "library.insert_prompt") => {
+            Some("请用收藏「{title}」的 v{version}（收藏条目 {id}）重新运行：")
+        }
         (Locale::Zh, "library.add") => Some("加入收藏库"),
         (Locale::Zh, "library.remove") => Some("移出收藏库"),
         (Locale::Zh, "library.read_failed") => Some("无法读取该收藏。"),

--- a/ui/src/library.rs
+++ b/ui/src/library.rs
@@ -1,7 +1,7 @@
 use crate::app_support::{compose_icon, copy_text, RpCodeView};
 use crate::bindings::{invoke, invoke_checked, reveal_saved_mark};
 use crate::dto::{LibraryItem, LibraryItemDetail, LibraryItemVersion};
-use crate::i18n::{t, Locale};
+use crate::i18n::{t, tf, Locale};
 use crate::text::event_target_value;
 use leptos::*;
 use serde_wasm_bindgen::to_value;
@@ -72,6 +72,10 @@ pub(super) fn LibraryScreen(
     on_close: Callback<()>,
     on_open_source: Callback<(String, String)>,
     on_changed: Callback<()>,
+    /// Drop a "re-run this version" request into the session composer (#474).
+    on_insert: Callback<String>,
+    /// False on the Projects landing, where there is no composer to fill.
+    can_insert: Signal<bool>,
 ) -> impl IntoView {
     let query = create_rw_signal(String::new());
     let filter = create_rw_signal("all");
@@ -210,7 +214,6 @@ pub(super) fn LibraryScreen(
                 let delete_id = item.id.clone();
                 let project_id = item.source_project_id.clone();
                 let session_id = item.source_session_id.clone();
-                let code_copy = item.code.clone();
                 let image_src = detail.base64.map(|base64| format!(
                     "data:{};base64,{base64}",
                     item.content_type.as_deref().unwrap_or("application/octet-stream")
@@ -246,18 +249,14 @@ pub(super) fn LibraryScreen(
                             } else if item.kind == "text" {
                                 view! { <div class="library-text">{item.code.clone()}</div> }.into_view()
                             } else {
-                                view! { <CodeVersionPanel locale=locale item=item.clone() /> }.into_view()
+                                view! { <CodeVersionPanel locale=locale item=item.clone()
+                                    on_insert=on_insert can_insert=can_insert /> }.into_view()
                             }}
                             {(is_figure && !item.code.is_empty()).then(|| view! {
                                 <section class="library-generating-code">
-                                    <div class="library-code-head">
-                                        <h3>{move || t(locale.get(), "library.generating_code")}</h3>
-                                        <button type="button" class="icon-btn"
-                                            title=move || t(locale.get(), "tool.copy_code")
-                                            aria-label=move || t(locale.get(), "tool.copy_code")
-                                            on:click=move |_| copy_text(code_copy.clone())>{compose_icon("copy")}</button>
-                                    </div>
-                                    <RpCodeView lang=item.language.clone().unwrap_or_default() body=item.code.clone() />
+                                    <h3>{move || t(locale.get(), "library.generating_code")}</h3>
+                                    <CodeVersionPanel locale=locale item=item.clone()
+                                        on_insert=on_insert can_insert=can_insert />
                                 </section>
                             })}
                             <footer>
@@ -280,7 +279,13 @@ pub(super) fn LibraryScreen(
 /// version and never rewrites history. Shows the newest version by default
 /// with read-only switching to older ones.
 #[component]
-fn CodeVersionPanel(locale: ReadSignal<Locale>, item: LibraryItem) -> impl IntoView {
+fn CodeVersionPanel(
+    locale: ReadSignal<Locale>,
+    item: LibraryItem,
+    on_insert: Callback<String>,
+    can_insert: Signal<bool>,
+) -> impl IntoView {
+    let title = item.title.clone();
     let seed = LibraryItemVersion {
         id: item.id.clone(),
         item_id: item.id.clone(),
@@ -395,10 +400,27 @@ fn CodeVersionPanel(locale: ReadSignal<Locale>, item: LibraryItem) -> impl IntoV
                 } else {
                     let copy_code = current.code.clone();
                     let draft_seed = current.code.clone();
+                    // The rerun request carries item id + version number so the
+                    // reply can be traced back to the exact starred version (#474).
+                    let insert_message = tf(
+                        locale.get_untracked(),
+                        "library.insert_prompt",
+                        &[
+                            ("title", &title),
+                            ("version", &current.version_number.to_string()),
+                            ("id", &current.item_id),
+                        ],
+                    ) + &format!("\n```{}\n{}\n```", language, current.code.trim_end());
                     view! {
                         <div class="library-code-head">
                             <h3>{format!("v{}", current.version_number)}</h3>
                             <div class="library-detail-actions">
+                                {can_insert.get().then(|| view! {
+                                    <button type="button" class="btn-ghost library-insert"
+                                        on:click=move |_| on_insert.call(insert_message.clone())>
+                                        {t(locale.get_untracked(), "library.insert")}
+                                    </button>
+                                })}
                                 <button type="button" class="icon-btn"
                                     title=t(locale.get_untracked(), "tool.copy_code")
                                     aria-label=t(locale.get_untracked(), "tool.copy_code")

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -6367,6 +6367,12 @@ fn App() -> impl IntoView {
                 on_close=Callback::new(move |_| show_library.set(false))
                 on_open_source=palette_open_session
                 on_changed=refresh_library_items
+                on_insert=Callback::new(move |text: String| {
+                    input.set(text);
+                    show_library.set(false);
+                    focus_composer();
+                })
+                can_insert=Signal::derive(move || !show_projects.get())
             />
         })}
         {move || ssh_connectivity_modal.get().map(|modal| {

--- a/ui/src/styles/projects.css
+++ b/ui/src/styles/projects.css
@@ -161,6 +161,7 @@ body:has(.window-titlebar) .library-screen { top: 38px; }
 .library-figure { max-height: 54vh; overflow: auto; display: flex; justify-content: center; padding: 10px; border-radius: var(--radius-sm); background: var(--bg-sunken); }
 .library-figure img { display: block; max-width: 100%; height: auto; object-fit: contain; }
 .library-generating-code { min-height: 0; }
+.library-generating-code > h3 { margin: 0 0 6px; font-size: 13px; }
 .library-code-panel { display: flex; flex-direction: column; gap: 8px; min-height: 0; }
 .library-versions { align-self: flex-start; }
 .library-edit-area { width: 100%; min-height: 240px; resize: vertical; padding: 10px; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--bg-sunken); color: var(--text); font-family: var(--font-mono); font-size: 12px; line-height: 1.5; }


### PR DESCRIPTION
Closes #474。承接 #470（不可变版本）与 #471（产物弹窗编辑重跑），把版本能力接进日常会话工作流。

## 改动

- **按版本填入对话框**：收藏详情的版本面板新增「填入对话框」，把选中版本的代码 + 条目 ID + 版本号预填进 composer（不自动发送），沿用 #471 的模式。在项目落地页（没有输入框）时该按钮隐藏。
- **figure 生成代码可编辑**：图片条目的「生成代码」改用同一个 `CodeVersionPanel`，可编辑保存为新版本；图片快照与 v1 不变。后端本就允许（只有 text 划线被冻结，因为它锚定高亮）。
- **Playwright**：新增 3 条用例——版本切换 + 编辑保存 + 按版本填入、figure 生成代码编辑、产物弹窗编辑重跑；mock bridge 补上 `list_library_item_versions` / `update_library_code`。
- 顺带更新 `docs/global-library.md`（原文还写着 provenance code 只读）。

## 结构化回链的决策

不做。会话侧的溯源就是 append-only 的 `execution_log`，重跑产生的新产物本来就绑定到实际跑的那份代码；缺的只是"这次重跑来自哪个收藏版本"，消息文本里的条目 ID + 版本号已经足够反查。加 schema 绑定属于为不存在的漂移付成本（同 #455 调研结论）。

## 验证

`npx playwright test -g "library|figure|highlight|artifact modal"` 14 passed，新增 3 条单独跑也通过；`cargo check --target wasm32-unknown-unknown` 干净。另外在 trunk + `?mock=1` 里手动走了一遍：点「填入对话框」后收藏库关闭、输入框预填、焦点回到 composer、消息未发送。

🤖 Generated with [Claude Code](https://claude.com/claude-code)