### PR TITLE
Keep the expanded thinking block open while reasoning streams

### DIFF
--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -3649,6 +3649,24 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
                 }, 3_100);
               });
             }
+            if (String(arg("message") ?? "").includes("RZSTREAM")) {
+              // Staggered reasoning deltas keep rebuilding the fingerprint-keyed
+              // chat row; the expanded thinking block must not snap shut.
+              return await new Promise<string>((resolve) => {
+                setTimeout(() => {
+                  emit("agent", { kind: "User", frame_id: fid, text: msg });
+                  emit("agent", { kind: "Reasoning", frame_id: fid, delta: "First thought." });
+                }, 30);
+                setTimeout(() => {
+                  emit("agent", { kind: "Reasoning", frame_id: fid, delta: " More reasoning arrives." });
+                }, 1_200);
+                setTimeout(() => {
+                  emit("agent", { kind: "Text", frame_id: fid, delta: "Stream done." });
+                  emit("agent", { kind: "Done", frame_id: fid });
+                  resolve(fid);
+                }, 1_500);
+              });
+            }
             if (String(arg("message") ?? "").includes("RNOTEBOOK")) {
               setTimeout(() => {
                 emit("agent", { kind: "User", frame_id: fid, text: msg });

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -3652,6 +3652,23 @@ test("monitor_run renders a live Run card inline without get_run polling", async
   await expect(card).toContainText("Cancelled");
 });
 
+test("reasoning details stays open while more thinking streams in", async ({ page }) => {
+  await enterApp(page);
+  await composer(page).fill("RZSTREAM");
+  await page.getByRole("button", { name: "Send" }).click();
+
+  const rz = page.locator("details.rz");
+  await expect(rz).toBeVisible();
+  await rz.locator("summary").click();
+  await expect(rz).toHaveAttribute("open", "open");
+
+  // The next streaming delta rebuilds the fingerprint-keyed row; the open
+  // state must survive the rebuild.
+  await expect(rz).toContainText("More reasoning arrives.");
+  await expect(rz).toHaveAttribute("open", "open");
+  await expect(rz).toContainText("First thought.");
+});
+
 test("active session Runs appear automatically with elapsed time and heartbeat (#593)", async ({ page }) => {
   await page.goto("/");
   await page.evaluate(() => {

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -9258,6 +9258,7 @@ fn App() -> impl IntoView {
                                                 i, &item, timestamp, &arts, on_artifact_select, on_file_link,
                                                 run_records, busy.read_only(), compact_assistant, active_acp_agent_id.get().is_none(), can_undo, edit_message, branch_message, undo_message, session_id,
                                                 respond_confirm, on_resume, on_queue,
+                                                step_disclosure_state,
                                                 plan_mode_active, plan_compat, on_plan_decision,
                                                 on_question_answer, jump_to_review_message,
                                             )}
@@ -13743,6 +13744,7 @@ fn render_item(
     on_approval: Callback<(String, bool, Option<String>, String)>,
     on_resume: Callback<usize>,
     on_queue: Callback<QueueOp>,
+    disclosure_state: RwSignal<HashMap<String, bool>>,
     plan_mode_active: Signal<bool>,
     plan_compat: Signal<bool>,
     on_plan_decision: Callback<PlanDecision>,
@@ -13839,9 +13841,19 @@ fn render_item(
             />
         }.into_view(),
         ChatItem::Reasoning(s) => {
+            // The chat row is fingerprint-keyed, so every streaming delta
+            // rebuilds it and a plain `<details>` would snap shut mid-stream.
+            // Keep the open state in the shared disclosure map, like the step
+            // group does, and drive `open` from it.
+            let open_id = format!("{session_id}:reasoning:{ui_index}");
+            let toggle_id = open_id.clone();
             view! {
-                <details class="rz">
-                    <summary>{move || t(locale.get(), "chat.thinking")}</summary>
+                <details class="rz"
+                    open=move || disclosure_open(disclosure_state, &open_id, false)>
+                    <summary on:click=move |event| {
+                        event.prevent_default();
+                        toggle_disclosure(disclosure_state, &toggle_id, false);
+                    }>{move || t(locale.get(), "chat.thinking")}</summary>
                     <div class="body">{s.clone()}</div>
                 </details>
             }.into_view()


### PR DESCRIPTION
## Problem

While the model is thinking, the standalone "思考中 / Thinking" block could not be read: clicking it open was immediately undone, because every streaming delta rebuilt the row and the plain `<details>` reset to closed.

## Root cause

The chat transcript's `<For>` keys rows by a content fingerprint. Each reasoning delta changes the fingerprint, so the row (and its `<details class="rz">`) is destroyed and recreated mid-stream, losing the UA-held open state.

## Changes

- `ui/src/main.rs`: `render_item` now takes the shared `step_disclosure_state` map. The `ChatItem::Reasoning` arm drives `open` from that map (key `{session_id}:reasoning:{ui_index}`, stable across deltas) and toggles it from the summary click with `prevent_default`, matching the existing step-group disclosure pattern. Markup and `.rz` styling are unchanged.
- `ui-tests/tests/mock-tauri.ts`: new `RZSTREAM` scenario emitting reasoning in two staggered deltas.
- `ui-tests/tests/ui.spec.ts`: new test asserting the expanded block stays open when the next delta rebuilds the row.

## Tests

- `cargo fmt --all -- --check` — pass
- `cargo test --workspace` — pass
- `cargo check -p wisp-ui --target wasm32-unknown-unknown` — pass
- New Playwright test `reasoning details stays open while more thinking streams in` — pass
- Regression on adjacent cases (`monitor_run` live card, both completed-activity fold tests) — pass

## Manual smoke

1. Send a prompt that produces streamed thinking.
2. While tokens are still arriving, click "思考中" to expand it.
3. The block stays open and keeps appending text; clicking again collapses it.

## Known limitations / follow-ups

- None. The run-monitor environment `<details>` already used this signal-driven pattern and is unaffected.