### PR TITLE
Fix runaway automatic context compaction

### DIFF
--- a/crates/wisp-core/src/agent.rs
+++ b/crates/wisp-core/src/agent.rs
@@ -28,16 +28,14 @@ const STUCK_REPEAT_LIMIT: usize = 5;
 /// other calls between each repeat.
 const STUCK_WINDOW: usize = 16;
 const STUCK_LOOP_MESSAGE: &str = "检测到智能体连续多次发出完全相同的工具调用且没有进展，已中断以避免空转烧 token——通常是模型退化，建议换用更强的模型或换一种问法。(aborted: agent repeated an identical tool call with no progress)";
-/// Interpreter/shell output is an unbounded print stream, not content the model
-/// asked to read — budget it at ingestion: the context message is written once
-/// and never rewritten (provider prefix caches stay valid), while the full text
-/// still reaches the user via the tool_result/stdout events emitted before the
-/// truncation. read/grep/edit results keep their own tool-level caps instead:
-/// budgeting a requested file read would break the read.
-const STREAM_OUTPUT_TOOLS: [&str; 3] = ["shell", "python", "r"];
-/// Total byte budget (head + tail) for a stream tool result in the context.
+/// Tool output is an unbounded external payload, not durable conversation
+/// state. Budget every textual result at ingestion: the full text still
+/// reaches the user through the tool-result event emitted before truncation,
+/// while the main model gets a bounded head/tail excerpt. This also covers
+/// read/grep/browser/MCP tools whose own safety cap can exceed a model window.
+/// Total byte budget (head + tail) for one tool result in the model context.
 /// ~16 KiB ≈ 4K estimated tokens. Override with WISP_TOOL_RESULT_BUDGET
-/// (bytes; 0 disables). ponytail: env knob only, per-tool budgets when needed.
+/// (bytes; 0 disables).
 const DEFAULT_STREAM_RESULT_BUDGET: usize = 16 * 1024;
 
 fn auto_compact_archive_path(root: &Path) -> PathBuf {
@@ -48,25 +46,26 @@ fn auto_compact_archive_path(root: &Path) -> PathBuf {
     ))
 }
 
-/// Head/tail-truncate a stream tool's text result to the ingestion budget,
+/// Head/tail-truncate a tool's text result to the ingestion budget,
 /// with a marker telling the model what was elided and how to get it back.
