### PR TITLE
feat(onboarding): bind the built-in Reader to the flash tier

### DIFF
--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -1573,6 +1573,14 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
             const useForImageGeneration = Boolean(
               arg("useForImageGeneration") ?? profile.use_for_image_generation,
             );
+            // Mirror the backend: an empty id creates a fresh profile.
+            if (!profile.id) {
+              let n = 1;
+              while (mockModels.some((m) => m.id === `m${n}`)) n += 1;
+              profile.id = `m${n}`;
+              if (!profile.label) profile.label = profile.model;
+              mockModels = [...mockModels, profile];
+            }
             mockModels = mockModels.map((m) => m.id === profile.id ? {
               ...m,
               ...profile,

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -3256,6 +3256,15 @@ test("onboarding key setup adds the flash model before the pro model", async ({ 
       const profile = args.profile instanceof Map ? Object.fromEntries(args.profile) : args.profile;
       return profile.model;
     }))).toEqual(["deepseek-v4-flash", "deepseek-v4-pro"]);
+  // The built-in Reader gets bound to the flash profile so reading-heavy
+  // work runs on the cheap tier out of the box.
+  await expect.poll(() => page.evaluate(() => ((window as any).__skillInvokeLog ?? [])
+    .filter((c: any) => c.cmd === "save_specialist_cmd")
+    .map((c: any) => {
+      const args = c.args instanceof Map ? Object.fromEntries(c.args) : c.args;
+      const spec = args.spec instanceof Map ? Object.fromEntries(args.spec) : args.spec;
+      return { id: spec.id, model_id: spec.model_id };
+    }))).toEqual([{ id: "reader", model_id: "m1" }]);
 });
 
 test("gpt-image-2 can be assigned for generation but not selected for chat", async ({ page }) => {

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -4610,6 +4610,34 @@ fn App() -> impl IntoView {
                     }
                 }
             }
+            // Bind the built-in Reader to the flash tier so reading-heavy work
+            // runs on the cheap model out of the box. An already-bound Reader
+            // is the user's choice — leave it alone.
+            let flash_id = models
+                .get_untracked()
+                .iter()
+                .find(|p| p.model == DEEPSEEK_FLASH_MODEL)
+                .map(|p| p.id.clone());
+            if let Some(flash_id) = flash_id {
+                if let Ok(v) = invoke_checked("list_specialists", JsValue::UNDEFINED).await {
+                    if let Ok(list) = serde_wasm_bindgen::from_value::<Vec<Specialist>>(v) {
+                        if let Some(mut reader) = list
+                            .into_iter()
+                            .find(|s| s.id == "reader" && s.model_id.trim().is_empty())
+                        {
+                            reader.model_id = flash_id;
+                            let arg = to_value(&serde_json::json!({ "spec": reader })).unwrap();
+                            if let Ok(v) = invoke_checked("save_specialist_cmd", arg).await {
+                                if let Ok(list) =
+                                    serde_wasm_bindgen::from_value::<Vec<Specialist>>(v)
+                                {
+                                    specialists.set(list);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
             onboard_key.set(String::new());
         });
     });


### PR DESCRIPTION
## Summary
- Onboarding already creates both `deepseek-v4-flash` and `deepseek-v4-pro`, but nothing used the flash tier automatically — it just sat there until a user manually switched session models or set a specialist's `model_id`.
- After onboarding saves both profiles, it now binds the built-in Reader specialist's `model_id` to the flash profile. Reader ("Searches project sessions in parallel and returns compact, cited evidence") is exactly the reading-heavy LLM loop the cheap tier is for, and the per-specialist model override already existed — this just wires onboarding to use it.
- A Reader the user has already bound to something else is left untouched (only binds when `model_id` is empty).
- Other candidate hooks were considered and ruled out: `vision_model_id` already guards against non-vision assignment (no-op for DeepSeek flash), and the LLM-backed `/compact` summarization path is rare and quality-sensitive, not a good fit for a cheap model.

## Changes
- `ui/src/main.rs`: after the onboarding `save_model` calls, look up the flash profile's id and, if Reader is unbound, save it with `model_id` pointed at flash.
- `ui-tests/tests/mock-tauri.ts`: `save_model` mock now mirrors the backend's create-on-empty-id behavior (was update-only), so newly onboarded profiles are actually observable in tests.
- `ui-tests/tests/ui.spec.ts`: extends the existing onboarding test to assert Reader gets bound to the new flash model id.

## Test plan
- [x] `cargo check --target wasm32-unknown-unknown` in `ui/` passes
- [x] `npx playwright test -g "model|specialist|onboarding|Reader|reader"` — 16/16 passed
- [x] `npx playwright test -g "onboarding key setup"` — passes with the new Reader-binding assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)