### PR TITLE
Fix Alibaba reasoning stream grouping

### DIFF
--- a/crates/wisp-llm/src/openai.rs
+++ b/crates/wisp-llm/src/openai.rs
@@ -295,6 +295,34 @@ fn ensure_named_tool_calls(calls: &[ToolCall]) -> Result<()> {
     Ok(())
 }
 
+fn append_stream_content_delta(
+    delta: &Value,
+    content: &mut String,
+    reasoning: &mut String,
+    sink: &mut dyn StreamSink,
+) {
+    // Some compatible endpoints (notably Alibaba/DashScope thinking streams)
+    // include `content: ""` beside every non-empty `reasoning_content` delta.
+    // Emitting that empty text event breaks an otherwise contiguous reasoning
+    // run into one UI disclosure per token fragment.
+    if let Some(t) = delta
+        .get("content")
+        .and_then(|v| v.as_str())
+        .filter(|t| !t.is_empty())
+    {
+        content.push_str(t);
+        sink.on_text(t);
+    }
+    if let Some(r) = delta
+        .get("reasoning_content")
+        .and_then(|v| v.as_str())
+        .filter(|r| !r.is_empty())
+    {
+        reasoning.push_str(r);
+        sink.on_reasoning(r);
+    }
+}
+
 #[async_trait]
 impl Provider for OpenAiProvider {
     fn name(&self) -> &str {
@@ -407,14 +435,7 @@ impl Provider for OpenAiProvider {
                         continue;
                     };
                     let delta = choice.get("delta").cloned().unwrap_or(Value::Null);
-                    if let Some(t) = delta.get("content").and_then(|v| v.as_str()) {
-                        content.push_str(t);
-                        sink.on_text(t);
-                    }
-                    if let Some(r) = delta.get("reasoning_content").and_then(|v| v.as_str()) {
-                        reasoning.push_str(r);
-                        sink.on_reasoning(r);
-                    }
+                    append_stream_content_delta(&delta, &mut content, &mut reasoning, sink);
                     if let Some(tcs) = delta.get("tool_calls").and_then(|v| v.as_array()) {
                         for tc in tcs {
                             let i = tc.get("index").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
@@ -504,6 +525,47 @@ fn parse_usage_obj(u: &Value) -> Option<Usage> {
 mod tests {
     use super::*;
     use crate::message::Message;
+
+    #[derive(Default)]
+    struct RecordingSink {
+        text: Vec<String>,
+        reasoning: Vec<String>,
+    }
+
+    impl StreamSink for RecordingSink {
+        fn on_text(&mut self, delta: &str) {
+            self.text.push(delta.into());
+        }
+
+        fn on_reasoning(&mut self, delta: &str) {
+            self.reasoning.push(delta.into());
+        }
+
+        fn on_tool_call(&mut self, _: usize, _: &str, _: &str) {}
+
+        fn on_usage(&mut self, _: Usage) {}
+    }
+
+    #[test]
+    fn ignores_empty_content_between_alibaba_reasoning_deltas() {
+        let mut content = String::new();
+        let mut reasoning = String::new();
+        let mut sink = RecordingSink::default();
+
+        for delta in [
+            json!({"content": "", "reasoning_content": "column in"}),
+            json!({"content": "", "reasoning_content": " test fixtures"}),
+            json!({"content": "", "reasoning_content": ""}),
+            json!({"content": "Fixed.", "reasoning_content": null}),
+        ] {
+            append_stream_content_delta(&delta, &mut content, &mut reasoning, &mut sink);
+        }
+
+        assert_eq!(content, "Fixed.");
+        assert_eq!(reasoning, "column in test fixtures");
+        assert_eq!(sink.text, ["Fixed."]);
+        assert_eq!(sink.reasoning, ["column in", " test fixtures"]);
+    }
 
     #[test]
     fn parses_cache_hits_across_providers() {

--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -67,6 +67,11 @@ and does not generate a billable validation image.
 | OpenAI (Responses API) | OpenAI reasoning/tool-call models through `/v1/responses` | API URL, Model ID, API key |
 | Anthropic | Claude API through `/v1/messages` | API URL, Model ID, API key |
 
+OpenAI-compatible reasoning streams are normalized into one reasoning channel.
+Empty `content` placeholders sent alongside Alibaba/DashScope
+`reasoning_content` chunks are ignored, so a continuous thought process remains
+one disclosure in the conversation.
+
 For OpenAI-compatible and Responses API profiles, Wisp sends its internal
 `python` REPL tool as `wisp_python` and maps returned calls back to `python`.
 This avoids the reserved `python` function-name collision on Codex models,


### PR DESCRIPTION
## Problem

Alibaba/DashScope thinking streams can send an empty `content` string beside each non-empty `reasoning_content` fragment. Wisp emitted both values as UI events, so every empty text event interrupted the reasoning run and rendered the next fragment as a separate “Thinking” disclosure.

## Changes

- Normalize streamed OpenAI-compatible text and reasoning deltas through one helper.
- Ignore only zero-length `content` and `reasoning_content` values while preserving whitespace and all non-empty fragments.
- Add a regression test matching the Alibaba stream shape shown in the debug report.
- Document the OpenAI-compatible reasoning normalization behavior.

## User impact

Alibaba API reasoning now remains one continuous collapsed disclosure, matching DeepSeek and Codex ACP behavior, instead of producing a disclosure for every short token fragment.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p wisp-llm` — 23 passed
- `cargo test --workspace` — full workspace passed
- `git diff --check`

## Manual smoke

1. Configure an OpenAI-compatible Alibaba/DashScope thinking model.
2. Start a prompt that produces multiple streamed reasoning chunks.
3. Verify the reasoning text accumulates in one “Thinking” disclosure and the final answer remains separate.

## Known limitations

This change affects newly received stream events; it does not rewrite malformed UI event sequences that may already have been persisted by an older build.
