### PR TITLE
Fix language select showing English while the saved locale is Chinese

### DIFF
--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -118,6 +118,7 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
   const mockOAuthPending = query.get("mockOAuthPending") === "1";
   const mockOnboarding = query.get("mockOnboarding") === "1";
   const mockSyncUnconfigured = query.get("mockSyncUnconfigured") === "1";
+  let mockLocale = query.get("mockLocale") === "zh" ? "zh" : "en";
   const mockSessions: any[] = mockPlanFlow
     ? [{ id: "s1", title: "Plan mode regression", ts: 2000, running: false }]
     : mockPublication
@@ -1916,7 +1917,7 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
               api_url: "https://api.deepseek.com",
               model: "deepseek-v4-pro",
               has_api_key: true,
-              locale: "en",
+              locale: mockLocale,
               max_iter: 100,
               auto_compact: true,
               max_tokens: 4096,
@@ -3121,6 +3122,8 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
             const next = plain(arg("settings") ?? {});
             mockPetEnabled = Boolean(next.pet_enabled);
             mockPetDirectory = String(next.pet_directory ?? "");
+            mockLocale = String(next.locale ?? mockLocale);
+            (window as any).__lastSetSettings = next;
             return null;
           }
           case "check_for_updates":

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -325,6 +325,31 @@ test("general settings can use Ctrl+Enter to send and Enter for newline", async 
   });
 });
 
+test("language select shows the saved locale so Chinese can switch to English directly (#431)", async ({ page }) => {
+  await page.goto("/?mockLocale=zh");
+  await page.locator(".proj-card-main").first().click();
+  await expect(page.locator(".sidebar").getByRole("button", { name: "新建会话" })).toBeVisible();
+
+  await page.getByRole("button", { name: "设置", exact: true }).click();
+  await page.getByRole("button", { name: "常规", exact: true }).click();
+  const language = page.getByTestId("settings-language");
+  // Regression: the select's value binding was applied before its options
+  // existed, so it fell back to the first option ("en") while the saved locale
+  // was Chinese — picking English then fired no change event and never saved.
+  await expect(language).toHaveValue("zh");
+
+  await language.selectOption("en");
+  // Selecting a language re-renders the UI in that language immediately.
+  await page.locator(".settings-footer").getByRole("button", { name: "Save" }).click();
+  await expect.poll(() =>
+    page.evaluate(() => (window as any).__lastSetSettings?.locale)
+  ).toBe("en");
+
+  // The app stays in English and the select stays on English after reopening.
+  await page.getByRole("button", { name: "Settings", exact: true }).click();
+  await expect(page.getByTestId("settings-language")).toHaveValue("en");
+});
+
 test("problem reports stay local until a reviewed Markdown draft is explicitly opened (#596)", async ({ page, context }) => {
   await context.grantPermissions(["clipboard-read", "clipboard-write"]);
   await enterApp(page);

--- a/ui/src/settings_view.rs
+++ b/ui/src/settings_view.rs
@@ -991,7 +991,7 @@ pub(super) fn SettingsView(
                     <div class="settings-pane">
                         <div class="settings-form-grid">
                         <label class="span-2">{move || t(locale.get(), "settings.language")}
-                            <select
+                            <select data-testid="settings-language"
                                 on:change=move|ev| {
                                     let code = dom_value(&ev);
                                     let loc = Locale::from_code(&code);
@@ -999,9 +999,13 @@ pub(super) fn SettingsView(
                                     set_document_lang(loc);
                                     settings.update(|s| s.locale = code);
                                 }
-                                prop:value=move || locale.get().code().to_string()>
-                                <option value="en">{move || t(locale.get(), "settings.language.en")}</option>
-                                <option value="zh">{move || t(locale.get(), "settings.language.zh")}</option>
+                                // Bind `selected` on the options instead of `value` on the
+                                // select: the select's `value` property is applied before the
+                                // option children exist, so it falls back to the first option
+                                // and shows "English" while the locale is Chinese (#431).
+                                >
+                                <option value="en" prop:selected=move || locale.get() == Locale::En>{move || t(locale.get(), "settings.language.en")}</option>
+                                <option value="zh" prop:selected=move || locale.get() == Locale::Zh>{move || t(locale.get(), "settings.language.zh")}</option>
                             </select>
                         </label>
                         <label class="span-2">{move || t(locale.get(), "settings.workspace_dir")}


### PR DESCRIPTION
## Problem

With the locale set to Chinese, the language dropdown in Settings showed "English" instead of "中文". Picking English from that state fired no `change` event (the DOM value already was `en`), so the new language was never saved — users had to select Chinese first, then English, then save, to actually switch (#431).

## Root cause

The select bound `prop:value`, which Leptos applies when the element is created — before its `<option>` children exist. With no options to match, the assignment did not stick and the browser fell back to the first option (`en`). The reactive binding only re-ran when the locale changed, so the stale "English" display persisted for Chinese-locale users.

## Changes

- `ui/src/settings_view.rs`: bind `prop:selected` on each `<option>` instead of `prop:value` on the `<select>`, matching how every other select in the codebase is written; added `data-testid="settings-language"`.
- `ui-tests/tests/mock-tauri.ts`: mock `get_settings` accepts a `?mockLocale=zh` query param and `set_settings` records its payload / updates the mocked locale.
- `ui-tests/tests/ui.spec.ts`: regression test — boots in Chinese, asserts the select shows `zh`, switches to English, saves, and asserts `set_settings` received `locale: "en"` and the UI stays in English after reopening Settings.

## Tests

- New Playwright regression test passes.
- Full suite: 263 passed, 1 skipped.
- `cargo test --workspace` and `cargo fmt --all -- --check` pass; `cargo check --target wasm32-unknown-unknown` passes.

## Manual smoke

1. Set language to 中文, restart the app.
2. Open 设置 → 常规: the language dropdown shows 中文 (previously English).
3. Select English → the UI re-renders in English immediately → Save.
4. Reopen Settings: the dropdown shows English.

## Known limitations

None; follow-up work not required.