### PR TITLE
fix: harden scientific workflows and plugin diagnostics

### DIFF
--- a/crates/wisp-core/src/system_prompt.rs
+++ b/crates/wisp-core/src/system_prompt.rs
@@ -63,7 +63,8 @@ with the current platform's directory-listing command because the `read` tool ca
 **1. Think before coding.** State assumptions. If uncertain, ask rather than guess.\n\
 **2. Minimum code.** If 200 lines can be 50, rewrite. No features beyond what was asked.\n\
 **3. Surgical changes.** Touch only what you must. Don't 'improve' adjacent code or refactor things that aren't broken. Match existing style.\n\
-**4. Verify before completion.** Transform tasks into verifiable goals: 'Write tests for X, then make them pass.' For multi-step work, state a brief plan first.\n".into()
+**4. Verify before completion.** Transform tasks into verifiable goals: 'Write tests for X, then make them pass.' For multi-step work, state a brief plan first.\n\
+**5. Respect cancellations and course corrections.** When the user cancels or removes work, stop it, revise the active plan immediately, and mark the removed step `cancelled` when using `update_plan`. A cancelled step is terminal: never resume it merely because an older plan or message still lists it. Only restore it after a new explicit user request.\n".into()
     }
 
     fn tool_guidance() -> String {
@@ -83,6 +84,15 @@ Use the existing **python** tool for ordinary analysis; its variables and loaded
 Use the existing **r** tool when R is the appropriate analysis environment. It requires an existing `Rscript` and `jsonlite`; do not silently install R or packages. Interpreter paths belong to the selected execution context's persisted settings. When the user supplies or asks to change a Python/R path, use `set_runtime_interpreter` with the matching `context_id` if that tool is available; never try to change the Wisp host process environment from a shell tool.\n\
 When packages or a project-specific scientific stack are needed, call `use_skill` for `local-env-setup` first. For local bioinformatics/scientific package work, prefer a project-local **pixi** environment: `pixi init`, `pixi add ...`, then `pixi run python ...` from the project directory.\n\
 Before any `pip`, `uv`, `npm`, or `pixi add` download, consider the user's network. If mainland-China or corporate-mirror access is likely or requested, configure PyPI/uv and pixi conda/PyPI mirrors first; otherwise use defaults.\n".into()
+    }
+
+    fn scientific_deliverables_guidance() -> String {
+        "## Scientific Deliverables\n\n\
+Scientific figures and multi-stage analyses use the bundled reproducibility workflows by default, not only when the user happens to name a skill.\n\
+- Before creating or revising any scientific plot, search for and load `figure-style`; for a multi-panel figure also load `figure-composer`. Render the saved file, inspect it, and fix legibility or correctness defects before presenting it.\n\
+- Before a multi-stage analysis that produces scripts, tables, or figures, search for and load `analysis-workflow`. Organize outputs into self-contained analysis modules and update each module's README with exact inputs, methods, result-changing parameters, direct package/database versions, scripts, and outputs.\n\
+- Never invent environment or dependency versions. Read them from the runtime, lock file, or recorded session metadata; write `unavailable` when an exact value cannot be observed.\n\
+If a named workflow is disabled or unavailable, follow the same principles directly and state that the skill could not be loaded.\n".into()
     }
 
     fn skills_guidance(&self) -> String {
@@ -142,6 +152,7 @@ Before any `pip`, `uv`, `npm`, or `pixi add` download, consider the user's netwo
             Self::builtin_rules(),
             Self::tool_guidance(),
             Self::environment_guidance(),
+            Self::scientific_deliverables_guidance(),
             self.skills_guidance(),
         ];
         if let Some(hosts) = &self.compute_hosts {
@@ -246,6 +257,28 @@ mod tests {
         assert!(
             out.contains("nested-quote one-liners"),
             "ssh quoting guidance missing:\n{out}"
+        );
+    }
+
+    #[test]
+    fn prompt_makes_user_cancelled_plan_steps_terminal() {
+        let skills = SkillIndex::default();
+        let out = SystemPrompt::new(std::path::Path::new("/tmp"), &skills, None).assemble();
+        assert!(out.contains("mark the removed step `cancelled`"), "{out}");
+        assert!(out.contains("never resume it"), "{out}");
+        assert!(out.contains("new explicit user request"), "{out}");
+    }
+
+    #[test]
+    fn prompt_routes_scientific_outputs_through_reproducibility_skills() {
+        let skills = SkillIndex::default();
+        let out = SystemPrompt::new(std::path::Path::new("/tmp"), &skills, None).assemble();
+        assert!(out.contains("load `figure-style`"), "{out}");
+        assert!(out.contains("load `analysis-workflow`"), "{out}");
+        assert!(out.contains("self-contained analysis modules"), "{out}");
+        assert!(
+            out.contains("Never invent environment or dependency versions"),
+            "{out}"
         );
     }
 

--- a/crates/wisp-skills/src/index.rs
+++ b/crates/wisp-skills/src/index.rs
@@ -332,6 +332,8 @@ mod tests {
         };
         let idx = SkillIndex::load(&[dir]);
         assert!(idx.get("agent-infini").is_some());
+        assert!(idx.get("analysis-workflow").is_some());
+        assert!(idx.get("figure-style").is_some());
         assert!(idx.get("journal-club-ppt").is_some());
     }
 

