### PR TITLE
feat(plan): 计划模式阶段 2 —— compat 徽章、保存退出、模式状态重启丢失

### DIFF
--- a/src-tauri/src/acp.rs
+++ b/src-tauri/src/acp.rs
@@ -179,6 +179,46 @@ pub(crate) async fn get_acp_session_agent(
         .map(|binding| binding.agent_profile_id))
 }
 
+/// The mode controls need `availableModes`, but nothing launches the agent until
+/// the first turn, so after an app restart they would stay hidden until the user
+/// sent a message. Serve the cached list for the bound profile instead.
+///
+/// `currentModeId` is deliberately left out: it belongs to a session whose agent
+/// process is gone, and the caller seeds this without overwriting a live one.
+#[tauri::command]
+pub(crate) async fn get_acp_session_state(
+    state: State<'_, AppState>,
+    window: tauri::WebviewWindow,
+    frame_id: String,
+) -> Result<Option<serde_json::Value>, String> {
+    let project = state.active(window.label());
+    if state
+        .store
+        .frame_project_id(&frame_id)
+        .await
+        .map_err(|error| error.to_string())?
+        .as_deref()
+        != Some(project.id.as_str())
+    {
+        return Err("Session does not belong to the active project.".into());
+    }
+    let Some(binding) = state
+        .store
+        .get_acp_session(&frame_id)
+        .await
+        .map_err(|error| error.to_string())?
+    else {
+        return Ok(None);
+    };
+    Ok(state
+        .store
+        .get_setting(&available_modes_key(&binding.profile_fingerprint))
+        .await
+        .map_err(|error| error.to_string())?
+        .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok())
+        .map(|modes| serde_json::json!({ "availableModes": modes })))
+}
+
 #[tauri::command]
 pub(crate) async fn save_acp_agent(
     state: State<'_, AppState>,
@@ -411,6 +451,10 @@ pub(crate) fn project_mcp_server(
     ))
 }
 
+fn available_modes_key(profile_fingerprint: &str) -> String {
+    format!("acp.available_modes.{profile_fingerprint}")
+}
+
 async fn runtime_for(
     state: &AppState,
     project: &ActiveProject,
@@ -507,6 +551,24 @@ async fn runtime_for(
             .map_err(|error| error.to_string())?;
         (start.session_id, start.state)
     };
+    // `availableModes` decides whether the plan toggle and the plan card actions
+    // render at all, and it is a property of the profile rather than of this
+    // session — cache it so those controls survive an app restart, which leaves
+    // no agent process to ask. Keyed by fingerprint so a profile whose launch
+    // command changed re-learns its modes instead of reusing stale ones.
+    if let Some(modes) = session_state
+        .modes
+        .as_ref()
+        .and_then(|modes| modes.get("availableModes"))
+    {
+        let _ = state
+            .store
+            .set_setting(
+                &available_modes_key(&profile_fingerprint),
+                &modes.to_string(),
+            )
+            .await;
+    }
     let runtime = Arc::new(AcpRuntime {
         profile_id: profile.id.clone(),
         fingerprint: profile_fingerprint.clone(),
@@ -1151,13 +1213,10 @@ pub(crate) async fn set_acp_session_mode(
     {
         return Err("Session does not belong to the active project.".into());
     }
-    let runtime = state
-        .acp_sessions
-        .lock()
-        .await
-        .get(&frame_id)
-        .cloned()
-        .ok_or_else(|| "ACP session is not active.".to_string())?;
+    // Not `acp_sessions` directly: the mode controls are visible from the cached
+    // `availableModes` before the session's first turn, so switching mode has to
+    // launch and resume the agent the same way sending a message would.
+    let runtime = runtime_for(&state, &project, &frame_id, None).await?;
     runtime
         .handle
         .set_mode(runtime.session_id.clone(), mode_id.clone())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6039,6 +6039,7 @@ pub fn run() {
             channels::weixin_unbind,
             acp::list_acp_agents,
             acp::get_acp_session_agent,
+            acp::get_acp_session_state,
             acp::save_acp_agent,
             acp::remove_acp_agent,
             acp::test_acp_agent,

--- a/ui/mock-bridge.js
+++ b/ui/mock-bridge.js
@@ -269,6 +269,10 @@
             return { id: "default", name: project.name, workspace_dir: project.root, session_count: sessions.length, artifact_count: 3, updated_at: 1 };
           case "delete_project":
             return null;
+          case "get_acp_session_state":
+            // Matches the real command: `availableModes` only, never
+            // `currentModeId`. Swap "plan" for another id to see a compat card.
+            return { availableModes: [{ id: "default" }, { id: "plan" }] };
           case "pick_directory":
             return "/Users/mock/Desktop/demo-project";
           case "load_session":

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -4664,6 +4664,16 @@ fn App() -> impl IntoView {
         })
     });
 
+    // Agents without a plan mode still push plan updates — a Claude Code todo
+    // list arrives as one. The card renders, but there is no mode to approve out
+    // of, so it is badged as a read-only compatibility plan instead.
+    let plan_compat = Signal::derive(move || {
+        let Some(session_id) = active_session.get() else {
+            return true;
+        };
+        acp_session_modes.with(|all| plan_mode_pair(all.get(&session_id)).is_none())
+    });
+
     // ponytail: an ACP plan update is a todo list with no id to approve, so
     // "approve" is the mode switch plus one ordinary turn. Upgrade to a
     // structured approval only if ACP ever gains a plan-decision request.
@@ -8167,7 +8177,7 @@ fn App() -> impl IntoView {
                                                 i, &item, timestamp, &arts, on_artifact_select, on_file_link,
                                                 run_records, busy.read_only(), compact_assistant, active_acp_agent_id.get().is_none(), can_undo, edit_message, branch_message, undo_message, sid,
                                                 respond_confirm, on_resume, on_queue,
-                                                plan_mode_active, on_plan_decision,
+                                                plan_mode_active, plan_compat, on_plan_decision,
                                             )}
                                         </div>
                                     }.into_view()
