### PR TITLE
Add StickS3 Pet resource endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2156,10 +2156,21 @@ checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
+ "image-webp",
  "moxcms",
  "num-traits",
  "png 0.18.1",
  "tiff",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -201,8 +201,11 @@ documented in [Feature plugins](docs/feature-plugins.md).
 
 The experimental **StickS3 Device Bridge** is configured beside Feishu and
 WeChat under **Settings → Remote Access**. LAN mode uses authenticated HTTP
-polling on one explicitly selected IPv4 address; a separate relay-server mode is
-reserved for a later phase. See the [StickS3 Device Bridge guide](docs/sticks3-device-bridge.md).
+polling on one explicitly selected IPv4 address. It exposes the current
+physical-pet state plus authenticated manifest and `120×130` PNG frame
+resources generated from the configured Codex-compatible v2 desktop Pet. A
+separate relay-server mode is reserved for a later phase. See the
+[StickS3 Device Bridge guide](docs/sticks3-device-bridge.md).
 
 Projects can also be synchronized explicitly between devices. Configure either
 a self-hosted relay or a folder managed by the Baidu Netdisk/Nutstore desktop

--- a/docs/sticks3-device-bridge.md
+++ b/docs/sticks3-device-bridge.md
@@ -130,6 +130,80 @@ State values are `idle`, `working`, `review`, `needs_user`, `done`, and
 `seq` increases monotonically whenever the authoritative state changes.
 `sessionId` lets the physical button focus the relevant desktop session.
 
+### `GET /pet/manifest`
+
+Requires `X-Wisp-Device-Token`. When the desktop Pet setting points to a valid
+Codex-compatible v2 Pet package, this endpoint describes the frames available
+to StickS3:
+
+```json
+{
+  "type": "pet_manifest",
+  "protocol": 1,
+  "enabled": true,
+  "id": "wispy",
+  "displayName": "Wispy",
+  "revision": "64-character-lowercase-sha256",
+  "format": "png",
+  "frameWidth": 120,
+  "frameHeight": 130,
+  "frameIntervalMs": 180,
+  "frameCounts": {
+    "idle": 7,
+    "working": 6,
+    "review": 6,
+    "needs_user": 6,
+    "done": 5,
+    "failed": 8
+  }
+}
+```
+
+The revision covers the Pet manifest, atlas contents, validation data,
+effective frame counts, identity, and StickS3 rendering parameters. It changes
+whenever any StickS3-visible Pet output can change.
+
+If the desktop Pet is disabled, unconfigured, or invalid, the endpoint still
+returns HTTP 200 with `enabled: false`. It may include a short reason, but never
+includes the configured Pet directory or another local path:
+
+```json
+{
+  "type": "pet_manifest",
+  "protocol": 1,
+  "enabled": false,
+  "reason": "Pet is disabled."
+}
+```
+
+### `GET /pet/frame?revision=<revision>&state=<state>&frame=<index>`
+
+Requires `X-Wisp-Device-Token`. A successful response is an immutable,
+transparent `image/png` frame with exact dimensions `120×130` and an accurate
+`Content-Length`. Wisp Science crops one `192×208` atlas cell and scales it at
+the same aspect ratio. PNG and WebP v2 source atlases are supported.
+
+The accepted states form a closed list:
+
+| Bridge state | v2 atlas row | Row index | Default frame count |
+|---|---|---:|---:|
+| `idle` | `idle` | 0 | 7 |
+| `working` | `running` | 7 | 6 |
+| `review` | `review` | 8 | 6 |
+| `needs_user` | `waiting` | 6 | 6 |
+| `done` | `jumping` | 4 | 5 |
+| `failed` | `failed` | 5 | 8 |
+
+Valid `validation.json` cell data overrides the default frame counts in both
+the manifest and frame-index validation. Unknown states and invalid or
+out-of-range frame requests return HTTP 400 or 404. A stale revision returns
+HTTP 409 so the device can fetch the manifest again. If no valid Pet is
+available, the frame endpoint returns HTTP 404.
+
+The endpoint accepts no path, filename, dimensions, or arbitrary file
+parameter. Rendered frames are held in a bounded in-memory cache keyed by
+revision, state, and frame; changing revision invalidates the previous cache.
+
 ### `POST /action`
 
 Requires `X-Wisp-Device-Token`. Only three actions are accepted:
@@ -188,6 +262,8 @@ the replacement starts. Application exit also stops the listener.
 - Relay server mode is designed but not implemented or deployed.
 - There is no cloud relay, router port-forwarding workflow, or automatic
   pairing.
+- Pet resources use the configured local desktop Pet only; there is no remote
+  Pet catalog or Pet upload endpoint.
 - StickS3 cannot approve tools, submit prompts, run commands, or read full
   conversation content.
 - One bounded action stream is provided for diagnostics; there is no complex

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -44,8 +44,8 @@ portable-pty = { workspace = true }
 async-trait = { workspace = true }
 axum = { workspace = true }
 zip = { version = "2", default-features = false, features = ["deflate"] }
-# TIFF -> PNG transcode for OOXML preview media (browsers cannot decode TIFF).
-image = { version = "0.25", default-features = false, features = ["tiff", "png"] }
+# TIFF -> PNG transcode for OOXML preview media plus PNG/WebP Pet atlases.
+image = { version = "0.25", default-features = false, features = ["tiff", "png", "webp"] }
 which = "7"
 walkdir = { workspace = true }
 wisp-core = { workspace = true }

--- a/src-tauri/src/device_bridge.rs
+++ b/src-tauri/src/device_bridge.rs
@@ -5,22 +5,34 @@
 //! pre-shared token. The action surface is a closed list and never enters the
 //! Agent/tool execution path.
 
