### PR TITLE
Harden literature delegation, destructive cleanup, and local SSH uploads

### DIFF
--- a/crates/wisp-core/src/system_prompt.rs
+++ b/crates/wisp-core/src/system_prompt.rs
@@ -47,7 +47,16 @@ with the current platform's directory-listing command because the `read` tool ca
     }
 
     fn safety() -> String {
-        "## Safety\n\nDestructive commands and any access outside the project root require explicit user confirmation.\n".into()
+        "## Safety\n\n\
+Destructive commands and any access outside the project root require explicit user confirmation.\n\
+Before deleting scientific data, run directories, intermediate files, or inputs—even when the \
+user supplied the deletion command—first perform a read-only inventory of the exact targets and \
+check whether active or incomplete work still depends on them and whether a verified recovery copy \
+exists. If deletion could make the requested outcome incomplete or unrecoverable, stop and explain \
+the concrete impact before asking for confirmation. After a destructive action, report retained \
+temporary and derived files precisely; never claim everything was deleted when items remain, and \
+never reduce the promised samples or scientific objective without the user's explicit agreement.\n"
+            .into()
     }
 
     fn shell_name() -> &'static str {
@@ -218,6 +227,15 @@ mod tests {
             "- Shell: POSIX sh"
         };
         assert!(out.contains(expected), "shell environment mismatch:\n{out}");
+    }
+
+    #[test]
+    fn safety_requires_dependency_inventory_before_scientific_cleanup() {
+        let skills = SkillIndex::default();
+        let out = SystemPrompt::new(std::path::Path::new("/tmp"), &skills, None).assemble();
+        assert!(out.contains("even when the user supplied the deletion command"));
+        assert!(out.contains("active or incomplete work still depends on them"));
+        assert!(out.contains("never reduce the promised samples or scientific objective"));
     }
 
     #[test]

--- a/docs/server-transfers.md
+++ b/docs/server-transfers.md
@@ -1,7 +1,8 @@
-# Transfers from SSH contexts
+# Transfers between local and SSH contexts
 
 Wisp transfers one exact file or directory from a registered, probed SSH
-execution context either to another SSH context or to the local machine.
+execution context either to another SSH context or to the local machine, and
+uploads one exact local file or directory to a selected SSH context.
 Agent-generated free-form `ssh`, `scp`, and `rsync -e ssh` commands remain
 disabled.
 
@@ -33,6 +34,18 @@ download, it renames the staged item to the requested path. Existing
 destinations are rejected and partial downloads are removed after failure,
 cancellation, or timeout.
 
+## Upload from the local machine
+
+Set `source_context_id` to `local`, provide an exact existing absolute local
+path, and select an SSH destination. Local uploads accept `route=auto|relay`
+and `transport=auto|scp`. Globs, roots, missing paths, symbolic links, and
+special files are rejected.
+
+Before uploading, Wisp checks through the configured SSH connection that the
+exact remote destination does not exist. It then uploads with scp as a
+persisted `file_transfer` Run, preserving cancellation, timeout, progress, and
+audit records. Existing remote destinations are never silently overwritten.
+
 ## User-approved trust
 
 `configure_ssh_trust` always requires approval.
@@ -56,6 +69,7 @@ themselves; it does not generate or copy a key.
 
 - Direct rsync is resumable at rsync's file-transfer level; scp relay is not.
 - SSH-to-local downloads use scp and are not resumable yet.
+- Local-to-SSH uploads use scp and are not resumable yet.
 - Relay temporarily needs local free space approximately equal to the source.
 - scp recursive copies follow symlinks according to the installed OpenSSH
   implementation.

--- a/skills/remote-compute-ssh/SKILL.md
+++ b/skills/remote-compute-ssh/SKILL.md
@@ -95,11 +95,16 @@ For a small result that must become local, wait until the Run is terminal,
 then transfer it as a separate quick operation and register the local file.
 Large outputs should remain remote references.
 
