### PR TITLE
fix(windows): recover User PATH entries ending in backslash

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,9 @@ cargo tauri build    # produce an MSI/NSIS installer under target/release/bundle
   the `winver` result, WebView2 Runtime version, installer filename, and
   reproduction steps in an issue. Never post API keys, tokens, passwords, or
   private keys.
+- At startup, the desktop app normalizes trailing backslashes in `PATH` and
+  recovers affected entries from the Windows User PATH, so tools such as Pixi
+  remain available to the built-in shell.
 
 Desktop development uses port `1421`. UI tests use `1422`, and their Trunk
 outputs are isolated in `ui/dist-dev` and `ui/dist-test`; release packaging

--- a/README_zh.md
+++ b/README_zh.md
@@ -116,6 +116,8 @@ cargo tauri build    # 在 target/release/bundle 下生成 MSI/NSIS 安装程序
 - WebView2 安装完成后重新打开 Wisp Science；如果窗口仍未恢复，请重启 Windows
   后再试。问题仍存在时，请在 issue 中附上 `winver` 结果、WebView2 Runtime
   版本、安装包文件名和复现步骤；不要上传 API Key、Token、密码或私钥。
+- 桌面应用启动时会规范化 `PATH` 条目末尾的反斜杠，并从 Windows User PATH
+  恢复受影响的条目，因此 Pixi 等工具在内置 shell 中仍然可用。
 
 桌面开发固定使用 `1421` 端口，UI 测试使用 `1422`。对应的 Trunk 输出分别
 隔离在 `ui/dist-dev` 与 `ui/dist-test`，发布构建继续使用 `ui/dist`，避免正在

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5738,9 +5738,9 @@ fn set_dev_flag(app: &tauri::AppHandle) {
 /// missing. Resolve the user's real login-shell `PATH` once, up front, and set
 /// it on the process so every downstream consumer sees the same `PATH` the
 /// terminal does. Runs before any threads spawn children (env mutation is safe
-/// here). No-op on Windows.
+/// here).
 #[cfg(not(target_os = "windows"))]
-fn inherit_login_shell_path() {
+fn inherit_user_path() {
     let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".into());
     // Markers survive noisy rc files that print to stdout (p10k instant prompt,
     // MOTD, a stray `echo` in .zshrc). `-ilc` sources both login (.zprofile,
@@ -5767,12 +5767,66 @@ fn inherit_login_shell_path() {
     }
 }
 
+#[cfg(any(target_os = "windows", test))]
+fn trim_windows_path_entry(entry: &str) -> &str {
+    let trimmed = entry.trim_end_matches('\\');
+    let is_drive_root = trimmed.len() == 2 && trimmed.as_bytes()[1] == b':';
+    if trimmed.is_empty() || is_drive_root {
+        entry
+    } else {
+        trimmed
+    }
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn repair_windows_path(inherited_path: &str, user_path: &str) -> String {
+    let mut entries = if inherited_path.is_empty() {
+        Vec::new()
+    } else {
+        inherited_path
+            .split(';')
+            .map(|entry| trim_windows_path_entry(entry).to_owned())
+            .collect::<Vec<_>>()
+    };
+
+    // Explorer can omit User PATH entries ending in `\` from a desktop app's
+    // environment block. Recover only those affected entries from the registry
+    // so terminal-specific additions to the inherited PATH remain intact.
+    for entry in user_path.split(';').filter(|entry| entry.ends_with('\\')) {
+        let entry = trim_windows_path_entry(entry);
+        if !entry.is_empty()
+            && !entries
+                .iter()
+                .any(|existing| existing.eq_ignore_ascii_case(entry))
+        {
+            entries.push(entry.to_owned());
+        }
+    }
+
+    entries.join(";")
+}
+
 #[cfg(target_os = "windows")]
-fn inherit_login_shell_path() {}
+fn inherit_user_path() {
+    use winreg::enums::HKEY_CURRENT_USER;
+    use winreg::RegKey;
+
+    let Ok(inherited_path) = std::env::var("PATH") else {
+        return;
+    };
+    let user_path: String = RegKey::predef(HKEY_CURRENT_USER)
+        .open_subkey("Environment")
+        .and_then(|key| key.get_value("Path"))
+        .unwrap_or_default();
+    let repaired_path = repair_windows_path(&inherited_path, &user_path);
+    if !repaired_path.is_empty() && repaired_path != inherited_path {
+        std::env::set_var("PATH", repaired_path);
+    }
+}
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    inherit_login_shell_path();
+    inherit_user_path();
     let filter = tracing_subscriber::EnvFilter::from_default_env()
         .add_directive("wisp=info".parse().unwrap());
     let subscriber = tracing_subscriber::fmt().with_env_filter(filter);

--- a/src-tauri/src/lib_tests.rs
+++ b/src-tauri/src/lib_tests.rs
@@ -1203,6 +1203,17 @@ fn windows_close_to_tray_applies_only_to_the_main_window() {
 }
 
 #[test]
+fn windows_path_repair_recovers_trailing_user_entries() {
+    let inherited = r"C:\Windows\System32;C:\TOOLS\;C:\";
+    let user = r"C:\IgnoredWithoutSlash;C:\tools\;C:\Users\Ada\AppData\Local\pixi\bin\;D:\";
+
+    assert_eq!(
+        super::repair_windows_path(inherited, user),
+        r"C:\Windows\System32;C:\TOOLS;C:\;C:\Users\Ada\AppData\Local\pixi\bin;D:\"
+    );
+}
+
+#[test]
 fn project_window_url_carries_the_target_session() {
     assert_eq!(
         super::project_commands::project_window_url("abc", None),


### PR DESCRIPTION
## Problem

Closes #542.

Windows desktop launches can omit User PATH entries ending in a trailing backslash, making tools such as Pixi unavailable to the built-in shell even though they work in an external PowerShell session.

## Changes

- Normalize trailing backslashes in the inherited Windows process PATH before child processes start.
- Recover only affected trailing-backslash entries from the read-only User PATH registry value.
- Preserve drive roots such as `C:\`, keep process-specific PATH additions, and deduplicate recovered entries case-insensitively.
- Document the startup behavior in the English and Chinese READMEs.
- Add a pure regression test for omission recovery, normalization, root preservation, and deduplication.

No new dependency, persistence schema, or UI surface is introduced.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p wisp-tauri windows_path_repair_recovers_trailing_user_entries`
- `cargo test --workspace`
- Isolated `x86_64-pc-windows-msvc` type-check of the Windows registry access

## Manual smoke

1. On Windows, add a User PATH entry such as `C:\Users\<user>\AppData\Local\pixi\bin\` with the trailing backslash.
2. Fully quit and reopen Wisp Science.
3. Run `pixi --version` in the built-in shell.
4. Confirm `$env:PATH` contains the normalized Pixi directory.

## Known limitation / follow-up

A packaged-app smoke test on a physical Windows host remains before release. The full repository Windows cross-check cannot run on this Linux host without the MSVC `lib.exe` toolchain; the platform-specific registry call was type-checked separately.