-use crate::{desktop_lifecycle, device_hub::DeviceHub, AppState};
+use crate::{
+    desktop_lifecycle,
+    device_hub::DeviceHub,
+    pet_commands::{load_pet_source, ValidatedPetSource},
+    AppState,
+};
 use async_trait::async_trait;
 use axum::{
-    extract::{DefaultBodyLimit, State},
-    http::{HeaderMap, StatusCode},
+    body::{Body, Bytes},
+    extract::{DefaultBodyLimit, Query, State},
+    http::{
+        header::{CACHE_CONTROL, CONTENT_LENGTH, CONTENT_TYPE, ETAG},
+        HeaderMap, StatusCode, Uri,
+    },
     response::{IntoResponse, Response},
     routing::{get, post},
     Json, Router,
 };
 use base64::Engine;
+use image::{codecs::png::PngEncoder, imageops::FilterType, ImageEncoder, ImageFormat};
 use ring::{hmac, rand as ring_rand};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
 use std::{
-    collections::VecDeque,
+    collections::{BTreeMap, VecDeque},
     net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+    path::Path,
     sync::{Arc, Mutex as StdMutex, RwLock as StdRwLock},
 };
 use tauri::{AppHandle, Manager, State as TauriState};
@@ -40,6 +52,60 @@ const SETTING_PORT: &str = "device_bridge_port";
 const DEVICE_TOKEN_HEADER: &str = "x-wisp-device-token";
 const ACTION_HISTORY_LIMIT: usize = 50;
 const MAX_ACTION_ID_BYTES: usize = 160;
+const PET_FRAME_WIDTH: u32 = 120;
+const PET_FRAME_HEIGHT: u32 = 130;
+const PET_FRAME_INTERVAL_MS: u32 = 180;
+const PET_ATLAS_CELL_WIDTH: u32 = 192;
+const PET_ATLAS_CELL_HEIGHT: u32 = 208;
+const PET_FRAME_CACHE_LIMIT: usize = 48;
+const MAX_PET_FRAME_BYTES: usize = 512 * 1024;
+
+#[derive(Clone, Copy)]
+struct PetStateSpec {
+    bridge_state: &'static str,
+    atlas_state: &'static str,
+    row: u32,
+    default_frames: u8,
+}
+
+const PET_STATE_SPECS: [PetStateSpec; 6] = [
+    PetStateSpec {
+        bridge_state: "idle",
+        atlas_state: "idle",
+        row: 0,
+        default_frames: 7,
+    },
+    PetStateSpec {
+        bridge_state: "working",
+        atlas_state: "running",
+        row: 7,
+        default_frames: 6,
+    },
+    PetStateSpec {
+        bridge_state: "review",
+        atlas_state: "review",
+        row: 8,
+        default_frames: 6,
+    },
+    PetStateSpec {
+        bridge_state: "needs_user",
+        atlas_state: "waiting",
+        row: 6,
+        default_frames: 6,
+    },
+    PetStateSpec {
+        bridge_state: "done",
+        atlas_state: "jumping",
+        row: 4,
+        default_frames: 5,
+    },
+    PetStateSpec {
+        bridge_state: "failed",
+        atlas_state: "failed",
+        row: 5,
+        default_frames: 8,
+    },
+];
 
 /// The bridge transport is explicit from v1 so adding the out-of-LAN relay
 /// later does not overload LAN bind settings or silently change exposure.
