### PR TITLE
Fix agent pause boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,12 @@ Permission** switch. Enabling it requires an explicit warning confirmation and
 then automatically approves ordinary tools, dangerous commands, and ACP
 permission requests for that conversation until it is turned off or the app is
 restarted. It does not remove project-path restrictions or override tools that
-the user explicitly blocked.
+the user explicitly blocked. Without Full Permission, a pending approval keeps
+the agent turn suspended until the user explicitly approves, rejects, or stops
+it; it never times out into an implicit rejection. Rejecting an action also
+skips any later tool calls the model placed in the same batch. `ask_user` and
+plan submission are hard turn boundaries: later batched calls do not run while
+the agent is waiting for the user's next message.
 **Conversations persist to that SQLite database** — each turn's
 messages are appended to the active session frame, so restarting the app
 restores the full history. The headless CLI keeps using `.wisp/session.json` for

--- a/crates/wisp-core/src/agent.rs
+++ b/crates/wisp-core/src/agent.rs
@@ -14,7 +14,7 @@ use std::time::Duration;
 use wisp_llm::{
     is_retriable, Completion, Content, LlmError, Message, Part, Provider, ToolCall, ToolSchema,
 };
-use wisp_tools::{ask_user::ASK_USER, ImageData, Registry, ToolEnv};
+use wisp_tools::{ImageData, Registry, ToolControl, ToolEnv};
 
 const RETRY_DELAYS: [u64; 5] = [2_000, 10_000, 30_000, 60_000, 120_000];
 const TRUNCATED_OUTPUT_MESSAGE: &str = "模型输出在达到 max_tokens 上限时被截断，任务可能尚未完成——请在设置中调高该模型的 max_tokens，或直接继续对话让我接着做。(output truncated at max_tokens)";
@@ -301,9 +301,8 @@ async fn agent_loop_inner(
             anyhow::bail!(STUCK_LOOP_MESSAGE);
         }
 
