### PR TITLE
fix(preview): 38 MB PDF preview and TIFF figures in DOCX

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,6 +468,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -782,6 +788,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1003,7 +1015,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1216,7 +1228,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1245,6 +1257,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -1795,6 +1813,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2117,6 +2146,20 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
+ "tiff",
 ]
 
 [[package]]
@@ -2510,6 +2553,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "muda"
 version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2527,7 +2580,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2592,7 +2645,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2626,7 +2679,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -3201,10 +3254,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
+
+[[package]]
 name = "qrcode"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -3561,7 +3626,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4063,7 +4128,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4790,10 +4855,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4853,6 +4918,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -5235,7 +5314,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5282,7 +5361,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5686,6 +5765,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
 name = "which"
 version = "7.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5719,7 +5804,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6432,6 +6517,7 @@ dependencies = [
  "flate2",
  "futures-util",
  "glob",
+ "image",
  "portable-pty",
  "pulldown-cmark",
  "qrcode",
@@ -6788,6 +6874,21 @@ dependencies = [
  "crc32fast",
  "log",
  "simd-adler32",
+]
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -43,6 +43,8 @@ same-file = { workspace = true }
 portable-pty = { workspace = true }
 async-trait = { workspace = true }
 zip = { version = "2", default-features = false, features = ["deflate"] }
+# TIFF -> PNG transcode for OOXML preview media (browsers cannot decode TIFF).
+image = { version = "0.25", default-features = false, features = ["tiff", "png"] }
 which = "7"
 walkdir = { workspace = true }
 wisp-core = { workspace = true }

--- a/src-tauri/src/file_browser.rs
+++ b/src-tauri/src/file_browser.rs
@@ -7,8 +7,11 @@ use tauri::{ipc::Response, State, WebviewWindow};
 
 const REMOTE_DIR_PROTOCOL: &[u8] = b"WISP_REMOTE_DIR_V1\0";
 const REMOTE_FILE_PROTOCOL: &[u8] = b"WISP_REMOTE_FILE_V1\0";
-/// Same ceiling as local previews: `read_file` caps at 32 MB.
+/// Remote previews stay capped at 32 MB: the bytes cross an SSH connection.
 const REMOTE_FILE_MAX_BYTES: u64 = 32 * 1024 * 1024;
+/// Local previews match the 100 MB upload cap — a 38 MB journal PDF is routine
+/// and pdf.js renders one page at a time, so memory stays bounded (#485).
+const LOCAL_FILE_MAX_BYTES: u64 = 100 * 1024 * 1024;
 const DEFAULT_FILE_MAX_BYTES: u64 = 8 * 1024 * 1024;
 const OOXML_MAX_ENTRIES: usize = 4096;
 const OOXML_MAX_ENTRY_BYTES: u64 = 64 * 1024 * 1024;
@@ -141,7 +144,7 @@ pub(super) fn mime_for_path(path: &Path) -> &'static str {
 fn preview_byte_cap(max_bytes: Option<u64>) -> u64 {
     max_bytes
         .unwrap_or(DEFAULT_FILE_MAX_BYTES)
-        .min(REMOTE_FILE_MAX_BYTES)
+        .min(LOCAL_FILE_MAX_BYTES)
 }
 
 fn is_ooxml_path(path: &Path) -> bool {
@@ -268,6 +271,87 @@ pub(super) fn validate_ooxml_archive(bytes: &[u8]) -> Result<(), String> {
         }
     }
     Ok(())
