### PR TITLE
feat(ui): 接通 Plan 模式 UI（composer 开关 + 计划卡动作条）

### DIFF
--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -468,6 +468,97 @@ fn acp_plan_text(payload: &serde_json::Value) -> String {
         .unwrap_or_default()
 }
 
+/// ACP has no flag marking a mode as "plans without executing"; agents name it
+/// themselves (`plan`, `plan_mode`, …), so match the id.
+fn is_plan_mode_id(id: &str) -> bool {
+    id.to_ascii_lowercase().contains("plan")
+}
+
+/// `(plan mode, mode to return to)` from a session's `availableModes`, or `None`
+/// for agents that expose no plan mode — the plan toggle stays hidden for those.
+fn plan_mode_pair(state: Option<&serde_json::Value>) -> Option<(String, String)> {
+    let ids: Vec<&str> = state?
+        .get("availableModes")?
+        .as_array()?
+        .iter()
+        .filter_map(|mode| mode.get("id")?.as_str())
+        .collect();
+    let plan = ids.iter().find(|id| is_plan_mode_id(id))?;
+    let exit = ids
+        .iter()
+        .find(|id| **id == "default")
+        .or_else(|| ids.iter().find(|id| !is_plan_mode_id(id)))?;
+    Some((plan.to_string(), exit.to_string()))
+}
+
+fn acp_current_mode_id(state: Option<&serde_json::Value>) -> Option<&str> {
+    state?.get("currentModeId")?.as_str()
+}
+
+#[cfg(test)]
+mod plan_mode_tests {
+    use super::plan_mode_pair;
+
+    fn state(ids: &[&str]) -> serde_json::Value {
+        serde_json::json!({
+            "availableModes": ids.iter().map(|id| serde_json::json!({ "id": id })).collect::<Vec<_>>()
+        })
+    }
+
+    #[test]
+    fn pairs_plan_mode_with_the_mode_to_return_to() {
+        let modes = state(&["default", "plan", "acceptEdits"]);
+        assert_eq!(
+            plan_mode_pair(Some(&modes)),
+            Some(("plan".into(), "default".into()))
+        );
+        // No `default`: fall back to the first mode that is not a plan mode.
+        let modes = state(&["plan_mode", "yolo"]);
+        assert_eq!(
+            plan_mode_pair(Some(&modes)),
+            Some(("plan_mode".into(), "yolo".into()))
+        );
+    }
+
+    #[test]
+    fn no_pair_means_no_plan_toggle() {
+        assert_eq!(plan_mode_pair(None), None);
+        assert_eq!(plan_mode_pair(Some(&state(&["default", "yolo"]))), None);
+        assert_eq!(plan_mode_pair(Some(&state(&["plan"]))), None);
+        assert_eq!(plan_mode_pair(Some(&serde_json::json!({}))), None);
+    }
+}
+
+/// `session/set_mode` returns no state, so the applied id is merged locally to
+/// preserve the `availableModes` captured from the initial SessionModeState.
+/// Returns whether the agent accepted the switch.
+async fn apply_acp_mode(
+    modes: RwSignal<HashMap<String, serde_json::Value>>,
+    frame_id: String,
+    mode_id: String,
+) -> bool {
+    let args = to_value(&serde_json::json!({
+        "frameId": frame_id.clone(),
+        "modeId": mode_id,
+    }))
+    .unwrap();
+    if let Ok(value) = invoke_checked("set_acp_session_mode", args).await {
+        if let Some(applied) = value.as_string() {
+            modes.update(|all| {
+                let entry = all.entry(frame_id).or_insert_with(|| serde_json::json!({}));
+                if let serde_json::Value::Object(map) = entry {
+                    map.insert("currentModeId".into(), serde_json::Value::String(applied));
+                }
+            });
+            return true;
+        }
+    }
+    // Notify anyway so a control that already moved optimistically (the plan
+    // checkbox, the mode select) snaps back to the mode the agent is really in.
+    modes.update(|_| {});
+    false
+}
+
 fn acp_select_options(option: &serde_json::Value) -> Vec<(String, String)> {
     let mut result = Vec::new();
     for row in option
@@ -4391,6 +4482,52 @@ fn App() -> impl IntoView {
         )
     };
 
