### PR TITLE
Fix Windows Run launch monitoring and Plan card replay

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1287,6 +1287,39 @@ fn events_to_items(events: &[AgentEvent]) -> (Vec<UiItem>, HashMap<i64, usize>) 
                 duration_ms,
                 ..
             } => {
+                // These successful tool results are complete UI cards. Live
+                // rendering suppresses their call rows and does the same
+                // conversion; replay must mirror that path or a refresh turns
+                // the card back into a raw tool row (and loses its actions).
+                let card_role = match name.as_str() {
+                    wisp_tools::plan::PROPOSE_PLAN if *ok => Some("plan"),
+                    wisp_tools::ask_user::ASK_USER if *ok => Some("question"),
+                    _ => None,
+                };
+                if let Some(role) = card_role {
+                    if let Some(index) = items.iter().rposition(|item| {
+                        item.role == "tool"
+                            && item.tool_name.as_deref() == Some(name)
+                            && item.ok.is_none()
+                    }) {
+                        items.remove(index);
+                    }
+                    items.push(UiItem {
+                        role: role.into(),
+                        text: content.clone(),
+                        tool_name: None,
+                        ok: None,
+                        duration_ms: None,
+                        input: None,
+                        model_name: None,
+                        call_id: None,
+                        kind: None,
+                        status: None,
+                        locations: None,
+                        resources: Vec::new(),
+                    });
+                    continue;
+                }
                 if let Some(item) = items.iter_mut().rev().find(|item| {
                     item.role == "tool"
                         && item.tool_name.as_deref() == Some(name)

--- a/src-tauri/src/lib_tests.rs
+++ b/src-tauri/src/lib_tests.rs
@@ -439,6 +439,49 @@ fn persisted_ui_events_keep_live_step_order_and_boundaries() {
 }
 
 #[test]
+fn persisted_ui_events_restore_native_plan_and_question_cards() {
+    let frame_id = "f".to_string();
+    let events = vec![
+        AgentEvent::ToolCall {
+            frame_id: frame_id.clone(),
+            name: wisp_tools::plan::PROPOSE_PLAN.into(),
+            preview: "1 steps".into(),
+        },
+        AgentEvent::ToolResult {
+            frame_id: frame_id.clone(),
+            name: wisp_tools::plan::PROPOSE_PLAN.into(),
+            ok: true,
+            content: r#"{"v":1,"source":"native","entries":[{"content":"Fix replay","status":"pending","priority":"high"}]}"#.into(),
+            duration_ms: 1,
+        },
+        AgentEvent::ToolCall {
+            frame_id: frame_id.clone(),
+            name: wisp_tools::ask_user::ASK_USER.into(),
+            preview: "Which option?".into(),
+        },
+        AgentEvent::ToolResult {
+            frame_id,
+            name: wisp_tools::ask_user::ASK_USER.into(),
+            ok: true,
+            content: r#"{"v":1,"source":"native","question":"Which option?","options":[]}"#.into(),
+            duration_ms: 1,
+        },
+    ];
+
+    let (items, _) = events_to_items(&events);
+    assert_eq!(
+        items
+            .iter()
+            .map(|item| item.role.as_str())
+            .collect::<Vec<_>>(),
+        vec!["plan", "question"]
+    );
+    assert!(items[0].text.contains("Fix replay"));
+    assert!(items[1].text.contains("Which option?"));
+    assert!(items.iter().all(|item| item.tool_name.is_none()));
+}
+
+#[test]
 fn persisted_usage_folds_per_turn_and_floats_to_tail() {
     let frame_id = "f".to_string();
     let usage = |round, input, output, cached| AgentEvent::Usage {

--- a/src-tauri/src/run_context/local_detached.rs
+++ b/src-tauri/src/run_context/local_detached.rs
@@ -503,9 +503,11 @@ if (-not $proc) {{
 $identity = $null
 for ($i = 0; $i -lt 5; $i++) {{
   try {{
-    $cim = Get-CimInstance Win32_Process -Filter ("ProcessId=" + $proc.Id)
-    if ($cim -and $cim.CreationDate) {{
-      $identity = $cim.CreationDate.ToString('o')
+    # Start-Process -PassThru already owns the authoritative process object.
+    # CIM can be unavailable, and a fast command can exit before a separate
+    # Win32_Process lookup observes it, even though launch succeeded.
+    if ($proc.StartTime) {{
+      $identity = [string]$proc.StartTime.ToUniversalTime().Ticks
       break
     }}
   }} catch {{ }}
@@ -638,14 +640,26 @@ if (-not (Test-Path -LiteralPath $submitted)) {{
   if ($acquired) {{
     Set-Content -LiteralPath $ownerPath -Value ([string]$PID) -Encoding ascii
     $supervisor = Join-Path $workdir 'supervisor.ps1'
-    Start-Process -FilePath 'powershell' -ArgumentList @('-NoProfile','-NonInteractive','-File', $supervisor) -WindowStyle Hidden | Out-Null
+    $supervisorStdout = Join-Path $workdir 'supervisor.stdout.log'
+    $supervisorStderr = Join-Path $workdir 'supervisor.stderr.log'
+    Start-Process -FilePath 'powershell' -ArgumentList @('-NoProfile','-NonInteractive','-File', $supervisor) -WindowStyle Hidden -RedirectStandardOutput $supervisorStdout -RedirectStandardError $supervisorStderr | Out-Null
   }}
 }}
 for ($i = 0; $i -lt 10 -and -not (Test-Path -LiteralPath $submitted); $i++) {{
   Start-Sleep -Seconds 1
 }}
 if (-not (Test-Path -LiteralPath $submitted)) {{
-  Write-Error 'local supervisor did not acknowledge launch'
+  $detail = ''
+  $statusPath = Join-Path $workdir '_status'
+  $supervisorStderr = Join-Path $workdir 'supervisor.stderr.log'
+  if (Test-Path -LiteralPath $statusPath) {{
+    $detail = (Get-Content -LiteralPath $statusPath -Raw -ErrorAction SilentlyContinue).Trim()
+  }}
+  if (-not $detail -and (Test-Path -LiteralPath $supervisorStderr)) {{
+    $detail = (Get-Content -LiteralPath $supervisorStderr -Raw -ErrorAction SilentlyContinue).Trim()
+  }}
+  if ($detail) {{ Write-Error ('local supervisor did not acknowledge launch: ' + $detail) }}
+  else {{ Write-Error 'local supervisor did not acknowledge launch' }}
   exit 70
 }}
 Write-Output ('__WISP_HANDLE__:' + (Get-Content -LiteralPath $submitted -Raw).Trim())
@@ -676,9 +690,8 @@ $workdir = Join-Path $env:USERPROFILE '{workdir_win}'
 $state = 'lost:control directory missing'
 function Same-Identity {{
   try {{
-    $cim = Get-CimInstance Win32_Process -Filter 'ProcessId={pgid}'
-    if (-not $cim -or -not $cim.CreationDate) {{ return $false }}
-    return $cim.CreationDate.ToString('o') -eq {identity_q}
+    $process = Get-Process -Id {pgid} -ErrorAction Stop
+    return ([string]$process.StartTime.ToUniversalTime().Ticks) -eq {identity_q}
   }} catch {{ return $false }}
 }}
 function Read-Status {{
@@ -757,9 +770,8 @@ pub(super) fn windows_cancel_payload(handle: &RemoteRunHandle) -> Result<String,
 $workdir = Join-Path $env:USERPROFILE '{workdir_win}'
 function Same-Identity {{
   try {{
-    $cim = Get-CimInstance Win32_Process -Filter 'ProcessId={pgid}'
-    if (-not $cim -or -not $cim.CreationDate) {{ return $false }}
-    return $cim.CreationDate.ToString('o') -eq {identity_q}
+    $process = Get-Process -Id {pgid} -ErrorAction Stop
+    return ([string]$process.StartTime.ToUniversalTime().Ticks) -eq {identity_q}
   }} catch {{ return $false }}
 }}
 function Terminal-Status {{

--- a/src-tauri/src/run_context/tests.rs
+++ b/src-tauri/src/run_context/tests.rs
@@ -1916,7 +1916,7 @@ fn windows_control_payloads_contain_process_identity_and_timeout() {
             token: "test-token".into(),
             inputs_staged: true,
             pgid: Some(4242),
-            start_identity: Some("20260803105500.000000-000".into()),
+            start_identity: Some("639000105000000000".into()),
             command_cwd: Some(r"C:\project".into()),
         },
     };
@@ -1937,26 +1937,30 @@ fn windows_control_payloads_contain_process_identity_and_timeout() {
             .expect("valid supervisor base64"),
     )
     .expect("utf8 supervisor script");
-    // The supervisor must be idempotent and use a culture-stable identity.
+    // The supervisor must be idempotent and use a culture-stable identity
+    // directly from Start-Process; CIM can be unavailable or miss fast exits.
     assert!(supervisor.contains("if (Test-Path -LiteralPath (Join-Path $workdir '_submitted'))"));
-    assert!(supervisor.contains(".ToString('o')"));
+    assert!(supervisor.contains("$proc.StartTime.ToUniversalTime().Ticks"));
+    assert!(!supervisor.contains("Get-CimInstance"));
     let launch = launch_payload(&remote.handle);
     assert!(launch.contains("Start-Process"));
     // Only the launcher that created the lock may start the supervisor, and a
     // live lock owner must not be raced.
     assert!(launch.contains("if ($acquired)"));
     assert!(launch.contains("Get-Process -Id $ownerId"));
+    assert!(launch.contains("supervisor.stderr.log"));
+    assert!(launch.contains("local supervisor did not acknowledge launch: "));
     let poll = poll_payload(&remote.handle).unwrap();
-    assert!(poll.contains("Win32_Process"));
+    assert!(poll.contains("Get-Process -Id 4242"));
     assert!(poll.contains("__WISP_RUN_STATUS__"));
-    assert!(poll.contains(".ToString('o')"));
+    assert!(poll.contains("StartTime.ToUniversalTime().Ticks"));
     // Log tails must share the writer's handle and stay bounded.
     assert!(poll.contains("[System.IO.FileShare]::ReadWrite"));
     assert!(!poll.contains("ReadAllBytes"));
     let cancel = cancel_payload(&remote.handle).unwrap();
     assert!(cancel.contains("taskkill.exe"));
     assert!(cancel.contains("__WISP_CANCEL__"));
-    assert!(cancel.contains(".ToString('o')"));
+    assert!(cancel.contains("StartTime.ToUniversalTime().Ticks"));
 }
 
 #[test]

--- a/src-tauri/src/seed.rs
+++ b/src-tauri/src/seed.rs
@@ -277,8 +277,7 @@ mod tests {
             assert!(!blob.contains("kimi-k3"));
             assert!(!blob.contains("{{artifact:"));
             assert!(
-                demo
-                    .items
+                demo.items
                     .iter()
                     .filter_map(|i| i.model_name.as_deref())
                     .all(|m| m == "deepseek-v4-pro"),

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -3926,31 +3926,27 @@ test("runtime inspector lists object metadata without loading object contents", 
     .toHaveAttribute("aria-pressed", "true");
 
   const beforeDrag = await rEnvironment.boundingBox();
-  await rEnvironment.locator(".runtime-environment-title").evaluate((handle) => {
-    const rect = handle.getBoundingClientRect();
-    const startX = rect.left + rect.width / 2;
-    const startY = rect.top + rect.height / 2;
-    handle.dispatchEvent(new PointerEvent("pointerdown", {
-      bubbles: true,
-      button: 0,
-      pointerId: 7,
-      clientX: startX,
-      clientY: startY,
-    }));
-    handle.dispatchEvent(new PointerEvent("pointermove", {
-      bubbles: true,
-      buttons: 1,
-      pointerId: 7,
-      clientX: startX - 120,
-      clientY: startY + 48,
-    }));
-    handle.dispatchEvent(new PointerEvent("pointerup", {
-      bubbles: true,
-      button: 0,
-      pointerId: 7,
-      clientX: startX - 120,
-      clientY: startY + 48,
-    }));
+  const dragHandle = rEnvironment.locator(".runtime-environment-title");
+  const dragBox = await dragHandle.boundingBox();
+  expect(dragBox).not.toBeNull();
+  const startX = dragBox!.x + dragBox!.width / 2;
+  const startY = dragBox!.y + dragBox!.height / 2;
+  // Dispatch each pointer phase separately and wait for the drag state before
+  // moving. Sending all three events in one evaluate callback lets Leptos batch
+  // the state transitions on a busy CI worker, so the move can observe no
+  // active drag even though the same sequence passes locally.
+  await dragHandle.dispatchEvent("pointerdown", {
+    button: 0,
+    pointerId: 7,
+    clientX: startX,
+    clientY: startY,
+  });
+  await expect(rEnvironment).toHaveClass(/is-dragging/);
+  await dragHandle.dispatchEvent("pointermove", {
+    buttons: 1,
+    pointerId: 7,
+    clientX: startX - 120,
+    clientY: startY + 48,
   });
   await expect.poll(async () => {
     const afterDrag = await rEnvironment.boundingBox();
@@ -3960,6 +3956,13 @@ test("runtime inspector lists object metadata without loading object contents", 
     const afterDrag = await rEnvironment.boundingBox();
     return beforeDrag && afterDrag ? Math.round(afterDrag.y - beforeDrag.y) : 0;
   }).toBeGreaterThan(30);
+  await dragHandle.dispatchEvent("pointerup", {
+    button: 0,
+    pointerId: 7,
+    clientX: startX - 120,
+    clientY: startY + 48,
+  });
+  await expect(rEnvironment).not.toHaveClass(/is-dragging/);
 
   await page.keyboard.press("Escape");
   await expect(rEnvironment).toHaveCount(0);


### PR DESCRIPTION
## Problem

Two user-visible regressions were captured in debug requests:

- Windows local detached Runs could fail during the supervisor handshake before the user command started, reporting `local supervisor did not acknowledge launch`.
- A successfully submitted built-in Plan disappeared when the persisted UI event transcript was replayed, removing the Plan card and its approval actions while the backend remained in Plan mode.

## Root cause

- The Windows supervisor queried `Win32_Process` through CIM after `Start-Process`. CIM may be unavailable, and a fast process can exit before that second lookup observes it, so `_submitted` was never written even after a successful process launch.
- Live `propose_plan` results were converted into Plan cards, but the persisted UI event reducer still reconstructed them as ordinary tool rows.

## Changes

- Derive the Windows process identity directly from the `Start-Process -PassThru` process object's UTC `StartTime` ticks.
- Use the same identity representation for Run polling and cancellation.
- Capture supervisor stdout/stderr and include `_status` or supervisor stderr in failed launch diagnostics.
- Restore successful `propose_plan` and `ask_user` tool results as their native cards during UI event replay.
- Add regression coverage for card replay and the Windows launch/poll/cancel script contract.
- Keep the formatter-only seeded demo test adjustment in a separate commit.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cd ui && cargo check --target wasm32-unknown-unknown`
- `cd ui-tests && npx playwright test -g "built-in propose_plan renders a plan card with a working action bar"`

## Manual smoke steps

1. On Windows, submit a local detached Run and verify it transitions from submitted to running, then completes or reports the actual command failure.
2. Enter built-in Plan mode, submit a plan, refresh/reopen the conversation, and verify the Plan card and approval actions remain visible.
3. Approve the restored plan and verify the conversation exits Plan mode before execution starts.

## Known limitation

The development host was macOS and did not have `pwsh`, so the Windows supervisor could not be exercised as a real local process here. The generated PowerShell contract is covered by Rust tests; Windows manual smoke remains recommended.