### PR TITLE
Harden detached local/WSL run payloads after review of #641

### DIFF
--- a/src-tauri/src/run_context.rs
+++ b/src-tauri/src/run_context.rs
@@ -594,6 +594,7 @@ const REMOTE_START_LEASE_SECS: i64 = 360;
 const ACTIVE_LEASE_SECS: i64 = 30;
 const RECONCILE_INTERVAL: Duration = Duration::from_secs(5);
 const SSH_RETRY_STOPPED_MARKER: &str = "SSH automatic retry stopped";
+const LOCAL_RETRY_STOPPED_MARKER: &str = "Automatic Run retry stopped";
 
 impl RunManager {
     pub async fn has_in_flight_project(
@@ -2122,12 +2123,11 @@ fn local_detached_handle_for(
             return Err("local detached handle requires a local or WSL context".into());
         }
     };
-    let command_cwd = match ctx.kind {
-        wisp_store::ExecutionContextKind::Local => cwd
-            .map(|path| path.to_string_lossy().into_owned())
-            .filter(|path| !path.is_empty()),
-        _ => None,
-    };
+    // Local commands run in the project root directly; WSL stores the Windows
+    // project root and translates it through wslpath inside the distro.
+    let command_cwd = cwd
+        .map(|path| path.to_string_lossy().into_owned())
+        .filter(|path| !path.is_empty());
     Ok(RemoteRunHandle::LocalDetached {
         transport,
         workdir: format!(".wisp-science/runs/{run_id}"),
@@ -2197,16 +2197,19 @@ async fn finish_remote_run(
 }
 
 fn retry_stopped_error(handle: &RemoteRunHandle, error: &str) -> String {
-    if error.contains(SSH_RETRY_STOPPED_MARKER) {
+    let marker = if handle.is_local_detached() {
+        LOCAL_RETRY_STOPPED_MARKER
+    } else {
+        SSH_RETRY_STOPPED_MARKER
+    };
+    if error.contains(marker) {
         return error.to_string();
     }
     if handle.is_local_detached() {
-        format!(
-            "{SSH_RETRY_STOPPED_MARKER} after the first failed start attempt. Manual retry is required. {error}"
-        )
+        format!("{marker} after the first failed start attempt. Manual retry is required. {error}")
     } else {
         format!(
-            "{SSH_RETRY_STOPPED_MARKER} after the first failed attempt to protect the server. Manual retry is required. {error}"
+            "{marker} after the first failed attempt to protect the server. Manual retry is required. {error}"
         )
     }
 }

--- a/src-tauri/src/run_context/local_detached.rs
+++ b/src-tauri/src/run_context/local_detached.rs
@@ -22,6 +22,9 @@ pub(super) fn transport_script_command(
                 stdin: Some(payload),
                 envs: Vec::new(),
             }),
+            // `-Command -` parses stdin line-by-line like an interactive
+            // session in Windows PowerShell 5.1; read the whole payload and
+            // execute it as one script instead.
             LocalTransport::Windows { context_id } => Ok(RunCommand {
                 context_id: context_id.clone(),
                 program: "powershell".into(),
@@ -29,7 +32,7 @@ pub(super) fn transport_script_command(
                     "-NoProfile".into(),
                     "-NonInteractive".into(),
                     "-Command".into(),
-                    "-".into(),
+                    "[Console]::In.ReadToEnd() | Invoke-Expression".into(),
                 ],
                 script: label.into(),
                 cwd: None,
@@ -68,6 +71,7 @@ fn b64(value: &str) -> String {
 
 pub(super) fn posix_prepare_payload(remote: &RemoteRun) -> String {
     let RemoteRunHandle::LocalDetached {
+        transport,
         workdir,
         token,
         command_cwd,
@@ -76,8 +80,18 @@ pub(super) fn posix_prepare_payload(remote: &RemoteRun) -> String {
     else {
         unreachable!("posix prepare requires LocalDetached");
     };
+    let is_wsl = matches!(
+        transport,
+        LocalTransport::Posix { context_id, .. } if context_id.starts_with("wsl:")
+    );
     let delimiter = command_delimiter(token, &remote.command);
     let cd_line = match command_cwd.as_deref().filter(|cwd| !cwd.is_empty()) {
+        // WSL stores the Windows project root; translate it inside the distro
+        // so project-relative commands and output harvest keep working.
+        Some(cwd) if is_wsl => format!(
+            "if command -v wslpath >/dev/null 2>&1; then\n  cd \"$(wslpath {})\" || exit 125\nfi\n",
+            shell_single_quote(cwd)
+        ),
         Some(cwd) => format!("cd {} || exit 125\n", shell_single_quote(cwd)),
         None => String::new(),
     };
@@ -127,6 +141,10 @@ stop_tree() {{
   kill "-$signal" "-$pid" 2>/dev/null || true
   kill "-$signal" "$pid" 2>/dev/null || true
 }}
+if [ -f _submitted ]; then
+  # A supervisor already ran for this workdir; never launch the command twice.
+  exit 0
+fi
 if ! command -v bash >/dev/null 2>&1; then
   write_state _status 'lost:local detached Run requires bash'
   exit 69
@@ -136,12 +154,13 @@ if ! command -v nohup >/dev/null 2>&1; then
   exit 69
 fi
 rm -f _command_exit _cancel_requested
-# Prefer setsid so the command owns an independent process group. macOS and
-# other hosts without setsid fall back to PID tracking; kill tries both the
-# process and its process group.
+# Prefer setsid so the command owns an independent process group. macOS lacks
+# setsid; enable job control there so the background job still gets its own
+# process group and group kill reaches the whole command tree.
 if command -v setsid >/dev/null 2>&1; then
   setsid sh -c 'bash -l "$1"; rc=$?; tmp="$2.tmp.$$"; printf "%s\n" "$rc" > "$tmp" && mv "$tmp" "$2"; exit "$rc"' sh "$PWD/command.sh" "$PWD/_command_exit" >stdout.log 2>stderr.log &
 else
+  set -m 2>/dev/null || true
   (
     bash -l "$PWD/command.sh"
     rc=$?
@@ -149,6 +168,7 @@ else
     printf '%s\n' "$rc" > "$tmp" && mv "$tmp" "$PWD/_command_exit"
     exit "$rc"
   ) >stdout.log 2>stderr.log &
+  set +m 2>/dev/null || true
 fi
 pgid=$!
 i=0
@@ -249,7 +269,13 @@ if [ ! -f "$workdir/_submitted" ] && mkdir "$lock" 2>/dev/null; then
   printf '%s:%s\n' "$$" "$lock_start" > "$lock/owner"
   command -v nohup >/dev/null 2>&1 || {{ echo 'local detached Runs require nohup' >&2; exit 69; }}
   command -v bash >/dev/null 2>&1 || {{ echo 'local detached Runs require bash' >&2; exit 69; }}
-  nohup sh "$workdir/supervisor.sh" </dev/null >/dev/null 2>&1 &
+  # Detach the supervisor into its own session when possible so signals sent
+  # to the app's process group cannot kill it while the command keeps running.
+  if command -v setsid >/dev/null 2>&1; then
+    nohup setsid sh "$workdir/supervisor.sh" </dev/null >/dev/null 2>&1 &
+  else
+    nohup sh "$workdir/supervisor.sh" </dev/null >/dev/null 2>&1 &
+  fi
 fi
 if [ ! -f "$workdir/_submitted" ]; then
   i=0
@@ -451,6 +477,9 @@ function Write-State([string]$Path, [string]$Value) {{
   Set-Content -LiteralPath $tmp -Value $Value -Encoding ascii
   Move-Item -LiteralPath $tmp -Destination $Path -Force
 }}
+if (Test-Path -LiteralPath (Join-Path $workdir '_submitted')) {{
+  exit 0
+}}
 Remove-Item -LiteralPath (Join-Path $workdir '_command_exit') -ErrorAction SilentlyContinue
 Remove-Item -LiteralPath (Join-Path $workdir '_cancel_requested') -ErrorAction SilentlyContinue
 $stdout = Join-Path $workdir 'stdout.log'
@@ -475,7 +504,10 @@ $identity = $null
 for ($i = 0; $i -lt 5; $i++) {{
   try {{
     $cim = Get-CimInstance Win32_Process -Filter ("ProcessId=" + $proc.Id)
-    if ($cim -and $cim.CreationDate) {{ $identity = [string]$cim.CreationDate; break }}
+    if ($cim -and $cim.CreationDate) {{
+      $identity = $cim.CreationDate.ToString('o')
+      break
+    }}
   }} catch {{ }}
   Start-Sleep -Seconds 1
 }}
@@ -582,12 +614,29 @@ if (-not (Test-Path -LiteralPath $tokenPath) -or ((Get-Content -LiteralPath $tok
 }}
 $submitted = Join-Path $workdir '_submitted'
 $lock = Join-Path $workdir '_launch_lock'
+$ownerPath = Join-Path $lock 'owner'
 if ((Test-Path -LiteralPath $lock) -and -not (Test-Path -LiteralPath $submitted)) {{
-  Remove-Item -LiteralPath $lock -Recurse -Force -ErrorAction SilentlyContinue
+  # Only clear the lock when its recorded owner process is gone; a live owner
+  # is still mid-launch and must not be raced.
+  $ownerAlive = $false
+  try {{
+    $ownerId = [int]((Get-Content -LiteralPath $ownerPath -Raw -ErrorAction Stop).Trim())
+    if ($ownerId -gt 0 -and (Get-Process -Id $ownerId -ErrorAction SilentlyContinue)) {{
+      $ownerAlive = $true
+    }}
+  }} catch {{ }}
+  if (-not $ownerAlive) {{
+    Remove-Item -LiteralPath $lock -Recurse -Force -ErrorAction SilentlyContinue
+  }}
 }}
 if (-not (Test-Path -LiteralPath $submitted)) {{
-  New-Item -ItemType Directory -Path $lock -ErrorAction SilentlyContinue | Out-Null
-  if (Test-Path -LiteralPath $lock) {{
+  $acquired = $false
+  try {{
+    New-Item -ItemType Directory -Path $lock -ErrorAction Stop | Out-Null
+    $acquired = $true
+  }} catch {{ }}
+  if ($acquired) {{
+    Set-Content -LiteralPath $ownerPath -Value ([string]$PID) -Encoding ascii
     $supervisor = Join-Path $workdir 'supervisor.ps1'
     Start-Process -FilePath 'powershell' -ArgumentList @('-NoProfile','-NonInteractive','-File', $supervisor) -WindowStyle Hidden | Out-Null
   }}
@@ -628,8 +677,8 @@ $state = 'lost:control directory missing'
 function Same-Identity {{
   try {{
     $cim = Get-CimInstance Win32_Process -Filter 'ProcessId={pgid}'
-    if (-not $cim) {{ return $false }}
-    return ([string]$cim.CreationDate) -eq {identity_q}
+    if (-not $cim -or -not $cim.CreationDate) {{ return $false }}
+    return $cim.CreationDate.ToString('o') -eq {identity_q}
   }} catch {{ return $false }}
 }}
 function Read-Status {{
@@ -641,6 +690,24 @@ function Read-Status {{
   if ($status -eq 'cancelled') {{ $script:state = 'cancelled'; return $true }}
   if ($status -like 'lost:*') {{ $script:state = $status; return $true }}
   return $false
+}}
+function Read-Tail([string]$Path) {{
+  # The command still holds the log open for writing, so share read+write and
+  # only pull the last 4000 bytes instead of loading the whole file.
+  if (-not (Test-Path -LiteralPath $Path)) {{ return '' }}
+  try {{
+    $fs = [System.IO.File]::Open($Path, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite)
+    try {{
+      $take = [int][Math]::Min($fs.Length, 4000)
+      if ($take -le 0) {{ return '' }}
+      $fs.Seek(-$take, [System.IO.SeekOrigin]::End) | Out-Null
+      $buffer = New-Object byte[] $take
+      $read = $fs.Read($buffer, 0, $take)
+      return [System.Text.Encoding]::UTF8.GetString($buffer, 0, $read)
+    }} finally {{
+      $fs.Dispose()
+    }}
+  }} catch {{ return '' }}
 }}
 $tokenPath = Join-Path $workdir 'token'
 if ((Test-Path -LiteralPath $tokenPath) -and ((Get-Content -LiteralPath $tokenPath -Raw).Trim() -eq '{token}')) {{
@@ -660,20 +727,10 @@ if ((Test-Path -LiteralPath $tokenPath) -and ((Get-Content -LiteralPath $tokenPa
 }}
 Write-Output ('__WISP_RUN_STATUS__:' + $state)
 Write-Output '__WISP_STDOUT__'
-$stdout = Join-Path $workdir 'stdout.log'
-if (Test-Path -LiteralPath $stdout) {{
-  $bytes = [System.IO.File]::ReadAllBytes($stdout)
-  if ($bytes.Length -gt 4000) {{ $bytes = $bytes[($bytes.Length-4000)..($bytes.Length-1)] }}
-  [Console]::Out.Write([System.Text.Encoding]::UTF8.GetString($bytes))
-}}
+[Console]::Out.Write((Read-Tail (Join-Path $workdir 'stdout.log')))
 Write-Output ''
 Write-Output '__WISP_STDERR__'
-$stderr = Join-Path $workdir 'stderr.log'
-if (Test-Path -LiteralPath $stderr) {{
-  $bytes = [System.IO.File]::ReadAllBytes($stderr)
-  if ($bytes.Length -gt 4000) {{ $bytes = $bytes[($bytes.Length-4000)..($bytes.Length-1)] }}
-  [Console]::Out.Write([System.Text.Encoding]::UTF8.GetString($bytes))
-}}
+[Console]::Out.Write((Read-Tail (Join-Path $workdir 'stderr.log')))
 "#,
     ))
 }
@@ -701,8 +758,8 @@ $workdir = Join-Path $env:USERPROFILE '{workdir_win}'
 function Same-Identity {{
   try {{
     $cim = Get-CimInstance Win32_Process -Filter 'ProcessId={pgid}'
-    if (-not $cim) {{ return $false }}
-    return ([string]$cim.CreationDate) -eq {identity_q}
+    if (-not $cim -or -not $cim.CreationDate) {{ return $false }}
+    return $cim.CreationDate.ToString('o') -eq {identity_q}
   }} catch {{ return $false }}
 }}
 function Terminal-Status {{

--- a/src-tauri/src/run_context/tests.rs
+++ b/src-tauri/src/run_context/tests.rs
@@ -1200,7 +1200,18 @@ fn remote_control_payloads_are_valid_posix_shell() {
         input_refs: Vec::new(),
         output_specs: Vec::new(),
         harvest_root: None,
-        handle: test_local_handle("local-payload", true, None),
+        handle: test_local_handle("local-payload", true, Some("/home/user/project")),
+    };
+    let wsl = RemoteRun {
+        run_id: "wsl-payload".into(),
+        project_id: "p".into(),
+        frame_id: None,
+        command: "printf '%s\\n' ok".into(),
+        timeout: Duration::from_secs(60),
+        input_refs: Vec::new(),
+        output_specs: Vec::new(),
+        harvest_root: None,
+        handle: test_wsl_handle("wsl-payload", true, Some(r"C:\Users\me\project")),
     };
     let scripts = [
         prepare_payload(&remote),
@@ -1211,6 +1222,10 @@ fn remote_control_payloads_are_valid_posix_shell() {
         launch_payload(&local.handle),
         poll_payload(&local.handle).unwrap(),
         cancel_payload(&local.handle).unwrap(),
+        prepare_payload(&wsl),
+        launch_payload(&wsl.handle),
+        poll_payload(&wsl.handle).unwrap(),
+        cancel_payload(&wsl.handle).unwrap(),
     ];
     for script in scripts {
         let mut child = std::process::Command::new("sh")
@@ -1226,8 +1241,18 @@ fn remote_control_payloads_are_valid_posix_shell() {
             .unwrap();
         assert!(child.wait().unwrap().success(), "invalid shell payload");
     }
-    assert!(prepare_payload(&local).contains("sleep 60"));
-    assert!(!prepare_payload(&local).contains("setsid timeout"));
+    let local_prepare = prepare_payload(&local);
+    assert!(local_prepare.contains("sleep 60"));
+    assert!(!local_prepare.contains("setsid timeout"));
+    // A relaunched supervisor must never rerun the command.
+    assert!(local_prepare.contains("if [ -f _submitted ]; then"));
+    // The local project root is entered directly; WSL goes through wslpath.
+    assert!(local_prepare.contains("cd '/home/user/project' || exit 125"));
+    assert!(!local_prepare.contains("wslpath"));
+    let wsl_prepare = prepare_payload(&wsl);
+    assert!(wsl_prepare.contains(r#"cd "$(wslpath 'C:\Users\me\project')" || exit 125"#));
+    // Signals to the app's process group must not reach a detached supervisor.
+    assert!(launch_payload(&local.handle).contains("nohup setsid sh"));
 }
 
 #[test]
@@ -1583,6 +1608,28 @@ fn test_local_handle(run_id: &str, confirmed: bool, command_cwd: Option<&str>) -
     }
 }
 
+fn test_wsl_handle(run_id: &str, confirmed: bool, command_cwd: Option<&str>) -> RemoteRunHandle {
+    RemoteRunHandle::LocalDetached {
+        transport: LocalTransport::Posix {
+            context_id: "wsl:Ubuntu".into(),
+            program: "wsl.exe".into(),
+            args: vec![
+                "-d".into(),
+                "Ubuntu".into(),
+                "--".into(),
+                "sh".into(),
+                "-s".into(),
+            ],
+        },
+        workdir: format!(".wisp-science/runs/{run_id}"),
+        token: "test-token".into(),
+        inputs_staged: true,
+        pgid: confirmed.then_some(4242),
+        start_identity: confirmed.then(|| "999".into()),
+        command_cwd: command_cwd.map(str::to_string),
+    }
+}
+
 #[test]
 fn permanent_remote_start_errors_require_user_intervention() {
     for error in [
@@ -1873,17 +1920,89 @@ fn windows_control_payloads_contain_process_identity_and_timeout() {
             command_cwd: Some(r"C:\project".into()),
         },
     };
+    use base64::Engine as _;
     let prepare = prepare_payload(&remote);
     assert!(prepare.contains("FromBase64String"));
     assert!(prepare.contains("__WISP_PREPARED__"));
+    let supervisor = String::from_utf8(
+        base64::engine::general_purpose::STANDARD
+            .decode(
+                prepare
+                    .lines()
+                    .find(|line| line.starts_with("[System.IO.File]::WriteAllText($supervisorPath"))
+                    .and_then(|line| line.split("FromBase64String('").nth(1))
+                    .and_then(|rest| rest.split('\'').next())
+                    .expect("supervisor base64 in prepare payload"),
+            )
+            .expect("valid supervisor base64"),
+    )
+    .expect("utf8 supervisor script");
+    // The supervisor must be idempotent and use a culture-stable identity.
+    assert!(supervisor.contains("if (Test-Path -LiteralPath (Join-Path $workdir '_submitted'))"));
+    assert!(supervisor.contains(".ToString('o')"));
     let launch = launch_payload(&remote.handle);
     assert!(launch.contains("Start-Process"));
+    // Only the launcher that created the lock may start the supervisor, and a
+    // live lock owner must not be raced.
+    assert!(launch.contains("if ($acquired)"));
+    assert!(launch.contains("Get-Process -Id $ownerId"));
     let poll = poll_payload(&remote.handle).unwrap();
     assert!(poll.contains("Win32_Process"));
     assert!(poll.contains("__WISP_RUN_STATUS__"));
+    assert!(poll.contains(".ToString('o')"));
+    // Log tails must share the writer's handle and stay bounded.
+    assert!(poll.contains("[System.IO.FileShare]::ReadWrite"));
+    assert!(!poll.contains("ReadAllBytes"));
     let cancel = cancel_payload(&remote.handle).unwrap();
     assert!(cancel.contains("taskkill.exe"));
     assert!(cancel.contains("__WISP_CANCEL__"));
+    assert!(cancel.contains(".ToString('o')"));
+}
+
+#[test]
+fn windows_transport_executes_stdin_as_one_script() {
+    let handle = RemoteRunHandle::LocalDetached {
+        transport: LocalTransport::Windows {
+            context_id: "local".into(),
+        },
+        workdir: ".wisp-science/runs/win".into(),
+        token: "test-token".into(),
+        inputs_staged: true,
+        pgid: None,
+        start_identity: None,
+        command_cwd: None,
+    };
+    let command =
+        local_detached::transport_script_command(&handle, "prepare local Run", "exit 0".into())
+            .unwrap();
+    assert_eq!(command.program, "powershell");
+    // `-Command -` parses stdin line-by-line like an interactive session on
+    // Windows PowerShell 5.1, so the payload is executed as a single script.
+    assert!(!command.args.contains(&"-".to_string()));
+    assert!(command
+        .args
+        .contains(&"[Console]::In.ReadToEnd() | Invoke-Expression".to_string()));
+    assert_eq!(command.stdin.as_deref(), Some("exit 0"));
+}
+
+#[test]
+fn handle_ack_preserves_identities_containing_colons_and_spaces() {
+    let handle = test_local_handle("mac", false, None);
+    let confirmed = remote::handle_from_ack(
+        &handle,
+        "__WISP_HANDLE__:test-token:4242:Mon Aug  3 10:55:00 2026\n",
+    )
+    .unwrap();
+    let RemoteRunHandle::LocalDetached {
+        pgid,
+        start_identity,
+        ..
+    } = confirmed
+    else {
+        panic!("expected LocalDetached");
+    };
+    assert_eq!(pgid, Some(4242));
+    assert_eq!(start_identity.as_deref(), Some("Mon Aug  3 10:55:00 2026"));
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Post-merge review of [#641](https://github.com/xuzhougeng/wisp-science/pull/641) found several functional defects in the detached local/WSL control plane, mostly on the Windows and macOS branches:

1. **Windows polling broke while a command was running.** Log tails used `[System.IO.File]::ReadAllBytes`, which cannot open a file the redirected child still holds open for writing (share-mode conflict), so every poll errored until the process exited; it also loaded entire logs into memory.
2. **Windows launch had a double-execution race.** The launcher unconditionally deleted a possibly-live launch lock, and the loser of the `New-Item` race still saw `Test-Path $lock` succeed and started a second supervisor, which would rerun the user command.
3. **Windows transport used `powershell -Command -`,** which Windows PowerShell 5.1 parses line-by-line like an interactive session, making multi-line payload execution unreliable.
4. **Windows process identity used `[string]$cim.CreationDate`,** a culture-dependent conversion.
5. **macOS (no `setsid`) kill leak.** Timeout/cancel only killed the tracked subshell PID; the `bash -l command.sh` tree survived because the job had no dedicated process group.
6. **Supervisors were not idempotent** — a duplicate launch would rerun the command.
7. **POSIX supervisors were not `setsid`'d themselves,** so a signal to the app's process group (e.g. terminal Ctrl+C) could kill the supervisor while the command kept running, orphaning the Run into `lost`.
8. **WSL commands ran in the distro-side control workdir,** so project-relative paths and output harvest silently stopped matching the project.
9. Local run failure messages carried an SSH-specific "SSH automatic retry stopped" prefix.

## Solution

- **Windows poll**: `Read-Tail` opens logs via `FileStream` with `FileShare::ReadWrite` and seeks to the last 4000 bytes.
- **Windows launch**: the lock directory records an owner PID; only a dead owner's lock is cleared, and only the launcher that actually created the lock (`New-Item` success) starts the supervisor.
- **Windows transport**: payloads run as one script via `-Command "[Console]::In.ReadToEnd() | Invoke-Expression"`.
- **Windows identity**: `CreationDate.ToString('o')` on both the writer and the comparers.
- **POSIX supervisor**: exits early when `_submitted` exists; the no-`setsid` branch enables job control (`set -m`) so the background job owns a process group and group kill reaches the whole tree.
- **POSIX launch**: `nohup setsid sh supervisor.sh` when `setsid` exists (matching the SSH launcher).
- **WSL cwd**: the handle stores the Windows project root and `command.sh` enters it via `wslpath`, restoring project-relative commands and harvest.
- **Messages**: local detached runs use a neutral "Automatic Run retry stopped" marker.

## Changed files

- `src-tauri/src/run_context/local_detached.rs`: all payload fixes above
- `src-tauri/src/run_context.rs`: WSL `command_cwd`, neutral local retry marker
- `src-tauri/src/run_context/tests.rs`: WSL payload added to the `sh -n` validity suite with `wslpath`/idempotency/`setsid` assertions; Windows payload structure assertions (decoded supervisor, lock-owner gating, `ToString('o')`, `FileShare::ReadWrite`, no `ReadAllBytes`); one-script stdin transport test; colon/space-preserving handle-ack parse test

## Tests

- `cargo fmt --all -- --check` clean
- `cargo test --workspace` passes (run_context: 52 tests, including the real local-shell lifecycle integration test on unix)

## Manual smoke

1. Windows local: submit a Run producing continuous output; the run card should show live tails during execution rather than poll errors.
2. Windows local: submit the same Run twice quickly (or trigger recovery mid-launch); the command must execute once.
3. WSL: `run_in_context` with a project-relative output path plus `output_specs`; the artifact should harvest from the project root.
4. macOS: cancel a Run whose command spawns children; verify no orphan processes remain (`pgrep`).

## Known limitations

- On macOS the supervisor itself still cannot be `setsid`'d (no binary); `set -m` protects the command tree, but a signal aimed at the app's process group can still kill the supervisor, after which the Run is reported `lost` while the detached command finishes.
- Windows behavior is verified through payload structure tests and PowerShell semantics review, not a live Windows run; the manual smoke list above covers that gap.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aa0d1feb-cf43-47b9-9952-4e68759c0cfc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aa0d1feb-cf43-47b9-9952-4e68759c0cfc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