+    // Plan mode is an ACP session mode, so the plan card's action bar only makes
+    // sense while the bound agent is actually in it.
+    let plan_mode_active = Signal::derive(move || {
+        let Some(session_id) = active_session.get() else {
+            return false;
+        };
+        acp_session_modes.with(|all| {
+            acp_current_mode_id(all.get(&session_id)).is_some_and(is_plan_mode_id)
+        })
+    });
+
+    // ponytail: an ACP plan update is a todo list with no id to approve, so
+    // "approve" is the mode switch plus one ordinary turn. Upgrade to a
+    // structured approval only if ACP ever gains a plan-decision request.
+    let on_plan_decision = Callback::new(move |approve: bool| {
+        let loc = locale.get_untracked();
+        if !approve {
+            focus_composer();
+            show_toast(&t(loc, "plan.modify_hint"));
+            return;
+        }
+        let Some(session_id) = active_session.get_untracked() else {
+            return;
+        };
+        let exit_mode = acp_session_modes
+            .with_untracked(|all| plan_mode_pair(all.get(&session_id)))
+            .map(|(_, exit)| exit);
+        spawn_local(async move {
+            // Await the mode switch before sending: `session/set_mode` and
+            // `session/prompt` are separate calls, and a prompt that lands first
+            // just makes the agent re-plan.
+            if let Some(exit_mode) = exit_mode {
+                if !apply_acp_mode(acp_session_modes, session_id, exit_mode).await {
+                    return;
+                }
+            }
+            // A draft in the composer is the user's own go-ahead; only fill in a
+            // default so approving never discards what they typed.
+            if input.get_untracked().trim().is_empty() {
+                input.set(t(loc, "plan.approve").into());
+            }
+            send.call(ComposerSendAction::Normal);
+            show_toast(&t(loc, "plan.executing"));
+        });
+    });
+
     let on_sidebar_resize_start = move |ev: web_sys::MouseEvent| {
         ev.prevent_default();
         sidebar_dragging.set(true);
@@ -7748,6 +7885,7 @@ fn App() -> impl IntoView {
                                                 i, &item, timestamp, &arts, on_artifact_select, on_file_link,
                                                 run_records, busy.read_only(), compact_assistant, active_acp_agent_id.get().is_none(), edit_message, branch_message, sid,
                                                 respond_confirm, on_resume, on_queue,
+                                                plan_mode_active, on_plan_decision,
                                             )}
                                         </div>
                                     }.into_view()
@@ -8347,6 +8485,36 @@ fn App() -> impl IntoView {
                                 }></div>
                                 <div class="compose-menu agent-menu" role="menu"
                                     aria-label=move || t(locale.get(), "composer.agent_options")>
+                                    {move || {
+                                        // Shortcut for the plan/default pair of the ACP mode picker
+                                        // in the model menu; agents without a plan mode get no row.
+                                        let session_id = active_session.get()?;
+                                        let (plan_mode, exit_mode) = acp_session_modes
+                                            .with(|all| plan_mode_pair(all.get(&session_id)))?;
+                                        let on_plan = plan_mode_active.get();
+                                        Some(view! {
+                                            <label class="agent-menu-row"
+                                                title=move || t(locale.get(), if on_plan { "plan.switch_default" } else { "plan.switch_plan" })>
+                                                <span>{move || t(locale.get(), "composer.plan_first")}</span>
+                                                <span class="toggle agent-menu-toggle">
+                                                    <input type="checkbox" data-testid="plan-first-toggle"
+                                                        prop:checked=on_plan
+                                                        on:change=move |ev| {
+                                                            let enabled = event_target_checked(&ev);
+                                                            let target = if enabled { plan_mode.clone() } else { exit_mode.clone() };
+                                                            let session_id = session_id.clone();
+                                                            let loc = locale.get_untracked();
+                                                            spawn_local(async move {
+                                                                if apply_acp_mode(acp_session_modes, session_id, target).await {
+                                                                    show_toast(&t(loc, if enabled { "plan.enabled" } else { "plan.default_enabled" }));
+                                                                }
+                                                            });
+                                                        } />
+                                                    <span class="toggle-track" aria-hidden="true"></span>
+                                                </span>
+                                            </label>
+                                        })
+                                    }}
                                     <label class="agent-menu-row">
                                         <span>{move || t(locale.get(), "composer.delegation")}</span>
                                         <span class="toggle agent-menu-toggle">
