### PR TITLE
fix: expose ACP model options before first prompt

### DIFF
--- a/docs/acp-agents.md
+++ b/docs/acp-agents.md
@@ -111,7 +111,9 @@ npm install -g @agentclientprotocol/claude-agent-acp
 
 ## Using an ACP session
 
-- Select the agent on an empty session, then chat normally.
+- Select the agent on an empty session. Wisp initializes the ACP session without
+  sending a prompt, so the Agent's `Model`, `Reasoning effort`, and mode options
+  are available from the compact model menu before the first message.
 - Selecting an ACP Agent from a conversation that already has messages creates
   and opens a fresh ACP session automatically. Existing transcript history is
   left unchanged because ACP cannot bind it as native session history.

--- a/docs/plans/2026-07-29-acp-pre-first-turn-config.md
+++ b/docs/plans/2026-07-29-acp-pre-first-turn-config.md
@@ -1,0 +1,36 @@
+# ACP 首轮前模型配置修复计划
+
+## 问题
+
+空白会话选择 ACP Agent 时，前端目前只保存临时选择；真正的 ACP
+session 要到第一条消息发送时才创建。因此 Agent 在 `session/new` 返回的
+`configOptions`（例如 `Model`、`Reasoning effort`）在发送前不会显示。
+
+## 验收标准
+
+1. 空白会话选择 ACP Agent 后，Wisp 创建或复用一个空 frame，并在不发送
+   prompt 的情况下初始化 ACP session。
+2. Agent 返回的 `configOptions` 和 `modes` 在第一条消息发送前即可从发送
+   按钮旁的模型菜单调整。
+3. 初始化不会清空编辑器草稿，也不会生成用户或助手消息。
+4. 从已有对话切换到 ACP 时，仍创建新的 ACP session，并保留原对话。
+5. UI mock 测试、相关 Rust 测试、WASM check 和 Playwright 测试通过。
+
+## 状态
+
+- [x] 复现并定位延迟初始化问题
+- [x] 冻结最小修复边界
+- [x] 后端增加无 prompt 的 ACP prepare 命令
+- [x] 前端在选择 ACP 时 prepare 并显示配置
+- [x] 自动化与真实 macOS 界面验收
+
+## 验收记录
+
+- `cargo fmt --all -- --check`：通过。
+- `cargo test --workspace`：通过；沙箱内 Keychain 用例因 macOS 权限失败后，
+  已在沙箱外完整重跑并通过。
+- `cd ui && cargo check --target wasm32-unknown-unknown`：通过。
+- `cd ui-tests && npx playwright test`：232 项通过，1 项按测试配置跳过。
+- macOS 调试应用真实验收：空白会话选择 `Codex ACP` 后，在未发送草稿
+  `今天是几号` 的情况下显示 `Model`、`Reasoning effort`、`Mode`、
+  `Collaboration mode` 和 `Fast mode`；模型列表与推理强度列表均可展开。

--- a/src-tauri/src/acp.rs
+++ b/src-tauri/src/acp.rs
@@ -219,6 +219,45 @@ pub(crate) async fn get_acp_session_state(
         .map(|modes| serde_json::json!({ "availableModes": modes })))
 }
 