-fn budget_stream_result(tool_name: &str, content: Content) -> Content {
-    if !STREAM_OUTPUT_TOOLS.contains(&tool_name) {
-        return content;
-    }
-    let Content::Text(text) = &content else {
-        return content;
-    };
+fn budget_tool_result(tool_name: &str, content: Content) -> Content {
     let budget = std::env::var("WISP_TOOL_RESULT_BUDGET")
         .ok()
         .and_then(|s| s.parse::<usize>().ok())
         .unwrap_or(DEFAULT_STREAM_RESULT_BUDGET);
+    budget_tool_result_with_limit(tool_name, content, budget)
+}
+
+fn budget_tool_result_with_limit(tool_name: &str, content: Content, budget: usize) -> Content {
+    let Content::Text(text) = &content else {
+        return content;
+    };
     if budget == 0 || text.len() <= budget {
         return content;
     }
     let half = budget / 2;
     let marker = format!(
-        "[... ~{} bytes omitted to fit the context budget; the full output was shown to the user. Persist data you need to a file, or re-run with narrower filters (head/tail/grep). ...]",
+        "[... ~{} bytes omitted from {tool_name} to fit the model-context budget; the full output was shown to the user. Re-run with narrower ranges or filters for omitted details. ...]",
         text.len() - budget
     );
     Content::text(ContextManager::truncate_middle(text, half, half, &marker))
@@ -252,29 +251,37 @@ async fn agent_loop_inner(
             }
         }
         iteration += 1;
+        let schemas = tools.schemas();
+        let fixed_request_tokens = ContextManager::estimated_tool_tokens(&schemas);
         // Match the long-context behaviour used by mangopi-cli: check the
         // budget at every model boundary, not only when the user first sends a
         // turn. Wisp's archive-first compactor preserves the full transcript
         // on disk before folding old turns, so automatic recovery has the same
         // retrievability contract as manual `/compact`.
-        if ctx.needs_auto_compact() {
+        if ctx.needs_auto_compact_with_reserve(fixed_request_tokens) {
             let archive = auto_compact_archive_path(root);
-            match ctx.compact(provider, &archive).await {
+            match ctx
+                .compact_with_reserve(provider, &archive, fixed_request_tokens)
+                .await
+            {
                 Ok((before, after)) => output.compaction(before, after, "auto"),
-                Err(error) => tracing::warn!(
-                    archive = %archive.display(),
-                    "automatic context compaction failed: {error}"
-                ),
+                Err(error) => {
+                    tracing::warn!(
+                        archive = %archive.display(),
+                        "automatic context compaction failed: {error}"
+                    );
+                    anyhow::bail!(
+                        "automatic context compaction failed before the model call: {error}"
+                    );
+                }
             }
         }
-        let messages = ctx.prepare_for_api(output);
+        let messages = ctx.prepare_for_api_with_reserve(output, fixed_request_tokens);
         let mut sink = match cancel {
             Some(c) => StreamSinkAdapter::with_cancel(output, c),
             None => StreamSinkAdapter::new(output),
         };
-        let comp = match stream_with_retry(provider, &messages, &tools.schemas(), &mut sink, cancel)
-            .await
-        {
+        let comp = match stream_with_retry(provider, &messages, &schemas, &mut sink, cancel).await {
             // ponytail: no auto-retry after a cut — re-streaming would duplicate the
             // already-emitted deltas in the UI; add a sink reset event if this recurs.
             Err(LlmError::Incomplete) => anyhow::bail!(STREAM_CUT_MESSAGE),
@@ -299,7 +306,7 @@ async fn agent_loop_inner(
                 comp.usage.output_tokens,
                 comp.usage.reasoning_tokens,
                 comp.usage.cached_input_tokens,
-                ctx.total_tokens(),
+                ctx.request_tokens_with_reserve(fixed_request_tokens),
                 ctx.max_context,
             );
             anyhow::bail!(EMPTY_RESPONSE_MESSAGE);
@@ -319,7 +326,7 @@ async fn agent_loop_inner(
             comp.usage.output_tokens,
             comp.usage.reasoning_tokens,
             comp.usage.cached_input_tokens,
-            ctx.total_tokens(),
+            ctx.request_tokens_with_reserve(fixed_request_tokens),
             ctx.max_context,
         );
 
@@ -424,7 +431,7 @@ async fn agent_loop_inner(
                 )
             };
             output.tool_result(&tools.event_name(&name, &args), ok, &tool_text, duration_ms);
-            ctx.append_tool(&tc.id, &name, budget_stream_result(&name, content));
+            ctx.append_tool(&tc.id, &name, budget_tool_result(&name, content));
             if let Some(m) = ctx.messages.last() {
                 output.on_message(m);
             }
@@ -615,6 +622,23 @@ mod tests {
         assert!(iteration_limit_reached(100, 100));
     }
 
+    #[test]
+    fn every_text_tool_result_is_bounded_before_it_enters_model_context() {
+        let raw = format!("BEGIN\n{}\nEND", "界".repeat(20_000));
+        let original_len = raw.len();
+
+        let bounded = budget_tool_result_with_limit("read", Content::text(raw), 16 * 1024);
+        let text = bounded.as_text();
+
+        assert!(text.len() < original_len);
+        assert!(text.contains("bytes omitted from read"));
+        assert!(text.starts_with("BEGIN"));
+        assert!(text.ends_with("END"));
+        assert!(
+            ContextManager::estimated_tokens(&Message::tool("call-read", "read", text)) < 5_000
+        );
+    }
+
     struct FixedProvider {
         completion: Completion,
     }
@@ -650,6 +674,44 @@ mod tests {
     struct SequenceProvider {
         completions: Mutex<VecDeque<Completion>>,
         stream_calls: AtomicUsize,
+    }
+
+    struct FailingCompactProvider {
+        complete_requests: Mutex<Vec<Vec<Message>>>,
+        stream_calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl Provider for FailingCompactProvider {
+        fn name(&self) -> &str {
+            "failing-compact"
+        }
+
+        fn model(&self) -> &str {
+            "failing-compact"
+        }
+
+        async fn complete(
+            &self,
+            messages: &[Message],
+            _tools: &[ToolSchema],
+        ) -> wisp_llm::Result<Completion> {
+            self.complete_requests
+                .lock()
+                .unwrap()
+                .push(messages.to_vec());
+            Err(LlmError::Config("forced compact failure".into()))
+        }
+
+        async fn stream(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSchema],
+            _sink: &mut dyn wisp_llm::StreamSink,
+        ) -> wisp_llm::Result<Completion> {
+            self.stream_calls.fetch_add(1, Ordering::SeqCst);
+            Err(LlmError::Config("main stream must not run".into()))
+        }
     }
 
     impl SequenceProvider {
@@ -764,6 +826,7 @@ mod tests {
         }]);
         let output = CompactionCounter(AtomicUsize::new(0));
         let mut ctx = ContextManager::new(1_000);
+        let tools = Registry::builtins().filtered(&[]);
         for turn in 0..12 {
             ctx.append_user(format!("question {turn} {}", "u".repeat(180)));
             ctx.append_assistant(format!("answer {turn} {}", "a".repeat(180)), vec![], None);
@@ -771,15 +834,7 @@ mod tests {
         assert!(ctx.needs_auto_compact());
 
         agent_loop(
-            &mut ctx,
-            &provider,
-            None,
-            &Registry::builtins(),
-            &root,
-            &output,
-            "continue",
-            0,
-            None,
+            &mut ctx, &provider, None, &tools, &root, &output, "continue", 0, None,
         )
         .await
         .unwrap();
@@ -793,6 +848,50 @@ mod tests {
             .unwrap();
         assert_eq!(archives.len(), 1, "automatic compaction must archive once");
         assert!(archives[0].path().is_file());
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn failed_auto_compaction_never_sends_the_oversized_main_request() {
+        let root = std::env::temp_dir().join(format!(
+            "wisp_auto_compact_failure_{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let provider = FailingCompactProvider {
+            complete_requests: Mutex::new(Vec::new()),
+            stream_calls: AtomicUsize::new(0),
+        };
+        let mut ctx = ContextManager::new(10_000);
+        ctx.append_user(format!("oversized {}", "x".repeat(50_000)));
+        let original = serde_json::to_string(&ctx.messages).unwrap();
+        let tools = Registry::builtins().filtered(&[]);
+
+        let error = agent_loop_continue(
+            &mut ctx,
+            &provider,
+            None,
+            &tools,
+            &root,
+            &NullOutput,
+            0,
+            None,
+            None,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("automatic context compaction failed before the model call"));
+        assert_eq!(provider.stream_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(serde_json::to_string(&ctx.messages).unwrap(), original);
+        assert!(!ctx.messages.iter().any(|message| message
+            .content
+            .as_text()
+            .contains("Create a detailed summary of the conversation so far")));
+        assert_eq!(provider.complete_requests.lock().unwrap().len(), 1);
 
         let _ = std::fs::remove_dir_all(root);
     }
@@ -1375,11 +1474,11 @@ mod tests {
         }
     }
 
-    // Stream-tool (shell/python/r) results are budgeted when INGESTED into the
-    // context — written once, never rewritten — while other tools' results are
-    // stored verbatim. The elision marker tells the model how to recover.
+    // Every text tool result is budgeted when INGESTED into model context —
+    // written once, never rewritten. The elision marker names the source tool
+    // and tells the model how to recover omitted details with a narrower call.
     #[tokio::test]
-    async fn stream_tool_results_are_budgeted_at_ingestion_others_untouched() {
+    async fn all_text_tool_results_are_budgeted_at_ingestion() {
         let call = |id: &str, name: &str| ToolCall {
             id: id.into(),
             kind: "function".into(),
@@ -1439,7 +1538,10 @@ mod tests {
         assert!(py.ends_with("TAIL-MARK"), "tail kept");
         assert!(py.contains("bytes omitted"), "elision marker present");
         let other = by_name("noisy_other");
-        assert!(other.len() > 40_000, "non-stream result stored verbatim");
+        assert!(other.len() < 20_000, "all text tools use the same budget");
+        assert!(other.starts_with("HEAD-MARK"), "other head kept");
+        assert!(other.ends_with("TAIL-MARK"), "other tail kept");
+        assert!(other.contains("bytes omitted from noisy_other"));
         std::fs::remove_dir_all(root).ok();
     }
 

--- a/crates/wisp-core/src/context.rs
+++ b/crates/wisp-core/src/context.rs
@@ -8,17 +8,25 @@
 //! read/grep it to retrieve anything folded away — then:
 //! 1. `fold_old_turns` — tombstone old tool outputs, truncate oversized old
 //!    assistant text/reasoning, replace old images with text notes.
-//! 2. `compact_conversation` — drop oldest turns while still over budget.
-//! 3. `full_compact` — LLM-driven summary (last resort).
+//! 2. `fold_oversized_tool_results` — bound even recent tool payloads that can
+//!    exceed a whole context window on their own.
+//! 3. `compact_conversation` — drop oldest turns while still over budget.
+//! 4. `full_compact` — LLM-driven summary (last resort).
 
 use crate::output::Output;
 use std::path::Path;
-use wisp_llm::{Content, Message, Part, Provider, Role, ToolCall};
+use wisp_llm::{Content, Message, Part, Provider, Role, ToolCall, ToolSchema};
 
 /// Turns kept verbatim by `/compact`.
 const RETAIN_TURNS: usize = 10;
 /// Recent turns the drop-oldest fallback protects when folding isn't enough.
 const RETAIN_TURNS_HARD: usize = 8;
+/// Automatic compaction triggers at 80%, but targets 60% so one ordinary tool
+/// result cannot immediately cross the trigger again.
+const COMPACTION_TARGET_PERCENT: usize = 60;
+/// Head + tail bytes retained when a recent tool result is the part preventing
+/// compaction. The full result remains in the archive named by the marker.
+const RECENT_TOOL_EXCERPT_BYTES: usize = 4 * 1024;
 /// Old assistant text larger than this (estimated tokens) is head/tail-cut.
 const OLD_ASSISTANT_MAX_TOKENS: usize = 1500;
 const OLD_ASSISTANT_KEEP: (usize, usize) = (350, 350);
@@ -119,7 +127,13 @@ impl ContextManager {
     /// warning. Checking this immediately before every model call also covers
     /// tool-heavy turns that grow substantially after the user's first send.
     pub fn needs_auto_compact(&self) -> bool {
-        self.auto_compact && !self.under_threshold()
+        self.needs_auto_compact_with_reserve(0)
+    }
+
+    /// Same threshold check, including fixed request payload such as tool
+    /// schemas that are not represented as conversation messages.
+    pub fn needs_auto_compact_with_reserve(&self, fixed_tokens: usize) -> bool {
+        self.auto_compact && self.request_tokens_with_reserve(fixed_tokens) >= self.warn_threshold
     }
 
     pub fn compaction_revision(&self) -> u64 {
@@ -264,8 +278,34 @@ impl ContextManager {
         turns
     }
 
-    fn under_threshold(&self) -> bool {
-        self.total_tokens() < self.warn_threshold
+    /// Estimated tokens in the actual next provider request: durable history
+    /// plus ephemeral host/reviewer/attachment injections.
+    pub fn request_tokens(&self) -> usize {
+        self.total_tokens()
+            + self
+                .runtime_injections
+                .iter()
+                .map(Self::estimated_tokens)
+                .sum::<usize>()
+    }
+
+    pub fn request_tokens_with_reserve(&self, fixed_tokens: usize) -> usize {
+        self.request_tokens().saturating_add(fixed_tokens)
+    }
+
+    /// Use one estimator everywhere Wisp reports or budgets tool definitions,
+    /// so debug exports and automatic compaction agree about request size.
+    pub fn estimated_tool_schema_tokens(tool: &ToolSchema) -> usize {
+        let params = tool.function.parameters.to_string();
+        (tool.function.name.len() + tool.function.description.len() + params.len()) / 4 + 2
+    }
+
+    pub fn estimated_tool_tokens(tools: &[ToolSchema]) -> usize {
+        tools.iter().map(Self::estimated_tool_schema_tokens).sum()
+    }
+
+    fn compaction_target(&self) -> usize {
+        self.max_context.saturating_mul(COMPACTION_TARGET_PERCENT) / 100
     }
 
     /// Rough token estimate (~JSON length / 4) from field lengths directly.
@@ -369,7 +409,57 @@ impl ContextManager {
         true
     }
 
-    fn compact_conversation(&mut self, retain_turns: usize) {
+    /// Bound the largest still-live tool results first. A single `read`,
+    /// `grep`, browser, or MCP response can be larger than the complete model
+    /// window, including when it belongs to the newest turn that normal
+    /// compaction deliberately protects.
+    fn fold_oversized_tool_results(
+        &mut self,
+        target: usize,
+        fixed_tokens: usize,
+        tombstone: &str,
+    ) -> bool {
+        let mut candidates = self
+            .messages
+            .iter()
+            .enumerate()
+            .filter_map(|(index, message)| {
+                if message.role != Role::Tool {
+                    return None;
+                }
+                let content = message.content.as_text();
+                if content.starts_with(TOMBSTONE_PREFIX)
+                    || content.len() <= RECENT_TOOL_EXCERPT_BYTES
+                {
+                    return None;
+                }
+                Some((index, Self::estimated_tokens(message)))
+            })
+            .collect::<Vec<_>>();
+        candidates.sort_unstable_by_key(|(_, tokens)| std::cmp::Reverse(*tokens));
+
+        let mut changed = false;
+        for (index, _) in candidates {
+            if self.request_tokens_with_reserve(fixed_tokens) <= target {
+                break;
+            }
+            let content = self.messages[index].content.as_text();
+            let half = RECENT_TOOL_EXCERPT_BYTES / 2;
+            let excerpt = Self::truncate_middle(
+                &content,
+                half,
+                half,
+                "[... middle omitted from the model context ...]",
+            );
+            self.messages[index].content = Content::text(format!(
+                "{tombstone}\n[bounded excerpt from this recent tool result]\n{excerpt}"
+            ));
+            changed = true;
+        }
+        changed
+    }
+
+    fn compact_conversation(&mut self, retain_turns: usize, target: usize) {
         let systems: Vec<Message> = self
             .messages
             .iter()
@@ -384,7 +474,7 @@ impl ContextManager {
         for turn in &turns {
             rebuilt.extend(turn.clone());
         }
-        if rebuilt.iter().map(Self::estimated_tokens).sum::<usize>() <= self.warn_threshold {
+        if rebuilt.iter().map(Self::estimated_tokens).sum::<usize>() <= target {
             self.messages = rebuilt;
             return;
         }
@@ -399,7 +489,7 @@ impl ContextManager {
             for turn in recent {
                 candidate.extend(turn.clone());
             }
-            if candidate.iter().map(Self::estimated_tokens).sum::<usize>() <= self.warn_threshold {
+            if candidate.iter().map(Self::estimated_tokens).sum::<usize>() <= target {
                 self.messages = candidate;
                 return;
             }
@@ -411,7 +501,7 @@ impl ContextManager {
             for turn in &trimmed_recent {
                 candidate.extend(turn.clone());
             }
-            if candidate.iter().map(Self::estimated_tokens).sum::<usize>() <= self.warn_threshold {
+            if candidate.iter().map(Self::estimated_tokens).sum::<usize>() <= target {
                 self.messages = candidate;
                 return;
             }
@@ -440,9 +530,15 @@ work in progress. Use this structure:
 6. All user messages
 7. Pending Tasks
 8. Current Work";
-        self.append_user(PROMPT);
+        // The compaction instruction is request-local control data, not a user
+        // turn. Never append it to `self.messages`: if the provider rejects the
+        // summary request, leaking this prompt into the main loop makes the
+        // agent treat compaction as the user's task and can trigger repeated
+        // reads of the just-written archive.
+        let mut summary_request = self.messages.clone();
+        summary_request.push(Message::user(PROMPT));
         let comp = provider
-            .complete(&self.messages, &[])
+            .complete(&summary_request, &[])
             .await
             .map_err(|e| format!("full compact err: {e}"))?;
         let summary = comp.content;
@@ -471,8 +567,19 @@ work in progress. Use this structure:
         provider: &dyn Provider,
         archive_path: &Path,
     ) -> Result<(usize, usize), String> {
+        self.compact_with_reserve(provider, archive_path, 0).await
+    }
+
+    /// Compact while reserving tokens for fixed request payloads (currently
+    /// tool schemas). Returned estimates include that reserve.
+    pub async fn compact_with_reserve(
+        &mut self,
+        provider: &dyn Provider,
+        archive_path: &Path,
+        fixed_tokens: usize,
+    ) -> Result<(usize, usize), String> {
         self.invalidate_last_request();
-        let before = self.total_tokens();
+        let before = self.request_tokens_with_reserve(fixed_tokens);
         self.save(archive_path);
         if !archive_path.is_file() {
             // Never fold anything we failed to archive — retrievability is the
@@ -483,30 +590,49 @@ work in progress. Use this structure:
             ));
         }
         let tombstone = format!(
-            "{TOMBSTONE_PREFIX} full content archived at {} — read/grep that file to retrieve it]",
+            "{TOMBSTONE_PREFIX} full content archived at {} — retrieve only narrow ranges with read/grep; do not load the whole archive back into context]",
             archive_path.display()
         );
         let archive_note = format!(
-            "[The pre-compact conversation history is archived at {} — read/grep that file to retrieve details.]",
+            "[The pre-compact conversation history is archived at {} — retrieve only narrow ranges with read/grep; do not load the whole archive back into context.]",
             archive_path.display()
         );
+        let original_messages = self.messages.clone();
+        let target = self.compaction_target();
+        let injection_tokens = self
+            .runtime_injections
+            .iter()
+            .map(Self::estimated_tokens)
+            .sum::<usize>();
+        let durable_target = target.saturating_sub(injection_tokens.saturating_add(fixed_tokens));
         self.fold_old_turns(RETAIN_TURNS, &tombstone);
-        if !self.under_threshold() {
-            self.compact_conversation(RETAIN_TURNS_HARD);
+        if self.request_tokens_with_reserve(fixed_tokens) > target {
+            self.fold_oversized_tool_results(target, fixed_tokens, &tombstone);
         }
-        if !self.under_threshold() {
-            self.full_compact(provider, &archive_note)
-                .await
-                .map_err(|e| {
-                    format!(
-                        "folded to ~{} tokens, but the LLM summary step failed: {e}",
-                        self.total_tokens()
-                    )
-                })?;
+        if self.request_tokens_with_reserve(fixed_tokens) > target {
+            self.compact_conversation(RETAIN_TURNS_HARD, durable_target);
+        }
+        if self.request_tokens_with_reserve(fixed_tokens) > target {
+            if let Err(error) = self.full_compact(provider, &archive_note).await {
+                let folded_tokens = self.request_tokens_with_reserve(fixed_tokens);
+                self.messages = original_messages;
+                return Err(format!(
+                    "folded to ~{} request tokens, but the LLM summary step failed: {error}",
+                    folded_tokens
+                ));
+            }
+        }
+        let after = self.request_tokens_with_reserve(fixed_tokens);
+        if after >= self.warn_threshold {
+            self.messages = original_messages;
+            return Err(format!(
+                "compaction could not bring the request below the warning threshold (estimated {after} tokens, threshold {})",
+                self.warn_threshold
+            ));
         }
         self.warned = false;
         self.compaction_revision = self.compaction_revision.wrapping_add(1);
-        Ok((before, self.total_tokens()))
+        Ok((before, after))
     }
 
     /// Return the messages to send to the model (persisted + runtime
@@ -515,7 +641,17 @@ work in progress. Use this structure:
     /// threshold fires `Output::context_warning` once; it re-arms after a
     /// manual or automatic compaction brings the estimate back under.
     pub fn prepare_for_api(&mut self, output: &dyn Output) -> std::borrow::Cow<'_, [Message]> {
-        let total = self.total_tokens();
+        self.prepare_for_api_with_reserve(output, 0)
+    }
+
+    /// Prepare a provider request while including fixed payload (tool schemas)
+    /// in warning/accounting decisions.
+    pub fn prepare_for_api_with_reserve(
+        &mut self,
+        output: &dyn Output,
+        fixed_tokens: usize,
+    ) -> std::borrow::Cow<'_, [Message]> {
+        let total = self.request_tokens_with_reserve(fixed_tokens);
         if total < self.warn_threshold {
             self.warned = false;
         } else if !self.warned {
@@ -618,7 +754,8 @@ mod tests {
     }
 
     use async_trait::async_trait;
-    use wisp_llm::{Completion, ToolSchema};
+    use std::sync::Mutex;
+    use wisp_llm::{Completion, LlmError, ToolSchema};
 
     /// Provider stub for /compact tests. Panics if the LLM-summary step is
     /// reached when a test expects folding alone to suffice.
@@ -644,6 +781,36 @@ mod tests {
                 content: "summary".into(),
                 ..Completion::default()
             })
+        }
+        async fn stream(
+            &self,
+            messages: &[Message],
+            tools: &[ToolSchema],
+            _sink: &mut dyn wisp_llm::StreamSink,
+        ) -> wisp_llm::Result<Completion> {
+            self.complete(messages, tools).await
+        }
+    }
+
+    struct FailingSummaryProvider {
+        requests: Mutex<Vec<Vec<Message>>>,
+    }
+
+    #[async_trait]
+    impl Provider for FailingSummaryProvider {
+        fn name(&self) -> &str {
+            "failing-summary"
+        }
+        fn model(&self) -> &str {
+            "failing-summary"
+        }
+        async fn complete(
+            &self,
+            messages: &[Message],
+            _tools: &[ToolSchema],
+        ) -> wisp_llm::Result<Completion> {
+            self.requests.lock().unwrap().push(messages.to_vec());
+            Err(LlmError::Config("forced summary failure".into()))
         }
         async fn stream(
             &self,
@@ -761,6 +928,94 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn compact_bounds_an_oversized_tool_result_in_the_newest_turn() {
+        let mut ctx = ContextManager::new(100_000);
+        ctx.append_system("system");
+        ctx.append_user("inspect the archive");
+        ctx.append_assistant("".into(), vec![], None);
+        ctx.append_tool(
+            "call-large",
+            "grep",
+            Content::text(format!("BEGIN\n{}\nEND", "x".repeat(500_000))),
+        );
+        let archive = archive_path("oversized-recent-tool.json");
+        let provider = StubProvider {
+            allow_summary: false,
+        };
+
+        let (before, after) = ctx.compact(&provider, &archive).await.unwrap();
+
+        assert!(before > ctx.warn_threshold);
+        assert!(after <= ctx.compaction_target());
+        let tool = ctx
+            .messages
+            .iter()
+            .find(|message| message.role == Role::Tool)
+            .unwrap()
+            .content
+            .as_text();
+        assert!(tool.starts_with(TOMBSTONE_PREFIX));
+        assert!(tool.contains("bounded excerpt"));
+        assert!(tool.contains("BEGIN"));
+        assert!(tool.contains("END"));
+        assert!(tool.len() < 8_000, "tool result remained too large");
+        assert!(
+            std::fs::read_to_string(&archive)
+                .unwrap()
+                .contains(&"x".repeat(100_000)),
+            "the archive must retain the complete result"
+        );
+    }
+
+    #[tokio::test]
+    async fn compact_targets_sixty_percent_instead_of_barely_crossing_eighty() {
+        let mut ctx = ContextManager::new(10_000);
+        for turn in 0..12 {
+            ctx.append_user(format!("question {turn} {}", "u".repeat(1_500)));
+            ctx.append_assistant(format!("answer {turn} {}", "a".repeat(1_500)), vec![], None);
+        }
+        let archive = archive_path("target-headroom.json");
+        let provider = StubProvider {
+            allow_summary: false,
+        };
+
+        let (before, after) = ctx.compact(&provider, &archive).await.unwrap();
+
+        assert!(before > ctx.warn_threshold);
+        assert!(after <= ctx.compaction_target());
+        assert!(after < ctx.warn_threshold);
+    }
+
+    #[tokio::test]
+    async fn failed_summary_is_transactional_and_never_leaks_its_prompt() {
+        let mut ctx = ContextManager::new(10_000);
+        ctx.append_system("system");
+        ctx.append_user(format!("oversized user input {}", "x".repeat(50_000)));
+        let original = serde_json::to_string(&ctx.messages).unwrap();
+        let archive = archive_path("summary-failure.json");
+        let provider = FailingSummaryProvider {
+            requests: Mutex::new(Vec::new()),
+        };
+
+        let error = ctx.compact(&provider, &archive).await.unwrap_err();
+
+        assert!(error.contains("forced summary failure"));
+        assert_eq!(serde_json::to_string(&ctx.messages).unwrap(), original);
+        assert!(!ctx.messages.iter().any(|message| {
+            message
+                .content
+                .as_text()
+                .contains("Create a detailed summary of the conversation so far")
+        }));
+        let requests = provider.requests.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        assert!(requests[0].last().is_some_and(|message| message
+            .content
+            .as_text()
+            .contains("Create a detailed summary of the conversation so far")));
+    }
+
     struct WarnCounter(std::sync::atomic::AtomicUsize);
     impl Output for WarnCounter {
         fn context_warning(&self, _ctx_tokens: usize, _max_context: usize) {
@@ -804,6 +1059,17 @@ mod tests {
         assert!(!ctx.needs_auto_compact());
         ctx.prepare_for_api(&counter);
         assert_eq!(counter.0.load(std::sync::atomic::Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn request_estimate_includes_ephemeral_user_injections() {
+        let mut ctx = ContextManager::new(10_000);
+        ctx.append_user("durable");
+        let durable = ctx.total_tokens();
+        ctx.inject_user("r".repeat(40_000));
+
+        assert!(ctx.request_tokens() > durable + 9_000);
+        assert!(ctx.needs_auto_compact());
     }
 
     // An image attached under a vision model stays in history; sending it to a

--- a/crates/wisp-core/src/lib.rs
+++ b/crates/wisp-core/src/lib.rs
@@ -205,7 +205,12 @@ impl Agent {
             .join(".wisp")
             .join("history")
             .join(format!("session-{}.json", chrono::Utc::now().timestamp()));
-        let (before, after) = self.ctx.compact(self.provider.as_ref(), &archive).await?;
+        let schemas = self.tools.schemas();
+        let fixed_tokens = ContextManager::estimated_tool_tokens(&schemas);
+        let (before, after) = self
+            .ctx
+            .compact_with_reserve(self.provider.as_ref(), &archive, fixed_tokens)
+            .await?;
         Ok((before, after, archive))
     }
 

--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -88,14 +88,21 @@ turns while preserving an archive of the full history.
 **Settings → General → Automatically compact long conversations** is enabled by
 default. Following mangopi-cli's model-boundary approach, Wisp checks the
 estimated context before every native-agent model call, including later calls
-after large tool results. At 80% it archives the complete pre-compact history,
-folds older turns while protecting recent turns, and uses an LLM summary only
-if the deterministic folds are still too large. Each automatic or manual
-rewrite leaves a persistent **Context automatically compacted** / **Context
-compacted** flag in the conversation with the before and after token estimates.
-Turning the setting off keeps the warning, manual `/compact`, and overflow
-recovery dialog available. ACP agents are not modified because their remote
-transcripts are owned by the ACP process.
+after large tool results and ephemeral host/reviewer injections. At 80% it
+archives the complete pre-compact history and targets 60%, leaving headroom so
+the next ordinary result does not immediately trigger another rewrite. Older
+turns are folded first; oversized recent tool payloads become bounded excerpts
+that point to the archive; an LLM summary is the last resort. The internal
+summary instruction is never added to the conversation, and a failed
+compaction stops before Wisp can send the known-oversized main request. Tool
+results are also capped to a 16 KiB head/tail excerpt when they enter model
+context (the full result is still shown in the tool event), preventing one
+read, grep, browser, or MCP response from consuming the whole window. Each
+automatic or manual rewrite leaves a persistent **Context automatically
+compacted** / **Context compacted** flag in the conversation with the before
+and after request-token estimates. Turning the setting off keeps the warning,
+manual `/compact`, and overflow recovery dialog available. ACP agents are not
+modified because their remote transcripts are owned by the ACP process.
 
 When the provider explicitly rejects a built-in Wisp-agent request for
 exceeding its context window, the conversation opens a recovery dialog instead

--- a/src-tauri/src/debug_request.rs
+++ b/src-tauri/src/debug_request.rs
@@ -123,10 +123,7 @@ fn build_snapshot(
     let tool_schemas: Vec<DebugToolSchema> = tools
         .iter()
         .map(|t| {
-            let params = t.function.parameters.to_string();
-            // ponytail: 4-chars-per-token heuristic, same ballpark as the
-            // message estimator; exact tool tokenization isn't worth it here.
-            let est = (t.function.name.len() + t.function.description.len() + params.len()) / 4 + 2;
+            let est = ContextManager::estimated_tool_schema_tokens(t);
             total += est;
             DebugToolSchema {
                 name: t.function.name.clone(),

--- a/src-tauri/src/seed.rs
+++ b/src-tauri/src/seed.rs
@@ -12,8 +12,8 @@ use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
 use tauri::State;
 
-use crate::AppState;
 use crate::resource_refs;
+use crate::AppState;
 
 /// Bundled demo manifests (`seed/`).
 pub fn bundled_dir() -> Option<PathBuf> {
@@ -237,7 +237,11 @@ mod tests {
     #[test]
     fn lists_and_loads_bundled_demos() {
         let demos = list_demos();
-        assert_eq!(demos.len(), 5, "bundled seed should ship the five ESR1 demos");
+        assert_eq!(
+            demos.len(),
+            5,
+            "bundled seed should ship the five ESR1 demos"
+        );
         assert_eq!(
             demos.iter().map(|d| d.id.as_str()).collect::<Vec<_>>(),
             [
@@ -253,7 +257,11 @@ mod tests {
             assert!(!demo.request.is_empty());
             assert!(!demo.request.contains("English reply"));
             assert!(!demo.request.to_ascii_lowercase().contains("guotosky"));
-            assert!(!demo.items.is_empty(), "{} should ship transcript items", info.id);
+            assert!(
+                !demo.items.is_empty(),
+                "{} should ship transcript items",
+                info.id
+            );
             assert!(
                 demo.items.iter().any(|i| i.role == "tool"),
                 "{} should include tool operation records",


### PR DESCRIPTION
## Problem

Automatic context compaction could oscillate between barely crossing the 80% threshold and collapsing to a tiny summary, while tool-heavy sessions repeatedly re-expanded past the model window.

The supplied debug captures showed a 426.9k-token live request dominated by large `read` results, plus an 869k-character `grep` result reading a compaction archive.

## Root cause

- `full_compact` appended its internal summary instruction as a durable user message. When the summary request failed, the main loop retained and executed that internal instruction.
- The model then read the newly written `.wisp/history` archive back into the main context, creating a compaction/read/recompaction feedback loop.
- Recent turns were protected even when one recent tool result exceeded the useful context budget.
- Compaction stopped immediately below the 80% trigger, leaving no hysteresis.
- Request estimates omitted ephemeral host/reviewer injections and tool schemas, so debug exports, UI estimates, and compaction decisions could disagree.
- Only shell/Python/R results were context-bounded; read, grep, browser, and MCP results could each consume most or all of a model window.

## Changes

- Budget every textual tool result to a 16 KiB head/tail excerpt before it enters model context; keep the full result in the tool event.
- Trigger automatic compaction at 80% and target 60% to preserve headroom.
- Archive and bound oversized tool results even in the newest protected turn.
- Keep the internal summary instruction request-local instead of appending it to conversation history.
- Make compaction transactional: restore the original context on summary failure.
- Stop before the main model call when automatic compaction fails.
- Include runtime injections and tool-schema estimates in request accounting and reuse the same schema estimator in debug exports.
- Document the updated behavior.
- Keep pre-existing Rust formatting drift in `src-tauri/src/seed.rs` as a separate formatting-only commit.

## Tests

Added regression coverage for:

- oversized tool results in the newest turn;
- 60% compaction headroom;
- failed-summary rollback and internal-prompt isolation;
- preventing a main stream request after failed compaction;
- all textual tools using the ingestion budget;
- ephemeral user injections participating in request estimates.

Validation performed:

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cd ui && cargo check --target wasm32-unknown-unknown`
- `cd ui-tests && npm ci && npx playwright test`

The Playwright run completed with 260 passed, 1 skipped, and 1 unrelated failure. The failing existing example-project assertion expects `Re-run pipeline with fixed STAR index`, while the mocked page renders the run-monitor card as `Monitoring run`; it fails again when run alone. Context-compaction UI tests pass.

## Manual smoke steps

1. Enable automatic context compaction and use a model profile with a known context window.
2. Produce a tool result larger than 16 KiB through read/grep/R/browser/MCP.
3. Confirm the user-visible tool event keeps the complete output while the next model request contains a bounded excerpt.
4. Grow the request past 80% and confirm the compaction marker reports a result near or below the 60% target.
5. Force the summary provider to reject the compaction request and confirm no internal summary prompt appears in the conversation and no oversized main request is sent.

## Known limitations

- The model must re-run a tool with narrower ranges or filters to recover details omitted from a 16 KiB context excerpt.
- Runtime injections that independently exceed the model window fail closed; this change does not introduce a separate persistence/archive mechanism for those ephemeral payloads.