@@ -12325,6 +12335,7 @@ fn render_item(
     on_resume: Callback<usize>,
     on_queue: Callback<QueueOp>,
     plan_mode_active: Signal<bool>,
+    plan_compat: Signal<bool>,
     on_plan_decision: Callback<bool>,
 ) -> impl IntoView {
     let locale = use_locale();
@@ -12510,7 +12521,8 @@ fn render_item(
             let streaming = plan.state == PlanState::Streaming;
             let entries = plan.entries.clone();
             view! {
-                <article class="plan-card" class:streaming=streaming data-testid="plan-card">
+                <article class="plan-card" class:streaming=streaming
+                    class:compat=move || plan_compat.get() data-testid="plan-card">
                     <header class="plan-card-head">
                         <span class="plan-card-icon">{compose_icon("plan")}</span>
                         <div>
@@ -12523,6 +12535,12 @@ fn render_item(
                                 })
                             }}
                         </div>
+                        {move || plan_compat.get().then(|| view! {
+                            <span class="plan-card-compat" data-testid="plan-compat"
+                                title=move || t(locale.get(), "plan.compat_full")>
+                                {move || t(locale.get(), "plan.compat")}
+                            </span>
+                        })}
                     </header>
                     <ul class="plan-card-body" data-testid="plan-entries">
                         {entries.into_iter().map(|entry| {

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -505,6 +505,15 @@ fn plan_mode_pair(state: Option<&serde_json::Value>) -> Option<(String, String)>
     Some((plan.to_string(), exit.to_string()))
 }
 
+/// What the plan card's action bar was asked to do. All three end plan mode
+/// except `Modify`, which keeps it so the agent re-plans from the composer.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum PlanDecision {
+    Approve,
+    Modify,
+    SaveExit,
+}
+
 fn acp_current_mode_id(state: Option<&serde_json::Value>) -> Option<&str> {
     state?.get("currentModeId")?.as_str()
 }
@@ -4677,9 +4686,9 @@ fn App() -> impl IntoView {
     // ponytail: an ACP plan update is a todo list with no id to approve, so
     // "approve" is the mode switch plus one ordinary turn. Upgrade to a
     // structured approval only if ACP ever gains a plan-decision request.
-    let on_plan_decision = Callback::new(move |approve: bool| {
+    let on_plan_decision = Callback::new(move |decision: PlanDecision| {
         let loc = locale.get_untracked();
-        if !approve {
+        if decision == PlanDecision::Modify {
             focus_composer();
             show_toast(&t(loc, "plan.modify_hint"));
             return;
@@ -4698,6 +4707,13 @@ fn App() -> impl IntoView {
                 if !apply_acp_mode(acp_session_modes, session_id, exit_mode).await {
                     return;
                 }
+            }
+            // The plan itself is already persisted, so "save and exit" is the
+            // mode switch and nothing else — that is its whole difference from
+            // approve.
+            if decision == PlanDecision::SaveExit {
+                show_toast(&t(loc, "plan.saved"));
+                return;
             }
             // A draft in the composer is the user's own go-ahead; only fill in a
             // default so approving never discards what they typed.
@@ -12336,7 +12352,7 @@ fn render_item(
     on_queue: Callback<QueueOp>,
     plan_mode_active: Signal<bool>,
     plan_compat: Signal<bool>,
-    on_plan_decision: Callback<bool>,
+    on_plan_decision: Callback<PlanDecision>,
 ) -> impl IntoView {
     let locale = use_locale();
     match item {
@@ -12566,12 +12582,16 @@ fn render_item(
                     {move || plan_mode_active.get().then(|| view! {
                         <footer class="plan-card-actions">
                             <button type="button" class="primary" data-testid="plan-approve"
-                                on:click=move |_| on_plan_decision.call(true)>
+                                on:click=move |_| on_plan_decision.call(PlanDecision::Approve)>
                                 {move || t(locale.get(), "plan.approve")}
                             </button>
                             <button type="button" data-testid="plan-modify"
-                                on:click=move |_| on_plan_decision.call(false)>
+                                on:click=move |_| on_plan_decision.call(PlanDecision::Modify)>
                                 {move || t(locale.get(), "plan.modify")}
+                            </button>
+                            <button type="button" data-testid="plan-save-exit"
+                                on:click=move |_| on_plan_decision.call(PlanDecision::SaveExit)>
+                                {move || t(locale.get(), "plan.save_exit")}
                             </button>
                         </footer>
                     })}

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -1094,6 +1094,33 @@ fn App() -> impl IntoView {
             active_acp_agent_id.set(next);
         });
     });
+    // `acp-session-state` only fires while a turn runs, so after an app restart
+    // the mode controls would stay hidden until the user sent a message. Seed
+    // the cached `availableModes` on open instead — `or_insert` so a session
+    // that already has live state (including `currentModeId`) is left alone.
+    create_effect(move |_| {
+        let Some(session_id) = active_session.get() else {
+            return;
+        };
+        if acp_session_modes.with_untracked(|all| all.contains_key(&session_id)) {
+            return;
+        }
+        spawn_local(async move {
+            let args = to_value(&serde_json::json!({ "frameId": session_id.clone() })).unwrap();
+            let Ok(value) = invoke_checked("get_acp_session_state", args).await else {
+                return;
+            };
+            let Ok(Some(modes)) =
+                serde_wasm_bindgen::from_value::<Option<serde_json::Value>>(value)
+            else {
+                return;
+            };
+            acp_session_modes.update(|all| {
+                all.entry(session_id).or_insert(modes);
+            });
+        });
+    });
+
     refresh_session_history();
     refresh_folders(folders);
 

--- a/ui/src/styles/chat.css
+++ b/ui/src/styles/chat.css
@@ -136,6 +136,7 @@
 .plan-card-head > div { display: flex; min-width: 0; flex: 1; flex-direction: column; gap: 1px; }
 .plan-card-head strong { color: var(--text); font-size: 11.5px; }
 .plan-card-head > div > span { color: var(--text-faint); font-size: 9.5px; }
+.plan-card-compat { flex: none; padding: 1px 7px; border-radius: 999px; background: var(--bg-sunken); color: var(--text-faint); font-size: 9.5px; font-weight: 700; letter-spacing: .04em; text-transform: uppercase; }
 .plan-card-body { margin: 0; padding: 14px 16px; color: var(--text); font-size: 13px; line-height: 1.62; list-style: none; }
 .plan-card-body > :first-child { margin-top: 0; }
 .plan-card-body > :last-child { margin-bottom: 0; }


### PR DESCRIPTION
计划模式双源路线的阶段 2：ACP 侧收尾三件套。基于阶段 1（8588cc7 / 2f97aea）的结构化计划卡。三个提交按三件事拆分。

## 1. compat 兼容徽章 (`e497ea3`)

计划卡存在、但当前会话的 ACP agent 不支持计划模式时，卡片加 `.compat` class 并显示徽章。

新增 `plan_compat` 信号，判据就是现成的 `plan_mode_pair(...) == None`，放在 `plan_mode_active` 旁边对称。徽章文案 `plan.compat`，`title` 用 `plan.compat_full`（i18n 双语已预留）。`.plan-card.compat` 的边框规则 chat.css 里本来就有，只补了徽章本身的 `.plan-card-compat`（照 `.plan-entry-priority` 的样式写法）。

## 2. save_exit 保存退出按钮 (`852ab16`)

计划卡动作条第三个按钮，显示条件与 approve 相同（`plan_mode_active`）。行为 = `apply_acp_mode` 切到 exit mode + toast `plan.saved`，**不发消息**。

实现上把 approve/modify 的 `bool` 换成了 `PlanDecision{Approve,Modify,SaveExit}`，而不是加第二个 callback——这样第三个按钮直接复用同一段 awaited 的 `apply_acp_mode`，不用把切模式的逻辑抄一遍。

## 3. 修模式状态重启丢失 (`d61c8e1`)

**卡片里列的两条路线按原样都不成立**：重启后 agent 进程根本不存在，既没有状态可推（路线 a），也没有状态可查（路线 b）。`take()` 改 `clone()` 解决不了任何问题——状态只在 agent 启动时才产生，而 agent 只在第一次发消息时才启动。

实际做法：`availableModes` 是 **profile 的属性、不是 session 的属性**，所以在 `runtime_for` 建立 runtime 时按 profile fingerprint 缓存进 settings KV（复用现成的 `set_setting`/`get_setting`，不需要新建表和迁移），新命令 `get_acp_session_state` 在会话打开时读缓存。

几个刻意的选择：

- **完全不 emit**，UI 直接 invoke 拿返回值——顺带绕开了 `emit` 广播所有窗口的坑，不需要 `emit_to`。
- **不缓存 `currentModeId`**：它属于一个 agent 进程已经没了的会话。缓存只回 `{availableModes}`，于是 `plan_mode_active` 为 false → 开关可见但处于关闭态，下一轮真实状态到达时自动纠正。
- **UI 侧用 `or_insert` 只做 seed**，绝不覆盖已有的活状态（含 `currentModeId`）。
- **按 fingerprint 做 key**：profile 的启动命令改了，缓存自动失效重学，不会用旧的。
- 没碰 `get_session_model` 的 `acp:<label>` 链路。

### 超出卡片范围的一处改动

`set_acp_session_mode` 从直接读 `acp_sessions` 改成走 `runtime_for`。

卡片的验收标准只写了"开关可见"，但只做到可见的话，重启后点这个开关会直接报 `"ACP session is not active."`——一个点了就报错的开关比藏起来更糟。`runtime_for` 本来就有 relaunch + resume 的逻辑，改动 6 行。这属于同一个根因的另一半，如果 reviewer 认为应该拆开或不做，我可以单独回滚这一段。

## 验证

- `ui/` `cargo check --target wasm32-unknown-unknown` 通过
- `src-tauri` `cargo check` 通过
- `ui/` 宿主 `cargo test`：147 passed, 0 failed（CI 不跑 ui 单测，所以本地跑了）
- **没有**对 `ui/` 跑 `cargo fmt`

### `?mock=1` 会话 s1 卡片渲染

给 mock-bridge 补了 `get_acp_session_state` 的 case（返回值与真实命令一致：只有 `availableModes`，没有 `currentModeId`）。验证时临时改 mock 跑了两种状态，改回来了：

| 状态 | 结果 |
|---|---|
| 计划模式激活 | `plan-approve` / `plan-modify` / `plan-save-exit` 三个按钮都在，无徽章 |
| agent 无计划模式 | `.plan-card compat`，徽章 `compat`，title `Compatibility plan`，动作条 0 个按钮 |

深色模式一并看了，徽章用的是全局 `--text-faint` 一档，和卡片副标题一致。

> ⚠️ 截图工具报 browser pane hidden，取到的是过期画面，所以上面的 UI 证据是 DOM 断言 + computed style，不是截图。

### 第 3 条的手动验证步骤（需要真实 ACP 会话重启场景）

1. 绑定一个暴露了计划模式的 ACP agent，发一条消息，确认"先计划"开关出现。
2. **完全退出并重启应用**，重新打开该会话。开关应当**不发任何消息就可见**（修复前要等下一条消息）。
3. 点击该开关：agent 重新拉起并 resume，切换成功（修复前报 `"ACP session is not active."`）。

## 已知小瑕疵

会话打开的瞬间，徽章会先显示一帧再消失（缓存读回来之前 `plan_compat` 默认为 true）。读的是本地 sqlite，很短。加三态跟踪能消掉，但为这个引入额外状态不划算，先记在这里。

## 并行提醒

另一张"阶段 3a"卡也在动 `ui/src/main.rs`（composer 区域）。本 PR 没碰 composer 开关本体，冲突面小；谁后合并谁 rebase main。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