-## Transfers from SSH contexts
+## Transfers between local and SSH contexts
 
 Use `transfer_between_contexts` for one exact remote file or directory. The
 destination may be another selected SSH context or `local`. Never compose
 nested `ssh`, `scp`, or `rsync -e ssh` inside `run_in_context`.
+
+For a local upload, set `source_context_id` to `local`, provide the exact
+existing absolute local file or directory, and select an SSH destination.
+Wisp rejects globs, symlinks, special files, and existing remote destinations.
+Call `monitor_run` once with the returned Run id.
 
 For a local download, set `destination_context_id` to `local` and provide the
 exact new absolute local path. Ask the user when that path is unspecified.

--- a/src-tauri/src/quick_actions.rs
+++ b/src-tauri/src/quick_actions.rs
@@ -144,7 +144,10 @@ fn literature_base_proposal() -> dynamic_workflow::DynamicAgentWorkflowProposal 
     let search_rules = "Use the enabled scholarly-search Skills or literature connectors. \
         Search for real publications, verify titles and identifiers against tool results, and \
         never invent a paper. Do not write to the project. Prefer primary research and systematic \
-        reviews; state when evidence is indirect or unavailable.";
+        reviews; state when evidence is indirect or unavailable. Keep at most 8 of the most \
+        relevant papers. Search narrowly, discard verbose tool excerpts after extracting the \
+        citation and finding, and return the required JSON as soon as the evidence is sufficient; \
+        do not spend the remaining budget on exhaustive searching.";
     dynamic_workflow::DynamicAgentWorkflowProposal {
         goal: "Review the literature evidence for a selected passage".into(),
         context: String::new(),
@@ -163,7 +166,11 @@ fn literature_base_proposal() -> dynamic_workflow::DynamicAgentWorkflowProposal 
                 isolated: false,
                 model_id: None,
                 executor: None,
-                budget: None,
+                budget: Some(dynamic_workflow::AgentBudgetProposal {
+                    max_tokens: Some(32_000),
+                    max_tool_calls: Some(8),
+                    max_cost_microunits: None,
+                }),
             },
             dynamic_workflow::DynamicAgentTaskProposal {
                 id: "challenging_evidence".into(),
@@ -179,7 +186,11 @@ fn literature_base_proposal() -> dynamic_workflow::DynamicAgentWorkflowProposal 
                 isolated: false,
                 model_id: None,
                 executor: None,
-                budget: None,
+                budget: Some(dynamic_workflow::AgentBudgetProposal {
+                    max_tokens: Some(32_000),
+                    max_tool_calls: Some(8),
+                    max_cost_microunits: None,
+                }),
             },
             dynamic_workflow::DynamicAgentTaskProposal {
                 id: "synthesize".into(),
@@ -196,7 +207,11 @@ fn literature_base_proposal() -> dynamic_workflow::DynamicAgentWorkflowProposal 
                 isolated: false,
                 model_id: None,
                 executor: None,
-                budget: None,
+                budget: Some(dynamic_workflow::AgentBudgetProposal {
+                    max_tokens: Some(16_000),
+                    max_tool_calls: Some(2),
+                    max_cost_microunits: None,
+                }),
             },
         ],
     }
@@ -829,6 +844,16 @@ mod tests {
             ["literature_search".to_string()]
         );
         assert_eq!(proposal.tasks[2].capabilities, ["reasoning".to_string()]);
+        for task in &proposal.tasks[..2] {
+            let budget = task.budget.as_ref().expect("search budget");
+            assert_eq!(budget.max_tokens, Some(32_000));
+            assert_eq!(budget.max_tool_calls, Some(8));
+            assert!(task.instruction.contains("at most 8"));
+            assert!(task.instruction.contains("return the required JSON"));
+        }
+        let synthesis_budget = proposal.tasks[2].budget.as_ref().expect("synthesis budget");
+        assert_eq!(synthesis_budget.max_tokens, Some(16_000));
+        assert_eq!(synthesis_budget.max_tool_calls, Some(2));
         assert!(proposal.context.contains("notes/claim.md"));
         assert!(proposal.context.contains("A testable biological claim."));
     }

