### PR TITLE
Add guarded project data deletion

### DIFF
--- a/docs/project-transfer.md
+++ b/docs/project-transfer.md
@@ -43,3 +43,17 @@ archive manifest and are not followed. Export rejects workspaces with more than
 For repeated device switching, use [Manual project sync](project-sync.md). It
 uses the same portable project snapshot rules while transferring only changed
 workspace files.
+
+## Removing a project
+
+The delete action on a project card offers two distinct choices:
+
+- **Remove from Wisp only** deletes the project's Wisp metadata while keeping
+  its project directory and files on disk.
+- **Delete project and local data** also permanently deletes the registered
+  project directory. This choice opens a second warning that shows the exact
+  directory; its final delete button stays disabled for five seconds. The data
+  deletion cannot be undone.
+
+Pressing Escape from the permanent-delete warning returns to the first choice
+dialog. Pressing Escape again closes project removal without making changes.

--- a/src-tauri/src/lib_tests.rs
+++ b/src-tauri/src/lib_tests.rs
@@ -1341,6 +1341,33 @@ fn project_window_url_carries_the_target_session() {
     );
 }
 
+#[tokio::test]
+async fn project_workspace_data_deletion_removes_only_the_resolved_project_directory() {
+    let root = std::env::temp_dir().join(format!("wisp_project_delete_{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(root.join("data")).unwrap();
+    std::fs::write(root.join("data").join("results.csv"), b"value\n1\n").unwrap();
+
+    let target =
+        super::project_commands::project_workspace_delete_target(root.to_string_lossy().as_ref())
+            .unwrap()
+            .unwrap();
+    super::project_commands::delete_project_workspace_data(target)
+        .await
+        .unwrap();
+
+    assert!(!root.exists());
+}
+
+#[test]
+fn project_workspace_data_deletion_rejects_filesystem_root() {
+    let temp = std::fs::canonicalize(std::env::temp_dir()).unwrap();
+    let root = temp.ancestors().last().unwrap();
+    let error =
+        super::project_commands::project_workspace_delete_target(root.to_string_lossy().as_ref())
+            .unwrap_err();
+    assert_eq!(error, "Refusing to delete a filesystem root.");
+}
+
 #[test]
 fn app_activation_restores_workspace_windows_but_not_the_pet() {
     assert!(should_activate_workspace_window("main"));

--- a/src-tauri/src/project_commands.rs
+++ b/src-tauri/src/project_commands.rs
@@ -330,8 +330,20 @@ pub(super) async fn delete_project(
     state: State<'_, AppState>,
     window: tauri::WebviewWindow,
     id: String,
+    delete_data: Option<bool>,
 ) -> Result<(), String> {
     let _project_activity = state.begin_project_activity(&id)?;
+    let workspace_delete_target = if delete_data.unwrap_or(false) {
+        let (_, workspace_dir) = state
+            .store
+            .get_project(&id)
+            .await
+            .map_err(|e| format!("{e}"))?
+            .ok_or_else(|| "Project not found".to_string())?;
+        project_workspace_delete_target(&workspace_dir)?
+    } else {
+        None
+    };
     // The delete ✕ is only reachable from the projects list, so a project may
     // legitimately be deleted while it's still the backend's *active* one
     // (returning to the list is a frontend-only nav — it never told the backend
@@ -342,6 +354,9 @@ pub(super) async fn delete_project(
     // the store cascade removes them); other projects keep running (#52).
     cancel_project_sessions(state.inner(), &id).await;
     state.runtime_manager.stop_project(&id).await;
+    if let Some(target) = workspace_delete_target {
+        delete_project_workspace_data(target).await?;
+    }
     state
         .store
         .delete_project(&id)
@@ -352,6 +367,81 @@ pub(super) async fn delete_project(
         let _ = set_active_project(state.inner(), window.label(), "default").await;
     }
     Ok(())
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum ProjectWorkspaceDeleteTarget {
+    Directory(PathBuf),
+    Symlink(PathBuf),
+}
+
+/// Resolve the registered project root before stopping any sessions. Missing
+/// workspaces are already effectively data-free, but broad filesystem roots
+/// are never valid deletion targets even after an explicit UI confirmation.
+pub(super) fn project_workspace_delete_target(
+    workspace_dir: &str,
+) -> Result<Option<ProjectWorkspaceDeleteTarget>, String> {
+    if workspace_dir.trim().is_empty() {
+        return Err("Project workspace is empty; refusing to delete data.".into());
+    }
+    let path = PathBuf::from(workspace_dir);
+    let metadata = match std::fs::symlink_metadata(&path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(format!(
+                "Failed to inspect project workspace {}: {error}",
+                path.display()
+            ));
+        }
+    };
+    if metadata.file_type().is_symlink() {
+        return Ok(Some(ProjectWorkspaceDeleteTarget::Symlink(path)));
+    }
+    if !metadata.is_dir() {
+        return Err(format!(
+            "Project workspace is not a directory: {}",
+            path.display()
+        ));
+    }
+    let canonical = dunce::canonicalize(&path).map_err(|error| {
+        format!(
+            "Failed to inspect project workspace {}: {error}",
+            path.display()
+        )
+    })?;
+    if canonical.parent().is_none() {
+        return Err("Refusing to delete a filesystem root.".into());
+    }
+    Ok(Some(ProjectWorkspaceDeleteTarget::Directory(canonical)))
+}
+
+pub(super) async fn delete_project_workspace_data(
+    target: ProjectWorkspaceDeleteTarget,
+) -> Result<(), String> {
+    let display_path = match &target {
+        ProjectWorkspaceDeleteTarget::Directory(path)
+        | ProjectWorkspaceDeleteTarget::Symlink(path) => path.clone(),
+    };
+    let result = match target {
+        ProjectWorkspaceDeleteTarget::Directory(path) => tokio::fs::remove_dir_all(path).await,
+        ProjectWorkspaceDeleteTarget::Symlink(path) => {
+            #[cfg(target_os = "windows")]
+            {
+                tokio::fs::remove_dir(path).await
+            }
+            #[cfg(not(target_os = "windows"))]
+            {
+                tokio::fs::remove_file(path).await
+            }
+        }
+    };
+    result.map_err(|error| {
+        format!(
+            "Failed to delete project data at {}: {error}",
+            display_path.display()
+        )
+    })
 }
 
 #[derive(Serialize, Clone)]

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -6984,18 +6984,70 @@ test("queued follow-ups can be reordered up and down (#433)", async ({ page }) =
   )).toEqual(["move_up", "move_down"]);
 });
 
-test("deleting a project uses an in-app confirm modal, not native confirm (#96)", async ({ page }) => {
+test("project removal offers a files-preserving action in the in-app dialog (#96)", async ({ page }) => {
   // Native window.confirm() is a no-op in this webview (wry's WKUIDelegate has
   // no JS confirm panel), so the ✕ silently did nothing. Deletion now goes
   // through an in-app modal.
   await page.goto("/");
   await page.locator(".proj-card:not(.proj-example) .pc-del").first().click();
-  const modal = page.locator(".confirm-modal");
+  const modal = page.locator(".project-delete-choice-modal");
   await expect(modal).toBeVisible();
-  await modal.locator("button.primary").click();
+  await expect(modal.getByRole("button", { name: "Cancel", exact: true })).toBeVisible();
+  await expect(modal.getByRole("button", { name: "Remove from Wisp only", exact: true })).toBeVisible();
+  await expect(modal.getByRole("button", { name: "Delete project and local data", exact: true })).toBeVisible();
+
+  // Escape works immediately after opening; it does not depend on modal focus.
+  await page.keyboard.press("Escape");
+  await expect(modal).toHaveCount(0);
+  await page.locator(".proj-card:not(.proj-example) .pc-del").first().click();
+  await page.locator(".project-delete-choice-modal")
+    .getByRole("button", { name: "Remove from Wisp only", exact: true })
+    .click();
   await expect.poll(async () => page.evaluate(() =>
-    ((window as any).__skillInvokeLog ?? []).some((c: any) => c.cmd === "delete_project"),
-  )).toBe(true);
+    ((window as any).__skillInvokeLog ?? [])
+      .filter((c: any) => c.cmd === "delete_project")
+      .map((c: any) => c.args instanceof Map ? c.args.get("deleteData") : c.args?.deleteData),
+  )).toContain(false);
+});
+
+test("deleting project data requires a second confirmation and five-second countdown", async ({ page }) => {
+  await page.clock.install();
+  await page.goto("/");
+  const deleteButton = page.locator(".proj-card:not(.proj-example) .pc-del").first();
+  await deleteButton.click();
+  await page.getByRole("button", { name: "Delete project and local data", exact: true }).click();
+
+  const destructiveModal = page.locator(".project-delete-data-modal");
+  await expect(destructiveModal).toBeVisible();
+  await expect(destructiveModal).toContainText("This cannot be undone");
+  const permanentDelete = destructiveModal.getByRole("button", { name: /Permanently delete/ });
+  expect(await permanentDelete.textContent()).toBe("Permanently delete (5s)");
+  await expect(permanentDelete).toBeDisabled();
+
+  // One Escape closes only the topmost confirmation and returns to the choice
+  // dialog. A second press closes that parent dialog.
+  await page.keyboard.press("Escape");
+  await expect(destructiveModal).toHaveCount(0);
+  await expect(page.locator(".project-delete-choice-modal")).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(page.locator(".project-delete-choice-modal")).toHaveCount(0);
+
+  await deleteButton.click();
+  await page.getByRole("button", { name: "Delete project and local data", exact: true }).click();
+  const confirmedDelete = page.locator(".project-delete-data-modal")
+    .getByRole("button", { name: /Permanently delete/ });
+  await page.clock.fastForward(4_900);
+  await expect(confirmedDelete).toBeDisabled();
+  await page.clock.fastForward(200);
+  await expect(confirmedDelete).toBeEnabled();
+  await expect(confirmedDelete).toHaveText("Permanently delete");
+  await confirmedDelete.click();
+
+  await expect.poll(async () => page.evaluate(() =>
+    ((window as any).__skillInvokeLog ?? [])
+      .filter((c: any) => c.cmd === "delete_project")
+      .map((c: any) => c.args instanceof Map ? c.args.get("deleteData") : c.args?.deleteData),
+  )).toContain(true);
 });
 
 test("external links open in the system browser, not the app webview (#97)", async ({ page }) => {

--- a/ui/src/app_support.rs
+++ b/ui/src/app_support.rs
@@ -10343,6 +10343,38 @@ pub(super) fn ProjectsScreen(
     // implement the JS confirm panel), so it always returned false and the ✕
     // did nothing — use an in-app modal instead.
     let pending_delete = create_rw_signal(None::<String>);
+    let confirm_delete_data = create_rw_signal(false);
+    let delete_data_countdown = create_rw_signal(0_u8);
+    let delete_data_unlock_at = Rc::new(Cell::new(0_f64));
+
+    // The destructive confirmation unlocks only after five full seconds. Keep
+    // one owner-scoped timer and make it inert whenever that second layer is
+    // closed, so reopening always starts from five again.
+    let countdown_deadline = Rc::clone(&delete_data_unlock_at);
+    let countdown_tick = Closure::wrap(Box::new(move || {
+        if confirm_delete_data.get_untracked() {
+            let milliseconds = (countdown_deadline.get() - js_sys::Date::now()).max(0.0);
+            let remaining = (milliseconds / 1_000.0).ceil() as u8;
+            if delete_data_countdown.get_untracked() != remaining {
+                delete_data_countdown.set(remaining);
+            }
+        }
+    }) as Box<dyn FnMut()>);
+    let countdown_window = web_sys::window();
+    let countdown_interval = countdown_window.as_ref().and_then(|window| {
+        window
+            .set_interval_with_callback_and_timeout_and_arguments_0(
+                countdown_tick.as_ref().unchecked_ref(),
+                100,
+            )
+            .ok()
+    });
+    on_cleanup(move || {
+        if let (Some(window), Some(interval)) = (countdown_window, countdown_interval) {
+            window.clear_interval_with_handle(interval);
+        }
+        drop(countdown_tick);
+    });
 
     let reload = move || {
         spawn_local(async move {
@@ -10516,17 +10548,25 @@ pub(super) fn ProjectsScreen(
         });
     };
 
-    let delete = move |id: String| {
+    let delete = Callback::new(move |(id, delete_data): (String, bool)| {
         spawn_local(async move {
-            let arg = to_value(&serde_json::json!({ "id": id })).unwrap();
-            let _ = invoke("delete_project", arg).await;
-            let v = invoke("list_projects", JsValue::UNDEFINED).await;
-            if let Ok(list) = serde_wasm_bindgen::from_value::<Vec<ProjectSummary>>(v) {
-                projects.set(list);
+            let arg =
+                to_value(&serde_json::json!({ "id": id, "deleteData": delete_data })).unwrap();
+            match invoke_checked("delete_project", arg).await {
+                Ok(_) => {
+                    let v = invoke("list_projects", JsValue::UNDEFINED).await;
+                    if let Ok(list) = serde_wasm_bindgen::from_value::<Vec<ProjectSummary>>(v) {
+                        projects.set(list);
+                    }
+                }
+                Err(error) => {
+                    let message = localize_backend(locale.get_untracked(), &js_error_text(error));
+                    open_error.set(Some(message));
+                }
             }
         });
-    };
-    let delete_confirmed = delete.clone(); // used by the confirm modal below
+    });
+    let delete_confirmed = delete; // used by the confirm modal below
 
     let import_project = move |_| {
         if importing.get_untracked() {
@@ -10614,6 +10654,12 @@ pub(super) fn ProjectsScreen(
             return;
         };
         if ev.key() != "Escape" || ev.default_prevented() || ime_composing(ev) {
+            return;
+        }
+        if confirm_delete_data.get() {
+            ev.prevent_default();
+            confirm_delete_data.set(false);
+            delete_data_countdown.set(0);
             return;
         }
         if pending_delete.get().is_some() {
@@ -11056,6 +11102,8 @@ pub(super) fn ProjectsScreen(
                                     <button class="pc-del" title=t(loc, "projects.delete")
                                         on:click=move |e| {
                                             e.stop_propagation();
+                                            confirm_delete_data.set(false);
+                                            delete_data_countdown.set(0);
                                             pending_delete.set(Some(id_del.clone()));
                                         }>{compose_icon("close")}</button>
                                     </div>
@@ -11115,25 +11163,91 @@ pub(super) fn ProjectsScreen(
                     </div>
                 }
             })}
-            {move || pending_delete.get().map(|id| {
-                let confirm_del = delete_confirmed.clone();
-                view! {
-                    <div class="overlay">
-                        <div class="modal confirm-modal">
-                            <h2>{move || t(locale.get(), "confirm.title")}</h2>
-                            <div class="hint">{move || t(locale.get(), "projects.delete_confirm")}</div>
-                            <div class="row">
-                                <button on:click=move |_| pending_delete.set(None)>
-                                    {move || t(locale.get(), "settings.cancel")}</button>
-                                <button class="primary" on:click=move |_| {
-                                    pending_delete.set(None);
-                                    confirm_del(id.clone());
-                                }>{move || t(locale.get(), "confirm.approve")}</button>
+            {move || {
+                let delete_data_unlock_at = Rc::clone(&delete_data_unlock_at);
+                pending_delete.get().map(|id| {
+                if confirm_delete_data.get() {
+                    let confirm_del = delete_confirmed;
+                    let delete_id = id.clone();
+                    let workspace_dir = projects
+                        .get()
+                        .into_iter()
+                        .find(|project| project.id == id)
+                        .map(|project| project.workspace_dir)
+                        .unwrap_or_default();
+                    view! {
+                        <div class="overlay project-delete-data-overlay">
+                            <div class="modal confirm-modal project-delete-data-modal"
+                                role="alertdialog" aria-modal="true"
+                                aria-label=move || t(locale.get(), "projects.delete_data_title")>
+                                <h2>{move || t(locale.get(), "projects.delete_data_title")}</h2>
+                                <div class="hint project-delete-warning">
+                                    {move || t(locale.get(), "projects.delete_data_warning")}
+                                </div>
+                                <code class="project-delete-path">{move || tf(
+                                    locale.get(),
+                                    "projects.delete_data_path",
+                                    &[("path", &workspace_dir)],
+                                )}</code>
+                                <div class="row">
+                                    <button type="button" on:click=move |_| {
+                                        confirm_delete_data.set(false);
+                                        delete_data_countdown.set(0);
+                                    }>{move || t(locale.get(), "settings.back")}</button>
+                                    <button type="button" class="primary danger"
+                                        aria-live="polite"
+                                        disabled=move || delete_data_countdown.get() != 0
+                                        on:click=move |_| {
+                                            if delete_data_countdown.get_untracked() == 0 {
+                                                confirm_delete_data.set(false);
+                                                delete_data_countdown.set(0);
+                                                pending_delete.set(None);
+                                                confirm_del.call((delete_id.clone(), true));
+                                            }
+                                        }>{move || {
+                                            let remaining = delete_data_countdown.get();
+                                            if remaining > 0 {
+                                                tf(
+                                                    locale.get(),
+                                                    "projects.delete_data_countdown",
+                                                    &[("n", &remaining.to_string())],
+                                                )
+                                            } else {
+                                                t(locale.get(), "projects.delete_data_confirm").into()
+                                            }
+                                        }}</button>
+                                </div>
                             </div>
                         </div>
-                    </div>
+                    }.into_view()
+                } else {
+                    let confirm_del = delete_confirmed;
+                    let remove_id = id.clone();
+                    view! {
+                        <div class="overlay">
+                            <div class="modal confirm-modal project-delete-choice-modal"
+                                role="dialog" aria-modal="true"
+                                aria-label=move || t(locale.get(), "confirm.title")>
+                                <h2>{move || t(locale.get(), "confirm.title")}</h2>
+                                <div class="hint">{move || t(locale.get(), "projects.delete_confirm")}</div>
+                                <div class="row">
+                                    <button type="button" on:click=move |_| pending_delete.set(None)>
+                                        {move || t(locale.get(), "settings.cancel")}</button>
+                                    <button type="button" class="primary" on:click=move |_| {
+                                        pending_delete.set(None);
+                                        confirm_del.call((remove_id.clone(), false));
+                                    }>{move || t(locale.get(), "projects.remove_only")}</button>
+                                    <button type="button" class="delete-with-data" on:click=move |_| {
+                                        delete_data_unlock_at.set(js_sys::Date::now() + 5_000.0);
+                                        delete_data_countdown.set(5);
+                                        confirm_delete_data.set(true);
+                                    }>{move || t(locale.get(), "projects.remove_with_data")}</button>
+                                </div>
+                            </div>
+                        </div>
+                    }.into_view()
                 }
-            })}
+            })}}
         </div>
     }
 }

--- a/ui/src/i18n.rs
+++ b/ui/src/i18n.rs
@@ -1826,7 +1826,16 @@ Do not leave generated files in the project root.",
         (Locale::En, "projects.example_tag") => Some("Example"),
         (Locale::En, "projects.delete") => Some("Delete"),
         (Locale::En, "projects.new_window") => Some("Open in new window"),
-        (Locale::En, "projects.delete_confirm") => Some("Remove this project from Wisp? Your files on disk are kept."),
+        (Locale::En, "projects.delete_confirm") => Some("Choose whether to keep the project directory on disk or permanently delete it with the project."),
+        (Locale::En, "projects.remove_only") => Some("Remove from Wisp only"),
+        (Locale::En, "projects.remove_with_data") => Some("Delete project and local data"),
+        (Locale::En, "projects.delete_data_title") => Some("Permanently delete the project and local data?"),
+        (Locale::En, "projects.delete_data_warning") => Some("Every file in the project directory will be permanently deleted. This cannot be undone."),
+        (Locale::En, "projects.delete_data_path") => Some("Project directory: {path}"),
+        (Locale::En, "projects.delete_data_confirm") => Some("Permanently delete"),
+        (Locale::En, "projects.delete_data_countdown") => Some("Permanently delete ({n}s)"),
+        (Locale::En, "err.project_delete_workspace_empty") => Some("The project directory is empty, so Wisp refused to delete local data."),
+        (Locale::En, "err.project_delete_root") => Some("Wisp refused to delete a filesystem root."),
         (Locale::En, "projects.open_failed") => Some("Could not open the project: {msg}"),
         (Locale::En, "projects.star_hint") => Some("If Wisp is helpful to your work, please"),
         (Locale::En, "projects.star_link") => Some("give us a star on GitHub ★"),
@@ -3609,7 +3618,16 @@ Do not leave generated files in the project root.",
         (Locale::Zh, "projects.example_tag") => Some("示例"),
         (Locale::Zh, "projects.delete") => Some("删除"),
         (Locale::Zh, "projects.new_window") => Some("在新窗口打开"),
-        (Locale::Zh, "projects.delete_confirm") => Some("从 Wisp 移除该项目？磁盘上的文件会保留。"),
+        (Locale::Zh, "projects.delete_confirm") => Some("请选择保留磁盘上的项目目录，或将其与项目一起永久删除。"),
+        (Locale::Zh, "projects.remove_only") => Some("仅从 Wisp 移除"),
+        (Locale::Zh, "projects.remove_with_data") => Some("删除项目及本地数据"),
+        (Locale::Zh, "projects.delete_data_title") => Some("永久删除项目及本地数据？"),
+        (Locale::Zh, "projects.delete_data_warning") => Some("项目目录中的所有文件都将被永久删除，删除后不可恢复。"),
+        (Locale::Zh, "projects.delete_data_path") => Some("项目目录：{path}"),
+        (Locale::Zh, "projects.delete_data_confirm") => Some("确认永久删除"),
+        (Locale::Zh, "projects.delete_data_countdown") => Some("确认永久删除（{n} 秒）"),
+        (Locale::Zh, "err.project_delete_workspace_empty") => Some("项目目录为空，Wisp 已拒绝删除本地数据。"),
+        (Locale::Zh, "err.project_delete_root") => Some("Wisp 已拒绝删除文件系统根目录。"),
         (Locale::Zh, "projects.open_failed") => Some("无法打开项目：{msg}"),
         (Locale::Zh, "projects.star_hint") => Some("如果 Wisp 对你的工作有帮助，欢迎到"),
         (Locale::Zh, "projects.star_link") => Some("GitHub 点个 Star ★"),
@@ -3708,6 +3726,40 @@ pub fn localize_backend(locale: Locale, msg: &str) -> String {
             t(locale, "err.session_transfer_same_project")
         }
         "Target project not found." => t(locale, "err.session_transfer_target_missing"),
+        "Project workspace is empty; refusing to delete data." => {
+            t(locale, "err.project_delete_workspace_empty")
+        }
+        "Refusing to delete a filesystem root." => t(locale, "err.project_delete_root"),
+        m if m.starts_with("Project workspace is not a directory: ") => {
+            if locale == Locale::Zh {
+                format!(
+                    "项目目录不是文件夹：{}",
+                    m.trim_start_matches("Project workspace is not a directory: ")
+                )
+            } else {
+                msg.to_string()
+            }
+        }
+        m if m.starts_with("Failed to inspect project workspace ") => {
+            if locale == Locale::Zh {
+                format!(
+                    "无法检查项目目录：{}",
+                    m.trim_start_matches("Failed to inspect project workspace ")
+                )
+            } else {
+                msg.to_string()
+            }
+        }
+        m if m.starts_with("Failed to delete project data at ") => {
+            if locale == Locale::Zh {
+                format!(
+                    "无法删除项目本地数据：{}",
+                    m.trim_start_matches("Failed to delete project data at ")
+                )
+            } else {
+                msg.to_string()
+            }
+        }
         "Wait for every task in this project to finish before synchronizing."
         | "Wait for every task and run in this project to finish before synchronizing." => {
             t(locale, "err.sync_busy")

--- a/ui/src/styles/modals.css
+++ b/ui/src/styles/modals.css
@@ -108,6 +108,21 @@
 .confirm-modal { overflow: hidden; }
 .confirm-modal .hint { flex: 1 1 auto; min-height: 0; overflow-y: auto; white-space: pre-wrap; }
 .confirm-modal .row { flex: 0 0 auto; }
+.project-delete-choice-modal { max-width: 560px; }
+.project-delete-choice-modal .delete-with-data {
+  color: var(--err); border-color: color-mix(in srgb, var(--err) 42%, var(--border-strong));
+}
+.project-delete-choice-modal .delete-with-data:hover:not(:disabled) {
+  color: var(--err); border-color: var(--err);
+  background: color-mix(in srgb, var(--err) 8%, var(--bg-input));
+}
+.project-delete-data-modal { max-width: 520px; }
+.project-delete-data-modal .project-delete-warning { color: var(--err); font-weight: 600; }
+.project-delete-path {
+  display: block; padding: 9px 11px; border: 1px solid var(--border);
+  border-radius: var(--radius-xs); background: var(--bg-input); color: var(--text-muted);
+  font-size: 12px; line-height: 1.5; overflow-wrap: anywhere; user-select: text;
+}
 .turn-undo-modal { max-width: 560px; }
 .turn-undo-scroll { flex: 1 1 auto; min-height: 0; overflow-y: auto; display: flex; flex-direction: column; gap: 12px; }
 .turn-undo-body, .turn-undo-empty { margin: 0; color: var(--text-muted); font-size: 13px; line-height: 1.55; }


### PR DESCRIPTION
## What changed

- Replaced the single project-removal confirmation with explicit **Remove from Wisp only**, **Delete project and local data**, and **Cancel** actions.
- Added a second irreversible-data warning that displays the registered project directory and keeps the final destructive action disabled for five full seconds.
- Added window-level Escape ordering so one press returns from the destructive warning to the choice dialog and a second press closes project removal.
- Extended the Tauri project deletion command with an optional data-deletion path that stops project sessions and runtimes before removing the registered workspace directory.
- Added filesystem-root protection, localized error handling, danger styling, user documentation, backend tests, and Playwright coverage.

## Why

The existing dialog only removed Wisp metadata and always kept files on disk. Users had no explicit way to remove both a project and its local workspace data, while changing the existing action directly would make a previously safe operation unexpectedly destructive.

The new flow preserves the existing metadata-only behavior and places permanent filesystem deletion behind a clearly labeled second confirmation and timed lockout.

## User and developer impact

Users can now choose between preserving their project directory and permanently deleting it. The destructive path shows the exact directory before deletion and cannot be confirmed immediately.

For developers, `delete_project` now accepts an optional `deleteData` argument; omitted or false retains the backward-compatible metadata-only behavior.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cd ui && cargo check --target wasm32-unknown-unknown`
- `cd ui-tests && npm ci`
- `cd ui-tests && npx playwright test` — 260 passed, 1 optional Motif integration test skipped
- Targeted project deletion tests verify both command modes, the five-second lockout, and immediate Escape behavior.

## Manual smoke steps

1. Open the Projects screen and click a project's delete action.
2. Verify the three choices and use **Remove from Wisp only** to confirm files remain on disk.
3. Reopen deletion, choose **Delete project and local data**, and verify the registered directory and irreversible warning are shown.
4. Press Escape once to return to the first dialog; press Escape again to close it.
5. Reopen the destructive flow and verify the final button unlocks only after five seconds.

## Known limitations

- This deletes only the registered local workspace directory; remote data references and synchronized copies on other devices are not deleted.
- Filesystem deletion is intentionally irreversible and is refused when the registered workspace resolves to a filesystem root.