### PR TITLE
feat(sidebar): 分支会话在侧栏挂到源会话下 (#531)

### DIFF
--- a/crates/wisp-store/src/lib.rs
+++ b/crates/wisp-store/src/lib.rs
@@ -642,6 +642,14 @@ impl Store {
         sqlx::query("CREATE INDEX IF NOT EXISTS ix_frames_folder ON frames(folder_id)")
             .execute(pool)
             .await?;
+        // Which session a branch was forked from, so the sidebar can nest it under
+        // its source. Deliberately NOT root_frame_id (that one cascades deletes) and
+        // NOT parent_frame_id (parent_frame_id = id is the "root session" marker).
+        if !Self::has_column(pool, "frames", "branched_from").await? {
+            sqlx::query("ALTER TABLE frames ADD COLUMN branched_from TEXT")
+                .execute(pool)
+                .await?;
+        }
 
         sqlx::query(
             "CREATE TABLE IF NOT EXISTS execution_log (\

--- a/crates/wisp-store/src/sessions.rs
+++ b/crates/wisp-store/src/sessions.rs
@@ -784,11 +784,11 @@ impl Store {
     /// Root frames that have at least one user turn, most recently active first,
     /// each with a title derived from its first user message. Used to populate
     /// the UI's session-history sidebar. Returns
-    /// `(frame_id, title, activity_at, folder_id)`.
+    /// `(frame_id, title, activity_at, folder_id, branched_from)`.
     pub async fn list_sessions(
         &self,
         project_id: &str,
-    ) -> Result<Vec<(String, String, i64, Option<String>)>> {
+    ) -> Result<Vec<(String, String, i64, Option<String>, Option<String>)>> {
         self.list_sessions_page(project_id, None, usize::MAX).await
     }
 
@@ -800,14 +800,14 @@ impl Store {
         project_id: &str,
         cursor: Option<(i64, &str)>,
         limit: usize,
-    ) -> Result<Vec<(String, String, i64, Option<String>)>> {
+    ) -> Result<Vec<(String, String, i64, Option<String>, Option<String>)>> {
         let cursor_ts = cursor.map(|value| value.0);
         let cursor_id = cursor.map(|value| value.1);
         let rows = sqlx::query(
             "SELECT * FROM ( \
                 SELECT f.id AS id, \
                     COALESCE((SELECT MAX(NULLIF(m.ts, 0)) FROM messages m WHERE m.frame_id = f.id), f.updated_at) AS activity_at, \
-                    f.title AS custom_title, f.folder_id AS folder_id, \
+                    f.title AS custom_title, f.folder_id AS folder_id, f.branched_from AS branched_from, \
                     (SELECT content FROM messages m WHERE m.frame_id = f.id AND m.role = 'user' ORDER BY m.seq ASC LIMIT 1) AS first_user \
                 FROM frames f \
                 WHERE f.project_id = ? AND f.parent_frame_id = f.id \
@@ -829,26 +829,27 @@ impl Store {
             let id: String = row.try_get("id")?;
             let activity_at: i64 = row.try_get("activity_at")?;
             let folder_id: Option<String> = row.try_get("folder_id")?;
+            let branched_from: Option<String> = row.try_get("branched_from")?;
             let custom_title: Option<String> = row.try_get("custom_title")?;
             let first_user: Option<String> = row.try_get("first_user")?;
             let title = session_display_title(custom_title, first_user);
-            out.push((id, title, activity_at, folder_id));
+            out.push((id, title, activity_at, folder_id, branched_from));
         }
         Ok(out)
     }
 
     /// Pinned root frames for a project, newest first. Returned as
-    /// `(frame_id, title, activity_at, folder_id)` like `list_sessions_page`,
+    /// `(frame_id, title, activity_at, folder_id, branched_from)` like `list_sessions_page`,
     /// but unpaginated so the sidebar's "Pinned" section is complete regardless
     /// of how far the keyset history has been scrolled.
     pub async fn list_pinned_sessions(
         &self,
         project_id: &str,
-    ) -> Result<Vec<(String, String, i64, Option<String>)>> {
+    ) -> Result<Vec<(String, String, i64, Option<String>, Option<String>)>> {
         let rows = sqlx::query(
             "SELECT f.id AS id, \
                 COALESCE((SELECT MAX(NULLIF(m.ts, 0)) FROM messages m WHERE m.frame_id = f.id), f.updated_at) AS activity_at, \
-                f.title AS custom_title, f.folder_id AS folder_id, \
+                f.title AS custom_title, f.folder_id AS folder_id, f.branched_from AS branched_from, \
                 (SELECT content FROM messages m WHERE m.frame_id = f.id AND m.role = 'user' ORDER BY m.seq ASC LIMIT 1) AS first_user \
              FROM frames f \
              WHERE f.project_id = ? AND f.parent_frame_id = f.id AND COALESCE(f.pinned, 0) = 1 \
@@ -863,6 +864,7 @@ impl Store {
             let id: String = row.try_get("id")?;
             let activity_at: i64 = row.try_get("activity_at")?;
             let folder_id: Option<String> = row.try_get("folder_id")?;
+            let branched_from: Option<String> = row.try_get("branched_from")?;
             let custom_title: Option<String> = row.try_get("custom_title")?;
             let first_user: Option<String> = row.try_get("first_user")?;
             out.push((
@@ -870,6 +872,7 @@ impl Store {
                 session_display_title(custom_title, first_user),
                 activity_at,
                 folder_id,
+                branched_from,
             ));
         }
         Ok(out)
@@ -1187,6 +1190,17 @@ impl Store {
             anyhow::bail!("Folder not found");
         }
         tx.commit().await?;
+        Ok(())
+    }
+
+    /// Record which session a branch was forked from. Purely a display link for
+    /// the sidebar's nesting — it does not affect loading, deleting, or context.
+    pub async fn set_session_branched_from(&self, frame_id: &str, source_id: &str) -> Result<()> {
+        sqlx::query("UPDATE frames SET branched_from=? WHERE id=?")
+            .bind(source_id)
+            .bind(frame_id)
+            .execute(&self.pool)
+            .await?;
         Ok(())
     }
 

--- a/crates/wisp-store/src/store_tests.rs
+++ b/crates/wisp-store/src/store_tests.rs
@@ -1004,7 +1004,7 @@ async fn session_history_and_outline_use_message_times() {
     assert_eq!(
         sessions
             .iter()
-            .map(|(id, _, activity_at, _)| (id.as_str(), *activity_at))
+            .map(|(id, _, activity_at, ..)| (id.as_str(), *activity_at))
             .collect::<Vec<_>>(),
         [("older", 310), ("newer", 210)]
     );
@@ -1043,6 +1043,40 @@ async fn session_pages_are_stable_when_timestamps_match() {
         .map(|row| row.0.as_str())
         .collect::<Vec<_>>();
     assert_eq!(ids, vec!["c", "b", "a"]);
+    let _ = std::fs::remove_file(tmp);
+}
+
+#[tokio::test]
+async fn branched_from_survives_listing() {
+    let tmp = std::env::temp_dir().join(format!("wisp_branched_{}.sqlite", uuid::Uuid::new_v4()));
+    let store = Store::open(&tmp).await.unwrap();
+    store.create_project("p", "proj", "").await.unwrap();
+    for id in ["main", "fork"] {
+        store.create_frame(id, "p", "OPERON", "m").await.unwrap();
+        store
+            .append_message(id, 1, &Message::user(id))
+            .await
+            .unwrap();
+    }
+    store
+        .set_session_branched_from("fork", "main")
+        .await
+        .unwrap();
+
+    let listed = store.list_sessions("p").await.unwrap();
+    let source = |id: &str| {
+        listed
+            .iter()
+            .find(|row| row.0 == id)
+            .map(|row| row.4.clone())
+            .unwrap()
+    };
+    assert_eq!(source("fork").as_deref(), Some("main"));
+    assert_eq!(source("main"), None);
+
+    store.set_session_pinned("fork", "p", true).await.unwrap();
+    let pinned = store.list_pinned_sessions("p").await.unwrap();
+    assert_eq!(pinned[0].4.as_deref(), Some("main"));
     let _ = std::fs::remove_file(tmp);
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -705,6 +705,9 @@ struct SessionInfo {
     ts: i64,
     #[serde(skip_serializing_if = "Option::is_none")]
     folder_id: Option<String>,
+    /// Source session this one was branched from; the sidebar nests on it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    branched_from: Option<String>,
     running: bool,
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pinned: bool,

--- a/src-tauri/src/project_reader.rs
+++ b/src-tauri/src/project_reader.rs
@@ -134,7 +134,7 @@ pub async fn read_references(
             .await
             .map_err(|error| error.to_string())?
             .ok_or_else(|| format!("Project '{project_id}' no longer exists."))?;
-        for (id, title, _, _) in store
+        for (id, title, ..) in store
             .list_sessions(project_id)
             .await
             .map_err(|error| error.to_string())?

--- a/src-tauri/src/session_commands.rs
+++ b/src-tauri/src/session_commands.rs
@@ -31,6 +31,8 @@ pub(super) async fn branch_session(
     let _project_activity = state.begin_project_activity(&ap.id)?;
     let id = create_session_frame(&state.store, &ap.id).await?;
     if let Some(source) = session_id.as_deref().filter(|s| !s.is_empty()) {
+        // Display-only lineage so the sidebar can nest this branch under its source.
+        let _ = state.store.set_session_branched_from(&id, source).await;
         let model_id = models::session_profile_id(&state.store, source).await;
         state
             .store
@@ -104,24 +106,26 @@ pub(super) async fn list_sessions_page(
     let mut items: Vec<SessionInfo> = pinned_rows
         .into_iter()
         .filter(|(id, ..)| !page_ids.contains(id))
-        .map(|(id, title, ts, folder_id)| SessionInfo {
+        .map(|(id, title, ts, folder_id, branched_from)| SessionInfo {
             running: running.contains(&id),
             pinned: true,
             id,
             title,
             ts,
             folder_id,
+            branched_from,
         })
         .collect();
     items.extend(
         rows.into_iter()
-            .map(|(id, title, ts, folder_id)| SessionInfo {
+            .map(|(id, title, ts, folder_id, branched_from)| SessionInfo {
                 running: running.contains(&id),
                 pinned: pinned_ids.contains(&id),
                 id,
                 title,
                 ts,
                 folder_id,
+                branched_from,
             }),
     );
     Ok(SessionPage {

--- a/ui/mock-bridge.js
+++ b/ui/mock-bridge.js
@@ -11,6 +11,8 @@
     { id: "s1", title: "查找文献, FX-cell", ts: 1719900000, folder_id: "d1" },
     { id: "s2", title: "我确认下你你有什么skill", ts: 1719890000 },
     { id: "s3", title: "你能做啥", ts: 1719880000, pinned: true },
+    { id: "s4", title: "Branch: 换个思路再试一次", ts: 1719885000, branched_from: "s2" },
+    { id: "s5", title: "Branch: 再分一支", ts: 1719884000, branched_from: "s4" },
   ];
   const folders = [{ id: "d1", name: "Research" }];
   let libraryItems = [

--- a/ui/src/app_support.rs
+++ b/ui/src/app_support.rs
@@ -5859,6 +5859,98 @@ pub(super) fn refresh_folders(folders: RwSignal<Vec<FolderInfo>>) {
     });
 }
 
+/// Split the sidebar list into top-level sessions plus, per session id, the
+/// branches forked from it — the sidebar draws those nested underneath (#531).
+///
+/// A branch only nests when its source is in the same visible list *and* the
+/// same folder; otherwise it stays top-level, so nothing silently disappears
+/// when the source is on an older page or was dragged elsewhere. Branches of
+/// branches flatten onto the topmost visible source: one level of indent only.
+pub(super) fn nest_branch_sessions(
+    list: &[SessionInfo],
+) -> (Vec<SessionInfo>, HashMap<String, Vec<SessionInfo>>) {
+    let by_id: HashMap<&str, &SessionInfo> =
+        list.iter().map(|s| (s.id.as_str(), s)).collect();
+    let visible_source = |s: &SessionInfo| -> Option<String> {
+        let mut cur = s;
+        let mut hops = 0;
+        loop {
+            let Some(src) = cur.branched_from.as_deref().and_then(|id| by_id.get(id)) else {
+                break;
+            };
+            if src.folder_id != cur.folder_id {
+                return None;
+            }
+            cur = src;
+            hops += 1;
+            // ponytail: hop cap is the cycle guard; real branch chains are short.
+            if hops > 16 {
+                return None;
+            }
+        }
+        (cur.id != s.id).then(|| cur.id.clone())
+    };
+    let mut top = Vec::new();
+    let mut branches: HashMap<String, Vec<SessionInfo>> = HashMap::new();
+    for s in list {
+        match visible_source(s) {
+            Some(source) => branches.entry(source).or_default().push(s.clone()),
+            None => top.push(s.clone()),
+        }
+    }
+    (top, branches)
+}
+
+#[cfg(test)]
+mod branch_nesting_tests {
+    use super::*;
+
+    fn ses(id: &str, branched_from: Option<&str>, folder: Option<&str>) -> SessionInfo {
+        SessionInfo {
+            id: id.into(),
+            title: id.into(),
+            ts: 0,
+            folder_id: folder.map(Into::into),
+            branched_from: branched_from.map(Into::into),
+            pinned: false,
+        }
+    }
+
+    #[test]
+    fn branches_nest_under_their_visible_source() {
+        let list = vec![
+            ses("main", None, None),
+            ses("b1", Some("main"), None),
+            ses("b2", Some("b1"), None),
+            ses("other", None, None),
+        ];
+        let (top, branches) = nest_branch_sessions(&list);
+        assert_eq!(
+            top.iter().map(|s| s.id.as_str()).collect::<Vec<_>>(),
+            ["main", "other"]
+        );
+        // Branch-of-a-branch flattens onto the topmost visible source.
+        assert_eq!(
+            branches["main"].iter().map(|s| s.id.as_str()).collect::<Vec<_>>(),
+            ["b1", "b2"]
+        );
+    }
+
+    #[test]
+    fn branch_stays_top_level_when_source_is_absent_or_elsewhere() {
+        let list = vec![
+            ses("orphan", Some("gone"), None),
+            ses("main", None, None),
+            ses("moved", Some("main"), Some("f1")),
+            ses("cycle-a", Some("cycle-b"), None),
+            ses("cycle-b", Some("cycle-a"), None),
+        ];
+        let (top, branches) = nest_branch_sessions(&list);
+        assert!(branches.is_empty());
+        assert_eq!(top.len(), list.len());
+    }
+}
+
 pub(super) fn bucket_sessions_by_date(
     list: &[SessionInfo],
 ) -> (Vec<SessionInfo>, Vec<SessionInfo>) {

--- a/ui/src/dto.rs
+++ b/ui/src/dto.rs
@@ -932,6 +932,9 @@ pub(crate) struct SessionInfo {
     pub(crate) ts: i64,
     #[serde(default)]
     pub(crate) folder_id: Option<String>,
+    /// Source session this one was branched from; nested under it in the sidebar.
+    #[serde(default)]
+    pub(crate) branched_from: Option<String>,
     #[serde(default)]
     pub(crate) pinned: bool,
 }

--- a/ui/src/sidebar.rs
+++ b/ui/src/sidebar.rs
@@ -1,6 +1,6 @@
 use crate::app_support::{
     allow_drop, bucket_sessions_by_date, compose_icon, drag_session_id, load_view_pref,
-    save_view_pref, start_session_drag, AvailableUpdate, FolderModal,
+    nest_branch_sessions, save_view_pref, start_session_drag, AvailableUpdate, FolderModal,
 };
 use crate::dto::*;
 use crate::i18n::{t, tf, Locale};
@@ -247,12 +247,16 @@ pub(super) fn Sidebar(
                     if !pinned.is_empty() {
                         list.retain(|s| !s.pinned);
                     }
+                    // Branch sessions (#531) are lifted out of the flat list and drawn
+                    // nested under the session they were forked from, in whatever group
+                    // that session lands in.
+                    let (list, branch_kids) = nest_branch_sessions(&list);
                     let group = group_by.get();
                     // Whether any folder exists — used to keep the "ungrouped" drop
                     // zone available (so a session can be dragged out of a folder) without
                     // reading drag_session here, which would rebuild the whole list mid-drag.
                     let has_folders = !folder_list.is_empty();
-                    let make = move |s: &SessionInfo| {
+                    let item = move |s: &SessionInfo| {
                         let id = s.id.clone();
                         let id_active = id.clone();
                         let id_attr = id.clone();
@@ -319,6 +323,20 @@ pub(super) fn Sidebar(
                                         ev.stop_propagation();
                                         show_actions.call((ev, id_actions.clone(), title_actions.clone(), pinned));
                                     }>"⋯"</button>
+                            </div>
+                        }.into_view()
+                    };
+                    let make = move |s: &SessionInfo| {
+                        let kids = branch_kids.get(&s.id).cloned().unwrap_or_default();
+                        if kids.is_empty() {
+                            return item(s);
+                        }
+                        view! {
+                            <div class="side-branch-group">
+                                {item(s)}
+                                <div class="side-branch-kids">
+                                    {kids.iter().map(&item).collect_view()}
+                                </div>
                             </div>
                         }.into_view()
                     };

--- a/ui/src/styles/alignment.css
+++ b/ui/src/styles/alignment.css
@@ -106,6 +106,9 @@
 .folder-actions { position: static; flex: 0 0 auto; transform: none; margin: -3px -5px -3px 0; }
 .side-folder-sessions { display: flex; flex-direction: column; gap: 1px; padding-left: 12px; }
 .side-folder-sessions .side-item { padding-left: 18px; }
+/* Branch sessions nested under the session they were forked from (#531). */
+.side-branch-group { display: flex; flex-direction: column; gap: 1px; }
+.side-branch-kids { display: flex; flex-direction: column; gap: 1px; margin-left: 12px; padding-left: 8px; border-left: 1px solid var(--border); }
 .side-ungrouped { display: flex; flex-direction: column; gap: 1px; min-height: 24px; border-radius: 8px; border: 1px solid transparent; }
 .side-ungrouped.drop-target { background: var(--clay-soft); border-color: var(--clay); }
 .side-item.ses.dragging { opacity: .45; cursor: grabbing; }

--- a/ui/src/styles/sidebar.css
+++ b/ui/src/styles/sidebar.css
@@ -241,6 +241,7 @@ button.side-item.ses { cursor: pointer; user-select: none; padding-right: 34px; 
   .sidebar .side-folder .gi { margin: 0; }
   .sidebar .side-folder-sessions { padding-left: 0; }
   .sidebar .side-folder-sessions .side-item { padding-left: 8px; }
+  .sidebar .side-branch-kids { margin-left: 0; padding-left: 4px; }
   .sidebar .side-foot { padding-top: 8px; }
   .sidebar .nav { gap: 4px; }
 }


### PR DESCRIPTION
Closes #531

## 为什么

`branch_session` 之前只是复制前缀消息 + 给标题加 `Branch: ` 前缀，父子关系完全没落库，所以侧栏里分支和主会话平铺在一起，看不出关系。

Issue 里提了两个方案：合并回主会话，或者加层级关系/折叠。**合并没做** —— 两条转录时间线冲突、上下文翻倍，最后还得让用户勾选保留哪些消息。把血缘画出来、点一下就能跳回源会话，是这个需求的实际解法。

## 改了什么

- **`frames.branched_from`**：新增一列，纯展示用途。刻意不复用 `root_frame_id`（参与级联删除，删源会话会连坐删掉分支），也不复用 `parent_frame_id`（`parent_frame_id = id` 是侧栏判定"根会话"的条件）。跟 `folder_id` 一样走 `apply_control_plane_backfill` 的 `has_column` + ALTER，老库自动升级。
- **`branch_session`** 建完 frame 写入来源 id。
- **`list_sessions_page` / `list_pinned_sessions`** 多返回一列，`SessionInfo` 前后端各加一个同名字段。
- **`nest_branch_sessions()`**（`ui/src/app_support.rs`）：纯函数，把分支从平铺列表摘出来挂到源会话下。源不在当前页、或被拖到别的文件夹时保持顶层，不会凭空消失；分支的分支拍平到最上层可见源（只缩进一级），带环路保护。
- **侧栏渲染**拆成 `item` + `make`，分支缩进 + `border-left` 层级线。三种分组模式（文件夹 / 日期 / 无）和置顶块自动生效。

## 审阅要点

- 折叠开关没做：分支通常只有一两条，层级线足够；真嫌长再加 caret。
- 跨项目转移（`project_transfer.rs`）没同步这一列：老导出包没有这个字段，加进 SELECT 会让旧包导入直接失败。代价只是转移后丢失缩进。
- 文件夹标题上的会话计数只算顶层项，嵌套的分支不计入。

## 验证

- `cargo test -p wisp-store`：70 passed，含新增 `branched_from_survives_listing`
- `cd ui && cargo test branch_nesting`：2 个新用例通过（CI 不跑 ui 单测，故用宿主 target）
- `cd ui && cargo check --target wasm32-unknown-unknown`：通过
- mock 预览（`?mock=1`，fixture 里加了 s4/s5 两条分支）确认 `s2 → 分支 → 分支的分支` 正确嵌套、层级线渲染正常
- `cargo test -p wisp-tauri` 有 1 个 artifact 用例失败，`git stash` 后在 main 上同样失败，与本次改动无关

🤖 Generated with [Claude Code](https://claude.com/claude-code)