--- a/crates/wisp-tools/src/plan.rs
+++ b/crates/wisp-tools/src/plan.rs
@@ -50,7 +50,7 @@ fn render_plan(args: &Value) -> Result<String, String> {
     if steps.is_empty() {
         return Err("update_plan error: 'steps' must not be empty".into());
     }
-    let (mut done, mut running, mut pending) = (0usize, 0usize, 0usize);
+    let (mut done, mut running, mut pending, mut cancelled) = (0usize, 0usize, 0usize, 0usize);
     let mut lines = Vec::with_capacity(steps.len());
     for (i, s) in steps.iter().enumerate() {
         let text = s
@@ -76,9 +76,13 @@ fn render_plan(args: &Value) -> Result<String, String> {
                 pending += 1;
                 "[ ]"
             }
+            "cancelled" => {
+                cancelled += 1;
+                "[-]"
+            }
             other => {
                 return Err(format!(
-                    "update_plan error: step {} has invalid status '{}' (use pending|in_progress|completed)",
+                    "update_plan error: step {} has invalid status '{}' (use pending|in_progress|completed|cancelled)",
                     i + 1,
                     other
                 ))
@@ -92,7 +96,7 @@ fn render_plan(args: &Value) -> Result<String, String> {
         ));
     }
     let header = format!(
-        "Plan ({} steps · {done} done · {running} in progress · {pending} pending):",
+        "Plan ({} steps · {done} done · {running} in progress · {pending} pending · {cancelled} cancelled):",
         steps.len()
     );
     Ok(format!("{header}\n{}", lines.join("\n")))
@@ -134,7 +138,8 @@ impl Tool for UpdatePlanTool {
              work is genuinely multi-stage (several analyses to sequence, long compute, a pipeline worth \
              showing the user); skip it for lookups, a single computation, or reading one file. Keep at \
              most one step 'in_progress' at a time. A failed or cancelled tool call does not complete its \
-             related step; keep that step in_progress/pending or revise the plan.",
+             related step; keep a failed step in_progress/pending, and mark work the user explicitly removes \
+             as 'cancelled'. Never restore a cancelled step unless the user asks for it again.",
             json!({
                 "type": "object",
                 "properties": {
@@ -147,7 +152,7 @@ impl Tool for UpdatePlanTool {
                                 "step": { "type": "string", "description": "Short imperative description of the step." },
                                 "status": {
                                     "type": "string",
-                                    "enum": ["pending", "in_progress", "completed"],
+                                    "enum": ["pending", "in_progress", "completed", "cancelled"],
                                     "description": "Defaults to 'pending' if omitted."
                                 }
                             },
@@ -359,6 +364,9 @@ mod tests {
         assert!(!is_fresh_proposal(
             &json!({"steps": [{"step": "a", "status": "completed"}]})
         ));
+        assert!(!is_fresh_proposal(
+            &json!({"steps": [{"step": "a", "status": "cancelled"}]})
+        ));
         assert!(
             !is_fresh_proposal(&json!({"steps": []})),
             "empty is not a proposal"
@@ -370,14 +378,19 @@ mod tests {
         let out = render_plan(&json!({"steps": [
             {"step": "Load counts", "status": "completed"},
             {"step": "Run DESeq2", "status": "in_progress"},
+            {"step": "Download every MSigDB collection", "status": "cancelled"},
             {"step": "Write report"}
         ]}))
         .unwrap();
         assert!(out.contains("[x] Load counts"), "{out}");
         assert!(out.contains("[~] Run DESeq2"), "{out}");
+        assert!(
+            out.contains("[-] Download every MSigDB collection"),
+            "{out}"
+        );
         assert!(out.contains("[ ] Write report"), "{out}"); // omitted status -> pending
         assert!(
-            out.contains("3 steps · 1 done · 1 in progress · 1 pending"),
+            out.contains("4 steps · 1 done · 1 in progress · 1 pending · 1 cancelled"),
             "{out}"
         );
     }

--- a/skills/analysis-workflow/SKILL.md
+++ b/skills/analysis-workflow/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: analysis-workflow
+description: "Organize multi-step scientific analyses into reproducible, self-contained modules. Use for workflows such as QC→PCA→DEG→GSEA that produce scripts, inputs, figures, tables, and methods. Creates a stable module layout, records exact inputs/parameters/package and database versions in each module README, keeps large data as references instead of copies, and verifies outputs before completion."
+license: Apache-2.0
+---
+
+# Reproducible Analysis Modules
+
+Use this skill for a scientific workflow with two or more analysis stages or
+when a stage produces scripts plus result files. It defines project
+organization and methods capture; load `figure-style` as well whenever a stage
+creates or revises a plot.
+
+## 1. Plan module boundaries
+
+Before writing outputs, list the modules and the dependency edges between them.
+Use stable ASCII names. Conventional acronyms such as `QC`, `PCA`, `DEG`, and
+`GSEA` may stay uppercase; otherwise prefer a short kebab-case name.
+
+Respect a compatible layout that already exists. Do not reorganize unrelated
+user files merely to impose this convention.
+
+## 2. Default module layout
+
+Create only directories the module actually needs:
+
+```text
+<module>/
+├── scripts/
+├── input/
+├── output/
+│   ├── figures/
+│   └── tables/
+└── README.md
+```
+
+- `scripts/` contains the executable source for this module.
+- `input/` contains small module-specific inputs or a manifest/reference to the
+  canonical data. Do not duplicate a large dataset by default.
+- `output/figures/` contains rendered figures from this module only.
+- `output/tables/` contains machine-readable results from this module only.
+- `README.md` is the module's reproducibility record and methods source.
+
+Shared immutable/raw data may live in project-level `data/`. A downstream module
+references an upstream output by a project-relative path; it does not silently
+copy or rename that output.
+
+## 3. Make outputs attributable
+
+Every output must have one producing script or recorded command. Use
+deterministic filenames that identify the analysis and content. Keep temporary
+files outside the final output directories or name them clearly as temporary.
+
+Before completing a module, verify:
+
+1. every declared output exists and is non-empty;
+2. every table can be parsed in its declared format;
+3. every figure was rendered and visually inspected using `figure-style`;
+4. README input and output paths resolve from the project root;
+5. reported thresholds and parameters match the actual script.
+
+## 4. Update README.md at module completion
+
+Create or update these sections:
+
+```markdown
+# <Module>
+
+## Purpose
+<scientific question and role in the workflow>
+
+## Inputs
+- `<project-relative path>` — source, upstream module, checksum or version when available
+
+## Methods
+<method in prose, including transformations, statistical tests, correction method,
+thresholds, seeds, and other result-changing parameters>
+
+## Software and data sources
+- R/Python package: exact version
+- External API/database: release or access date
+- Wisp/model/runtime metadata: exact recorded value when available
+
+## Commands and scripts
+- `<project-relative script>` — how it was executed
+
+## Outputs
+- `<project-relative path>` — meaning and format
+
+## Limitations
+<assumptions, exclusions, and unresolved reproducibility gaps>
+```
+
+Write methods from executed code and recorded parameters, not from a generic
+template. Do not claim a package, database, model, OS, or version that was not
+actually used or observed.
+
+## 5. Capture exact versions without dumping the world
+
+Record direct dependencies used by the module:
+
+- R: `packageVersion("<package>")` for named packages and `sessionInfo()` for
+  the runtime context.
+- Python: `importlib.metadata.version("<distribution>")`; use the project lock
+  file when it is the authoritative environment record.
+- External databases/APIs: release identifier when available, otherwise access
+  date plus endpoint/source.
+- Wisp version and model profile: use runtime/session metadata only when it is
+  available. Write `unavailable` rather than guessing.
+
+Do not paste an entire global `pip freeze` into every module. If a complete
+environment export is useful, save it once as a separate artifact and link it
+from the README.
+
+## 6. Finish the workflow
+
+After all modules pass their checks, summarize the dependency chain and link the
+module READMEs. Treat those READMEs as the first-version source of truth.
+Generate a root `METHODS.md` only when the user asks for it or a deterministic
+project tool can derive it from the module records; do not maintain a second
+hand-edited copy that can drift.

--- a/skills/figure-style/SKILL.md
+++ b/skills/figure-style/SKILL.md
@@ -328,6 +328,15 @@ smallest plotted element have a stroke or stub? Do any leaders cross? Could any
 series colour be mistaken for another? Does the legend sit beside what it keys?
 A perceptual defect that passes §9.1 is still a defect.
 
+**9.3 Reliable R export.** For ggplot objects, prefer an explicit
+`ggsave(filename, plot = p, dpi = 300, bg = "white", ...)` call over relying on
+the current graphics device. For base graphics or packages that draw only to an
+active device, open `png(..., bg = "white", res = 300)`, draw explicitly, and
+always call `dev.off()`. After either path, assert that the file exists and is
+non-empty, then inspect the saved image. A successful R call with a missing,
+zero-byte, transparent-on-transparent, or visually blank file is a failed
+render.
+
 ---
 *When in doubt: fewer hues, more direct labels, raw data over summary stats, and
 state what is being measured before showing the result.*

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1792,6 +1792,10 @@ struct AppState {
     /// Scoped approvals granted from the inline confirmation card.
     approval_grants: Arc<StdMutex<ApprovalGrants>>,
     bootstrap: StdMutex<BootstrapStatus>,
+    /// Last plugin MCP startup errors observed while building a normal Agent,
+    /// grouped by project and plugin id so Settings can explain why an enabled
+    /// plugin contributed no tools to a new session.
+    plugin_runtime_errors: StdMutex<HashMap<String, HashMap<String, Vec<String>>>>,
     /// Session ids with an in-flight manual or automatic review. Reviews in
     /// unrelated conversations remain independent.
     reviewing: Arc<StdMutex<HashSet<String>>>,
@@ -3478,6 +3482,10 @@ fn r_kernel_worker_path() -> PathBuf {
 struct ToolWiringResult {
     errors: Vec<String>,
     added_tools: Vec<String>,
+    /// Plugin ids attempted while building this Agent and any startup or
+    /// tools/list errors observed for each one. An empty list means the latest
+    /// attempt succeeded and clears an older diagnostic.
+    plugin_runtime_checks: HashMap<String, Vec<String>>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -3689,25 +3697,37 @@ async fn finish_custom_mcp_wiring(
     let mut set = tokio::task::JoinSet::new();
     let (plugin_launches, plugin_errors) =
         plugins::enabled_plugin_mcp_launches(store, project_id).await;
-    result.errors.extend(plugin_errors);
+    for error in plugin_errors {
+        result
+            .plugin_runtime_checks
+            .entry(error.plugin_id)
+            .or_default()
+            .push(error.message.clone());
+        result.errors.push(error.message);
+    }
     let mut next_index = 0usize;
     for launch in plugin_launches
         .into_iter()
         .filter(|launch| connector_allow.is_none_or(|allow| allow.contains(&launch.connector_id)))
     {
+        let plugin_id = launch.plugin_id.clone();
+        result
+            .plugin_runtime_checks
+            .entry(plugin_id.clone())
+            .or_default();
         let index = next_index;
         next_index += 1;
         set.spawn(async move {
             let name = launch.display_name.clone();
             let res = connect_plugin_mcp(&launch).await;
-            (index, name, true, res)
+            (index, name, Some(plugin_id), true, res)
         });
     }
     for (i, conn) in conns.into_iter().enumerate() {
         let index = next_index + i;
         set.spawn(async move {
             let res = connect_mcp(&conn).await;
-            (index, conn.name, false, res)
+            (index, conn.name, None, false, res)
         });
     }
     let mut results = Vec::new();
@@ -3716,8 +3736,8 @@ async fn finish_custom_mcp_wiring(
             results.push(r);
         }
     }
-    results.sort_by_key(|(i, _, _, _)| *i);
-    for (_, name, require_approval, res) in results {
+    results.sort_by_key(|(i, _, _, _, _)| *i);
+    for (_, name, plugin_id, require_approval, res) in results {
         match res {
             Ok(client) => match register_mcp_with_approval(
                 registry,
@@ -3727,9 +3747,29 @@ async fn finish_custom_mcp_wiring(
             .await
             {
                 Ok(names) => result.added_tools.extend(names),
-                Err(error) => result.errors.push(format!("MCP '{name}': {error}")),
+                Err(error) => {
+                    let message = format!("MCP '{name}': {error}");
+                    if let Some(plugin_id) = plugin_id {
+                        result
+                            .plugin_runtime_checks
+                            .entry(plugin_id)
+                            .or_default()
+                            .push(message.clone());
+                    }
+                    result.errors.push(message);
+                }
             },
-            Err(e) => result.errors.push(format!("MCP '{name}': {e}")),
+            Err(error) => {
+                let message = format!("MCP '{name}': {error}");
+                if let Some(plugin_id) = plugin_id {
+                    result
+                        .plugin_runtime_checks
+                        .entry(plugin_id)
+                        .or_default()
+                        .push(message.clone());
+                }
+                result.errors.push(message);
+            }
         }
     }
     result
@@ -4674,6 +4714,17 @@ async fn send_message_inner(
             connector_allow.as_ref(),
         )
         .await;
+        {
+            let mut observed = state.plugin_runtime_errors.lock().unwrap();
+            let project_errors = observed.entry(ap.id.clone()).or_default();
+            for (plugin_id, errors) in &wiring.plugin_runtime_checks {
+                if errors.is_empty() {
+                    project_errors.remove(plugin_id);
+                } else {
+                    project_errors.insert(plugin_id.clone(), errors.clone());
+                }
+            }
+        }
         if !wiring.errors.is_empty() {
             state.bootstrap.lock().unwrap().errors.extend(wiring.errors);
         }
@@ -6233,6 +6284,7 @@ pub fn run() {
                 approvals,
                 approval_grants,
                 bootstrap,
+                plugin_runtime_errors: StdMutex::new(HashMap::new()),
                 reviewing: Arc::new(StdMutex::new(HashSet::new())),
                 scratch: std::sync::RwLock::new(HashMap::new()),
             };

--- a/src-tauri/src/plugins.rs
+++ b/src-tauri/src/plugins.rs
@@ -55,6 +55,7 @@ pub(crate) struct NormalizedPluginManifest {
 
 #[derive(Debug)]
 pub(crate) struct PluginMcpLaunch {
+    pub plugin_id: String,
     pub connector_id: String,
     pub display_name: String,
     pub command: PathBuf,
@@ -62,6 +63,12 @@ pub(crate) struct PluginMcpLaunch {
     pub env: BTreeMap<String, String>,
     pub cwd: PathBuf,
     pub install_root: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PluginRuntimeError {
+    pub plugin_id: String,
+    pub message: String,
 }
 
 impl NormalizedPluginManifest {
@@ -764,6 +771,17 @@ fn plugin_view(
     })
 }
 
+fn apply_observed_runtime_errors(view: &mut PluginView, errors: &[String]) {
+    for error in errors {
+        if !view.runtime_errors.contains(error) {
+            view.runtime_errors.push(error.clone());
+        }
+    }
+    if !view.runtime_errors.is_empty() {
+        view.runtime_status = "unavailable".into();
+    }
+}
+
 pub(crate) async fn enabled_plugin_manifests(
     store: &wisp_store::Store,
     project_id: &str,
@@ -849,6 +867,7 @@ fn plugin_mcp_launch(
         install_root.clone()
     };
     Ok(PluginMcpLaunch {
+        plugin_id: manifest.id.clone(),
         connector_id: format!("plugin:{}:{}", manifest.id, server.id),
         display_name: format!("{} / {}", manifest.display_name, server.id),
         command,
@@ -862,17 +881,20 @@ fn plugin_mcp_launch(
 pub(crate) async fn enabled_plugin_mcp_launches(
     store: &wisp_store::Store,
     project_id: &str,
-) -> (Vec<PluginMcpLaunch>, Vec<String>) {
+) -> (Vec<PluginMcpLaunch>, Vec<PluginRuntimeError>) {
     let mut launches = Vec::new();
     let mut errors = Vec::new();
     for (installation, manifest) in enabled_plugin_manifests(store, project_id).await {
         for server in &manifest.mcp_servers {
             match plugin_mcp_launch(&installation, &manifest, server) {
                 Ok(launch) => launches.push(launch),
-                Err(error) => errors.push(format!(
-                    "Plugin '{}' MCP '{}': {error}",
-                    manifest.display_name, server.id
-                )),
+                Err(error) => errors.push(PluginRuntimeError {
+                    plugin_id: manifest.id.clone(),
+                    message: format!(
+                        "Plugin '{}' MCP '{}': {error}",
+                        manifest.display_name, server.id
+                    ),
+                }),
             }
         }
     }
@@ -895,6 +917,13 @@ pub(super) async fn list_plugins(
         .filter(|binding| binding.enabled)
         .map(|binding| (binding.plugin_id, binding.version))
         .collect();
+    let observed_errors = state
+        .plugin_runtime_errors
+        .lock()
+        .unwrap()
+        .get(&project.id)
+        .cloned()
+        .unwrap_or_default();
     state
         .store
         .list_plugin_installations()
@@ -904,7 +933,19 @@ pub(super) async fn list_plugins(
         .map(|installation| {
             let is_enabled =
                 enabled.contains(&(installation.plugin_id.clone(), installation.version.clone()));
-            plugin_view(installation, is_enabled)
+            let plugin_id = installation.plugin_id.clone();
+            plugin_view(installation, is_enabled).map(|mut view| {
+                if is_enabled {
+                    apply_observed_runtime_errors(
+                        &mut view,
+                        observed_errors
+                            .get(&plugin_id)
+                            .map(Vec::as_slice)
+                            .unwrap_or_default(),
+                    );
+                }
+                view
+            })
         })
         .collect()
 }
@@ -1118,6 +1159,13 @@ pub(super) async fn set_plugin_enabled(
             .await
             .map_err(|error| error.to_string())?;
     }
+    state
+        .plugin_runtime_errors
+        .lock()
+        .unwrap()
+        .entry(project.id.clone())
+        .or_default()
+        .remove(&plugin_id);
     clear_idle_agents(&state).await;
     Ok(())
 }
@@ -1178,6 +1226,9 @@ pub(super) async fn remove_plugin(
     }
     if let Some(parent) = installed_root.parent() {
         let _ = tokio::fs::remove_dir(parent).await;
+    }
+    for errors in state.plugin_runtime_errors.lock().unwrap().values_mut() {
+        errors.remove(&plugin_id);
     }
     Ok(())
 }
@@ -1314,6 +1365,41 @@ mod tests {
     }
 
     #[test]
+    fn plugin_view_includes_errors_observed_during_new_session_startup() {
+        let root =
+            std::env::temp_dir().join(format!("wisp-plugin-observed-{}", uuid::Uuid::new_v4()));
+        fixture(&root);
+        let manifest = parse_manifest(&root).unwrap();
+        let installation = wisp_store::PluginInstallation {
+            plugin_id: manifest.id.clone(),
+            version: manifest.version.clone(),
+            display_name: manifest.display_name.clone(),
+            description: manifest.description.clone(),
+            author: manifest.author.clone(),
+            license: manifest.license.clone(),
+            source_uri: root.to_string_lossy().to_string(),
+            install_root: root.to_string_lossy().to_string(),
+            archive_sha256: "a".repeat(64),
+            manifest_json: serde_json::to_string(&manifest).unwrap(),
+            trust_state: "checksum_verified".into(),
+            installed_at: 0,
+            updated_at: 0,
+        };
+        let mut view = plugin_view(installation, true).unwrap();
+        assert_eq!(view.runtime_status, "ready");
+
+        apply_observed_runtime_errors(
+            &mut view,
+            &["Plugin 'Motif' MCP 'motif': process exited during tools/list".into()],
+        );
+
+        assert_eq!(view.runtime_status, "unavailable");
+        assert_eq!(view.runtime_errors.len(), 1);
+        assert!(view.runtime_errors[0].contains("tools/list"));
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn plugin_launch_expands_a_spawnable_canonical_root() {
         let root =
             std::env::temp_dir().join(format!("wisp-plugin-launch-{}", uuid::Uuid::new_v4()));
@@ -1339,6 +1425,7 @@ mod tests {
 
         let launch = plugin_mcp_launch(&installation, &manifest, &manifest.mcp_servers[0]).unwrap();
         let expected_root = dunce::canonicalize(&root).unwrap();
+        assert_eq!(launch.plugin_id, "motif");
         assert_eq!(launch.install_root, expected_root);
         assert_eq!(
             PathBuf::from(&launch.args[0]),

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -214,6 +214,14 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
   (window as any).__setMockWorkspaceR = (value: string) => { workspaceR = String(value); };
   let workspaceEntries = [
     { path: "data", is_dir: true, size: 0 },
+    { path: "DEG", is_dir: true, size: 0 },
+    { path: "DEG/scripts", is_dir: true, size: 0 },
+    { path: "DEG/scripts/04_limma_deg.R", is_dir: false, size: 512 },
+    { path: "DEG/output", is_dir: true, size: 0 },
+    { path: "DEG/output/figures", is_dir: true, size: 0 },
+    { path: "DEG/output/figures/volcano.png", is_dir: false, size: 4096 },
+    { path: "DEG/output/tables", is_dir: true, size: 0 },
+    { path: "DEG/output/tables/all_genes.tsv", is_dir: false, size: 8192 },
     { path: "report.csv", is_dir: false, size: 4096 },
     { path: "config.json", is_dir: false, size: 64 },
     { path: "model.pdb", is_dir: false, size: 256 },

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -2167,6 +2167,28 @@ test("workspace file context menu attaches its path to the composer", async ({ p
   await expect(composer(page)).toHaveValue("");
 });
 
+test("workspace Files panel navigates deeply nested analysis modules", async ({ page }) => {
+  await enterApp(page);
+  await page.getByRole("button", { name: "Files" }).click();
+
+  await page.locator('.fb-row[data-workspace-path="DEG"]').click();
+  await expect(page.locator(".fb-path")).toHaveText("DEG");
+  await expect(page.locator('.fb-row[data-workspace-path="DEG/scripts"]')).toBeVisible();
+  await expect(page.locator('.fb-row[data-workspace-path="DEG/output"]')).toBeVisible();
+
+  await page.locator('.fb-row[data-workspace-path="DEG/output"]').click();
+  await page.locator('.fb-row[data-workspace-path="DEG/output/figures"]').click();
+  await expect(page.locator(".fb-path")).toHaveText("DEG/output/figures");
+  await expect(
+    page.locator('.fb-row[data-workspace-path="DEG/output/figures/volcano.png"]'),
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: "Refresh" }).click();
+  await expect(
+    page.locator('.fb-row[data-workspace-path="DEG/output/figures/volcano.png"]'),
+  ).toBeVisible();
+});
+
 test("workspace file can be registered as an artifact", async ({ page }) => {
   await enterApp(page);
   await page.getByRole("button", { name: "Files" }).click();

--- a/ui/src/app_support.rs
+++ b/ui/src/app_support.rs
@@ -352,9 +352,9 @@ impl ComposerReferenceChip {
 
     pub(super) fn label(&self) -> String {
         match self {
-            Self::Artifact { name, .. }
-            | Self::Skill { name }
-            | Self::Workflow { name, .. } => name.clone(),
+            Self::Artifact { name, .. } | Self::Skill { name } | Self::Workflow { name, .. } => {
+                name.clone()
+            }
             Self::Session {
                 title,
                 project_name,
@@ -9707,10 +9707,16 @@ pub(super) fn ToolBlock(
     }
 }
 
-/// Parse a rendered plan checklist line (`[x] text` / `[~] text` / `[ ] text`)
+/// Parse a rendered plan checklist line
+/// (`[x] text` / `[~] text` / `[ ] text` / `[-] text`)
 /// into (status_class, text). Mirrors `update_plan`'s render in wisp-tools.
 pub(super) fn plan_step_line(line: &str) -> Option<(&'static str, &str)> {
-    for (prefix, cls) in [("[x] ", "done"), ("[~] ", "running"), ("[ ] ", "pending")] {
+    for (prefix, cls) in [
+        ("[x] ", "done"),
+        ("[~] ", "running"),
+        ("[ ] ", "pending"),
+        ("[-] ", "cancelled"),
+    ] {
         if let Some(rest) = line.strip_prefix(prefix) {
             return Some((cls, rest));
         }

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -10619,7 +10619,11 @@ fn App() -> impl IntoView {
                                 // resetting its scroll to the top (#25). Selection is
                                 // isolated to the `.active` class and the nested `.rp-view`
                                 // closure below, so the scroll container is preserved.
-                                let groups = group_artifact_indices(&arts);
+                                let project_root = project_info
+                                    .get()
+                                    .map(|project| project.root)
+                                    .unwrap_or_default();
+                                let groups = group_artifact_indices(&arts, &project_root);
                                 let tile_groups = groups.into_iter().map(|(key, indices)| {
                                     let label = artifact_group_label(&key, loc);
                                     let count = indices.len();

--- a/ui/src/styles/chat.css
+++ b/ui/src/styles/chat.css
@@ -542,7 +542,9 @@ button.tool-btn.card-copy { margin-left: auto; flex: 0 0 auto; padding: 2px 8px;
 .plan-step.done .plan-step-mark::after { content: "✓"; position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; font-size: 11px; color: var(--on-clay); }
 .plan-step.running .plan-step-mark { border-color: var(--clay); }
 .plan-step.running .plan-step-mark::after { content: ""; position: absolute; inset: 3px; border-radius: 2px; background: var(--clay); }
+.plan-step.cancelled .plan-step-mark::after { content: "−"; position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; color: var(--text-faint); }
 .plan-step.done .plan-step-text { color: var(--text-muted); text-decoration: line-through; text-decoration-color: var(--text-faint); }
+.plan-step.cancelled .plan-step-text { color: var(--text-faint); text-decoration: line-through; text-decoration-color: var(--text-faint); }
 .plan-step.pending .plan-step-text { color: var(--text-muted); }
 .plan-step-text { min-width: 0; }
 .plan-feedback { display: flex; flex-direction: column; gap: 8px; margin-top: 10px; }

--- a/ui/src/text.rs
+++ b/ui/src/text.rs
@@ -520,26 +520,76 @@ pub(crate) fn next_artifact_id(n: usize) -> String {
     format!("{:08x}", n + 1)
 }
 
-/// Group key for the artifacts panel: parent directory for files, `@kind` for inline artifacts.
-pub(crate) fn artifact_group_key(a: &crate::dto::Artifact) -> String {
+/// Return a workspace-relative spelling when `path` is inside `project_root`.
+/// Relative artifact paths are already workspace-relative. Absolute references
+/// outside the workspace and URI-backed artifacts keep the old last-directory
+/// grouping so the panel does not expose an unrelated full host path.
+fn artifact_workspace_path(path: &str, project_root: &str) -> String {
+    let normalized = path.trim().replace('\\', "/");
+    let normalized = normalized
+        .strip_prefix("./")
+        .unwrap_or(&normalized)
+        .trim_end_matches('/');
+    if normalized.contains("://") {
+        return normalized.to_string();
+    }
+
+    let root = project_root.trim().replace('\\', "/");
+    let root = root.trim_end_matches('/');
+    let windows_root = root.as_bytes().get(1) == Some(&b':');
+    let comparable_path = if windows_root {
+        normalized.to_ascii_lowercase()
+    } else {
+        normalized.to_string()
+    };
+    let comparable_root = if windows_root {
+        root.to_ascii_lowercase()
+    } else {
+        root.to_string()
+    };
+    let prefix = format!("{comparable_root}/");
+    if let Some(relative) = comparable_path.strip_prefix(&prefix) {
+        let offset = normalized.len().saturating_sub(relative.len());
+        return normalized[offset..].to_string();
+    }
+    normalized.to_string()
+}
+
+/// Group key for the artifacts panel: complete project-relative parent path for
+/// workspace files, `@kind` for inline artifacts.
+pub(crate) fn artifact_group_key(a: &crate::dto::Artifact, project_root: &str) -> String {
     use crate::dto::PreviewData;
     match &a.data {
-        PreviewData::File { path, .. } => path
-            .rsplit(['/', '\\'])
-            .nth(1)
-            .filter(|p| !p.is_empty())
-            .map(|p| format!("{p}/"))
-            .unwrap_or_else(|| ".".into()),
+        PreviewData::File { path, .. } => {
+            let relative = artifact_workspace_path(path, project_root);
+            let outside_workspace_absolute = relative == path.trim().replace('\\', "/")
+                && (relative.starts_with('/')
+                    || relative.as_bytes().get(1) == Some(&b':')
+                    || relative.contains("://"));
+            let parent = relative.rsplit_once('/').map(|(parent, _)| parent);
+            match parent.filter(|parent| !parent.is_empty()) {
+                Some(parent) if outside_workspace_absolute => parent
+                    .rsplit('/')
+                    .next()
+                    .map(|name| format!("{name}/"))
+                    .unwrap_or_else(|| ".".into()),
+                Some(parent) => format!("{parent}/"),
+                None => ".".into(),
+            }
+        }
         _ => format!("@{}", a.kind),
     }
 }
 
 /// Sorted artifact groups: directories first (alpha), then inline kinds.
-pub(crate) fn group_artifact_indices(arts: &[crate::dto::Artifact]) -> Vec<(String, Vec<usize>)> {
+pub(crate) fn group_artifact_indices(
+    arts: &[crate::dto::Artifact],
+    project_root: &str,
+) -> Vec<(String, Vec<usize>)> {
     use std::collections::BTreeMap;
     let mut map: BTreeMap<(u8, String), (String, Vec<usize>)> = BTreeMap::new();
     for (i, a) in arts.iter().enumerate() {
-        let key = artifact_group_key(a);
+        let key = artifact_group_key(a, project_root);
         let sort = if let Some(kind) = key.strip_prefix('@') {
             (1, kind.to_string())
         } else {
@@ -551,6 +601,68 @@ pub(crate) fn group_artifact_indices(arts: &[crate::dto::Artifact]) -> Vec<(Stri
             .push(i);
     }
     map.into_values().collect()
+}
+
+#[cfg(test)]
+mod artifact_group_tests {
+    use super::{artifact_group_key, group_artifact_indices};
+    use crate::dto::{Artifact, PreviewData};
+
+    fn file(path: &str) -> Artifact {
+        Artifact {
+            id: path.into(),
+            name: path.rsplit(['/', '\\']).next().unwrap_or(path).into(),
+            kind: "image",
+            data: PreviewData::File {
+                path: path.into(),
+                kind: "image".into(),
+            },
+            source_item: 0,
+            superseded: false,
+        }
+    }
+
+    #[test]
+    fn artifact_groups_keep_nested_workspace_paths() {
+        let relative = file("DEG/output/figures/volcano.png");
+        assert_eq!(
+            artifact_group_key(&relative, r"D:\project"),
+            "DEG/output/figures/"
+        );
+
+        let absolute = file(r"D:\project\GSEA\output\tables\hallmark.tsv");
+        assert_eq!(
+            artifact_group_key(&absolute, r"d:\PROJECT"),
+            "GSEA/output/tables/"
+        );
+    }
+
+    #[test]
+    fn artifact_groups_do_not_expose_unrelated_absolute_paths() {
+        let outside = file(r"C:\external\results\plot.png");
+        assert_eq!(artifact_group_key(&outside, r"D:\project"), "results/");
+        let remote = file("ssh://gpu/work/results/plot.png");
+        assert_eq!(artifact_group_key(&remote, r"D:\project"), "results/");
+    }
+
+    #[test]
+    fn nested_groups_remain_distinct() {
+        let artifacts = vec![
+            file("PCA/output/figures/plot.png"),
+            file("DEG/output/figures/plot.png"),
+        ];
+        let groups = group_artifact_indices(&artifacts, r"D:\project");
+        assert_eq!(
+            groups
+                .iter()
+                .map(|(key, indices)| (key.as_str(), indices.as_slice()))
+                .collect::<Vec<_>>(),
+            vec![
+                ("DEG/output/figures/", &[1][..]),
+                ("PCA/output/figures/", &[0][..]),
+            ]
+        );
+    }
 }
 
 pub(crate) fn normalize_path(path: &str) -> String {


### PR DESCRIPTION
## Summary

This PR addresses the July 31 scientific-workflow reports from `Yu-Qiao-sjtu`:

- surface per-project/plugin MCP startup and `tools/list` failures in Plugin Settings instead of silently appearing disabled;
- route scientific plotting through the bundled figure workflows by default and require render/visual verification;
- add a terminal `cancelled` plan state and prevent cancelled work from being silently resumed;
- add a bundled `analysis-workflow` skill for self-contained analysis modules and reproducible module READMEs;
- preserve complete project-relative Artifact group paths and cover deep Files navigation.

## Root causes and implementation

### Plugin activation diagnostics

Project plugin enablement was already persisted. The missing behavior was observability: failures while a new-session Agent built plugin MCP connections were only added to bootstrap errors. The app now records those checks by project and plugin, merges them into Plugin Settings, reports the plugin as unavailable, and clears stale errors after a later successful check or successful lifecycle change.

### Scientific workflow defaults

The system prompt now explicitly routes scientific figures through `figure-style` (and multi-panel figures through `figure-composer`) and routes multi-stage analyses through the new `analysis-workflow` skill. The workflow defines module-local scripts, inputs, figures, tables, and README methods/version capture without duplicating large data or inventing unavailable versions. `figure-style` now includes reliable R export and saved-file verification guidance.

### Cancellation and workspace paths

`update_plan` accepts and renders terminal `cancelled` steps, with matching UI styling and prompt guidance. Artifact grouping now retains complete workspace-relative parents such as `DEG/output/figures/`, while unrelated absolute host paths remain abbreviated. Files navigation has a regression test for deeply nested analysis modules and refresh.

## User impact

Users get actionable plugin startup errors, cancelled work stays cancelled, scientific outputs follow reproducibility/figure checks by default, and nested module artifacts retain their origin in the UI.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cd ui && cargo check --target wasm32-unknown-unknown`
- `cd ui-tests && npx playwright test` — 236 passed, 1 skipped
- `cargo run -p wisp-mcp --example smoke`
- `git diff --check`

## Manual smoke steps

1. Enable a plugin with an invalid MCP command, start a new session, and verify Plugin Settings reports the concrete startup error as unavailable.
2. Ask for a scientific plot and confirm the prompt routes through the figure workflow and verifies the saved image.
3. Render a plan containing a cancelled step and confirm it stays terminal and visibly cancelled.
4. Create `DEG/output/figures/volcano.png`, refresh Files, and verify both deep navigation and the full Artifact group path.

## Known limitations

- `Scientific Figure Library v0.1.1` has not been reproduced package-for-package because its ZIP/manifest/public URL has not yet been provided. This PR fixes the silent-diagnostic gap but does not claim every package-specific Windows launch issue is resolved.
- Module READMEs are the first-version methods source of truth; this PR does not add a separately hand-maintained root `METHODS.md`.
- Artifacts remain registered/generated outputs rather than a mirror of every script or empty directory; the Files panel remains the filesystem view.

Related to #585
Closes #586
Closes #587
Closes #588
Closes #589
Closes #591