### PR TITLE
feat(plan): 计划模式阶段 3a — 内建会话开关 + 只读工具门

### DIFF
--- a/crates/wisp-core/src/output.rs
+++ b/crates/wisp-core/src/output.rs
@@ -56,6 +56,11 @@ pub trait Output: Send + Sync {
     fn danger_auto_approve(&self) -> bool {
         false
     }
+    /// True while the session is in plan mode, so the tool registry refuses
+    /// everything outside its read-only set. Default `false`.
+    fn plan_mode(&self) -> bool {
+        false
+    }
     /// Fired once per message appended to the context during a turn (user,
     /// assistant, tool). Lets the host persist incrementally so a crash or a
     /// mid-turn "new session" doesn't lose the whole turn. Default: no-op.
@@ -123,6 +128,9 @@ impl<'a> wisp_tools::ToolEnv for ToolEnvAdapter<'a> {
     }
     fn danger_auto_approve(&self) -> bool {
         self.out.danger_auto_approve()
+    }
+    fn plan_mode(&self) -> bool {
+        self.out.plan_mode()
     }
     fn is_cancelled(&self) -> bool {
         self.cancel

--- a/crates/wisp-tools/src/env.rs
+++ b/crates/wisp-tools/src/env.rs
@@ -106,6 +106,12 @@ pub trait ToolEnv: Send + Sync {
     async fn approval_mode(&self, _tool: &str) -> Approval {
         Approval::Allow
     }
+    /// Whether this session is in plan mode: the agent researches and drafts a
+    /// plan, so `Registry::run` refuses every tool outside
+    /// [`crate::PLAN_MODE_READ_ONLY`]. Default `false`.
+    fn plan_mode(&self) -> bool {
+        false
+    }
     /// Whether the "full" approval scope is active — auto-approve everything,
     /// dangerous commands included. Only the shell danger check consults this;
     /// default `false` keeps the CLI and tests prompting on dangerous commands.

--- a/crates/wisp-tools/src/lib.rs
+++ b/crates/wisp-tools/src/lib.rs
@@ -33,6 +33,53 @@ const USE_MCP_TOOL: &str = "use_mcp_tool";
 /// derives the matching result name.
 pub const MCP_EVENT_PREFIX: &str = "mcp:";
 const DEFAULT_MCP_SEARCH_LIMIT: usize = 5;
+
+/// Tools that stay callable while a session is in plan mode (see
+/// [`ToolEnv::plan_mode`]). Everything else is refused at the registry gate:
+/// writes, shell/python/R, delegation, state changes, and every MCP-backed
+/// tool. `search_mcp_tools` is a schema lookup and is allowed by its own path.
+///
+/// ponytail: a name whitelist rather than per-tool metadata — one list to read,
+/// and it fails closed for anything nobody classified. It deliberately names
+/// host tools this crate never sees. Upgrade path, once a tool needs to
+/// disagree or MCP `readOnlyHint` should be honoured: a `Tool::read_only()`
+/// method defaulting to false, with this list kept only as the host override.
+pub const PLAN_MODE_READ_ONLY: &[&str] = &[
+    // wisp-tools built-ins
+    "read",
+    "search",
+    "grep",
+    "view_image",
+    "update_plan",
+    "attempt_completion",
+    // wisp-core / wisp-skills
+    "search_memory",
+    "search_skills",
+    "use_skill",
+    // Desktop host tools that only read or retrieve
+    "web_scan",
+    "web_open_tab",
+    "web_screenshot",
+    "get_run",
+    "monitor_run",
+    "get_delegated_result",
+    // The plan proposal tool: plan mode is exactly when it has to run.
+    "propose_plan",
+];
+
+fn plan_mode_blocks(name: &str) -> bool {
+    !PLAN_MODE_READ_ONLY.contains(&name)
+}
+
+/// Refusal text for a blocked call. Written at the agent, not the user: it has
+/// to steer the model back to planning instead of hunting for a workaround.
+fn plan_mode_refusal(name: &str) -> String {
+    format!(
+        "tool '{name}' is unavailable: this conversation is in plan mode, so it investigates and \
+         writes a plan instead of executing one. Keep researching with read-only tools and finish \
+         the plan; the user approves it before anything runs."
+    )
+}
 const MAX_MCP_SEARCH_LIMIT: usize = 10;
 const MAX_MCP_DESCRIPTION_CHARS: usize = 2_048;
 
@@ -259,6 +306,11 @@ impl Registry {
 
 async fn run_registered_tool(tool: &dyn Tool, args: &Value, env: &dyn ToolEnv) -> ToolResult {
     let name = tool.name();
+    // Plan-mode gate, ahead of approvals: a session that is only allowed to
+    // plan never reaches the approval prompt for a tool that would execute.
+    if env.plan_mode() && plan_mode_blocks(name) {
+        return ToolResult::fail(plan_mode_refusal(name));
+    }
     // Per-tool approval gate. `Deny` blocks before the call card even shows;
     // `Ask` shows the card then routes through `confirm`; `Allow` runs as before.
     let approval = match (env.approval_mode(name).await, tool.minimum_approval()) {
@@ -524,6 +576,53 @@ mod approval_tests {
         // Allow: runs without asking.
         let (ran, res) = run_with(Approval::Allow, false).await;
         assert!(ran && res.success, "allow must run the tool");
+    }
+
+    struct PlanEnv {
+        root: PathBuf,
+        plan: bool,
+    }
+    #[async_trait::async_trait]
+    impl ToolEnv for PlanEnv {
+        fn project_root(&self) -> &Path {
+            &self.root
+        }
+        async fn confirm(&self, _message: &str) -> bool {
+            true
+        }
+        fn plan_mode(&self) -> bool {
+            self.plan
+        }
+        async fn emit(&self, _event: ToolEvent) {}
+    }
+
+    #[tokio::test]
+    async fn plan_mode_blocks_writers_and_lets_readers_through() {
+        let dir = std::env::temp_dir().join("wisp-plan-mode-gate");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("note.txt"), "hello").unwrap();
+        let reg = Registry::builtins();
+        let write = serde_json::json!({ "path": "gated.txt", "content": "no" });
+        let read = serde_json::json!({ "path": dir.join("note.txt").to_string_lossy() });
+
+        let planning = PlanEnv {
+            root: dir.clone(),
+            plan: true,
+        };
+        let blocked = reg.run("write", &write, &planning).await;
+        assert!(!blocked.success);
+        assert!(blocked.content.contains("plan mode"), "{}", blocked.content);
+        assert!(!dir.join("gated.txt").exists(), "the write must not happen");
+        assert!(reg.run("read", &read, &planning).await.success);
+
+        // Same calls with plan mode off: the gate is invisible.
+        let executing = PlanEnv {
+            root: dir.clone(),
+            plan: false,
+        };
+        assert!(reg.run("write", &write, &executing).await.success);
+        assert!(reg.run("read", &read, &executing).await.success);
+        let _ = std::fs::remove_dir_all(dir);
     }
 
     #[tokio::test]

--- a/src-tauri/src/delegation_runtime.rs
+++ b/src-tauri/src/delegation_runtime.rs
@@ -137,18 +137,13 @@ async fn require_workflow_delegation(
 }
 
 pub(crate) fn sync_delegation_prompt(prompt: &mut String, enabled: bool) {
-    while let Some(start) = prompt.find(DELEGATION_PROMPT_START) {
-        let body_start = start + DELEGATION_PROMPT_START.len();
-        let Some(relative_end) = prompt[body_start..].find(DELEGATION_PROMPT_END) else {
-            prompt.truncate(start);
-            break;
-        };
-        let end = body_start + relative_end + DELEGATION_PROMPT_END.len();
-        prompt.replace_range(start..end, "");
-    }
-    if enabled {
-        prompt.push_str(DELEGATION_PROMPT_SECTION);
-    }
+    crate::sync_prompt_section(
+        prompt,
+        DELEGATION_PROMPT_START,
+        DELEGATION_PROMPT_END,
+        DELEGATION_PROMPT_SECTION,
+        enabled,
+    );
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2844,6 +2844,24 @@ fn specialist_prompt_section(spec: &specialists::Specialist) -> String {
     format!("\n\n## Specialist: {}\n{}", spec.name, spec.instructions)
 }
 
+/// Idempotently add or remove a delimited system-prompt section. The prompt is
+/// persisted as message 0 and reloaded on every runtime rebuild, so a toggled-off
+/// capability has to strip whatever an earlier turn appended (including a
+/// truncated section from an interrupted write).
+fn sync_prompt_section(prompt: &mut String, start: &str, end: &str, section: &str, enabled: bool) {
+    while let Some(at) = prompt.find(start) {
+        let body = at + start.len();
+        let Some(relative_end) = prompt[body..].find(end) else {
+            prompt.truncate(at);
+            break;
+        };
+        prompt.replace_range(at..body + relative_end + end.len(), "");
+    }
+    if enabled {
+        prompt.push_str(section);
+    }
+}
+
 async fn load_mcp_connections(store: &Store) -> Vec<McpConnection> {
     store
         .get_setting("mcp_connections")
@@ -4167,6 +4185,7 @@ async fn send_message_inner(
     let specialist = specialists::session_specialist(&state.store, &frame_id).await;
     let delegation_enabled =
         delegation_runtime::session_delegation_enabled(&state.store, &frame_id).await;
+    let plan_mode_enabled = plan_mode::session_plan_mode(&state.store, &frame_id).await;
     let (provider, api_url, model, api_key, max_tokens, reasoning_effort) = match &specialist {
         Some(spec) if !spec.model_id.trim().is_empty() => {
             specialists::specialist_llm(&state.store, spec).await
@@ -4397,6 +4416,7 @@ async fn send_message_inner(
         if let Some(message) = agent.ctx.messages.first_mut() {
             if let wisp_llm::Content::Text(prompt) = &mut message.content {
                 delegation_runtime::sync_delegation_prompt(prompt, delegation_enabled);
+                plan_mode::sync_plan_prompt(prompt, plan_mode_enabled);
             }
         }
         if let Some(spec) = &specialist {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -45,6 +45,7 @@ mod memory_commands;
 mod models;
 mod native_delegation;
 mod pet_commands;
+mod plan_mode;
 mod plugins;
 mod project_commands;
 mod project_reader;
@@ -6050,6 +6051,8 @@ pub fn run() {
             delegation_runtime::list_agent_workflows,
             delegation_runtime::get_session_delegation_enabled,
             delegation_runtime::set_session_delegation_enabled,
+            plan_mode::get_session_plan_mode,
+            plan_mode::set_session_plan_mode,
             delegation_completion::get_session_agent_completion,
             delegation_completion::set_session_agent_completion,
             delegation_runtime::create_dynamic_agent_workflow,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1866,6 +1866,9 @@ struct TauriOutput {
     awaiting_confirm: Arc<StdMutex<HashSet<String>>>,
     /// Shared live approval policy (see `AppState::approvals`).
     approvals: Arc<StdRwLock<ApprovalPolicy>>,
+    /// Built-in plan mode for this session, read once per turn. ACP-bound
+    /// frames never set it — their plan mode lives on the agent side.
+    plan_mode: bool,
     approval_grants: Arc<StdMutex<ApprovalGrants>>,
     /// Incremental-persistence sink: each message the turn produces is sent here
     /// and written to SQLite by a background task, so a crash or mid-turn "new
@@ -2058,6 +2061,9 @@ impl Output for TauriOutput {
     }
     fn danger_auto_approve(&self) -> bool {
         self.approvals.read().map(|p| p.full()).unwrap_or(false)
+    }
+    fn plan_mode(&self) -> bool {
+        self.plan_mode
     }
     fn on_message(&self, msg: &Message) {
         if msg.role == wisp_llm::Role::User {
@@ -4732,6 +4738,7 @@ async fn send_message_inner(
         confirms: state.confirms.clone(),
         awaiting_confirm: state.awaiting_confirm.clone(),
         approvals: state.approvals.clone(),
+        plan_mode: plan_mode_enabled,
         approval_grants: state.approval_grants.clone(),
         persist: Some(persist_tx),
         ui_events: Some(ui_event_tx),

--- a/src-tauri/src/plan_mode.rs
+++ b/src-tauri/src/plan_mode.rs
@@ -10,8 +10,27 @@
 use tauri::State;
 use wisp_store::Store;
 
+const PLAN_PROMPT_START: &str = "\n\n<plan_mode>";
+const PLAN_PROMPT_END: &str = "</plan_mode>";
+/// ponytail: stage 3b replaces this wording with instructions to call the
+/// `propose_plan` tool, so the whole contract stays a one-const diff.
+const PLAN_PROMPT_SECTION: &str = "\n\n<plan_mode>\nThe user turned on plan mode for this conversation. Investigate the task and produce a plan; do not carry it out.\nResearch first — read files, search the project, and look things up until you actually understand the task. Then write the plan as ordered, concrete steps, each naming what would change and how it would be verified. Call out the open questions and the risks you found.\nDo not execute the plan. Tools that write files, run shell/Python/R code, or otherwise change state are blocked in this mode and will refuse the call; that refusal is expected, not an error to work around. Stop once the plan is written and wait for the user to approve it.\n</plan_mode>";
+
 fn setting_key(frame_id: &str) -> String {
     format!("frame_plan_mode:{frame_id}")
+}
+
+/// Add or remove the plan-mode section on a session's system prompt. Called on
+/// the rebuilt runtime, so a toggle mid-session lands on the next turn (see
+/// `set_session_plan_mode`, which evicts idle runtimes).
+pub(crate) fn sync_plan_prompt(prompt: &mut String, enabled: bool) {
+    crate::sync_prompt_section(
+        prompt,
+        PLAN_PROMPT_START,
+        PLAN_PROMPT_END,
+        PLAN_PROMPT_SECTION,
+        enabled,
+    );
 }
 
 /// Whether this frame is in built-in plan mode. ACP-bound frames always report
@@ -89,6 +108,16 @@ pub(crate) async fn set_session_plan_mode(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn prompt_section_toggles_without_stacking() {
+        let mut prompt = String::from("base");
+        sync_plan_prompt(&mut prompt, true);
+        sync_plan_prompt(&mut prompt, true);
+        assert_eq!(prompt.matches(PLAN_PROMPT_START).count(), 1);
+        sync_plan_prompt(&mut prompt, false);
+        assert_eq!(prompt, "base");
+    }
 
     #[tokio::test]
     async fn flag_round_trips_per_frame() {

--- a/src-tauri/src/plan_mode.rs
+++ b/src-tauri/src/plan_mode.rs
@@ -1,0 +1,110 @@
+//! Plan mode for built-in (non-ACP) sessions: the agent investigates and
+//! drafts a plan instead of executing it. ACP-bound sessions have their own
+//! plan mode on the agent side and never use this flag.
+//!
+//! The flag rides the `settings` kv table keyed by frame, exactly like
+//! `frame_delegation_enabled` — a per-session boolean does not deserve a
+//! migration, and it must never touch the `frames.model` column (that field's
+//! `acp:<label>` marker is a contract with the UI's model badge).
+
+use tauri::State;
+use wisp_store::Store;
+
+fn setting_key(frame_id: &str) -> String {
+    format!("frame_plan_mode:{frame_id}")
+}
+
+/// Whether this frame is in built-in plan mode. ACP-bound frames always report
+/// `false`: their plan mode lives on the agent side, so the local tool gate
+/// must stay out of their way.
+pub(crate) async fn session_plan_mode(store: &Store, frame_id: &str) -> bool {
+    if matches!(store.get_acp_session(frame_id).await, Ok(Some(_))) {
+        return false;
+    }
+    store
+        .get_setting(&setting_key(frame_id))
+        .await
+        .ok()
+        .flatten()
+        .and_then(|value| value.parse::<bool>().ok())
+        .unwrap_or(false)
+}
+
+async fn ensure_project_frame(
+    store: &Store,
+    project_id: &str,
+    frame_id: &str,
+) -> Result<(), String> {
+    match store
+        .frame_project_id(frame_id)
+        .await
+        .map_err(|error| error.to_string())?
+        .as_deref()
+    {
+        Some(owner) if owner == project_id => Ok(()),
+        Some(_) => Err("Conversation does not belong to the active project.".into()),
+        None => Err("Conversation does not exist.".into()),
+    }
+}
+
+/// `None` means the session is ACP-bound, so the composer toggle must drive the
+/// ACP mode picker instead of this flag.
+#[tauri::command]
+pub(crate) async fn get_session_plan_mode(
+    state: State<'_, crate::AppState>,
+    window: tauri::WebviewWindow,
+    session_id: String,
+) -> Result<Option<bool>, String> {
+    let project = state.active(window.label());
+    ensure_project_frame(&state.store, &project.id, &session_id).await?;
+    if matches!(state.store.get_acp_session(&session_id).await, Ok(Some(_))) {
+        return Ok(None);
+    }
+    Ok(Some(session_plan_mode(&state.store, &session_id).await))
+}
+
+#[tauri::command]
+pub(crate) async fn set_session_plan_mode(
+    state: State<'_, crate::AppState>,
+    window: tauri::WebviewWindow,
+    session_id: String,
+    enabled: bool,
+) -> Result<bool, String> {
+    let project = state.active(window.label());
+    ensure_project_frame(&state.store, &project.id, &session_id).await?;
+    if matches!(state.store.get_acp_session(&session_id).await, Ok(Some(_))) {
+        return Err("This conversation is bound to an ACP agent; use its own plan mode.".into());
+    }
+    state
+        .store
+        .set_setting(&setting_key(&session_id), &enabled.to_string())
+        .await
+        .map_err(|error| error.to_string())?;
+    // The system prompt section is stitched in when the session runtime is
+    // built, so evict idle runtimes to make the toggle take effect this turn.
+    crate::clear_idle_agents(&state).await;
+    Ok(enabled)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn flag_round_trips_per_frame() {
+        let path =
+            std::env::temp_dir().join(format!("wisp_plan_mode_{}.sqlite", uuid::Uuid::new_v4()));
+        let store = Store::open(&path).await.unwrap();
+        store.create_project("p", "One", "").await.unwrap();
+        store
+            .create_frame("f", "p", "Agent", "model")
+            .await
+            .unwrap();
+        assert!(!session_plan_mode(&store, "f").await);
+        store.set_setting(&setting_key("f"), "true").await.unwrap();
+        assert!(session_plan_mode(&store, "f").await);
+        assert!(!session_plan_mode(&store, "other").await);
+        drop(store);
+        let _ = std::fs::remove_file(path);
+    }
+}

--- a/ui/mock-bridge.js
+++ b/ui/mock-bridge.js
@@ -140,6 +140,8 @@
   let nextCustomCredential = 1;
   // frame_id -> enabled execution context ids, mirroring session_execution_contexts.
   const sessionContexts = {};
+  // frame_id -> built-in plan mode flag (settings key frame_plan_mode:<id>).
+  const mockPlanMode = {};
   // Agent-created SSH trust edges (ssh_trust_edges_v1). One edge whose
   // destination context no longer exists, to exercise the orphan rendering.
   const mockTrustEdges = [
@@ -820,6 +822,13 @@
             edits.push(version);
             return version;
           }
+          // Built-in plan mode: `null` would mean "ACP-bound", which hides the
+          // composer toggle, so the mock always answers with a real boolean.
+          case "get_session_plan_mode":
+            return mockPlanMode[args?.sessionId] ?? false;
+          case "set_session_plan_mode":
+            mockPlanMode[args?.sessionId] = !!args?.enabled;
+            return mockPlanMode[args?.sessionId];
           default:
             return null;
         }

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -4990,10 +4990,12 @@ fn App() -> impl IntoView {
         delegation_enabled.set(false);
         delegation_setting_busy.set(false);
         plan_mode_busy.set(false);
+        // Reset before the fetch: otherwise the previous session's flag shows
+        // on the new one for as long as the round trip takes.
+        local_plan_mode.set(Some(false));
         agent_completion.set(AgentCompletionSettings::default());
         agent_completion_busy.set(false);
         let Some(session_id) = active_session.get() else {
-            local_plan_mode.set(Some(false));
             return;
         };
         spawn_local(async move {

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -4979,14 +4979,21 @@ fn App() -> impl IntoView {
     let auto_review_enabled = create_rw_signal(false);
     let delegation_enabled = create_rw_signal(false);
     let delegation_setting_busy = create_rw_signal(false);
+    // Built-in plan mode for the active session. `None` = the session is
+    // ACP-bound, so the composer's "Plan first" toggle drives the ACP mode
+    // picker instead of this flag. A session-less composer counts as built-in.
+    let local_plan_mode = create_rw_signal::<Option<bool>>(Some(false));
+    let plan_mode_busy = create_rw_signal(false);
     let agent_completion = create_rw_signal(AgentCompletionSettings::default());
     let agent_completion_busy = create_rw_signal(false);
     create_effect(move |_| {
         delegation_enabled.set(false);
         delegation_setting_busy.set(false);
+        plan_mode_busy.set(false);
         agent_completion.set(AgentCompletionSettings::default());
         agent_completion_busy.set(false);
         let Some(session_id) = active_session.get() else {
+            local_plan_mode.set(Some(false));
             return;
         };
         spawn_local(async move {
@@ -4995,6 +5002,10 @@ fn App() -> impl IntoView {
                 .await
                 .ok()
                 .and_then(|value| value.as_bool());
+            let plan = invoke_checked("get_session_plan_mode", args.clone())
+                .await
+                .ok()
+                .map(|value| value.as_bool());
             let completion = invoke_checked("get_session_agent_completion", args)
                 .await
                 .ok()
@@ -5003,6 +5014,7 @@ fn App() -> impl IntoView {
                 });
             if active_session.get_untracked().as_deref() == Some(session_id.as_str()) {
                 delegation_enabled.set(enabled.unwrap_or(false));
+                local_plan_mode.set(plan.unwrap_or(None));
                 agent_completion.set(completion.unwrap_or_default());
             }
         });
@@ -8809,12 +8821,20 @@ fn App() -> impl IntoView {
                                 <div class="compose-menu agent-menu" role="menu"
                                     aria-label=move || t(locale.get(), "composer.agent_options")>
                                     {move || {
-                                        // Shortcut for the plan/default pair of the ACP mode picker
-                                        // in the model menu; agents without a plan mode get no row.
-                                        let session_id = active_session.get()?;
-                                        let (plan_mode, exit_mode) = acp_session_modes
-                                            .with(|all| plan_mode_pair(all.get(&session_id)))?;
-                                        let on_plan = plan_mode_active.get();
+                                        // One control, two backends: ACP-bound sessions switch the
+                                        // agent's own plan/default mode pair (and get no row when the
+                                        // agent has none), built-in sessions flip the local flag.
+                                        let session_id = active_session.get();
+                                        let local = local_plan_mode.get();
+                                        let acp_pair = match (&local, &session_id) {
+                                            (None, Some(id)) => acp_session_modes
+                                                .with(|all| plan_mode_pair(all.get(id))),
+                                            _ => None,
+                                        };
+                                        if local.is_none() && acp_pair.is_none() {
+                                            return None;
+                                        }
+                                        let on_plan = local.unwrap_or_else(|| plan_mode_active.get());
                                         Some(view! {
                                             <label class="agent-menu-row"
                                                 title=move || t(locale.get(), if on_plan { "plan.switch_default" } else { "plan.switch_plan" })>
@@ -8822,11 +8842,56 @@ fn App() -> impl IntoView {
                                                 <span class="toggle agent-menu-toggle">
                                                     <input type="checkbox" data-testid="plan-first-toggle"
                                                         prop:checked=on_plan
+                                                        disabled=move || plan_mode_busy.get()
                                                         on:change=move |ev| {
                                                             let enabled = event_target_checked(&ev);
-                                                            let target = if enabled { plan_mode.clone() } else { exit_mode.clone() };
-                                                            let session_id = session_id.clone();
                                                             let loc = locale.get_untracked();
+                                                            let Some((plan_mode, exit_mode)) = acp_pair.clone() else {
+                                                                local_plan_mode.set(Some(enabled));
+                                                                plan_mode_busy.set(true);
+                                                                spawn_local(async move {
+                                                                    let (session_id, created_session) = match active_session.get_untracked() {
+                                                                        Some(session_id) => (session_id, false),
+                                                                        None if enabled => {
+                                                                            let Some(session_id) = invoke("new_session", JsValue::UNDEFINED).await.as_string() else {
+                                                                                local_plan_mode.set(Some(false));
+                                                                                plan_mode_busy.set(false);
+                                                                                return;
+                                                                            };
+                                                                            (session_id, true)
+                                                                        }
+                                                                        None => {
+                                                                            local_plan_mode.set(Some(false));
+                                                                            plan_mode_busy.set(false);
+                                                                            return;
+                                                                        }
+                                                                    };
+                                                                    let args = to_value(&serde_json::json!({
+                                                                        "sessionId": session_id.clone(),
+                                                                        "enabled": enabled,
+                                                                    })).unwrap();
+                                                                    let saved = invoke_checked("set_session_plan_mode", args).await
+                                                                        .ok()
+                                                                        .and_then(|value| value.as_bool());
+                                                                    if created_session {
+                                                                        active_session.set(Some(session_id.clone()));
+                                                                        items.set(vec![]);
+                                                                        refresh_session_history();
+                                                                    }
+                                                                    if active_session.get_untracked().as_deref() == Some(session_id.as_str()) {
+                                                                        local_plan_mode.set(Some(saved.unwrap_or(!enabled)));
+                                                                        plan_mode_busy.set(false);
+                                                                    }
+                                                                    if saved.is_some() {
+                                                                        show_toast(&t(loc, if enabled { "plan.enabled" } else { "plan.default_enabled" }));
+                                                                    }
+                                                                });
+                                                                return;
+                                                            };
+                                                            let target = if enabled { plan_mode } else { exit_mode };
+                                                            let Some(session_id) = session_id.clone() else {
+                                                                return;
+                                                            };
                                                             spawn_local(async move {
                                                                 if apply_acp_mode(acp_session_modes, session_id, target).await {
                                                                     show_toast(&t(loc, if enabled { "plan.enabled" } else { "plan.default_enabled" }));


### PR DESCRIPTION
计划模式双源路线的**阶段 3a**：给内建（非 ACP 绑定）会话加上计划模式开关，并在工具注册表的中央闸门加只读门。

`propose_plan` 工具和批准环是**下一张卡（3b）**的活，本卡不做。合并后的中间态是有意的：内建会话开了计划模式后，agent 收到"只调研、产计划、不执行"的指令，写类工具被闸门拦截，计划以**普通文本回复**呈现——还不是结构化卡片。

## 改了什么

**1. 会话级 plan 标志**（`src-tauri/src/plan_mode.rs`）
复用现有的 `settings` kv 表，键 `frame_plan_mode:<frame_id>`，跟 `frame_delegation_enabled` 完全同款——**没有新迁移**。刻意不碰 `frames.model` 列：那个字段的 `acp:<label>` 标记与 UI model badge 是配对契约。
新命令 `get_session_plan_mode` / `set_session_plan_mode`；前者对 ACP 绑定会话返回 `null`，这是 UI 分路的依据。

**2. composer "先计划"开关扩展到内建会话**（`ui/src/main.rs`）
同一个控件两条后端路径：ACP 绑定会话保持原逻辑（切 agent 自己的 plan/default 模式对，agent 没有 plan 模式就照旧不渲染）；非 ACP 会话恒显示，切换本地标志。无活跃会话时打开开关会先建会话（沿用 Delegation 那条已验证的路径）。状态跟着持久化走，重启后还原。

**3. 系统提示注入**（`src-tauri/src/lib.rs`）
挂在 `seed_system_prompt` 之后、delegation section 旁边——同一条链。指令文案单独一个 const（3b 会改它，届时指示 agent 调 `propose_plan`）。
顺带把 delegation 与 plan 两处 section 的"先剥离再追加"算法合并成一个 `sync_prompt_section` helper，净减代码，delegation 的既有单测原样通过。

**4. 只读工具门**（`crates/wisp-tools/src/lib.rs`，本卡核心）
`run_registered_tool` 里**一处 guard**，排在连接器审批门之前。直接调用和 `use_mcp_tool` 转发都必经此处，不需逐工具改。plan 模式下非白名单工具返回结构化拒绝，文案是写给模型看的（继续用只读工具完善计划，别找绕过办法）。
白名单 `PLAN_MODE_READ_ONLY` 枚举了现有注册表里的内建工具（读文件/列目录/搜索/网页读取放行；写文件、shell/python/R、委派、状态变更拦截），并已包含 `propose_plan`——3b 直接可用。`ponytail:` 注释标注了这是白名单式分类及升级路径（`Tool::read_only()` + MCP `readOnlyHint`）。

## 约束遵守情况

- **ACP 绑定会话完全不受影响**：`session_plan_mode` 先查 `get_acp_session`，绑定的一律返回 false；`set_session_plan_mode` 对绑定会话直接报错。
- `ui/` 独立 workspace，**没跑 `cargo fmt`**。
- webview 两侧 DTO 逐字段对齐，invoke 参数 key 全 camelCase，两个新命令都补了 `ui/mock-bridge.js` case。
- 没有新增事件推送，不涉及 `emit` / `emit_to`。

## 验证

- `ui/` `cargo check --target wasm32-unknown-unknown` ✅
- `src-tauri` `cargo check` ✅
- `cargo test --workspace` ✅ —— 唯一失败 `artifact_commands::tests::artifact_registration_requires_an_existing_file`，在干净树（stash 后）同样失败，与本卡无关
- 工具门单测 `plan_mode_blocks_writers_and_lets_readers_through`：plan 模式下 `write` 被拒**且文件确实没落盘**、`read` 放行；非 plan 模式两者都通
- `plan_mode` 模块单测：标志按 frame 隔离；提示 section 反复开关不叠加、关掉后还原原文
- `?mock=1` 实测过渲染：非 ACP 会话下 "Plan first" 正常出现，开/关都能翻，无相关 console 报错

## Reviewer 需要知道的

**MCP 工具在 plan 模式下一律被拦截**，包括内置的 bio 检索连接器。这是白名单失败关闭的必然结果——MCP 工具名是运行时动态的，wisp-mcp 目前也没采集 `readOnlyHint` 注解。如果认为计划阶段必须能做文献检索，升级路径已写在 `ponytail:` 注释里，可以作为后续一张小卡。

**并行提醒**：另一张"阶段 2"卡也在动 `ui/src/main.rs`（计划卡动作条区域），本卡不碰计划卡，冲突面小；谁后合并谁 rebase main。

🤖 Generated with [Claude Code](https://claude.com/claude-code)