### PR TITLE
fix(vision): stop text-only models 400ing on images left in history

### DIFF
--- a/crates/wisp-core/src/context.rs
+++ b/crates/wisp-core/src/context.rs
@@ -29,6 +29,10 @@ const OLD_REASONING_KEEP: (usize, usize) = (125, 125);
 /// repoint at a newer archive that itself only contains tombstones.
 pub const TOMBSTONE_PREFIX: &str = "[compacted;";
 
+/// Stands in for an image part when the target model cannot read images.
+pub const IMAGE_UNSUPPORTED_NOTE: &str =
+    "[image omitted: the active model does not accept image input]";
+
 /// Largest char boundary `<= i` (std's `floor_char_boundary` is still unstable).
 fn floor_char_boundary(s: &str, mut i: usize) -> usize {
     if i >= s.len() {
@@ -56,6 +60,10 @@ pub struct ContextManager {
     /// Set once the warning fired; reset when back under the threshold.
     warned: bool,
     pub runtime_injections: Vec<Message>,
+    /// Whether the model this context is about to be sent to accepts image
+    /// content parts. Set per turn from the active profile; `true` by default
+    /// so anything that builds a context without asking keeps sending images.
+    pub supports_vision: bool,
     /// Persisted prefix and ephemeral messages used by the latest model call.
     /// Keeping only the prefix length avoids cloning the full conversation on
     /// every agent-loop iteration.
@@ -71,6 +79,7 @@ impl ContextManager {
             warn_threshold: (max_context as f64 * 0.8) as usize,
             warned: false,
             runtime_injections: vec![],
+            supports_vision: true,
             last_request_message_count: None,
             last_request_runtime_injections: vec![],
         }
@@ -543,13 +552,29 @@ work in progress. Use this structure:
         self.last_request_message_count = Some(self.messages.len());
         self.last_request_runtime_injections
             .clone_from(&self.runtime_injections);
-        if self.runtime_injections.is_empty() {
-            std::borrow::Cow::Borrowed(&self.messages)
+        let mut prepared = if self.runtime_injections.is_empty() {
+            std::borrow::Cow::Borrowed(&self.messages[..])
         } else {
             let mut out = self.messages.clone();
             out.extend(self.runtime_injections.iter().cloned());
             std::borrow::Cow::Owned(out)
+        };
+        // A text-only model rejects the whole request over one image part, and
+        // an image sent under an earlier vision model stays in history forever
+        // — so the session would fail on every send until it is rewound. Drop
+        // the parts on the way out instead. History itself is untouched, and
+        // the substitution is deterministic, so the prefix stays cacheable for
+        // as long as the model does not change.
+        if !self.supports_vision && prepared.iter().any(Self::has_image) {
+            for m in prepared.to_mut() {
+                Self::age_images(m, IMAGE_UNSUPPORTED_NOTE);
+            }
         }
+        prepared
+    }
+
+    fn has_image(m: &Message) -> bool {
+        matches!(&m.content, Content::Parts(parts) if parts.iter().any(|p| matches!(p, Part::Image { .. })))
     }
 }
 
@@ -793,6 +818,42 @@ mod tests {
         ctx.append_user("y".repeat(4_000));
         ctx.prepare_for_api(&counter);
         assert_eq!(counter.0.load(std::sync::atomic::Ordering::SeqCst), 2);
+    }
+
+    // An image attached under a vision model stays in history; sending it to a
+    // text-only model 400s the whole request ("unknown variant `image_url`"),
+    // which would otherwise repeat on every later send in the session.
+    #[test]
+    fn prepare_for_api_drops_images_for_a_text_only_model() {
+        let counter = WarnCounter(std::sync::atomic::AtomicUsize::new(0));
+        let mut ctx = ContextManager::new(1_000_000);
+        ctx.append_user_content(image_content("plot", "data:image/png;base64,AAAA"));
+        ctx.inject_user("runtime note");
+        let before = serde_json::to_string(&ctx.messages).unwrap();
+
+        assert!(
+            has_image_part(&ctx.prepare_for_api(&counter)),
+            "a vision-capable model still receives the image"
+        );
+
+        ctx.supports_vision = false;
+        let prepared = ctx.prepare_for_api(&counter).into_owned();
+        assert!(!has_image_part(&prepared), "image part must not be sent");
+        assert!(prepared[0].content.as_text().contains("plot"), "label kept");
+        assert!(prepared[0]
+            .content
+            .as_text()
+            .contains(IMAGE_UNSUPPORTED_NOTE));
+        assert_eq!(prepared.len(), 2, "runtime injection still appended");
+        assert_eq!(
+            serde_json::to_string(&ctx.messages).unwrap(),
+            before,
+            "stripping happens on the way out, never in history"
+        );
+    }
+
+    fn has_image_part(messages: &[Message]) -> bool {
+        messages.iter().any(ContextManager::has_image)
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4635,6 +4635,10 @@ async fn send_message_inner(
     };
 
     let turn_start = agent.ctx.messages.len();
+    // Re-stated every turn: the session may have been switched to a different
+    // model since the last one, and images already in history must follow the
+    // model that is about to receive them, not the one that accepted them.
+    agent.ctx.supports_vision = primary_supports_vision;
     state.running_turns.lock().await.insert(frame_id.clone());
     let result = if resume {
         agent

--- a/ui/src/i18n.rs
+++ b/ui/src/i18n.rs
@@ -2982,6 +2982,18 @@ pub fn localize_backend(locale: Locale, msg: &str) -> String {
 /// `http: ...` from wisp-llm). Provider error bodies vary too much to parse,
 /// so this is substring classification — specific causes first, generic last.
 pub fn api_error_hint(locale: Locale, msg: &str) -> Option<String> {
+    api_error_hint_key(msg).map(|key| t(locale, key))
+}
+
+/// True when the provider rejected the request because it cannot take image
+/// content parts. Goes through the full classifier, so an unrelated failure
+/// that happens to mention `image_url` (out of balance, rate limited) does not
+/// misfire the automatic turn rollback.
+pub fn is_image_unsupported(msg: &str) -> bool {
+    api_error_hint_key(msg) == Some("err.hint.image")
+}
+
+fn api_error_hint_key(msg: &str) -> Option<&'static str> {
     if !msg.contains("api: ") && !msg.contains("http: ") {
         return None;
     }
@@ -3023,7 +3035,7 @@ pub fn api_error_hint(locale: Locale, msg: &str) -> Option<String> {
     } else {
         return None;
     };
-    Some(t(locale, key))
+    Some(key)
 }
 
 #[cfg(test)]
@@ -3052,6 +3064,19 @@ mod api_error_hint_tests {
         for (msg, key) in cases {
             assert_eq!(hint_key(msg), Some(t(Locale::En, key)), "for: {msg}");
         }
+    }
+
+    // Only this classification may auto-roll-back a turn, so a failure that
+    // merely mentions image_url must not trip it.
+    #[test]
+    fn image_unsupported_gates_the_rollback() {
+        assert!(is_image_unsupported(
+            r#"api: 400 {"error":{"message":"unknown variant `image_url`, expected `text`"}}"#
+        ));
+        assert!(!is_image_unsupported(
+            r#"api: 402 {"error":{"message":"Insufficient Balance for image_url request"}}"#
+        ));
+        assert!(!is_image_unsupported("tool `python` failed: image_url"));
     }
 
     #[test]

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -1667,6 +1667,39 @@ fn App() -> impl IntoView {
         },
     );
     let project_info_cb = project_info;
+    // Roll the active conversation back to just before user message `ui_index`
+    // and return its text to the composer. Shared by message-edit and by the
+    // automatic rollback when a turn dies on a model that cannot take images.
+    let rewind_to_user_item = move |ui_index: usize| {
+        let list = items.get();
+        let Some(user_idx) = user_message_index(&list, ui_index) else {
+            return;
+        };
+        let Some(ChatItem::User(text)) = list.get(ui_index) else {
+            return;
+        };
+        let draft = composer_text_from_user_message(text);
+        let sid = active_session.get();
+        let user_idx = user_idx
+            + sid
+                .as_deref()
+                .and_then(|id| transcript_pages.with(|pages| pages.get(id).copied()))
+                .map_or(0, |page| page.user_offset);
+        if let Some(id) = sid.as_deref() {
+            conversation_outlines.update(|outlines| {
+                if let Some(outline) = outlines.get_mut(id) {
+                    outline.retain(|entry| entry.user_index < user_idx);
+                }
+            });
+        }
+        items.set(list.into_iter().take(ui_index).collect());
+        input.set(draft);
+        focus_composer();
+        spawn_local(async move {
+            let arg = to_value(&tauri_args::rewind_session(&sid, user_idx)).unwrap();
+            let _ = invoke("rewind_session", arg).await;
+        });
+    };
     // Streaming deltas are buffered and flushed on a timer (~20 fps) instead of
     // being applied per token; see the "Streaming delta batching" block above.
     let delta_buf: DeltaBuf = Rc::new(RefCell::new(HashMap::new()));
@@ -1930,19 +1963,40 @@ fn App() -> impl IntoView {
             AgentEvent::Error { frame_id, message } => {
                 flush_now();
                 notify_desktop(&frame_id, "error", &message);
-                let model = session_model_label(
-                    &models_cb.get_untracked(),
-                    &session_models_cb.get_untracked(),
-                    Some(&frame_id),
-                );
-                route_items(active_cb, items_cb, transcripts_cb, &frame_id, |v| {
-                    strip_approval_pending(v);
-                    v.push(ChatItem::Assistant {
-                        text: format!("Error: {message}"),
-                        model,
-                        resources: Vec::new(),
+                // A model that cannot take images leaves the attachment sitting
+                // in history, so every later send fails the same way. Toast the
+                // fix and roll the turn back into the composer instead of
+                // parking an error card on a conversation that is now stuck.
+                let rolled_back = i18n::is_image_unsupported(&message)
+                    && active_cb.get_untracked().as_deref() == Some(&frame_id)
+                    && {
+                        let last_user = items_cb
+                            .get_untracked()
+                            .iter()
+                            .rposition(|item| matches!(item, ChatItem::User(_)));
+                        if let Some(index) = last_user {
+                            // Truncating at the user turn also drops any
+                            // approval-pending rows the dead turn left behind.
+                            rewind_to_user_item(index);
+                            show_warning_toast(&t(locale_cb.get_untracked(), "err.hint.image"));
+                        }
+                        last_user.is_some()
+                    };
+                if !rolled_back {
+                    let model = session_model_label(
+                        &models_cb.get_untracked(),
+                        &session_models_cb.get_untracked(),
+                        Some(&frame_id),
+                    );
+                    route_items(active_cb, items_cb, transcripts_cb, &frame_id, |v| {
+                        strip_approval_pending(v);
+                        v.push(ChatItem::Assistant {
+                            text: format!("Error: {message}"),
+                            model,
+                            resources: Vec::new(),
+                        });
                     });
-                });
+                }
                 approval_cb.update(|s| {
                     s.remove(&frame_id);
                 });
@@ -2720,34 +2774,7 @@ fn App() -> impl IntoView {
         if busy.get() {
             return;
         }
-        let list = items.get();
-        let Some(user_idx) = user_message_index(&list, ui_index) else {
-            return;
-        };
-        let Some(ChatItem::User(text)) = list.get(ui_index) else {
-            return;
-        };
-        let draft = composer_text_from_user_message(text);
-        let sid = active_session.get();
-        let user_idx = user_idx
-            + sid
-                .as_deref()
-                .and_then(|id| transcript_pages.with(|pages| pages.get(id).copied()))
-                .map_or(0, |page| page.user_offset);
-        if let Some(id) = sid.as_deref() {
-            conversation_outlines.update(|outlines| {
-                if let Some(outline) = outlines.get_mut(id) {
-                    outline.retain(|entry| entry.user_index < user_idx);
-                }
-            });
-        }
-        items.set(list.into_iter().take(ui_index).collect());
-        input.set(draft);
-        focus_composer();
-        spawn_local(async move {
-            let arg = to_value(&tauri_args::rewind_session(&sid, user_idx)).unwrap();
-            let _ = invoke("rewind_session", arg).await;
-        });
+        rewind_to_user_item(ui_index);
     };
     let branch_message = {
         let locale = locale;


### PR DESCRIPTION
## 问题

用户在勾了「支持图片输入」的模型下附图后，图片以原生 `image_url` content part 存进对话历史并一直留着。此后没有任何地方按当前模型能力剥离它，所以只要会话切到纯文本模型（或者某个 profile 被勾了「支持图片输入」但端点其实不支持），**每一次**发送都会失败：

```
api: 400 {"error":{"message":"Failed to deserialize the JSON body into the target type:
messages[227]: unknown variant `image_url`, expected `text`", ...}}
```

报错指向历史深处的某条消息，用户看不出所以然，且除了新开会话没有出路。

## 改动

**1. 发送前剥离（根因）**

`ContextManager::prepare_for_api` 是所有请求的唯一出口，剥离放在这一处，openai / anthropic / responses 三个序列化器全覆盖，不用各改一遍。

- `ContextManager` 新增 `supports_vision: bool`，默认 `true`（不知道就照发，保持现状）。
- `send_message_inner` 每轮开跑前从当前 profile 重设一次 —— 会话中途换模型也能跟上，且 `resume` / `automatic_review` 路径一并覆盖。
- 为 `false` 且历史里真有图时才 `Cow::to_mut()`，复用已有的 `age_images` 把 image part 换成文本说明。没图时零拷贝快路径不变。
- **不改 history**，只改发出去的那份副本：切回 vision 模型图还在；替换是确定性的，前缀逐字节稳定，provider prefix cache 不受影响。

**2. 兜底：toast + 回退**

万一仍有 image 类错误冒出来（比如端点连 `input_image` 也不认），UI 不再往一个已经废掉的会话里塞错误卡片，而是：弹 warning toast 说明「当前模型不支持图片输入，请换用支持视觉的模型」（复用现成的 `err.hint.image` 文案，未新增 i18n key），并把这一轮回退、原文退回输入框。

- 回退逻辑从 `edit_message` 里提取成 `rewind_to_user_item` 共用，不是复制一份。
- `i18n` 的分类链拆出 `is_image_unsupported`，走完整优先级判定 —— 一条「余额不足」里恰好带 `image_url` 不会误触发回退。
- 只在错误属于**当前**会话时自动回退（composer 是当前会话的）；后台会话仍显示错误卡片。

## 验证

- `cargo check --workspace` ✅
- `cargo check --target wasm32-unknown-unknown`（ui）✅
- `cargo test -p wisp-core context::` — 9 passed，含新增 `prepare_for_api_drops_images_for_a_text_only_model`
- `cd ui && cargo test i18n::` — 4 passed，含新增 `image_unsupported_gates_the_rollback`（CI 不跑 ui 单测，宿主手动跑的）

## Reviewer 注意

- `supports_vision` 默认 `true` 是刻意的：任何不经 `send_message_inner` 构造 context 的地方（CLI、测试）行为不变。
- 仓库里另有两处预先存在的 `cargo fmt` diff（`file_browser.rs`、`workspace_manifest.rs`），不是本次引入的，没有一并动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)