### PR TITLE
fix(ui): preserve rule-wrapped assistant replies

### DIFF
--- a/ui/src/app_support.rs
+++ b/ui/src/app_support.rs
@@ -11,10 +11,10 @@ use crate::i18n::{localize_backend, t, tf, use_locale, Locale};
 use crate::text::{
     code_lang, decode_href, dom_value, event_target_value, extract_href_from_tag, fasta_seq_count,
     fenced_blocks, file_kind, format_bytes, format_duration_ms, html_escape, ime_composing,
-    is_external_href, is_separator, is_table_row, md_inline_to_html, md_to_html, next_artifact_id,
-    normalize_path, opens_in_system_browser, parent_path, parse_csv_line, parse_notebook,
-    pretty_json, provider_defaults, provider_value, split_row, tool_card_label, tool_lang,
-    unique_dom_id,
+    is_external_href, is_separator, is_table_row, md_document_to_html, md_inline_to_html,
+    md_to_html, next_artifact_id, normalize_path, opens_in_system_browser, parent_path,
+    parse_csv_line, parse_notebook, pretty_json, provider_defaults, provider_value, split_row,
+    tool_card_label, tool_lang, unique_dom_id,
     user_message_presentation, NbOutput, Notebook,
 };
 use leptos::{ev, window_event_listener, *};
