### PR TITLE
fix(review): restore transcript source jumps

### DIFF
--- a/crates/wisp-store/src/ask_user_requests.rs
+++ b/crates/wisp-store/src/ask_user_requests.rs
@@ -61,10 +61,7 @@ impl Store {
     }
 
     /// Host side: the pendings the turn loop has to surface to the UI.
-    pub async fn pending_ask_user_requests(
-        &self,
-        frame_id: &str,
-    ) -> Result<Vec<(String, String)>> {
+    pub async fn pending_ask_user_requests(&self, frame_id: &str) -> Result<Vec<(String, String)>> {
         Ok(sqlx::query_as(
             "SELECT request_id, payload_json FROM ask_user_requests \
              WHERE frame_id=? AND status='pending' ORDER BY created_at, rowid",
@@ -169,7 +166,10 @@ mod tests {
 
         assert!(store.answer_ask_user_request("ask-1", "yes").await.unwrap());
         assert!(
-            !store.answer_ask_user_request("ask-1", "again").await.unwrap(),
+            !store
+                .answer_ask_user_request("ask-1", "again")
+                .await
+                .unwrap(),
             "a second answer is refused"
         );
 

--- a/crates/wisp-store/src/lib.rs
+++ b/crates/wisp-store/src/lib.rs
@@ -27,7 +27,6 @@ mod sessions;
 mod turn_undo;
 
 pub use acp_sessions::AcpSessionBinding;
-pub use ask_user_requests::AskUserPoll;
 pub use agent_workflow_attempts::{
     AgentWorkflowAttempt, AgentWorkflowAttemptStart, AgentWorkflowAttemptStatus,
 };
@@ -36,6 +35,7 @@ pub use agent_workflows::{
     AgentDelegationRootLimits, AgentWorkflow, AgentWorkflowStatus, AgentWorkflowStep,
     MAX_ROOT_AGENT_DEPTH, MAX_ROOT_AGENT_TASKS,
 };
+pub use ask_user_requests::AskUserPoll;
 pub use external_session_cache::ExternalSessionCacheRecord;
 pub use library::{
     LibraryItem, LibraryItemDetail, LibraryItemVersion, LibraryStore, NewLibraryItem,

--- a/crates/wisp-tools/src/ask_user.rs
+++ b/crates/wisp-tools/src/ask_user.rs
@@ -171,10 +171,9 @@ mod tests {
     fn options_are_optional_but_freeform_only_questions_need_freeform() {
         let body = question_body(&json!({ "question": "Proceed how?" })).unwrap();
         assert_eq!(body["options"], json!([]));
-        assert!(question_body(
-            &json!({ "question": "Proceed how?", "allow_freeform": false })
-        )
-        .is_err());
+        assert!(
+            question_body(&json!({ "question": "Proceed how?", "allow_freeform": false })).is_err()
+        );
     }
 
     #[test]

--- a/docs/acp-agents.md
+++ b/docs/acp-agents.md
@@ -180,7 +180,8 @@ API, timeout, or JSON parsing failures are shown in the chat rather than
 silently disappearing. One-shot ACP reviewer calls time out after 90 seconds
 and can be cancelled with the active turn. Automatic correction instructions
 remain control-plane messages instead of being added to the user-authored
-conversation history.
+conversation history. **Go to transcript** on a finding scrolls to the cited
+message even when token-usage or reviewer-status rows appear between turns.
 
 ## Importing Codex CLI and Claude Code conversations
 

--- a/src-tauri/src/acp.rs
+++ b/src-tauri/src/acp.rs
@@ -886,7 +886,11 @@ async fn surface_pending_asks(
         }
         asks.insert(request_id.clone(), frame_id.to_string());
         drop(asks);
-        state.awaiting_confirm.lock().unwrap().insert(frame_id.to_string());
+        state
+            .awaiting_confirm
+            .lock()
+            .unwrap()
+            .insert(frame_id.to_string());
         state.device_hub.mark_needs_user(frame_id, None);
         let payload: serde_json::Value = serde_json::from_str(&payload_json).unwrap_or_default();
         emit_ask_event(

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -2473,6 +2473,25 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
               }, 1200);
               return fid;
             }
+            if (String(arg("message") ?? "").includes("REVIEWBASE")) {
+              setTimeout(() => {
+                emit("agent", { kind: "User", frame_id: fid, text: msg });
+                emit("agent", { kind: "Text", frame_id: fid, delta: "Earlier answer." });
+                emit("agent", {
+                  kind: "Usage",
+                  frame_id: fid,
+                  round: 1,
+                  input: 100,
+                  output: 10,
+                  reasoning: 0,
+                  cached: 0,
+                  ctx_tokens: 110,
+                  max_context: 8_000,
+                });
+                emit("agent", { kind: "Done", frame_id: fid });
+              }, 30);
+              return fid;
+            }
             if (String(arg("message") ?? "").includes("AUTOREVIEWUNREVIEWABLE")) {
               const incompleteReport = {
                 id: "review-auto-unreviewable",
@@ -2529,7 +2548,7 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
                 reviewer_effort: "high",
                 findings: [
                   {
-                    message_index: 1,
+                    message_index: 3,
                     claim: "The analysis reports 5 significant genes.",
                     evidence: "The tool result reports 3 significant genes.",
                     fix: "Change the count from 5 to 3.",

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -829,15 +829,19 @@ test("post-start send failures keep the persisted user row and hide the phase pr
   await expect(composer(page)).toHaveValue("");
 });
 
-test("automatic reviewer separates the correction and resolves its finding", async ({ page }) => {
+test("automatic reviewer resolves its finding and jumps past UI-only rows (#550)", async ({ page }) => {
   await enterApp(page);
+  await composer(page).fill("REVIEWBASE");
+  await page.getByRole("button", { name: "Send" }).click();
+  await expect(page.locator(".msg.assistant")).toContainText("Earlier answer.");
+
   await composer(page).fill("AUTOREVIEW inspect the result");
   await page.getByRole("button", { name: "Send" }).click();
 
   const assistants = page.locator(".msg.assistant");
-  await expect(assistants).toHaveCount(2);
-  await expect(assistants.nth(0)).toContainText("5 significant genes");
-  await expect(assistants.nth(1)).toContainText("Correction: the analysis found 3 significant genes");
+  await expect(assistants).toHaveCount(3);
+  await expect(assistants.nth(1)).toContainText("5 significant genes");
+  await expect(assistants.nth(2)).toContainText("Correction: the analysis found 3 significant genes");
 
   const handoffs = page.locator(".review-transition");
   await expect(handoffs).toHaveCount(2);
@@ -853,7 +857,20 @@ test("automatic reviewer separates the correction and resolves its finding", asy
   await expect(review).toContainText("resolved");
   await expect(review).toContainText("All findings fixed and independently rechecked.");
   await expect(review.locator(".review-finding")).toHaveCount(1);
+  const scroller = page.locator("#chat-scroller");
+  await scroller.evaluate((element) => {
+    element.style.height = "180px";
+    element.scrollTop = element.scrollHeight;
+  });
+  await expect(assistants.nth(1)).not.toBeInViewport();
   await review.getByRole("button", { name: "Go to transcript" }).click();
+  await expect.poll(async () => {
+    const [target, viewport] = await Promise.all([
+      assistants.nth(1).boundingBox(),
+      scroller.boundingBox(),
+    ]);
+    return target && viewport ? Math.abs(target.y - viewport.y) : Number.POSITIVE_INFINITY;
+  }).toBeLessThan(4);
 });
 
 test("automatic reviewer visibly returns a clean response without correction", async ({ page }) => {

--- a/ui/src/app_support.rs
+++ b/ui/src/app_support.rs
@@ -2925,12 +2925,62 @@ pub(super) fn scroll_picker_item(selector: &str, index: usize) {
     }
 }
 
-pub(super) fn scroll_to_transcript(index: usize) {
-    let Some(document) = web_sys::window().and_then(|window| window.document()) else {
-        return;
-    };
-    if let Ok(Some(row)) = document.query_selector(&format!("[data-ui-index=\"{index}\"]")) {
-        row.scroll_into_view();
+/// Map the reviewer's `[msg:N]` index to the live UI row. Usage, reviewer
+/// handoffs, approvals, and review cards are UI-only and must not shift it.
+pub(super) fn review_message_ui_index(items: &[ChatItem], message_index: usize) -> Option<usize> {
+    items
+        .iter()
+        .enumerate()
+        .filter(|(_, item)| match item {
+            ChatItem::User(text) | ChatItem::Assistant { text, .. } | ChatItem::Reasoning(text) => {
+                !text.trim().is_empty()
+            }
+            ChatItem::Tool { name, .. } => name != "attempt_completion",
+            ChatItem::AcpTool { .. } | ChatItem::Plan(_) | ChatItem::Question(_) => true,
+            ChatItem::QueuedUser { .. }
+            | ChatItem::ApprovalPending { .. }
+            | ChatItem::AcpPermission { .. }
+            | ChatItem::Usage { .. }
+            | ChatItem::ReviewTransition { .. }
+            | ChatItem::Review(_) => false,
+        })
+        .nth(message_index)
+        .map(|(ui_index, _)| ui_index)
+}
+
+#[cfg(test)]
+mod review_jump_tests {
+    use super::review_message_ui_index;
+    use crate::dto::{ChatItem, ReviewTransitionPhase};
+
+    fn assistant(text: &str) -> ChatItem {
+        ChatItem::Assistant {
+            text: text.into(),
+            model: None,
+            resources: vec![],
+        }
+    }
+
+    #[test]
+    fn review_indices_ignore_ui_only_rows() {
+        let items = vec![
+            ChatItem::User("earlier question".into()),
+            assistant("earlier answer"),
+            ChatItem::Usage {
+                input: 10,
+                output: 2,
+                reasoning: 0,
+                cached: 0,
+            },
+            ChatItem::ReviewTransition {
+                phase: ReviewTransitionPhase::Reviewing,
+                model: None,
+            },
+            ChatItem::User("current question".into()),
+            assistant("problematic answer"),
+        ];
+
+        assert_eq!(review_message_ui_index(&items, 3), Some(5));
     }
 }
 

--- a/ui/src/bindings.rs
+++ b/ui/src/bindings.rs
@@ -134,6 +134,14 @@ pub(crate) fn jump_chat_to_user(index: usize) {
     );
 }
 
+/// Jump to one rendered transcript item by its UI row index.
+pub(crate) fn jump_chat_to_item(index: usize) {
+    jump_chat_scroll(
+        CHAT_SCROLLER_ID,
+        &format!("[data-ui-index=\"{index}\"], [data-ui-indices~=\"{index}\"]"),
+    );
+}
+
 /// Jump to the latest user turn (floating "Your last message" pill).
 pub(crate) fn jump_chat_to_last_user() {
     jump_chat_scroll_last_user(CHAT_SCROLLER_ID);

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -20,12 +20,11 @@ use agent_workflows::{
 };
 use bindings::{
     attach_chat_autoscroll, clear_selection, close_mcp_app, force_chat_bottom, invoke,
-    invoke_checked, invoke_timeout, is_mac, is_windows, jump_chat_to_last_user,
-    jump_chat_to_user, listen,
-    listen_native_file_drop, mount_mcp_app, mount_terminal, native_drop_in_composer,
-    open_external_url, park_mcp_app, pasted_image_count, preserve_chat_prepend_position,
-    preview_selection, schedule_chat_follow, set_saved_marks, set_terminal_active,
-    unmount_terminal, CHAT_SCROLLER_ID, CHAT_THREAD_ID,
+    invoke_checked, invoke_timeout, is_mac, is_windows, jump_chat_to_item, jump_chat_to_last_user,
+    jump_chat_to_user, listen, listen_native_file_drop, mount_mcp_app, mount_terminal,
+    native_drop_in_composer, open_external_url, park_mcp_app, pasted_image_count,
+    preserve_chat_prepend_position, preview_selection, schedule_chat_follow, set_saved_marks,
+    set_terminal_active, unmount_terminal, CHAT_SCROLLER_ID, CHAT_THREAD_ID,
 };
 use context_menu::{ContextMenuPortal, CtxMenu};
 use dto::*;
@@ -4629,6 +4628,14 @@ fn App() -> impl IntoView {
         });
     });
 
+    let jump_to_review_message = Callback::new(move |message_index: usize| {
+        if let Some(ui_index) =
+            items.with_untracked(|rows| review_message_ui_index(rows, message_index))
+        {
+            jump_chat_to_item(ui_index);
+        }
+    });
+
     let jump_to_conversation_outline =
         Callback::new(move |(target, before_seq): (usize, Option<i64>)| {
             let Some(id) = active_session.get_untracked() else {
@@ -8284,8 +8291,16 @@ fn App() -> impl IntoView {
                                     let mut h = std::collections::hash_map::DefaultHasher::new();
                                     for (idx, it) in &run { (idx, it.fingerprint()).hash(&mut h); }
                                     true.hash(&mut h);
+                                    let ui_indices = run
+                                        .iter()
+                                        .map(|(index, _)| index.to_string())
+                                        .collect::<Vec<_>>()
+                                        .join(" ");
                                     let items_only = run.into_iter().map(|(_, item)| item).collect();
-                                    rows.push((start, h.finish(), ThreadRow::Activity { items: items_only }));
+                                    rows.push((start, h.finish(), ThreadRow::Activity {
+                                        items: items_only,
+                                        ui_indices,
+                                    }));
                                     i = end;
                                 } else if is_tool_activity(&list[i]) {
                                     let start = i;
@@ -8304,8 +8319,17 @@ fn App() -> impl IntoView {
                                     let mut h = std::collections::hash_map::DefaultHasher::new();
                                     for (idx, it) in &run { (idx, it.fingerprint()).hash(&mut h); }
                                     live.hash(&mut h);
+                                    let ui_indices = run
+                                        .iter()
+                                        .map(|(index, _)| index.to_string())
+                                        .collect::<Vec<_>>()
+                                        .join(" ");
                                     let items_only: Vec<ChatItem> = run.into_iter().map(|(_, c)| c).collect();
-                                    rows.push((start, h.finish(), ThreadRow::Steps { items: items_only, live }));
+                                    rows.push((start, h.finish(), ThreadRow::Steps {
+                                        items: items_only,
+                                        live,
+                                        ui_indices,
+                                    }));
                                     i = j;
                                 } else {
                                     let commentary = is_commentary_at(list, i);
@@ -8390,18 +8414,18 @@ fn App() -> impl IntoView {
                                                 run_records, busy.read_only(), compact_assistant, active_acp_agent_id.get().is_none(), can_undo, edit_message, branch_message, undo_message, sid,
                                                 respond_confirm, on_resume, on_queue,
                                                 plan_mode_active, plan_compat, on_plan_decision,
-                                                on_question_answer,
+                                                on_question_answer, jump_to_review_message,
                                             )}
                                         </div>
                                     }.into_view()
                                 }
-                                ThreadRow::Steps { items, live } => {
+                                ThreadRow::Steps { items, live, ui_indices } => {
                                     let sid = active_session.get().unwrap_or_default();
                                     // ponytail: position-keyed; move to stable
                                     // row ids if mid-list edits ever shift groups.
                                     let group_id = format!("{sid}:steps:{start}");
                                     view! {
-                                        <div class="steps-wrap">{
+                                        <div class="steps-wrap" data-ui-indices=ui_indices>{
                                             render_steps_group(
                                                 items,
                                                 live,
@@ -8412,11 +8436,11 @@ fn App() -> impl IntoView {
                                         }</div>
                                     }.into_view()
                                 },
-                                ThreadRow::Activity { items } => {
+                                ThreadRow::Activity { items, ui_indices } => {
                                     let sid = active_session.get().unwrap_or_default();
                                     let group_id = format!("{sid}:activity:{start}");
                                     view! {
-                                        <div class="steps-wrap">{
+                                        <div class="steps-wrap" data-ui-indices=ui_indices>{
                                             render_steps_group(
                                                 items,
                                                 false,
@@ -12023,9 +12047,11 @@ enum ThreadRow {
     Steps {
         items: Vec<ChatItem>,
         live: bool,
+        ui_indices: String,
     },
     Activity {
         items: Vec<ChatItem>,
+        ui_indices: String,
     },
 }
 
@@ -12607,6 +12633,7 @@ fn render_item(
     plan_compat: Signal<bool>,
     on_plan_decision: Callback<PlanDecision>,
     on_question_answer: Callback<(usize, Option<String>, String)>,
+    on_review_jump: Callback<usize>,
 ) -> impl IntoView {
     let locale = use_locale();
     match item {
@@ -12971,7 +12998,7 @@ fn render_item(
                                 <span class=severity_class>{finding.severity}</span>
                                 <span class="review-pill status">{move || t(locale.get(), status_key)}</span>
                                 <button type="button" class="tool-btn review-jump"
-                                    on:click=move |_| scroll_to_transcript(message_index)>
+                                    on:click=move |_| on_review_jump.call(message_index)>
                                     {move || t(locale.get(), "review.go_to_transcript")}
                                 </button>
                             </div>


### PR DESCRIPTION
## Problem

Review findings expose **Go to transcript / 定位到原文**, but reviewer `[msg:N]`
indices were used directly as rendered UI row indices. Token-usage and reviewer
status rows shifted the target, while collapsed activity groups were not
addressable, so the action could jump to the wrong turn or appear inert.

Fixes #550.

## Changes

- map reviewer transcript indices to transcript-backed chat items before scrolling
- reuse the existing chat jump path and make collapsed activity groups addressable
- add a focused unit test and a Playwright regression with a preceding usage row
- document the corrected user-visible behavior
- apply pre-existing `rustfmt` drift in a separate formatting-only commit, as required by the pre-push hook

## Verification

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cd ui && cargo test review_indices_ignore_ui_only_rows`
- `cd ui && cargo check --target wasm32-unknown-unknown`
- `cd ui-tests && npm ci`
- `cd ui-tests && npx playwright test tests/ui.spec.ts --grep "#550" --reporter=line`
- full Playwright run: 223 passed, 1 skipped, with one unrelated runtime-inspector drag test failing in suite order and passing when rerun alone

## Manual smoke

1. Complete at least two turns so a token-usage row exists before the reviewed answer.
2. Run automatic or manual review with a finding.
3. Click **Go to transcript / 定位到原文**.
4. Verify the cited answer aligns in the chat viewport, including when activity is collapsed.

## Known limitations / follow-up

- The full Playwright suite still has the unrelated, order-dependent runtime-inspector drag failure noted above.
- No follow-up is required for #550.
