### PR TITLE
refactor: remove unused legacy code paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6362,16 +6362,13 @@ dependencies = [
  "anyhow",
  "chrono",
  "dirs 5.0.1",
- "serde_json",
  "tokio",
- "tracing",
  "tracing-subscriber",
  "wisp-core",
  "wisp-llm",
  "wisp-mcp",
  "wisp-runtime",
  "wisp-skills",
- "wisp-tools",
 ]
 
 [[package]]
@@ -6400,15 +6397,12 @@ dependencies = [
 name = "wisp-llm"
 version = "0.24.0"
 dependencies = [
- "anyhow",
  "async-trait",
  "futures-util",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "tokio",
- "tracing",
  "url",
 ]
 
@@ -6441,7 +6435,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tracing",
  "uuid",
  "which",
  "wisp-llm",
@@ -6454,10 +6447,7 @@ name = "wisp-skills"
 version = "0.24.0"
 dependencies = [
  "async-trait",
- "serde",
  "serde_json",
- "tokio",
- "tracing",
  "walkdir",
  "wisp-llm",
  "wisp-paths",
@@ -6478,7 +6468,6 @@ dependencies = [
  "sha2",
  "sqlx",
  "tokio",
- "tracing",
  "uuid",
  "wisp-llm",
 ]
@@ -6564,16 +6553,13 @@ dependencies = [
 name = "wisp-tools"
 version = "0.24.0"
 dependencies = [
- "anyhow",
  "async-trait",
  "base64 0.22.1",
  "dunce",
  "glob",
  "regex",
- "serde",
  "serde_json",
  "tokio",
- "tracing",
  "walkdir",
  "wisp-llm",
 ]

--- a/crates/wisp-acp/src/lib.rs
+++ b/crates/wisp-acp/src/lib.rs
@@ -60,12 +60,6 @@ impl AcpAgentProfile {
         }
     }
 
-    /// Adds one explicit environment override for the ACP child process.
-    pub fn with_env(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
-        self.env.insert(key.into(), value.into());
-        self
-    }
-
     fn validate(&self) -> Result<(), AcpError> {
         if self.id.trim().is_empty() {
             return Err(AcpError::InvalidProfile("agent id is empty"));
@@ -81,42 +75,6 @@ impl AcpAgentProfile {
         }
         Ok(())
     }
-}
-
-/// Applies the Codex ACP policy used for controlled project execution.
-///
-/// Codex's `agent` mode is deliberately approval-aware: each turn is confined
-/// to workspace-write with network disabled, and requests outside that sandbox
-/// are returned to the ACP client. Callers must reject escalations at their
-/// permission boundary instead of treating this profile as approval-free.
-pub fn codex_project_sandbox_profile(mut profile: AcpAgentProfile) -> AcpAgentProfile {
-    let config = serde_json::json!({
-        "approval_policy": "on-request",
-        "sandbox_mode": "workspace-write",
-        "sandbox_workspace_write": {
-            "network_access": false,
-        },
-        "web_search": "disabled",
-        "mcp_servers": {},
-    });
-    profile.env.insert(
-        "CODEX_CONFIG".into(),
-        serde_json::to_string(&config).expect("static Codex config serializes"),
-    );
-    profile
-        .env
-        .insert("INITIAL_AGENT_MODE".into(), "agent".into());
-    for value in [
-        r#"approval_policy="on-request""#,
-        r#"sandbox_mode="workspace-write""#,
-        "sandbox_workspace_write.network_access=false",
-        r#"web_search="disabled""#,
-        "mcp_servers={}",
-    ] {
-        profile.args.push("-c".into());
-        profile.args.push(value.into());
-    }
-    profile
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/wisp-acp/tests/process.rs
+++ b/crates/wisp-acp/tests/process.rs
@@ -1,5 +1,4 @@
 use std::{
-    io::{BufRead, Write},
     path::PathBuf,
     process::ExitCode,
     sync::{
@@ -37,9 +36,6 @@ use wisp_acp::{
 
 fn main() -> ExitCode {
     let args = std::env::args().skip(1).collect::<Vec<_>>();
-    if args.first().is_some_and(|arg| arg == "app-server") {
-        return fake_codex_app_server();
-    }
     if args.first().is_some_and(|arg| arg == "--fake-agent") {
         return fake_agent(&args[1..]);
     }
@@ -62,7 +58,6 @@ fn main() -> ExitCode {
 
 async fn run_tests() -> Result<(), String> {
     test_environment_propagation().await?;
-    test_installed_codex_acp_effective_policy().await?;
     test_full_lifecycle().await?;
     test_protocol_mismatch().await?;
     test_capability_omission().await?;
@@ -71,107 +66,12 @@ async fn run_tests() -> Result<(), String> {
     Ok(())
 }
 
-async fn test_installed_codex_acp_effective_policy() -> Result<(), String> {
-    let Some(command) = find_codex_acp() else {
-        println!("codex-acp not installed; skipping adapter conformance check");
-        return Ok(());
-    };
-    let capture = unique_temp_path("wisp-codex-acp-policy");
-    let profile = wisp_acp::codex_project_sandbox_profile(AcpAgentProfile::new(
-        "codex-policy",
-        "Codex policy probe",
-        command,
-        vec![],
-    ))
-    .with_env(
-        "CODEX_PATH",
-        std::env::current_exe()
-            .map_err(stringify)?
-            .to_string_lossy(),
-    )
-    .with_env(
-        "WISP_FAKE_CODEX_CAPTURE",
-        capture.to_string_lossy().to_string(),
-    );
-    let handle = AcpSessionHandle::launch(profile).await.map_err(stringify)?;
-    let start = handle
-        .new_session(std::env::current_dir().map_err(stringify)?, vec![])
-        .await
-        .map_err(stringify)?;
-    let prompt = handle.prompt_text(start.session_id, "capture effective policy");
-    tokio::pin!(prompt);
-    let outcome = loop {
-        tokio::select! {
-            result = &mut prompt => break result.map_err(stringify)?,
-            event = handle.next_event() => match event {
-                Some(AcpSessionEvent::Permission(request)) => {
-                    let reject = request.options.iter()
-                        .find(|option| matches!(option.kind, AcpPermissionKind::RejectOnce | AcpPermissionKind::RejectAlways))
-                        .ok_or("Codex escalation offered no reject option")?;
-                    handle.respond_permission(request.request_id, Some(reject.id.clone())).map_err(stringify)?;
-                }
-                Some(AcpSessionEvent::Exited { error }) => return Err(error.unwrap_or_else(|| "codex-acp exited".into())),
-                Some(_) => {}
-                None => return Err("codex-acp event stream closed".into()),
-            }
-        }
-    };
-    check(
-        outcome.stop_reason == AcpStopReason::EndTurn,
-        "Codex policy probe completed",
-    )?;
-    let raw = std::fs::read_to_string(&capture).map_err(stringify)?;
-    let captured: serde_json::Value = serde_json::from_str(&raw).map_err(stringify)?;
-    let turn = &captured["turn"];
-    check(
-        turn["approvalPolicy"] == "on-request",
-        "effective Codex approval policy is on-request",
-    )?;
-    check(
-        turn["sandboxPolicy"]["type"] == "workspaceWrite",
-        "effective Codex sandbox is workspace-write",
-    )?;
-    check(
-        turn["sandboxPolicy"]["networkAccess"] == false,
-        "effective Codex sandbox network is disabled",
-    )?;
-    check(
-        captured["thread"]["config"]["mcp_servers"] == serde_json::json!({}),
-        "Codex session MCP config is empty",
-    )?;
-    check(
-        captured["approval"]["decision"] == "decline",
-        "Codex command escalation was rejected",
-    )?;
-    handle.shutdown(Duration::from_secs(1)).await;
-    let _ = std::fs::remove_file(capture);
-    Ok(())
-}
-
-fn find_codex_acp() -> Option<PathBuf> {
-    if let Some(path) = std::env::var_os("WISP_CODEX_ACP_BIN").map(PathBuf::from) {
-        return path.is_file().then_some(path);
-    }
-    let names: &[&str] = if cfg!(windows) {
-        // async-process launches binaries directly; npm's `.cmd` shim needs a
-        // shell and is intentionally not used by this no-shell conformance test.
-        &["codex-acp.exe"]
-    } else {
-        &["codex-acp"]
-    };
-    std::env::var_os("PATH").and_then(|paths| {
-        std::env::split_paths(&paths)
-            .flat_map(|directory| names.iter().map(move |name| directory.join(name)))
-            .find(|path| path.is_file())
-    })
-}
-
 async fn test_environment_propagation() -> Result<(), String> {
-    let handle = AcpSessionHandle::launch(
-        profile("environment", vec![]).with_env("WISP_ACP_TEST_ENV", "controlled-child"),
-    )
-    .await
-    .map_err(stringify)?;
+    let mut profile = profile("environment", vec![]);
+    profile
+        .env
+        .insert("WISP_ACP_TEST_ENV".into(), "controlled-child".into());
+    let handle = AcpSessionHandle::launch(profile).await.map_err(stringify)?;
     check(handle.info().protocol_version == 1, "child environment")?;
     handle.shutdown(Duration::from_secs(1)).await;
     Ok(())
@@ -501,162 +401,6 @@ fn fake_agent(args: &[String]) -> ExitCode {
             ExitCode::FAILURE
         }
     }
-}
-
-fn fake_codex_app_server() -> ExitCode {
-    let Some(capture_path) = std::env::var_os("WISP_FAKE_CODEX_CAPTURE").map(PathBuf::from) else {
-        eprintln!("fake Codex app-server capture path is missing");
-        return ExitCode::FAILURE;
-    };
-    let stdin = std::io::stdin();
-    let mut stdout = std::io::stdout().lock();
-    let mut thread_start = None;
-    let mut turn_start = None;
-    for line in stdin.lock().lines() {
-        let Ok(line) = line else {
-            return ExitCode::FAILURE;
-        };
-        let Ok(message) = serde_json::from_str::<serde_json::Value>(&line) else {
-            continue;
-        };
-        if let Some(method) = message.get("method").and_then(serde_json::Value::as_str) {
-            let Some(id) = message.get("id").cloned() else {
-                continue;
-            };
-            let params = message
-                .get("params")
-                .cloned()
-                .unwrap_or_else(|| serde_json::json!({}));
-            let result = match method {
-                "initialize" => serde_json::json!({}),
-                "account/read" => serde_json::json!({
-                    "account": { "type": "chatgpt", "email": "policy@example.invalid" },
-                    "requiresOpenaiAuth": false,
-                }),
-                "config/read" => serde_json::json!({ "config": {} }),
-                "skills/extraRoots/set" => serde_json::json!({}),
-                "skills/list" => serde_json::json!({ "data": [] }),
-                "thread/start" => {
-                    thread_start = Some(params);
-                    serde_json::json!({
-                        "thread": { "id": "fake-thread" },
-                        "model": "gpt-5",
-                        "reasoningEffort": "medium",
-                        "modelProvider": "openai",
-                        "serviceTier": null,
-                    })
-                }
-                "model/list" => serde_json::json!({
-                    "data": [{
-                        "id": "gpt-5",
-                        "displayName": "GPT-5",
-                        "description": "Policy test model",
-                        "isDefault": true,
-                        "defaultReasoningEffort": "medium",
-                        "supportedReasoningEfforts": [{
-                            "reasoningEffort": "medium",
-                            "description": "Policy test effort",
-                        }],
-                        "inputModalities": ["text"],
-                    }],
-                    "nextCursor": null,
-                }),
-                "turn/start" => {
-                    turn_start = Some(params);
-                    serde_json::json!({
-                        "turn": {
-                            "id": "fake-turn",
-                            "status": "inProgress",
-                            "items": [],
-                            "itemsView": "notLoaded",
-                            "error": null,
-                        }
-                    })
-                }
-                _ => serde_json::json!({}),
-            };
-            if write_json_line(
-                &mut stdout,
-                &serde_json::json!({ "jsonrpc": "2.0", "id": id, "result": result }),
-            )
-            .is_err()
-            {
-                return ExitCode::FAILURE;
-            }
-            if method == "turn/start"
-                && write_json_line(
-                    &mut stdout,
-                    &serde_json::json!({
-                        "jsonrpc": "2.0",
-                        "id": 900,
-                        "method": "item/commandExecution/requestApproval",
-                        "params": {
-                            "threadId": "fake-thread",
-                            "turnId": "fake-turn",
-                            "itemId": "escape-command",
-                            "command": "curl https://example.invalid",
-                            "cwd": "/",
-                            "reason": "policy escalation probe",
-                        }
-                    }),
-                )
-                .is_err()
-            {
-                return ExitCode::FAILURE;
-            }
-            continue;
-        }
-        if message.get("id").and_then(serde_json::Value::as_i64) == Some(900) {
-            let approval = message
-                .get("result")
-                .cloned()
-                .unwrap_or_else(|| serde_json::json!({}));
-            let capture = serde_json::json!({
-                "thread": thread_start,
-                "turn": turn_start,
-                "approval": approval,
-            });
-            if std::fs::write(
-                &capture_path,
-                serde_json::to_vec_pretty(&capture).expect("capture serializes"),
-            )
-            .is_err()
-            {
-                return ExitCode::FAILURE;
-            }
-            if write_json_line(
-                &mut stdout,
-                &serde_json::json!({
-                    "jsonrpc": "2.0",
-                    "method": "turn/completed",
-                    "params": {
-                        "threadId": "fake-thread",
-                        "turn": {
-                            "id": "fake-turn",
-                            "status": "completed",
-                            "items": [],
-                            "itemsView": "notLoaded",
-                            "error": null,
-                            "startedAt": null,
-                            "completedAt": null,
-                            "durationMs": null,
-                        }
-                    }
-                }),
-            )
-            .is_err()
-            {
-                return ExitCode::FAILURE;
-            }
-        }
-    }
-    ExitCode::SUCCESS
-}
-
-fn write_json_line(output: &mut impl Write, value: &serde_json::Value) -> std::io::Result<()> {
-    serde_json::to_writer(&mut *output, value)?;
-    output.write_all(b"\n")?;
-    output.flush()
 }
 
 #[derive(Default)]

--- a/crates/wisp-cli/Cargo.toml
+++ b/crates/wisp-cli/Cargo.toml
@@ -12,8 +12,6 @@ path = "src/main.rs"
 [dependencies]
 tokio = { workspace = true }
 anyhow = { workspace = true }
-serde_json = { workspace = true }
-tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 dirs = "5"
 chrono = { workspace = true }
@@ -22,4 +20,3 @@ wisp-mcp = { workspace = true }
 wisp-llm = { workspace = true }
 wisp-core = { workspace = true }
 wisp-skills = { workspace = true }
-wisp-tools = { workspace = true }

--- a/crates/wisp-core/src/context.rs
+++ b/crates/wisp-core/src/context.rs
@@ -155,14 +155,6 @@ impl ContextManager {
         self.messages.push(m);
     }
 
-    pub fn get_messages(&self) -> &[Message] {
-        &self.messages
-    }
-    pub fn get_latest(&self, n: usize) -> &[Message] {
-        let start = self.messages.len().saturating_sub(n);
-        &self.messages[start..]
-    }
-
     pub fn load(&mut self, path: &Path) {
         self.invalidate_last_request();
         match std::fs::read_to_string(path) {
@@ -242,57 +234,8 @@ impl ContextManager {
         turns
     }
 
-    fn role_msgs(&self, role: Role, n: Option<usize>) -> Vec<&Message> {
-        let slice = match n {
-            Some(n) => self.get_latest(n),
-            None => &self.messages[..],
-        };
-        slice.iter().filter(|m| m.role == role).collect()
-    }
-
-    fn tool_names_of(msgs: &[&Message]) -> Vec<String> {
-        msgs.iter()
-            .filter(|m| m.role == Role::Tool)
-            .filter_map(|m| m.tool_name.clone())
-            .collect()
-    }
-
-    #[allow(dead_code)]
-    fn last_user_content(&self, msgs: Option<&[Message]>) -> String {
-        let src = msgs.unwrap_or(&self.messages);
-        src.iter()
-            .rev()
-            .find(|m| m.role == Role::User)
-            .map(|m| m.content.as_text())
-            .unwrap_or_default()
-    }
-
     fn under_threshold(&self) -> bool {
         self.total_tokens() < self.warn_threshold
-    }
-
-    pub fn tool_pattern(&self, n: usize) -> Option<Vec<String>> {
-        let tools = Self::tool_names_of(&self.role_msgs(Role::Tool, Some(n)));
-        if tools.is_empty() {
-            None
-        } else {
-            Some(tools)
-        }
-    }
-
-    pub fn tool_context(&self, n: usize, cap: usize) -> String {
-        let mut tc = vec![];
-        for m in self.role_msgs(Role::Tool, Some(n)) {
-            let content = m.content.as_text();
-            let compacted = if content.len() > cap {
-                Self::compact_text(&content, 200, 200)
-            } else {
-                content.clone()
-            };
-            let name = m.tool_name.clone().unwrap_or_default();
-            tc.push(format!("[{name} tool] {compacted}"));
-        }
-        tc.join("\n\n")
     }
 
     /// Rough token estimate (~JSON length / 4) from field lengths directly.

--- a/crates/wisp-core/src/delegation.rs
+++ b/crates/wisp-core/src/delegation.rs
@@ -140,12 +140,6 @@ impl PermissionSet {
     }
 }
 
-impl PermissionSet {
-    pub fn is_subset_of(&self, ceiling: &Self) -> bool {
-        self.intersect(ceiling) == *self
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct ContextPolicy {
     #[serde(default)]
@@ -450,22 +444,6 @@ impl AgentSpec {
             anyhow::bail!("dynamic agent workspace_policy is required");
         }
         Ok(())
-    }
-
-    pub fn constrained_by(
-        &self,
-        permission_ceiling: &PermissionSet,
-        context_ceiling: &ContextPolicy,
-        budget_ceiling: &AgentBudget,
-        timeout_ceiling: Option<u64>,
-    ) -> Self {
-        Self {
-            permissions: self.permissions.intersect(permission_ceiling),
-            context_policy: self.context_policy.restrict(context_ceiling),
-            budget: self.budget.restrict(budget_ceiling),
-            timeout_secs: restrict_limit(self.timeout_secs, timeout_ceiling),
-            ..self.clone()
-        }
     }
 }
 

--- a/crates/wisp-llm/Cargo.toml
+++ b/crates/wisp-llm/Cargo.toml
@@ -6,13 +6,10 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { workspace = true }
 futures-util = { workspace = true }
 async-trait = "0.1"
-anyhow = { workspace = true }
 thiserror = { workspace = true }
-tracing = { workspace = true }
 url = { workspace = true }

--- a/crates/wisp-runtime/Cargo.toml
+++ b/crates/wisp-runtime/Cargo.toml
@@ -11,7 +11,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 async-trait = "0.1"
 anyhow = { workspace = true }
-tracing = { workspace = true }
 which = "7"
 uuid = { workspace = true }
 wisp-llm = { workspace = true }

--- a/crates/wisp-runtime/src/manager.rs
+++ b/crates/wisp-runtime/src/manager.rs
@@ -50,10 +50,6 @@ impl RuntimeKey {
             language: RuntimeLanguage::R,
         }
     }
-
-    pub fn local_r(project_id: impl Into<String>) -> Self {
-        Self::r(project_id, LOCAL_CONTEXT_ID)
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -951,7 +947,7 @@ mod tests {
         let launcher = FakeLauncher::default();
         let manager = manager(&launcher);
         let python = RuntimeKey::local_python("project-a");
-        let r = RuntimeKey::local_r("project-a");
+        let r = RuntimeKey::r("project-a", LOCAL_CONTEXT_ID);
         let cwd = PathBuf::from("project-a");
 
         finished(manager.execute(&python, &cwd, "set:3").await.unwrap())

--- a/crates/wisp-skills/Cargo.toml
+++ b/crates/wisp-skills/Cargo.toml
@@ -6,11 +6,8 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-tokio = { workspace = true }
-serde = { workspace = true }
 serde_json = { workspace = true }
 async-trait = "0.1"
-tracing = { workspace = true }
 walkdir = { workspace = true }
 wisp-llm = { workspace = true }
 wisp-tools = { workspace = true }

--- a/crates/wisp-store/Cargo.toml
+++ b/crates/wisp-store/Cargo.toml
@@ -12,7 +12,6 @@ serde_json = { workspace = true }
 sqlx = { workspace = true }
 anyhow = { workspace = true }
 futures-util = { workspace = true }
-tracing = { workspace = true }
 chrono = { workspace = true }
 hex = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/wisp-store/src/acp_sessions.rs
+++ b/crates/wisp-store/src/acp_sessions.rs
@@ -74,14 +74,6 @@ impl Store {
         .await?;
         row.map(from_row).transpose()
     }
-
-    pub async fn delete_acp_session(&self, frame_id: &str) -> Result<bool> {
-        let result = sqlx::query("DELETE FROM acp_sessions WHERE frame_id=?")
-            .bind(frame_id)
-            .execute(&self.pool)
-            .await?;
-        Ok(result.rows_affected() == 1)
-    }
 }
 
 #[cfg(test)]
@@ -145,9 +137,6 @@ mod tests {
         assert_eq!(loaded.created_at, 10);
         assert_eq!(loaded.updated_at, 20);
 
-        assert!(store.delete_acp_session("f1").await.unwrap());
-        assert!(!store.delete_acp_session("f1").await.unwrap());
-        assert!(store.get_acp_session("f1").await.unwrap().is_none());
         drop(store);
         let _ = std::fs::remove_file(path);
     }

--- a/crates/wisp-store/src/agent_workflow_attempts.rs
+++ b/crates/wisp-store/src/agent_workflow_attempts.rs
@@ -805,22 +805,6 @@ impl Store {
         Ok(updated.rows_affected() == 1)
     }
 
-    pub async fn request_agent_workflow_attempt_cancel(&self, id: &str) -> Result<bool> {
-        let root_workflow_id = sqlx::query_scalar::<_, String>(
-            "SELECT root_workflow_id FROM agent_workflow_attempts WHERE id=?",
-        )
-        .bind(id)
-        .fetch_optional(&self.pool)
-        .await?;
-        match root_workflow_id {
-            Some(root_workflow_id) => Ok(self
-                .request_agent_workflow_cancel(&root_workflow_id)
-                .await?
-                > 0),
-            None => Ok(false),
-        }
-    }
-
     pub async fn request_agent_workflow_cancel(&self, workflow_id: &str) -> Result<u64> {
         let root_workflow_id = sqlx::query_scalar::<_, String>(
             "SELECT root_workflow_id FROM agent_workflows WHERE id=?",

--- a/crates/wisp-store/src/agent_workflows.rs
+++ b/crates/wisp-store/src/agent_workflows.rs
@@ -600,23 +600,6 @@ async fn insert_step(tx: &mut Transaction<'_, Sqlite>, step: &AgentWorkflowStep)
     Ok(())
 }
 
-async fn bump_draft_workflow_version(
-    tx: &mut Transaction<'_, Sqlite>,
-    workflow_id: &str,
-) -> Result<()> {
-    let updated = sqlx::query(
-        "UPDATE agent_workflows SET version=version+1,updated_at=? WHERE id=? AND status='draft'",
-    )
-    .bind(chrono::Utc::now().timestamp())
-    .bind(workflow_id)
-    .execute(&mut **tx)
-    .await?;
-    if updated.rows_affected() != 1 {
-        anyhow::bail!("agent workflow plan is missing or immutable");
-    }
-    Ok(())
-}
-
 const SELECT_WORKFLOW: &str = "SELECT id,project_id,workspace_id,frame_id,root_workflow_id,parent_attempt_id,depth,root_limits_json,name,description,goal,mode,status,max_parallel,requires_confirmation,plan_json,version,enabled,approved_at,created_at,updated_at FROM agent_workflows";
 
 impl super::Store {
@@ -673,18 +656,6 @@ impl super::Store {
         }
         tx.commit().await?;
         Ok(())
-    }
-
-    pub async fn get_agent_workflow_plan(
-        &self,
-        id: &str,
-    ) -> Result<Option<(AgentWorkflow, Vec<AgentWorkflowStep>)>> {
-        let workflow = match self.get_agent_workflow(id).await? {
-            Some(workflow) => workflow,
-            None => return Ok(None),
-        };
-        let steps = self.list_agent_workflow_steps(id).await?;
-        Ok(Some((workflow, steps)))
     }
 
     pub async fn replace_agent_workflow_plan(
@@ -815,40 +786,6 @@ impl super::Store {
         Ok(changed)
     }
 
-    pub async fn create_agent_workflow(&self, workflow: &AgentWorkflow) -> Result<()> {
-        workflow.validate()?;
-        if workflow.status != AgentWorkflowStatus::Draft {
-            anyhow::bail!("new agent workflows must start as draft");
-        }
-        sqlx::query(
-            "INSERT INTO agent_workflows(id,project_id,workspace_id,frame_id,root_workflow_id,parent_attempt_id,depth,root_limits_json,name,description,goal,mode,status,max_parallel,requires_confirmation,plan_json,version,enabled,approved_at,created_at,updated_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
-        )
-        .bind(&workflow.id)
-        .bind(&workflow.project_id)
-        .bind(&workflow.workspace_id)
-        .bind(workflow.frame_id.as_deref())
-        .bind(&workflow.root_workflow_id)
-        .bind(workflow.parent_attempt_id.as_deref())
-        .bind(workflow.depth)
-        .bind(&workflow.root_limits_json)
-        .bind(&workflow.name)
-        .bind(&workflow.description)
-        .bind(&workflow.goal)
-        .bind(&workflow.mode)
-        .bind(workflow.status.as_str())
-        .bind(workflow.max_parallel)
-        .bind(workflow.requires_confirmation as i64)
-        .bind(&workflow.plan_json)
-        .bind(workflow.version)
-        .bind(workflow.enabled as i64)
-        .bind(workflow.approved_at)
-        .bind(workflow.created_at)
-        .bind(workflow.updated_at)
-        .execute(&self.pool)
-        .await?;
-        Ok(())
-    }
-
     pub async fn get_agent_workflow(&self, id: &str) -> Result<Option<AgentWorkflow>> {
         sqlx::query(&format!("{SELECT_WORKFLOW} WHERE id=?"))
             .bind(id)
@@ -867,50 +804,6 @@ impl super::Store {
         .fetch_all(&self.pool)
         .await?;
         rows.iter().map(workflow_from_row).collect()
-    }
-
-    pub async fn update_agent_workflow(&self, workflow: &AgentWorkflow) -> Result<bool> {
-        workflow.validate()?;
-        let current = match self.get_agent_workflow(&workflow.id).await? {
-            Some(current) => current,
-            None => return Ok(false),
-        };
-        if current.status != AgentWorkflowStatus::Draft
-            || workflow.status != AgentWorkflowStatus::Draft
-        {
-            anyhow::bail!("approved or running agent workflow plans are immutable");
-        }
-        if workflow.version < current.version {
-            anyhow::bail!(
-                "workflow version must not move backwards ({} < {})",
-                workflow.version,
-                current.version
-            );
-        }
-        let version = workflow.version.max(current.version.saturating_add(1));
-        let updated = sqlx::query(
-            "UPDATE agent_workflows SET project_id=?,workspace_id=?,frame_id=?,name=?,description=?,goal=?,mode=?,status=?,max_parallel=?,requires_confirmation=?,plan_json=?,version=?,enabled=?,approved_at=?,updated_at=? WHERE id=? AND version=? AND status='draft'",
-        )
-        .bind(&workflow.project_id)
-        .bind(&workflow.workspace_id)
-        .bind(workflow.frame_id.as_deref())
-        .bind(&workflow.name)
-        .bind(&workflow.description)
-        .bind(&workflow.goal)
-        .bind(&workflow.mode)
-        .bind(workflow.status.as_str())
-        .bind(workflow.max_parallel)
-        .bind(workflow.requires_confirmation as i64)
-        .bind(&workflow.plan_json)
-        .bind(version)
-        .bind(workflow.enabled as i64)
-        .bind(workflow.approved_at)
-        .bind(chrono::Utc::now().timestamp())
-        .bind(&workflow.id)
-        .bind(current.version)
-        .execute(&self.pool)
-        .await?;
-        Ok(updated.rows_affected() == 1)
     }
 
     pub async fn delete_agent_workflow(&self, id: &str) -> Result<bool> {
@@ -935,39 +828,6 @@ impl super::Store {
         Ok(deleted_workflow.rows_affected() == 1)
     }
 
-    pub async fn create_agent_workflow_step(&self, step: &AgentWorkflowStep) -> Result<()> {
-        step.validate()?;
-        let mut tx = self.begin_write().await?;
-        bump_draft_workflow_version(&mut tx, &step.workflow_id).await?;
-        sqlx::query(
-            "INSERT INTO agent_workflow_steps(id,workflow_id,position,agent_id,template_id,role,backend,model,prompt_template,input_schema_json,output_schema_json,input_contract_json,output_contract_json,permissions_json,context_policy_json,budget_json,spec_json,timeout_secs,created_at,updated_at) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
-        )
-        .bind(&step.id)
-        .bind(&step.workflow_id)
-        .bind(step.position)
-        .bind(&step.agent_id)
-        .bind(&step.template_id)
-        .bind(&step.role)
-        .bind(&step.backend)
-        .bind(step.model.as_deref())
-        .bind(&step.prompt_template)
-        .bind(&step.input_schema_json)
-        .bind(&step.output_schema_json)
-        .bind(&step.input_contract_json)
-        .bind(&step.output_contract_json)
-        .bind(&step.permissions_json)
-        .bind(&step.context_policy_json)
-        .bind(&step.budget_json)
-        .bind(&step.spec_json)
-        .bind(step.timeout_secs)
-        .bind(step.created_at)
-        .bind(step.updated_at)
-        .execute(&mut *tx)
-        .await?;
-        tx.commit().await?;
-        Ok(())
-    }
-
     pub async fn get_agent_workflow_step(&self, id: &str) -> Result<Option<AgentWorkflowStep>> {
         sqlx::query("SELECT id,workflow_id,position,agent_id,template_id,role,backend,model,prompt_template,input_schema_json,output_schema_json,input_contract_json,output_contract_json,permissions_json,context_policy_json,budget_json,spec_json,timeout_secs,created_at,updated_at FROM agent_workflow_steps WHERE id=?")
             .bind(id)
@@ -987,57 +847,5 @@ impl super::Store {
             .fetch_all(&self.pool)
             .await?;
         rows.iter().map(step_from_row).collect()
-    }
-
-    pub async fn update_agent_workflow_step(&self, step: &AgentWorkflowStep) -> Result<bool> {
-        step.validate()?;
-        let mut tx = self.begin_write().await?;
-        let current_workflow_id = sqlx::query_scalar::<_, String>(
-            "SELECT workflow_id FROM agent_workflow_steps WHERE id=?",
-        )
-        .bind(&step.id)
-        .fetch_optional(&mut *tx)
-        .await?;
-        let Some(current_workflow_id) = current_workflow_id else {
-            tx.rollback().await?;
-            return Ok(false);
-        };
-        if current_workflow_id != step.workflow_id {
-            anyhow::bail!("workflow steps cannot be moved between plans");
-        }
-        bump_draft_workflow_version(&mut tx, &current_workflow_id).await?;
-        let updated = sqlx::query("UPDATE agent_workflow_steps SET workflow_id=?,position=?,agent_id=?,template_id=?,role=?,backend=?,model=?,prompt_template=?,input_schema_json=?,output_schema_json=?,input_contract_json=?,output_contract_json=?,permissions_json=?,context_policy_json=?,budget_json=?,spec_json=?,timeout_secs=?,updated_at=? WHERE id=?")
-            .bind(&step.workflow_id).bind(step.position).bind(&step.agent_id)
-            .bind(&step.template_id).bind(&step.role).bind(&step.backend).bind(step.model.as_deref())
-            .bind(&step.prompt_template).bind(&step.input_schema_json)
-            .bind(&step.output_schema_json).bind(&step.input_contract_json)
-            .bind(&step.output_contract_json).bind(&step.permissions_json)
-            .bind(&step.context_policy_json).bind(&step.budget_json).bind(&step.spec_json)
-            .bind(step.timeout_secs).bind(chrono::Utc::now().timestamp())
-            .bind(&step.id)
-            .execute(&mut *tx).await?;
-        tx.commit().await?;
-        Ok(updated.rows_affected() == 1)
-    }
-
-    pub async fn delete_agent_workflow_step(&self, id: &str) -> Result<bool> {
-        let mut tx = self.begin_write().await?;
-        let workflow_id = sqlx::query_scalar::<_, String>(
-            "SELECT workflow_id FROM agent_workflow_steps WHERE id=?",
-        )
-        .bind(id)
-        .fetch_optional(&mut *tx)
-        .await?;
-        let Some(workflow_id) = workflow_id else {
-            tx.rollback().await?;
-            return Ok(false);
-        };
-        bump_draft_workflow_version(&mut tx, &workflow_id).await?;
-        let deleted = sqlx::query("DELETE FROM agent_workflow_steps WHERE id=?")
-            .bind(id)
-            .execute(&mut *tx)
-            .await?;
-        tx.commit().await?;
-        Ok(deleted.rows_affected() == 1)
     }
 }

--- a/crates/wisp-store/src/artifacts.rs
+++ b/crates/wisp-store/src/artifacts.rs
@@ -105,18 +105,6 @@ impl Store {
         Ok(updated)
     }
 
-    pub async fn list_artifact_versions(&self, artifact_id: &str) -> Result<Vec<ArtifactVersion>> {
-        let rows = sqlx::query(
-            "SELECT id,artifact_id,version_number,content_type,storage_path,size_bytes,checksum,\
-                    parent_version_id,producing_run_id,env_snapshot_hash,created_at \
-             FROM artifact_versions WHERE artifact_id=? ORDER BY version_number DESC",
-        )
-        .bind(artifact_id)
-        .fetch_all(&self.pool)
-        .await?;
-        rows.into_iter().map(artifact_version_from_row).collect()
-    }
-
     pub async fn get_artifact_version(&self, version_id: &str) -> Result<Option<ArtifactVersion>> {
         let row = sqlx::query(
             "SELECT id,artifact_id,version_number,content_type,storage_path,size_bytes,checksum,\

--- a/crates/wisp-store/src/models.rs
+++ b/crates/wisp-store/src/models.rs
@@ -608,59 +608,6 @@ pub(crate) fn research_edge_from_row(row: SqliteRow) -> Result<ResearchEdge> {
     })
 }
 
-pub(crate) fn validate_run_transition(from: RunStatus, to: RunStatus) -> Result<()> {
-    if from == to {
-        return Ok(());
-    }
-    let ok = match from {
-        RunStatus::Draft => matches!(
-            to,
-            RunStatus::Submitted | RunStatus::Running | RunStatus::Cancelled
-        ),
-        RunStatus::Submitted => matches!(
-            to,
-            RunStatus::Running
-                | RunStatus::Cancelling
-                | RunStatus::Succeeded
-                | RunStatus::Failed
-                | RunStatus::Cancelled
-                | RunStatus::TimedOut
-                | RunStatus::Lost
-        ),
-        RunStatus::Running => matches!(
-            to,
-            RunStatus::Cancelling
-                | RunStatus::Succeeded
-                | RunStatus::Failed
-                | RunStatus::Cancelled
-                | RunStatus::TimedOut
-                | RunStatus::Lost
-        ),
-        RunStatus::Cancelling => matches!(
-            to,
-            RunStatus::Succeeded
-                | RunStatus::Failed
-                | RunStatus::Cancelled
-                | RunStatus::TimedOut
-                | RunStatus::Lost
-        ),
-        RunStatus::Succeeded
-        | RunStatus::Failed
-        | RunStatus::Cancelled
-        | RunStatus::TimedOut
-        | RunStatus::Lost => false,
-    };
-    if ok {
-        Ok(())
-    } else {
-        anyhow::bail!(
-            "Invalid run status transition: {} -> {}",
-            from.as_str(),
-            to.as_str()
-        )
-    }
-}
-
 pub(crate) fn session_display_title(
     custom_title: Option<String>,
     first_user: Option<String>,

--- a/crates/wisp-store/src/project_sync.rs
+++ b/crates/wisp-store/src/project_sync.rs
@@ -72,14 +72,6 @@ impl Store {
         .await?;
         Ok(())
     }
-
-    pub async fn delete_project_sync_state(&self, project_id: &str) -> Result<()> {
-        sqlx::query("DELETE FROM project_sync_state WHERE project_id=?")
-            .bind(project_id)
-            .execute(&self.pool)
-            .await?;
-        Ok(())
-    }
 }
 
 #[cfg(test)]
@@ -101,8 +93,6 @@ mod tests {
             store.get_project_sync_state("p1").await.unwrap(),
             Some(state)
         );
-        store.delete_project_sync_state("p1").await.unwrap();
-        assert!(store.get_project_sync_state("p1").await.unwrap().is_none());
         store.pool.close().await;
         let _ = std::fs::remove_file(path);
     }

--- a/crates/wisp-store/src/project_transfer.rs
+++ b/crates/wisp-store/src/project_transfer.rs
@@ -999,7 +999,6 @@ mod tests {
         let workflow =
             crate::AgentWorkflow::new("workflow-1", "project-1", "workspace-1", "Review QC")
                 .unwrap();
-        source.create_agent_workflow(&workflow).await.unwrap();
         let step = crate::AgentWorkflowStep::new(
             "workflow-step-1",
             "workflow-1",
@@ -1010,7 +1009,10 @@ mod tests {
             "Review {{input}}",
         )
         .unwrap();
-        source.create_agent_workflow_step(&step).await.unwrap();
+        source
+            .create_agent_workflow_plan(&workflow, &[step.clone()])
+            .await
+            .unwrap();
         let workflow = source
             .get_agent_workflow("workflow-1")
             .await
@@ -1068,11 +1070,8 @@ mod tests {
             Some(r#"{"identity_file":"C:\\Users\\Alice\\.ssh\\id_ed25519","pid":42}"#.into());
         run.progress_json = r#"{"phase":"uploading"}"#.into();
         run.env_snapshot_json = r#"{"SSH_AUTH_SOCK":"/tmp/private-agent"}"#.into();
+        run.status = RunStatus::Submitted;
         source.create_run(&run).await.unwrap();
-        source
-            .update_run_status("run-1", RunStatus::Submitted)
-            .await
-            .unwrap();
 
         let stats = source
             .export_project_database("project-1", &archive_path)

--- a/crates/wisp-store/src/runs.rs
+++ b/crates/wisp-store/src/runs.rs
@@ -1,9 +1,8 @@
 use super::{
-    artifact_node_id, run_from_row, run_node_id, validate_run_transition, ResearchEdge,
-    ResearchNode, ResearchNodeKind, RunRecord, RunStatus, Store,
+    artifact_node_id, run_from_row, run_node_id, ResearchEdge, ResearchNode, ResearchNodeKind,
+    RunRecord, RunStatus, Store,
 };
 use anyhow::Result;
-use sqlx::Row;
 
 impl Store {
     pub async fn project_has_active_runs(&self, project_id: &str) -> Result<bool> {
@@ -106,42 +105,6 @@ impl Store {
         rows.into_iter().map(run_from_row).collect()
     }
 
-    /// Advance a Run only if its status has not changed since validation.
-    pub async fn update_run_status(&self, id: &str, status: RunStatus) -> Result<bool> {
-        let run = self
-            .get_run(id)
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("Run not found"))?;
-        validate_run_transition(run.status, status)?;
-        let now = chrono::Utc::now().timestamp();
-        let started_at = if status == RunStatus::Running && run.started_at.is_none() {
-            Some(now)
-        } else {
-            run.started_at
-        };
-        let ended_at = if status.is_terminal() {
-            Some(now)
-        } else {
-            run.ended_at
-        };
-        let updated = sqlx::query(
-            "UPDATE runs SET status=?, started_at=?, ended_at=?, \
-             lifecycle_owner=CASE WHEN ? THEN NULL ELSE lifecycle_owner END, \
-             lifecycle_lease_until=CASE WHEN ? THEN NULL ELSE lifecycle_lease_until END \
-             WHERE id=? AND status=?",
-        )
-        .bind(status.as_str())
-        .bind(started_at)
-        .bind(ended_at)
-        .bind(status.is_terminal())
-        .bind(status.is_terminal())
-        .bind(id)
-        .bind(run.status.as_str())
-        .execute(&self.pool)
-        .await?;
-        Ok(updated.rows_affected() == 1)
-    }
-
     pub async fn claim_run_lifecycle(
         &self,
         id: &str,
@@ -238,48 +201,6 @@ impl Store {
         Ok(updated.rows_affected() == 1)
     }
 
-    pub async fn release_run_lifecycle(&self, id: &str, owner: &str) -> Result<bool> {
-        let updated = sqlx::query(
-            "UPDATE runs SET lifecycle_owner=NULL, lifecycle_lease_until=NULL \
-             WHERE id=? AND lifecycle_owner=?",
-        )
-        .bind(id)
-        .bind(owner)
-        .execute(&self.pool)
-        .await?;
-        Ok(updated.rows_affected() == 1)
-    }
-
-    pub async fn update_run_output(
-        &self,
-        id: &str,
-        stdout_tail: Option<&str>,
-        stderr_tail: Option<&str>,
-    ) -> Result<()> {
-        sqlx::query("UPDATE runs SET stdout_tail=?, stderr_tail=? WHERE id=?")
-            .bind(stdout_tail)
-            .bind(stderr_tail)
-            .bind(id)
-            .execute(&self.pool)
-            .await?;
-        Ok(())
-    }
-
-    pub async fn set_run_remote_handle(
-        &self,
-        id: &str,
-        remote_handle_json: &str,
-        remote_workdir: &str,
-    ) -> Result<()> {
-        sqlx::query("UPDATE runs SET remote_handle_json=?, remote_workdir=? WHERE id=?")
-            .bind(remote_handle_json)
-            .bind(remote_workdir)
-            .bind(id)
-            .execute(&self.pool)
-            .await?;
-        Ok(())
-    }
-
     pub async fn set_run_remote_handle_owned(
         &self,
         id: &str,
@@ -301,27 +222,6 @@ impl Store {
         .execute(&self.pool)
         .await?;
         Ok(updated.rows_affected() == 1)
-    }
-
-    pub async fn record_run_poll(
-        &self,
-        id: &str,
-        stdout_tail: Option<&str>,
-        stderr_tail: Option<&str>,
-        error: Option<&str>,
-    ) -> Result<()> {
-        sqlx::query(
-            "UPDATE runs SET last_polled_at=?, stdout_tail=COALESCE(?,stdout_tail), \
-             stderr_tail=COALESCE(?,stderr_tail), last_poll_error=? WHERE id=?",
-        )
-        .bind(chrono::Utc::now().timestamp())
-        .bind(stdout_tail)
-        .bind(stderr_tail)
-        .bind(error)
-        .bind(id)
-        .execute(&self.pool)
-        .await?;
-        Ok(())
     }
 
     pub async fn record_run_poll_owned(
@@ -412,31 +312,6 @@ impl Store {
         Ok(updated.rows_affected() == 1)
     }
 
-    pub async fn finish_active_run(
-        &self,
-        id: &str,
-        status: RunStatus,
-        exit_code: Option<i64>,
-    ) -> Result<bool> {
-        if !status.is_terminal() {
-            anyhow::bail!("finish_active_run requires a terminal status");
-        }
-        let now = chrono::Utc::now().timestamp();
-        let updated = sqlx::query(
-            "UPDATE runs SET status=?, started_at=COALESCE(started_at,?), ended_at=?, exit_code=?, \
-             lifecycle_owner=NULL, lifecycle_lease_until=NULL \
-             WHERE id=? AND status IN ('submitted','running','cancelling')",
-        )
-        .bind(status.as_str())
-        .bind(now)
-        .bind(now)
-        .bind(exit_code)
-        .bind(id)
-        .execute(&self.pool)
-        .await?;
-        Ok(updated.rows_affected() == 1)
-    }
-
     pub async fn finish_active_run_owned(
         &self,
         id: &str,
@@ -469,54 +344,6 @@ impl Store {
     pub async fn mark_run_lost_owned(&self, id: &str, owner: &str) -> Result<bool> {
         self.finish_active_run_owned(id, owner, RunStatus::Lost, None)
             .await
-    }
-
-    pub async fn mark_run_lost(&self, id: &str) -> Result<bool> {
-        self.finish_active_run(id, RunStatus::Lost, None).await
-    }
-
-    /// A desktop restart cannot safely reattach to an in-memory direct process.
-    pub async fn mark_active_runs_lost(&self) -> Result<u64> {
-        let now = chrono::Utc::now().timestamp();
-        let updated = sqlx::query(
-            "UPDATE runs SET status='lost', ended_at=?, lifecycle_owner=NULL, lifecycle_lease_until=NULL \
-             WHERE status IN ('submitted','running','cancelling')",
-        )
-        .bind(now)
-        .execute(&self.pool)
-        .await?;
-        Ok(updated.rows_affected())
-    }
-
-    pub async fn finish_run(
-        &self,
-        id: &str,
-        status: RunStatus,
-        exit_code: Option<i64>,
-    ) -> Result<bool> {
-        if !status.is_terminal() {
-            anyhow::bail!("finish_run requires a terminal status");
-        }
-        let run = self
-            .get_run(id)
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("Run not found"))?;
-        validate_run_transition(run.status, status)?;
-        let now = chrono::Utc::now().timestamp();
-        let started_at = run.started_at.or(Some(now));
-        let updated = sqlx::query(
-            "UPDATE runs SET status=?, started_at=?, ended_at=?, exit_code=?, \
-             lifecycle_owner=NULL, lifecycle_lease_until=NULL WHERE id=? AND status=?",
-        )
-        .bind(status.as_str())
-        .bind(started_at)
-        .bind(now)
-        .bind(exit_code)
-        .bind(id)
-        .bind(run.status.as_str())
-        .execute(&self.pool)
-        .await?;
-        Ok(updated.rows_affected() == 1)
     }
 
     pub async fn save_run_artifact_link(
@@ -558,17 +385,5 @@ impl Store {
         )?)
         .await?;
         Ok(())
-    }
-
-    pub async fn list_run_artifacts(&self, run_id: &str) -> Result<Vec<(String, String)>> {
-        let rows = sqlx::query(
-            "SELECT artifact_id, role FROM run_artifacts WHERE run_id=? ORDER BY created_at ASC, id ASC",
-        )
-        .bind(run_id)
-        .fetch_all(&self.pool)
-        .await?;
-        rows.into_iter()
-            .map(|r| Ok((r.try_get("artifact_id")?, r.try_get("role")?)))
-            .collect()
     }
 }

--- a/crates/wisp-store/src/sessions.rs
+++ b/crates/wisp-store/src/sessions.rs
@@ -1236,21 +1236,6 @@ impl Store {
         Ok(())
     }
 
-    pub async fn list_root_frames(&self, project_id: &str) -> Result<Vec<(String, String, i64)>> {
-        let rows = sqlx::query("SELECT id, agent_name, created_at FROM frames WHERE project_id=? AND parent_frame_id=id ORDER BY created_at DESC")
-            .bind(project_id)
-            .fetch_all(&self.pool).await?;
-        let mut out = vec![];
-        for row in rows {
-            out.push((
-                row.try_get::<String, _>("id")?,
-                row.try_get::<String, _>("agent_name")?,
-                row.try_get::<i64, _>("created_at")?,
-            ));
-        }
-        Ok(out)
-    }
-
     /// Persist an artifact and mint an immutable version for its current location.
 
     pub async fn search_sessions(

--- a/crates/wisp-store/src/store_tests.rs
+++ b/crates/wisp-store/src/store_tests.rs
@@ -111,9 +111,6 @@ async fn roundtrip() {
         [0, 1]
     );
     assert_eq!(sequenced[1].1.content.as_text(), "hello");
-    let frames = store.list_root_frames("p1").await.unwrap();
-    assert_eq!(frames.len(), 1);
-
     // list_sessions derives a title from the first user message and skips
     // frames with no user turn.
     store.create_frame("f2", "p1", "OPERON", "m").await.unwrap();
@@ -305,17 +302,6 @@ async fn agent_workflow_and_steps_roundtrip() {
     let mut workflow = AgentWorkflow::new("wf", "p", "workspace-1", "review").unwrap();
     assert_eq!(workflow.mode, "manual");
     workflow.description = "Review an implementation with a second agent".into();
-    store.create_agent_workflow(&workflow).await.unwrap();
-    assert_eq!(
-        store.list_agent_workflows("p").await.unwrap(),
-        vec![workflow.clone()]
-    );
-    workflow.name = "review-v2".into();
-    assert!(store.update_agent_workflow(&workflow).await.unwrap());
-    let updated_workflow = store.get_agent_workflow("wf").await.unwrap().unwrap();
-    assert_eq!(updated_workflow.name, "review-v2");
-    assert_eq!(updated_workflow.version, 2);
-
     let mut step = AgentWorkflowStep::new(
         "step-1",
         "wf",
@@ -328,14 +314,28 @@ async fn agent_workflow_and_steps_roundtrip() {
     .unwrap();
     assert!(step.template_id.is_empty());
     step.permissions_json = r#"{"tools":["read_file"]}"#.into();
-    store.create_agent_workflow_step(&step).await.unwrap();
+    store
+        .create_agent_workflow_plan(&workflow, &[step.clone()])
+        .await
+        .unwrap();
+    assert_eq!(
+        store.list_agent_workflows("p").await.unwrap(),
+        vec![workflow.clone()]
+    );
     assert_eq!(
         store.list_agent_workflow_steps("wf").await.unwrap(),
         vec![step.clone()]
     );
 
+    workflow.name = "review-v2".into();
     step.position = 1;
-    assert!(store.update_agent_workflow_step(&step).await.unwrap());
+    assert!(store
+        .replace_agent_workflow_plan(&workflow, &[step.clone()], 1)
+        .await
+        .unwrap());
+    let updated_workflow = store.get_agent_workflow("wf").await.unwrap().unwrap();
+    assert_eq!(updated_workflow.name, "review-v2");
+    assert_eq!(updated_workflow.version, 2);
     assert_eq!(
         store
             .get_agent_workflow_step("step-1")
@@ -386,7 +386,8 @@ async fn agent_workflow_plan_edit_and_approval_are_versioned() {
         .replace_agent_workflow_plan(&workflow, &[], 1)
         .await
         .unwrap());
-    let (edited, steps) = store.get_agent_workflow_plan("wf").await.unwrap().unwrap();
+    let edited = store.get_agent_workflow("wf").await.unwrap().unwrap();
+    let steps = store.list_agent_workflow_steps("wf").await.unwrap();
     assert_eq!(edited.version, 2);
     assert_eq!(edited.max_parallel, 1);
     assert_eq!(steps.len(), 1);
@@ -396,69 +397,13 @@ async fn agent_workflow_plan_edit_and_approval_are_versioned() {
     assert_eq!(approved.status, AgentWorkflowStatus::Approved);
     assert_eq!(approved.version, 3);
     assert!(approved.approved_at.is_some());
-    assert!(store.update_agent_workflow_step(&steps[0]).await.is_err());
-    assert!(store.delete_agent_workflow_step("code").await.is_err());
-    let mut reverted = approved;
+    let mut reverted = approved.clone();
     reverted.status = AgentWorkflowStatus::Draft;
-    assert!(store.update_agent_workflow(&reverted).await.is_err());
+    assert!(!store
+        .replace_agent_workflow_plan(&reverted, &steps, 3)
+        .await
+        .unwrap());
     assert!(store.delete_agent_workflow("wf").await.unwrap());
-    store.pool.close().await;
-    let _ = std::fs::remove_file(tmp);
-}
-
-#[tokio::test]
-async fn legacy_step_mutations_invalidate_the_reviewed_plan_version() {
-    let tmp = std::env::temp_dir().join(format!(
-        "wisp_agent_plan_step_cas_{}.sqlite",
-        uuid::Uuid::new_v4()
-    ));
-    let store = Store::open(&tmp).await.unwrap();
-    store.create_project("p", "proj", "").await.unwrap();
-
-    let workflow = AgentWorkflow::new("wf", "p", "workspace", "Delegated analysis").unwrap();
-    store.create_agent_workflow(&workflow).await.unwrap();
-    let mut step =
-        AgentWorkflowStep::new("code", "wf", 0, "code", "coder", "acp", "controlled prompt")
-            .unwrap();
-
-    store.create_agent_workflow_step(&step).await.unwrap();
-    assert!(!store.approve_agent_workflow_plan("wf", 1).await.unwrap());
-    assert_eq!(
-        store
-            .get_agent_workflow("wf")
-            .await
-            .unwrap()
-            .unwrap()
-            .version,
-        2
-    );
-
-    step.position = 1;
-    assert!(store.update_agent_workflow_step(&step).await.unwrap());
-    assert!(!store.approve_agent_workflow_plan("wf", 2).await.unwrap());
-    assert_eq!(
-        store
-            .get_agent_workflow("wf")
-            .await
-            .unwrap()
-            .unwrap()
-            .version,
-        3
-    );
-
-    assert!(store.delete_agent_workflow_step("code").await.unwrap());
-    assert!(!store.approve_agent_workflow_plan("wf", 3).await.unwrap());
-    assert_eq!(
-        store
-            .get_agent_workflow("wf")
-            .await
-            .unwrap()
-            .unwrap()
-            .version,
-        4
-    );
-    assert!(store.approve_agent_workflow_plan("wf", 4).await.unwrap());
-
     store.pool.close().await;
     let _ = std::fs::remove_file(tmp);
 }
@@ -472,11 +417,13 @@ async fn agent_workflow_attempts_persist_cas_lifecycle_and_usage() {
     let store = Store::open(&tmp).await.unwrap();
     store.create_project("p", "proj", "").await.unwrap();
     let workflow = AgentWorkflow::new("wf", "p", "workspace", "Delegated analysis").unwrap();
-    store.create_agent_workflow(&workflow).await.unwrap();
     let step = AgentWorkflowStep::new("code", "wf", 0, "code", "coder", "acp", "controlled prompt")
         .unwrap();
-    store.create_agent_workflow_step(&step).await.unwrap();
-    assert!(store.approve_agent_workflow_plan("wf", 2).await.unwrap());
+    store
+        .create_agent_workflow_plan(&workflow, &[step])
+        .await
+        .unwrap();
+    assert!(store.approve_agent_workflow_plan("wf", 1).await.unwrap());
     assert!(store
         .transition_agent_workflow_status(
             "wf",
@@ -576,10 +523,12 @@ async fn interrupted_agent_workflows_recover_to_failed_terminal_state() {
     let store = Store::open(&tmp).await.unwrap();
     store.create_project("p", "proj", "").await.unwrap();
     let workflow = AgentWorkflow::new("wf", "p", "workspace", "Delegation").unwrap();
-    store.create_agent_workflow(&workflow).await.unwrap();
     let step = AgentWorkflowStep::new("step", "wf", 0, "step", "coder", "acp", "prompt").unwrap();
-    store.create_agent_workflow_step(&step).await.unwrap();
-    assert!(store.approve_agent_workflow_plan("wf", 2).await.unwrap());
+    store
+        .create_agent_workflow_plan(&workflow, &[step])
+        .await
+        .unwrap();
+    assert!(store.approve_agent_workflow_plan("wf", 1).await.unwrap());
     assert!(store
         .transition_agent_workflow_status(
             "wf",
@@ -629,10 +578,12 @@ async fn workflow_cancellation_is_persisted_and_cleared_for_retry() {
     let store = Store::open(&tmp).await.unwrap();
     store.create_project("p", "proj", "").await.unwrap();
     let workflow = AgentWorkflow::new("wf", "p", "workspace", "Delegation").unwrap();
-    store.create_agent_workflow(&workflow).await.unwrap();
     let step = AgentWorkflowStep::new("step", "wf", 0, "step", "coder", "acp", "prompt").unwrap();
-    store.create_agent_workflow_step(&step).await.unwrap();
-    assert!(store.approve_agent_workflow_plan("wf", 2).await.unwrap());
+    store
+        .create_agent_workflow_plan(&workflow, &[step])
+        .await
+        .unwrap();
+    assert!(store.approve_agent_workflow_plan("wf", 1).await.unwrap());
     assert!(store
         .transition_agent_workflow_status(
             "wf",
@@ -2462,7 +2413,10 @@ async fn reserved_background_generation_is_failed_instead_of_resumed_after_resta
     store.create_frame("f", "p", "OPERON", "m").await.unwrap();
     let mut workflow = AgentWorkflow::new("wf", "p", "workspace", "Background batch").unwrap();
     workflow.frame_id = Some("f".into());
-    store.create_agent_workflow(&workflow).await.unwrap();
+    store
+        .create_agent_workflow_plan(&workflow, &[])
+        .await
+        .unwrap();
     assert!(store
         .approve_agent_workflow_plan("wf", workflow.version)
         .await
@@ -2693,34 +2647,41 @@ async fn run_manager_roundtrip_and_lifecycle() {
     let progress: RunProgress = serde_json::from_str(&got.progress_json).unwrap();
     assert_eq!(progress.completed_bytes, 512);
 
-    store
-        .update_run_status("r1", RunStatus::Submitted)
+    assert!(store
+        .activate_run_lifecycle("r1", RunStatus::Submitted, "roundtrip-owner", 60)
         .await
-        .unwrap();
-    store
-        .set_run_remote_handle(
+        .unwrap());
+    assert!(store
+        .set_run_remote_handle_owned(
             "r1",
+            "roundtrip-owner",
             r#"{"kind":"ssh_direct","pid":42,"start_time":7}"#,
             "/scratch/wisp/r1",
         )
         .await
-        .unwrap();
-    store
-        .update_run_status("r1", RunStatus::Running)
+        .unwrap());
+    assert!(store
+        .transition_run_to_running_owned("r1", "roundtrip-owner")
         .await
-        .unwrap();
-    store
-        .record_run_poll("r1", Some("ok stdout"), None, Some("temporary error"))
+        .unwrap());
+    assert!(store
+        .record_run_poll_owned(
+            "r1",
+            "roundtrip-owner",
+            Some("ok stdout"),
+            None,
+            Some("temporary error"),
+        )
         .await
-        .unwrap();
-    store
-        .record_run_poll("r1", None, Some("warn stderr"), None)
+        .unwrap());
+    assert!(store
+        .record_run_poll_owned("r1", "roundtrip-owner", None, Some("warn stderr"), None,)
         .await
-        .unwrap();
-    store
-        .finish_run("r1", RunStatus::Succeeded, Some(0))
+        .unwrap());
+    assert!(store
+        .finish_active_run_owned("r1", "roundtrip-owner", RunStatus::Succeeded, Some(0),)
         .await
-        .unwrap();
+        .unwrap());
 
     let finished = store.get_run("r1").await.unwrap().unwrap();
     assert_eq!(finished.status, RunStatus::Succeeded);
@@ -2758,22 +2719,19 @@ async fn run_can_cancel_then_time_out() {
         .await
         .unwrap();
 
-    store
-        .update_run_status("r1", RunStatus::Submitted)
+    assert!(store
+        .activate_run_lifecycle("r1", RunStatus::Submitted, "cancel-owner", 60)
         .await
-        .unwrap();
-    store
-        .update_run_status("r1", RunStatus::Cancelling)
-        .await
-        .unwrap();
+        .unwrap());
+    assert!(store.request_run_cancellation("r1").await.unwrap());
     assert_eq!(
         store.get_run("r1").await.unwrap().unwrap().status,
         RunStatus::Cancelling
     );
-    store
-        .finish_run("r1", RunStatus::TimedOut, None)
+    assert!(store
+        .finish_active_run_owned("r1", "cancel-owner", RunStatus::TimedOut, None)
         .await
-        .unwrap();
+        .unwrap());
     assert_eq!(
         store.get_run("r1").await.unwrap().unwrap().status,
         RunStatus::TimedOut
@@ -2800,42 +2758,43 @@ async fn conditional_terminal_update_does_not_overwrite_winner() {
             .await
             .unwrap();
     }
-    store
-        .update_run_status("submitted", RunStatus::Submitted)
-        .await
-        .unwrap();
-    store
-        .update_run_status("running", RunStatus::Running)
-        .await
-        .unwrap();
-    store
-        .update_run_status("cancelling", RunStatus::Running)
-        .await
-        .unwrap();
-    store
-        .update_run_status("cancelling", RunStatus::Cancelling)
-        .await
-        .unwrap();
+    for (id, status) in [
+        ("submitted", RunStatus::Submitted),
+        ("running", RunStatus::Running),
+        ("cancelling", RunStatus::Running),
+    ] {
+        assert!(store
+            .activate_run_lifecycle(id, status, "race-owner", 60)
+            .await
+            .unwrap());
+    }
+    assert!(store.request_run_cancellation("cancelling").await.unwrap());
 
     let active = store.list_active_runs().await.unwrap();
     assert_eq!(active.len(), 3);
     assert!(active.iter().any(|run| run.status == RunStatus::Cancelling));
-    assert!(store.mark_run_lost("running").await.unwrap());
-    assert!(!store.mark_run_lost("running").await.unwrap());
     assert!(store
-        .finish_active_run("cancelling", RunStatus::Cancelled, None)
+        .mark_run_lost_owned("running", "race-owner")
         .await
         .unwrap());
     assert!(!store
-        .finish_active_run("cancelling", RunStatus::TimedOut, None)
-        .await
-        .unwrap());
-    assert!(!store
-        .finish_active_run("draft", RunStatus::Failed, Some(1))
+        .mark_run_lost_owned("running", "race-owner")
         .await
         .unwrap());
     assert!(store
-        .finish_active_run("submitted", RunStatus::Succeeded, Some(0))
+        .finish_active_run_owned("cancelling", "race-owner", RunStatus::Cancelled, None,)
+        .await
+        .unwrap());
+    assert!(!store
+        .finish_active_run_owned("cancelling", "race-owner", RunStatus::TimedOut, None,)
+        .await
+        .unwrap());
+    assert!(!store
+        .finish_active_run_owned("draft", "race-owner", RunStatus::Failed, Some(1))
+        .await
+        .unwrap());
+    assert!(store
+        .finish_active_run_owned("submitted", "race-owner", RunStatus::Succeeded, Some(0),)
         .await
         .unwrap());
     assert_eq!(
@@ -2843,23 +2802,9 @@ async fn conditional_terminal_update_does_not_overwrite_winner() {
         RunStatus::Cancelled
     );
     assert!(store
-        .finish_active_run("draft", RunStatus::Running, None)
+        .finish_active_run_owned("draft", "race-owner", RunStatus::Running, None)
         .await
         .is_err());
-
-    let mut restart_cancel = RunRecord::new("restart-cancel", "p", "local", "rc", "command");
-    restart_cancel.status = RunStatus::Cancelling;
-    store.create_run(&restart_cancel).await.unwrap();
-    assert_eq!(store.mark_active_runs_lost().await.unwrap(), 1);
-    assert_eq!(
-        store
-            .get_run("restart-cancel")
-            .await
-            .unwrap()
-            .unwrap()
-            .status,
-        RunStatus::Lost
-    );
 
     let lease_run = RunRecord::new("lease", "p", "ssh:gpu", "lease", "ssh_direct");
     store.create_run(&lease_run).await.unwrap();
@@ -2910,41 +2855,6 @@ async fn conditional_terminal_update_does_not_overwrite_winner() {
         .finish_active_run_owned("lease", "owner-a", RunStatus::Cancelled, None)
         .await
         .unwrap());
-
-    let _ = std::fs::remove_file(&tmp);
-}
-
-#[tokio::test]
-async fn run_status_transitions_are_validated() {
-    let tmp = std::env::temp_dir().join(format!(
-        "wisp_store_run_status_{}.sqlite",
-        uuid::Uuid::new_v4()
-    ));
-    let store = Store::open(&tmp).await.unwrap();
-    store.create_project("p", "proj", "").await.unwrap();
-    store
-        .upsert_execution_context(&ExecutionContext::new("local", "Local").unwrap())
-        .await
-        .unwrap();
-    store
-        .create_run(&RunRecord::new("r1", "p", "local", "Terminal", "command"))
-        .await
-        .unwrap();
-    store
-        .update_run_status("r1", RunStatus::Running)
-        .await
-        .unwrap();
-    store
-        .finish_run("r1", RunStatus::Failed, Some(1))
-        .await
-        .unwrap();
-
-    let err = store
-        .update_run_status("r1", RunStatus::Running)
-        .await
-        .unwrap_err()
-        .to_string();
-    assert!(err.contains("Invalid run status transition"), "{err}");
 
     let _ = std::fs::remove_file(&tmp);
 }
@@ -3046,19 +2956,16 @@ async fn artifacts_keep_version_lineage() {
         .save_artifact("a", "p", "f", "report.md", "text/markdown", "reports/v1.md")
         .await
         .unwrap();
-    store
+    let second = store
         .save_artifact("a", "p", "f", "report.md", "text/markdown", "reports/v2.md")
         .await
         .unwrap();
-    let versions = store.list_artifact_versions("a").await.unwrap();
-    assert_eq!(versions.len(), 2);
-    assert_eq!(versions[0].version_number, 2);
-    assert_eq!(
-        versions[0].parent_version_id.as_deref(),
-        Some(first.as_str())
-    );
-    assert_eq!(versions[0].storage_path, "reports/v2.md");
-    assert_eq!(versions[1].version_number, 1);
+    let latest = store.get_artifact_version(&second).await.unwrap().unwrap();
+    let original = store.get_artifact_version(&first).await.unwrap().unwrap();
+    assert_eq!(latest.version_number, 2);
+    assert_eq!(latest.parent_version_id.as_deref(), Some(first.as_str()));
+    assert_eq!(latest.storage_path, "reports/v2.md");
+    assert_eq!(original.version_number, 1);
 
     assert!(store
         .relocate_artifact_storage("a", "durable/isolated-report.md")
@@ -3072,9 +2979,24 @@ async fn artifacts_keep_version_lineage() {
         store.get_artifact("a").await.unwrap().unwrap().2,
         "durable/isolated-report.md"
     );
-    let relocated = store.list_artifact_versions("a").await.unwrap();
-    assert_eq!(relocated[0].storage_path, "durable/isolated-report.md");
-    assert_eq!(relocated[1].storage_path, "reports/v1.md");
+    assert_eq!(
+        store
+            .get_artifact_version(&second)
+            .await
+            .unwrap()
+            .unwrap()
+            .storage_path,
+        "durable/isolated-report.md"
+    );
+    assert_eq!(
+        store
+            .get_artifact_version(&first)
+            .await
+            .unwrap()
+            .unwrap()
+            .storage_path,
+        "reports/v1.md"
+    );
 
     let graph = store.research_graph("p").await.unwrap();
     assert!(graph

--- a/crates/wisp-tools/Cargo.toml
+++ b/crates/wisp-tools/Cargo.toml
@@ -7,11 +7,8 @@ license.workspace = true
 
 [dependencies]
 tokio = { workspace = true }
-serde = { workspace = true }
 serde_json = { workspace = true }
 async-trait = "0.1"
-anyhow = { workspace = true }
-tracing = { workspace = true }
 regex = { workspace = true }
 glob = { workspace = true }
 walkdir = { workspace = true }

--- a/mcp-servers/bio-tools/lib/arrayexpress_experiments/search.py
+++ b/mcp-servers/bio-tools/lib/arrayexpress_experiments/search.py
@@ -133,7 +133,6 @@ def search_experiments(
     ``BioStudiesError`` if the number of unique retrieved accessions does not equal
     ``total_hits`` (unless ``max_records`` truncated the walk).
     """
-    own_client = client is None
     client = client or BioStudiesClient()
     params = spec.to_params()
     page_size = min(page_size, PAGE_SIZE_MAX)

--- a/mcp-servers/bio-tools/lib/biomart_query/runner.py
+++ b/mcp-servers/bio-tools/lib/biomart_query/runner.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import json
 from typing import Mapping
 
-from .client import BiomartClient, QueryResult
+from .client import BiomartClient
 
 
 def plan_requests(battery: Mapping) -> list:

--- a/mcp-servers/bio-tools/lib/civic_evidence/tool.py
+++ b/mcp-servers/bio-tools/lib/civic_evidence/tool.py
@@ -8,7 +8,7 @@ silently drops everything after it.
 """
 from __future__ import annotations
 
-from .client import CivicClient, CivicApiError, GraphQLError
+from .client import CivicClient, CivicApiError
 from .records import (ASSERTION_FIELDS, DISEASE_FIELDS, EVIDENCE_FIELDS,
                       GENE_FIELDS, MOLECULAR_PROFILE_FIELDS, THERAPY_FIELDS,
                       VARIANT_CORE_FIELDS, normalize)

--- a/mcp-servers/bio-tools/lib/clinicaltrials_fetch/spec.py
+++ b/mcp-servers/bio-tools/lib/clinicaltrials_fetch/spec.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field, asdict
+from dataclasses import dataclass, asdict
 from typing import Any
 
 # Enumerations taken from GET /api/v2/studies/enums (API version 2.0.5).

--- a/mcp-servers/bio-tools/lib/clinvar_records/client.py
+++ b/mcp-servers/bio-tools/lib/clinvar_records/client.py
@@ -109,7 +109,7 @@ class ClinVarClient:
                     f"{endpoint} HTTP {resp.status_code}: {resp.text[:200]}")
             try:
                 return resp.json()
-            except ValueError as exc:
+            except ValueError:
                 raise ClinVarApiError(
                     f"{endpoint} returned non-JSON: {resp.text[:200]}")
         raise ClinVarApiError(f"{endpoint} retries exhausted: {last_err!r}")

--- a/mcp-servers/bio-tools/lib/emdb_meta/records.py
+++ b/mcp-servers/bio-tools/lib/emdb_meta/records.py
@@ -77,7 +77,6 @@ def extract_entry_record(entry: dict) -> dict:
     method = sd.get("method")
     aggregation_state = sd.get("aggregation_state")
     resolution = None
-    resolution_units = None
     resolution_method = None
     image_processing = _listify(sd.get("image_processing"))
     if image_processing:
@@ -85,8 +84,6 @@ def extract_entry_record(entry: dict) -> dict:
         res_node = final.get("resolution")
         if res_node is not None:
             resolution = _as_float(_value_of(res_node))
-            if isinstance(res_node, dict):
-                resolution_units = res_node.get("units")
         resolution_method = final.get("resolution_method")
 
     # ---- sample / macromolecules

--- a/mcp-servers/bio-tools/lib/emdb_meta/sections.py
+++ b/mcp-servers/bio-tools/lib/emdb_meta/sections.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from .records import _as_float, _date_only, _listify, _value_of
+from .records import _as_float, _listify, _value_of
 
 
 def _unit_value(node: Any) -> dict:

--- a/mcp-servers/bio-tools/lib/eqtl_catalogue/client.py
+++ b/mcp-servers/bio-tools/lib/eqtl_catalogue/client.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import json
 import re
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any
 
 import requests

--- a/mcp-servers/bio-tools/lib/europepmc_fulltext/client.py
+++ b/mcp-servers/bio-tools/lib/europepmc_fulltext/client.py
@@ -55,7 +55,7 @@ class EuropePMCClient:
                 resp = self._session.get(url, params=params, timeout=self.timeout_s)
                 self.n_requests += 1
                 self.bytes_downloaded += len(resp.content)
-            except (requests.ConnectionError, requests.Timeout) as exc:
+            except (requests.ConnectionError, requests.Timeout):
                 attempt += 1
                 if attempt > self.max_retries:
                     raise

--- a/mcp-servers/bio-tools/lib/geo_meta/client.py
+++ b/mcp-servers/bio-tools/lib/geo_meta/client.py
@@ -96,7 +96,7 @@ class PoliteClient:
             self._pacer.pace(url, self.min_interval)
             try:
                 response = self._client.request(method, url, **kwargs)
-            except httpx.TransportError as exc:
+            except httpx.TransportError:
                 attempt += 1
                 if attempt > self.max_retries:
                     raise

--- a/mcp-servers/bio-tools/lib/grants_gov_search/client.py
+++ b/mcp-servers/bio-tools/lib/grants_gov_search/client.py
@@ -13,7 +13,7 @@ Endpoint: https://api.grants.gov/v1/api/search2
 from __future__ import annotations
 
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 import requests
 

--- a/mcp-servers/bio-tools/lib/grants_gov_search/spec.py
+++ b/mcp-servers/bio-tools/lib/grants_gov_search/spec.py
@@ -1,7 +1,7 @@
 """Query specification for the Grants.gov search2 API."""
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 VALID_STATUSES = ("forecasted", "posted", "closed", "archived")
 ALL_STATUSES = "forecasted|posted|closed|archived"

--- a/mcp-servers/bio-tools/lib/interpro_domains/client.py
+++ b/mcp-servers/bio-tools/lib/interpro_domains/client.py
@@ -27,7 +27,6 @@ Notes
 
 from __future__ import annotations
 
-import json
 import time
 import urllib.parse
 from dataclasses import dataclass, field

--- a/mcp-servers/bio-tools/lib/mcp_chembl/server.py
+++ b/mcp-servers/bio-tools/lib/mcp_chembl/server.py
@@ -8,7 +8,6 @@ reshapes raw ChEMBL REST payloads into the original output formats.
 
 from __future__ import annotations
 
-import urllib.parse
 from functools import lru_cache
 
 from mcp_servers_common import Tier1Server, load_schemas

--- a/mcp-servers/bio-tools/lib/openfda_drugsfda/retrieve.py
+++ b/mcp-servers/bio-tools/lib/openfda_drugsfda/retrieve.py
@@ -23,7 +23,7 @@ Encapsulated endpoint behavior (all measured live 2026-06-08):
 from __future__ import annotations
 
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Optional
 
 import requests

--- a/mcp-servers/bio-tools/lib/pheweb_portals/client.py
+++ b/mcp-servers/bio-tools/lib/pheweb_portals/client.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import json
 import time
 import urllib.parse
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any
 
 import requests

--- a/mcp-servers/bio-tools/lib/pubchem_compounds/tool.py
+++ b/mcp-servers/bio-tools/lib/pubchem_compounds/tool.py
@@ -7,7 +7,7 @@ ordering; marshalling/caps live in the tier-2 server.
 
 from __future__ import annotations
 
-from .client import PUG_BASE, PUG_VIEW_BASE, NotFound, PubChemApiError, PugRestClient
+from .client import PUG_BASE, PUG_VIEW_BASE, NotFound, PugRestClient
 
 # The 2025 PUG REST property names: ``SMILES`` is the full (isomeric) SMILES,
 # ``ConnectivitySMILES`` the stereo-stripped one (formerly CanonicalSMILES).

--- a/mcp-servers/bio-tools/lib/quickgo_annotations/queries.py
+++ b/mcp-servers/bio-tools/lib/quickgo_annotations/queries.py
@@ -1,7 +1,7 @@
 """Query specification for annotation retrieval (gene products + aspect/evidence filters)."""
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 # GO aspects accepted by the QuickGO annotation endpoints.
 ASPECTS = ("biological_process", "molecular_function", "cellular_component")

--- a/skills/skill-creator/scripts/generate_report.py
+++ b/skills/skill-creator/scripts/generate_report.py
@@ -16,7 +16,6 @@ from pathlib import Path
 def generate_html(data: dict, auto_refresh: bool = False, skill_name: str = "") -> str:
     """Generate HTML report from loop output data. If auto_refresh is True, adds a meta refresh tag."""
     history = data.get("history", [])
-    holdout = data.get("holdout", 0)
     title_prefix = html.escape(skill_name + " \u2014 ") if skill_name else ""
 
     # Get all unique queries from train and test sets, with should_trigger info
@@ -154,7 +153,6 @@ def generate_html(data: dict, auto_refresh: bool = False, skill_name: str = "") 
 
     # Summary section
     best_test_score = data.get('best_test_score')
-    best_train_score = data.get('best_train_score')
     html_parts.append(f"""
     <div class="summary">
         <p><strong>Original:</strong> {html.escape(data.get('original_description', 'N/A'))}</p>
@@ -211,10 +209,6 @@ def generate_html(data: dict, auto_refresh: bool = False, skill_name: str = "") 
     # Add rows for each iteration
     for h in history:
         iteration = h.get("iteration", "?")
-        train_passed = h.get("train_passed", h.get("passed", 0))
-        train_total = h.get("train_total", h.get("total", 0))
-        test_passed = h.get("test_passed")
-        test_total = h.get("test_total")
         description = h.get("description", "")
         train_results = h.get("train_results", h.get("results", []))
         test_results = h.get("test_results", [])

--- a/skills/skill-creator/scripts/quick_validate.py
+++ b/skills/skill-creator/scripts/quick_validate.py
@@ -4,7 +4,6 @@ Quick validation script for skills - minimal version
 """
 
 import sys
-import os
 import re
 import yaml
 from pathlib import Path

--- a/src-tauri/src/channels/mod.rs
+++ b/src-tauri/src/channels/mod.rs
@@ -1403,7 +1403,10 @@ mod tests {
         let feishu = feishu.unwrap();
         let wechat = wechat.unwrap();
         assert_eq!(feishu, wechat);
-        assert_eq!(store.list_root_frames("project-1").await.unwrap().len(), 1);
+        assert_eq!(
+            store.frame_project_id(&feishu).await.unwrap().as_deref(),
+            Some("project-1")
+        );
         drop(store);
         let _ = std::fs::remove_file(path);
     }

--- a/src-tauri/src/delegation_completion.rs
+++ b/src-tauri/src/delegation_completion.rs
@@ -539,7 +539,10 @@ mod tests {
         assert!(!session_completion_settings(&store, "f").await.auto_resume);
         let mut workflow = wisp_store::AgentWorkflow::new("wf", "p", "workspace", "batch").unwrap();
         workflow.frame_id = Some("f".into());
-        store.create_agent_workflow(&workflow).await.unwrap();
+        store
+            .create_agent_workflow_plan(&workflow, &[])
+            .await
+            .unwrap();
         assert!(store
             .approve_agent_workflow_plan("wf", workflow.version)
             .await

--- a/src-tauri/src/delegation_runtime.rs
+++ b/src-tauri/src/delegation_runtime.rs
@@ -5853,7 +5853,10 @@ mod tests {
             "steps": []
         })
         .to_string();
-        store.create_agent_workflow(&unsupported).await.unwrap();
+        store
+            .create_agent_workflow_plan(&unsupported, &[])
+            .await
+            .unwrap();
 
         assert!(tokio::time::timeout(
             Duration::from_secs(2),

--- a/src-tauri/src/harvest.rs
+++ b/src-tauri/src/harvest.rs
@@ -231,11 +231,12 @@ mod tests {
         assert_eq!(artifacts.len(), 1);
         assert!(std::path::Path::new(&artifacts[0].3)
             .ends_with(std::path::Path::new("results").join("table.tsv")));
-        let links = store.list_run_artifacts("r").await.unwrap();
-        assert_eq!(
-            links,
-            vec![(harvested[0].artifact_id.clone(), "table".into())]
-        );
+        let graph = store.research_graph("p").await.unwrap();
+        assert!(graph.edges.iter().any(|edge| {
+            edge.source_id == "run:r"
+                && edge.target_id == format!("artifact:{}", harvested[0].artifact_id)
+                && edge.relation == "produced"
+        }));
 
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6073,7 +6073,6 @@ pub fn run() {
             project_sync::resolve_project_sync,
             project_sync::project_sync_code,
             project_sync::join_synced_project,
-            project_sync::get_project_sync_status,
             project_commands::create_project,
             project_commands::open_project,
             project_commands::open_project_window,

--- a/src-tauri/src/project_sync.rs
+++ b/src-tauri/src/project_sync.rs
@@ -40,16 +40,6 @@ pub(super) struct ProjectSyncResult {
     skipped_paths: Vec<String>,
 }
 
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub(super) struct ProjectSyncStatus {
-    configured: bool,
-    transport_kind: Option<String>,
-    last_synced_at: Option<i64>,
-    last_direction: Option<String>,
-    revision: Option<String>,
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct JoinCode {
     version: u32,
@@ -1483,34 +1473,6 @@ pub(super) async fn resolve_project_sync(
         clear_project_runtime_cache(&state, &id, &old_frame_ids).await;
     }
     Ok(result)
-}
-
-#[tauri::command]
-pub(super) async fn get_project_sync_status(
-    state: State<'_, AppState>,
-    id: String,
-) -> Result<ProjectSyncStatus, String> {
-    let cursor = state
-        .store
-        .get_project_sync_state(&id)
-        .await
-        .map_err(|error| error.to_string())?;
-    Ok(match cursor {
-        Some(cursor) => ProjectSyncStatus {
-            configured: cursor.base_revision.is_some(),
-            transport_kind: Some(cursor.transport_kind),
-            last_synced_at: cursor.last_synced_at,
-            last_direction: cursor.last_direction,
-            revision: cursor.base_revision,
-        },
-        None => ProjectSyncStatus {
-            configured: false,
-            transport_kind: None,
-            last_synced_at: None,
-            last_direction: None,
-            revision: None,
-        },
-    })
 }
 
 #[tauri::command]

--- a/src-tauri/src/run_context/tests.rs
+++ b/src-tauri/src/run_context/tests.rs
@@ -241,10 +241,15 @@ async fn monitor_run_waits_once_for_an_existing_run() {
         .unwrap();
     let run = wisp_store::RunRecord::new("long-run", "p", "local", "Long run", "command");
     store.create_run(&run).await.unwrap();
-    store
-        .update_run_status("long-run", wisp_store::RunStatus::Submitted)
+    assert!(store
+        .activate_run_lifecycle(
+            "long-run",
+            wisp_store::RunStatus::Submitted,
+            "monitor-owner",
+            60,
+        )
         .await
-        .unwrap();
+        .unwrap());
     let snapshot = GetRunTool::new(store.clone(), "p".into())
         .run(
             &serde_json::json!({ "run_id": "long-run" }),
@@ -257,14 +262,19 @@ async fn monitor_run_waits_once_for_an_existing_run() {
     let finishing_store = store.clone();
     tokio::spawn(async move {
         tokio::time::sleep(Duration::from_millis(25)).await;
-        finishing_store
-            .update_run_status("long-run", wisp_store::RunStatus::Running)
+        assert!(finishing_store
+            .transition_run_to_running_owned("long-run", "monitor-owner")
             .await
-            .unwrap();
-        finishing_store
-            .update_run_status("long-run", wisp_store::RunStatus::Succeeded)
+            .unwrap());
+        assert!(finishing_store
+            .finish_active_run_owned(
+                "long-run",
+                "monitor-owner",
+                wisp_store::RunStatus::Succeeded,
+                Some(0),
+            )
             .await
-            .unwrap();
+            .unwrap());
     });
 
     let tool = MonitorRunTool::new(store, "p".into());
@@ -440,10 +450,14 @@ async fn submit_run_harvests_output_specs_on_success() {
     .await
     .unwrap();
 
-    let links = store.list_run_artifacts(&res.run_id).await.unwrap();
-    assert_eq!(links.len(), 1);
-    assert_eq!(links[0].1, "table");
-    assert_eq!(store.list_artifacts("f").await.unwrap().len(), 1);
+    let artifacts = store.list_artifacts("f").await.unwrap();
+    assert_eq!(artifacts.len(), 1);
+    let graph = store.research_graph("p").await.unwrap();
+    assert!(graph.edges.iter().any(|edge| {
+        edge.source_id == format!("run:{}", res.run_id)
+            && edge.target_id == format!("artifact:{}", artifacts[0].0)
+            && edge.relation == "produced"
+    }));
 
     let _ = std::fs::remove_dir_all(&tmp);
 }
@@ -719,11 +733,8 @@ async fn recovery_fails_unconfirmed_ssh_run_without_reconnecting() {
     run.last_poll_error = Some("connection timed out".into());
     run.remote_workdir = Some("~/.wisp-science/runs/stale".into());
     run.remote_handle_json = Some(serde_json::to_string(&test_handle("stale", false)).unwrap());
+    run.status = wisp_store::RunStatus::Submitted;
     store.create_run(&run).await.unwrap();
-    store
-        .update_run_status("stale", wisp_store::RunStatus::Submitted)
-        .await
-        .unwrap();
     let runner = Arc::new(ScriptedRunRunner::new(Vec::new()));
     let manager = RunManager::with_runner(runner.clone());
 
@@ -756,18 +767,12 @@ async fn recovery_reattaches_ssh_after_transient_error_and_marks_local_lost() {
     remote.timeout_secs = Some(3600);
     remote.remote_workdir = Some("~/.wisp-science/runs/remote".into());
     remote.remote_handle_json = Some(serde_json::to_string(&test_handle("remote", true)).unwrap());
+    remote.status = wisp_store::RunStatus::Running;
     store.create_run(&remote).await.unwrap();
-    store
-        .update_run_status("remote", wisp_store::RunStatus::Running)
-        .await
-        .unwrap();
 
-    let local = wisp_store::RunRecord::new("local-run", "p", "local", "Local", "command");
+    let mut local = wisp_store::RunRecord::new("local-run", "p", "local", "Local", "command");
+    local.status = wisp_store::RunStatus::Running;
     store.create_run(&local).await.unwrap();
-    store
-        .update_run_status("local-run", wisp_store::RunStatus::Running)
-        .await
-        .unwrap();
 
     let runner = Arc::new(ScriptedRunRunner::new(vec![
         Err("temporary SSH disconnect".into()),
@@ -804,11 +809,8 @@ async fn confirmed_ssh_run_stops_polling_after_authentication_failure() {
     run.timeout_secs = Some(3600);
     run.remote_workdir = Some("~/.wisp-science/runs/remote".into());
     run.remote_handle_json = Some(serde_json::to_string(&test_handle("remote", true)).unwrap());
+    run.status = wisp_store::RunStatus::Running;
     store.create_run(&run).await.unwrap();
-    store
-        .update_run_status("remote", wisp_store::RunStatus::Running)
-        .await
-        .unwrap();
 
     let runner = Arc::new(ScriptedRunRunner::new(vec![Err(
         "Permission denied (publickey).".into(),
@@ -843,11 +845,8 @@ async fn ssh_cancel_stays_cancelling_until_remote_group_confirms() {
     run.timeout_secs = Some(3600);
     run.remote_workdir = Some("~/.wisp-science/runs/remote".into());
     run.remote_handle_json = Some(serde_json::to_string(&test_handle("remote", true)).unwrap());
+    run.status = wisp_store::RunStatus::Running;
     store.create_run(&run).await.unwrap();
-    store
-        .update_run_status("remote", wisp_store::RunStatus::Running)
-        .await
-        .unwrap();
     let runner = Arc::new(ScriptedRunRunner::new(vec![ok_output(
         "__WISP_CANCEL__:cancelled\n",
     )]));
@@ -905,11 +904,8 @@ async fn cancelling_ssh_input_staging_aborts_the_transfer() {
         updated_at: chrono::Utc::now().timestamp(),
     })
     .unwrap();
+    run.status = wisp_store::RunStatus::Submitted;
     store.create_run(&run).await.unwrap();
-    store
-        .update_run_status("upload", wisp_store::RunStatus::Submitted)
-        .await
-        .unwrap();
     assert!(store
         .claim_run_lifecycle("upload", &manager.owner_id, ACTIVE_LEASE_SECS)
         .await

--- a/src-tauri/src/ssh_hosts.rs
+++ b/src-tauri/src/ssh_hosts.rs
@@ -575,40 +575,6 @@ pub fn parse_ssh_config_aliases(config: &str) -> Vec<String> {
     out
 }
 
-#[cfg(test)]
-pub fn render_hosts_section(hosts: &[SshHost]) -> Option<String> {
-    if hosts.is_empty() {
-        return None;
-    }
-    let mut s = String::from(
-        "## Compute hosts\n\n\
-The user has these SSH hosts available. Submit remote discovery, real work, and all long-running commands with \
-`run_in_context` using the `ssh:<alias>` context. Do not use shell `sleep`, \
-`ssh ... ps`, `nohup`, background `&`, or polling loops to monitor work. After \
-submission, observe or cancel it through the Runs control plane. Remote paths \
-live on the host, not on this machine. To watch a submitted Run or wait for its \
-result, call `monitor_run` exactly once with its Run id. Wisp shows a live card, \
-suspends the tool, and resumes after completion without repeated `get_run` calls.\n\n",
-    );
-    for h in hosts {
-        let mut conn = String::new();
-        if let Some(u) = &h.user {
-            conn.push_str(u);
-            conn.push('@');
-        }
-        conn.push_str(&h.alias);
-        if let Some(p) = h.port {
-            conn.push_str(&format!(":{p}"));
-        }
-        s.push_str(&format!("- {} — {}", h.alias, conn));
-        if let Some(n) = h.notes.as_deref().filter(|n| !n.trim().is_empty()) {
-            s.push_str(&format!(" — {n}"));
-        }
-        s.push('\n');
-    }
-    Some(s)
-}
-
 pub fn render_contexts_section(contexts: &[wisp_store::ExecutionContext]) -> Option<String> {
     let contexts: Vec<_> = contexts
         .iter()
@@ -1321,43 +1287,6 @@ Host -unsafe bad/name !negated
         // The pre-existing entry (with its notes) must not be overwritten.
         assert_eq!(merged[0].notes.as_deref(), Some("slurm cluster"));
         assert!(merged[1].notes.is_none());
-    }
-
-    #[test]
-    fn render_empty_is_none() {
-        assert!(render_hosts_section(&[]).is_none());
-    }
-
-    #[test]
-    fn render_lists_conn_and_notes() {
-        let hosts = vec![
-            SshHost {
-                alias: "gpu".into(),
-                host_name: None,
-                user: Some("alice".into()),
-                port: Some(2222),
-                identity_file: None,
-                notes: Some("slurm; sbatch".into()),
-                auth_method: None,
-                has_password: false,
-                password: None,
-            },
-            host("plain", None),
-        ];
-        let s = render_hosts_section(&hosts).unwrap();
-        assert!(s.starts_with("## Compute hosts"), "{s}");
-        assert!(
-            s.contains("`run_in_context`"),
-            "must direct real work to the run manager:\n{s}"
-        );
-        assert!(
-            s.contains("Runs control plane"),
-            "runs guidance missing:\n{s}"
-        );
-        assert!(s.contains("`nohup`"), "shell prohibition missing:\n{s}");
-        assert!(s.contains("alice@gpu:2222"), "conn missing:\n{s}");
-        assert!(s.contains("slurm; sbatch"), "notes missing:\n{s}");
-        assert!(s.contains("- plain"), "bare alias missing:\n{s}");
     }
 
     #[tokio::test]

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -1137,8 +1137,6 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
             return { status: "synced", direction: arg("strategy") === "remote" ? "pull" : "push", revision: "revision-2", uploadedFiles: 1, downloadedFiles: 1, skippedPaths: [] };
           case "project_sync_code":
             return "wisp-sync:mock-secret-code";
-          case "get_project_sync_status":
-            return { configured: true, transportKind: "folder", lastSyncedAt: 1, lastDirection: "push", revision: "revision-1" };
           case "delete_project":
             return null;
           case "open_project_window":

--- a/ui/src/app_support.rs
+++ b/ui/src/app_support.rs
@@ -7905,29 +7905,6 @@ pub(super) fn artifact_preview(a: &Artifact, dom_id: String, locale: Locale) -> 
     }
 }
 
-#[component]
-pub(super) fn CodeBlock(lang: String, body: String) -> impl IntoView {
-    let lang_class = if lang.is_empty() {
-        "plaintext".to_string()
-    } else {
-        lang.clone()
-    };
-    let hid = unique_dom_id("code");
-    let hid_for_effect = hid.clone();
-    let lang_track = lang_class.clone();
-    let body_track = body.clone();
-    create_effect(move |_| {
-        let _ = (&lang_track, &body_track);
-        schedule_highlight(hid_for_effect.clone());
-    });
-    view! {
-        <div class="code-block" id=hid.clone()>
-            {(!lang.is_empty()).then(|| view! { <div class="code-lang">{lang.clone()}</div> })}
-            <pre class="md-code"><code class=format!("language-{lang_class}")>{body.clone()}</code></pre>
-        </div>
-    }
-}
-
 /// Right-pane code view with a line-number gutter (Claude Science style).
 /// The gutter is a plain <pre> (no <code>) so highlight.js skips it.
 #[component]

--- a/ui/src/context_menu.rs
+++ b/ui/src/context_menu.rs
@@ -144,7 +144,7 @@ pub(crate) fn selection_text() -> Option<String> {
 }
 
 fn text_from_code_block(el: &web_sys::Element) -> Option<String> {
-    for sel in [".code-block", ".tool-panel", "pre.md-code", "pre.rp-pre"] {
+    for sel in [".tool-panel", "pre.md-code", "pre.rp-pre"] {
         let Some(block) = closest(el, sel) else {
             continue;
         };

--- a/ui/src/styles/chat.css
+++ b/ui/src/styles/chat.css
@@ -612,16 +612,6 @@ code.hljs .hljs-deletion { color: var(--syntax-deletion); background-color: var(
 @media (min-width: 960px) {
   .md pre.md-code code.language-catalog { column-count: 3; }
 }
-.code-block { display: flex; flex-direction: column; gap: 0; min-width: 0; }
-.code-lang {
-  font-size: 11px; font-weight: 650; text-transform: uppercase; letter-spacing: .05em;
-  color: var(--text-faint); padding: 8px 12px 6px; border: 1px solid var(--border);
-  border-bottom: none; border-radius: var(--radius-sm) var(--radius-sm) 0 0;
-  background: var(--bg-elev);
-}
-.code-block .md-code { border-radius: 0 0 var(--radius-sm) var(--radius-sm); margin: 0; }
-.code-block .code-lang + .md-code { border-top: none; border-radius: 0 0 var(--radius-sm) var(--radius-sm); }
-
 .art-ref {
   display: inline; background: var(--clay-soft);
   color: var(--clay-strong); border: 1px solid rgba(13, 148, 136, 0.22);


### PR DESCRIPTION
## Problem

The workspace retained legacy store mutations, test-only helpers, an unused Tauri command and UI component, unused direct dependencies, and Python unused imports and locals. This enlarged the maintenance surface and let tests exercise paths no longer used by production code.

## Changes

- Remove legacy workflow CRUD in favor of the atomic workflow-plan APIs.
- Remove unowned Run mutations; migrate tests to lifecycle-owner APIs and validate Run artifact links through the Research Graph.
- Remove unused store, core, runtime, ACP, Tauri, SSH, and UI helpers, plus stale mocks and CSS.
- Remove 14 unused direct Rust dependency edges and 25 Python unused imports or locals.
- Add no schema migration or user-visible behavior change.

## Verification

- cargo fmt --all -- --check
- cargo test --workspace
- cd ui && cargo check --target wasm32-unknown-unknown --all-targets
- cd ui-tests && npx playwright test: 203 passed, 1 skipped
- ruff check python mcp-servers/bio-tools skills --select F401,F841
- git diff --check

## Suggested manual smoke steps

- Open a project and verify markdown code blocks and code context-menu copy behavior.
- Run project sync and verify the existing sync controls still complete.
- Submit, cancel, and recover a Run, then verify produced artifacts remain visible through the Research Graph.

## Known limitations and follow-up

- register_artifact and Research Graph edge metadata remain because they are unfinished product capabilities rather than dead code.
- Linux builds still report the existing platform-gated desktop lifecycle warnings; those functions are used on Windows or macOS.