### PR TITLE
Attach artifacts to the chat from the artifact panel

### DIFF
--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -2511,6 +2511,28 @@ test("workspace file context menu attaches its path to the composer", async ({ p
   await expect(composer(page)).toHaveValue("");
 });
 
+test("artifact tile attaches to the chat from its context and more menus", async ({ page }) => {
+  await enterApp(page);
+  await composer(page).fill("make a volcano plot volcano.png");
+  await page.getByRole("button", { name: "Send" }).click();
+  await expect(page.getByText("Hello from mock wisp-science.")).toBeVisible({ timeout: 10_000 });
+  await page.getByRole("button", { name: "Toggle panel" }).click();
+
+  const tile = page.locator('.rp-tile[data-artifact-name="volcano.png"]');
+  await expect(tile).toBeVisible();
+
+  // Right-click → "Attach to chat" drops the artifact path into the composer.
+  await tile.click({ button: "right" });
+  await page.locator(".ctx-menu").getByRole("button", { name: "Attach to chat" }).click();
+  await expect(page.locator(".composer-attachment.ready")).toHaveText("volcano.png");
+  await expect(composer(page)).toHaveValue("");
+
+  // The "More" menu offers the same handoff; re-attaching dedupes to one chip.
+  await tile.getByRole("button", { name: "More" }).click();
+  await page.locator(".rp-tile-menu").getByRole("button", { name: "Attach to chat" }).click();
+  await expect(page.locator(".composer-attachment.ready")).toHaveCount(1);
+});
+
 test("workspace Files panel navigates deeply nested analysis modules", async ({ page }) => {
   await enterApp(page);
   await page.getByRole("button", { name: "Files" }).click();

--- a/ui/src/context_menu.rs
+++ b/ui/src/context_menu.rs
@@ -463,6 +463,14 @@ pub fn build(
                         path.clone(),
                     ),
                 );
+                items.insert(
+                    1,
+                    item(
+                        "attachWorkspaceFile",
+                        i18n::t(locale, "ctx.attach_file"),
+                        path.clone(),
+                    ),
+                );
                 items.push(item(
                     "downloadFile",
                     i18n::t(locale, "artifact.download"),

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -11153,6 +11153,7 @@ fn App() -> impl IntoView {
                                                 let (p, n, k) = (path.clone(), vn.clone(), fkind.clone());
                                                 let (mv, sp, dw) = (p.clone(), p.clone(), p.clone());
                                                 let rv = p.clone();
+                                                let at = p.clone();
                                                 let oc = CenterFileTab::new(p.clone(), n.clone(), k.clone());
                                                 let (mvn, mvk) = (n.clone(), k.clone());
                                                 view! {
@@ -11173,6 +11174,13 @@ fn App() -> impl IntoView {
                                                                 center_file.set(Some(oc.path.clone()));
                                                             }>
                                                             {move || t(locale.get(), "center.open_file")}</button>
+                                                        <button type="button" class="rp-tile-menu-item"
+                                                            on:click=move |_| {
+                                                                artifact_menu.set(None);
+                                                                let _ = attach_ready_path(attachments, at.clone());
+                                                                focus_composer();
+                                                            }>
+                                                            {move || t(locale.get(), "ctx.attach_file")}</button>
                                                         <button type="button" class="rp-tile-menu-item"
                                                             on:click=move |_| {
                                                                 artifact_menu.set(None);


### PR DESCRIPTION
## Problem

Artifacts collected in the right-hand Artifacts panel (run outputs, images, tables exported to files) could be opened, downloaded, or revealed in the file manager — but there was no way to hand one back to the agent without retyping its path. The Files panel already has **Attach to chat**; the artifact panel did not.

## Changes

- `ui/src/context_menu.rs`: the artifact tile right-click menu gains **Attach to chat** (after **Open in center**), reusing the existing `attachWorkspaceFile` action and `ctx.attach_file` strings — no new i18n keys.
- `ui/src/main.rs`: the tile's **⋯ (More)** menu gets the same entry; clicking it attaches the artifact path to the composer and focuses the input. Re-attaching the same path dedupes via the existing `attach_ready_path` check.
- `ui-tests/tests/ui.spec.ts`: new test `artifact tile attaches to the chat from its context and more menus` covering both entries and the dedupe.

Tiles without a file backing (in-memory previews such as chat tables) have no readable path, so the entry does not appear — consistent with the backend requirement that an attached artifact resolves to a readable file.

## Tests

- New Playwright test passes; attach-related suite 6/6, artifact-related suite 17/17.
- `cargo fmt --all -- --check`, `cargo check --target wasm32-unknown-unknown` (ui), and `cargo test --workspace` all green.

## Manual smoke

1. Run a turn that produces an image/file artifact, open the Artifacts panel.
2. Right-click the artifact tile → **附加到对话 / Attach to chat** → the composer shows the attachment chip and focus lands in the input.
3. Repeat from the tile's ⋯ menu; confirm only one chip appears.

## Known limitations / follow-ups

- In-memory (non-file) artifacts such as inline tables cannot be attached; attaching them would need a serialized snapshot (e.g. CSV export) first.