### PR TITLE
feat(ui): show the project's research graph in the right pane

### DIFF
--- a/ui/mock-bridge.js
+++ b/ui/mock-bridge.js
@@ -591,6 +591,18 @@
             return null;
           case "list_library_items":
             return libraryItems;
+          case "get_research_graph":
+            return {
+              nodes: [
+                { id: "d1", project_id: "p1", kind: "decision", title: "Use DESeq2 over edgeR for the DE call", ref_id: null, metadata_json: "{}", created_at: 0, updated_at: 0 },
+                { id: "p1", project_id: "p1", kind: "paper", title: "Love et al. 2014, Moderated estimation of fold change", ref_id: "10.1186/s13059-014-0550-8", metadata_json: "{}", created_at: 0, updated_at: 0 },
+                { id: "a1", project_id: "p1", kind: "data_asset", title: "counts.tsv", ref_id: "data/counts.tsv", metadata_json: "{}", created_at: 0, updated_at: 0 },
+              ],
+              edges: [
+                { id: "e1", project_id: "p1", source_id: "d1", target_id: "p1", relation: "cites", metadata_json: "{}", created_at: 0 },
+                { id: "e2", project_id: "p1", source_id: "d1", target_id: "a1", relation: "applies to", metadata_json: "{}", created_at: 0 },
+              ],
+            };
           case "star_library_text": {
             const text = String(args?.text ?? "");
             const existing = libraryItems.find(

--- a/ui/src/app_support.rs
+++ b/ui/src/app_support.rs
@@ -4912,7 +4912,7 @@ pub(super) fn modal_image_nav_targets(
     (prev, next)
 }
 
-pub(super) const ALL_RIGHT_TABS: [RightTab; 8] = [
+pub(super) const ALL_RIGHT_TABS: [RightTab; 9] = [
     RightTab::Artifacts,
     RightTab::Agents,
     RightTab::Notebook,
@@ -4920,6 +4920,7 @@ pub(super) const ALL_RIGHT_TABS: [RightTab; 8] = [
     RightTab::File,
     RightTab::Provenance,
     RightTab::Hosts,
+    RightTab::Graph,
     RightTab::SideChat,
 ];
 

--- a/ui/src/dto.rs
+++ b/ui/src/dto.rs
@@ -1462,6 +1462,31 @@ pub(crate) struct OnboardingState {
     pub(crate) has_api_key: bool,
 }
 
+/// Mirrors `wisp_store::ResearchNode`. `kind` stays a plain string because the
+/// backend enum serializes to snake_case and the pane only ever groups on it.
+#[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ResearchNode {
+    pub(crate) id: String,
+    pub(crate) kind: String,
+    pub(crate) title: String,
+    pub(crate) ref_id: Option<String>,
+}
+
+#[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ResearchEdge {
+    pub(crate) source_id: String,
+    pub(crate) target_id: String,
+    pub(crate) relation: String,
+}
+
+#[derive(Deserialize, Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct ResearchGraph {
+    #[serde(default)]
+    pub(crate) nodes: Vec<ResearchNode>,
+    #[serde(default)]
+    pub(crate) edges: Vec<ResearchEdge>,
+}
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub(crate) enum RightTab {
     Artifacts,
@@ -1471,6 +1496,7 @@ pub(crate) enum RightTab {
     File,
     Provenance,
     Hosts,
+    Graph,
     SideChat,
 }
 

--- a/ui/src/i18n.rs
+++ b/ui/src/i18n.rs
@@ -461,6 +461,17 @@ fn lookup(locale: Locale, key: &str) -> Option<&'static str> {
         (Locale::En, "agents.risk.external") => Some("external"),
         (Locale::En, "right.notebook") => Some("Notebook"),
         (Locale::En, "right.notebook_n") => Some("Notebook ({n})"),
+        (Locale::En, "right.graph") => Some("Research graph"),
+        (Locale::En, "right.graph_n") => Some("Research graph ({n})"),
+        (Locale::En, "graph.kind.decision") => Some("Decisions"),
+        (Locale::En, "graph.kind.paper") => Some("Papers"),
+        (Locale::En, "graph.kind.data_asset") => Some("Data assets"),
+        (Locale::En, "graph.kind.run") => Some("Runs"),
+        (Locale::En, "graph.kind.artifact") => Some("Artifacts"),
+        (Locale::En, "graph.empty.title") => Some("Nothing recorded yet"),
+        (Locale::En, "graph.empty.body") => {
+            Some("Decisions, papers and data assets the agent records for this project show up here.")
+        }
         (Locale::En, "right.file") => Some("Files"),
         (Locale::En, "right.provenance") => Some("Provenance"),
         (Locale::En, "right.provenance_n") => Some("Provenance ({n})"),
@@ -1814,6 +1825,17 @@ Do not leave generated files in the project root.",
         (Locale::Zh, "agents.risk.external") => Some("外部服务"),
         (Locale::Zh, "right.notebook") => Some("Notebook"),
         (Locale::Zh, "right.notebook_n") => Some("Notebook ({n})"),
+        (Locale::Zh, "right.graph") => Some("研究图谱"),
+        (Locale::Zh, "right.graph_n") => Some("研究图谱 ({n})"),
+        (Locale::Zh, "graph.kind.decision") => Some("决策"),
+        (Locale::Zh, "graph.kind.paper") => Some("文献"),
+        (Locale::Zh, "graph.kind.data_asset") => Some("数据资产"),
+        (Locale::Zh, "graph.kind.run") => Some("运行"),
+        (Locale::Zh, "graph.kind.artifact") => Some("产物"),
+        (Locale::Zh, "graph.empty.title") => Some("还没有记录"),
+        (Locale::Zh, "graph.empty.body") => {
+            Some("模型在这个项目里记录的决策、文献和数据资产会出现在这里。")
+        }
         (Locale::Zh, "right.file") => Some("文件"),
         (Locale::Zh, "right.provenance") => Some("溯源"),
         (Locale::Zh, "right.provenance_n") => Some("溯源 ({n})"),

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -9,6 +9,7 @@ mod notebook;
 mod overlays;
 mod pet;
 mod project_landing;
+mod research;
 mod settings_view;
 mod sidebar;
 mod text;
@@ -38,6 +39,7 @@ use notebook::{collect_notebook_cells, NotebookCache, NotebookView};
 use overlays::{AddHostOverlay, CapabilitiesOverlay, OnboardingOverlay, RuntimeInterpreterOverlay};
 use pet::{PetDesktop, PetOverlay};
 use project_landing::{ProjectLanding, ProjectLandingState};
+use research::{refresh_research_graph, ResearchGraphPane};
 use serde_wasm_bindgen::to_value;
 use settings_view::{DeleteConfirm, SettingsView, SettingsViewState};
 use sidebar::{Sidebar, SidebarState};
@@ -1109,6 +1111,9 @@ fn App() -> impl IntoView {
     let right_tab_add_menu_open = create_rw_signal(false);
     let rp_tab_drag = create_rw_signal(None::<RightTab>);
     let rp_tab_drop = create_rw_signal(None::<RightTab>);
+    // Project-scoped, and the agent writes to it mid-turn — refetched when the
+    // tab is opened rather than kept live.
+    let research_graph = create_rw_signal(ResearchGraph::default());
     create_effect(move |_| {
         side_chat_items.with(|items| items.len());
         if !show_right.get() || right_tab.get() != RightTab::SideChat {
@@ -8873,6 +8878,7 @@ fn App() -> impl IntoView {
                             let notebook_n = notebook_cells.get().len();
                             let prov_n = items.get().iter().filter(|i| matches!(i, ChatItem::Tool { .. })).count();
                             let highlight_n = session_highlight_count(active_session.get(), &library_items.get());
+                            let graph_n = research_graph.get().nodes.len();
                             open_right_tabs.get().into_iter().map(|tab| {
                                 let label = match tab {
                                     RightTab::Artifacts => tab_count(loc, "right.artifacts", art_n),
@@ -8882,6 +8888,7 @@ fn App() -> impl IntoView {
                                     RightTab::Provenance => tab_count(loc, "right.provenance", prov_n),
                                     RightTab::File => t(loc, "right.file").into(),
                                     RightTab::Hosts => t(loc, "contexts.title").into(),
+                                    RightTab::Graph => tab_count(loc, "right.graph", graph_n),
                                     RightTab::SideChat => t(loc, "sidechat.title").into(),
                                 };
                                 let is_active = active == tab;
@@ -8954,6 +8961,9 @@ fn App() -> impl IntoView {
                                                     RightTab::Agents => {
                                                         refresh_agent_workflows(agent_panel)
                                                     }
+                                                    RightTab::Graph => {
+                                                        refresh_research_graph(research_graph)
+                                                    }
                                                     _ => {}
                                                 }
                                             }>{label}</button>
@@ -8983,6 +8993,7 @@ fn App() -> impl IntoView {
                                     let notebook_n = notebook_cells.get().len();
                                     let prov_n = items.get().iter().filter(|i| matches!(i, ChatItem::Tool { .. })).count();
                                     let highlight_n = session_highlight_count(active_session.get(), &library_items.get());
+                                    let graph_n = research_graph.get().nodes.len();
                                     ALL_RIGHT_TABS.iter().copied().map(|tab| {
                                         let label = match tab {
                                             RightTab::Artifacts => tab_count(loc, "right.artifacts", art_n),
@@ -8992,6 +9003,7 @@ fn App() -> impl IntoView {
                                             RightTab::Provenance => tab_count(loc, "right.provenance", prov_n),
                                             RightTab::File => t(loc, "right.file").into(),
                                             RightTab::Hosts => t(loc, "contexts.title").into(),
+                                            RightTab::Graph => tab_count(loc, "right.graph", graph_n),
                                             RightTab::SideChat => t(loc, "sidechat.title").into(),
                                         };
                                         let is_open = open.contains(&tab);
@@ -9017,6 +9029,9 @@ fn App() -> impl IntoView {
                                                         }
                                                         RightTab::Agents => {
                                                             refresh_agent_workflows(agent_panel)
+                                                        }
+                                                        RightTab::Graph => {
+                                                            refresh_research_graph(research_graph)
                                                         }
                                                         _ => {}
                                                     }
@@ -9258,6 +9273,11 @@ fn App() -> impl IntoView {
                                     active_session=active_session.read_only()
                                     library_items=library_items.read_only()
                                     on_library_changed=refresh_library_items />
+                            }.into_view()
+                        }
+                        RightTab::Graph => {
+                            view! {
+                                <ResearchGraphPane locale=locale.get() graph=research_graph.get() />
                             }.into_view()
                         }
                         RightTab::Highlights => {

--- a/ui/src/research.rs
+++ b/ui/src/research.rs
@@ -1,0 +1,181 @@
+use crate::bindings::invoke;
+use crate::dto::{ResearchEdge, ResearchGraph, ResearchNode};
+use crate::i18n::{t, Locale};
+use leptos::*;
+use std::collections::HashMap;
+use wasm_bindgen::JsValue;
+
+/// Node kinds in display order, paired with their i18n key. Closed set — it
+/// mirrors `wisp_store::ResearchNodeKind`, so every stored node lands in a
+/// section here.
+const KINDS: [(&str, &str); 5] = [
+    ("decision", "graph.kind.decision"),
+    ("paper", "graph.kind.paper"),
+    ("data_asset", "graph.kind.data_asset"),
+    ("run", "graph.kind.run"),
+    ("artifact", "graph.kind.artifact"),
+];
+
+/// A node plus the outgoing links rendered under it, as `(relation, target label)`.
+pub(super) struct GraphRow {
+    pub(super) node: ResearchNode,
+    pub(super) links: Vec<(String, String)>,
+}
+
+/// Bucket nodes by kind and hang each node's outgoing edges off it.
+///
+/// Both endpoints are guaranteed to name a node in the same project — the store
+/// counts them before inserting an edge (`Store::save_research_edge`) and every
+/// delete path drops edges before their nodes — so no edge goes unrendered.
+pub(super) fn group_graph(graph: &ResearchGraph) -> Vec<(&'static str, Vec<GraphRow>)> {
+    let titles: HashMap<&str, &str> = graph
+        .nodes
+        .iter()
+        .map(|node| (node.id.as_str(), node.title.as_str()))
+        .collect();
+    let label = |id: &str| {
+        titles
+            .get(id)
+            .map(|t| (*t).to_string())
+            .unwrap_or_else(|| id.to_string())
+    };
+
+    let mut outgoing: HashMap<&str, Vec<&ResearchEdge>> = HashMap::new();
+    for edge in &graph.edges {
+        outgoing
+            .entry(edge.source_id.as_str())
+            .or_default()
+            .push(edge);
+    }
+
+    KINDS
+        .into_iter()
+        .filter_map(|(kind, label_key)| {
+            let rows = graph
+                .nodes
+                .iter()
+                .filter(|node| node.kind == kind)
+                .map(|node| GraphRow {
+                    node: node.clone(),
+                    links: outgoing
+                        .get(node.id.as_str())
+                        .map(|edges| {
+                            edges
+                                .iter()
+                                .map(|edge| (edge.relation.clone(), label(&edge.target_id)))
+                                .collect()
+                        })
+                        .unwrap_or_default(),
+                })
+                .collect::<Vec<_>>();
+            (!rows.is_empty()).then_some((label_key, rows))
+        })
+        .collect()
+}
+
+/// Read-only view of the project's research graph — the decisions, papers and
+/// data assets the agent records through the `research_graph` tool.
+///
+/// ponytail: a grouped list, not a canvas. Printing each node's outgoing edges
+/// inline carries the structure without a layout engine. Reach for a real graph
+/// renderer when a project outgrows a scrollable list.
+#[component]
+pub(super) fn ResearchGraphPane(locale: Locale, graph: ResearchGraph) -> impl IntoView {
+    if graph.nodes.is_empty() && graph.edges.is_empty() {
+        return view! {
+            <div class="rp-empty">
+                <span class="rp-empty-icon"></span>
+                <div class="rp-empty-title">{t(locale, "graph.empty.title")}</div>
+                <p>{t(locale, "graph.empty.body")}</p>
+            </div>
+        }
+        .into_view();
+    }
+    let sections = group_graph(&graph);
+    view! {
+        <div class="rp-graph">
+            <div class="context-list-pane">
+                {sections.into_iter().map(|(label_key, rows)| view! {
+                    <section class="control-section">
+                        <div class="control-section-head">
+                            <span>{t(locale, label_key)}</span>
+                            <span class="control-count">{rows.len().to_string()}</span>
+                        </div>
+                        {rows.into_iter().map(|row| view! {
+                            <article class="context-card graph-node">
+                                <div class="graph-node-title">{row.node.title}</div>
+                                {row.node.ref_id
+                                    .filter(|id| !id.trim().is_empty())
+                                    .map(|id| view! { <div class="graph-node-ref">{id}</div> })}
+                                {(!row.links.is_empty()).then(|| view! {
+                                    <ul class="graph-node-links">
+                                        {row.links.into_iter().map(|(relation, target)| view! {
+                                            <li>
+                                                <span class="graph-rel">{relation}</span>
+                                                <span class="graph-target">{target}</span>
+                                            </li>
+                                        }).collect_view()}
+                                    </ul>
+                                })}
+                            </article>
+                        }).collect_view()}
+                    </section>
+                }).collect_view()}
+            </div>
+        </div>
+    }
+    .into_view()
+}
+
+pub(super) fn refresh_research_graph(graph: RwSignal<ResearchGraph>) {
+    spawn_local(async move {
+        let value = invoke("get_research_graph", JsValue::UNDEFINED).await;
+        if let Ok(next) = serde_wasm_bindgen::from_value::<ResearchGraph>(value) {
+            graph.set(next);
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn node(id: &str, kind: &str, title: &str) -> ResearchNode {
+        ResearchNode {
+            id: id.into(),
+            kind: kind.into(),
+            title: title.into(),
+            ref_id: None,
+        }
+    }
+
+    fn edge(source: &str, target: &str, relation: &str) -> ResearchEdge {
+        ResearchEdge {
+            source_id: source.into(),
+            target_id: target.into(),
+            relation: relation.into(),
+        }
+    }
+
+    #[test]
+    fn groups_by_kind_and_resolves_link_targets() {
+        let graph = ResearchGraph {
+            nodes: vec![
+                node("d1", "decision", "Use DESeq2"),
+                node("a1", "data_asset", "counts.tsv"),
+            ],
+            edges: vec![edge("d1", "a1", "uses")],
+        };
+        let sections = group_graph(&graph);
+        // Decision sorts before data_asset, matching KINDS order.
+        assert_eq!(sections.len(), 2);
+        assert_eq!(sections[0].0, "graph.kind.decision");
+        assert_eq!(sections[1].0, "graph.kind.data_asset");
+        assert_eq!(
+            sections[0].1[0].links,
+            vec![("uses".to_string(), "counts.tsv".to_string())]
+        );
+        // The link hangs off the source only; the target repeats nothing.
+        assert!(sections[1].1[0].links.is_empty());
+    }
+}

--- a/ui/src/styles/right-pane.css
+++ b/ui/src/styles/right-pane.css
@@ -659,3 +659,14 @@
 .highlight-text { flex: 1; min-width: 0; text-align: left; background: none; border: none; margin: 0; padding: 2px 0 2px 10px; border-left: 3px solid var(--clay); color: var(--text); font: inherit; font-size: 13px; line-height: 1.55; cursor: pointer; white-space: pre-wrap; word-break: break-word; }
 .highlight-text:hover { color: var(--clay-strong); }
 .highlight-actions { display: flex; flex-direction: column; gap: 2px; }
+
+/* Research graph tab: nodes grouped by kind, each printing its outgoing links. */
+.rp-graph { flex: 1 1 auto; min-height: 0; overflow: hidden; display: flex; flex-direction: column; background: var(--bg-elev); }
+.graph-node + .graph-node { margin-top: 8px; }
+.graph-node-title { font-size: 13px; font-weight: 600; color: var(--text); line-height: 1.45; word-break: break-word; }
+.graph-node-ref { margin-top: 3px; font-family: var(--font-mono); font-size: 11.5px; color: var(--text-faint); word-break: break-all; }
+.graph-node-links { list-style: none; margin: 8px 0 0; padding: 8px 0 0; border-top: 1px solid var(--border); display: flex; flex-direction: column; gap: 4px; }
+.graph-node-links li { display: flex; align-items: baseline; gap: 6px; font-size: 12px; color: var(--text-muted); min-width: 0; }
+.graph-rel { flex: 0 0 auto; padding: 1px 6px; border-radius: 999px; background: var(--clay-soft); color: var(--clay-strong); font-size: 11px; font-weight: 600; }
+.graph-rel::after { content: " →"; }
+.graph-target { min-width: 0; word-break: break-word; }


### PR DESCRIPTION
## Problem

The agent has been recording decisions, papers and data assets through the `research_graph` tool since it shipped. `Store::research_graph` reads them back, and `get_research_graph` is registered as a Tauri command — but **nothing in the UI ever invoked it**. The only reader was the MCP bridge ([mcp_bridge.rs:813](https://github.com/xuzhougeng/wisp-science/blob/main/src-tauri/src/mcp_bridge.rs#L813)), so the graph was invisible to the person whose project it describes.

This came out of an audit of the 222 registered Tauri commands: 13 have no UI caller, and they cluster almost entirely in the research-workbench layer (`get_research_graph`, `list_artifacts`, `register_artifact`, `save_workspace_file_by_kind`, …). The chat/agent side is fully wired; the workbench side was built but had no door.

## What changed

A **Research graph** right-pane tab. Nodes grouped by kind, each printing its outgoing edges inline:

```
DECISIONS                                    1
  Use DESeq2 over edgeR for the DE call
    cites →      Love et al. 2014, Moderated estimation…
    applies to → counts.tsv
PAPERS                                       1
  Love et al. 2014, …
  10.1186/s13059-014-0550-8
DATA ASSETS                                  1
  counts.tsv   data/counts.tsv
```

**No backend changes.** The command and the data were already there.

| File | Change |
|---|---|
| `ui/src/research.rs` | new — `ResearchGraphPane` + `group_graph` + `refresh_research_graph` |
| `ui/src/dto.rs` | `ResearchNode` / `ResearchEdge` / `ResearchGraph` DTOs, `RightTab::Graph` |
| `ui/src/main.rs` | signal, tab label, panel body, refresh on tab open |
| `ui/src/app_support.rs` | `ALL_RIGHT_TABS` 8 → 9 |
| `ui/src/i18n.rs` | en + zh strings |
| `ui/src/styles/right-pane.css` | reuses `.control-section` / `.context-card`; ~11 new rules |
| `ui/mock-bridge.js` | `get_research_graph` fixture so `?mock=1` exercises the pane |

## Notes for a reviewer

**Not a canvas, on purpose.** A grouped list carries the structure without a layout engine or a graph dependency. The threshold for reaching for a real renderer is written into a `ponytail:` comment on the component rather than left implicit.

**Refetched on tab open, not kept live.** The graph is project-scoped and the agent writes to it mid-turn, so `refresh_research_graph` runs from both paths that open the tab (strip click and add-menu), matching how `Hosts` and `Agents` already behave.

**Dangling edges are not handled, and that is deliberate.** An earlier draft defended against edges whose endpoints name no node. They cannot occur: `Store::save_research_edge` counts both endpoints before inserting and bails unless it finds 2, and every delete path drops edges before their nodes (`sessions.rs` deletes on both `source_id` and `target_id`; `project_transfer.rs` deletes edges then nodes). Worth knowing that `PRAGMA foreign_keys` is never enabled, so the schema's `ON DELETE CASCADE` is decorative — the app-level check is what actually holds, and it holds on every write path.

**`ui` crate was not run through `cargo fmt`** — CI only `cargo check`s it and it has never been fmt-enforced, so a full format would bury this diff in unrelated churn. Only the new file was formatted.

## Verification

- `cargo check --target wasm32-unknown-unknown` — clean
- `cargo test` in `ui/` — 113 passed, including 1 new test covering kind grouping and link-target resolution
- Trunk preview (`?mock=1`), light and dark mode, no new console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)