### PR TITLE
feat(browser): 追踪并一键关闭浏览过程中开的标签页

### DIFF
--- a/browser-extension/background.js
+++ b/browser-extension/background.js
@@ -193,6 +193,17 @@ async function runCommand(tabId, command) {
         });
         return { id: tab.id, url: tab.url, title: tab.title };
       }
+      if (command.method === "close") {
+        const ids = (command.tabIds ?? [command.tabId ?? tabId]).filter((id) => Number.isInteger(id));
+        const closed = [];
+        for (const id of ids) {
+          try {
+            await chrome.tabs.remove(id);
+            closed.push(id);
+          } catch (_) {}
+        }
+        return { closed, remaining: await browserTabs() };
+      }
       if (command.method === "switch") {
         const tab = await chrome.tabs.update(command.tabId || tabId, { active: true });
         await chrome.windows.update(tab.windowId, { focused: true });

--- a/browser-extension/manifest.json
+++ b/browser-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Wisp Real Browser Bridge",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAp+1W8tqVOLPTzYkx6AXoi5r6bSpmgA1obuaybI31/TKE0xhPbIrDARTZ5FhyUPJubSZKYBijaVEmLdeo74T1UQVNr1RVPYMgy1SqW/877SYj7vsw9KDYnWlQ0kWaMg7pif8y/zk+17RepOJru4b2nfoeHeiVf6K64FPHWPknH9RdR1r4WbGNsIYYyXOI0PB7gzRkj0HfzyonTA9ut2cQ79EB+1Z2OYLqH6i6znWTPjyP4W2u+UENnPRLr4wQZthpD31X5NL1r7FAqQvIRU5J/OXyYd9YORnmxdhojBn3BbNRwzjTgpL6uWEMHHvX8UG+g7Vj7m7MtlxueoF8sLAJRQIDAQAB",
   "minimum_chrome_version": "116",
   "description": "Connects Wisp to tabs in this persistent Chrome/Chromium profile.",

--- a/skills/browser-use/SKILL.md
+++ b/skills/browser-use/SKILL.md
@@ -48,6 +48,7 @@ until the popup shows *Connected to Wisp*. Never invent the path.
 |---|---|
 | Switch to & focus a tab (so the user sees it) | `{"cmd":"tabs","method":"switch","tabId":<id>}` |
 | List tabs | `{"cmd":"tabs"}` (or just `web_scan tabs_only`) |
+| Close tabs you opened | `{"cmd":"tabs","method":"close","tabIds":[<id>,...]}` — returns `closed` + `remaining` |
 | Trusted click when `.click()` is ignored | `{"cmd":"cdp","method":"Input.dispatchMouseEvent","params":{"type":"mousePressed","x":<x>,"y":<y>,"button":"left","clickCount":1}}` then the same with `"type":"mouseReleased"` — use the element's `rect` centre from `web_scan` |
 
 Prefer plain JS. Reach for `cmd:cdp` only when a page blocks synthetic
@@ -65,6 +66,26 @@ Pass `question` to say what to read out of it, e.g.
 
 It goes through the configured vision model, so `web_scan` stays the cheaper
 default — screenshot when you need eyes, not for every step.
+
+## Tab hygiene — track what you open, offer to close it
+
+Browsing tasks (searching papers, opening a dozen results) leave the user
+with a pile of tabs to close by hand. So:
+
+1. Every `web_open_tab` returns `tab.id`. **Keep a running list of the ids
+   you opened in this task**, in your own message text — e.g. after a batch
+   write `opened tabs: 1234, 1235, 1236`. `{"cmd":"tabs"}` cannot tell you
+   which tabs are yours, only what exists.
+2. When the task is done, before your final answer, **ask the user**:
+   name the count and offer to close them, e.g. *"我为这次检索开了 6 个标签
+   页，需要我关掉吗？"* Do not close anything without a yes.
+3. On a yes, close them in one call:
+   `{"cmd":"tabs","method":"close","tabIds":[1234,1235,1236]}`. Report
+   `closed`; ids already gone are skipped silently.
+
+Close **only ids you opened yourself**. Tabs the user had open, or ones
+they opened during the task, are theirs — never include them, and never
+close a tab mid-task that later steps still need.
 
 ## Stop conditions (do not automate through these)
 


### PR DESCRIPTION
Closes #498

检索类任务会在用户的 Chrome 里留下一堆标签页，得手动一个个叉掉。

## 改动

- `browser-extension/background.js`：`tabs` 命令新增 `close` 方法（`chrome.tabs.remove`，支持批量 `tabIds`），返回 `closed` + `remaining`。`tabs` 权限已有，未新增权限。manifest 版本 0.1.0 → 0.2.0，方便判断扩展有没有重新加载。
- `skills/browser-use/SKILL.md`：新增 Tab hygiene 小节——`web_open_tab` 返回的 id 逐批记录在消息里；任务结束前主动问用户"开了 N 个标签页，要关吗"；得到肯定后一次 `close` 全部关掉。只关自己开的，用户原有标签页不动，任务中途也不关。

## 未做

后端 Rust 里维护"哪些 tab 是我开的"白名单来硬拦截误关——跟踪按 issue 讨论放在 skill 层。等真出现关错用户标签页再加服务端校验。

## 注意

改了 `background.js`，用户需要在 `chrome://extensions` 刷新扩展（或重启 Chrome）才生效；旧扩展收到 `method:"close"` 会退化成返回标签页列表而不是真关闭。

## 验证

`node --check browser-extension/background.js` 通过。close 路径需装载扩展的真实 Chrome 才能端到端验证，我这边没有跑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)