### PR TITLE
fix: multi-window jump to finished session + ACP badge fallback

### DIFF
--- a/src-tauri/src/desktop_lifecycle.rs
+++ b/src-tauri/src/desktop_lifecycle.rs
@@ -55,7 +55,10 @@ pub(crate) fn activate_workspace_window(
     let _ = window.show();
     let _ = window.unminimize();
     if let Some(target) = target {
-        let _ = window.emit("open-session", target);
+        // `emit` broadcasts to every window (all open projects would jump to
+        // this session); `emit_to` keeps the navigation in the one window
+        // being activated.
+        let _ = window.emit_to(window.label(), "open-session", target);
     }
     let _ = window.set_focus();
 }

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -878,6 +878,15 @@ pub async fn get_session_model(
     {
         return Err("Session not found".into());
     }
+    // ACP-bound frames run through the agent, not an HTTP model. Return the
+    // agent's label under an `acp:` marker so message badges don't fall back
+    // to the active HTTP model.
+    if let Ok(Some(binding)) = state.store.get_acp_session(&session_id).await {
+        let label = crate::acp::profile_label(&state.store, &binding.agent_profile_id)
+            .await
+            .unwrap_or_else(|| "ACP Agent".into());
+        return Ok(format!("acp:{label}"));
+    }
     Ok(session_profile_id(&state.store, &session_id).await)
 }
 

--- a/ui/src/dto.rs
+++ b/ui/src/dto.rs
@@ -325,6 +325,14 @@ pub(crate) fn active_model_label(models: &[ModelProfile]) -> Option<String> {
 }
 
 pub(crate) fn model_label(models: &[ModelProfile], model_id: Option<&str>) -> Option<String> {
+    // `get_session_model` marks ACP-bound frames as `acp:<label>`; show that
+    // label as-is instead of falling back to the active HTTP model.
+    if let Some(label) = model_id
+        .and_then(|id| id.strip_prefix("acp:"))
+        .filter(|label| !label.is_empty())
+    {
+        return Some(label.to_string());
+    }
     models
         .iter()
         .find(|model| model.is_chat_model() && model_id == Some(model.id.as_str()))
@@ -347,6 +355,21 @@ pub(crate) fn session_model_label(
         models,
         session_id.and_then(|session_id| session_models.get(session_id).map(String::as_str)),
     )
+}
+
+#[cfg(test)]
+mod model_label_tests {
+    use super::model_label;
+
+    #[test]
+    fn acp_marker_shows_agent_label_instead_of_http_fallback() {
+        assert_eq!(
+            model_label(&[], Some("acp:Codex ACP")).as_deref(),
+            Some("Codex ACP")
+        );
+        // A bare marker carries no label — fall through to the normal lookup.
+        assert_eq!(model_label(&[], Some("acp:")), None);
+    }
 }
 
 /// Selection captured from a file preview by `api.js`'s `preview_selection`.


### PR DESCRIPTION
## What

Two multi-window (多开) bugs when several project windows run analyses concurrently:

1. **Every window jumped to the session whose analysis finished first.** `activate_workspace_window` sent `open-session` with `window.emit`, which in Tauri v2 broadcasts to *all* windows — so clicking B's desktop notification navigated A, B, and C to B's session. Now uses `emit_to(window.label())`, matching the other `open-session` senders (`drain_pending_notify_target`, `spawn_project_window`, `open_pet_session`).

2. **ACP sessions appeared to switch to the default HTTP model.** Display-only: sends still route through the saved `acp_sessions` binding. But assistant rows created during streaming get their badge from `session_model_label`, which only knows HTTP profiles, so ACP turns were labeled with the active model (e.g. `deepseek-v4-pro`) instead of the agent (e.g. `Codex ACP`). `get_session_model` now returns `acp:<label>` for ACP-bound frames, and the UI's `model_label` shows that label directly instead of falling back — fixing all badge call sites at their single shared funnel.

## Reviewer notes

- The `acp:` marker is a paired contract between `models.rs::get_session_model` and `ui/src/dto.rs::model_label`.
- Known small gap: a background ACP session that was never activated in a window can still show the fallback badge mid-stream; it corrects on reload (persisted `model_name` was already right). Not worth a per-frame push.
- Verified: `cargo check -p wisp-tauri`, `cargo test -p wisp-tauri --no-run`, host `cargo test` in `ui/` (new `model_label` prefix test passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)