@@ -7486,7 +7486,7 @@ pub(super) fn FilePreview(dom_id: String, path: String, kind: String) -> impl In
             if kind == "markdown" {
                 if let Some(el) = el {
                     el.set_class_name("rp-heavy md");
-                    el.set_inner_html(&md_to_html(fc.text.as_deref().unwrap_or("")));
+                    el.set_inner_html(&md_document_to_html(fc.text.as_deref().unwrap_or("")));
                     schedule_highlight(dom_id.clone());
                 }
                 return;
@@ -7532,7 +7532,8 @@ pub(super) fn artifact_preview(a: &Artifact, dom_id: String, locale: Locale) -> 
         PreviewData::Markdown(s) => {
             let hid_for_effect = dom_id.clone();
             create_effect(move |_| schedule_highlight(hid_for_effect.clone()));
-            view! { <div class="md rp-md" id=dom_id inner_html=md_to_html(s)></div> }.into_view()
+            view! { <div class="md rp-md" id=dom_id inner_html=md_document_to_html(s)></div> }
+                .into_view()
         }
         PreviewData::Latex { tex, display } => {
             let payload = serde_json::json!({ "tex": tex, "display": display }).to_string();

--- a/ui/src/text.rs
+++ b/ui/src/text.rs
@@ -183,12 +183,15 @@ pub(crate) fn md_to_html(src: &str) -> String {
     out
 }
 
-fn preprocess_markdown(src: &str) -> std::borrow::Cow<'_, str> {
+/// Render a standalone Markdown document, hiding leading YAML front matter.
+/// Chat messages must use `md_to_html` so ordinary thematic breaks are kept.
+pub(crate) fn md_document_to_html(src: &str) -> String {
     let src = strip_yaml_front_matter(src);
-    let src = match rewrite_image_tags(src.as_ref()) {
-        std::borrow::Cow::Borrowed(_) => src,
-        std::borrow::Cow::Owned(s) => std::borrow::Cow::Owned(s),
-    };
+    md_to_html(src.as_ref())
+}
+
+fn preprocess_markdown(src: &str) -> std::borrow::Cow<'_, str> {
+    let src = rewrite_image_tags(src);
     match normalize_math_delimiters(src.as_ref()) {
         std::borrow::Cow::Borrowed(_) => src,
         std::borrow::Cow::Owned(s) => std::borrow::Cow::Owned(s),
@@ -1076,10 +1079,10 @@ pub(crate) fn fasta_seq_count(text: &str) -> usize {
 #[cfg(test)]
 mod md_catalog_tests {
     use super::{
-        code_lang, decode_href, fence_identifier_line_runs, file_kind, format_bytes, md_to_html,
-        parent_path, parse_notebook, pretty_json, push_nb_output, runtime_language, strip_ansi,
-        tool_card_label, user_message_presentation, NbOutput, MAX_NB_OUTPUT_BYTES,
-        MAX_NB_TOTAL_OUTPUT_BYTES,
+        code_lang, decode_href, fence_identifier_line_runs, file_kind, format_bytes,
+        md_document_to_html, md_to_html, parent_path, parse_notebook, pretty_json, push_nb_output,
+        runtime_language, strip_ansi, tool_card_label, user_message_presentation, NbOutput,
+        MAX_NB_OUTPUT_BYTES, MAX_NB_TOTAL_OUTPUT_BYTES,
     };
 
     #[test]
@@ -1154,7 +1157,58 @@ mod md_catalog_tests {
     #[test]
     fn strips_yaml_front_matter_from_markdown_preview() {
         let src = "---\nskill: bear-counter\ntopic: demo\n---\n\n# Title\n\nBody\n";
+        let html = md_document_to_html(src);
+        assert!(html.contains("<h1>Title</h1>"), "{html}");
+        assert!(!html.contains("skill: bear-counter"), "{html}");
+        assert!(!html.contains("topic: demo"), "{html}");
+    }
+
+    #[test]
+    fn keeps_front_matter_like_text_in_chat_messages() {
+        let src = "---\nskill: bear-counter\ntopic: demo\n---\n\n# Title\n\nBody\n";
         let html = md_to_html(src);
+        assert!(html.contains("skill: bear-counter"), "{html}");
+        assert!(html.contains("topic: demo"), "{html}");
+        assert!(html.contains("<h1>Title</h1>"), "{html}");
+    }
+
+    #[test]
+    fn keeps_rule_wrapped_chat_body_after_closing_rule_streams_in() {
+        let partial = "---\n\n**Figure 3. Example title.**\n\nColor scale: RdBu_r.";
+        let partial_html = md_to_html(partial);
+        assert!(
+            partial_html.contains("Figure 3. Example title."),
+            "{partial_html}"
+        );
+        assert!(
+            partial_html.contains("Color scale: RdBu_r."),
+            "{partial_html}"
+        );
+
+        let complete = format!("{partial}\n\n---\n");
+        let complete_html = md_to_html(&complete);
+        assert!(
+            complete_html.contains("Figure 3. Example title."),
+            "{complete_html}"
+        );
+        assert!(
+            complete_html.contains("Color scale: RdBu_r."),
+            "{complete_html}"
+        );
+    }
+
+    #[test]
+    fn keeps_rule_wrapped_chat_body_with_crlf() {
+        let src = "---\r\n\r\n**Figure 3.**\r\n\r\nColor scale: RdBu_r.\r\n\r\n---\r\n";
+        let html = md_to_html(src);
+        assert!(html.contains("Figure 3."), "{html}");
+        assert!(html.contains("Color scale: RdBu_r."), "{html}");
+    }
+
+    #[test]
+    fn strips_crlf_yaml_front_matter_from_markdown_preview() {
+        let src = "---\r\nskill: bear-counter\r\ntopic: demo\r\n---\r\n\r\n# Title\r\n";
+        let html = md_document_to_html(src);
         assert!(html.contains("<h1>Title</h1>"), "{html}");
         assert!(!html.contains("skill: bear-counter"), "{html}");
         assert!(!html.contains("topic: demo"), "{html}");


### PR DESCRIPTION
## Problem

Assistant replies that started and ended with standalone `---` lines could lose their entire main body after streaming completed. The shared Markdown renderer treated ordinary rule-wrapped prose containing `:` as YAML front matter, so users saw only text after the closing rule—or a completely blank reply—even though the full message was persisted.

Closes #496.

## What changed

- Keep chat Markdown preprocessing non-destructive so thematic breaks remain visible.
- Add a document-specific Markdown rendering entry point that continues hiding YAML front matter.
- Route Markdown file and artifact previews through the document renderer.
- Add regression coverage for:
  - rule-wrapped chat replies before and after the closing streamed delimiter;
  - replies with nothing after the closing delimiter;
  - LF and CRLF chat content;
  - genuine LF and CRLF YAML front matter in document previews.

Changed files:

- `ui/src/text.rs`: split chat and document rendering behavior and add tests.
- `ui/src/app_support.rs`: use document rendering for Markdown file/artifact previews.

## User impact

Long or structured assistant replies no longer disappear when the model uses horizontal rules around colon-labelled prose. Existing Markdown document previews retain their front-matter behavior. No persisted data or schema changes are involved.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cd ui && cargo test` — 122 passed
- `cd ui && cargo check --target wasm32-unknown-unknown`
- `cd ui-tests && npm ci && npx playwright test` — 197 passed, 1 skipped by configuration

## Manual smoke steps

1. Stream an assistant reply beginning with `---`, containing a line such as `Color scale: RdBu_r.`, and ending with `---`; confirm the full body remains visible after completion.
2. Repeat with CRLF content on Windows.
3. Open a Markdown file or Markdown artifact with genuine `key: value` YAML front matter; confirm the metadata remains hidden while the document body renders.

## Known limitations / follow-up

- Front-matter recognition remains the existing lightweight heuristic, but is now limited to standalone document previews where it is intended.
- No physical Windows smoke test was performed; CRLF behavior is covered by unit tests and the mocked cross-platform UI suite.