+fn acp_session_state_payload(
+    frame_id: &str,
+    state: Option<&wisp_acp::AcpSessionState>,
+) -> serde_json::Value {
+    serde_json::json!({
+        "frameId": frame_id,
+        "modes": state.and_then(|state| state.modes.clone()),
+        "configOptions": state.and_then(|state| state.config_options.clone()),
+    })
+}
+
+/// Launch and bind an ACP Agent to an empty frame without sending a prompt.
+///
+/// ACP Agents advertise model, reasoning-effort, and mode controls in the
+/// `session/new` response. Preparing on picker selection lets the composer show
+/// those controls before the first user-authored turn.
+#[tauri::command]
+pub(crate) async fn prepare_acp_session(
+    state: State<'_, AppState>,
+    window: tauri::WebviewWindow,
+    frame_id: String,
+    agent_profile_id: String,
+) -> Result<serde_json::Value, String> {
+    let project = state.active(window.label());
+    if state
+        .store
+        .frame_project_id(&frame_id)
+        .await
+        .map_err(|error| error.to_string())?
+        .as_deref()
+        != Some(project.id.as_str())
+    {
+        return Err("Session does not belong to the active project.".into());
+    }
+    let runtime = runtime_for(&state, &project, &frame_id, Some(agent_profile_id.as_str())).await?;
+    let session_state = runtime.session_state.lock().await;
+    Ok(acp_session_state_payload(&frame_id, session_state.as_ref()))
+}
+
 #[tauri::command]
 pub(crate) async fn save_acp_agent(
     state: State<'_, AppState>,
@@ -1565,6 +1604,24 @@ mod tests {
         assert!(event.get("requestId").is_some());
         assert!(event.get("frameId").is_some());
         assert!(event.get("toolCall").is_some());
+    }
+
+    #[test]
+    fn prepared_session_payload_exposes_config_before_a_prompt() {
+        let state = wisp_acp::AcpSessionState {
+            modes: Some(serde_json::json!({
+                "currentModeId": "agent",
+                "availableModes": [{"id": "agent", "name": "Agent"}],
+            })),
+            config_options: Some(vec![]),
+        };
+        let payload = acp_session_state_payload("frame-1", Some(&state));
+        assert_eq!(payload["frameId"], serde_json::json!("frame-1"));
+        assert_eq!(
+            payload["modes"]["currentModeId"],
+            serde_json::json!("agent")
+        );
+        assert_eq!(payload["configOptions"], serde_json::json!([]));
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6180,6 +6180,7 @@ pub fn run() {
             acp::list_acp_agents,
             acp::get_acp_session_agent,
             acp::get_acp_session_state,
+            acp::prepare_acp_session,
             acp::save_acp_agent,
             acp::remove_acp_agent,
             acp::test_acp_agent,

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -1373,6 +1373,45 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
           }
           case "get_acp_session_agent":
             return acpBindings[String(arg("frameId") ?? "")] ?? null;
+          case "prepare_acp_session": {
+            const frameId = String(arg("frameId") ?? "");
+            const agentProfileId = String(arg("agentProfileId") ?? "");
+            acpBindings[frameId] = agentProfileId;
+            return {
+              frameId,
+              modes: {
+                currentModeId: "agent",
+                availableModes: [
+                  { id: "read-only", name: "Read Only" },
+                  { id: "agent", name: "Agent" },
+                  { id: "full-access", name: "Full Access" },
+                ],
+              },
+              configOptions: [
+                {
+                  id: "model",
+                  name: "Model",
+                  type: "select",
+                  currentValue: "smart",
+                  options: [
+                    { value: "fast", name: "Fast" },
+                    { value: "smart", name: "Smart" },
+                  ],
+                },
+                {
+                  id: "reasoning_effort",
+                  name: "Reasoning effort",
+                  type: "select",
+                  currentValue: "high",
+                  options: [
+                    { value: "medium", name: "Medium" },
+                    { value: "high", name: "High" },
+                    { value: "xhigh", name: "Extra high" },
+                  ],
+                },
+              ],
+            };
+          }
           case "save_acp_agent": {
             const profile = { ...(plain(arg("profile")) ?? {}) };
             if (!profile.id) profile.id = `acp-${mockAcpAgents.length + 1}`;

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -516,6 +516,33 @@ test("selecting an ACP Agent from a populated HTTP session starts a fresh sessio
   expect(secondSend.sessionId).not.toBe(firstSend.sessionId);
 });
 
+test("ACP model and reasoning options are available before the first prompt", async ({ page }) => {
+  await enterApp(page);
+  await composer(page).fill("preserved first prompt");
+
+  await page.locator(".model-picker-btn").click();
+  await page.getByRole("button", { name: /Test ACP Agent/ }).click();
+
+  await expect.poll(() => lastInvokeArgs(page, "prepare_acp_session")).toMatchObject({
+    frameId: expect.any(String),
+    agentProfileId: "acp-test",
+  });
+  await expect(composer(page)).toHaveValue("preserved first prompt");
+  await expect.poll(() => lastInvokeArgs(page, "send_message")).toBeNull();
+
+  await page.locator(".model-picker-btn").click();
+  const config = page.getByTestId("acp-session-config");
+  await expect(config.getByLabel("Model")).toHaveValue("smart");
+  await expect(config.getByLabel("Reasoning effort")).toHaveValue("high");
+  await config.getByLabel("Reasoning effort").selectOption("xhigh");
+  await expect.poll(() => lastInvokeArgs(page, "set_acp_session_config")).toMatchObject({
+    frameId: expect.any(String),
+    configId: "reasoning_effort",
+    value: { value: "xhigh" },
+  });
+  await expect.poll(() => lastInvokeArgs(page, "send_message")).toBeNull();
+});
+
 test("ACP turn maps config, overlapping tools, plan, usage, and exact permission response", async ({ page }) => {
   await enterApp(page);
   await newSessionButton(page).click();

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -857,6 +857,7 @@ fn App() -> impl IntoView {
     let acp_session_configs =
         create_rw_signal::<HashMap<String, Vec<serde_json::Value>>>(HashMap::new());
     let acp_session_modes = create_rw_signal::<HashMap<String, serde_json::Value>>(HashMap::new());
+    let acp_prepare_busy = create_rw_signal(false);
     let show_projects = create_rw_signal(true); // app lands on the Projects screen
     let show_library = create_rw_signal(false);
     let show_session_import = create_rw_signal(None::<SessionImportProvider>);
@@ -3538,7 +3539,7 @@ fn App() -> impl IntoView {
         upload_from_paste(attachments, uploading, event, count);
     };
 
-    let composer_blocked = move || uploading.get();
+    let composer_blocked = move || uploading.get() || acp_prepare_busy.get();
 
     let run_update_check = Rc::new(move || {
         if update_check_busy.get() {
@@ -9749,6 +9750,7 @@ fn App() -> impl IntoView {
                             {move || (!models.get().is_empty() || !acp_agents.get().is_empty()).then(|| view! {
                                 <div class="model-picker">
                                     <button type="button" class="model-picker-btn" class:active=move || model_menu_open.get()
+                                        disabled=move || acp_prepare_busy.get()
                                         on:click=move |_| model_menu_open.update(|o| *o = !*o)>
                                         <span class="model-picker-label">{move || {
                                             if let Some(id) = active_acp_agent_id.get() {
@@ -9772,7 +9774,10 @@ fn App() -> impl IntoView {
                                                     session_model_ids.with(|models| models.get(&session_id).cloned())
                                                 });
                                                 let acp_selected = active_acp_agent_id.get().is_some();
-                                                let acp_locked = acp_selected && items.with(|rows| !rows.is_empty());
+                                                // Picker selection now binds an ACP session before
+                                                // the first prompt so config options are available.
+                                                // A bound frame cannot safely switch back to HTTP.
+                                                let acp_locked = acp_selected;
                                                 list.into_iter().filter(ModelProfile::is_chat_model).map(|m| {
                                                     let pick_id = m.id.clone();
                                                     let pick_label = m.label.clone();
@@ -9818,42 +9823,116 @@ fn App() -> impl IntoView {
                                                 <div class="compose-group-label">"ACP Agents"</div>
                                                 {acp_agents.get().into_iter().map(|agent| {
                                                     let id = agent.id.clone();
-                                                    let active = active_acp_agent_id.get().as_deref() == Some(agent.id.as_str());
-                                                    let starts_new_session = items.with(|rows| !rows.is_empty()) && !active;
+                                                    let selected_agent = active_acp_agent_id.get();
+                                                    let previous_agent_id = selected_agent.clone();
+                                                    let active = selected_agent.as_deref() == Some(agent.id.as_str());
+                                                    // A prepared ACP session is already bound even
+                                                    // before it has transcript rows. Switching to a
+                                                    // different Agent therefore needs a fresh frame.
+                                                    let starts_new_session = !active
+                                                        && (items.with(|rows| !rows.is_empty())
+                                                            || selected_agent.is_some());
                                                     view! {
                                                         <div class="model-menu-row" class:active=active>
                                                             <button type="button" class="model-menu-pick"
                                                                 title=starts_new_session.then_some("Start a new session with this ACP Agent")
                                                                 on:click=move |_| {
                                                                     model_menu_open.set(false);
-                                                                    if !starts_new_session {
-                                                                        if let Some(frame_id) = active_session.get_untracked() {
-                                                                            provisional_acp_selection.set(Some((frame_id, id.clone())));
-                                                                        }
-                                                                        active_acp_agent_id.set(Some(id.clone()));
+                                                                    if active {
                                                                         return;
                                                                     }
+                                                                    acp_prepare_busy.set(true);
                                                                     let agent_id = id.clone();
+                                                                    let had_items = items.with_untracked(|rows| !rows.is_empty());
                                                                     demo_mode.set(false);
-                                                                    if let Some(old) = active_session.get_untracked() {
-                                                                        transcripts.update(|cache| {
-                                                                            cache.insert(old, items.get_untracked());
-                                                                        });
+                                                                    if starts_new_session {
+                                                                        if let Some(old) = active_session.get_untracked() {
+                                                                            transcripts.update(|cache| {
+                                                                                cache.insert(old, items.get_untracked());
+                                                                            });
+                                                                        }
                                                                     }
+                                                                    let existing_frame = (!starts_new_session)
+                                                                        .then(|| active_session.get_untracked())
+                                                                        .flatten();
+                                                                    if let Some(frame_id) = existing_frame.as_ref() {
+                                                                        provisional_acp_selection.set(Some((
+                                                                            frame_id.clone(),
+                                                                            agent_id.clone(),
+                                                                        )));
+                                                                    }
+                                                                    active_acp_agent_id.set(Some(agent_id.clone()));
                                                                     sel_artifact.set(0);
                                                                     right_tab.set(RightTab::Artifacts);
+                                                                    let restore_agent_id = previous_agent_id.clone();
                                                                     spawn_local(async move {
-                                                                        let Some(frame_id) = invoke("new_session", JsValue::UNDEFINED).await.as_string() else {
-                                                                            status.set(t(locale.get(), "status.send_failed").into());
-                                                                            return;
+                                                                        let frame_id = if let Some(frame_id) = existing_frame {
+                                                                            frame_id
+                                                                        } else {
+                                                                            let Some(frame_id) = invoke("new_session", JsValue::UNDEFINED).await.as_string() else {
+                                                                                active_acp_agent_id.set(restore_agent_id);
+                                                                                acp_prepare_busy.set(false);
+                                                                                status.set(t(locale.get(), "status.send_failed").into());
+                                                                                return;
+                                                                            };
+                                                                            provisional_acp_selection.set(Some((
+                                                                                frame_id.clone(),
+                                                                                agent_id.clone(),
+                                                                            )));
+                                                                            active_session.set(Some(frame_id.clone()));
+                                                                            items.set(vec![]);
+                                                                            refresh_session_history();
+                                                                            focus_composer();
+                                                                            if starts_new_session && had_items {
+                                                                                show_toast(&t(locale.get(), "composer.acp_new_session_toast"));
+                                                                            }
+                                                                            frame_id
                                                                         };
-                                                                        provisional_acp_selection.set(Some((frame_id.clone(), agent_id.clone())));
-                                                                        active_acp_agent_id.set(Some(agent_id));
-                                                                        active_session.set(Some(frame_id));
-                                                                        items.set(vec![]);
-                                                                        refresh_session_history();
-                                                                        focus_composer();
-                                                                        show_toast(&t(locale.get(), "composer.acp_new_session_toast"));
+                                                                        let args = to_value(&serde_json::json!({
+                                                                            "frameId": frame_id.clone(),
+                                                                            "agentProfileId": agent_id.clone(),
+                                                                        }))
+                                                                        .unwrap();
+                                                                        match invoke_checked("prepare_acp_session", args).await {
+                                                                            Ok(value) => {
+                                                                                let Ok(state) = serde_wasm_bindgen::from_value::<AcpSessionState>(value) else {
+                                                                                    acp_prepare_busy.set(false);
+                                                                                    show_warning_toast("ACP session returned invalid configuration.");
+                                                                                    return;
+                                                                                };
+                                                                                if state.frame_id != frame_id {
+                                                                                    acp_prepare_busy.set(false);
+                                                                                    return;
+                                                                                }
+                                                                                acp_session_configs.update(|all| {
+                                                                                    all.insert(
+                                                                                        frame_id.clone(),
+                                                                                        state.config_options.unwrap_or_default(),
+                                                                                    );
+                                                                                });
+                                                                                if let Some(modes) = state.modes {
+                                                                                    acp_session_modes.update(|all| {
+                                                                                        all.insert(frame_id, modes);
+                                                                                    });
+                                                                                }
+                                                                                acp_prepare_busy.set(false);
+                                                                            }
+                                                                            Err(error) => {
+                                                                                if active_session.get_untracked().as_deref()
+                                                                                    == Some(frame_id.as_str())
+                                                                                    && active_acp_agent_id.get_untracked().as_deref()
+                                                                                        == Some(agent_id.as_str())
+                                                                                {
+                                                                                    provisional_acp_selection.set(None);
+                                                                                    active_acp_agent_id.set(None);
+                                                                                }
+                                                                                acp_prepare_busy.set(false);
+                                                                                show_warning_toast(&localize_backend(
+                                                                                    locale.get_untracked(),
+                                                                                    &js_error_text(error),
+                                                                                ));
+                                                                            }
+                                                                        }
                                                                     });
                                                                 }>
                                                                 <span class="model-menu-text">


### PR DESCRIPTION
## User-facing problem

On an empty conversation, selecting an ACP Agent only changed the provisional
picker label. Wisp did not create the ACP session until the first prompt, so
session-scoped controls such as `Model`, `Reasoning effort`, and mode were
missing exactly when users needed to configure them.

## Root cause

ACP Agents return `configOptions` and `modes` from `session/new`, but the
composer waited for `send_message` before calling the existing ACP runtime
initialization path. The UI also required a concrete frame ID before rendering
those controls.

## What changed

- Add `prepare_acp_session`, which launches and binds an ACP Agent to an empty
  frame and returns its initial session state without sending a prompt.
- Prepare the ACP session when the Agent is selected, creating a hidden empty
  frame only when needed.
- Preserve the composer draft and disable Send/model switching while
  preparation is in flight, preventing a race with the old HTTP frame.
- Render the returned model, reasoning, mode, collaboration, and fast-mode
  controls before the first message.
- Add backend and mocked UI regression coverage plus an implementation/QA note.

## User impact

After selecting Codex ACP, users can reopen the compact menu beside Send and
choose the Codex model and reasoning effort before sending their first message.
No synthetic message is created and no model turn is consumed.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cd ui && cargo check --target wasm32-unknown-unknown`
- `cd ui-tests && npm ci && npx playwright test` — 232 passed, 1 configured skip
- Real macOS smoke test with Codex ACP:
  - draft text remained unchanged and unsent;
  - model choices included GPT-5.6 Sol/Terra/Luna, GPT-5.5, GPT-5.4, and others;
  - reasoning choices included Low, Medium, High, Xhigh, Max, and Ultra.

## Known limitation

Preparing binds the empty frame to that ACP Agent. Switching back to an HTTP
model or to a different ACP Agent therefore requires a fresh session, matching
the existing ACP session-identity rule.