+}
+
+fn is_tiff_media_entry(name: &str) -> bool {
+    let lower = name.replace('\\', "/").to_ascii_lowercase();
+    lower.contains("/media/") && (lower.ends_with(".tif") || lower.ends_with(".tiff"))
+}
+
+/// Browsers cannot decode TIFF, so a DOCX whose embedded figures are TIFF
+/// previews as text with blank image boxes. Rewrite the archive in memory:
+/// TIFF media parts are transcoded to PNG under the same entry name (`<img>`
+/// sniffs magic bytes, not extensions) and the content-type map is pointed at
+/// image/png. Any failure returns the original bytes — a missing figure beats
+/// a failed preview. Runs only on archives that actually contain TIFF media.
+pub(super) fn transcode_ooxml_tiff_media(bytes: Vec<u8>) -> Vec<u8> {
+    let has_tiff = zip::ZipArchive::new(Cursor::new(&bytes))
+        .is_ok_and(|archive| archive.file_names().any(is_tiff_media_entry));
+    if !has_tiff {
+        return bytes;
+    }
+    match transcode_ooxml_tiff_media_inner(&bytes) {
+        Ok(rewritten) => rewritten,
+        Err(_) => bytes,
+    }
+}
+
+fn transcode_ooxml_tiff_media_inner(bytes: &[u8]) -> Result<Vec<u8>, String> {
+    let mut archive =
+        zip::ZipArchive::new(Cursor::new(bytes)).map_err(|error| error.to_string())?;
+    let mut out = zip::ZipWriter::new(Cursor::new(Vec::with_capacity(bytes.len())));
+    let options = zip::write::SimpleFileOptions::default();
+    for index in 0..archive.len() {
+        let name = archive
+            .by_index_raw(index)
+            .map_err(|error| error.to_string())?
+            .name()
+            .to_string();
+        if is_tiff_media_entry(&name) {
+            let mut tiff = Vec::new();
+            archive
+                .by_index(index)
+                .map_err(|error| error.to_string())?
+                .read_to_end(&mut tiff)
+                .map_err(|error| error.to_string())?;
+            match tiff_to_png(&tiff) {
+                Ok(png) => {
+                    out.start_file(name, options).map_err(|e| e.to_string())?;
+                    std::io::Write::write_all(&mut out, &png).map_err(|e| e.to_string())?;
+                }
+                // Undecodable TIFF (exotic colorspace/compression): keep the
+                // original part so the rest of the document still previews.
+                Err(_) => {
+                    let raw = archive.by_index_raw(index).map_err(|e| e.to_string())?;
+                    out.raw_copy_file(raw).map_err(|e| e.to_string())?;
+                }
+            }
+        } else if name == "[Content_Types].xml" {
+            let mut xml = String::new();
+            archive
+                .by_index(index)
+                .map_err(|error| error.to_string())?
+                .read_to_string(&mut xml)
+                .map_err(|error| error.to_string())?;
+            let patched = xml.replace("image/tiff", "image/png");
+            out.start_file(name, options).map_err(|e| e.to_string())?;
+            std::io::Write::write_all(&mut out, patched.as_bytes()).map_err(|e| e.to_string())?;
+        } else {
+            let raw = archive.by_index_raw(index).map_err(|e| e.to_string())?;
+            out.raw_copy_file(raw).map_err(|e| e.to_string())?;
+        }
+    }
+    Ok(out.finish().map_err(|e| e.to_string())?.into_inner())
+}
+
+fn tiff_to_png(tiff: &[u8]) -> Result<Vec<u8>, String> {
+    let decoded = image::load_from_memory_with_format(tiff, image::ImageFormat::Tiff)
+        .map_err(|error| error.to_string())?;
+    let mut png = Vec::new();
+    decoded
+        .write_to(&mut Cursor::new(&mut png), image::ImageFormat::Png)
+        .map_err(|error| error.to_string())?;
+    Ok(png)
 }
 
 fn is_text_mime(mime: &str) -> bool {
@@ -731,7 +815,7 @@ fn read_remote_file_bytes_with_runner(
     runner: &mut dyn RemoteRunner,
 ) -> Result<Vec<u8>, String> {
     crate::ssh_hosts::require_managed_ssh_ready(context)?;
-    let cap = preview_byte_cap(max_bytes);
+    let cap = preview_byte_cap(max_bytes).min(REMOTE_FILE_MAX_BYTES);
     let command = build_remote_file_command(context, path, cap)?;
     let output = match runner.run(&command) {
         Ok(output) => output,
@@ -758,12 +842,13 @@ fn read_remote_file_bytes_with_runner(
         return Err(error);
     }
     crate::ssh_guard::record_success(&context.id);
-    let bytes = protocol_payload(&output.stdout, REMOTE_FILE_PROTOCOL)?.to_vec();
+    let mut bytes = protocol_payload(&output.stdout, REMOTE_FILE_PROTOCOL)?.to_vec();
     if bytes.len() as u64 > cap {
         return Err(format!("remote file exceeds {cap} byte limit"));
     }
     if is_ooxml_path(Path::new(path)) {
         validate_ooxml_archive(&bytes)?;
+        bytes = transcode_ooxml_tiff_media(bytes);
     }
     Ok(bytes)
 }
@@ -874,9 +959,10 @@ pub(super) fn read_file_bytes_at(
     if len > cap {
         return Err(format!("file exceeds {cap} byte limit"));
     }
-    let bytes = std::fs::read(&real).map_err(|e| format!("{e}"))?;
+    let mut bytes = std::fs::read(&real).map_err(|e| format!("{e}"))?;
     if is_ooxml_path(&real) {
         validate_ooxml_archive(&bytes)?;
+        bytes = transcode_ooxml_tiff_media(bytes);
     }
     Ok(bytes)
 }
@@ -1265,6 +1351,67 @@ mod tests {
             .unwrap_err()
             .contains("invalid OOXML archive"));
         let _ = std::fs::remove_dir_all(base);
+    }
+
+    #[test]
+    fn ooxml_tiff_media_transcodes_to_png() {
+        let mut tiff = Vec::new();
+        image::DynamicImage::ImageRgb8(image::RgbImage::from_pixel(2, 2, image::Rgb([255, 0, 0])))
+            .write_to(&mut Cursor::new(&mut tiff), image::ImageFormat::Tiff)
+            .unwrap();
+        let bytes = test_ooxml(&[
+            (
+                "[Content_Types].xml",
+                br#"<Types><Default Extension="tiff" ContentType="image/tiff"/></Types>"#,
+            ),
+            ("word/document.xml", b"<document/>"),
+            ("word/media/image1.tiff", &tiff),
+        ]);
+        let rewritten = transcode_ooxml_tiff_media(bytes.clone());
+        assert_ne!(rewritten, bytes);
+        let mut archive = zip::ZipArchive::new(Cursor::new(&rewritten)).unwrap();
+        let mut media = Vec::new();
+        archive
+            .by_name("word/media/image1.tiff")
+            .unwrap()
+            .read_to_end(&mut media)
+            .unwrap();
+        assert!(media.starts_with(b"\x89PNG"));
+        let mut types = String::new();
+        archive
+            .by_name("[Content_Types].xml")
+            .unwrap()
+            .read_to_string(&mut types)
+            .unwrap();
+        assert!(types.contains("image/png"));
+        assert!(!types.contains("image/tiff"));
+        let mut doc = Vec::new();
+        archive
+            .by_name("word/document.xml")
+            .unwrap()
+            .read_to_end(&mut doc)
+            .unwrap();
+        assert_eq!(doc, b"<document/>");
+    }
+
+    #[test]
+    fn ooxml_without_tiff_media_passes_through_untouched() {
+        let plain = test_ooxml(&[
+            ("[Content_Types].xml", b"<Types/>"),
+            ("word/media/image1.png", b"\x89PNGnot-really"),
+        ]);
+        assert_eq!(transcode_ooxml_tiff_media(plain.clone()), plain);
+        // A TIFF that fails to decode keeps its original bytes.
+        let broken = test_ooxml(&[("word/media/image1.tiff", b"II*\0garbage")]);
+        let rewritten = transcode_ooxml_tiff_media(broken);
+        let mut archive = zip::ZipArchive::new(Cursor::new(&rewritten)).unwrap();
+        let mut media = Vec::new();
+        archive
+            .by_name("word/media/image1.tiff")
+            .unwrap()
+            .read_to_end(&mut media)
+            .unwrap();
+        assert_eq!(media, b"II*\0garbage");
     }
 
     #[test]

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -2591,7 +2591,7 @@ test("PDF artifacts render inside the app without a browser PDF plugin", async (
   // Single-page viewer: one page is rendered at a time, navigated with controls.
   await expect(modal.locator('.rp-pdf[data-page-count="2"][data-current-page="1"]')).toBeVisible();
   await expect.poll(() => lastInvokeArgs(page, "read_file_bytes"))
-    .toMatchObject({ path: "paper.pdf", maxBytes: 32 * 1024 * 1024 });
+    .toMatchObject({ path: "paper.pdf", maxBytes: 100 * 1024 * 1024 });
   const renderedPage = modal.locator('.rp-pdf-page[data-page="1"][data-rendered="true"]');
   await expect(renderedPage).toBeVisible();
   await expect(modal.locator(".rp-pdf-page")).toHaveCount(1);

--- a/ui/src/api.js
+++ b/ui/src/api.js
@@ -367,7 +367,9 @@ async function previewBytes(payload) {
   if (payload.b64) return base64Bytes(payload.b64);
   const path = String(payload.path || "");
   if (!path) throw new Error("Preview path is empty");
-  const maxBytes = Math.min(Number(payload.maxBytes) || 32 * 1024 * 1024, 32 * 1024 * 1024);
+  // 100 MB matches the backend's local preview ceiling (and the upload cap);
+  // the backend clamps remote reads to 32 MB on its own.
+  const maxBytes = Math.min(Number(payload.maxBytes) || 32 * 1024 * 1024, 100 * 1024 * 1024);
 
   let command = "read_file_bytes";
   let args = { path, maxBytes };

--- a/ui/src/app_support.rs
+++ b/ui/src/app_support.rs
@@ -7233,9 +7233,11 @@ pub(super) fn FilePreview(dom_id: String, path: String, kind: String) -> impl In
             // string -> decoded ArrayBuffer copies in the WebView.
             if matches!(kind.as_str(), "pdf" | "docx" | "xlsx" | "pptx") {
                 let payload = match kind.as_str() {
+                    // 100 MB: journal PDFs with embedded figures routinely pass
+                    // 32 MB; pdf.js renders page-at-a-time so memory is bounded.
                     "pdf" => serde_json::json!({
                         "path": path,
-                        "maxBytes": 32 * 1024 * 1024,
+                        "maxBytes": 100 * 1024 * 1024,
                         "loading": t(loc, "loading"),
                         "error": t(loc, "preview.pdf_error"),
                         "pageLabel": t(loc, "preview.pdf_page"),


### PR DESCRIPTION
## What

Fixes two preview failures hit with real literature files:

1. **PDF over 32 MB showed "Unable to preview this PDF."** The preview byte path was capped at 32 MB twice — the JS clamp in `previewBytes` (`ui/src/api.js`) and the `preview_byte_cap` ceiling in `src-tauri/src/file_browser.rs` — so a 38 MB journal PDF was rejected before pdf.js ever saw it. Local previews now allow 100 MB (matching the existing upload cap). Remote (SSH) reads keep the 32 MB clamp since those bytes cross the network.

2. **DOCX with TIFF figures rendered text but blank images.** Browsers cannot decode TIFF, and the affected supplement embeds its only figure as LZW TIFF. OOXML preview bytes are now rewritten in memory after validation: `media/*.tif(f)` entries are transcoded to PNG under the same entry name, and `[Content_Types].xml` is patched from `image/tiff` to `image/png` (docx-preview resolves image blob MIME from that map). Undecodable TIFFs keep their original bytes so the rest of the document still previews. Covers local, artifact, and remote read paths.

## Why not a pdf.js fix

The earlier ">20 MB webview render limit" theory doesn't hold: the actual 38 MB file parses to all 28 pages with the same vendored pdf.js once the byte cap is lifted, and pdf.js renders page-at-a-time so memory stays bounded.

## Reviewer notes

- New dependency: `image` 0.25 with only `tiff` + `png` features, used solely for the transcode.
- The transcode is a no-op (byte-identical passthrough) for archives without TIFF media; any rewrite failure falls back to the original bytes.
- Verified against the reporting files: the real 864 KB supplement transcodes to a valid 1269×1826 PNG with the content-type map patched; unit tests cover transcode, passthrough, and broken-TIFF fallback (`cargo test -p wisp-tauri file_browser::` — 22 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)