### PR TITLE
Fix stale update cards opening an older release

### DIFF
--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -3487,6 +3487,39 @@ test("check for updates shows an available-update modal before opening releases"
   });
 });
 
+test("stale update card refreshes to the latest release before opening it (#521)", async ({ page }) => {
+  await enterApp(page);
+  await setMockUpdateCheck(page, {
+    current_version: "0.23.0",
+    latest_version: "0.24.0",
+    update_available: true,
+    release_url: "https://github.com/xuzhougeng/wisp-science/releases/tag/v0.24.0",
+  });
+
+  await page.keyboard.press("Control+p");
+  const input = page.locator("#action-palette-input");
+  await input.fill("check for updates");
+  await input.press("Enter");
+  let modal = page.getByTestId("update-check-modal");
+  await expect(modal).toContainText("Wisp 0.24.0 is available.");
+  await modal.getByRole("button", { name: "Later" }).click();
+  await expect(page.getByTestId("update-card")).toContainText("v0.24.0");
+
+  await setMockUpdateCheck(page, {
+    latest_version: "0.25.0",
+    release_url: "https://github.com/xuzhougeng/wisp-science/releases/tag/v0.25.0",
+  });
+  await page.getByTestId("update-card").click();
+
+  modal = page.getByTestId("update-check-modal");
+  await expect(modal).toContainText("Wisp 0.25.0 is available.");
+  await expect(page.getByTestId("update-card")).toContainText("v0.25.0");
+  await modal.getByTestId("update-check-open-releases").click();
+  await expect.poll(() => lastInvokeArgs(page, "open_external_url")).toMatchObject({
+    url: "https://github.com/xuzhougeng/wisp-science/releases/tag/v0.25.0",
+  });
+});
+
 test("command palette check for updates also shows the result modal", async ({ page }) => {
   await enterApp(page);
   await setMockUpdateCheck(page, {

--- a/ui/src/app_support.rs
+++ b/ui/src/app_support.rs
@@ -446,8 +446,6 @@ pub(super) enum UpdateCheckModal {
 #[derive(Clone)]
 pub(super) struct AvailableUpdate {
     pub(super) version: String,
-    pub(super) notes: String,
-    pub(super) release_url: String,
 }
 
 /// First open vs after a failed probe (failed phase must not keep probing).

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -1548,8 +1548,6 @@ fn App() -> impl IntoView {
             if update.update_available {
                 update_banner.set(Some(AvailableUpdate {
                     version: update.latest_version,
-                    notes: update.notes,
-                    release_url: update.release_url,
                 }));
             }
         }
@@ -3172,10 +3170,14 @@ fn App() -> impl IntoView {
         let loc = locale;
         let modal = update_check_modal;
         let status_msg = status;
+        let banner = update_banner;
         spawn_local(async move {
             match invoke_checked("check_for_updates", JsValue::UNDEFINED).await {
                 Ok(v) => match serde_wasm_bindgen::from_value::<UpdateCheck>(v) {
                     Ok(update) if update.update_available => {
+                        banner.set(Some(AvailableUpdate {
+                            version: update.latest_version.clone(),
+                        }));
                         let text = tf(
                             loc.get(),
                             "status.update_available",
@@ -3190,6 +3192,7 @@ fn App() -> impl IntoView {
                         }));
                     }
                     Ok(update) => {
+                        banner.set(None);
                         let text = tf(
                             loc.get(),
                             "status.up_to_date",
@@ -6971,13 +6974,7 @@ fn App() -> impl IntoView {
                 update_banner,
             }
             open_update=Callback::new(move |_| {
-                if let Some(u) = update_banner.get() {
-                    update_check_modal.set(Some(UpdateCheckModal::Available {
-                        version: u.version,
-                        notes: u.notes,
-                        release_url: u.release_url,
-                    }));
-                }
+                run_update_check();
             })
             toggle_proj_menu=Callback::new(toggle_proj_menu)
             open_proj_settings=Callback::new(open_proj_settings)


### PR DESCRIPTION
## Problem

The silent update check runs once at startup. If a newer release is published while Wisp stays open, the sidebar card keeps the old version, release notes, and tag URL. Opening a cached v0.24 card after v0.25 is available therefore still sends the user to v0.24.

Fixes #521.

## Changes

- Route the sidebar update card through the existing live update-check flow.
- Synchronize the sidebar version after every successful manual check and clear it when the app is current.
- Stop caching release notes and URLs in the sidebar card; the modal receives fresh values from GitHub.
- Add a Playwright regression covering a v0.23 client with a stale v0.24 card refreshing to v0.25 before opening Releases.

## Verification

- `cargo fmt --all -- --check`
- `cd ui && cargo check --target wasm32-unknown-unknown`
- `cargo test --workspace`
- `cd ui-tests && npm ci`
- `cd ui-tests && npx playwright test` — 205 passed, 1 skipped

## Manual smoke

1. Surface an available-update card.
2. Publish or mock a newer stable GitHub Release while the app remains open.
3. Click the existing card.
4. Confirm the modal and Open Releases action use the newer version and tag page.

## Known limitations

- Already distributed clients cannot receive this code until they install a build containing it; restarting or using Check for updates still refreshes their one-time snapshot.
- This does not add periodic background polling. It refreshes when the user opens the update card.

## Follow-up

None required. Add periodic polling only if users need the card label to update without interacting with it.
