### PR TITLE
fix(ui): remove ProjectsScreen's Escape listener when it is disposed

### DIFF
--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -5998,3 +5998,17 @@ test("Ctrl+P imports paged Claude Code conversations into the claude group", asy
   await expect(page.locator('.side-folder[data-folder-name="claude"]')).toContainText("1");
   expect((await invokeArgsList(page, "list_claude_sessions")).length).toBe(scansBeforeImport);
 });
+
+test("Escape after leaving the projects screen does not touch disposed signals", async ({ page }) => {
+  const browserErrors: string[] = [];
+  page.on("pageerror", (error) => browserErrors.push(error.message));
+  page.on("console", (message) => {
+    if (message.type() === "error") browserErrors.push(message.text());
+  });
+  // Opening a project disposes ProjectsScreen; its window-level Escape listener
+  // must go with it, or this keypress reads signals that no longer exist.
+  await enterApp(page);
+  await page.keyboard.press("Escape");
+  await expect(newSessionButton(page)).toBeVisible();
+  expect(browserErrors.filter((message) => message.includes("disposed"))).toEqual([]);
+});

--- a/ui/src/app_support.rs
+++ b/ui/src/app_support.rs
@@ -9851,8 +9851,11 @@ pub(super) fn ProjectsScreen(
     });
 
     // Local Escape stack — ProjectsScreen owns its own modals, so the App
-    // window listener cannot see `creating` / `pending_delete`.
-    window_event_listener(ev::keydown, move |ev| {
+    // window listener cannot see `creating` / `pending_delete`. Opening a
+    // project disposes this component, so the listener has to go with it:
+    // window listeners outlive their owner and would keep reading the signals
+    // below after they are gone.
+    let escape_listener = window_event_listener(ev::keydown, move |ev| {
         let Some(ev) = ev.dyn_ref::<web_sys::KeyboardEvent>() else {
             return;
         };
@@ -9879,6 +9882,7 @@ pub(super) fn ProjectsScreen(
             creating.set(false);
         }
     });
+    on_cleanup(move || escape_listener.remove());
 
     view! {
         <div class="projects-screen">


### PR DESCRIPTION
Fixes #523.

## 根因

Leptos 的 `window_event_listener` 返回一个需要显式 `.remove()` 的句柄。`ProjectsScreen` 把它丢弃了，于是这个 window 级 keydown 监听器的生命周期长于组件本身。

打开项目时该组件会被销毁——`project_landing.rs` 是在 reactive 闭包 `show_projects.get().then(...)` 里渲染它的——但监听器还在。此后在应用里任何位置按 <kbd>Esc</kbd>，都会跑这个孤儿 handler 去读 `pending_delete`，而那个信号已经不存在了：

```
panicked at src/app_support.rs:9862:27:
Attempted to get a signal after it was disposed.
signal created here: src/app_support.rs:9591:26
```

除了 panic，这个泄漏的监听器还会继续对 Escape 调 `prevent_default()`，可能把按键从接替它的界面手里吞掉。

## 改动

接住句柄，在 `on_cleanup` 里移除。核心改动两行。

## 为什么只改这一处

全仓 13 处 `window_event_listener` 的返回值都被丢弃，但其余 12 处都在 `App` 或 `WindowTitlebar` 里——后者挂在**非** reactive 的 `is_windows().then(...)` 下，只决定一次、从不销毁。只有 `ProjectsScreen` 这处位于会被销毁的组件内，所以只有它会泄漏。其余按 YAGNI 不动，加了也是死代码。

## 验证

加了一个回归测试 `ui-tests/tests/ui.spec.ts`，走真实按键路径（`page.keyboard.press("Escape")`，不是合成事件）：

- **在父提交上跑会失败**，报的正是上面那个 panic — 这也顺带证实了该 bug 用户可达，不是只能靠合成事件触发
- 打上修复后通过
- 完整 ui-tests 套件：**205 passed / 1 skipped**（首轮有一个 `background Agent completion` 因等 `.proj-card-main` 超时，孤立重跑通过、完整重跑全绿，确认是 flake，与本改动无关）
- `cargo check --target wasm32-unknown-unknown` 无警告
- 按惯例 `ui/` 未跑 `cargo fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)