### PR TITLE
Purge stale seed resources on build

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,34 @@
+//! Build script: purge stale bundled seed copies before Tauri re-copies resources.
+//!
+//! Tauri's map-form `resources` merge into `target/{profile}/seed` and never
+//! delete removed files, so renamed demos (and old CRISPR/enzyme seeds) linger
+//! beside the binary and show up as extra Example-project sessions.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
 fn main() {
-    tauri_build::build()
+    purge_stale_seed_dirs();
+    tauri_build::build();
+}
+
+fn purge_stale_seed_dirs() {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let target = manifest_dir.join("..").join("target");
+    if !target.is_dir() {
+        return;
+    }
+    for profile in ["debug", "release"] {
+        for rel in ["seed", "_up_/seed"] {
+            let dir = target.join(profile).join(rel);
+            remove_dir_if_present(&dir);
+        }
+    }
+    println!("cargo:rerun-if-changed=../seed");
+}
+
+fn remove_dir_if_present(dir: &Path) {
+    if dir.is_dir() {
+        let _ = fs::remove_dir_all(dir);
+    }
 }


### PR DESCRIPTION
## Summary
- Delete `target/{debug,release}/seed` (and legacy `_up_/seed`) in `src-tauri/build.rs` before Tauri re-copies bundled resources.
- Prevents removed/renamed demos (e.g. old `manifest_esr1_rnaseq.json` with proxy wording, CRISPR/enzyme seeds) from lingering beside the binary and showing up as extra Example-project sessions.

## Test plan
- [ ] Confirm repo `seed/` has exactly 5 `manifest_esr1_0*.json` files
- [ ] `cargo build --manifest-path src-tauri/Cargo.toml`
- [ ] `target/debug/seed` (if present) contains only the 5 current manifests
- [ ] Open Example project and confirm exactly 5 demos, no proxy `Connect to the server...` entry
