### PR TITLE
test(plan): close plan mode regression coverage

### DIFF
--- a/src-tauri/src/artifact_commands.rs
+++ b/src-tauri/src/artifact_commands.rs
@@ -177,6 +177,7 @@ mod tests {
     fn artifact_registration_requires_an_existing_file() {
         let root = std::env::temp_dir().join(format!("wisp_register_artifact_{}", Uuid::new_v4()));
         std::fs::create_dir_all(root.join("results")).unwrap();
+        let root = dunce::canonicalize(root).unwrap();
         std::fs::write(root.join("results/report.csv"), b"a,b\n1,2\n").unwrap();
 
         assert_eq!(

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -165,6 +165,7 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
   let memoryEnabled = true;
   let autoReviewEnabled = false;
   const sessionDelegationEnabled: Record<string, boolean> = {};
+  const sessionPlanMode: Record<string, boolean> = {};
   const sessionAgentCompletion: Record<string, { policy: "inline" | "background"; auto_resume: boolean }> = {};
   let lastDelegationSessionId = "s-current";
   // Mutable workspace fixture lets live FileChanged events prove that open
@@ -1286,6 +1287,16 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
               },
             };
           }
+          case "get_acp_session_state": {
+            const frameId = String(arg("frameId") ?? "");
+            if (!acpBindings[frameId]) return null;
+            return {
+              availableModes: [
+                { id: "default", name: "Default" },
+                { id: "plan", name: "Plan" },
+              ],
+            };
+          }
           case "get_acp_session_agent":
             return acpBindings[String(arg("frameId") ?? "")] ?? null;
           case "save_acp_agent": {
@@ -2112,6 +2123,18 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
               }
             }
             return sessionDelegationEnabled[sessionId];
+          }
+          case "get_session_plan_mode": {
+            const sessionId = String(arg("sessionId") ?? "");
+            return acpBindings[sessionId] ? null : sessionPlanMode[sessionId] ?? false;
+          }
+          case "set_session_plan_mode": {
+            const sessionId = String(arg("sessionId") ?? "");
+            if (acpBindings[sessionId]) {
+              throw new Error("This conversation is bound to an ACP agent; use its own plan mode.");
+            }
+            sessionPlanMode[sessionId] = Boolean(arg("enabled"));
+            return sessionPlanMode[sessionId];
           }
           case "get_session_agent_completion": {
             const sessionId = String(arg("sessionId") ?? "");

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -53,13 +53,16 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
     has_api_key: true,
   };
   const query = new URLSearchParams(window.location.search);
+  const mockPlanFlow = query.get("mockPlanFlow");
   const mockLongPages = Number(query.get("mockLongPages") ?? 0);
   const mockLongSession = query.get("mockLongSession") === "1" || mockLongPages > 0;
   const mockResourceSession = query.get("mockResourceSession") === "1";
   const mockMcpAppSession = query.get("mockMcpAppSession") === "1";
   const mockOAuthPending = query.get("mockOAuthPending") === "1";
   const mockOnboarding = query.get("mockOnboarding") === "1";