@@ -8884,23 +9052,8 @@ fn App() -> impl IntoView {
                                                                                 on:change=move |event| {
                                                                                     let mode_id = dom_value(&event);
                                                                                     let frame_id = frame_id.clone();
-                                                                                    let args = to_value(&serde_json::json!({
-                                                                                        "frameId": frame_id,
-                                                                                        "modeId": mode_id,
-                                                                                    })).unwrap();
                                                                                     spawn_local(async move {
-                                                                                        if let Ok(value) = invoke_checked("set_acp_session_mode", args).await {
-                                                                                            if let Some(applied) = value.as_string() {
-                                                                                                // `session/set_mode` returns no state, so apply the
-                                                                                                // selected id locally, preserving availableModes.
-                                                                                                acp_session_modes.update(|all| {
-                                                                                                    let entry = all.entry(frame_id).or_insert_with(|| serde_json::json!({}));
-                                                                                                    if let serde_json::Value::Object(map) = entry {
-                                                                                                        map.insert("currentModeId".into(), serde_json::Value::String(applied));
-                                                                                                    }
-                                                                                                });
-                                                                                            }
-                                                                                        }
+                                                                                        apply_acp_mode(acp_session_modes, frame_id, mode_id).await;
                                                                                     });
                                                                                 }>
                                                                                 {available_modes.into_iter().map(|(mode_id, label)| {
@@ -11566,6 +11719,8 @@ fn render_item(
     on_approval: Callback<(String, bool, Option<String>, String)>,
     on_resume: Callback<usize>,
     on_queue: Callback<QueueOp>,
+    plan_mode_active: Signal<bool>,
+    on_plan_decision: Callback<bool>,
 ) -> impl IntoView {
     let locale = use_locale();
     match item {
@@ -11750,9 +11905,26 @@ fn render_item(
                 <article class="plan-card" data-testid="plan-card">
                     <header class="plan-card-head">
                         <span class="plan-card-icon">{compose_icon("plan")}</span>
-                        <div><strong>{move || t(locale.get(), "plan.card.title")}</strong></div>
+                        <div>
+                            <strong>{move || t(locale.get(), "plan.card.title")}</strong>
+                            {move || plan_mode_active.get().then(|| view! {
+                                <span>{t(locale.get(), "plan.card.ready")}</span>
+                            })}
+                        </div>
                     </header>
                     <div class="plan-card-body markdown" inner_html=html></div>
+                    {move || plan_mode_active.get().then(|| view! {
+                        <footer class="plan-card-actions">
+                            <button type="button" class="primary" data-testid="plan-approve"
+                                on:click=move |_| on_plan_decision.call(true)>
+                                {move || t(locale.get(), "plan.approve")}
+                            </button>
+                            <button type="button" data-testid="plan-modify"
+                                on:click=move |_| on_plan_decision.call(false)>
+                                {move || t(locale.get(), "plan.modify")}
+                            </button>
+                        </footer>
+                    })}
                 </article>
             }.into_view()
         }

--- a/ui/src/styles/chat.css
+++ b/ui/src/styles/chat.css
@@ -139,6 +139,9 @@
 .plan-card-body { padding: 14px 16px; color: var(--text); font-size: 13px; line-height: 1.62; }
 .plan-card-body > :first-child { margin-top: 0; }
 .plan-card-body > :last-child { margin-bottom: 0; }
+.plan-card-actions { display: flex; flex-wrap: wrap; gap: 7px; padding: 10px 12px; border-top: 1px solid var(--border); background: var(--bg-sunken); }
+.plan-card-actions button { padding: 6px 10px; border: 1px solid var(--border-strong); border-radius: 7px; background: var(--bg-elev); color: var(--text); font: inherit; font-size: 10.5px; cursor: pointer; }
+.plan-card-actions button.primary { border-color: var(--clay); background: var(--clay); color: var(--on-clay); }
 
 .topbar {
   position: relative; z-index: 20; display: flex; align-items: center; gap: 12px;


### PR DESCRIPTION
2026-07-27 审计里最大的一块半成品：`plan.*` 的 20 个 i18n key 和后端通道全都就位，但 UI 从来没装配上去，只有 `plan.card.title` 被用到。这个 PR 把能闭环的部分接上，接不上的说明原因。

## 改了什么

**1. Composer「先计划」开关** — 在已有的 agent options 菜单里加一行 `.agent-menu-row` + toggle（复用 delegation 那一套，零新 CSS）。只有当会话绑定的 ACP agent 的 `availableModes` 同时含 plan 类模式和一个可返回的模式时才渲染；本质是 model 菜单里那个通用 mode picker 的 plan/default 快捷方式，走同一个 `set_acp_session_mode`，没有引入第三套状态。文案用 `composer.plan_first` / `plan.switch_plan` / `plan.switch_default` / `plan.enabled` / `plan.default_enabled`。

**2. Plan 卡片底部动作条** — approve / modify 两个按钮，只在会话真的处于 plan 模式时显示（`plan_mode_active` 派生信号，模式一变就实时收起）。
- **approve**：先 `await` 模式切换再发消息。`session/set_mode` 和 `session/prompt` 是两次独立 RPC，prompt 先到只会让 agent 重新规划一遍。发送走 `send.call(ComposerSendAction::Normal)` 这条原路，**ACP 绑定检查和禁 rewind 都不绕过**。输入框里已有草稿时用草稿当批准正文，不覆盖用户已经打的字。
- **modify**：聚焦 composer + toast `plan.modify_hint`。这句是给用户看的提示而不是发给 agent 的正文，所以是 toast 不是预填。

**3. 顺手收敛** — model 菜单里那段内联的 set-mode 逻辑折进共享的 `apply_acp_mode`，并让它在失败时也 `notify`，这样乐观勾上的开关会弹回真实模式，而不是卡在那里谎报会话状态（原来的 select 有同样的问题）。

## 为什么没做 `plan.question.*`

后端没有对应的数据源。`AcpUpdateKind`（crates/wisp-acp/src/lib.rs:104）只有 `UserMessage / AgentMessage / AgentThought / ToolCall / ToolCallUpdate / Plan / AvailableCommands / CurrentMode / ConfigOptions / SessionInfo / Usage / Unknown`，没有任何「计划提问」事件；agent 的提问要么是普通文本，要么走 `permission-request`（已有卡片渲染）。不为没有数据的 UI 造后端，这 4 个 key 继续留作孤儿。

同理 `plan.compat` / `plan.compat_full` / `plan.save_exit` 也没启用——按范围只做 plan/default 两模式的切换，兼容模式没有实现支撑。

## 设计取舍

ACP 的 `SessionUpdate::Plan` 是 agent 的 todo 列表，**没有可批准的结构化 id**，`confirm_response` 那条通道是 wisp 原生审批流的，跟它没关系。所以 approve 只能是「切回执行模式 + 发一条继续消息」。代码里有 `ponytail:` 注释标了这个上限和升级路径（如果 ACP 以后出了结构化的 plan 决策请求就换掉）。

## 验证

- `cd ui && cargo check --target wasm32-unknown-unknown` 干净，无 warning。
- `plan_mode_pair` 加了 2 个单测，宿主 `cargo test` 通过（CI 对 ui 只跑 wasm check 不跑单测，需要本地跑）。
- CSS 在 preview.html 静态沙盒里确认亮/暗两套主题变量都正确解析（`--bg-sunken` / `--clay` / `--on-clay`）。
- **`?mock=1` 覆盖不到这块**：ui/mock-bridge.js 完全没有 ACP 支持，不发 `acp-session-update`，所以 mock 下 `acp_session_modes` 恒空、开关和动作条都不会渲染。为了验证去补一套 mock ACP 会话超出了这次范围，没有做。真机验证需要一个带 plan 模式的 ACP agent。

没有新增 invoke 命令，所以 mock-bridge 不需要补 case；没有改 DTO，所以没有两侧字段对齐问题。按惯例没有对 ui/ 跑 cargo fmt。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
