### PR TITLE
feat(settings): add Storage and Usage sections

### DIFF
--- a/crates/wisp-store/src/lib.rs
+++ b/crates/wisp-store/src/lib.rs
@@ -40,7 +40,7 @@ pub use library::{
 pub use models::*;
 pub use project_sync::ProjectSyncState;
 pub use project_transfer::ProjectTransferStats;
-pub use sessions::SessionTranscriptPage;
+pub use sessions::{SessionTokenUsage, SessionTranscriptPage};
 
 use anyhow::Result;
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};

--- a/crates/wisp-store/src/sessions.rs
+++ b/crates/wisp-store/src/sessions.rs
@@ -6,6 +6,19 @@ use anyhow::Result;
 use sqlx::{Row, Sqlite, Transaction};
 use wisp_llm::Message;
 
+/// Token totals for one root session, folded from the persisted per-round
+/// `Usage` transcript events (the `frames` token columns are never updated).
+#[derive(serde::Serialize)]
+pub struct SessionTokenUsage {
+    pub id: String,
+    pub title: String,
+    pub updated_at: i64,
+    pub input: i64,
+    pub output: i64,
+    pub reasoning: i64,
+    pub cached: i64,
+}
+
 /// One bounded, turn-aligned slice of a saved conversation.
 pub struct SessionTranscriptPage {
     pub messages: Vec<(i64, Message)>,
@@ -1276,5 +1289,42 @@ impl Store {
             .await?
             .into_iter()
             .next())
+    }
+
+    /// Per-session token totals for the Usage settings page. Sub-agent frames
+    /// fold into their root session. Serde tags internally-tagged enums first,
+    /// so the LIKE prefix is a cheap exact filter for `Usage` events.
+    pub async fn token_usage_by_session(&self) -> Result<Vec<SessionTokenUsage>> {
+        let rows = sqlx::query(
+            "SELECT r.id AS id, r.title AS custom_title, r.updated_at AS updated_at, \
+                    (SELECT content FROM messages m WHERE m.frame_id = r.id AND m.role='user' ORDER BY m.seq ASC LIMIT 1) AS first_user, \
+                    SUM(COALESCE(json_extract(e.event_json,'$.input'),0)) AS input, \
+                    SUM(COALESCE(json_extract(e.event_json,'$.output'),0)) AS output, \
+                    SUM(COALESCE(json_extract(e.event_json,'$.reasoning'),0)) AS reasoning, \
+                    SUM(COALESCE(json_extract(e.event_json,'$.cached'),0)) AS cached \
+             FROM session_ui_events e \
+             JOIN frames f ON f.id = e.frame_id \
+             JOIN frames r ON r.id = COALESCE(f.root_frame_id, f.id) \
+             WHERE e.event_json LIKE '{\"kind\":\"Usage\"%' \
+             GROUP BY r.id ORDER BY r.updated_at DESC",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter()
+            .map(|row| {
+                Ok(SessionTokenUsage {
+                    id: row.try_get("id")?,
+                    title: session_display_title(
+                        row.try_get::<Option<String>, _>("custom_title")?,
+                        row.try_get::<Option<String>, _>("first_user")?,
+                    ),
+                    updated_at: row.try_get("updated_at")?,
+                    input: row.try_get("input")?,
+                    output: row.try_get("output")?,
+                    reasoning: row.try_get("reasoning")?,
+                    cached: row.try_get("cached")?,
+                })
+            })
+            .collect()
     }
 }

--- a/crates/wisp-store/src/store_tests.rs
+++ b/crates/wisp-store/src/store_tests.rs
@@ -137,6 +137,66 @@ async fn roundtrip() {
 }
 
 #[tokio::test]