-        let mut completed = false;
-        let mut waiting_for_user = false;
-        for tc in &comp.tool_calls {
+        let mut batch_control = ToolControl::Continue;
+        for (index, tc) in comp.tool_calls.iter().enumerate() {
             let name = tc.function.name.clone();
             let args = tc.args_value();
             let producing = provenance::is_producing(&name);
@@ -329,6 +328,7 @@ async fn agent_loop_inner(
             };
             let t0 = std::time::Instant::now();
             let result = tools.run(&name, &args, &env).await;
+            let control = result.control;
             let duration_ms = t0.elapsed().as_millis() as u64;
             if let Some(root) = &root {
                 let root2 = root.clone();
@@ -386,19 +386,25 @@ async fn agent_loop_inner(
             if let Some(m) = ctx.messages.last() {
                 output.on_message(m);
             }
-            // `ask_user` is a turn boundary, not merely advice to the model.
-            // Finish the current tool-call batch so every call has a matching
-            // result, then stop before another model request. The user's
-            // answer starts the next turn as a normal user message.
-            if name == ASK_USER && ok {
-                waiting_for_user = true;
-            }
-            if name == "attempt_completion" {
-                completed = true;
+
+            if control != ToolControl::Continue {
+                // A user decision invalidates calls the model optimistically
+                // placed later in the same batch. Do not execute them, but do
+                // persist a synthetic result for each one: providers require
+                // every assistant tool call to have a matching tool message.
+                append_skipped_tool_results(
+                    ctx,
+                    tools,
+                    output,
+                    &comp.tool_calls[index + 1..],
+                    &name,
+                    control,
+                );
+                batch_control = control;
                 break;
             }
         }
-        if completed || waiting_for_user {
+        if batch_control == ToolControl::StopTurn {
             break;
         }
         if iteration_limit_reached(iteration, max_iter) {
@@ -409,6 +415,36 @@ async fn agent_loop_inner(
         }
     }
     Ok(())
+}
+
+fn append_skipped_tool_results(
+    ctx: &mut ContextManager,
+    tools: &Registry,
+    output: &dyn Output,
+    skipped: &[ToolCall],
+    boundary_name: &str,
+    control: ToolControl,
+) {
+    let reason = match control {
+        ToolControl::StopBatch => format!(
+            "Skipped because the user's decision on '{boundary_name}' invalidated later calls from the same model batch."
+        ),
+        ToolControl::StopTurn => format!(
+            "Skipped because '{boundary_name}' ended the turn before this call. Wait for the user's next message."
+        ),
+        ToolControl::Continue => return,
+    };
+    for tc in skipped {
+        let name = &tc.function.name;
+        let args = tc.args_value();
+        let event_name = tools.event_name(name, &args);
+        output.tool_call(&event_name, &reason);
+        output.tool_result(&event_name, false, &reason, 0);
+        ctx.append_tool(&tc.id, name, Content::text(reason.clone()));
+        if let Some(message) = ctx.messages.last() {
+            output.on_message(message);
+        }
+    }
 }
 
 fn iteration_limit_reached(iteration: usize, max_iter: usize) -> bool {
@@ -510,9 +546,10 @@ mod tests {
     use crate::output::NullOutput;
     use async_trait::async_trait;
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-    use std::sync::Mutex;
+    use std::sync::{Arc, Mutex};
     use wisp_llm::{FunctionCall, ToolCall};
-    use wisp_tools::{Registry, Tool, ToolEnv, ToolResult};
+    use wisp_tools::ask_user::ASK_USER;
+    use wisp_tools::{Approval, Registry, Tool, ToolEnv, ToolResult};
 
     #[test]
     fn retry_window_covers_sustained_provider_overload() {
@@ -619,22 +656,65 @@ mod tests {
         }
     }
 
+    struct CountingTool {
+        name: &'static str,
+        runs: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl Tool for CountingTool {
+        fn name(&self) -> &str {
+            self.name
+        }
+
+        fn schema(&self) -> ToolSchema {
+            ToolSchema::new(
+                self.name,
+                "count executions",
+                serde_json::json!({"type": "object"}),
+            )
+        }
+
+        async fn run(&self, _args: &serde_json::Value, _env: &dyn ToolEnv) -> ToolResult {
+            self.runs.fetch_add(1, Ordering::SeqCst);
+            ToolResult::ok("ran")
+        }
+    }
+
+    fn call(id: &str, name: &str, arguments: serde_json::Value) -> ToolCall {
+        ToolCall {
+            id: id.into(),
+            kind: "function".into(),
+            function: FunctionCall {
+                name: name.into(),
+                arguments: arguments.to_string(),
+            },
+        }
+    }
+
+    fn tool_result_ids(ctx: &ContextManager) -> Vec<&str> {
+        ctx.messages
+            .iter()
+            .filter_map(|message| message.tool_call_id.as_deref())
+            .collect()
+    }
+
     #[tokio::test]
-    async fn successful_ask_user_ends_turn_before_another_model_call() {
+    async fn successful_ask_user_skips_later_calls_and_ends_the_turn() {
+        let later_runs = Arc::new(AtomicUsize::new(0));
         let provider = SequenceProvider::new([
             Completion {
-                tool_calls: vec![ToolCall {
-                    id: "ask-1".into(),
-                    kind: "function".into(),
-                    function: FunctionCall {
-                        name: ASK_USER.into(),
-                        arguments: serde_json::json!({
+                tool_calls: vec![
+                    call(
+                        "ask-1",
+                        ASK_USER,
+                        serde_json::json!({
                             "question": "Which reference genome?",
                             "options": [{ "label": "GRCh38" }]
-                        })
-                        .to_string(),
-                    },
-                }],
+                        }),
+                    ),
+                    call("later-1", "later", serde_json::json!({})),
+                ],
                 finish_reason: Some("tool_calls".into()),
                 ..Completion::default()
             },
@@ -646,6 +726,10 @@ mod tests {
         ]);
         let mut tools = Registry::builtins();
         tools.add(Box::new(wisp_tools::ask_user::AskUserTool));
+        tools.add(Box::new(CountingTool {
+            name: "later",
+            runs: later_runs.clone(),
+        }));
         let mut ctx = ContextManager::new(100_000);
 
         agent_loop(
@@ -667,8 +751,177 @@ mod tests {
             1,
             "the loop must wait for the user's next message after ask_user"
         );
-        assert_eq!(ctx.messages.len(), 3, "user, assistant call, tool result");
+        assert_eq!(
+            later_runs.load(Ordering::SeqCst),
+            0,
+            "a sibling call after ask_user must not execute"
+        );
+        assert_eq!(ctx.messages.len(), 4);
         assert_eq!(ctx.messages[2].tool_name.as_deref(), Some(ASK_USER));
+        assert_eq!(tool_result_ids(&ctx), vec!["ask-1", "later-1"]);
+        assert!(ctx.messages[3].content.as_text().contains("ended the turn"));
+    }
+
+    #[tokio::test]
+    async fn successful_propose_plan_skips_later_calls_and_ends_the_turn() {
+        let later_runs = Arc::new(AtomicUsize::new(0));
+        let provider = SequenceProvider::new([
+            Completion {
+                tool_calls: vec![
+                    call(
+                        "plan-1",
+                        wisp_tools::plan::PROPOSE_PLAN,
+                        serde_json::json!({
+                            "entries": [{ "content": "Implement the fix" }]
+                        }),
+                    ),
+                    call("later-1", "later", serde_json::json!({})),
+                ],
+                finish_reason: Some("tool_calls".into()),
+                ..Completion::default()
+            },
+            Completion {
+                content: "continued without plan approval".into(),
+                finish_reason: Some("stop".into()),
+                ..Completion::default()
+            },
+        ]);
+        let mut tools = Registry::builtins();
+        tools.add(Box::new(wisp_tools::plan::ProposePlanTool));
+        tools.add(Box::new(CountingTool {
+            name: "later",
+            runs: later_runs.clone(),
+        }));
+        let mut ctx = ContextManager::new(100_000);
+
+        agent_loop(
+            &mut ctx,
+            &provider,
+            None,
+            &tools,
+            Path::new("."),
+            &NullOutput,
+            "plan the change",
+            0,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(provider.stream_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(later_runs.load(Ordering::SeqCst), 0);
+        assert_eq!(tool_result_ids(&ctx), vec!["plan-1", "later-1"]);
+    }
+
+    struct DenyApprovalOutput;
+
+    impl Output for DenyApprovalOutput {
+        fn confirm(&self, _message: &str) -> bool {
+            false
+        }
+
+        fn approval_mode(&self, tool: &str) -> Approval {
+            if tool == "approval_tool" {
+                Approval::Ask
+            } else {
+                Approval::Allow
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn denied_approval_skips_stale_siblings_before_the_model_reacts() {
+        let approved_tool_runs = Arc::new(AtomicUsize::new(0));
+        let later_runs = Arc::new(AtomicUsize::new(0));
+        let provider = SequenceProvider::new([
+            Completion {
+                tool_calls: vec![
+                    call("approval-1", "approval_tool", serde_json::json!({})),
+                    call("later-1", "later", serde_json::json!({})),
+                ],
+                finish_reason: Some("tool_calls".into()),
+                ..Completion::default()
+            },
+            Completion {
+                content: "I will respect the denial.".into(),
+                finish_reason: Some("stop".into()),
+                ..Completion::default()
+            },
+        ]);
+        let mut tools = Registry::builtins();
+        tools.add(Box::new(CountingTool {
+            name: "approval_tool",
+            runs: approved_tool_runs.clone(),
+        }));
+        tools.add(Box::new(CountingTool {
+            name: "later",
+            runs: later_runs.clone(),
+        }));
+        let mut ctx = ContextManager::new(100_000);
+
+        agent_loop(
+            &mut ctx,
+            &provider,
+            None,
+            &tools,
+            Path::new("."),
+            &DenyApprovalOutput,
+            "perform approved work",
+            0,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(provider.stream_calls.load(Ordering::SeqCst), 2);
+        assert_eq!(approved_tool_runs.load(Ordering::SeqCst), 0);
+        assert_eq!(later_runs.load(Ordering::SeqCst), 0);
+        assert_eq!(tool_result_ids(&ctx), vec!["approval-1", "later-1"]);
+        assert!(ctx.messages[3]
+            .content
+            .as_text()
+            .contains("invalidated later calls"));
+    }
+
+    #[tokio::test]
+    async fn successful_completion_skips_later_sibling_calls() {
+        let later_runs = Arc::new(AtomicUsize::new(0));
+        let provider = SequenceProvider::new([Completion {
+            tool_calls: vec![
+                call(
+                    "complete-1",
+                    "attempt_completion",
+                    serde_json::json!({"result": "done"}),
+                ),
+                call("later-1", "later", serde_json::json!({})),
+            ],
+            finish_reason: Some("tool_calls".into()),
+            ..Completion::default()
+        }]);
+        let mut tools = Registry::builtins();
+        tools.add(Box::new(CountingTool {
+            name: "later",
+            runs: later_runs.clone(),
+        }));
+        let mut ctx = ContextManager::new(100_000);
+
+        agent_loop(
+            &mut ctx,
+            &provider,
+            None,
+            &tools,
+            Path::new("."),
+            &NullOutput,
+            "finish",
+            0,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(provider.stream_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(later_runs.load(Ordering::SeqCst), 0);
+        assert_eq!(tool_result_ids(&ctx), vec!["complete-1", "later-1"]);
     }
 
     struct RecordingProvider {

--- a/crates/wisp-core/src/lib.rs
+++ b/crates/wisp-core/src/lib.rs
@@ -37,7 +37,7 @@ pub use orchestration::{
     DelegationMode, DelegationPlan, DelegationPlanStep, DYNAMIC_DELEGATION_SCHEMA_VERSION,
     MAX_DELEGATION_TASKS,
 };
-pub use output::{NullOutput, Output, StreamSinkAdapter, ToolEnvAdapter};
+pub use output::{NullOutput, Output, OutputFuture, StreamSinkAdapter, ToolEnvAdapter};
 pub use provenance::ProvenanceRecord;
 pub use subagent::ExploreTool;
 pub use system_prompt::SystemPrompt;

--- a/crates/wisp-core/src/output.rs
+++ b/crates/wisp-core/src/output.rs
@@ -6,6 +6,13 @@
 //! (confirmation prompts) is guarded with interior mutability in impls.
 
 use serde_json::Value;
+use std::future::Future;
+use std::pin::Pin;
+
+/// Object-safe async hook used by interactive outputs. Most headless outputs
+/// keep the synchronous defaults below; desktop outputs return a future that
+/// yields while the UI sends its decision back.
+pub type OutputFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
 pub trait Output: Send + Sync {
     fn assistant_text(&self, _delta: &str) {}
@@ -42,6 +49,19 @@ pub trait Output: Send + Sync {
         } else {
             wisp_tools::ConfirmDecision::Denied { feedback: None }
         }
+    }
+    /// Async confirmation path used by [`ToolEnvAdapter`]. The default bridges
+    /// existing CLI/test outputs to their synchronous implementation; GUI
+    /// hosts should override it so waiting never blocks their command runtime.
+    fn confirm_async<'a>(&'a self, message: &'a str) -> OutputFuture<'a, bool> {
+        Box::pin(async move { self.confirm(message) })
+    }
+    /// Async variant carrying rejection feedback.
+    fn confirm_decision_async<'a>(
+        &'a self,
+        message: &'a str,
+    ) -> OutputFuture<'a, wisp_tools::ConfirmDecision> {
+        Box::pin(async move { self.confirm_decision(message) })
     }
     /// Approval mode for a tool about to run. Default `Allow` preserves the old
     /// auto-run behaviour; the Tauri host overrides it from its saved policy.
@@ -123,10 +143,10 @@ impl<'a> wisp_tools::ToolEnv for ToolEnvAdapter<'a> {
         self.out.restrict_read_paths_to_project()
     }
     async fn confirm(&self, message: &str) -> bool {
-        self.out.confirm(message)
+        self.out.confirm_async(message).await
     }
     async fn confirm_decision(&self, message: &str) -> wisp_tools::ConfirmDecision {
-        self.out.confirm_decision(message)
+        self.out.confirm_decision_async(message).await
     }
     async fn approval_mode(&self, tool: &str) -> wisp_tools::Approval {
         self.out.approval_mode(tool)
@@ -206,6 +226,7 @@ impl<'a> wisp_llm::StreamSink for StreamSinkAdapter<'a> {
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Mutex;
     use wisp_llm::StreamSink;
 
     // The streaming loops break on `sink.is_cancelled()`; this proves the Stop
@@ -224,5 +245,54 @@ mod tests {
         );
         // A sink built without a cancel flag never reports cancelled.
         assert!(!StreamSinkAdapter::new(&out).is_cancelled());
+    }
+
+    struct AsyncConfirmOutput {
+        receiver: Mutex<Option<tokio::sync::oneshot::Receiver<wisp_tools::ConfirmDecision>>>,
+        sync_called: AtomicBool,
+    }
+
+    impl Output for AsyncConfirmOutput {
+        fn confirm_decision(&self, _message: &str) -> wisp_tools::ConfirmDecision {
+            self.sync_called.store(true, Ordering::SeqCst);
+            wisp_tools::ConfirmDecision::Denied { feedback: None }
+        }
+
+        fn confirm_decision_async<'a>(
+            &'a self,
+            _message: &'a str,
+        ) -> OutputFuture<'a, wisp_tools::ConfirmDecision> {
+            let receiver = self.receiver.lock().unwrap().take().unwrap();
+            Box::pin(async move {
+                receiver
+                    .await
+                    .unwrap_or(wisp_tools::ConfirmDecision::Denied { feedback: None })
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn tool_env_yields_while_async_confirmation_is_pending() {
+        let (sender, receiver) = tokio::sync::oneshot::channel();
+        let output = AsyncConfirmOutput {
+            receiver: Mutex::new(Some(receiver)),
+            sync_called: AtomicBool::new(false),
+        };
+        let env = ToolEnvAdapter::new(std::path::PathBuf::from("."), &output);
+        let decision = wisp_tools::ToolEnv::confirm_decision(&env, "Run tool?");
+        tokio::pin!(decision);
+
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(20), &mut decision)
+                .await
+                .is_err(),
+            "a pending UI decision must keep the tool call suspended"
+        );
+        sender.send(wisp_tools::ConfirmDecision::Approved).unwrap();
+        assert_eq!(decision.await, wisp_tools::ConfirmDecision::Approved);
+        assert!(
+            !output.sync_called.load(Ordering::SeqCst),
+            "the adapter must not fall back to the runtime-blocking sync hook"
+        );
     }
 }

--- a/crates/wisp-runtime/src/tool.rs
+++ b/crates/wisp-runtime/src/tool.rs
@@ -114,6 +114,7 @@ async fn run_runtime(
                         success,
                         content: format_response(&response),
                         image: None,
+                        control: wisp_tools::ToolControl::Continue,
                     };
                 }
                 Some(RuntimeEvent::Finished(Err(error))) => {

--- a/crates/wisp-tools/src/ask_user.rs
+++ b/crates/wisp-tools/src/ask_user.rs
@@ -127,7 +127,7 @@ impl Tool for AskUserTool {
     }
     async fn run(&self, args: &Value, _env: &dyn ToolEnv) -> ToolResult {
         match question_body(args) {
-            Ok(body) => ToolResult::ok(body.to_string()),
+            Ok(body) => ToolResult::ok(body.to_string()).stop_turn(),
             Err(error) => ToolResult::fail(error),
         }
     }
@@ -136,8 +136,25 @@ impl Tool for AskUserTool {
 #[cfg(test)]
 mod tests {
     use super::{question_body, AskUserTool, ASK_USER};
+    use crate::env::{ToolControl, ToolEnv, ToolEvent};
     use crate::tool::Tool;
     use serde_json::json;
+    use std::path::Path;
+
+    struct NoEnv;
+
+    #[async_trait::async_trait]
+    impl ToolEnv for NoEnv {
+        fn project_root(&self) -> &Path {
+            Path::new(".")
+        }
+
+        async fn confirm(&self, _message: &str) -> bool {
+            false
+        }
+
+        async fn emit(&self, _event: ToolEvent) {}
+    }
 
     #[test]
     fn builds_the_persisted_card_shape() {
@@ -165,6 +182,15 @@ mod tests {
             "the result has to stop the agent, not invite it to keep going"
         );
         assert_eq!(AskUserTool.name(), ASK_USER);
+    }
+
+    #[tokio::test]
+    async fn successful_question_is_a_hard_turn_boundary() {
+        let result = AskUserTool
+            .run(&json!({ "question": "Continue?" }), &NoEnv)
+            .await;
+        assert!(result.success);
+        assert_eq!(result.control, ToolControl::StopTurn);
     }
 
     #[test]

--- a/crates/wisp-tools/src/attempt_completion.rs
+++ b/crates/wisp-tools/src/attempt_completion.rs
@@ -31,6 +31,6 @@ impl Tool for AttemptCompletionTool {
             Ok(r) => r,
             Err(e) => return ToolResult::fail(e),
         };
-        ToolResult::ok(result)
+        ToolResult::ok(result).stop_turn()
     }
 }

--- a/crates/wisp-tools/src/env.rs
+++ b/crates/wisp-tools/src/env.rs
@@ -155,6 +155,18 @@ pub struct ToolResult {
     pub success: bool,
     pub content: String,
     pub image: Option<ImageData>,
+    /// Code-level control flow for the agent loop. This keeps user-decision
+    /// boundaries out of prompt wording: stale sibling calls can be skipped,
+    /// and tools such as `ask_user` can end the turn outright.
+    pub control: ToolControl,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ToolControl {
+    #[default]
+    Continue,
+    StopBatch,
+    StopTurn,
 }
 
 #[derive(Debug, Clone)]
@@ -171,6 +183,7 @@ impl ToolResult {
             success: true,
             content: content.into(),
             image: None,
+            control: ToolControl::Continue,
         }
     }
     pub fn fail(content: impl Into<String>) -> Self {
@@ -178,6 +191,7 @@ impl ToolResult {
             success: false,
             content: content.into(),
             image: None,
+            control: ToolControl::Continue,
         }
     }
     pub fn image(img: ImageData) -> Self {
@@ -186,6 +200,19 @@ impl ToolResult {
             success: true,
             content: label,
             image: Some(img),
+            control: ToolControl::Continue,
         }
+    }
+    /// Skip tool calls that the model placed later in the same batch, then let
+    /// the model react to this result in a fresh iteration.
+    pub fn stop_batch(mut self) -> Self {
+        self.control = ToolControl::StopBatch;
+        self
+    }
+    /// Skip later calls in the batch and return control to the user without
+    /// issuing another model request.
+    pub fn stop_turn(mut self) -> Self {
+        self.control = ToolControl::StopTurn;
+        self
     }
 }

--- a/crates/wisp-tools/src/lib.rs
+++ b/crates/wisp-tools/src/lib.rs
@@ -20,7 +20,7 @@ pub mod shell;
 pub mod tool;
 pub mod write;
 
-pub use env::{Approval, ConfirmDecision, ImageData, ToolEnv, ToolEvent, ToolResult};
+pub use env::{Approval, ConfirmDecision, ImageData, ToolControl, ToolEnv, ToolEvent, ToolResult};
 pub use tool::Tool;
 
 use serde_json::Value;
@@ -217,7 +217,8 @@ impl Registry {
                 .await
         {
             env.emit(ToolEvent::Result { ok: false }).await;
-            return ToolResult::fail(format!("tool '{SEARCH_MCP_TOOLS}' was denied by the user"));
+            return ToolResult::fail(format!("tool '{SEARCH_MCP_TOOLS}' was denied by the user"))
+                .stop_batch();
         }
         let result = self.search_mcp_tools(args);
         env.emit(ToolEvent::Result { ok: result.success }).await;
@@ -346,7 +347,7 @@ async fn run_registered_tool(tool: &dyn Tool, args: &Value, env: &dyn ToolEnv) -
     .await;
     if approval == env::Approval::Ask && !env.confirm(&format!("Run tool '{name}'?")).await {
         env.emit(ToolEvent::Result { ok: false }).await;
-        return ToolResult::fail(format!("tool '{name}' was denied by the user"));
+        return ToolResult::fail(format!("tool '{name}' was denied by the user")).stop_batch();
     }
     tool.before(args, env).await;
     let result = tool.run(args, env).await;
@@ -600,6 +601,7 @@ mod approval_tests {
             .run("third_party", &serde_json::json!({}), &env)
             .await;
         assert!(!result.success);
+        assert_eq!(result.control, ToolControl::StopBatch);
         assert!(!RAN.load(Ordering::SeqCst));
     }
 
@@ -641,9 +643,11 @@ mod approval_tests {
         // Deny: never runs, fails.
         let (ran, res) = run_with(Approval::Deny, true).await;
         assert!(!ran && !res.success, "deny must block the tool");
+        assert_eq!(res.control, ToolControl::Continue);
         // Ask + confirm no: never runs, fails.
         let (ran, res) = run_with(Approval::Ask, false).await;
         assert!(!ran && !res.success, "ask+deny must block the tool");
+        assert_eq!(res.control, ToolControl::StopBatch);
         // Ask + confirm yes: runs.
         let (ran, res) = run_with(Approval::Ask, true).await;
         assert!(ran && res.success, "ask+approve must run the tool");

--- a/crates/wisp-tools/src/plan.rs
+++ b/crates/wisp-tools/src/plan.rs
@@ -186,7 +186,7 @@ impl Tool for UpdatePlanTool {
             {
                 ConfirmDecision::Approved => {}
                 ConfirmDecision::Denied { feedback } => {
-                    return ToolResult::fail(plan_rejection_message(feedback));
+                    return ToolResult::fail(plan_rejection_message(feedback)).stop_batch();
                 }
             }
         }
@@ -317,7 +317,7 @@ impl Tool for ProposePlanTool {
     }
     async fn run(&self, args: &Value, _env: &dyn ToolEnv) -> ToolResult {
         match normalize_entries(args) {
-            Ok(entries) => ToolResult::ok(plan_body(entries).to_string()),
+            Ok(entries) => ToolResult::ok(plan_body(entries).to_string()).stop_turn(),
             Err(error) => ToolResult::fail(error),
         }
     }
@@ -326,7 +326,7 @@ impl Tool for ProposePlanTool {
 #[cfg(test)]
 mod tests {
     use super::{is_fresh_proposal, render_plan, ProposePlanTool, UpdatePlanTool, PROPOSE_PLAN};
-    use crate::env::{ConfirmDecision, ToolEnv, ToolEvent};
+    use crate::env::{ConfirmDecision, ToolControl, ToolEnv, ToolEvent};
     use crate::tool::Tool;
     use serde_json::json;
     use std::path::{Path, PathBuf};
@@ -450,6 +450,7 @@ mod tests {
             "the result has to stop the agent, not invite it to execute"
         );
         assert_eq!(ProposePlanTool.name(), PROPOSE_PLAN);
+        assert_eq!(result.control, ToolControl::StopTurn);
     }
 
     #[tokio::test]
@@ -491,6 +492,7 @@ mod tests {
             .await;
 
         assert!(!result.success);
+        assert_eq!(result.control, ToolControl::StopBatch);
         assert!(
             result
                 .content

--- a/crates/wisp-tools/src/shell.rs
+++ b/crates/wisp-tools/src/shell.rs
@@ -86,7 +86,7 @@ async fn run_shell(args: &serde_json::Value, env: &dyn ToolEnv, timeout: Duratio
         if let Some(danger) = crate::safety::check_command_safety(&cmd) {
             let msg = format!("Dangerous command detected ({}): {}", danger.label(), cmd);
             if !env.confirm(&msg).await {
-                return ToolResult::fail("error: User denied action");
+                return ToolResult::fail("error: User denied action").stop_batch();
             }
         }
     }
@@ -294,7 +294,7 @@ impl Tool for ShellTool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::env::ToolEvent;
+    use crate::env::{ToolControl, ToolEvent};
     use crate::tool::Tool;
     use std::path::{Path, PathBuf};
 
@@ -308,6 +308,21 @@ mod tests {
 
         async fn confirm(&self, _message: &str) -> bool {
             true
+        }
+
+        async fn emit(&self, _event: ToolEvent) {}
+    }
+
+    struct DenyEnv(PathBuf);
+
+    #[async_trait::async_trait]
+    impl ToolEnv for DenyEnv {
+        fn project_root(&self) -> &Path {
+            &self.0
+        }
+
+        async fn confirm(&self, _message: &str) -> bool {
+            false
         }
 
         async fn emit(&self, _event: ToolEvent) {}
@@ -341,6 +356,20 @@ mod tests {
         );
         let preview = ShellTool.preview(&json!({ "cmd": cmd.clone() }));
         assert_eq!(preview, cmd);
+    }
+
+    #[tokio::test]
+    async fn denied_dangerous_command_stops_the_model_batch() {
+        let env = DenyEnv(std::env::current_dir().unwrap());
+        let result = run_shell(
+            &json!({ "cmd": "rm -rf generated-output" }),
+            &env,
+            Duration::from_secs(1),
+        )
+        .await;
+
+        assert!(!result.success);
+        assert_eq!(result.control, ToolControl::StopBatch);
     }
 
     #[tokio::test]

--- a/src-tauri/src/approval_commands.rs
+++ b/src-tauri/src/approval_commands.rs
@@ -28,6 +28,17 @@ pub(crate) fn session_full_permission(state: &AppState, session_id: &str) -> boo
         .unwrap_or(false)
 }
 
+pub(super) fn cancel_pending_confirmation(state: &AppState, session_id: &str) {
+    let pending = state.confirms.lock().unwrap().remove(session_id);
+    if let Some(pending) = pending {
+        let _ = pending
+            .tx
+            .send(wisp_tools::ConfirmDecision::Denied { feedback: None });
+    }
+    state.awaiting_confirm.lock().unwrap().remove(session_id);
+    state.device_hub.resolve_needs_user(session_id);
+}
+
 #[tauri::command]
 pub(super) async fn get_session_full_permission(
     state: State<'_, AppState>,

--- a/src-tauri/src/delegation_tool.rs
+++ b/src-tauri/src/delegation_tool.rs
@@ -450,9 +450,17 @@ impl Tool for DelegateTasksTool {
 
     async fn run(&self, args: &Value, env: &dyn ToolEnv) -> ToolResult {
         match self.run_batch(args, env).await {
-            Ok(value) => ToolResult::ok(serde_json::to_string(&value).unwrap_or_else(|_| {
-                r#"{"status":"failed","error":"result serialization failed"}"#.into()
-            })),
+            Ok(value) => {
+                let denied = value.get("status").and_then(Value::as_str) == Some("denied");
+                let result = ToolResult::ok(serde_json::to_string(&value).unwrap_or_else(|_| {
+                    r#"{"status":"failed","error":"result serialization failed"}"#.into()
+                }));
+                if denied {
+                    result.stop_batch()
+                } else {
+                    result
+                }
+            }
             Err(error) => ToolResult::fail(format!("delegate_tasks error: {error}")),
         }
     }
@@ -1980,6 +1988,7 @@ mod tests {
         assert_eq!(value["status"], "denied");
         assert_eq!(value["feedback"], "keep this read-only");
         assert!(value["results"].as_array().unwrap().is_empty());
+        assert_eq!(result.control, wisp_tools::ToolControl::StopBatch);
         assert!(delegator.calls().is_empty());
         {
             let prompts = env.prompts.lock().unwrap();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,7 +12,7 @@ use tauri::menu::{
 };
 use tauri::{ipc::Response, AppHandle, Emitter, Manager, State};
 use uuid::Uuid;
-use wisp_core::{Agent, MemoryManager, Output};
+use wisp_core::{Agent, MemoryManager, Output, OutputFuture};
 use wisp_llm::{Message, ProviderConfig};
 use wisp_skills::{SkillIndex, SkillSource};
 use wisp_store::{LibraryStore, Store};
@@ -225,7 +225,14 @@ struct ConfirmRequest {
     preview: String,
 }
 
-type ConfirmSender = std::sync::mpsc::Sender<wisp_tools::ConfirmDecision>;
+type ConfirmSender = tokio::sync::oneshot::Sender<wisp_tools::ConfirmDecision>;
+type ConfirmReceiver = tokio::sync::oneshot::Receiver<wisp_tools::ConfirmDecision>;
+
+async fn receive_confirm_decision(receiver: ConfirmReceiver) -> wisp_tools::ConfirmDecision {
+    receiver
+        .await
+        .unwrap_or(wisp_tools::ConfirmDecision::Denied { feedback: None })
+}
 
 struct PendingConfirm {
     tx: ConfirmSender,
@@ -2030,9 +2037,10 @@ fn ensure_writable(dir: PathBuf, app_data: &std::path::Path) -> PathBuf {
     }
 }
 
-/// `wisp_core::Output` backed by Tauri events. `confirm` blocks on a std
-/// channel satisfied by the `confirm_response` command. `frame_id` is the
-/// session frame id (carried on every event so the UI can route by session).
+/// `wisp_core::Output` backed by Tauri events. Confirmation awaits a Tokio
+/// oneshot satisfied by the `confirm_response` command, yielding the runtime
+/// so that command remains clickable. `frame_id` is the session frame id
+/// (carried on every event so the UI can route by session).
 struct TauriOutput {
     app: AppHandle,
     frame_id: String,
@@ -2213,54 +2221,68 @@ impl Output for TauriOutput {
             chunk: chunk.into(),
         });
     }
-    fn confirm(&self, message: &str) -> bool {
-        self.confirm_decision(message).approved()
+    // Desktop approval must use the async hooks below. Fail closed if a future
+    // caller accidentally reaches the legacy synchronous compatibility path.
+    fn confirm(&self, _message: &str) -> bool {
+        false
     }
-    fn confirm_decision(&self, message: &str) -> wisp_tools::ConfirmDecision {
-        if self.full_permission() {
-            return wisp_tools::ConfirmDecision::Approved;
-        }
-        let (tool, preview) = parse_confirm_payload(message);
-        let grant = approval_grant_key(message);
-        if grant.as_ref().is_some_and(|key| {
-            self.approval_grants
+    fn confirm_decision(&self, _message: &str) -> wisp_tools::ConfirmDecision {
+        wisp_tools::ConfirmDecision::Denied { feedback: None }
+    }
+    fn confirm_async<'a>(&'a self, message: &'a str) -> OutputFuture<'a, bool> {
+        Box::pin(async move { self.confirm_decision_async(message).await.approved() })
+    }
+    fn confirm_decision_async<'a>(
+        &'a self,
+        message: &'a str,
+    ) -> OutputFuture<'a, wisp_tools::ConfirmDecision> {
+        Box::pin(async move {
+            if self.full_permission() {
+                return wisp_tools::ConfirmDecision::Approved;
+            }
+            let (tool, preview) = parse_confirm_payload(message);
+            let grant = approval_grant_key(message);
+            if grant.as_ref().is_some_and(|key| {
+                self.approval_grants
+                    .lock()
+                    .map(|grants| grants.allows(&self.frame_id, &self.project_id, key))
+                    .unwrap_or(false)
+            }) {
+                return wisp_tools::ConfirmDecision::Approved;
+            }
+            let (tx, rx) = tokio::sync::oneshot::channel();
+            self.confirms.lock().unwrap().insert(
+                self.frame_id.clone(),
+                PendingConfirm {
+                    tx,
+                    grant,
+                    project_id: self.project_id.clone(),
+                },
+            );
+            self.awaiting_confirm
                 .lock()
-                .map(|grants| grants.allows(&self.frame_id, &self.project_id, key))
-                .unwrap_or(false)
-        }) {
-            return wisp_tools::ConfirmDecision::Approved;
-        }
-        let (tx, rx) = std::sync::mpsc::channel::<wisp_tools::ConfirmDecision>();
-        self.confirms.lock().unwrap().insert(
-            self.frame_id.clone(),
-            PendingConfirm {
-                tx,
-                grant,
-                project_id: self.project_id.clone(),
-            },
-        );
-        self.awaiting_confirm
-            .lock()
-            .unwrap()
-            .insert(self.frame_id.clone());
-        self.device_hub
-            .mark_needs_user(&self.frame_id, Some(&self.project_id));
-        let _ = self.app.emit(
-            "confirm-request",
-            ConfirmRequest {
-                frame_id: self.frame_id.clone(),
-                message: message.into(),
-                tool,
-                preview,
-            },
-        );
-        let decision = rx
-            .recv_timeout(std::time::Duration::from_secs(180))
-            .unwrap_or(wisp_tools::ConfirmDecision::Denied { feedback: None });
-        self.confirms.lock().unwrap().remove(&self.frame_id);
-        self.awaiting_confirm.lock().unwrap().remove(&self.frame_id);
-        self.device_hub.resolve_needs_user(&self.frame_id);
-        decision
+                .unwrap()
+                .insert(self.frame_id.clone());
+            self.device_hub
+                .mark_needs_user(&self.frame_id, Some(&self.project_id));
+            let _ = self.app.emit(
+                "confirm-request",
+                ConfirmRequest {
+                    frame_id: self.frame_id.clone(),
+                    message: message.into(),
+                    tool,
+                    preview,
+                },
+            );
+
+            // There is deliberately no timeout: lack of approval must never be
+            // converted into a denial that lets the same agent turn continue.
+            let decision = receive_confirm_decision(rx).await;
+            self.confirms.lock().unwrap().remove(&self.frame_id);
+            self.awaiting_confirm.lock().unwrap().remove(&self.frame_id);
+            self.device_hub.resolve_needs_user(&self.frame_id);
+            decision
+        })
     }
     fn approval_mode(&self, tool: &str) -> wisp_tools::Approval {
         self.approvals
@@ -5331,19 +5353,31 @@ fn message_uses_resource_bindings(message: &Message) -> bool {
 #[tauri::command]
 async fn stop_agent(state: State<'_, AppState>, session_id: Option<String>) -> Result<(), String> {
     // Cancel only the named session's turn; other conversations keep running.
-    let targets: Vec<Arc<SessionRuntime>> = match session_id.as_deref().filter(|s| !s.is_empty()) {
-        Some(id) => state
-            .sessions
-            .lock()
-            .await
-            .get(id)
-            .cloned()
-            .into_iter()
-            .collect(),
-        None => state.sessions.lock().await.values().cloned().collect(),
-    };
-    for rt in targets {
+    let targets: Vec<(String, Arc<SessionRuntime>)> =
+        match session_id.as_deref().filter(|s| !s.is_empty()) {
+            Some(id) => state
+                .sessions
+                .lock()
+                .await
+                .get(id)
+                .cloned()
+                .map(|runtime| (id.to_string(), runtime))
+                .into_iter()
+                .collect(),
+            None => state
+                .sessions
+                .lock()
+                .await
+                .iter()
+                .map(|(id, runtime)| (id.clone(), runtime.clone()))
+                .collect(),
+        };
+    for (id, rt) in targets {
         rt.cancel.store(true, Ordering::Relaxed);
+        // Wake an agent suspended on the async approval receiver. The loop
+        // observes the cancel flag after the denied tool result and exits
+        // instead of leaving the Stop button waiting forever.
+        approval_commands::cancel_pending_confirmation(&state, &id);
     }
     if let Some(id) = session_id.as_deref().filter(|id| !id.is_empty()) {
         acp::cancel_frame(&state, id).await;

--- a/src-tauri/src/lib_tests.rs
+++ b/src-tauri/src/lib_tests.rs
@@ -6,8 +6,8 @@ use super::{
     branch_title, copy_dir_recursive, enable_referenced_contexts, events_to_items,
     merge_pending_ui_event, message_uses_resource_bindings, messages_to_items,
     parse_disabled_skills, parse_enabled_skill_names, parse_skill_tags, persist_ui_events,
-    resolve_acp_artifact_references, resolve_composer_references, resolve_reader_references,
-    resolve_review_backend, resolve_workspace, session_runtime_status,
+    receive_confirm_decision, resolve_acp_artifact_references, resolve_composer_references,
+    resolve_reader_references, resolve_review_backend, resolve_workspace, session_runtime_status,
     should_hide_app_on_macos_close, should_persist_ui_event, side_chat_prompt, user_message_start,
     AgentEvent, ComposerReferenceArg, McpConnection, McpHttpAuth, McpTransport, QueuedItem,
     SessionRuntime, MAX_PENDING_UI_EVENT_BYTES,
@@ -15,6 +15,22 @@ use super::{
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::{atomic::AtomicBool, Arc};
+
+#[tokio::test]
+async fn native_confirmation_waits_for_an_explicit_response() {
+    let (sender, receiver) = tokio::sync::oneshot::channel();
+    let decision = receive_confirm_decision(receiver);
+    tokio::pin!(decision);
+
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(20), &mut decision)
+            .await
+            .is_err(),
+        "an unanswered permission request must remain blocked"
+    );
+    sender.send(wisp_tools::ConfirmDecision::Approved).unwrap();
+    assert_eq!(decision.await, wisp_tools::ConfirmDecision::Approved);
+}
 
 #[test]
 fn mcp_app_context_is_latest_only_and_session_scoped() {

--- a/src-tauri/src/run_context/tests.rs
+++ b/src-tauri/src/run_context/tests.rs
@@ -125,6 +125,47 @@ impl wisp_tools::ToolEnv for RunToolTestEnv {
     async fn emit(&self, _event: wisp_tools::ToolEvent) {}
 }
 
+struct DenyRunToolEnv(PathBuf);
+
+#[async_trait::async_trait]
+impl wisp_tools::ToolEnv for DenyRunToolEnv {
+    fn project_root(&self) -> &std::path::Path {
+        &self.0
+    }
+
+    async fn confirm(&self, _message: &str) -> bool {
+        false
+    }
+
+    async fn emit(&self, _event: wisp_tools::ToolEvent) {}
+}
+
+#[tokio::test]
+async fn denied_dangerous_run_stops_the_model_batch() {
+    use wisp_tools::{Tool, ToolControl};
+    let tmp = std::env::temp_dir().join(format!("wisp_run_deny_{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&tmp).unwrap();
+    let store = wisp_store::Store::open(&tmp.join("wisp.sqlite"))
+        .await
+        .unwrap();
+    let tool = RunInContextTool::new(store, RunManager::new(), "p".into(), None);
+
+    let result = tool
+        .run(
+            &serde_json::json!({
+                "context_id": "local",
+                "command": "rm -rf generated-output"
+            }),
+            &DenyRunToolEnv(tmp.clone()),
+        )
+        .await;
+
+    assert!(!result.success);
+    assert_eq!(result.control, ToolControl::StopBatch);
+    drop(tool);
+    let _ = std::fs::remove_dir_all(tmp);
+}
+
 #[tokio::test]
 async fn run_in_context_can_suspend_until_terminal_without_get_run_calls() {
     use wisp_tools::Tool;

--- a/src-tauri/src/run_context/tools.rs
+++ b/src-tauri/src/run_context/tools.rs
@@ -138,7 +138,7 @@ impl Tool for RunInContextTool {
                     request.command
                 );
                 if !env.confirm(&msg).await {
-                    return ToolResult::fail("error: User denied action");
+                    return ToolResult::fail("error: User denied action").stop_batch();
                 }
             }
         }

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -677,6 +677,8 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
   const acpPermissionFrames: Record<string, string> = {};
   const askUserFrames: Record<string, string> = {};
   const acpLongResolvers: Record<string, (value: string) => void> = {};
+  const nativeConfirmResolvers: Record<string, (value: string) => void> = {};
+  (window as any).__nativeConfirmPending = {};
   let mockCredentials: Record<string, boolean> = {
     openalex_api_key: false,
     infinisynapse_api_key: false,
@@ -2927,7 +2929,24 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
             }
             return `Side answer: ${question}`;
           }
-          case "confirm_response":
+          case "confirm_response": {
+            const frameId = String(arg("sessionId") ?? "");
+            const resolve = nativeConfirmResolvers[frameId];
+            if (resolve) {
+              delete nativeConfirmResolvers[frameId];
+              (window as any).__nativeConfirmPending[frameId] = false;
+              emit("agent", {
+                kind: "ToolResult",
+                frame_id: frameId,
+                name: "shell",
+                ok: Boolean(arg("approved")),
+                content: arg("approved") ? "approved" : "denied",
+              });
+              emit("agent", { kind: "Done", frame_id: frameId, stop_reason: "end_turn" });
+              resolve(frameId);
+            }
+            return null;
+          }
           case "dismiss_onboarding":
             return null;
           case "stop_session":
@@ -3061,6 +3080,22 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
                 50,
               );
               return fid;
+            }
+            if (String(arg("message") ?? "").includes("BLOCKINGCONFIRM")) {
+              setTimeout(
+                () =>
+                  emit("confirm-request", {
+                    frame_id: fid,
+                    message: "Dangerous command detected:\nRemove generated files?",
+                    tool: "shell",
+                    preview: "Remove-Item generated.tmp",
+                  }),
+                50,
+              );
+              (window as any).__nativeConfirmPending[fid] = true;
+              return await new Promise<string>((resolve) => {
+                nativeConfirmResolvers[fid] = resolve;
+              });
             }
             if (String(arg("message") ?? "").includes("NEEDCONFIRM")) {
               const longBody = Array.from({ length: 120 }, (_, i) => `rm -rf /mock/path/line-${i}`).join("\n");

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -5296,6 +5296,28 @@ test("inline approval card keeps its buttons reachable with a long preview (#63)
   await expect(allow).toBeInViewport();
 });
 
+test("native approval remains clickable while the agent turn is blocked", async ({ page }) => {
+  await enterApp(page);
+  await composer(page).fill("BLOCKINGCONFIRM");
+  await page.getByRole("button", { name: "Send" }).click();
+
+  const allow = page.getByRole("button", { name: "Allow once" });
+  await expect(allow).toBeVisible({ timeout: 10_000 });
+  await expect.poll(() => page.evaluate(() =>
+    Object.values((window as any).__nativeConfirmPending ?? {}).some(Boolean)
+  )).toBe(true);
+
+  await allow.click();
+
+  await expect.poll(() => lastInvokeArgs(page, "confirm_response")).toMatchObject({
+    approved: true,
+    scope: "once",
+  });
+  await expect.poll(() => page.evaluate(() =>
+    Object.values((window as any).__nativeConfirmPending ?? {}).some(Boolean)
+  )).toBe(false);
+});
+
 test("Escape closes plan feedback before rejecting the plan", async ({ page }) => {
   await enterApp(page);
   await composer(page).fill("NEEDPLAN");


### PR DESCRIPTION
## Problem

Native permission confirmation blocked the Tauri runtime on a synchronous channel. The approval buttons could become unresponsive, and after 180 seconds the wait silently turned into a denial while the agent continued. Separately, native `ask_user` and `propose_plan` only relied on model instructions: later tool calls from the same model batch could still execute before the user answered.

## What changed

- Added object-safe async confirmation hooks to the core output interface.
- Replaced the desktop blocking channel and timeout with a Tokio oneshot that waits until approve, reject, Full Permission, or Stop.
- Added typed tool-loop control: continue, stop the current batch, or stop the turn.
- Made successful `ask_user`, `propose_plan`, and `attempt_completion` hard turn boundaries.
- Skip later sibling calls after a hard boundary while persisting synthetic tool results so provider tool-call/result pairing remains valid.
- Stop stale sibling calls after explicit denial in registry approvals, dangerous shell and Run requests, plan approval, and delegation approval.
- Wake pending confirmation waits when Stop is pressed.
- Documented the user-visible pause behavior.

ACP permission handling and the MCP bridge `ask_user` path were audited; both already wait asynchronously without converting an unanswered request into a timed denial.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p wisp-tools -p wisp-core` — 114 passed
- Targeted Tauri confirmation, Run denial, and delegation denial tests
- `cd ui && cargo check --target wasm32-unknown-unknown`
- `cd ui-tests && npm ci && UI_TEST_PORT=1437 npx playwright test` — 249 passed, 1 skipped
- `cargo test --workspace` — all change-related tests passed; three unrelated Windows baseline failures remain:
  - `publication_commands::tests::artifact_binding_resolves_latest_version_once`
  - `publication_commands::tests::run_binding_and_workspace_are_project_scoped`
  - `run_context::tests::ssh_launch_failure_stops_after_the_first_attempt`

## Manual smoke

1. Trigger a native shell/tool approval and verify the card remains clickable while the turn is suspended.
2. Leave the request unanswered and verify the agent does not continue or auto-deny it.
3. Approve or reject and verify the turn resumes appropriately.
4. Press Stop while approval is pending and verify the task exits without leaving a stuck approval card.

## Known limitations / follow-up

- The three existing Windows workspace-test failures above are outside this PR.
- No follow-up is required for the audited native, ACP permission, or bridge question paths.