@@ -162,6 +228,105 @@ struct DeviceActionRequest {
     session_id: Option<String>,
 }
 
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PetManifestResponse {
+    r#type: &'static str,
+    protocol: u8,
+    enabled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    display_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    revision: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    format: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    frame_width: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    frame_height: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    frame_interval_ms: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    frame_counts: Option<BTreeMap<&'static str, u8>>,
+}
+
+impl PetManifestResponse {
+    fn disabled(reason: &'static str) -> Self {
+        Self {
+            r#type: "pet_manifest",
+            protocol: 1,
+            enabled: false,
+            reason: Some(reason),
+            id: None,
+            display_name: None,
+            revision: None,
+            format: None,
+            frame_width: None,
+            frame_height: None,
+            frame_interval_ms: None,
+            frame_counts: None,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PetFrameQuery {
+    revision: String,
+    state: String,
+    frame: u8,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct PetFrameCacheKey {
+    revision: String,
+    state: String,
+    frame: u8,
+}
+
+#[derive(Default)]
+struct PetFrameCache {
+    revision: Option<String>,
+    entries: VecDeque<(PetFrameCacheKey, Bytes)>,
+}
+
+impl PetFrameCache {
+    fn invalidate(&mut self) {
+        self.entries.clear();
+        self.revision = None;
+    }
+
+    fn prepare_revision(&mut self, revision: &str) {
+        if self.revision.as_deref() != Some(revision) {
+            self.entries.clear();
+            self.revision = Some(revision.to_string());
+        }
+    }
+
+    fn get(&mut self, key: &PetFrameCacheKey) -> Option<Bytes> {
+        self.prepare_revision(&key.revision);
+        self.entries
+            .iter()
+            .find(|(cached, _)| cached == key)
+            .map(|(_, bytes)| bytes.clone())
+    }
+
+    fn insert(&mut self, key: PetFrameCacheKey, bytes: Bytes) {
+        self.prepare_revision(&key.revision);
+        if self.entries.iter().any(|(cached, _)| cached == &key) {
+            return;
+        }
+        if self.entries.len() == PET_FRAME_CACHE_LIMIT {
+            self.entries.pop_front();
+        }
+        self.entries.push_back((key, bytes));
+    }
+}
+
 #[async_trait]
 pub(crate) trait SessionFocus: Send + Sync {
     async fn focus_session(&self, session_id: &str) -> Result<(), String>;
@@ -211,8 +376,10 @@ impl SessionFocus for TauriSessionFocus {
 #[derive(Clone)]
 struct HttpState {
     hub: Arc<DeviceHub>,
+    store: Store,
     token: Arc<StdRwLock<Option<Vec<u8>>>>,
     actions: Arc<StdMutex<VecDeque<DeviceActionRecord>>>,
+    pet_frames: Arc<StdMutex<PetFrameCache>>,
     focus: Arc<dyn SessionFocus>,
 }
 
@@ -224,18 +391,22 @@ struct RunningBridge {
 
 pub struct DeviceBridge {
     hub: Arc<DeviceHub>,
+    store: Store,
     token: Arc<StdRwLock<Option<Vec<u8>>>>,
     actions: Arc<StdMutex<VecDeque<DeviceActionRecord>>>,
+    pet_frames: Arc<StdMutex<PetFrameCache>>,
     runtime: Mutex<Option<RunningBridge>>,
     status: Arc<StdMutex<DeviceBridgeRuntimeStatus>>,
 }
 
 impl DeviceBridge {
-    pub fn new(hub: Arc<DeviceHub>) -> Self {
+    pub fn new(hub: Arc<DeviceHub>, store: Store) -> Self {
         Self {
             hub,
+            store,
             token: Arc::new(StdRwLock::new(None)),
             actions: Arc::new(StdMutex::new(VecDeque::with_capacity(ACTION_HISTORY_LIMIT))),
+            pet_frames: Arc::new(StdMutex::new(PetFrameCache::default())),
             runtime: Mutex::new(None),
             status: Arc::new(StdMutex::new(DeviceBridgeRuntimeStatus::default())),
         }
@@ -280,8 +451,10 @@ impl DeviceBridge {
         *self.token.write().unwrap() = Some(token.into_bytes());
         let router = router(HttpState {
             hub: self.hub.clone(),
+            store: self.store.clone(),
             token: self.token.clone(),
             actions: self.actions.clone(),
+            pet_frames: self.pet_frames.clone(),
             focus,
         });
         let (shutdown, shutdown_rx) = oneshot::channel();
@@ -377,6 +550,8 @@ fn router(state: HttpState) -> Router {
     Router::new()
         .route("/health", get(health))
         .route("/state", get(get_state))
+        .route("/pet/manifest", get(get_pet_manifest))
+        .route("/pet/frame", get(get_pet_frame))
         .route("/action", post(post_action))
         .route("/actions", get(get_actions))
         .layer(DefaultBodyLimit::max(4 * 1024))
@@ -389,6 +564,219 @@ async fn health() -> Json<Value> {
         "service": "wisp-device-bridge",
         "protocol": 1,
     }))
+}
+
+enum CurrentPet {
+    Available(ValidatedPetSource),
+    Unavailable(&'static str),
+}
+
+async fn current_pet(store: &Store) -> CurrentPet {
+    let enabled = store
+        .get_setting("pet_enabled")
+        .await
+        .ok()
+        .flatten()
+        .is_some_and(|value| value == "true");
+    if !enabled {
+        return CurrentPet::Unavailable("Pet is disabled.");
+    }
+    let directory = store
+        .get_setting("pet_directory")
+        .await
+        .ok()
+        .flatten()
+        .unwrap_or_default();
+    if directory.trim().is_empty() {
+        return CurrentPet::Unavailable("Pet is not configured.");
+    }
+    match tokio::task::spawn_blocking(move || load_pet_source(Path::new(&directory))).await {
+        Ok(Ok(source)) => CurrentPet::Available(source),
+        Ok(Err(_)) | Err(_) => CurrentPet::Unavailable("Configured Pet is invalid."),
+    }
+}
+
+fn pet_frame_count(source: &ValidatedPetSource, spec: PetStateSpec) -> u8 {
+    source
+        .frame_counts
+        .get(spec.atlas_state)
+        .copied()
+        .unwrap_or(spec.default_frames)
+}
+
+fn pet_revision(source: &ValidatedPetSource) -> String {
+    let mut revision = Sha256::new();
+    revision.update(b"wisp-sticks3-pet-protocol-1\0");
+    revision.update(source.package_revision.as_bytes());
+    revision.update(b"\0png\0");
+    revision.update(PET_FRAME_WIDTH.to_le_bytes());
+    revision.update(PET_FRAME_HEIGHT.to_le_bytes());
+    revision.update(PET_FRAME_INTERVAL_MS.to_le_bytes());
+    revision.update(PET_ATLAS_CELL_WIDTH.to_le_bytes());
+    revision.update(PET_ATLAS_CELL_HEIGHT.to_le_bytes());
+    revision.update(b"resize:lanczos3\0");
+    for spec in PET_STATE_SPECS {
+        revision.update(spec.bridge_state.as_bytes());
+        revision.update([0]);
+        revision.update(spec.atlas_state.as_bytes());
+        revision.update([0]);
+        revision.update(spec.row.to_le_bytes());
+        revision.update([pet_frame_count(source, spec)]);
+    }
+    format!("{:x}", revision.finalize())
+}
+
+async fn get_pet_manifest(State(state): State<HttpState>, headers: HeaderMap) -> Response {
+    if !authorized(&state, &headers) {
+        return unauthorized();
+    }
+    let source = match current_pet(&state.store).await {
+        CurrentPet::Available(source) => source,
+        CurrentPet::Unavailable(reason) => {
+            state.pet_frames.lock().unwrap().invalidate();
+            return Json(PetManifestResponse::disabled(reason)).into_response();
+        }
+    };
+    let revision = pet_revision(&source);
+    state.pet_frames.lock().unwrap().prepare_revision(&revision);
+    let frame_counts = PET_STATE_SPECS
+        .into_iter()
+        .map(|spec| (spec.bridge_state, pet_frame_count(&source, spec)))
+        .collect();
+    let manifest = PetManifestResponse {
+        r#type: "pet_manifest",
+        protocol: 1,
+        enabled: true,
+        reason: None,
+        id: Some(source.id.clone()),
+        display_name: Some(source.display_name.clone()),
+        revision: Some(revision),
+        format: Some("png"),
+        frame_width: Some(PET_FRAME_WIDTH),
+        frame_height: Some(PET_FRAME_HEIGHT),
+        frame_interval_ms: Some(PET_FRAME_INTERVAL_MS),
+        frame_counts: Some(frame_counts),
+    };
+    Json(manifest).into_response()
+}
+
+async fn get_pet_frame(State(state): State<HttpState>, headers: HeaderMap, uri: Uri) -> Response {
+    if !authorized(&state, &headers) {
+        return unauthorized();
+    }
+    let Query(query) = match Query::<PetFrameQuery>::try_from_uri(&uri) {
+        Ok(query) => query,
+        Err(_) => {
+            return pet_frame_error(StatusCode::BAD_REQUEST, "Invalid Pet frame request.");
+        }
+    };
+    let spec = match PET_STATE_SPECS
+        .into_iter()
+        .find(|spec| spec.bridge_state == query.state)
+    {
+        Some(spec) => spec,
+        None => return pet_frame_error(StatusCode::BAD_REQUEST, "Unknown Pet state."),
+    };
+    let source = match current_pet(&state.store).await {
+        CurrentPet::Available(source) => source,
+        CurrentPet::Unavailable(_) => {
+            state.pet_frames.lock().unwrap().invalidate();
+            return pet_frame_error(StatusCode::NOT_FOUND, "No valid Pet is available.");
+        }
+    };
+    let revision = pet_revision(&source);
+    state.pet_frames.lock().unwrap().prepare_revision(&revision);
+    if query.revision != revision {
+        return pet_frame_error(StatusCode::CONFLICT, "Pet revision changed.");
+    }
+    if query.frame >= pet_frame_count(&source, spec) {
+        return pet_frame_error(StatusCode::NOT_FOUND, "Pet frame does not exist.");
+    }
+
+    let cache_key = PetFrameCacheKey {
+        revision: revision.clone(),
+        state: spec.bridge_state.to_string(),
+        frame: query.frame,
+    };
+    if let Some(bytes) = state.pet_frames.lock().unwrap().get(&cache_key) {
+        return pet_frame_response(bytes, &cache_key);
+    }
+
+    let frame = query.frame;
+    let bytes =
+        match tokio::task::spawn_blocking(move || render_pet_frame(source, spec, frame)).await {
+            Ok(Ok(bytes)) => Bytes::from(bytes),
+            Ok(Err(_)) | Err(_) => {
+                return pet_frame_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Pet frame could not be rendered.",
+                );
+            }
+        };
+    state
+        .pet_frames
+        .lock()
+        .unwrap()
+        .insert(cache_key.clone(), bytes.clone());
+    pet_frame_response(bytes, &cache_key)
+}
+
+fn render_pet_frame(
+    source: ValidatedPetSource,
+    spec: PetStateSpec,
+    frame: u8,
+) -> Result<Vec<u8>, String> {
+    let format = match source.spritesheet_mime {
+        "image/png" => ImageFormat::Png,
+        "image/webp" => ImageFormat::WebP,
+        _ => return Err("unsupported Pet spritesheet format".into()),
+    };
+    let atlas = image::load_from_memory_with_format(&source.spritesheet, format)
+        .map_err(|_| "Pet spritesheet could not be decoded".to_string())?
+        .into_rgba8();
+    if atlas.dimensions() != (PET_ATLAS_CELL_WIDTH * 8, PET_ATLAS_CELL_HEIGHT * 11) {
+        return Err("Pet spritesheet dimensions changed".into());
+    }
+    let x = u32::from(frame) * PET_ATLAS_CELL_WIDTH;
+    let y = spec.row * PET_ATLAS_CELL_HEIGHT;
+    let cropped =
+        image::imageops::crop_imm(&atlas, x, y, PET_ATLAS_CELL_WIDTH, PET_ATLAS_CELL_HEIGHT)
+            .to_image();
+    let resized = image::imageops::resize(
+        &cropped,
+        PET_FRAME_WIDTH,
+        PET_FRAME_HEIGHT,
+        FilterType::Lanczos3,
+    );
+    let mut output = Vec::new();
+    PngEncoder::new(&mut output)
+        .write_image(
+            resized.as_raw(),
+            PET_FRAME_WIDTH,
+            PET_FRAME_HEIGHT,
+            image::ExtendedColorType::Rgba8,
+        )
+        .map_err(|_| "Pet frame could not be encoded".to_string())?;
+    if output.len() > MAX_PET_FRAME_BYTES {
+        return Err("Pet frame exceeds output limit".into());
+    }
+    Ok(output)
+}
+
+fn pet_frame_response(bytes: Bytes, key: &PetFrameCacheKey) -> Response {
+    let etag = format!("\"{}-{}-{}\"", key.revision, key.state, key.frame);
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(CONTENT_TYPE, "image/png")
+        .header(CONTENT_LENGTH, bytes.len().to_string())
+        .header(CACHE_CONTROL, "private, max-age=31536000, immutable")
+        .header(ETAG, etag)
+        .body(Body::from(bytes))
+        .unwrap()
+}
+
+fn pet_frame_error(status: StatusCode, error: &'static str) -> Response {
+    (status, Json(json!({ "ok": false, "error": error }))).into_response()
 }
 
 async fn get_state(State(state): State<HttpState>, headers: HeaderMap) -> Response {
@@ -737,7 +1125,12 @@ pub(crate) async fn revoke_device_bridge_token(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use image::{ImageBuffer, Rgba, RgbaImage};
+    use std::{
+        fs,
+        path::{Path, PathBuf},
+        sync::atomic::{AtomicUsize, Ordering},
+    };
 
     #[derive(Default)]
     struct FakeFocus {
@@ -768,10 +1161,19 @@ mod tests {
         DeviceBridgeConfig::parse("127.0.0.1", u32::from(port)).unwrap()
     }
 
-    async fn start_test_bridge() -> (Arc<DeviceBridge>, Arc<FakeFocus>, String, String, u16) {
+    async fn test_store() -> (Store, PathBuf) {
+        let root =
+            std::env::temp_dir().join(format!("wisp-device-bridge-store-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&root).unwrap();
+        (Store::open(&root.join("wisp.sqlite")).await.unwrap(), root)
+    }
+
+    async fn start_test_bridge_with_store(
+        store: Store,
+    ) -> (Arc<DeviceBridge>, Arc<FakeFocus>, String, String, u16) {
         let hub = Arc::new(DeviceHub::default());
         hub.mark_working("frame-a", Some("project-a"));
-        let bridge = Arc::new(DeviceBridge::new(hub));
+        let bridge = Arc::new(DeviceBridge::new(hub, store));
         let focus = Arc::new(FakeFocus::default());
         let token = "test-token-that-is-not-logged".to_string();
         let port = free_port();
@@ -786,6 +1188,76 @@ mod tests {
             format!("http://127.0.0.1:{port}"),
             port,
         )
+    }
+
+    async fn start_test_bridge() -> (
+        Arc<DeviceBridge>,
+        Arc<FakeFocus>,
+        String,
+        String,
+        u16,
+        PathBuf,
+    ) {
+        let (store, root) = test_store().await;
+        let (bridge, focus, token, url, port) = start_test_bridge_with_store(store).await;
+        (bridge, focus, token, url, port, root)
+    }
+
+    fn pet_directory(name: &str) -> PathBuf {
+        let directory =
+            std::env::temp_dir().join(format!("wisp-device-pet-{name}-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&directory).unwrap();
+        directory
+    }
+
+    fn row_color(row: u32) -> [u8; 4] {
+        [
+            10 + row as u8 * 17,
+            220 - row as u8 * 11,
+            30 + row as u8 * 13,
+            63 + row as u8 * 13,
+        ]
+    }
+
+    fn write_test_atlas(directory: &Path, format: ImageFormat) -> &'static str {
+        let atlas: RgbaImage = ImageBuffer::from_fn(
+            PET_ATLAS_CELL_WIDTH * 8,
+            PET_ATLAS_CELL_HEIGHT * 11,
+            |_, y| Rgba(row_color(y / PET_ATLAS_CELL_HEIGHT)),
+        );
+        let (file_name, manifest_path) = match format {
+            ImageFormat::Png => ("spritesheet.png", "spritesheet.png"),
+            ImageFormat::WebP => ("spritesheet.webp", "spritesheet.webp"),
+            _ => panic!("unsupported test format"),
+        };
+        atlas
+            .save_with_format(directory.join(file_name), format)
+            .unwrap();
+        manifest_path
+    }
+
+    fn write_test_pet(directory: &Path, format: ImageFormat) {
+        let spritesheet_path = write_test_atlas(directory, format);
+        fs::write(
+            directory.join("pet.json"),
+            serde_json::json!({
+                "id": "wispy",
+                "displayName": "Wispy",
+                "description": "test pet",
+                "spriteVersionNumber": 2,
+                "spritesheetPath": spritesheet_path,
+            })
+            .to_string(),
+        )
+        .unwrap();
+    }
+
+    async fn enable_test_pet(store: &Store, directory: &Path) {
+        store.set_setting("pet_enabled", "true").await.unwrap();
+        store
+            .set_setting("pet_directory", &directory.to_string_lossy())
+            .await
+            .unwrap();
     }
 
     #[test]
@@ -812,8 +1284,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn health_is_public_but_state_requires_the_exact_token() {
-        let (bridge, _, token, url, _) = start_test_bridge().await;
+    async fn health_is_public_but_state_and_pet_routes_require_the_exact_token() {
+        let (bridge, _, token, url, _, store_root) = start_test_bridge().await;
         let client = reqwest::Client::new();
         let health: Value = client
             .get(format!("{url}/health"))
@@ -827,28 +1299,34 @@ mod tests {
             health,
             json!({"ok": true, "service": "wisp-device-bridge", "protocol": 1})
         );
-        assert_eq!(
-            client
-                .get(format!("{url}/state"))
-                .send()
-                .await
-                .unwrap()
-                .status(),
-            StatusCode::UNAUTHORIZED
-        );
-        assert_eq!(
-            client
-                .get(format!("{url}/state"))
-                .header("X-Wisp-Device-Token", "wrong")
-                .send()
-                .await
-                .unwrap()
-                .status(),
-            StatusCode::UNAUTHORIZED
-        );
+        for path in [
+            "/state",
+            "/pet/manifest",
+            "/pet/frame?revision=none&state=idle&frame=0",
+        ] {
+            assert_eq!(
+                client
+                    .get(format!("{url}{path}"))
+                    .send()
+                    .await
+                    .unwrap()
+                    .status(),
+                StatusCode::UNAUTHORIZED
+            );
+            assert_eq!(
+                client
+                    .get(format!("{url}{path}"))
+                    .header("X-Wisp-Device-Token", "wrong")
+                    .send()
+                    .await
+                    .unwrap()
+                    .status(),
+                StatusCode::UNAUTHORIZED
+            );
+        }
         let state: Value = client
             .get(format!("{url}/state"))
-            .header("X-Wisp-Device-Token", token)
+            .header("X-Wisp-Device-Token", &token)
             .send()
             .await
             .unwrap()
@@ -859,12 +1337,33 @@ mod tests {
         assert_eq!(state["state"], "working");
         assert_eq!(state["sessionId"], "frame-a");
         assert!(state.get("seq").is_some());
+
+        let manifest: Value = client
+            .get(format!("{url}/pet/manifest"))
+            .header("X-Wisp-Device-Token", token)
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        assert_eq!(
+            manifest,
+            json!({
+                "type": "pet_manifest",
+                "protocol": 1,
+                "enabled": false,
+                "reason": "Pet is disabled.",
+            })
+        );
         bridge.stop().await;
+        drop(bridge);
+        let _ = fs::remove_dir_all(store_root);
     }
 
     #[tokio::test]
     async fn action_surface_is_bounded_and_ping_has_no_focus_side_effect() {
-        let (bridge, focus, token, url, _) = start_test_bridge().await;
+        let (bridge, focus, token, url, _, store_root) = start_test_bridge().await;
         let client = reqwest::Client::new();
         let unknown = client
             .post(format!("{url}/action"))
@@ -900,11 +1399,13 @@ mod tests {
             ACTION_HISTORY_LIMIT
         );
         bridge.stop().await;
+        drop(bridge);
+        let _ = fs::remove_dir_all(store_root);
     }
 
     #[tokio::test]
     async fn focus_session_rejects_missing_and_orphaned_sessions() {
-        let (bridge, focus, token, url, _) = start_test_bridge().await;
+        let (bridge, focus, token, url, _, store_root) = start_test_bridge().await;
         let client = reqwest::Client::new();
         for session_id in ["missing", "orphan"] {
             let response = client
@@ -934,11 +1435,209 @@ mod tests {
         assert_eq!(valid.status(), StatusCode::OK);
         assert_eq!(focus.calls.load(Ordering::SeqCst), 3);
         bridge.stop().await;
+        drop(bridge);
+        let _ = fs::remove_dir_all(store_root);
+    }
+
+    #[tokio::test]
+    async fn png_pet_manifest_frames_mapping_validation_and_revision_are_enforced() {
+        let directory = pet_directory("png");
+        write_test_pet(&directory, ImageFormat::Png);
+        fs::write(
+            directory.join("validation.json"),
+            serde_json::json!({
+                "ok": true,
+                "columns": 8,
+                "rows": 11,
+                "width": PET_ATLAS_CELL_WIDTH * 8,
+                "height": PET_ATLAS_CELL_HEIGHT * 11,
+                "cells": [
+                    {"state": "running", "column": 0, "used": true},
+                    {"state": "running", "column": 1, "used": true},
+                    {"state": "running", "column": 2, "used": false}
+                ]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let (store, store_root) = test_store().await;
+        enable_test_pet(&store, &directory).await;
+        let (bridge, _, token, url, _) = start_test_bridge_with_store(store).await;
+        let client = reqwest::Client::new();
+
+        let manifest: Value = client
+            .get(format!("{url}/pet/manifest"))
+            .header("X-Wisp-Device-Token", &token)
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        assert_eq!(manifest["type"], "pet_manifest");
+        assert_eq!(manifest["protocol"], 1);
+        assert_eq!(manifest["enabled"], true);
+        assert_eq!(manifest["id"], "wispy");
+        assert_eq!(manifest["displayName"], "Wispy");
+        assert_eq!(manifest["format"], "png");
+        assert_eq!(manifest["frameWidth"], PET_FRAME_WIDTH);
+        assert_eq!(manifest["frameHeight"], PET_FRAME_HEIGHT);
+        assert_eq!(manifest["frameIntervalMs"], PET_FRAME_INTERVAL_MS);
+        assert_eq!(
+            manifest["frameCounts"],
+            json!({
+                "idle": 7,
+                "working": 2,
+                "review": 6,
+                "needs_user": 6,
+                "done": 5,
+                "failed": 8,
+            })
+        );
+        let revision = manifest["revision"].as_str().unwrap();
+        assert_eq!(revision.len(), 64);
+        assert!(revision
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte)));
+
+        for spec in PET_STATE_SPECS {
+            let response = client
+                .get(format!(
+                    "{url}/pet/frame?revision={revision}&state={}&frame=0",
+                    spec.bridge_state
+                ))
+                .header("X-Wisp-Device-Token", &token)
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            assert_eq!(
+                response.headers()[CONTENT_TYPE],
+                axum::http::HeaderValue::from_static("image/png")
+            );
+            let content_length = response
+                .headers()
+                .get(CONTENT_LENGTH)
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .parse::<usize>()
+                .unwrap();
+            let bytes = response.bytes().await.unwrap();
+            assert_eq!(content_length, bytes.len());
+            let frame = image::load_from_memory_with_format(&bytes, ImageFormat::Png)
+                .unwrap()
+                .into_rgba8();
+            assert_eq!(frame.dimensions(), (PET_FRAME_WIDTH, PET_FRAME_HEIGHT));
+            assert_eq!(
+                frame.get_pixel(PET_FRAME_WIDTH / 2, PET_FRAME_HEIGHT / 2).0,
+                row_color(spec.row),
+                "wrong atlas row for {}",
+                spec.bridge_state
+            );
+        }
+
+        let out_of_range = client
+            .get(format!(
+                "{url}/pet/frame?revision={revision}&state=working&frame=2"
+            ))
+            .header("X-Wisp-Device-Token", &token)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(out_of_range.status(), StatusCode::NOT_FOUND);
+
+        for query in [
+            format!("revision={revision}&state=../../pet.json&frame=0"),
+            format!("revision={revision}&state=idle&frame=0&path=pet.json"),
+        ] {
+            let response = client
+                .get(format!("{url}/pet/frame?{query}"))
+                .header("X-Wisp-Device-Token", &token)
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        }
+
+        let mut pet_json: Value =
+            serde_json::from_slice(&fs::read(directory.join("pet.json")).unwrap()).unwrap();
+        pet_json["displayName"] = json!("Wispy revised");
+        fs::write(directory.join("pet.json"), pet_json.to_string()).unwrap();
+        let stale = client
+            .get(format!(
+                "{url}/pet/frame?revision={revision}&state=idle&frame=0"
+            ))
+            .header("X-Wisp-Device-Token", &token)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(stale.status(), StatusCode::CONFLICT);
+        let revised: Value = client
+            .get(format!("{url}/pet/manifest"))
+            .header("X-Wisp-Device-Token", &token)
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        assert_ne!(revised["revision"], revision);
+
+        bridge.stop().await;
+        drop(bridge);
+        let _ = fs::remove_dir_all(directory);
+        let _ = fs::remove_dir_all(store_root);
+    }
+
+    #[tokio::test]
+    async fn webp_pet_is_rendered_as_a_transparent_png_frame() {
+        let directory = pet_directory("webp");
+        write_test_pet(&directory, ImageFormat::WebP);
+        let (store, store_root) = test_store().await;
+        enable_test_pet(&store, &directory).await;
+        let (bridge, _, token, url, _) = start_test_bridge_with_store(store).await;
+        let client = reqwest::Client::new();
+        let manifest: Value = client
+            .get(format!("{url}/pet/manifest"))
+            .header("X-Wisp-Device-Token", &token)
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        assert_eq!(manifest["enabled"], true);
+        assert_eq!(manifest["format"], "png");
+        let revision = manifest["revision"].as_str().unwrap();
+        let response = client
+            .get(format!(
+                "{url}/pet/frame?revision={revision}&state=idle&frame=0"
+            ))
+            .header("X-Wisp-Device-Token", &token)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let frame =
+            image::load_from_memory_with_format(&response.bytes().await.unwrap(), ImageFormat::Png)
+                .unwrap()
+                .into_rgba8();
+        assert_eq!(frame.dimensions(), (PET_FRAME_WIDTH, PET_FRAME_HEIGHT));
+        assert_eq!(
+            frame.get_pixel(PET_FRAME_WIDTH / 2, PET_FRAME_HEIGHT / 2).0,
+            row_color(0)
+        );
+
+        bridge.stop().await;
+        drop(bridge);
+        let _ = fs::remove_dir_all(directory);
+        let _ = fs::remove_dir_all(store_root);
     }
 
     #[tokio::test]
     async fn repeated_start_reuses_one_listener_and_stop_releases_the_port() {
-        let (bridge, focus, token, url, port) = start_test_bridge().await;
+        let (bridge, focus, token, url, port, store_root) = start_test_bridge().await;
         bridge
             .start(test_config(port), token.clone(), focus)
             .await
@@ -954,5 +1653,8 @@ mod tests {
         bridge.stop().await;
         let rebound = TcpListener::bind(("127.0.0.1", port)).await;
         assert!(rebound.is_ok(), "listener port was not released");
+        drop(rebound);
+        drop(bridge);
+        let _ = fs::remove_dir_all(store_root);
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6070,8 +6070,10 @@ pub fn run() {
                 browser_bridge::BrowserBridge::start(browser_extension_dir),
             );
             let device_hub = Arc::new(device_hub::DeviceHub::default());
-            let device_bridge =
-                Arc::new(device_bridge::DeviceBridge::new(device_hub.clone()));
+            let device_bridge = Arc::new(device_bridge::DeviceBridge::new(
+                device_hub.clone(),
+                store.clone(),
+            ));
             if let Ok((attempts, workflows)) = tauri::async_runtime::block_on(
                 store.recover_interrupted_agent_workflows(),
             ) {

--- a/src-tauri/src/pet_commands.rs
+++ b/src-tauri/src/pet_commands.rs
@@ -1,6 +1,7 @@
 use super::{desktop_lifecycle, AppState};
 use base64::{engine::general_purpose::STANDARD, Engine as _};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::{collections::BTreeMap, fs, path::Path};
 use tauri::{Emitter, State};
 
@@ -28,6 +29,18 @@ pub(super) struct PetAsset {
     sprite_version_number: u8,
     spritesheet_data_url: String,
     frame_counts: BTreeMap<String, u8>,
+}
+
+#[derive(Debug)]
+pub(super) struct ValidatedPetSource {
+    pub(super) id: String,
+    pub(super) display_name: String,
+    pub(super) description: String,
+    pub(super) sprite_version_number: u8,
+    pub(super) spritesheet_mime: &'static str,
+    pub(super) spritesheet: Vec<u8>,
+    pub(super) frame_counts: BTreeMap<String, u8>,
+    pub(super) package_revision: String,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -143,15 +156,16 @@ fn image_format_and_dimensions(bytes: &[u8]) -> Option<(&'static str, (u32, u32)
         .or_else(|| png_dimensions(bytes).map(|dimensions| ("image/png", dimensions)))
 }
 
-fn validation_frame_counts(directory: &Path) -> Result<BTreeMap<String, u8>, String> {
+fn validation_frame_counts(
+    directory: &Path,
+) -> Result<(BTreeMap<String, u8>, Option<Vec<u8>>), String> {
     let path = directory.join("validation.json");
     if !path.is_file() {
-        return Ok(default_frame_counts());
+        return Ok((default_frame_counts(), None));
     }
-    let report: ValidationReport = serde_json::from_slice(
-        &fs::read(&path).map_err(|e| format!("Cannot read {}: {e}", path.display()))?,
-    )
-    .map_err(|e| format!("Invalid {}: {e}", path.display()))?;
+    let bytes = fs::read(&path).map_err(|e| format!("Cannot read {}: {e}", path.display()))?;
+    let report: ValidationReport =
+        serde_json::from_slice(&bytes).map_err(|e| format!("Invalid {}: {e}", path.display()))?;
     if !report.ok
         || report.columns != 8
         || report.rows != 11
@@ -173,10 +187,10 @@ fn validation_frame_counts(directory: &Path) -> Result<BTreeMap<String, u8>, Str
             counts.insert(state, used.clamp(1, 8));
         }
     }
-    Ok(counts)
+    Ok((counts, Some(bytes)))
 }
 
-pub(super) fn load_pet_asset(directory: &Path) -> Result<PetAsset, String> {
+pub(super) fn load_pet_source(directory: &Path) -> Result<ValidatedPetSource, String> {
     if !directory.is_absolute() {
         return Err("Pet directory must be an absolute path.".into());
     }
@@ -187,11 +201,10 @@ pub(super) fn load_pet_asset(directory: &Path) -> Result<PetAsset, String> {
         return Err(format!("Pet path is not a directory: {}", root.display()));
     }
     let manifest_path = root.join("pet.json");
-    let manifest: PetManifest = serde_json::from_slice(
-        &fs::read(&manifest_path)
-            .map_err(|e| format!("Cannot read {}: {e}", manifest_path.display()))?,
-    )
-    .map_err(|e| format!("Invalid {}: {e}", manifest_path.display()))?;
+    let manifest_bytes = fs::read(&manifest_path)
+        .map_err(|e| format!("Cannot read {}: {e}", manifest_path.display()))?;
+    let manifest: PetManifest = serde_json::from_slice(&manifest_bytes)
+        .map_err(|e| format!("Invalid {}: {e}", manifest_path.display()))?;
     if manifest.id.trim().is_empty() || manifest.display_name.trim().is_empty() {
         return Err("Pet id and displayName are required.".into());
     }
@@ -223,14 +236,53 @@ pub(super) fn load_pet_asset(directory: &Path) -> Result<PetAsset, String> {
             dimensions.0, dimensions.1
         ));
     }
-    let frame_counts = validation_frame_counts(&root)?;
-    Ok(PetAsset {
+    let (frame_counts, validation_bytes) = validation_frame_counts(&root)?;
+    let mut revision = Sha256::new();
+    revision.update(b"wisp-pet-package-v2\0pet.json\0");
+    revision.update((manifest_bytes.len() as u64).to_le_bytes());
+    revision.update(&manifest_bytes);
+    revision.update(b"\0spritesheet\0");
+    revision.update((spritesheet.len() as u64).to_le_bytes());
+    revision.update(&spritesheet);
+    revision.update(b"\0validation.json\0");
+    match validation_bytes {
+        Some(bytes) => {
+            revision.update([1]);
+            revision.update((bytes.len() as u64).to_le_bytes());
+            revision.update(bytes);
+        }
+        None => revision.update([0]),
+    }
+    revision.update(b"\0effective-frame-counts\0");
+    for (state, count) in &frame_counts {
+        revision.update(state.as_bytes());
+        revision.update([0, *count]);
+    }
+    Ok(ValidatedPetSource {
         id: manifest.id,
         display_name: manifest.display_name,
         description: manifest.description,
         sprite_version_number: manifest.sprite_version_number,
-        spritesheet_data_url: format!("data:{mime};base64,{}", STANDARD.encode(spritesheet)),
+        spritesheet_mime: mime,
+        spritesheet,
         frame_counts,
+        package_revision: format!("{:x}", revision.finalize()),
+    })
+}
+
+pub(super) fn load_pet_asset(directory: &Path) -> Result<PetAsset, String> {
+    let source = load_pet_source(directory)?;
+    Ok(PetAsset {
+        id: source.id,
+        display_name: source.display_name,
+        description: source.description,
+        sprite_version_number: source.sprite_version_number,
+        spritesheet_data_url: format!(
+            "data:{};base64,{}",
+            source.spritesheet_mime,
+            STANDARD.encode(source.spritesheet)
+        ),
+        frame_counts: source.frame_counts,
     })
 }
 


### PR DESCRIPTION
## Problem

StickS3 can poll Wisp Science for state and actions, but it cannot fetch the configured desktop Pet artwork. The firmware needs a small, authenticated, revisioned manifest/frame protocol without gaining access to arbitrary local files or paths.

## What changed

- Added authenticated `GET /pet/manifest` and `GET /pet/frame` Device Bridge routes.
- Reused the desktop Pet validation rules through a shared validated Pet source model instead of round-tripping through a data URL.
- Added deterministic SHA-256 revisions covering the Pet package, effective frame counts, state mapping, and StickS3 rendering parameters.
- Added the closed six-state atlas-row mapping, `192x208` crop, and deterministic `120x130` transparent PNG output.
- Added WebP atlas decoding while preserving the existing TIFF and PNG image features.
- Moved Device Bridge file reads, hashing, decoding, cropping, scaling, and PNG encoding to blocking tasks.
- Added a bounded 48-frame in-memory cache keyed by revision/state/frame with revision invalidation and a 512 KiB output limit.
- Kept `/state`, `/action`, token handling, and LAN/relay scope unchanged.
- Updated the StickS3 protocol guide and README.

## User impact

A StickS3 configured with the existing `X-Wisp-Device-Token` can now discover the active desktop Pet and fetch immutable PNG animation frames. Disabled, missing, and invalid Pet packages fail closed without exposing configured directories or local paths.

## Validation

- `cargo test -p wisp-tauri device_bridge::tests` — 8 passed
- `cargo test -p wisp-tauri pet_commands::tests` — 4 passed
- `git diff --check` — passed
- Targeted `rustfmt --check` for changed Rust modules — passed
- `cargo test --workspace` — all related tests passed; the existing Windows-only line-ending assertions in `delegation_isolation::tests::independent_changes_merge_and_every_worktree_is_cleaned` and `delegation_isolation::tests::conflicting_change_is_preserved_without_touching_the_merged_file` still fail because Git produces `\r\n` while the assertions expect `\n` (436 other `wisp-tauri` tests passed).
- `cargo fmt --all -- --check` remains blocked by pre-existing formatting drift in unrelated `ask_user`/ACP files; this PR does not include unrelated formatting changes.

## Manual smoke steps

1. Enable a valid Codex-compatible v2 desktop Pet and the StickS3 Device Bridge.
2. Request `/pet/manifest` with the exact device token and verify a 64-character lowercase revision and six frame counts.
3. Request an idle frame using that revision and verify `Content-Type: image/png`, exact `120x130` dimensions, and transparency.
4. Change the configured Pet or `validation.json`, then verify the old revision returns HTTP 409 and the new manifest revision changes.
5. Disable the Pet and verify the manifest returns HTTP 200 with `enabled: false` while the frame route returns HTTP 404.

## Known limitations

- Relay transport remains out of scope; these resources are served by the existing LAN bridge only.
- There is no Pet upload, arbitrary path, arbitrary size, or remote Pet catalog endpoint.