+async fn token_usage_folds_usage_events_into_root_sessions() {
+    let tmp = std::env::temp_dir().join(format!(
+        "wisp_store_token_usage_{}.sqlite",
+        uuid::Uuid::new_v4()
+    ));
+    let store = Store::open(&tmp).await.unwrap();
+    store.create_project("p", "proj", "").await.unwrap();
+    store
+        .create_frame("root", "p", "OPERON", "m")
+        .await
+        .unwrap();
+    store
+        .append_message("root", 1, &Message::user("hello usage"))
+        .await
+        .unwrap();
+    store
+        .create_child_frame("child", "root", "p", "Sub", "m")
+        .await
+        .unwrap();
+    let usage = |input: i64, output: i64| {
+        format!(
+            "{{\"kind\":\"Usage\",\"frame_id\":\"x\",\"round\":1,\"input\":{input},\"output\":{output},\"reasoning\":1,\"cached\":2,\"ctx_tokens\":0,\"max_context\":0}}"
+        )
+    };
+    store
+        .append_session_ui_event("root", 1, &usage(100, 10))
+        .await
+        .unwrap();
+    store
+        .append_session_ui_event(
+            "root",
+            2,
+            "{\"kind\":\"Text\",\"frame_id\":\"root\",\"delta\":\"hi\"}",
+        )
+        .await
+        .unwrap();
+    store
+        .append_session_ui_event("child", 1, &usage(50, 5))
+        .await
+        .unwrap();
+    // A session with no usage events must not appear at all.
+    store
+        .create_frame("quiet", "p", "OPERON", "m")
+        .await
+        .unwrap();
+
+    let rows = store.token_usage_by_session().await.unwrap();
+    assert_eq!(rows.len(), 1);
+    let row = &rows[0];
+    assert_eq!(row.id, "root");
+    assert_eq!(row.title, "hello usage");
+    assert_eq!(
+        (row.input, row.output, row.reasoning, row.cached),
+        (150, 15, 2, 4)
+    );
+
+    let _ = std::fs::remove_file(&tmp);
+}
+
+#[tokio::test]
 async fn child_agent_frames_stay_out_of_top_level_session_history() {
     let tmp = std::env::temp_dir().join(format!(
         "wisp_store_child_frames_{}.sqlite",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6062,6 +6062,8 @@ pub fn run() {
             approval_commands::revoke_all_approval_grants,
             settings_commands::get_settings,
             settings_commands::set_settings,
+            settings_commands::get_storage_usage,
+            settings_commands::get_token_usage,
             settings_commands::set_api_key,
             settings_commands::credential_status,
             settings_commands::set_credential,

--- a/src-tauri/src/settings_commands.rs
+++ b/src-tauri/src/settings_commands.rs
@@ -671,3 +671,85 @@ pub(super) async fn set_update_check_enabled(
     save_update_check_enabled(&state.store, enabled).await?;
     Ok(enabled)
 }
+
+/// Sum of file sizes under `path`; 0 for a missing path.
+fn dir_size(path: &Path) -> u64 {
+    walkdir::WalkDir::new(path)
+        .follow_links(false)
+        .into_iter()
+        .filter_map(|entry| entry.ok())
+        .filter_map(|entry| entry.metadata().ok())
+        .filter(|meta| meta.is_file())
+        .map(|meta| meta.len())
+        .sum()
+}
+
+#[tauri::command]
+pub(super) async fn get_storage_usage(
+    state: State<'_, AppState>,
+) -> Result<serde_json::Value, String> {
+    let app_data = state.app_data.clone();
+    // Every project workspace, deduped; roots inside app_data would double
+    // count the scan below, so they are skipped.
+    let workspace_dirs: Vec<PathBuf> = state
+        .store
+        .list_projects()
+        .await
+        .map_err(|error| error.to_string())?
+        .into_iter()
+        .map(|(_, _, root, ..)| PathBuf::from(root))
+        .filter(|root| !root.as_os_str().is_empty() && !root.starts_with(&app_data))
+        .collect::<std::collections::BTreeSet<_>>()
+        .into_iter()
+        .collect();
+    tokio::task::spawn_blocking(move || {
+        let (mut database, mut python, mut plugins, mut other) = (0u64, 0u64, 0u64, 0u64);
+        for entry in fs::read_dir(&app_data).into_iter().flatten().flatten() {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            let bytes = if entry.path().is_dir() {
+                dir_size(&entry.path())
+            } else {
+                entry.metadata().map(|meta| meta.len()).unwrap_or(0)
+            };
+            match name.as_str() {
+                name if name.contains(".sqlite") => database += bytes,
+                "python" => python += bytes,
+                "plugins" | "plugin-staging" | "plugin-downloads" => plugins += bytes,
+                _ => other += bytes,
+            }
+        }
+        let workspace: u64 = workspace_dirs.iter().map(|dir| dir_size(dir)).sum();
+        let entries = [
+            ("database", database),
+            ("python", python),
+            ("plugins", plugins),
+            ("workspace", workspace),
+            ("other", other),
+        ];
+        Ok(json!({
+            "data_dir": app_data.to_string_lossy(),
+            "workspace_dirs": workspace_dirs
+                .iter()
+                .map(|dir| dir.to_string_lossy())
+                .collect::<Vec<_>>(),
+            "entries": entries
+                .iter()
+                .map(|(key, bytes)| json!({ "key": key, "bytes": bytes }))
+                .collect::<Vec<_>>(),
+            "total_bytes": entries.iter().map(|(_, bytes)| bytes).sum::<u64>(),
+        }))
+    })
+    .await
+    .map_err(|error| error.to_string())?
+}
+
+#[tauri::command]
+pub(super) async fn get_token_usage(
+    state: State<'_, AppState>,
+) -> Result<Vec<wisp_store::SessionTokenUsage>, String> {
+    state
+        .store
+        .token_usage_by_session()
+        .await
+        .map_err(|error| error.to_string())
+}

--- a/ui/mock-bridge.js
+++ b/ui/mock-bridge.js
@@ -293,6 +293,25 @@
             return { provider: "openai", api_url: "https://api.deepseek.com", model: "deepseek-v4-pro", label: "deepseek-v4-pro", has_api_key: true, locale: "en", max_iter: 100, max_tokens: 4096, reasoning_effort: "", supports_vision: true };
           case "list_models":
             return mockModels;
+          case "get_storage_usage":
+            return {
+              data_dir: "C:\\mock\\AppData\\wisp-science",
+              workspace_dirs: ["C:\\mock\\wisp-science"],
+              entries: [
+                { key: "database", bytes: 23 * 1024 * 1024 },
+                { key: "python", bytes: 428 * 1024 * 1024 },
+                { key: "plugins", bytes: 5632 * 1024 },
+                { key: "workspace", bytes: 96 * 1024 * 1024 },
+                { key: "other", bytes: 300 * 1024 },
+              ],
+              total_bytes: (23 + 428 + 96) * 1024 * 1024 + 5632 * 1024 + 300 * 1024,
+            };
+          case "get_token_usage":
+            return [
+              { id: "s1", title: "查找文献, FX-cell", updated_at: 1719900000, input: 355570, output: 5548, reasoning: 0, cached: 252928 },
+              { id: "s2", title: "我确认下你你有什么skill", updated_at: 1719890000, input: 131917, output: 1462, reasoning: 319, cached: 101888 },
+              { id: "s3", title: "你能做啥", updated_at: 1719880000, input: 5085, output: 428, reasoning: 0, cached: 0 },
+            ];
           case "credential_status":
             return Object.entries(mockCredentials);
           case "list_custom_credentials":

--- a/ui/src/app_support.rs
+++ b/ui/src/app_support.rs
@@ -4598,6 +4598,8 @@ pub(super) fn settings_section_label(loc: Locale, section: &str) -> String {
         "channels" => t(loc, "settings.nav.channels"),
         "credentials" => t(loc, "settings.nav.credentials"),
         "permissions" => t(loc, "settings.nav.permissions"),
+        "storage" => t(loc, "settings.nav.storage"),
+        "usage" => t(loc, "settings.nav.usage"),
         _ => t(loc, "settings.title"),
     }
     .into()

--- a/ui/src/dto.rs
+++ b/ui/src/dto.rs
@@ -515,6 +515,37 @@ pub(crate) struct SshHost {
     pub(crate) password: Option<String>,
 }
 
+/// Mirrors the `get_storage_usage` payload built in
+/// src-tauri/src/settings_commands.rs — align field by field on both sides.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub(crate) struct StorageEntry {
+    pub(crate) key: String,
+    pub(crate) bytes: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub(crate) struct StorageUsage {
+    pub(crate) data_dir: String,
+    #[serde(default)]
+    pub(crate) workspace_dirs: Vec<String>,
+    #[serde(default)]
+    pub(crate) entries: Vec<StorageEntry>,
+    pub(crate) total_bytes: u64,
+}
+
+/// Mirrors `SessionTokenUsage` in crates/wisp-store/src/sessions.rs — align
+/// field by field on both sides.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub(crate) struct SessionTokenUsage {
+    pub(crate) id: String,
+    pub(crate) title: String,
+    pub(crate) updated_at: i64,
+    pub(crate) input: i64,
+    pub(crate) output: i64,
+    pub(crate) reasoning: i64,
+    pub(crate) cached: i64,
+}
+
 /// Mirrors `SshTrustEdge` in src-tauri/src/run_context/transfer.rs — align
 /// field by field on both sides.
 #[derive(Clone, Debug, Deserialize, PartialEq)]

--- a/ui/src/i18n.rs
+++ b/ui/src/i18n.rs
@@ -808,6 +808,29 @@ fn lookup(locale: Locale, key: &str) -> Option<&'static str> {
         (Locale::En, "settings.nav.credentials") => Some("Credentials"),
         (Locale::En, "settings.nav.permissions") => Some("Permissions"),
         (Locale::En, "settings.nav.environments") => Some("Environments"),
+        (Locale::En, "settings.nav.storage") => Some("Storage"),
+        (Locale::En, "settings.nav.usage") => Some("Usage"),
+        (Locale::En, "settings.storage.data_dir") => Some("Data location"),
+        (Locale::En, "settings.storage.data_dir_hint") => {
+            Some("Where wisp-science keeps its database, Python environment and plugins on this machine")
+        }
+        (Locale::En, "settings.storage.workspace_hint") => Some("Workspace: {dirs}"),
+        (Locale::En, "settings.storage.loading") => Some("Calculating…"),
+        (Locale::En, "settings.storage.database") => Some("Database (sessions & tool results)"),
+        (Locale::En, "settings.storage.python") => Some("Python environment"),
+        (Locale::En, "settings.storage.plugins") => Some("Plugins"),
+        (Locale::En, "settings.storage.workspace") => Some("Workspace files"),
+        (Locale::En, "settings.storage.other") => Some("Other"),
+        (Locale::En, "settings.storage.total") => Some("Total"),
+        (Locale::En, "settings.usage.hint") => {
+            Some("Tokens recorded per session — sub-agent turns count toward their session.")
+        }
+        (Locale::En, "settings.usage.empty") => Some("No token usage recorded yet."),
+        (Locale::En, "settings.usage.session") => Some("Session"),
+        (Locale::En, "settings.usage.input") => Some("Input"),
+        (Locale::En, "settings.usage.output") => Some("Output"),
+        (Locale::En, "settings.usage.reasoning") => Some("Reasoning"),
+        (Locale::En, "settings.usage.cached") => Some("Cached"),
         (Locale::En, "environments.hint") => Some("Manage, probe, and configure local or remote environments here. Choose remote compute separately for each conversation from the Compute menu."),
         (Locale::En, "environments.empty") => Some("No environments are available."),
         (Locale::En, "environments.remove") => Some("Remove server"),
@@ -2177,6 +2200,29 @@ Do not leave generated files in the project root.",
         (Locale::Zh, "settings.nav.credentials") => Some("凭据"),
         (Locale::Zh, "settings.nav.permissions") => Some("权限"),
         (Locale::Zh, "settings.nav.environments") => Some("环境"),
+        (Locale::Zh, "settings.nav.storage") => Some("存储"),
+        (Locale::Zh, "settings.nav.usage") => Some("用量"),
+        (Locale::Zh, "settings.storage.data_dir") => Some("数据目录"),
+        (Locale::Zh, "settings.storage.data_dir_hint") => {
+            Some("wisp-science 在本机保存数据库、Python 环境和插件的位置")
+        }
+        (Locale::Zh, "settings.storage.workspace_hint") => Some("工作区：{dirs}"),
+        (Locale::Zh, "settings.storage.loading") => Some("计算中…"),
+        (Locale::Zh, "settings.storage.database") => Some("数据库（会话与工具结果）"),
+        (Locale::Zh, "settings.storage.python") => Some("Python 环境"),
+        (Locale::Zh, "settings.storage.plugins") => Some("插件"),
+        (Locale::Zh, "settings.storage.workspace") => Some("工作区文件"),
+        (Locale::Zh, "settings.storage.other") => Some("其他"),
+        (Locale::Zh, "settings.storage.total") => Some("总计"),
+        (Locale::Zh, "settings.usage.hint") => {
+            Some("按会话记录的 token 用量——子代理轮次计入所属会话。")
+        }
+        (Locale::Zh, "settings.usage.empty") => Some("还没有记录任何 token 用量。"),
+        (Locale::Zh, "settings.usage.session") => Some("会话"),
+        (Locale::Zh, "settings.usage.input") => Some("输入"),
+        (Locale::Zh, "settings.usage.output") => Some("输出"),
+        (Locale::Zh, "settings.usage.reasoning") => Some("思考"),
+        (Locale::Zh, "settings.usage.cached") => Some("缓存"),
         (Locale::Zh, "environments.hint") => Some("在这里管理、探测并配置本地或远程环境。远程计算资源请在每个会话的「计算」菜单中单独选择。"),
         (Locale::Zh, "environments.empty") => Some("暂无可用环境。"),
         (Locale::Zh, "environments.remove") => Some("移除服务器"),

--- a/ui/src/settings_view.rs
+++ b/ui/src/settings_view.rs
@@ -1,8 +1,9 @@
 use crate::app_support::{
     allow_drop, build_conn_json, close_details_ancestor, compose_icon, conn_form_from_row,
-    context_capability_summary, drag_session_id, focus_element_soon, join_tags, js_error_text,
-    new_acp_form, new_model_form, profile_to_form, reviewer_backend_key, reviewer_backend_label,
-    reviewer_missing_acp_profile_id, set_reviewer_backend, settings_section_label,
+    context_capability_summary, drag_session_id, focus_element_soon, format_relative_time,
+    join_tags, js_error_text, new_acp_form, new_model_form, profile_to_form, reviewer_backend_key,
+    reviewer_backend_label, reviewer_missing_acp_profile_id, set_reviewer_backend,
+    settings_section_label,
     settings_subpage_label, skill_matches_filter, start_session_drag, CRED_GROUPS,
 };
 use crate::bindings::{invoke, invoke_checked, is_mac, is_windows};
@@ -48,6 +49,17 @@ impl DeleteConfirm {
 
 fn trust_alias(context_id: &str) -> &str {
     context_id.strip_prefix("ssh:").unwrap_or(context_id)
+}
+
+/// i18n label for a `get_storage_usage` entry key.
+fn storage_entry_label_key(key: &str) -> &'static str {
+    match key {
+        "database" => "settings.storage.database",
+        "python" => "settings.storage.python",
+        "plugins" => "settings.storage.plugins",
+        "workspace" => "settings.storage.workspace",
+        _ => "settings.storage.other",
+    }
 }
 
 fn valid_sha256(value: &str) -> bool {
@@ -425,6 +437,34 @@ pub(super) fn SettingsView(
             });
         }
     });
