### PR TITLE
feat(ui): 研究图面板显示节点 metadata (#484 收尾)

### DIFF
--- a/ui/mock-bridge.js
+++ b/ui/mock-bridge.js
@@ -641,9 +641,9 @@
           case "get_research_graph":
             return {
               nodes: [
-                { id: "d1", project_id: "p1", kind: "decision", title: "Use DESeq2 over edgeR for the DE call", ref_id: null, metadata_json: "{}", created_at: 0, updated_at: 0 },
-                { id: "p1", project_id: "p1", kind: "paper", title: "Love et al. 2014, Moderated estimation of fold change", ref_id: "10.1186/s13059-014-0550-8", metadata_json: "{}", created_at: 0, updated_at: 0 },
-                { id: "a1", project_id: "p1", kind: "data_asset", title: "counts.tsv", ref_id: "data/counts.tsv", metadata_json: "{}", created_at: 0, updated_at: 0 },
+                { id: "d1", project_id: "p1", kind: "decision", title: "Use DESeq2 over edgeR for the DE call", ref_id: null, metadata_json: JSON.stringify({ rationale: "Shrinkage estimator handles the 3-replicate design better", alternatives: "edgeR, limma-voom" }), created_at: 0, updated_at: 0 },
+                { id: "p1", project_id: "p1", kind: "paper", title: "Love et al. 2014, Moderated estimation of fold change", ref_id: "10.1186/s13059-014-0550-8", metadata_json: JSON.stringify({ journal: "Genome Biology", year: 2014 }), created_at: 0, updated_at: 0 },
+                { id: "a1", project_id: "p1", kind: "data_asset", title: "counts.tsv", ref_id: "data/counts.tsv", metadata_json: JSON.stringify({ rows: 24567, columns: 9 }), created_at: 0, updated_at: 0 },
                 // run:/artifact: nodes + "produced" edges are what a run card reads.
                 { id: "run:r1", project_id: "p1", kind: "run", title: "DESeq2 differential expression", ref_id: "r1", metadata_json: "{}", created_at: 0, updated_at: 0 },
                 { id: "artifact:h1", project_id: "p1", kind: "artifact", title: "deseq2_results.tsv", ref_id: "h1", metadata_json: "{}", created_at: 0, updated_at: 0 },

--- a/ui/src/app_support.rs
+++ b/ui/src/app_support.rs
@@ -2268,6 +2268,7 @@ mod run_artifact_link_tests {
             source_id: source.into(),
             target_id: target.into(),
             relation: relation.into(),
+            metadata_json: "{}".into(),
         }
     }
 
@@ -2279,6 +2280,7 @@ mod run_artifact_link_tests {
                 kind: "artifact".into(),
                 title: "table.tsv".into(),
                 ref_id: Some("a1".into()),
+                metadata_json: "{}".into(),
             }],
             edges: vec![
                 edge("run:r1", "artifact:a1", "produced"),

--- a/ui/src/dto.rs
+++ b/ui/src/dto.rs
@@ -1486,12 +1486,14 @@ pub(crate) struct OnboardingState {
 
 /// Mirrors `wisp_store::ResearchNode`. `kind` stays a plain string because the
 /// backend enum serializes to snake_case and the pane only ever groups on it.
+/// `metadata_json` arrives as the store's raw JSON string, not an object.
 #[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
 pub(crate) struct ResearchNode {
     pub(crate) id: String,
     pub(crate) kind: String,
     pub(crate) title: String,
     pub(crate) ref_id: Option<String>,
+    pub(crate) metadata_json: String,
 }
 
 #[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
@@ -1499,6 +1501,9 @@ pub(crate) struct ResearchEdge {
     pub(crate) source_id: String,
     pub(crate) target_id: String,
     pub(crate) relation: String,
+    // Carried through so the wire shape matches the store; nothing renders it yet.
+    #[allow(dead_code)]
+    pub(crate) metadata_json: String,
 }
 
 #[derive(Deserialize, Clone, Debug, Default, PartialEq, Eq)]

--- a/ui/src/research.rs
+++ b/ui/src/research.rs
@@ -22,6 +22,22 @@ pub(super) struct GraphRow {
     pub(super) links: Vec<(String, String)>,
 }
 
+/// Parse a node's raw `metadata_json` into displayable `key: value` pairs.
+/// String values render bare; anything else renders as compact JSON. Empty,
+/// non-object, or unparseable metadata yields no pairs, so nothing renders.
+pub(super) fn metadata_pairs(metadata_json: &str) -> Vec<(String, String)> {
+    match serde_json::from_str::<serde_json::Value>(metadata_json) {
+        Ok(serde_json::Value::Object(map)) => map
+            .into_iter()
+            .map(|(key, value)| match value {
+                serde_json::Value::String(text) => (key, text),
+                other => (key, other.to_string()),
+            })
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
 /// Bucket nodes by kind and hang each node's outgoing edges off it.
 ///
 /// Both endpoints are guaranteed to name a node in the same project — the store
@@ -107,6 +123,16 @@ pub(super) fn ResearchGraphPane(locale: Locale, graph: ResearchGraph) -> impl In
                                 {row.node.ref_id
                                     .filter(|id| !id.trim().is_empty())
                                     .map(|id| view! { <div class="graph-node-ref">{id}</div> })}
+                                {{
+                                    let meta = metadata_pairs(&row.node.metadata_json)
+                                        .into_iter()
+                                        .map(|(key, value)| format!("{key}: {value}"))
+                                        .collect::<Vec<_>>()
+                                        .join(" · ");
+                                    (!meta.is_empty()).then(|| view! {
+                                        <div class="graph-node-ref graph-node-meta">{meta}</div>
+                                    })
+                                }}
                                 {(!row.links.is_empty()).then(|| view! {
                                     <ul class="graph-node-links">
                                         {row.links.into_iter().map(|(relation, target)| view! {
@@ -146,6 +172,7 @@ mod tests {
             kind: kind.into(),
             title: title.into(),
             ref_id: None,
+            metadata_json: "{}".into(),
         }
     }
 
@@ -154,6 +181,7 @@ mod tests {
             source_id: source.into(),
             target_id: target.into(),
             relation: relation.into(),
+            metadata_json: "{}".into(),
         }
     }
 
@@ -177,5 +205,32 @@ mod tests {
         );
         // The link hangs off the source only; the target repeats nothing.
         assert!(sections[1].1[0].links.is_empty());
+    }
+
+    #[test]
+    fn grouping_keeps_node_metadata() {
+        let mut asset = node("a1", "data_asset", "counts.tsv");
+        asset.metadata_json = r#"{"rows": 1204}"#.into();
+        let graph = ResearchGraph {
+            nodes: vec![asset],
+            edges: vec![],
+        };
+        let sections = group_graph(&graph);
+        assert_eq!(sections[0].1[0].node.metadata_json, r#"{"rows": 1204}"#);
+    }
+
+    #[test]
+    fn metadata_pairs_formats_values_and_skips_non_objects() {
+        assert_eq!(
+            metadata_pairs(r#"{"doi": "10.1/x", "rows": 1204, "tags": ["a"]}"#),
+            vec![
+                ("doi".to_string(), "10.1/x".to_string()),
+                ("rows".to_string(), "1204".to_string()),
+                ("tags".to_string(), r#"["a"]"#.to_string()),
+            ]
+        );
+        assert!(metadata_pairs("{}").is_empty());
+        assert!(metadata_pairs("not json").is_empty());
+        assert!(metadata_pairs(r#"["an", "array"]"#).is_empty());
     }
 }

--- a/ui/src/styles/right-pane.css
+++ b/ui/src/styles/right-pane.css
@@ -669,6 +669,8 @@
 .graph-node + .graph-node { margin-top: 8px; }
 .graph-node-title { font-size: 13px; font-weight: 600; color: var(--text); line-height: 1.45; word-break: break-word; }
 .graph-node-ref { margin-top: 3px; font-family: var(--font-mono); font-size: 11.5px; color: var(--text-faint); word-break: break-all; }
+/* Metadata reuses the ref row, but reads as prose (decision rationale, DOI details). */
+.graph-node-meta { font-family: inherit; font-size: 12px; color: var(--text-muted); word-break: break-word; }
 .graph-node-links { list-style: none; margin: 8px 0 0; padding: 8px 0 0; border-top: 1px solid var(--border); display: flex; flex-direction: column; gap: 4px; }
 .graph-node-links li { display: flex; align-items: baseline; gap: 6px; font-size: 12px; color: var(--text-muted); min-width: 0; }
 .graph-rel { flex: 0 0 auto; padding: 1px 6px; border-radius: 999px; background: var(--clay-soft); color: var(--clay-strong); font-size: 11px; font-weight: 600; }


### PR DESCRIPTION
## 问题

`research_graph` 工具写入的节点/边 `metadata`（决策理由、DOI 详情、数据资产行数）由 `get_research_graph` 完整返回，MCP 侧 `wisp_get_research_graph` 也一直把整个 graph 序列化给 agent——但 `ui/src/dto.rs` 的 `ResearchNode`/`ResearchEdge` 只取了 id/kind/title/ref_id，把 metadata 丢掉了。metadata 是这些内容唯一的栖身处，结果只有 agent 看得到，人看的面板看不到。

## 改动

- **DTO 两侧对齐**：`ResearchNode`/`ResearchEdge` 各加 `metadata_json: String`。后端 `wisp_store` 里存的是序列化后的 JSON **字符串**（不是对象），且结构体没有 `rename_all`，所以线上字段名就是 snake_case 的 `metadata_json`，与已有的 `ref_id`/`source_id` 同一套命名。
  **刻意不加 `serde(default)`**：后端每次都发这个字段，缺字段应该报错而不是被静默吞成空串——这正是 #200/#201 那类错配的根因。
- **渲染**：`ui/src/research.rs` 新增 `metadata_pairs()`，解析成对象就吐 `key: value`（字符串值裸显示，其他值按紧凑 JSON 显示），空对象/非对象/解析失败一律返回空 vec，于是不渲染任何行。节点行下面复用已有的 `.graph-node-ref` 行样式，只加一条 CSS 覆盖 `.graph-node-meta` 把等宽字体和 `break-all` 换掉（决策理由是散文，不是路径）。
- **边的 metadata** 只做线形状对齐，标了 `#[allow(dead_code)]`，目前没有展示位。
- **mock fixture**：`get_research_graph` 的三个节点填上真实 metadata，方便预览验证。

## 验证

- ui 宿主 `cargo test`：118 项全过，含新增两项——分组保留节点 metadata、`metadata_pairs` 的格式化与非对象兜底。
- `cargo check --target wasm32-unknown-unknown` 干净。按惯例 ui/ crate 没跑 fmt。
- trunk + `?mock=1` 预览实测：决策行显示「alternatives: edgeR, limma-voom · rationale: Shrinkage estimator handles the 3-replicate design better」，论文行「journal: Genome Biology · year: 2014」，数据资产「columns: 9 · rows: 24567」；run/artifact 节点 metadata 为 `{}`，如期不渲染。

## Reviewer 注意

- 没加 i18n 文案：metadata 的 key 是 agent 写进去的自由文本，翻译不了也不该翻译。
- key 的显示顺序由 `serde_json` 的 `Map`（BTreeMap）决定，即按字母序，稳定可预期。
- 跳过的：边 metadata 的渲染（没有展示位，等边上真有内容要看时再说）；节点多时的折叠/截断（列表本来就是滚动的）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)