### PR TITLE
fix: preserve cross-project session transfer target

### DIFF
--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -2819,6 +2819,7 @@ export function parallelMock(): void {
             return [
               { id: "default", name: project.name, workspace_dir: project.root, session_count: 0, updated_at: 1, running_count: 0, needs_you_count: 0 },
               { id: "other", name: "Other project", workspace_dir: "/mock/other", session_count: 0, updated_at: 1, running_count: 0, needs_you_count: 0 },
+              { id: "archive", name: "Archive project", workspace_dir: "/mock/archive", session_count: 0, updated_at: 1, running_count: 0, needs_you_count: 0 },
             ];
           case "list_recent_sessions": return sessions.map((s) => ({
             id: s.id, project_id: "default", title: s.title, ts: s.ts,

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -1331,7 +1331,7 @@ test("rename session modal autofocuses so Ctrl+A selects the title", async ({ pa
   )).toBe(true);
 });
 
-test("conversation action button renames, transfers, and deletes sessions", async ({ page }) => {
+test("conversation action button renames, transfers, and deletes sessions (#557)", async ({ page }) => {
   await page.addInitScript(parallelMock);
   await page.goto("/");
   await page.locator(".proj-card-main").first().click();
@@ -1410,12 +1410,14 @@ test("conversation action button renames, transfers, and deletes sessions", asyn
   await openActions();
   await page.getByRole("button", { name: "Move to another project…", exact: true }).click();
   transfer = page.locator(".session-transfer-modal");
+  await transfer.getByLabel("Target project").selectOption("archive");
+  await expect(transfer.getByLabel("Target project")).toHaveValue("archive");
   await transfer.getByRole("button", { name: "Move", exact: true }).click();
   await expect.poll(() => page.evaluate(() => {
     const calls = ((window as any).__sendInvokeLog ?? []).filter((call: any) => call.cmd === "transfer_session_to_project");
     const args = calls.at(-1)?.args;
     return args instanceof Map ? Object.fromEntries(args) : args;
-  })).toMatchObject({ targetProjectId: "other", mode: "move" });
+  })).toMatchObject({ targetProjectId: "archive", mode: "move" });
   await expect(session).toHaveCount(0);
 
   await newSessionButton(page).click();

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -11223,6 +11223,7 @@ fn App() -> impl IntoView {
                 .filter(|project| project.id != active_project_id)
                 .collect::<Vec<_>>();
             let has_target = !targets.is_empty() && !transfer.target_project_id.is_empty();
+            let target_project_id = transfer.target_project_id.clone();
             let title_key = if transfer.mode == SessionTransferMode::Copy {
                 "session.copy_title"
             } else {
@@ -11241,7 +11242,6 @@ fn App() -> impl IntoView {
                     <label>
                         {move || t(locale.get(), "session.target_project")}
                         <select
-                            prop:value=transfer.target_project_id
                             disabled=move || session_transfer_busy.get()
                             on:change=move |ev| {
                                 let value = event_target_value(&ev);
@@ -11251,8 +11251,11 @@ fn App() -> impl IntoView {
                                     }
                                 });
                             }>
-                            {targets.into_iter().map(|project| view! {
-                                <option value=project.id>{project.name}</option>
+                            {targets.into_iter().map(|project| {
+                                let selected = project.id == target_project_id;
+                                view! {
+                                    <option value=project.id prop:selected=selected>{project.name}</option>
+                                }
                             }).collect_view()}
                         </select>
                     </label>


### PR DESCRIPTION
## Problem

When the conversation-transfer dialog lists multiple target projects, selecting
any project after the first immediately resets the select element to the first
option. The transfer therefore cannot be directed to the intended project.

Fixes #557.

## Changes

- Bind the transfer target to each option's selected property so dynamic option
  mounting preserves the chosen project.
- Extend the mocked project list with a second eligible transfer target.
- Cover choosing a non-first project and verify the same project ID reaches the
  transfer command.

## Tests

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cd ui && cargo check --target wasm32-unknown-unknown`
- `cd ui-tests && npm ci`
- `cd ui-tests && npx playwright test` (226 passed, 1 skipped)

## Manual smoke

1. Open a project with a saved conversation and at least two other projects.
2. Choose **Move to another project...** from the conversation actions.
3. Select a project other than the first option and confirm the selection stays
   visible.
4. Move the conversation and verify it appears in the selected target project.

## Known limitations and follow-up

No new limitations. Existing transcript-only transfer semantics remain
unchanged: project files, runs, and linked artifact records stay in the source
project. No follow-up is required for this selector fix.