-  const mockSessions: any[] = query.get("mockManySessions") === "1"
+  const mockSessions: any[] = mockPlanFlow
+    ? [{ id: "s1", title: "Plan mode regression", ts: 2000, running: false }]
+    : query.get("mockManySessions") === "1"
     ? Array.from({ length: 101 }, (_, index) => ({
         id: `session-${String(index + 1).padStart(3, "0")}`,
         title: `Paged session ${index + 1}`,
@@ -487,7 +490,8 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
     seedMockAgentWorkflow(otherAgentWorkflow);
     lastDelegationSessionId = currentSessionId;
   }
-  const acpBindings: Record<string, string> = {};
+  const acpBindings: Record<string, string> =
+    mockPlanFlow === "acp" || mockPlanFlow === "compat" ? { s1: "acp-test" } : {};
   const acpPermissionFrames: Record<string, string> = {};
   const acpLongResolvers: Record<string, (value: string) => void> = {};
   let mockCredentials: Record<string, boolean> = {
@@ -831,6 +835,31 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
           case "load_demo":
             return demo;
           case "load_session":
+            if (mockPlanFlow) {
+              return {
+                items: [
+                  { role: "user", text: "Prepare the regression plan", tool_name: null, ok: null },
+                  // This is the load_session row produced from the persisted
+                  // `wisp:plan` tool message; LoadedItem::into_chat rebuilds it.
+                  {
+                    role: "plan",
+                    text: JSON.stringify({
+                      v: 1,
+                      source: "acp",
+                      entries: [
+                        { content: "Inspect the existing behavior", status: "completed", priority: "medium" },
+                        { content: "Wire the plan flow", status: "in_progress", priority: "high" },
+                        { content: "Run regression checks", status: "pending", priority: "low" },
+                      ],
+                    }),
+                    tool_name: null,
+                    ok: null,
+                  },
+                ],
+                next_before_seq: null,
+                user_offset: 0,
+              };
+            }
             if (mockMcpAppSession) {
               return {
                 items: [
@@ -1291,10 +1320,15 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
             const frameId = String(arg("frameId") ?? "");
             if (!acpBindings[frameId]) return null;
             return {
-              availableModes: [
-                { id: "default", name: "Default" },
-                { id: "plan", name: "Plan" },
-              ],
+              availableModes: mockPlanFlow === "compat"
+                ? [
+                    { id: "default", name: "Default" },
+                    { id: "agent", name: "Agent" },
+                  ]
+                : [
+                    { id: "default", name: "Default" },
+                    { id: "plan", name: "Plan" },
+                  ],
             };
           }
           case "get_acp_session_agent":

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -43,6 +43,36 @@ async function enterApp(page: Page, path = "/") {
   }
 }
 
+async function openMockPlanSession(page: Page, kind: "acp" | "compat" | "native") {
+  await enterApp(page, `/?mockPlanFlow=${kind}`);
+  const session = page.locator('[data-session-id="s1"]');
+  await expect(session).toBeVisible();
+  await session.click();
+  await expect(page.getByTestId("plan-card")).toBeVisible();
+}
+
+async function emitTauriEvent(page: Page, event: string, payload: unknown) {
+  await expect.poll(() => page.evaluate((name) =>
+    Boolean((window as any).__tauriListenerReady?.(name)), event
+  )).toBe(true);
+  await page.evaluate(({ name, value }) => {
+    (window as any).__tauriEmit(name, value);
+  }, { name: event, value: payload });
+}
+
+async function activateAcpPlanMode(page: Page) {
+  await emitTauriEvent(page, "acp-session-state", {
+    frameId: "s1",
+    modes: {
+      currentModeId: "plan",
+      availableModes: [
+        { id: "default", name: "Default" },
+        { id: "plan", name: "Plan" },
+      ],
+    },
+  });
+}
+
 function composer(page: Page) {
   return page.locator("#composer-input");
 }
@@ -506,6 +536,139 @@ test("ACP turn maps config, overlapping tools, plan, usage, and exact permission
 
   await page.locator(".model-picker-btn").click();
   await expect(page.getByRole("button", { name: /deepseek-v4-pro/ })).toBeDisabled();
+});
+
+test("persisted wisp:plan reload rebuilds all entry states and priority", async ({ page }) => {
+  await openMockPlanSession(page, "acp");
+
+  const assertPlan = async () => {
+    const card = page.getByTestId("plan-card");
+    const completed = card.locator('li[data-status="completed"]');
+    const inProgress = card.locator('li[data-status="in_progress"]');
+    const pending = card.locator('li[data-status="pending"]');
+
+    await expect(completed.locator(".plan-entry-mark")).toHaveText("✓");
+    await expect(inProgress.locator(".plan-entry-mark")).toHaveText("▸");
+    await expect(inProgress).toHaveCSS("font-weight", "600");
+    await expect(inProgress.getByRole("img", { name: "High priority" })).toHaveText("!");
+    await expect(pending.locator(".plan-entry-mark")).toHaveText("");
+  };
+  await assertPlan();
+
+  await page.reload();
+  await page.locator(".proj-card-main").first().click();
+  await expect(newSessionButton(page)).toBeVisible();
+  await page.locator('[data-session-id="s1"]').click();
+  await assertPlan();
+});
+
+test("live plan is dashed while streaming and settles on Done", async ({ page }) => {
+  await openMockPlanSession(page, "acp");
+  await activateAcpPlanMode(page);
+  await emitTauriEvent(page, "acp-session-update", {
+    frameId: "s1",
+    kind: "Plan",
+    payload: {
+      entries: [
+        { content: "Stream the proposed change", status: "in_progress", priority: "high" },
+      ],
+    },
+  });
+
+  const live = page.getByTestId("plan-card").last();
+  await expect(page.getByTestId("plan-card")).toHaveCount(2);
+  await expect(live).toHaveClass(/streaming/);
+  await expect(live).toHaveCSS("border-style", "dashed");
+  await expect(live).toContainText("Planning…");
+
+  await emitTauriEvent(page, "agent", {
+    kind: "Done",
+    frame_id: "s1",
+    stop_reason: "end_turn",
+  });
+  await expect(live).not.toHaveClass(/streaming/);
+  await expect(live).toHaveCSS("border-style", "solid");
+  await expect(live).toContainText("Review before execution");
+  await expect(live).not.toContainText("Planning…");
+});
+
+test("agent without plan mode renders a read-only compatibility plan", async ({ page }) => {
+  await openMockPlanSession(page, "compat");
+
+  const card = page.getByTestId("plan-card");
+  await expect(card).toHaveClass(/compat/);
+  await expect(card.getByTestId("plan-compat")).toHaveText("compat");
+  await expect(card.locator(".plan-card-actions button")).toHaveCount(0);
+});
+
+test("plan action bar dispatches approve, modify, and save-exit correctly", async ({ page }) => {
+  await openMockPlanSession(page, "acp");
+  await activateAcpPlanMode(page);
+
+  await expect(page.getByTestId("plan-approve")).toBeVisible();
+  await expect(page.getByTestId("plan-modify")).toBeVisible();
+  await expect(page.getByTestId("plan-save-exit")).toBeVisible();
+
+  await page.getByTestId("plan-modify").click();
+  await expect(composer(page)).toBeFocused();
+  expect(await invokeArgsList(page, "set_acp_session_mode")).toHaveLength(0);
+  expect(await invokeArgsList(page, "send_message")).toHaveLength(0);
+
+  await page.getByTestId("plan-save-exit").click();
+  await expect(page.locator(".copy-toast")).toContainText("Plan saved; Default mode restored");
+  await expect.poll(() => invokeArgsList(page, "set_acp_session_mode")).toEqual([
+    expect.objectContaining({ frameId: "s1", modeId: "default" }),
+  ]);
+  expect(await invokeArgsList(page, "send_message")).toHaveLength(0);
+
+  await activateAcpPlanMode(page);
+  await page.getByTestId("plan-approve").click();
+  await expect.poll(() => invokeArgsList(page, "set_acp_session_mode")).toHaveLength(2);
+  await expect.poll(() => lastInvokeArgs(page, "send_message")).toMatchObject({
+    sessionId: "s1",
+    acpAgentId: "acp-test",
+    message: "Approve and execute",
+  });
+});
+
+test("composer plan toggle routes ACP and built-in sessions separately", async ({ page }) => {
+  await openMockPlanSession(page, "acp");
+  let menu = await openAgentMenu(page);
+  let row = menu.locator("label.agent-menu-row", { hasText: "Plan first" });
+  let toggle = row.getByTestId("plan-first-toggle");
+  await expect(row).toBeVisible();
+  await expect(toggle).not.toBeChecked();
+  await row.click();
+  await expect.poll(() => lastInvokeArgs(page, "set_acp_session_mode")).toMatchObject({
+    frameId: "s1",
+    modeId: "plan",
+  });
+  await expect(toggle).toBeChecked();
+  await row.click();
+  await expect.poll(() => lastInvokeArgs(page, "set_acp_session_mode")).toMatchObject({
+    frameId: "s1",
+    modeId: "default",
+  });
+  await expect(toggle).not.toBeChecked();
+
+  await openMockPlanSession(page, "native");
+  menu = await openAgentMenu(page);
+  row = menu.locator("label.agent-menu-row", { hasText: "Plan first" });
+  toggle = row.getByTestId("plan-first-toggle");
+  await expect(row).toBeVisible();
+  await expect(toggle).not.toBeChecked();
+  await row.click();
+  await expect.poll(() => lastInvokeArgs(page, "set_session_plan_mode")).toMatchObject({
+    sessionId: "s1",
+    enabled: true,
+  });
+  await expect(toggle).toBeChecked();
+  await row.click();
+  await expect.poll(() => lastInvokeArgs(page, "set_session_plan_mode")).toMatchObject({
+    sessionId: "s1",
+    enabled: false,
+  });
+  await expect(toggle).not.toBeChecked();
 });
 
 test("ACP turns retain explicitly selected Wisp skills", async ({ page }) => {

--- a/ui/mock-bridge.js
+++ b/ui/mock-bridge.js
@@ -140,6 +140,8 @@
   let nextCustomCredential = 1;
   // frame_id -> enabled execution context ids, mirroring session_execution_contexts.
   const sessionContexts = {};
+  // s1 demonstrates an ACP-bound conversation; the others use built-in agents.
+  const mockAcpSessions = new Set(["s1"]);
   // frame_id -> built-in plan mode flag (settings key frame_plan_mode:<id>).
   const mockPlanMode = {};
   // Agent-created SSH trust edges (ssh_trust_edges_v1). One edge whose
@@ -271,10 +273,12 @@
             return { id: "default", name: project.name, workspace_dir: project.root, session_count: sessions.length, artifact_count: 3, updated_at: 1 };
           case "delete_project":
             return null;
-          case "get_acp_session_state":
+          case "get_acp_session_state": {
+            if (!mockAcpSessions.has(args?.frameId)) return null;
             // Matches the real command: `availableModes` only, never
             // `currentModeId`. Swap "plan" for another id to see a compat card.
             return { availableModes: [{ id: "default" }, { id: "plan" }] };
+          }
           case "pick_directory":
             return "/Users/mock/Desktop/demo-project";
           case "load_session":
@@ -826,11 +830,13 @@
             edits.push(version);
             return version;
           }
-          // Built-in plan mode: `null` would mean "ACP-bound", which hides the
-          // composer toggle, so the mock always answers with a real boolean.
           case "get_session_plan_mode":
+            if (mockAcpSessions.has(args?.sessionId)) return null;
             return mockPlanMode[args?.sessionId] ?? false;
           case "set_session_plan_mode":
+            if (mockAcpSessions.has(args?.sessionId)) {
+              throw new Error("This conversation is bound to an ACP agent; use its own plan mode.");
+            }
             mockPlanMode[args?.sessionId] = !!args?.enabled;
             return mockPlanMode[args?.sessionId];
           default:


### PR DESCRIPTION
## Problem

The plan-mode rollout needed a final wiring regression pass, but `artifact_registration_requires_an_existing_file` failed on a clean macOS tree and polluted the signal from every later `cargo test --workspace` run. The two UI mock bridges also did not consistently model the three new session commands, and the end-to-end suite did not cover the plan card/action/toggle/reload wiring.

This work started only after confirming that both prerequisite PRs were already on `origin/main`: #544 (`claude/ecstatic-mahavira-ee92f2`, built-in `plan_mode` flag and tool gate) and #545 (compat badge, save-exit, and cached ACP session state).

## What changed

- Canonicalize the test-created artifact root before comparing it with the path-safety helper's canonical result. This removes the macOS `/var` versus `/private/var` alias dependency while keeping the existing-file, directory, and missing-file assertions self-contained.
- Add/align `get_acp_session_state`, `get_session_plan_mode`, and `set_session_plan_mode` cases in both `ui/mock-bridge.js` and `ui-tests/tests/mock-tauri.ts`.
  - ACP-bound sessions return `null` from `get_session_plan_mode`.
  - Non-ACP sessions return a persisted boolean.
  - The ACP cached-state shape contains `availableModes` but no `currentModeId`, matching the real command.
  - The built-in setter rejects ACP-bound sessions.
- Add Playwright coverage using the existing mock harness and session `s1` for:
  - pending / in-progress / completed plan entries and the high-priority badge;
  - streaming dashed state and `Done` settlement;
  - compatibility badge with no action buttons;
  - approve, modify, and save-exit dispatch behavior;
  - ACP and built-in composer plan toggles;
  - persisted `wisp:plan` reconstruction through the `load_session` / `LoadedItem::into_chat` path.

## User/developer impact

Plan-mode wiring now has an end-to-end safety net across persistence, live ACP events, action dispatch, and both toggle backends. Workspace test failures once again identify real regressions instead of the platform-specific artifact fixture mismatch.

## Validation

Run locally and recorded here for manual regression independently of CI:

```bash
cargo fmt --all -- --check
cargo test --workspace
cd ui && cargo check --target wasm32-unknown-unknown
cd ../ui-tests && npm ci
npx playwright test -g 'persisted wisp:plan|live plan|agent without plan mode|plan action bar|composer plan toggle'
npx playwright test
```

Results:

- targeted plan flow: 5 passed;
- full Playwright suite: 220 passed, 1 skipped (the existing real Motif test requires `WISP_MOTIF_APP_HTML`);
- all Rust workspace tests and the UI wasm check passed.

Manual smoke focus:

1. Reopen an ACP plan session and confirm the structured card is reconstructed.
2. Enter plan mode and exercise Modify, Save and exit, and Approve and execute.
3. Open Agent options in an ACP session and a built-in session and flip Plan first in both.

## Known limitation / follow-up

Opening a session can flash the compat badge for one frame before cached ACP modes land. Phase 2 intentionally avoided tri-state loading for this state; this PR records the behavior and does not change it.

The mocked `send_message` path does not update the thread UI under `?mock=1`, so action-bar e2e assertions intentionally stop at the invoke dispatch layer.