### PR TITLE
计划模式阶段 3b：内建 propose_plan 工具 + 非阻塞批准环

### DIFF
--- a/crates/wisp-mcp/src/client.rs
+++ b/crates/wisp-mcp/src/client.rs
@@ -52,6 +52,17 @@ impl RemoteTool {
             .and_then(Value::as_str)
     }
 
+    /// The server's `readOnlyHint`: this tool only retrieves. Plan mode uses it
+    /// to keep retrieval available while blocking everything else, so an absent
+    /// or `false` hint has to stay blocked.
+    pub fn read_only(&self) -> bool {
+        self.annotations
+            .as_ref()
+            .and_then(|annotations| annotations.get("readOnlyHint"))
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+    }
+
     /// MCP Apps may publish app-only helper tools. Those remain discoverable
     /// on the server connection but must not enter the agent's tool catalog.
     pub fn visible_to_model(&self) -> bool {
@@ -577,6 +588,8 @@ mod tests {
         assert!(tools[0].output_schema.is_some());
         assert!(tools[0].annotations.is_some());
         assert!(tools[0].visible_to_model());
+        // Plan mode's retrieval passthrough reads exactly this hint.
+        assert!(tools[0].read_only());
 
         let app_only = tools_into_remote(vec![json!({
             "name": "motif_refresh",
@@ -584,6 +597,10 @@ mod tests {
             "_meta": { "ui": { "visibility": ["app"] } }
         })]);
         assert!(!app_only[0].visible_to_model());
+        assert!(
+            !app_only[0].read_only(),
+            "no hint means unclassified, not read-only"
+        );
     }
 
     #[test]

--- a/crates/wisp-mcp/src/tool.rs
+++ b/crates/wisp-mcp/src/tool.rs
@@ -181,6 +181,12 @@ impl Tool for McpTool {
             Approval::Allow
         }
     }
+    /// The server's own `readOnlyHint`, which the bundled bio/literature
+    /// retrieval servers set on every query tool. Anything that omits it — or
+    /// says `false` — stays blocked in plan mode.
+    fn read_only(&self) -> bool {
+        self.remote.read_only()
+    }
     fn preview(&self, args: &Value) -> String {
         let s = args.to_string();
         s.chars().take(120).collect()

--- a/crates/wisp-tools/src/lib.rs
+++ b/crates/wisp-tools/src/lib.rs
@@ -35,15 +35,15 @@ pub const MCP_EVENT_PREFIX: &str = "mcp:";
 const DEFAULT_MCP_SEARCH_LIMIT: usize = 5;
 
 /// Tools that stay callable while a session is in plan mode (see
-/// [`ToolEnv::plan_mode`]). Everything else is refused at the registry gate:
-/// writes, shell/python/R, delegation, state changes, and every MCP-backed
-/// tool. `search_mcp_tools` is a schema lookup and is allowed by its own path.
+/// [`ToolEnv::plan_mode`]), on top of any tool that reports
+/// [`Tool::read_only`]. Everything else is refused at the registry gate:
+/// writes, shell/python/R, delegation, and state changes.
+/// `search_mcp_tools` is a schema lookup and is allowed by its own path.
 ///
-/// ponytail: a name whitelist rather than per-tool metadata — one list to read,
-/// and it fails closed for anything nobody classified. It deliberately names
-/// host tools this crate never sees. Upgrade path, once a tool needs to
-/// disagree or MCP `readOnlyHint` should be honoured: a `Tool::read_only()`
-/// method defaulting to false, with this list kept only as the host override.
+/// ponytail: the host override half of the gate — one list to read, naming
+/// host tools this crate never sees. The other half is `Tool::read_only()`,
+/// which covers the tools a list cannot name: MCP retrieval tools, whose
+/// server declares `readOnlyHint`. Both fail closed.
 pub const PLAN_MODE_READ_ONLY: &[&str] = &[
     // wisp-tools built-ins
     "read",
@@ -308,7 +308,7 @@ async fn run_registered_tool(tool: &dyn Tool, args: &Value, env: &dyn ToolEnv) -
     let name = tool.name();
     // Plan-mode gate, ahead of approvals: a session that is only allowed to
     // plan never reaches the approval prompt for a tool that would execute.
-    if env.plan_mode() && plan_mode_blocks(name) {
+    if env.plan_mode() && plan_mode_blocks(name) && !tool.read_only() {
         return ToolResult::fail(plan_mode_refusal(name));
     }
     // Per-tool approval gate. `Deny` blocks before the call card even shows;
@@ -488,8 +488,31 @@ mod approval_tests {
         fn defer_schema(&self) -> bool {
             true
         }
+        /// What the bundled bio/literature servers declare via `readOnlyHint`.
+        fn read_only(&self) -> bool {
+            true
+        }
         async fn run(&self, args: &Value, _env: &dyn ToolEnv) -> ToolResult {
             ToolResult::ok(format!("searched {}", args["query"]))
+        }
+    }
+
+    /// An MCP tool whose server says nothing about writing — the unclassified
+    /// case the gate has to keep refusing.
+    struct DeferredWriteTool;
+    #[async_trait::async_trait]
+    impl Tool for DeferredWriteTool {
+        fn name(&self) -> &str {
+            "zenodo_upload_record"
+        }
+        fn schema(&self) -> ToolSchema {
+            ToolSchema::new(self.name(), "Upload a record.", serde_json::json!({}))
+        }
+        fn defer_schema(&self) -> bool {
+            true
+        }
+        async fn run(&self, _args: &Value, _env: &dyn ToolEnv) -> ToolResult {
+            ToolResult::ok("uploaded")
         }
     }
 
@@ -623,6 +646,44 @@ mod approval_tests {
         assert!(reg.run("write", &write, &executing).await.success);
         assert!(reg.run("read", &read, &executing).await.success);
         let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn plan_mode_lets_read_only_retrieval_through() {
+        let mut reg = Registry { tools: vec![] };
+        reg.add(Box::new(DeferredTool));
+        reg.add(Box::new(DeferredWriteTool));
+        let planning = PlanEnv {
+            root: PathBuf::from("."),
+            plan: true,
+        };
+
+        // Dispatched the way the model reaches a deferred MCP tool.
+        let searched = reg
+            .run(
+                USE_MCP_TOOL,
+                &serde_json::json!({
+                    "tool_name": "pubmed_search_articles",
+                    "tool_input": { "query": "tp53" },
+                }),
+                &planning,
+            )
+            .await;
+        assert!(searched.success, "{}", searched.content);
+        assert!(searched.content.contains("tp53"));
+
+        let blocked = reg
+            .run(
+                USE_MCP_TOOL,
+                &serde_json::json!({
+                    "tool_name": "zenodo_upload_record",
+                    "tool_input": {},
+                }),
+                &planning,
+            )
+            .await;
+        assert!(!blocked.success, "an unhinted MCP tool must stay blocked");
+        assert!(blocked.content.contains("plan mode"), "{}", blocked.content);
     }
 
     #[tokio::test]

--- a/crates/wisp-tools/src/lib.rs
+++ b/crates/wisp-tools/src/lib.rs
@@ -64,7 +64,7 @@ pub const PLAN_MODE_READ_ONLY: &[&str] = &[
     "monitor_run",
     "get_delegated_result",
     // The plan proposal tool: plan mode is exactly when it has to run.
-    "propose_plan",
+    plan::PROPOSE_PLAN,
 ];
 
 fn plan_mode_blocks(name: &str) -> bool {

--- a/crates/wisp-tools/src/plan.rs
+++ b/crates/wisp-tools/src/plan.rs
@@ -5,6 +5,8 @@
 //! rendered checklist is returned as the tool result, so it both stays in the
 //! model's context (tracking) and shows up in the tool-call card (user sees it)
 //! without any new event plumbing.
+//!
+//! `propose_plan` — plan mode's output channel, see [`ProposePlanTool`].
 
 use crate::env::{ConfirmDecision, ToolEnv, ToolResult};
 use crate::tool::Tool;
@@ -187,9 +189,138 @@ impl Tool for UpdatePlanTool {
     }
 }
 
+/// Plan mode's output channel: the agent submits its finished plan here.
+pub const PROPOSE_PLAN: &str = "propose_plan";
+
+const PROPOSE_PLAN_NOTE: &str = "Plan submitted; it is now waiting for the user to approve it. \
+     End your turn here — do not start carrying the plan out.";
+
+/// Validate the `entries` argument into the canonical entry shape. Statuses and
+/// priorities are normalised here so the persisted body never carries a value
+/// the card would silently fall back on.
+fn normalize_entries(args: &Value) -> Result<Vec<Value>, String> {
+    let entries = args
+        .get("entries")
+        .and_then(|v| v.as_array())
+        .ok_or("propose_plan error: 'entries' must be an array of {content, status, priority}")?;
+    if entries.is_empty() {
+        return Err("propose_plan error: 'entries' must not be empty".into());
+    }
+    entries
+        .iter()
+        .enumerate()
+        .map(|(i, entry)| {
+            let content = entry
+                .get("content")
+                .and_then(|v| v.as_str())
+                .map(str::trim)
+                .filter(|text| !text.is_empty())
+                .ok_or_else(|| {
+                    format!("propose_plan error: entry {} is missing 'content' text", i + 1)
+                })?;
+            let status = entry
+                .get("status")
+                .and_then(|v| v.as_str())
+                .unwrap_or("pending");
+            if !matches!(status, "pending" | "in_progress" | "completed") {
+                return Err(format!(
+                    "propose_plan error: entry {} has invalid status '{status}' (use pending|in_progress|completed)",
+                    i + 1
+                ));
+            }
+            let priority = entry
+                .get("priority")
+                .and_then(|v| v.as_str())
+                .unwrap_or("medium");
+            if !matches!(priority, "low" | "medium" | "high") {
+                return Err(format!(
+                    "propose_plan error: entry {} has invalid priority '{priority}' (use low|medium|high)",
+                    i + 1
+                ));
+            }
+            Ok(json!({ "content": content, "status": status, "priority": priority }))
+        })
+        .collect()
+}
+
+/// The plan card's body, in the shape the ACP path already persists — the UI
+/// parses live tool results and reloaded tool messages with the one function.
+fn plan_body(entries: Vec<Value>) -> Value {
+    json!({ "v": 1, "source": "native", "entries": entries, "note": PROPOSE_PLAN_NOTE })
+}
+
+/// The built-in counterpart to an ACP agent's plan update.
+///
+/// ponytail: no store handle and no event of its own. The tool result IS the
+/// plan card — the registry already streams it to the UI, and the agent loop
+/// already persists it as a `Message::tool(_, "propose_plan", body)` that pairs
+/// with its own call. A separate `wisp:plan` row would need turn-end plumbing
+/// and would reload as an orphan tool message the provider rejects.
+/// Known ceiling: calling twice in one turn replaces the live card but keeps
+/// both rows, so a reloaded turn shows the revision. Collapsing them needs
+/// turn boundaries the windowed transcript loader does not have, and the
+/// prompt asks for one call followed by the end of the turn.
+pub struct ProposePlanTool;
+
+#[async_trait]
+impl Tool for ProposePlanTool {
+    fn name(&self) -> &str {
+        PROPOSE_PLAN
+    }
+    fn schema(&self) -> ToolSchema {
+        ToolSchema::new(
+            PROPOSE_PLAN,
+            "Submit the plan you researched for this conversation's plan mode. This is the only way \
+             a plan reaches the user: send the complete ordered list of steps in one call. Calling it \
+             again in the same turn replaces the plan you just submitted. The plan is not executed — \
+             the user reviews it and approves it, so end your turn right after this call.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "entries": {
+                        "type": "array",
+                        "description": "The full ordered plan, as concrete steps naming what changes and how it is verified.",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "content": { "type": "string", "description": "One plan step." },
+                                "status": {
+                                    "type": "string",
+                                    "enum": ["pending", "in_progress", "completed"],
+                                    "description": "Defaults to 'pending'; a fresh plan is all pending."
+                                },
+                                "priority": {
+                                    "type": "string",
+                                    "enum": ["low", "medium", "high"],
+                                    "description": "Defaults to 'medium'."
+                                }
+                            },
+                            "required": ["content"]
+                        }
+                    }
+                },
+                "required": ["entries"]
+            }),
+        )
+    }
+    fn preview(&self, args: &Value) -> String {
+        let count = args
+            .get("entries")
+            .and_then(|v| v.as_array())
+            .map_or(0, Vec::len);
+        format!("{count} steps")
+    }
+    async fn run(&self, args: &Value, _env: &dyn ToolEnv) -> ToolResult {
+        match normalize_entries(args) {
+            Ok(entries) => ToolResult::ok(plan_body(entries).to_string()),
+            Err(error) => ToolResult::fail(error),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{is_fresh_proposal, render_plan, UpdatePlanTool};
+    use super::{is_fresh_proposal, render_plan, ProposePlanTool, UpdatePlanTool, PROPOSE_PLAN};
     use crate::env::{ConfirmDecision, ToolEnv, ToolEvent};
     use crate::tool::Tool;
     use serde_json::json;
@@ -271,6 +402,59 @@ mod tests {
             .is_err(),
             "two in_progress"
         );
+    }
+
+    #[tokio::test]
+    async fn propose_plan_writes_the_persisted_card_shape() {
+        let env = PlanDecisionEnv {
+            root: PathBuf::from("."),
+            decision: ConfirmDecision::Approved,
+        };
+        let result = ProposePlanTool
+            .run(
+                &json!({ "entries": [
+                    { "content": " Read the loader ", "priority": "high" },
+                    { "content": "Wire the card", "status": "in_progress" }
+                ]}),
+                &env,
+            )
+            .await;
+
+        assert!(result.success, "{}", result.content);
+        let body: serde_json::Value = serde_json::from_str(&result.content).unwrap();
+        assert_eq!(body["v"], 1);
+        assert_eq!(body["source"], "native");
+        assert_eq!(
+            body["entries"],
+            json!([
+                { "content": "Read the loader", "status": "pending", "priority": "high" },
+                { "content": "Wire the card", "status": "in_progress", "priority": "medium" },
+            ]),
+            "statuses and priorities are normalised for the card"
+        );
+        assert!(
+            body["note"].as_str().unwrap().contains("End your turn"),
+            "the result has to stop the agent, not invite it to execute"
+        );
+        assert_eq!(ProposePlanTool.name(), PROPOSE_PLAN);
+    }
+
+    #[tokio::test]
+    async fn propose_plan_rejects_junk() {
+        let env = PlanDecisionEnv {
+            root: PathBuf::from("."),
+            decision: ConfirmDecision::Approved,
+        };
+        for args in [
+            json!({}),
+            json!({ "entries": [] }),
+            json!({ "entries": [{ "content": "  " }] }),
+            json!({ "entries": [{ "content": "x", "status": "blocked" }] }),
+            json!({ "entries": [{ "content": "x", "priority": "urgent" }] }),
+        ] {
+            let result = ProposePlanTool.run(&args, &env).await;
+            assert!(!result.success, "{args} should be refused");
+        }
     }
 
     #[tokio::test]

--- a/crates/wisp-tools/src/tool.rs
+++ b/crates/wisp-tools/src/tool.rs
@@ -20,6 +20,14 @@ pub trait Tool: Send + Sync {
     fn minimum_approval(&self) -> Approval {
         Approval::Allow
     }
+    /// Whether this tool only retrieves — no writes, no state changes, nothing
+    /// to undo. Read-only tools stay callable in plan mode on top of
+    /// [`crate::PLAN_MODE_READ_ONLY`], which cannot name tools it never sees
+    /// (every MCP-backed retrieval tool). Default `false`: a tool nobody
+    /// classified is refused while planning.
+    fn read_only(&self) -> bool {
+        false
+    }
     /// One-line preview shown in the tool-call card (e.g. the file path).
     fn preview(&self, _args: &Value) -> String {
         String::new()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1038,7 +1038,13 @@ fn messages_to_items(msgs: &[wisp_llm::Message]) -> Vec<UiItem> {
                             resources: Vec::new(),
                         });
                     }
-                } else if m.tool_name.as_deref() == Some(acp::PLAN_TOOL_NAME) {
+                } else if matches!(
+                    m.tool_name.as_deref(),
+                    // Both plan sources persist the same `{v, source, entries}`
+                    // body; the ACP one as its own row, the built-in one as the
+                    // `propose_plan` result that paired with the model's call.
+                    Some(acp::PLAN_TOOL_NAME) | Some(wisp_tools::plan::PROPOSE_PLAN)
+                ) {
                     out.push(UiItem {
                         role: "plan".into(),
                         text,
@@ -4388,6 +4394,12 @@ async fn send_message_inner(
         agent.add_tool(Box::new(specialist_tool::SaveSpecialistTool {
             store: state.store.clone(),
         }));
+        if plan_mode_enabled {
+            // Only while planning: outside plan mode there is nothing to approve,
+            // and an always-present tool just invites plans nobody asked for.
+            // Toggling the flag evicts idle runtimes, so this re-runs.
+            agent.add_tool(Box::new(wisp_tools::plan::ProposePlanTool));
+        }
         if delegation_enabled {
             agent.add_tool(Box::new(
                 delegation_tool::DelegateTasksTool::new(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1939,13 +1939,15 @@ impl Output for TauriOutput {
         });
     }
     fn tool_result(&self, name: &str, ok: bool, content: &str, duration_ms: u64) {
-        // ponytail: attempt_completion's "tool result" IS the final answer bubble,
-        // so the 4000-char preview clip must not apply to it.
-        let clipped: String = if name == "attempt_completion" {
-            content.to_string()
-        } else {
-            content.chars().take(4000).collect()
-        };
+        // ponytail: some tool results ARE the card the UI renders, not a preview
+        // of one — attempt_completion is the final answer bubble, propose_plan is
+        // the plan card's JSON body. A clip would truncate them into junk.
+        let clipped: String =
+            if matches!(name, "attempt_completion" | wisp_tools::plan::PROPOSE_PLAN) {
+                content.to_string()
+            } else {
+                content.chars().take(4000).collect()
+            };
         self.emit(AgentEvent::ToolResult {
             frame_id: self.frame_id.clone(),
             name: name.into(),

--- a/src-tauri/src/lib_tests.rs
+++ b/src-tauri/src/lib_tests.rs
@@ -297,6 +297,23 @@ fn reloaded_tool_items_keep_notebook_source() {
 }
 
 #[test]
+fn reloaded_propose_plan_result_rebuilds_the_plan_card() {
+    let plan = wisp_llm::Message::tool(
+        "call-plan",
+        wisp_tools::plan::PROPOSE_PLAN,
+        r#"{"v":1,"source":"native","entries":[{"content":"Read the loader","status":"pending","priority":"high"}]}"#,
+    );
+
+    let items = messages_to_items(&[plan]);
+
+    assert_eq!(items.len(), 1);
+    // "plan" is what LoadedItem::into_chat turns back into a plan card; a
+    // generic tool row here would render the raw JSON instead.
+    assert_eq!(items[0].role, "plan");
+    assert!(items[0].text.contains("\"source\":\"native\""));
+}
+
+#[test]
 fn reloaded_background_completion_keeps_terminal_status() {
     let mut completion = wisp_llm::Message::user(
         r#"{"type":"delegated_batch_completion","result":{"status":"cancelled"}}"#,

--- a/src-tauri/src/plan_mode.rs
+++ b/src-tauri/src/plan_mode.rs
@@ -12,9 +12,7 @@ use wisp_store::Store;
 
 const PLAN_PROMPT_START: &str = "\n\n<plan_mode>";
 const PLAN_PROMPT_END: &str = "</plan_mode>";
-/// ponytail: stage 3b replaces this wording with instructions to call the
-/// `propose_plan` tool, so the whole contract stays a one-const diff.
-const PLAN_PROMPT_SECTION: &str = "\n\n<plan_mode>\nThe user turned on plan mode for this conversation. Investigate the task and produce a plan; do not carry it out.\nResearch first — read files, search the project, and look things up until you actually understand the task. Then write the plan as ordered, concrete steps, each naming what would change and how it would be verified. Call out the open questions and the risks you found.\nDo not execute the plan. Tools that write files, run shell/Python/R code, or otherwise change state are blocked in this mode and will refuse the call; that refusal is expected, not an error to work around. Stop once the plan is written and wait for the user to approve it.\n</plan_mode>";
+const PLAN_PROMPT_SECTION: &str = "\n\n<plan_mode>\nThe user turned on plan mode for this conversation. Investigate the task and produce a plan; do not carry it out.\nResearch first — read files, search the project, and look things up until you actually understand the task. Then submit the plan with the `propose_plan` tool: ordered, concrete steps, each naming what would change and how it would be verified. Call out the open questions and the risks you found in your reply, not as plan steps. The tool call is how the plan reaches the user — a plan written only as prose is not submitted.\nDo not execute the plan. Tools that write files, run shell/Python/R code, or otherwise change state are blocked in this mode and will refuse the call; that refusal is expected, not an error to work around. End your turn right after `propose_plan` and wait for the user to approve it.\n</plan_mode>";
 
 fn setting_key(frame_id: &str) -> String {
     format!("frame_plan_mode:{frame_id}")

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -840,12 +840,13 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
                 items: [
                   { role: "user", text: "Prepare the regression plan", tool_name: null, ok: null },
                   // This is the load_session row produced from the persisted
-                  // `wisp:plan` tool message; LoadedItem::into_chat rebuilds it.
+                  // plan tool message — `wisp:plan` for ACP, the `propose_plan`
+                  // result for built-in; LoadedItem::into_chat rebuilds both.
                   {
                     role: "plan",
                     text: JSON.stringify({
                       v: 1,
-                      source: "acp",
+                      source: mockPlanFlow === "native" ? "native" : "acp",
                       entries: [
                         { content: "Inspect the existing behavior", status: "completed", priority: "medium" },
                         { content: "Wire the plan flow", status: "in_progress", priority: "high" },

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -631,6 +631,52 @@ test("plan action bar dispatches approve, modify, and save-exit correctly", asyn
   });
 });
 
+test("built-in propose_plan renders a plan card with a working action bar", async ({ page }) => {
+  await openMockPlanSession(page, "native");
+  const menu = await openAgentMenu(page);
+  await menu.locator("label.agent-menu-row", { hasText: "Plan first" }).click();
+  await expect.poll(() => lastInvokeArgs(page, "set_session_plan_mode")).toMatchObject({
+    sessionId: "s1", enabled: true,
+  });
+  await page.keyboard.press("Escape");
+
+  // The built-in plan tool streams through the ordinary tool events; its result
+  // is the card body, so neither event may leave a tool step behind.
+  await emitTauriEvent(page, "agent", {
+    kind: "ToolCall", frame_id: "s1", name: "propose_plan", preview: "1 steps",
+  });
+  await emitTauriEvent(page, "agent", {
+    kind: "ToolResult", frame_id: "s1", name: "propose_plan", ok: true,
+    content: JSON.stringify({
+      v: 1,
+      source: "native",
+      entries: [{ content: "Wire propose_plan", status: "pending", priority: "high" }],
+      note: "Plan submitted; end your turn.",
+    }),
+  });
+
+  const live = page.getByTestId("plan-card").last();
+  await expect(page.getByTestId("plan-card")).toHaveCount(2);
+  await expect(live).toHaveClass(/streaming/);
+  await expect(live).toContainText("Wire propose_plan");
+  await expect(live).not.toContainText("end your turn");
+  await expect(page.locator(".step")).toHaveCount(0);
+  await expect(live.getByTestId("plan-compat")).toHaveCount(0);
+
+  await emitTauriEvent(page, "agent", { kind: "Done", frame_id: "s1", stop_reason: "end_turn" });
+  await expect(live).not.toHaveClass(/streaming/);
+
+  await live.getByTestId("plan-approve").click();
+  await expect.poll(() => lastInvokeArgs(page, "set_session_plan_mode")).toMatchObject({
+    sessionId: "s1", enabled: false,
+  });
+  // ?mock=1 send_message does not update the thread, so assert at the invoke layer.
+  await expect.poll(() => lastInvokeArgs(page, "send_message")).toMatchObject({
+    sessionId: "s1", message: "Approve and execute",
+  });
+  await expect(page.locator(".copy-toast")).toContainText("Plan approved; execution is starting");
+});
+
 test("composer plan toggle routes ACP and built-in sessions separately", async ({ page }) => {
   await openMockPlanSession(page, "acp");
   let menu = await openAgentMenu(page);

--- a/ui/src/app_support.rs
+++ b/ui/src/app_support.rs
@@ -3581,6 +3581,21 @@ pub(super) fn strip_approval_pending(items: &mut Vec<ChatItem>) {
     });
 }
 
+/// Land a live plan update: it replaces only the card this turn is still
+/// writing, so plans from earlier turns stay as the plan's history. Shared by
+/// the ACP plan update and the built-in `propose_plan` result.
+pub(super) fn upsert_plan_card(items: &mut Vec<ChatItem>, card: PlanCard) {
+    if let Some(index) = items
+        .iter()
+        .rposition(|row| matches!(row, ChatItem::Plan(plan) if plan.state == PlanState::Streaming))
+    {
+        items[index] = ChatItem::Plan(card);
+    } else {
+        let index = process_item_insert_index(items);
+        items.insert(index, ChatItem::Plan(card));
+    }
+}
+
 /// Turn end freezes the plan the turn produced. `Streaming` also marks which
 /// card live updates may replace, so settling it keeps the next turn's plan a
 /// separate card instead of overwriting this one.

--- a/ui/src/dto.rs
+++ b/ui/src/dto.rs
@@ -392,8 +392,12 @@ impl From<String> for PlanPriority {
     }
 }
 
-/// Who produced the plan. Always `Acp` today; the native arm is the seat for
-/// the built-in `propose_plan` tool, which renders through the same card.
+/// The built-in plan tool. Its result is the plan card's body, so the tool
+/// event never renders as an ordinary tool row (see the `ToolResult` handler).
+pub(crate) const PROPOSE_PLAN_TOOL: &str = "propose_plan";
+
+/// Who produced the plan: the ACP agent's own plan updates, or the built-in
+/// `propose_plan` tool. Both render through the same card.
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, Default, Hash, PartialEq, Eq)]
 #[serde(rename_all = "snake_case", from = "String")]
 pub(crate) enum PlanSource {

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -1978,6 +1978,11 @@ fn App() -> impl IntoView {
                 set_pet_activity(&frame_id, "review");
                 flush_now();
                 route_items(active_cb, items_cb, transcripts_cb, &frame_id, |v| {
+                    // The plan tool has no call card: its result carries the
+                    // whole plan, and that lands as a plan card instead.
+                    if name == PROPOSE_PLAN_TOOL {
+                        return;
+                    }
                     let idx = process_item_insert_index(v);
                     v.insert(
                         idx,
@@ -2002,6 +2007,18 @@ fn App() -> impl IntoView {
                 set_pet_activity(&frame_id, if ok { "running" } else { "failed" });
                 flush_now();
                 route_items(active_cb, items_cb, transcripts_cb, &frame_id, |v| {
+                    // A submitted plan renders as the plan card, the same shape
+                    // the ACP path streams and the reload path rebuilds. A
+                    // refused call (bad entries) stays an ordinary tool row so
+                    // the agent's error is visible.
+                    if name == PROPOSE_PLAN_TOOL && ok {
+                        if let Ok(payload) = serde_json::from_str(&content) {
+                            let mut card = parse_plan_card(&payload);
+                            card.state = PlanState::Streaming;
+                            upsert_plan_card(v, card);
+                            return;
+                        }
+                    }
                     let queue_start = process_item_insert_index(v);
                     let idx = v[..queue_start].iter().rposition(
                         |c| matches!(c, ChatItem::Tool { name: n, ok: None, .. } if n == &name),
@@ -2508,18 +2525,7 @@ fn App() -> impl IntoView {
                     items,
                     transcripts,
                     &update.frame_id,
-                    |rows| {
-                        // Replace only the card this turn is still writing;
-                        // plans from earlier turns stay as the plan's history.
-                        if let Some(index) = rows.iter().rposition(|row| {
-                            matches!(row, ChatItem::Plan(plan) if plan.state == PlanState::Streaming)
-                        }) {
-                            rows[index] = ChatItem::Plan(card);
-                        } else {
-                            let index = trailing_queue_start(rows);
-                            rows.insert(index, ChatItem::Plan(card));
-                        }
-                    },
+                    |rows| upsert_plan_card(rows, card),
                 );
             }
             "ConfigOptions" => {

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -4695,9 +4695,19 @@ fn App() -> impl IntoView {
         )
     };
 
-    // Plan mode is an ACP session mode, so the plan card's action bar only makes
-    // sense while the bound agent is actually in it.
+    // Built-in plan mode for the active session. `None` = the session is
+    // ACP-bound, so the composer's "Plan first" toggle drives the ACP mode
+    // picker instead of this flag. A session-less composer counts as built-in.
+    let local_plan_mode = create_rw_signal::<Option<bool>>(Some(false));
+    let plan_mode_busy = create_rw_signal(false);
+
+    // One flag, two backends, exactly like the composer toggle: a built-in
+    // session reads its own plan flag, an ACP-bound one reads the agent's mode.
+    // The card's action bar only makes sense while plan mode is actually on.
     let plan_mode_active = Signal::derive(move || {
+        if let Some(enabled) = local_plan_mode.get() {
+            return enabled;
+        }
         let Some(session_id) = active_session.get() else {
             return false;
         };
@@ -4708,8 +4718,12 @@ fn App() -> impl IntoView {
 
     // Agents without a plan mode still push plan updates — a Claude Code todo
     // list arrives as one. The card renders, but there is no mode to approve out
-    // of, so it is badged as a read-only compatibility plan instead.
+    // of, so it is badged as a read-only compatibility plan instead. Built-in
+    // sessions always have one to approve out of.
     let plan_compat = Signal::derive(move || {
+        if local_plan_mode.get().is_some() {
+            return false;
+        }
         let Some(session_id) = active_session.get() else {
             return true;
         };
@@ -4729,14 +4743,28 @@ fn App() -> impl IntoView {
         let Some(session_id) = active_session.get_untracked() else {
             return;
         };
-        let exit_mode = acp_session_modes
-            .with_untracked(|all| plan_mode_pair(all.get(&session_id)))
+        // Built-in sessions leave plan mode by clearing their own flag; ACP ones
+        // by switching the agent back to its non-plan mode.
+        let native = local_plan_mode.get_untracked().is_some();
+        let exit_mode = (!native)
+            .then(|| acp_session_modes.with_untracked(|all| plan_mode_pair(all.get(&session_id))))
+            .flatten()
             .map(|(_, exit)| exit);
         spawn_local(async move {
-            // Await the mode switch before sending: `session/set_mode` and
-            // `session/prompt` are separate calls, and a prompt that lands first
-            // just makes the agent re-plan.
-            if let Some(exit_mode) = exit_mode {
+            // Await leaving plan mode before sending: the switch and the prompt
+            // are separate calls, and a prompt that lands first would just run
+            // the next turn with the tool gate still closed.
+            if native {
+                let args = to_value(&serde_json::json!({
+                    "sessionId": session_id.clone(),
+                    "enabled": false,
+                }))
+                .unwrap();
+                if invoke_checked("set_session_plan_mode", args).await.is_err() {
+                    return;
+                }
+                local_plan_mode.set(Some(false));
+            } else if let Some(exit_mode) = exit_mode {
                 if !apply_acp_mode(acp_session_modes, session_id, exit_mode).await {
                     return;
                 }
@@ -5038,11 +5066,6 @@ fn App() -> impl IntoView {
     let auto_review_enabled = create_rw_signal(false);
     let delegation_enabled = create_rw_signal(false);
     let delegation_setting_busy = create_rw_signal(false);
-    // Built-in plan mode for the active session. `None` = the session is
-    // ACP-bound, so the composer's "Plan first" toggle drives the ACP mode
-    // picker instead of this flag. A session-less composer counts as built-in.
-    let local_plan_mode = create_rw_signal::<Option<bool>>(Some(false));
-    let plan_mode_busy = create_rw_signal(false);
     let agent_completion = create_rw_signal(AgentCompletionSettings::default());
     let agent_completion_busy = create_rw_signal(false);
     create_effect(move |_| {
@@ -8895,7 +8918,9 @@ fn App() -> impl IntoView {
                                         if local.is_none() && acp_pair.is_none() {
                                             return None;
                                         }
-                                        let on_plan = local.unwrap_or_else(|| plan_mode_active.get());
+                                        // `plan_mode_active` already resolves the same
+                                        // two backends — keep one source of truth.
+                                        let on_plan = plan_mode_active.get();
                                         Some(view! {
                                             <label class="agent-menu-row"
                                                 title=move || t(locale.get(), if on_plan { "plan.switch_default" } else { "plan.switch_plan" })>


### PR DESCRIPTION
## 计划模式双源路线 · 阶段 3b：内建 `propose_plan` + 非阻塞批准环

内建（HTTP 模型）会话此前只有"写计划"的提示词，没有产出通道。本卡补上工具、实时卡片、动作条，并在计划模式下放行只读检索工具。

四个 commit：

1. `feat(plan): add the built-in propose_plan tool`
2. `feat(plan): render the built-in plan card live`
3. `feat(plan): dual-path plan card actions for built-in sessions`
4. `feat(plan): let read-only retrieval tools run in plan mode`

### 两处偏离原始设计（都比原方案更省，实现前评估过）

**① 计划不写单独的 `wisp:plan` 消息行，而是复用 `propose_plan` 的工具结果消息。**
内建会话重建 runtime 时 `load_messages` 会把持久化行直接灌进 `agent.ctx.messages`。凭空多出的一条 `Role::Tool` 行没有配对的 assistant `tool_call`，下一回合就是 provider 400。ACP 侧没这问题（那些消息只用于显示）。
所以工具结果的正文就是契约里的 `{v, source:"native", entries}`，落库为 `Message::tool(_, "propose_plan", body)`，loader 一行改成认两个 tool_name。持久化形状不变，`parse_plan_card` / `LoadedItem::into_chat` 原样复用。

**② 没有新增 `AgentEvent::Plan` 变体，实时渲染复用 ToolCall/ToolResult。**
工具结果本来就会流到 UI，且正文就是整张卡片。UI 在 `ToolResult` 里按工具名建卡（`ToolCall` 跳过 tool step），DTO 契约零改动——正好避开 dto.rs 里"加变体容易、删变体会炸"的那条教训。唯一代价：`TauriOutput::tool_result` 的 4000 字符截断要给 `propose_plan` 开口子（与 `attempt_completion` 同一处），否则长计划会被截成非法 JSON。

已知天花板（代码里有 `ponytail:` 注释）：同一回合调用两次，实时卡片替换、但两条消息都留在库里，重载会看到修订历史。折叠需要窗口化 loader 拿不到的回合边界，而提示词要求"提交后立即结束回合"。

### 检索放行（第 4 条，保守版）

取了白名单注释里预留的升级路径：`Tool::read_only()` 默认 false，MCP 工具从服务端 `readOnlyHint` 作答。vendored bio-tools 的 `mcp_bio`（聚合入口，全部工具带 READ_ONLY）、`mcp_literature` 等检索服务器都声明了；没声明或声明 false 的照旧拦。逐个列工具名不可维护——`PLAN_MODE_READ_ONLY` 这个 crate 根本看不到 MCP 工具名。审批门（connector allow/ask/deny）位置不变，仍在计划门之后。

### 验证

自动化（全部通过）：

- `cargo fmt --all -- --check` / `cargo test --workspace`（431 host + 32 wisp-tools + 其余）
- `cd ui && cargo check --target wasm32-unknown-unknown`；`cd ui && cargo test`（147）
- Playwright 全量 `221 passed, 1 skipped`
- 新增：工具写出正确形状 + 拒收脏输入（wisp-tools）；重载把 `propose_plan` 行还原成计划卡（host）；计划模式放行只读检索 / 拦截未声明的 MCP 工具（wisp-tools）；`readOnlyHint` 解析（wisp-mcp）；e2e 一条覆盖 native 卡渲染 + 无残留 tool step + 动作条批准链路
- 逐 commit 编译验证（bisect 可用）

**尚未执行的手动验证**（需要配好模型/API key 的真机桌面端，我这里跑不了）：

1. `cargo tauri dev` 启动，打开或新建一个内建（非 ACP 绑定）会话
2. Composer → Agent options → 打开"先计划"，确认 toast 与开关状态
3. 发一条需要调研的任务，确认：只读工具能跑、写类工具被拒（拒绝文案是给模型看的，不应出现红色报错卡）、检索类 MCP（如 bio/文献）能跑
4. agent 调用 `propose_plan` 后：卡片立即出现（虚线 Planning… 态），回合结束变实线 Review before execution，且**没有** `propose_plan` 的工具步骤行
5. 点"批准并执行"：确认 composer 的"先计划"开关自动关掉、续消息发出、这一回合写类工具不再被拦
6. 重开会话（或重启应用）：计划卡按原样重建，且下一回合不报 provider 400（验证消息链完整）
7. 点"保存并退出"：只关开关、不发消息；点"修改"：仅聚焦输入框、开关保持开启

🤖 Generated with [Claude Code](https://claude.com/claude-code)
