### PR TITLE
Fix cross-project completion focus navigation

### DIFF
--- a/src-tauri/src/app_commands.rs
+++ b/src-tauri/src/app_commands.rs
@@ -9,6 +9,7 @@ fn show_clickable_notification(
     title: String,
     body: String,
     target: Option<serde_json::Value>,
+    focus_fallback_armed: bool,
 ) -> Result<(), String> {
     use tauri_winrt_notification::Toast;
 
@@ -27,7 +28,7 @@ fn show_clickable_notification(
         .on_activated(move |_| {
             // The native callback identifies the notification exactly, so it
             // takes precedence over the latest-session focus fallback.
-            if claim_notify_activation(&callback_label, target.is_some()) {
+            if !focus_fallback_armed || claim_notify_activation(&callback_label, target.is_some()) {
                 desktop_lifecycle::activate_workspace_window(
                     &callback_app,
                     &callback_label,
@@ -47,6 +48,7 @@ fn show_clickable_notification(
     title: String,
     body: String,
     target: Option<serde_json::Value>,
+    focus_fallback_armed: bool,
 ) -> Result<(), String> {
     let application = if tauri::is_dev() {
         "com.apple.Terminal".to_string()
@@ -65,7 +67,8 @@ fn show_clickable_notification(
             .wait_for_click(true);
         match notification.send() {
             Ok(mac_notification_sys::NotificationResponse::Click) => {
-                if claim_notify_activation(&window_label, target.is_some()) {
+                if !focus_fallback_armed || claim_notify_activation(&window_label, target.is_some())
+                {
                     desktop_lifecycle::activate_workspace_window(&app, &window_label, target);
                 }
             }
@@ -85,6 +88,7 @@ fn show_clickable_notification(
     title: String,
     body: String,
     _target: Option<serde_json::Value>,
+    _focus_fallback_armed: bool,
 ) -> Result<(), String> {
     use tauri_plugin_notification::NotificationExt;
     app.notification()
@@ -120,19 +124,22 @@ pub(super) async fn notify_user(
         .await
         .ok()
         .flatten();
-    if state
-        .preferred_notification_window(&session_id, project_id.as_deref())
-        .as_deref()
-        != Some(window.label())
-    {
+    let Some(selection) = state.preferred_notification_window(&session_id, project_id.as_deref())
+    else {
+        return Ok(());
+    };
+    if selection.label != window.label() {
         return Ok(());
     }
-    // Arm click-to-open before showing: on this window's next focus it jumps to
-    // the session. Skipped if the session's project can't be resolved (the
-    // notification still shows, just without navigation).
+    // Keep the taskbar/Dock focus fallback only when this window still belongs
+    // to the session's project. A foreign-project fallback may show the native
+    // notification, but ordinary focus must not replace its current project;
+    // an explicit notification click can still navigate there.
     let target = project_id
         .map(|project_id| serde_json::json!({ "projectId": project_id, "sessionId": session_id }));
-    if let Some(target) = &target {
+    let focus_fallback_armed = selection.arm_focus_navigation && target.is_some();
+    if focus_fallback_armed {
+        let target = target.as_ref().expect("target checked above");
         pending_notify_targets()
             .lock()
             .unwrap()
@@ -144,6 +151,7 @@ pub(super) async fn notify_user(
         title,
         body,
         target,
+        focus_fallback_armed,
     )
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1854,7 +1854,7 @@ impl AppState {
         &self,
         frame_id: &str,
         project_id: Option<&str>,
-    ) -> Option<String> {
+    ) -> Option<NotificationWindowSelection> {
         let active = self.active.read().unwrap();
         let active_projects = active
             .iter()
@@ -1872,33 +1872,56 @@ impl AppState {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct NotificationWindowSelection {
+    label: String,
+    /// Whether merely focusing this window may consume the queued target.
+    ///
+    /// A window that has switched to another project can still host the native
+    /// notification, but it must navigate only after an explicit notification
+    /// click. Otherwise the next ordinary focus would replace that unrelated
+    /// project's view with the completed session.
+    arm_focus_navigation: bool,
+}
+
 /// Pick one frontend window to own a session notification.
 ///
-/// The originating window wins even if it has since navigated elsewhere. If it
-/// was closed, prefer a surviving window already showing the session, then one
-/// window from the owning project. Sorting makes all concurrent `notify_user`
-/// calls reach the same answer.
+/// The originating window wins while it still belongs to the session's project.
+/// If it has switched projects, prefer a surviving window already showing the
+/// session, then one window from the owning project. A foreign-project fallback
+/// may show the native notification, but focusing it must not navigate until the
+/// user explicitly clicks that notification. Sorting makes all concurrent
+/// `notify_user` calls reach the same answer.
 fn select_notification_window(
     origin: Option<&str>,
     frame_id: &str,
     project_id: Option<&str>,
     active_projects: &HashMap<String, String>,
     active_frames: &HashMap<String, String>,
-) -> Option<String> {
-    if let Some(origin) = origin.filter(|label| active_projects.contains_key(*label)) {
-        return Some(origin.to_string());
+) -> Option<NotificationWindowSelection> {
+    let belongs_to_project = |label: &str| {
+        label != "pet"
+            && active_projects.get(label).is_some_and(|active_project| {
+                project_id.is_none_or(|project_id| active_project == project_id)
+            })
+    };
+    let selection = |label: String, arm_focus_navigation| NotificationWindowSelection {
+        label,
+        arm_focus_navigation,
+    };
+
+    if let Some(origin) = origin.filter(|label| belongs_to_project(label)) {
+        return Some(selection(origin.to_string(), true));
     }
 
     let mut viewing = active_frames
         .iter()
-        .filter(|(label, viewed)| {
-            viewed.as_str() == frame_id && active_projects.contains_key(label.as_str())
-        })
+        .filter(|(label, viewed)| viewed.as_str() == frame_id && belongs_to_project(label.as_str()))
         .map(|(label, _)| label.clone())
         .collect::<Vec<_>>();
     viewing.sort();
     if let Some(label) = viewing.into_iter().next() {
-        return Some(label);
+        return Some(selection(label, true));
     }
 
     let mut project_windows = active_projects
@@ -1910,11 +1933,31 @@ fn select_notification_window(
         .map(|(label, _)| label.clone())
         .collect::<Vec<_>>();
     project_windows.sort_by_key(|label| (label != "main", label.clone()));
-    project_windows.into_iter().next().or_else(|| {
-        active_projects
-            .contains_key("main")
-            .then(|| "main".to_string())
-    })
+    if let Some(label) = project_windows.into_iter().next() {
+        return Some(selection(label, true));
+    }
+
+    // Keep desktop notifications available when the owning project has no open
+    // window, but never arm a focus-triggered project switch on this fallback.
+    let fallback_origin = origin
+        .filter(|label| *label != "pet" && active_projects.contains_key(*label))
+        .map(str::to_string);
+    let fallback_main = active_projects
+        .contains_key("main")
+        .then(|| "main".to_string());
+    let fallback_any = {
+        let mut labels = active_projects
+            .keys()
+            .filter(|label| label.as_str() != "pet")
+            .cloned()
+            .collect::<Vec<_>>();
+        labels.sort();
+        labels.into_iter().next()
+    };
+    fallback_origin
+        .or(fallback_main)
+        .or(fallback_any)
+        .map(|label| selection(label, false))
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib_tests.rs
+++ b/src-tauri/src/lib_tests.rs
@@ -1315,8 +1315,8 @@ fn session_notification_stays_in_its_origin_window_with_same_project_peers() {
             &active_projects,
             &active_frames,
         )
-        .as_deref(),
-        Some("proj-workspace"),
+        .map(|selection| (selection.label, selection.arm_focus_navigation)),
+        Some(("proj-workspace".to_string(), true)),
     );
 }
 
@@ -1339,8 +1339,50 @@ fn session_notification_falls_back_to_the_window_viewing_the_session() {
             &active_projects,
             &active_frames,
         )
-        .as_deref(),
-        Some("proj-workspace"),
+        .map(|selection| (selection.label, selection.arm_focus_navigation)),
+        Some(("proj-workspace".to_string(), true)),
+    );
+}
+
+#[test]
+fn session_notification_ignores_an_origin_window_that_switched_projects() {
+    let active_projects = HashMap::from([
+        ("main".to_string(), "project-b".to_string()),
+        ("proj-a".to_string(), "project-a".to_string()),
+    ]);
+    let active_frames = HashMap::from([
+        ("main".to_string(), "session-b".to_string()),
+        ("proj-a".to_string(), "session-a".to_string()),
+    ]);
+
+    assert_eq!(
+        super::select_notification_window(
+            Some("main"),
+            "session-a",
+            Some("project-a"),
+            &active_projects,
+            &active_frames,
+        )
+        .map(|selection| (selection.label, selection.arm_focus_navigation)),
+        Some(("proj-a".to_string(), true)),
+    );
+}
+
+#[test]
+fn foreign_project_notification_fallback_never_arms_focus_navigation() {
+    let active_projects = HashMap::from([("main".to_string(), "project-b".to_string())]);
+    let active_frames = HashMap::from([("main".to_string(), "session-b".to_string())]);
+
+    assert_eq!(
+        super::select_notification_window(
+            Some("main"),
+            "session-a",
+            Some("project-a"),
+            &active_projects,
+            &active_frames,
+        )
+        .map(|selection| (selection.label, selection.arm_focus_navigation)),
+        Some(("main".to_string(), false)),
     );
 }
 

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -1314,7 +1314,11 @@ test("Ctrl+P command palette runs commands and switches themes", async ({ page }
   await expect(palette.locator(".project-search-row.active")).toBeVisible();
   await input.fill("");
 
-  await input.press("ArrowDown");
+  // Filter by command name so inserting a new action does not change which row Enter runs.
+  await input.fill("search projects");
+  await expect(palette.locator(".project-search-row.active")).toContainText(
+    "Search projects, artifacts, and sessions",
+  );
   await input.press("Enter");
   await expect(page.getByPlaceholder("Search this project…")).toBeVisible();
   await page.keyboard.press("Escape");


### PR DESCRIPTION
## Problem

When several project windows are open, completing a task can leave a pending notification target on the window that originally launched the task even after that window has switched to another project. The next ordinary mouse click focuses that window, consumes the stale target, and replaces the unrelated project with the completed task's project/session.

## What changed

- Validate that a task's originating notification window still belongs to the session's project.
- If the origin has switched projects, prefer a window currently viewing the session, then another window belonging to the owning project.
- Allow a foreign-project fallback window to display the native notification without arming focus-triggered navigation; it navigates only after an explicit system-notification click.
- Preserve native notification click handling when no focus fallback is armed.
- Add regression coverage for a switched-project origin and for foreign-project fallbacks.
- Stabilize the command-palette E2E by selecting the search action by name instead of depending on menu position.

## User impact

Completing a task in one project no longer causes other project windows to jump to that completed session on their next mouse click. Explicitly clicking the task's system notification still opens the relevant project and session.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace` — passed
- `cd ui && cargo check --target wasm32-unknown-unknown` — passed
- `cd ui-tests && npx playwright test tests/ui.spec.ts:5762 --workers=1` — passed (notification navigation)
- `cd ui-tests && npx playwright test tests/ui.spec.ts:1285 --workers=1` — passed (command-palette stabilization)
- GitHub Actions run `30536141552` — all checks passed:
  - `rust (stable)`
  - `rust (1.88.0)`
  - `ui-e2e`

## Manual smoke steps

1. Start a task in project A.
2. Open project A in its own window and switch the original window to project B.
3. Let project A's task finish while Wisp is unfocused.
4. Click the project B window normally and confirm it stays on project B.
5. Click the system notification and confirm the relevant project A session opens.

## Known limitations / follow-up

- None identified for this change.