### PR TITLE
chore: remove dead Tauri commands, dead write APIs, and stale docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,7 +519,6 @@ If you use wisp-science in your research, please cite:
 - `FlashThinking` — phase-aware structured thinking-framework injection.
 - `loop_engine` — deeper Implementer / Verifier / Updater workflows beyond the
   bounded automatic Reviewer pass shipped today.
-- Artifact management + inline Mol* 3D structure viewer in the UI.
 - `RoutedProvider` LLM-score tier selection (keyword tier is already wired).
 
 ## Star History

--- a/crates/wisp-store/src/artifacts.rs
+++ b/crates/wisp-store/src/artifacts.rs
@@ -146,33 +146,6 @@ impl Store {
         Ok(())
     }
 
-    pub async fn save_artifact_dependency(
-        &self,
-        id: &str,
-        artifact_version_id: &str,
-        depends_on_version_id: &str,
-        reference_name: Option<&str>,
-    ) -> Result<()> {
-        if artifact_version_id == depends_on_version_id {
-            anyhow::bail!("An artifact version cannot depend on itself");
-        }
-        sqlx::query(
-            "INSERT INTO artifact_dependencies(\
-                id,artifact_version_id,depends_on_version_id,reference_name,created_at\
-             ) VALUES(?,?,?,?,?) \
-             ON CONFLICT(artifact_version_id,depends_on_version_id) DO UPDATE SET \
-                reference_name=excluded.reference_name",
-        )
-        .bind(id)
-        .bind(artifact_version_id)
-        .bind(depends_on_version_id)
-        .bind(reference_name)
-        .bind(chrono::Utc::now().timestamp())
-        .execute(&self.pool)
-        .await?;
-        Ok(())
-    }
-
     /// Artifacts for one conversation frame, newest first.
     pub async fn list_artifacts(
         &self,

--- a/crates/wisp-store/src/store_tests.rs
+++ b/crates/wisp-store/src/store_tests.rs
@@ -2891,7 +2891,7 @@ async fn research_graph_links_research_objects() {
 }
 
 #[tokio::test]
-async fn artifacts_keep_version_lineage_and_dependencies() {
+async fn artifacts_keep_version_lineage() {
     let tmp = std::env::temp_dir().join(format!(
         "wisp_artifact_versions_{}.sqlite",
         uuid::Uuid::new_v4()
@@ -2904,15 +2904,10 @@ async fn artifacts_keep_version_lineage_and_dependencies() {
         .save_artifact("a", "p", "f", "report.md", "text/markdown", "reports/v1.md")
         .await
         .unwrap();
-    let second = store
+    store
         .save_artifact("a", "p", "f", "report.md", "text/markdown", "reports/v2.md")
         .await
         .unwrap();
-    store
-        .save_artifact_dependency("dep", &second, &first, Some("prior-report"))
-        .await
-        .unwrap();
-
     let versions = store.list_artifact_versions("a").await.unwrap();
     assert_eq!(versions.len(), 2);
     assert_eq!(versions[0].version_number, 2);

--- a/src-tauri/src/artifact_commands.rs
+++ b/src-tauri/src/artifact_commands.rs
@@ -1,5 +1,5 @@
 use super::*;
-use super::{ensure_active_frame, workspace_manifest, ActiveProject, AppState, ArtifactInfo};
+use super::{ensure_active_frame, ActiveProject, AppState, ArtifactInfo};
 use crate::file_browser::mime_for_path;
 use base64::Engine;
 use tauri::State;
@@ -137,25 +137,6 @@ pub(super) async fn register_artifact(
     let ap = state.active(window.label());
     let _project_activity = state.begin_project_activity(&ap.id)?;
     register_artifact_at(&state, window.label(), &ap, path, content_type).await
-}
-
-#[tauri::command]
-pub(super) async fn save_workspace_file_by_kind(
-    state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
-    kind: workspace_manifest::WorkspaceFileKind,
-    filename: String,
-    content: String,
-) -> Result<String, String> {
-    let ap = state.active(window.label());
-    let _project_activity = state.begin_project_activity(&ap.id)?;
-    let path =
-        workspace_manifest::save_workspace_file(&ap.root, kind, &filename, content.as_bytes())?;
-    Ok(path
-        .strip_prefix(&ap.root)
-        .unwrap_or(&path)
-        .to_string_lossy()
-        .replace('\\', "/"))
 }
 
 #[cfg(test)]

--- a/src-tauri/src/file_browser.rs
+++ b/src-tauri/src/file_browser.rs
@@ -985,24 +985,6 @@ pub(super) fn append_review_note_at(
     Ok(rel)
 }
 
-/// Overwrite a text file inside the project root with edited content. Used by
-/// the preview's inline editor for Markdown/plain-text files. Rejects paths
-/// outside the root via the shared validator; the parent directory must exist.
-pub(super) fn write_file_at(root: &Path, path: &str, content: &str) -> Result<(), String> {
-    let real = wisp_tools::safety::validate_file_path(root, path)?;
-    std::fs::write(&real, content).map_err(|e| format!("could not write file: {e}"))
-}
-
-#[tauri::command]
-pub(super) fn write_file(
-    state: State<'_, AppState>,
-    window: WebviewWindow,
-    path: String,
-    content: String,
-) -> Result<(), String> {
-    write_file_at(&state.active(window.label()).root, &path, &content)
-}
-
 #[tauri::command]
 pub(super) fn append_review_note(
     state: State<'_, AppState>,
@@ -1481,25 +1463,4 @@ mod tests {
         let _ = std::fs::remove_dir_all(&base);
     }
 
-    #[test]
-    fn write_file_overwrites_within_root_and_blocks_escape() {
-        let base = std::env::temp_dir().join(format!(
-            "wisp_write_file_test_{}_{}",
-            std::process::id(),
-            uuid::Uuid::new_v4()
-        ));
-        std::fs::create_dir_all(&base).unwrap();
-        std::fs::write(base.join("notes.md"), b"# old\n").unwrap();
-
-        write_file_at(&base, "notes.md", "# new\n\nedited body\n").unwrap();
-        assert_eq!(
-            std::fs::read_to_string(base.join("notes.md")).unwrap(),
-            "# new\n\nedited body\n"
-        );
-
-        // Escaping the root is refused.
-        assert!(write_file_at(&base, "../escape.md", "nope").is_err());
-
-        let _ = std::fs::remove_dir_all(&base);
-    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -71,11 +71,11 @@ mod terminal_sessions;
 mod workspace_manifest;
 mod wsl_contexts;
 
-use artifact_commands::{register_artifact, save_workspace_file_by_kind, upload_file};
+use artifact_commands::{register_artifact, upload_file};
 use file_browser::{
     append_review_note, create_directory, create_file, delete_entry, list_dir, list_remote_dir,
     read_file, read_file_at, read_file_bytes, read_file_bytes_at, read_remote_file,
-    read_remote_file_bytes, rename_entry, search_files, write_file, FileContent,
+    read_remote_file_bytes, rename_entry, search_files, FileContent,
 };
 use session_export::{capture_env, export_session, get_artifact_provenance};
 #[cfg(test)]
@@ -5981,11 +5981,9 @@ pub fn run() {
             ssh_hosts::test_ssh_connection,
             ssh_hosts::remove_ssh_host,
             ssh_hosts::import_ssh_config_hosts,
-            wsl_contexts::list_wsl_distros,
             wsl_contexts::import_wsl_contexts,
             terminal_sessions::open_terminal,
             terminal_sessions::attach_terminal,
-            terminal_sessions::get_terminal,
             terminal_sessions::write_terminal,
             terminal_sessions::resize_terminal,
             terminal_sessions::terminate_terminal,
@@ -6001,7 +5999,6 @@ pub fn run() {
             runtime_commands::stop_runtime,
             runtime_commands::restart_runtime,
             runtime_commands::list_runs,
-            runtime_commands::get_run,
             runtime_commands::cancel_run,
             project_commands::get_research_graph,
             session_commands::delete_session,
@@ -6091,7 +6088,6 @@ pub fn run() {
             search_files,
             read_file,
             read_file_bytes,
-            write_file,
             append_review_note,
             artifact_commands::list_artifacts,
             artifact_commands::search_artifacts,
@@ -6104,7 +6100,6 @@ pub fn run() {
             session_commands::set_viewed_session,
             upload_file,
             register_artifact,
-            save_workspace_file_by_kind,
             get_artifact_provenance,
             library_commands::list_library_items,
             library_commands::star_library_code,

--- a/src-tauri/src/runtime_commands.rs
+++ b/src-tauri/src/runtime_commands.rs
@@ -164,25 +164,6 @@ pub(super) async fn list_runs(
 }
 
 #[tauri::command]
-pub(super) async fn get_run(
-    state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
-    run_id: String,
-) -> Result<wisp_store::RunRecord, String> {
-    let ap = state.active(window.label());
-    let run = state
-        .store
-        .get_run(&run_id)
-        .await
-        .map_err(|e| e.to_string())?
-        .ok_or_else(|| "Run not found".to_string())?;
-    if run.project_id != ap.id {
-        return Err("Run does not belong to the active project".into());
-    }
-    Ok(run)
-}
-
-#[tauri::command]
 pub(super) async fn cancel_run(
     state: State<'_, AppState>,
     window: tauri::WebviewWindow,

--- a/src-tauri/src/terminal_sessions.rs
+++ b/src-tauri/src/terminal_sessions.rs
@@ -454,14 +454,6 @@ pub fn attach_terminal(
 }
 
 #[tauri::command]
-pub fn get_terminal(
-    terminals: State<'_, TerminalManager>,
-    session_id: String,
-) -> Result<TerminalSessionSummary, String> {
-    Ok(terminals.get(&session_id)?.summary())
-}
-
-#[tauri::command]
 pub fn write_terminal(
     terminals: State<'_, TerminalManager>,
     session_id: String,

--- a/src-tauri/src/workspace_manifest.rs
+++ b/src-tauri/src/workspace_manifest.rs
@@ -1,5 +1,4 @@
-use serde::{Deserialize, Serialize};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 pub const WORKSPACE_DIRS: &[&str] = &[
     ".wisp",
@@ -21,38 +20,6 @@ pub const WORKSPACE_DIRS: &[&str] = &[
     "docs",
 ];
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum WorkspaceFileKind {
-    Script,
-    RawData,
-    ExternalData,
-    ProcessedData,
-    Table,
-    Model,
-    Report,
-    Figure,
-    Literature,
-    Doc,
-}
-
-impl WorkspaceFileKind {
-    pub fn dir(self) -> &'static str {
-        match self {
-            Self::Script => "analysis/scripts",
-            Self::RawData => "data/raw",
-            Self::ExternalData => "data/external",
-            Self::ProcessedData => "data/processed",
-            Self::Table => "results/tables",
-            Self::Model => "results/models",
-            Self::Report => "results/reports",
-            Self::Figure => "figures",
-            Self::Literature => "literature",
-            Self::Doc => "docs",
-        }
-    }
-}
-
 pub fn init_workspace_layout(root: &Path, project_id: &str, name: &str) -> Result<(), String> {
     std::fs::create_dir_all(root).map_err(|e| e.to_string())?;
     for dir in WORKSPACE_DIRS {
@@ -65,28 +32,6 @@ pub fn init_workspace_layout(root: &Path, project_id: &str, name: &str) -> Resul
         chrono::Utc::now().timestamp()
     );
     std::fs::write(root.join(".wisp").join("project.toml"), manifest).map_err(|e| e.to_string())
-}
-
-pub fn save_workspace_file(
-    root: &Path,
-    kind: WorkspaceFileKind,
-    filename: &str,
-    bytes: &[u8],
-) -> Result<PathBuf, String> {
-    let filename = sanitize_filename(filename)?;
-    let dir = root.join(kind.dir());
-    std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
-    let path = dir.join(filename);
-    std::fs::write(&path, bytes).map_err(|e| e.to_string())?;
-    Ok(path)
-}
-
-fn sanitize_filename(name: &str) -> Result<&str, String> {
-    let name = name.trim();
-    if name.is_empty() || name == "." || name == ".." || name.contains('/') || name.contains('\\') {
-        return Err("invalid workspace filename".into());
-    }
-    Ok(name)
 }
 
 fn toml_escape(s: &str) -> String {
@@ -130,23 +75,4 @@ mod tests {
         let _ = std::fs::remove_dir_all(&root);
     }
 
-    #[test]
-    fn save_workspace_file_places_content_by_kind() {
-        let root =
-            std::env::temp_dir().join(format!("wisp_manifest_save_{}", uuid::Uuid::new_v4()));
-        init_workspace_layout(&root, "p1", "Study").unwrap();
-
-        let script =
-            save_workspace_file(&root, WorkspaceFileKind::Script, "qc.py", b"print(1)").unwrap();
-        let table =
-            save_workspace_file(&root, WorkspaceFileKind::Table, "qc.tsv", b"a\tb").unwrap();
-
-        assert_eq!(script, root.join("analysis/scripts/qc.py"));
-        assert_eq!(table, root.join("results/tables/qc.tsv"));
-        assert_eq!(std::fs::read(script).unwrap(), b"print(1)");
-        assert_eq!(std::fs::read(table).unwrap(), b"a\tb");
-        assert!(save_workspace_file(&root, WorkspaceFileKind::Doc, "../bad.md", b"x").is_err());
-
-        let _ = std::fs::remove_dir_all(&root);
-    }
 }

--- a/src-tauri/src/wsl_contexts.rs
+++ b/src-tauri/src/wsl_contexts.rs
@@ -122,7 +122,6 @@ fn wsl_available() -> bool {
         .is_ok()
 }
 
-#[tauri::command]
 pub async fn list_wsl_distros() -> Result<Vec<WslDistro>, String> {
     #[cfg(target_os = "windows")]
     {

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -166,9 +166,8 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
   const sessionDelegationEnabled: Record<string, boolean> = {};
   const sessionAgentCompletion: Record<string, { policy: "inline" | "background"; auto_resume: boolean }> = {};
   let lastDelegationSessionId = "s-current";
-  // Mutable workspace fixtures let live FileChanged events prove that open
+  // Mutable workspace fixture lets live FileChanged events prove that open
   // previews re-read content written by an agent tool.
-  const workspaceMd: Record<string, string> = {};
   let workspaceR = 'library(Seurat)\nin_dir <- "data"\nplot(1:3)\n';
   (window as any).__setMockWorkspaceR = (value: string) => { workspaceR = String(value); };
   let workspaceEntries = [
@@ -1918,7 +1917,7 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
               return { path, mime: "image/png", text: null, base64: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9Z0mAAAAAASUVORK5CYII=" };
             }
             if (path.toLowerCase().endsWith(".md")) {
-              return { path, mime: "text/markdown", text: workspaceMd[path] ?? "# Draft manuscript\n\nOriginal body paragraph.\n", base64: null };
+              return { path, mime: "text/markdown", text: "# Draft manuscript\n\nOriginal body paragraph.\n", base64: null };
             }
             if (path.toLowerCase().includes(".json")) {
               return { path, mime: "application/json", text: '{"model":{"name":"wisp","enabled":true}}', base64: null };
@@ -1983,12 +1982,6 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
             const src = String(arg("sourcePath") ?? "");
             const stem = (src.split(/[\\/]/).pop() ?? "notes").replace(/\.[^.]+$/, "") || "notes";
             return `reviews/${stem}.md`;
-          }
-          case "write_file": {
-            // Persist so a follow-up read_file returns the edited body (proves the
-            // inline editor's save + reload cycle end-to-end).
-            workspaceMd[String(arg("path") ?? "")] = String(arg("content") ?? "");
-            return null;
           }
           case "export_session":
             return "/mock/export.zip";


### PR DESCRIPTION
## What changed

Pure deletions confirmed by the 2026-07-25 whole-project audit — net **-213 / +8 lines**, no behavior change:

- **Dead Tauri commands** (zero UI callers, verified before deleting): `get_run` (UI uses `list_runs` + `cancel_run` return values; the agent path uses `GetRunTool`), `get_terminal` (`attach_terminal` already returns the same summary), `write_file` (the inline editor was removed by product decision in 78d0689), `save_workspace_file_by_kind` (speculative API, never invoked), plus all five `lib.rs` registrations. `list_wsl_distros` loses only its `#[tauri::command]` attribute — `import_wsl_contexts` still calls it internally.
- **Code that only those commands used**: `write_file_at` and its test (including the stale "inline editor" doc comment), `WorkspaceFileKind` / `save_workspace_file` / `sanitize_filename` and their test (workspace_manifest.rs now only does layout init), and the `write_file` mock case in `mock-tauri.ts` with its stale save+reload comment plus the now always-empty `workspaceMd` fixture.
- **Dead table write API**: `save_artifact_dependency`, the only writer of the never-read `artifact_dependencies` table; its store test renamed to `artifacts_keep_version_lineage` with the dependency assertion removed.
- **Stale docs**: dropped the shipped "inline Mol* 3D structure viewer" roadmap line from README (3Dmol is live in `ui/src/api.js`).

## Why the three dead tables stay

`artifact_dependencies`, `proposed_plans`, and `codex_turn_configs` are not dropped: the project-import path references them unconditionally through the attached `transfer.*` database, and `portable_project_database_hash` fingerprints them. Dropping them would make new exports fail to import on older builds and shift sync fingerprints — real cross-version risk for empty tables that cost nothing. If we ever want them gone, that's a separate migration (plus the store_tests migration-list sync).

## Verification

- `cargo check --workspace` clean, zero warnings
- `cargo test -p wisp-store -p wisp-tauri`: 69 + 406 passed, 0 failed
- Re-grepped `ui/src` and `ui-tests` for all five command names: zero invocations remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)