+    // Storage / Usage panes fetch on every open; stale data stays visible
+    // while the refresh (a blocking directory scan for storage) runs.
+    let storage_usage = create_rw_signal(None::<StorageUsage>);
+    let token_usage = create_rw_signal(None::<Vec<SessionTokenUsage>>);
+    create_effect(move |_| {
+        if show_settings.get() && settings_section.get() == "storage" {
+            spawn_local(async move {
+                if let Ok(value) = invoke_checked("get_storage_usage", JsValue::UNDEFINED).await {
+                    if let Ok(usage) = serde_wasm_bindgen::from_value::<StorageUsage>(value) {
+                        storage_usage.set(Some(usage));
+                    }
+                }
+            });
+        }
+    });
+    create_effect(move |_| {
+        if show_settings.get() && settings_section.get() == "usage" {
+            spawn_local(async move {
+                if let Ok(value) = invoke_checked("get_token_usage", JsValue::UNDEFINED).await {
+                    if let Ok(rows) =
+                        serde_wasm_bindgen::from_value::<Vec<SessionTokenUsage>>(value)
+                    {
+                        token_usage.set(Some(rows));
+                    }
+                }
+            });
+        }
+    });
     create_effect(move |_| {
         if joining.get() {
             focus_element_soon("sync-device-code");
@@ -515,6 +555,12 @@ pub(super) fn SettingsView(
                     <button class:active=move || settings_section.get()=="environments"
                         on:click=move |_| go_settings_section.call("environments".into())>
                         {move || t(locale.get(), "settings.nav.environments")}</button>
+                    <button class:active=move || settings_section.get()=="storage"
+                        on:click=move |_| go_settings_section.call("storage".into())>
+                        {move || t(locale.get(), "settings.nav.storage")}</button>
+                    <button class:active=move || settings_section.get()=="usage"
+                        on:click=move |_| go_settings_section.call("usage".into())>
+                        {move || t(locale.get(), "settings.nav.usage")}</button>
                 </div>
                 <div class="settings-nav-group">
                     <span class="settings-nav-label">{move || t(locale.get(), "settings.nav.capabilities")}</span>
@@ -1001,6 +1047,125 @@ pub(super) fn SettingsView(
                                     on:click=join_project>{move || t(locale.get(), "projects.sync.join_action")}</button>
                             </div>
                         </div>
+                    </div>
+                })}
+                {move || (settings_section.get() == "storage").then(|| view! {
+                    <div class="settings-pane">
+                        <div class="settings-form-grid">
+                            <div class="span-2 appearance-config-row">
+                                <div>
+                                    <strong>{move || t(locale.get(), "settings.storage.data_dir")}</strong>
+                                    <span>{move || t(locale.get(), "settings.storage.data_dir_hint")}</span>
+                                </div>
+                            </div>
+                            {move || match storage_usage.get() {
+                                None => view! {
+                                    <div class="span-2 settings-field-hint">
+                                        {move || t(locale.get(), "settings.storage.loading")}
+                                    </div>
+                                }.into_view(),
+                                Some(usage) => {
+                                    let total = usage.total_bytes.max(1);
+                                    let loc = locale.get();
+                                    view! {
+                                        <div class="span-2 storage-block">
+                                            <code class="storage-path">{usage.data_dir.clone()}</code>
+                                            {(!usage.workspace_dirs.is_empty()).then(|| view! {
+                                                <span class="settings-field-hint">
+                                                    {tf(loc, "settings.storage.workspace_hint",
+                                                        &[("dirs", &usage.workspace_dirs.join(" · "))])}
+                                                </span>
+                                            })}
+                                            <div class="storage-bar">
+                                                {usage.entries.iter().filter(|entry| entry.bytes > 0).map(|entry| {
+                                                    let pct = entry.bytes as f64 / total as f64 * 100.0;
+                                                    view! {
+                                                        <span class=format!("storage-seg storage-seg-{}", entry.key)
+                                                            style:width=format!("{pct:.2}%")
+                                                            title=format!("{} {}", t(loc, storage_entry_label_key(&entry.key)), format_bytes(entry.bytes))>
+                                                        </span>
+                                                    }
+                                                }).collect_view()}
+                                            </div>
+                                            <div class="storage-legend">
+                                                {usage.entries.iter().map(|entry| view! {
+                                                    <div class="storage-legend-row">
+                                                        <span class=format!("storage-dot storage-seg-{}", entry.key) aria-hidden="true"></span>
+                                                        <span class="storage-legend-label">{t(loc, storage_entry_label_key(&entry.key))}</span>
+                                                        <span class="storage-legend-bytes">{format_bytes(entry.bytes)}</span>
+                                                    </div>
+                                                }).collect_view()}
+                                                <div class="storage-legend-row storage-legend-total">
+                                                    <span class="storage-dot" aria-hidden="true"></span>
+                                                    <span class="storage-legend-label">{t(loc, "settings.storage.total")}</span>
+                                                    <span class="storage-legend-bytes">{format_bytes(usage.total_bytes)}</span>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    }.into_view()
+                                }
+                            }}
+                        </div>
+                    </div>
+                })}
+                {move || (settings_section.get() == "usage").then(|| view! {
+                    <div class="settings-pane">
+                        {move || match token_usage.get() {
+                            None => view! {
+                                <div class="settings-field-hint">
+                                    {move || t(locale.get(), "settings.storage.loading")}
+                                </div>
+                            }.into_view(),
+                            Some(rows) if rows.is_empty() => view! {
+                                <div class="settings-field-hint">
+                                    {move || t(locale.get(), "settings.usage.empty")}
+                                </div>
+                            }.into_view(),
+                            Some(rows) => {
+                                let loc = locale.get();
+                                let totals = rows.iter().fold((0i64, 0i64, 0i64, 0i64), |acc, row| {
+                                    (acc.0 + row.input, acc.1 + row.output, acc.2 + row.reasoning, acc.3 + row.cached)
+                                });
+                                let tokens = |n: i64| crate::fmt_tokens(n.max(0) as u64);
+                                view! {
+                                    <p class="settings-field-hint">{t(loc, "settings.usage.hint")}</p>
+                                    <div class="usage-summary">
+                                        {[
+                                            ("settings.usage.input", totals.0),
+                                            ("settings.usage.output", totals.1),
+                                            ("settings.usage.reasoning", totals.2),
+                                            ("settings.usage.cached", totals.3),
+                                        ].into_iter().map(|(key, value)| view! {
+                                            <div class="usage-tile">
+                                                <span class="usage-tile-value">{tokens(value)}</span>
+                                                <span class="usage-tile-label">{t(loc, key)}</span>
+                                            </div>
+                                        }).collect_view()}
+                                    </div>
+                                    <div class="usage-table">
+                                        <div class="usage-row usage-row-head">
+                                            <span>{t(loc, "settings.usage.session")}</span>
+                                            <span class="usage-num">{t(loc, "settings.usage.input")}</span>
+                                            <span class="usage-num">{t(loc, "settings.usage.output")}</span>
+                                            <span class="usage-num">{t(loc, "settings.usage.reasoning")}</span>
+                                            <span class="usage-num">{t(loc, "settings.usage.cached")}</span>
+                                        </div>
+                                        {rows.iter().map(|row| view! {
+                                            <div class="usage-row">
+                                                <span class="usage-session">
+                                                    <span class="usage-session-title">{row.title.clone()}</span>
+                                                    <span class="usage-session-when">{format_relative_time(row.updated_at, loc)}</span>
+                                                </span>
+                                                <span class="usage-num">{tokens(row.input)}</span>
+                                                <span class="usage-num">{tokens(row.output)}</span>
+                                                <span class="usage-num">{tokens(row.reasoning)}</span>
+                                                <span class="usage-num">{tokens(row.cached)}</span>
+                                            </div>
+                                        }).collect_view()}
+                                    </div>
+                                }.into_view()
+                            }
+                        }}
                     </div>
                 })}
                 {move || (settings_section.get() == "appearance").then(|| view! {

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -1302,3 +1302,37 @@ body { font-size: var(--ui-font-size, 14px); }
 .demo-list { display: flex; flex-direction: column; gap: 7px; max-height: 340px; overflow-y: auto; margin: -2px; padding: 2px; }
 .demo-item { text-align: left; background: var(--bg-input); color: var(--text); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 12px 14px; cursor: pointer; font: inherit; font-size: 14px; transition: border-color .12s ease, background .12s ease; }
 .demo-item:hover { border-color: var(--clay); background: var(--bg-elev); }
+
+/* Storage section */
+.storage-block { display: flex; flex-direction: column; gap: 10px; padding-top: 12px; }
+.storage-path { font-size: 12px; color: var(--text-muted); word-break: break-all; background: var(--bg-sunken); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 8px 10px; }
+.storage-bar { display: flex; height: 14px; border-radius: 7px; overflow: hidden; background: var(--bg-sunken); border: 1px solid var(--border); }
+.storage-seg { display: block; min-width: 2px; }
+.storage-seg-database { background: var(--clay); }
+.storage-seg-python { background: var(--info); }
+.storage-seg-plugins { background: var(--warn); }
+.storage-seg-workspace { background: var(--ok); }
+.storage-seg-other { background: var(--border-strong); }
+.storage-legend { display: flex; flex-direction: column; }
+.storage-legend-row { display: flex; align-items: center; gap: 8px; min-height: 34px; border-bottom: 1px solid var(--border); font-size: 13px; }
+.storage-legend-row:last-child { border-bottom: none; }
+.storage-dot { width: 10px; height: 10px; border-radius: 3px; flex: none; }
+.storage-legend-label { flex: 1; min-width: 0; }
+.storage-legend-bytes { color: var(--text-muted); font-variant-numeric: tabular-nums; }
+.storage-legend-total { font-weight: 650; }
+.storage-legend-total .storage-legend-bytes { color: var(--text); }
+
+/* Usage section */
+.usage-summary { display: flex; gap: 10px; flex-wrap: wrap; margin: 12px 0 18px; }
+.usage-tile { flex: 1; min-width: 110px; display: flex; flex-direction: column; gap: 3px; background: var(--bg-sunken); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 10px 12px; }
+.usage-tile-value { font-size: 18px; font-weight: 650; font-variant-numeric: tabular-nums; }
+.usage-tile-label { font-size: 12px; color: var(--text-faint); }
+.usage-table { display: flex; flex-direction: column; }
+.usage-row { display: grid; grid-template-columns: 1fr 72px 72px 72px 72px; gap: 8px; align-items: center; min-height: 38px; border-bottom: 1px solid var(--border); font-size: 13px; }
+.usage-row:last-child { border-bottom: none; }
+.usage-row-head { color: var(--text-faint); font-size: 12px; min-height: 28px; }
+.usage-num { text-align: right; font-variant-numeric: tabular-nums; color: var(--text-muted); }
+.usage-row-head .usage-num { color: inherit; }
+.usage-session { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
+.usage-session-title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.usage-session-when { font-size: 11px; color: var(--text-faint); }


### PR DESCRIPTION
## What

Two new **Workspace** sections in Settings, per the `docs/claude-science-repro.md` §Settings/Capabilities reference:

- **Storage** — shows the app data directory path and a stacked disk-usage bar with legend (database / Python environment / plugins / workspace files / other) plus a total. Backed by a new `get_storage_usage` command that scans directories with the already-vendored `walkdir` on a blocking task; the pane shows a loading state until the scan returns, and stale data stays visible during refreshes.
- **Usage** — per-session token totals (input / output / reasoning / cached) with summary tiles and a session table. Backed by `Store::token_usage_by_session`, which aggregates the persisted per-round `Usage` transcript events in `session_ui_events` — the `frames.input_tokens/output_tokens` columns are inserted once and never updated, so the ui-event rows are the only real data source (verified read-only against a live database before wiring). Sub-agent frames fold into their root session; titles reuse the existing `session_display_title` fallback chain.

Both sections join the settings left-rail nav (existing `settings_section` pattern), with en+zh i18n, `mock-bridge.js` cases for both commands, and a small CSS block in `settings.css`.

## Deliberately out of scope

- **Change location** migration — display-only path, as agreed.
- **Available-on-disk** figure — needs a new dependency (`sysinfo`) or per-platform unsafe syscalls; easy follow-up if wanted.
- Storage categories reflect wisp's real on-disk layout (artifacts and tool results live inside the SQLite DB / workspace), not the reference product's exact labels.

## Testing

- New store test `token_usage_folds_usage_events_into_root_sessions` (child-frame folding, non-usage events ignored, sessions without usage excluded); full `wisp-store` suite passes (70/70).
- `cargo check` for backend crates and `cargo check --target wasm32-unknown-unknown` for `ui/` both clean; `wisp-store` formatted (`ui/` intentionally not run through fmt, per repo convention).
- Verified visually via the `?mock=1` trunk preview in both English and Chinese.

🤖 Generated with [Claude Code](https://claude.com/claude-code)