--- a/src-tauri/src/run_context/transfer.rs
+++ b/src-tauri/src/run_context/transfer.rs
@@ -173,16 +173,16 @@ impl Tool for TransferBetweenContextsTool {
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(
             self.name(),
-            "Transfer one exact file or directory from a selected SSH context to another selected SSH context or to `local` as a persisted Run. SSH-to-SSH `auto` uses a verified direct edge when available (rsync with scp fallback), otherwise it relays through a private local temporary directory. SSH-to-local downloads with the source context's configured credentials to an exact new absolute local path and never overwrites an existing item. Never use shell ssh/scp/rsync for this.",
+            "Transfer one exact file or directory between `local` and a selected SSH context, or between two selected SSH contexts, as a persisted Run. SSH-to-SSH `auto` uses a verified direct edge when available (rsync with scp fallback), otherwise it relays through a private local temporary directory. Local transfers use the SSH context's configured credentials and never overwrite an existing destination. Never use shell ssh/scp/rsync for this.",
             serde_json::json!({
                 "type": "object",
                 "properties": {
-                    "source_context_id": { "type": "string", "description": "Selected SSH context id" },
-                    "source_path": { "type": "string", "description": "Exact absolute or ~/ source path; globs are rejected" },
+                    "source_context_id": { "type": "string", "description": "Selected SSH context id, or `local` for an upload" },
+                    "source_path": { "type": "string", "description": "SSH: exact absolute or ~/ path. Local: exact absolute file/directory path. Globs are rejected." },
                     "destination_context_id": { "type": "string", "description": "Selected SSH context id, or `local` for a download" },
                     "destination_path": { "type": "string", "description": "SSH: exact absolute or ~/ path. Local: exact new absolute file/directory path; do not guess it—ask the user when unspecified. Globs are rejected." },
-                    "route": { "type": "string", "enum": ["auto", "direct", "relay"], "default": "auto", "description": "direct/relay apply to SSH-to-SSH; local accepts auto or relay" },
-                    "transport": { "type": "string", "enum": ["auto", "rsync", "scp"], "default": "auto", "description": "SSH-to-local accepts auto or scp" },
+                    "route": { "type": "string", "enum": ["auto", "direct", "relay"], "default": "auto", "description": "direct/relay apply to SSH-to-SSH; transfers involving local accept auto or relay" },
+                    "transport": { "type": "string", "enum": ["auto", "rsync", "scp"], "default": "auto", "description": "Transfers involving local currently accept auto or scp" },
                     "timeout_secs": { "type": "integer", "description": "Wall timeout, 1 second to 7 days" }
                 },
                 "required": ["source_context_id", "source_path", "destination_context_id", "destination_path"]
@@ -704,6 +704,30 @@ fn validate_local_destination(path: &str) -> Result<PathBuf, String> {
     Ok(destination)
 }
 
+fn validate_local_source(path: &str) -> Result<PathBuf, String> {
+    if path.is_empty()
+        || path.contains(['\0', '\n', '\r'])
+        || path.contains(['*', '?', '[', ']', '{', '}'])
+    {
+        return Err(
+            "source_path must be one exact local path without control characters or globs".into(),
+        );
+    }
+    let source = PathBuf::from(path);
+    if !source.is_absolute() || source.file_name().is_none() {
+        return Err("local source_path must be an absolute non-root path".into());
+    }
+    let metadata = std::fs::symlink_metadata(&source)
+        .map_err(|error| format!("local source_path is unavailable: {error}"))?;
+    if metadata.file_type().is_symlink() {
+        return Err("local source_path may not be a symbolic link".into());
+    }
+    if !metadata.is_file() && !metadata.is_dir() {
+        return Err("local source_path must be a regular file or directory".into());
+    }
+    Ok(source)
+}
+
 fn remote_item_name(path: &str) -> Result<&str, String> {
     let name = path
         .trim_end_matches('/')
@@ -722,18 +746,54 @@ async fn submit_transfer(
     project_root: &Path,
     request: TransferRequest,
 ) -> Result<serde_json::Value, String> {
-    validate_remote_path("source_path", &request.source_path)?;
     if !matches!(request.route.as_str(), "auto" | "direct" | "relay") {
         return Err("route must be 'auto', 'direct', or 'relay'".into());
     }
     if !matches!(request.transport.as_str(), "auto" | "rsync" | "scp") {
         return Err("transport must be 'auto', 'rsync', or 'scp'".into());
     }
-    let source = selected_ssh_context(store, frame_id, &request.source_context_id).await?;
     let timeout_secs = request
         .timeout_secs
         .unwrap_or(4 * 60 * 60)
         .clamp(1, 7 * 24 * 60 * 60);
+
+    if request.source_context_id == "local" {
+        if request.destination_context_id == "local" {
+            return Err("Source and destination contexts cannot both be local".into());
+        }
+        if request.route == "direct" {
+            return Err("Local-to-SSH transfers use route=auto or route=relay".into());
+        }
+        if request.transport == "rsync" {
+            return Err("Local-to-SSH transfers use transport=auto or transport=scp".into());
+        }
+        let source_path = validate_local_source(&request.source_path)?;
+        validate_remote_path("destination_path", &request.destination_path)?;
+        let destination =
+            selected_ssh_context(store, frame_id, &request.destination_context_id).await?;
+        let response = manager
+            .submit_local_upload_to_ssh(
+                store.clone(),
+                project_id,
+                frame_id,
+                &source_path,
+                &destination,
+                &request.destination_path,
+                Duration::from_secs(timeout_secs),
+            )
+            .await?;
+        return Ok(serde_json::json!({
+            "run_id": response.run_id,
+            "status": response.status,
+            "route": "local",
+            "transport": "scp",
+            "source_path": source_path,
+            "next_action": "Call monitor_run exactly once to wait for completion."
+        }));
+    }
+
+    validate_remote_path("source_path", &request.source_path)?;
+    let source = selected_ssh_context(store, frame_id, &request.source_context_id).await?;
 
     if request.destination_context_id == "local" {
         if request.route == "direct" {
@@ -941,6 +1001,122 @@ fi
 }
 
 impl RunManager {
+    #[allow(clippy::too_many_arguments)]
+    async fn submit_local_upload_to_ssh(
+        &self,
+        store: wisp_store::Store,
+        project_id: &str,
+        frame_id: Option<&str>,
+        source_path: &Path,
+        destination: &wisp_store::ExecutionContext,
+        destination_path: &str,
+        timeout: Duration,
+    ) -> Result<SubmitRunResponse, String> {
+        let destination_connection =
+            crate::ssh_hosts::SshConnection::from_execution_context(destination)?;
+        let item_name = source_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .ok_or_else(|| "local source_path has no portable item name".to_string())?
+            .to_string();
+        let run_id = uuid::Uuid::new_v4().to_string();
+        let started = Instant::now();
+        let mut run = wisp_store::RunRecord::new(
+            &run_id,
+            project_id,
+            &destination.id,
+            format!("Upload {item_name} to {}", destination.label),
+            "file_transfer",
+        );
+        run.frame_id = frame_id.map(Into::into);
+        run.command = Some(format!(
+            "upload local:{} -> {}:{}",
+            source_path.display(),
+            destination.id,
+            destination_path
+        ));
+        run.timeout_secs = Some(timeout.as_secs() as i64);
+        run.progress_json = serde_json::to_string(&transfer_progress(
+            "upload",
+            "uploading",
+            0,
+            0,
+            0,
+            0,
+            Some(item_name),
+            started,
+        ))
+        .map_err(|error| error.to_string())?;
+        run.env_snapshot_json = serde_json::json!({
+            "route": "local",
+            "transport": "scp",
+            "source_context_id": "local",
+            "destination_context_id": destination.id,
+            "source_path": source_path,
+            "destination_path": destination_path
+        })
+        .to_string();
+        store
+            .create_run(&run)
+            .await
+            .map_err(|error| error.to_string())?;
+        if !store
+            .activate_run_lifecycle(
+                &run_id,
+                wisp_store::RunStatus::Submitted,
+                &self.owner_id,
+                ACTIVE_LEASE_SECS,
+            )
+            .await
+            .map_err(|error| error.to_string())?
+        {
+            return Err("Upload Run changed state before it could start".into());
+        }
+
+        let runner = self.runner.clone();
+        let owner_id = self.owner_id.clone();
+        let active = self.active.clone();
+        let cleanup_id = run_id.clone();
+        let task_run_id = run_id.clone();
+        let source_path = source_path.to_path_buf();
+        let destination_path = destination_path.to_string();
+        let task_store = store.clone();
+        let task = tokio::spawn(async move {
+            let result = local_upload_lifecycle(
+                &task_store,
+                &owner_id,
+                &task_run_id,
+                runner,
+                source_path,
+                destination_connection,
+                destination_path,
+                timeout,
+                started,
+            )
+            .await;
+            if let Err(error) = result {
+                tracing::warn!(run_id = %task_run_id, "local upload lifecycle failed: {error}");
+            }
+        });
+        let abort = task.abort_handle();
+        self.active
+            .lock()
+            .await
+            .insert(run_id.clone(), ActiveRun { abort });
+        tokio::spawn(async move {
+            let _ = task.await;
+            active.lock().await.remove(&cleanup_id);
+        });
+        Ok(SubmitRunResponse {
+            run_id,
+            status: wisp_store::RunStatus::Submitted,
+            exit_code: None,
+            stdout_tail: None,
+            stderr_tail: None,
+            remote_workdir: None,
+        })
+    }
+
     #[allow(clippy::too_many_arguments)]
     async fn submit_ssh_download_to_local(
         &self,
@@ -1248,6 +1424,135 @@ async fn download_remote_item(
     let local_item = single_relay_item(staging_dir)?;
     let (total_bytes, files_total) = relay_item_stats(&local_item)?;
     Ok((download, local_item, total_bytes, files_total))
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn local_upload_lifecycle(
+    store: &wisp_store::Store,
+    owner_id: &str,
+    run_id: &str,
+    runner: Arc<dyn super::RunCommandRunner>,
+    source_path: PathBuf,
+    destination: crate::ssh_hosts::SshConnection,
+    destination_path: String,
+    timeout: Duration,
+    started: Instant,
+) -> Result<(), String> {
+    if !store
+        .transition_run_to_running_owned(run_id, owner_id)
+        .await
+        .map_err(|error| error.to_string())?
+    {
+        return Ok(());
+    }
+    let result = async {
+        let (total_bytes, files_total) = relay_item_stats(&source_path)?;
+        let destination_check = format!(
+            "set -eu\n{}\n[ ! -e \"$dst\" ] || {{ echo 'remote destination_path already exists' >&2; exit 73; }}\n",
+            remote_path_assignment("dst", &destination_path)
+        );
+        checked_output(
+            "Check upload destination",
+            run_with_lifecycle_lease(
+                store,
+                run_id,
+                owner_id,
+                runner.as_ref(),
+                ssh_script_command(
+                    &destination,
+                    "check local upload destination",
+                    destination_check,
+                )?,
+                timeout,
+            )
+            .await,
+        )?;
+        let remaining = timeout
+            .checked_sub(started.elapsed())
+            .ok_or_else(|| format!("run_in_context timed out after {}s", timeout.as_secs()))?;
+        let mut upload_args = destination.scp_option_args()?;
+        if source_path.is_dir() {
+            upload_args.push("-r".into());
+        }
+        upload_args.push(scp_local_path(&source_path));
+        upload_args.push(format!("{}:{destination_path}", destination.target()?));
+        let upload = checked_output(
+            "SSH upload",
+            run_with_lifecycle_lease(
+                store,
+                run_id,
+                owner_id,
+                runner.as_ref(),
+                RunCommand {
+                    context_id: format!("ssh:{}", destination.alias),
+                    program: "scp".into(),
+                    args: upload_args,
+                    script: "local upload".into(),
+                    cwd: source_path.parent().map(Path::to_path_buf),
+                    stdin: None,
+                    envs: crate::ssh_hosts::auth_envs_for_connection(&destination)?,
+                },
+                remaining,
+            )
+            .await,
+        )?;
+        Ok::<_, String>((upload, total_bytes, files_total))
+    }
+    .await;
+
+    let (status, exit_code, stdout, stderr, progress) = match result {
+        Ok((upload, total_bytes, files_total)) => (
+            wisp_store::RunStatus::Succeeded,
+            Some(0),
+            upload.stdout,
+            upload.stderr,
+            transfer_progress(
+                "upload",
+                "uploaded",
+                total_bytes,
+                total_bytes,
+                files_total,
+                files_total,
+                source_path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .map(Into::into),
+                started,
+            ),
+        ),
+        Err(error) if error == "run_in_context cancelled" => (
+            wisp_store::RunStatus::Cancelled,
+            None,
+            String::new(),
+            error,
+            transfer_progress("upload", "cancelled", 0, 0, 0, 0, None, started),
+        ),
+        Err(error) if error.starts_with("run_in_context timed out after ") => (
+            wisp_store::RunStatus::TimedOut,
+            Some(124),
+            String::new(),
+            error,
+            transfer_progress("upload", "failed", 0, 0, 0, 0, None, started),
+        ),
+        Err(error) => (
+            wisp_store::RunStatus::Failed,
+            Some(-1),
+            String::new(),
+            error,
+            transfer_progress("upload", "failed", 0, 0, 0, 0, None, started),
+        ),
+    };
+    let _ = store
+        .update_run_progress_owned(run_id, owner_id, &progress)
+        .await;
+    let _ = store
+        .update_run_output_owned(run_id, owner_id, Some(&tail(&stdout)), Some(&tail(&stderr)))
+        .await;
+    let _ = store
+        .finish_active_run_owned(run_id, owner_id, status, exit_code)
+        .await
+        .map_err(|error| error.to_string())?;
+    Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1601,6 +1906,12 @@ mod tests {
         let existing = root.join("existing.bam");
         std::fs::write(&existing, b"keep").unwrap();
         assert!(validate_local_destination(&existing.to_string_lossy()).is_err());
+        assert_eq!(
+            validate_local_source(&existing.to_string_lossy()).unwrap(),
+            existing
+        );
+        assert!(validate_local_source("relative.bam").is_err());
+        assert!(validate_local_source(&root.join("missing.bam").to_string_lossy()).is_err());
         let _ = std::fs::remove_dir_all(root);
     }
 
@@ -1919,6 +2230,64 @@ mod tests {
             .args
             .iter()
             .any(|arg| arg == "bob@b.example:/results/"));
+        drop(commands);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn local_source_uploads_to_selected_ssh_without_shell_transfer() {
+        let (root, store) = test_store().await;
+        let source = root.join("sample data.bam");
+        std::fs::write(&source, b"bam bytes").unwrap();
+        let runner = Arc::new(RelayRunner {
+            commands: StdMutex::new(Vec::new()),
+        });
+        let manager = RunManager::with_runner(runner.clone());
+        let response = submit_transfer(
+            &store,
+            &manager,
+            "p",
+            Some("f"),
+            &root,
+            TransferRequest {
+                source_context_id: "local".into(),
+                source_path: source.to_string_lossy().into_owned(),
+                destination_context_id: "ssh:a".into(),
+                destination_path: "/results/sample data.bam".into(),
+                route: "auto".into(),
+                transport: "auto".into(),
+                timeout_secs: Some(30),
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(response["route"], "local");
+        let run_id = response["run_id"].as_str().unwrap();
+        let run = loop {
+            let run = store.get_run(run_id).await.unwrap().unwrap();
+            if run.status.is_terminal() {
+                break run;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        };
+        assert_eq!(run.status, wisp_store::RunStatus::Succeeded);
+        assert_eq!(run.kind, "file_transfer");
+        let progress: wisp_store::RunProgress = serde_json::from_str(&run.progress_json).unwrap();
+        assert_eq!(progress.phase, "uploaded");
+        assert_eq!(progress.completed_bytes, 9);
+        let commands = runner.commands.lock().unwrap();
+        assert_eq!(commands.len(), 2);
+        assert_eq!(commands[0].script, "check local upload destination");
+        assert_eq!(commands[1].program, "scp");
+        assert_eq!(commands[1].script, "local upload");
+        assert!(commands[1]
+            .args
+            .iter()
+            .any(|arg| arg == "alice@a.example:/results/sample data.bam"));
+        assert!(commands[1]
+            .args
+            .iter()
+            .any(|arg| arg.contains("sample data.bam")));
         drop(commands);
         let _ = std::fs::remove_dir_all(root);
     }


### PR DESCRIPTION
## Problem

Three reported workflows could fail unsafely or force unnecessary recovery work:

- Literature evidence Agents inherited budgets that were too small for ordinary connector-backed searches, then discarded all evidence when they crossed the hard limit.
- Destructive cleanup required confirmation but did not tell the Agent to inventory unfinished scientific dependencies before executing a user-supplied delete command.
- `transfer_between_contexts` supported SSH→local and SSH→SSH, but not local→SSH recovery uploads.

Fixes #602
Fixes #605
Fixes #606

## Changes

- Give the built-in literature searches explicit 32k-token / 8-tool-call budgets, cap retained papers at eight, and require early structured convergence.
- Give literature synthesis its own bounded 16k-token / 2-tool-call budget.
- Strengthen the system safety contract around scientific cleanup:
  - inventory exact targets first;
  - check active/incomplete work and recovery copies;
  - report retained files precisely;
  - never silently reduce samples or the scientific objective.
- Add a persisted local→SSH `file_transfer` path:
  - exact absolute local files or directories;
  - reject globs, roots, missing items, symlinks, and special files;
  - require a selected, probe-ready SSH destination;
  - preflight that the remote target does not already exist;
  - upload with parameterized scp using the configured SSH connection;
  - retain existing Run lease, cancellation, timeout, progress, and audit behavior.
- Update server-transfer documentation and the bundled remote-compute SSH skill.

## Tests

- `cargo test -p wisp-tauri quick_actions --lib` — 6 passed.
- `cargo test -p wisp-core system_prompt::tests::safety_requires_dependency_inventory_before_scientific_cleanup --lib -- --exact` — passed.
- `cargo test -p wisp-tauri run_context::transfer::tests --lib` — 10 passed.
- `cargo fmt --all -- --check` — passed.
- `git diff --check` — passed.
- `cargo test --workspace` — all tests related to this change passed; the existing `run_context::tests::ssh_launch_failure_stops_after_the_first_attempt` fails with `artifact path is outside project root`, including when rerun alone.

## Manual smoke

1. Run **Research literature** on a narrow claim and confirm both search branches finish with bounded structured evidence before synthesis.
2. Ask to remove scientific inputs that are still needed by incomplete work and confirm the Agent inventories dependencies before proposing deletion.
3. Select an SSH context and call `transfer_between_contexts` with `source_context_id=local` for:
   - one local file;
   - one local directory;
   - an existing remote destination, which must fail without overwrite.
4. Confirm the upload appears as a `file_transfer` Run and can be cancelled.

## Known limitations / follow-ups

- Delegation does not yet persist partial structured evidence after a hard budget violation.
- Destructive dependency protection is currently a model safety contract; a future structured guard should intersect deletion targets with explicit Run input lineage.
- Local uploads currently use scp and do not yet provide rsync resume or checksum verification.
- WSL transfer directions are not included in this change.
