### PR TITLE
Fix Skill-bound sub-Agent token budget deadlock (#648)

### DIFF
--- a/crates/wisp-core/src/delegation_policy.rs
+++ b/crates/wisp-core/src/delegation_policy.rs
@@ -20,6 +20,12 @@ use thiserror::Error;
 
 const ELEVATED_TOKEN_THRESHOLD: u32 = 20_000;
 const ELEVATED_COST_THRESHOLD_MICROUNITS: u64 = 1_000_000;
+/// Default per-task token budget and the highest token budget a delegated task
+/// may request. Skill-bound literature/review tasks routinely consume
+/// 15k-25k tokens while loading the Skill and iterating on tool results, so
+/// the ceiling must leave comfortable room above that.
+const DEFAULT_TASK_TOKEN_BUDGET: u32 = 16_000;
+const TASK_TOKEN_BUDGET_CEILING: u32 = 64_000;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -231,8 +237,12 @@ pub enum ResolutionError {
     NoEligibleModel,
     #[error("no eligible executor is configured")]
     NoEligibleExecutor,
-    #[error("requested task budget exceeds the capability or host ceiling")]
-    BudgetExceeded,
+    #[error("requested task budget exceeds the {field} ceiling: requested {requested}, but the capability/host policy allows at most {ceiling}")]
+    BudgetExceeded {
+        field: &'static str,
+        requested: String,
+        ceiling: u64,
+    },
     #[error("dynamic delegation snapshot is stale: {0}")]
     StaleSnapshot(String),
     #[error("dynamic delegation snapshot integrity check failed")]
@@ -993,13 +1003,38 @@ fn select_budget(
             .and_then(|value| value.max_cost_microunits)
             .or(defaults.max_cost_microunits),
     };
-    if !limit_within(selected.max_tokens, ceiling.max_tokens)
-        || !limit_within(selected.max_tool_calls, ceiling.max_tool_calls)
-        || !limit_within(selected.max_cost_microunits, ceiling.max_cost_microunits)
-    {
-        return Err(ResolutionError::BudgetExceeded);
-    }
+    check_budget_limit("max_tokens", selected.max_tokens, ceiling.max_tokens)?;
+    check_budget_limit(
+        "max_tool_calls",
+        selected.max_tool_calls,
+        ceiling.max_tool_calls,
+    )?;
+    check_budget_limit(
+        "max_cost_microunits",
+        selected.max_cost_microunits,
+        ceiling.max_cost_microunits,
+    )?;
     Ok(selected)
+}
+
+fn check_budget_limit<T: Ord + Copy + Into<u64>>(
+    field: &'static str,
+    selected: Option<T>,
+    ceiling: Option<T>,
+) -> Result<(), ResolutionError> {
+    let exceeded = match (selected, ceiling) {
+        (_, None) => false,
+        (Some(selected), Some(ceiling)) => selected > ceiling,
+        (None, Some(_)) => true,
+    };
+    if exceeded {
+        return Err(ResolutionError::BudgetExceeded {
+            field,
+            requested: selected.map_or_else(|| "unset".into(), |value| value.into().to_string()),
+            ceiling: ceiling.map_or(0, Into::into),
+        });
+    }
+    Ok(())
 }
 
 fn select_timeout(host: &DelegationHostPolicy) -> Result<Option<u64>, ResolutionError> {
@@ -1220,14 +1255,6 @@ fn insert_sorted<T: Ord + Copy>(target: &mut Vec<T>, value: T) {
     }
 }
 
-fn limit_within<T: Ord>(selected: Option<T>, ceiling: Option<T>) -> bool {
-    match (selected, ceiling) {
-        (_, None) => true,
-        (Some(selected), Some(ceiling)) => selected <= ceiling,
-        (None, Some(_)) => false,
-    }
-}
-
 fn limit_greater<T: Ord>(selected: Option<T>, defaults: Option<T>) -> bool {
     match (selected, defaults) {
         (Some(selected), Some(default)) => selected > default,
@@ -1259,8 +1286,8 @@ fn builtin_capabilities() -> Vec<CapabilityDefinition> {
             &[],
             &[],
             AgentWorkspacePolicy::SharedReadOnly,
-            8_000,
-            16_000,
+            DEFAULT_TASK_TOKEN_BUDGET,
+            TASK_TOKEN_BUDGET_CEILING,
         ),
         capability(
             "project_read",
@@ -1275,8 +1302,8 @@ fn builtin_capabilities() -> Vec<CapabilityDefinition> {
             &[],
             &[],
             AgentWorkspacePolicy::SharedReadOnly,
-            8_000,
-            20_000,
+            DEFAULT_TASK_TOKEN_BUDGET,
+            TASK_TOKEN_BUDGET_CEILING,
         ),
         capability(
             "project_write",
@@ -1291,8 +1318,8 @@ fn builtin_capabilities() -> Vec<CapabilityDefinition> {
             &[],
             &[],
             AgentWorkspacePolicy::SerializedMutation,
-            10_000,
-            24_000,
+            DEFAULT_TASK_TOKEN_BUDGET,
+            TASK_TOKEN_BUDGET_CEILING,
         ),
         capability(
             "code_run",
@@ -1315,8 +1342,8 @@ fn builtin_capabilities() -> Vec<CapabilityDefinition> {
             &[],
             &[],
             AgentWorkspacePolicy::SerializedMutation,
-            12_000,
-            32_000,
+            DEFAULT_TASK_TOKEN_BUDGET,
+            TASK_TOKEN_BUDGET_CEILING,
         ),
         capability(
             "literature_search",
@@ -1334,8 +1361,8 @@ fn builtin_capabilities() -> Vec<CapabilityDefinition> {
             &[],
             &["literature"],
             AgentWorkspacePolicy::SharedReadOnly,
-            10_000,
-            32_000,
+            DEFAULT_TASK_TOKEN_BUDGET,
+            TASK_TOKEN_BUDGET_CEILING,
         ),
         capability(
             "external_research",
@@ -1350,8 +1377,8 @@ fn builtin_capabilities() -> Vec<CapabilityDefinition> {
             &[],
             &["web"],
             AgentWorkspacePolicy::SharedReadOnly,
-            10_000,
-            20_000,
+            DEFAULT_TASK_TOKEN_BUDGET,
+            TASK_TOKEN_BUDGET_CEILING,
         ),
         capability(
             "visualization",
@@ -1370,8 +1397,8 @@ fn builtin_capabilities() -> Vec<CapabilityDefinition> {
             &[],
             &[],
             AgentWorkspacePolicy::SerializedMutation,
-            12_000,
-            32_000,
+            DEFAULT_TASK_TOKEN_BUDGET,
+            TASK_TOKEN_BUDGET_CEILING,
         ),
         capability(
             "review",
@@ -1386,8 +1413,8 @@ fn builtin_capabilities() -> Vec<CapabilityDefinition> {
             &[],
             &[],
             AgentWorkspacePolicy::SharedReadOnly,
-            8_000,
-            16_000,
+            DEFAULT_TASK_TOKEN_BUDGET,
+            TASK_TOKEN_BUDGET_CEILING,
         ),
         delegation_capability(),
         capability_with_model(
@@ -1398,8 +1425,8 @@ fn builtin_capabilities() -> Vec<CapabilityDefinition> {
             &["read", "view_image"],
             &[ExecutorFeature::ProjectRead, ExecutorFeature::Vision],
             &[ModelFeature::Vision],
-            8_000,
-            16_000,
+            DEFAULT_TASK_TOKEN_BUDGET,
+            TASK_TOKEN_BUDGET_CEILING,
         ),
     ]
 }
@@ -1418,8 +1445,8 @@ fn delegation_capability() -> CapabilityDefinition {
         &[],
         &[],
         AgentWorkspacePolicy::SharedReadOnly,
-        8_000,
-        16_000,
+        DEFAULT_TASK_TOKEN_BUDGET,
+        TASK_TOKEN_BUDGET_CEILING,
     );
     definition.approval_reason =
         Some("Task may create a bounded nested Agent batch within root-wide limits".into());
@@ -1743,7 +1770,7 @@ mod tests {
             .resolve_task(proposal("work", &["project_read", "code_run"]), &host)
             .unwrap();
         assert_eq!(resolved.risk(), CapabilityRisk::Execute);
-        assert_eq!(resolved.budget_ceiling().max_tokens, Some(20_000));
+        assert_eq!(resolved.budget_ceiling().max_tokens, Some(32_000));
         assert!(resolved
             .spec()
             .permissions
@@ -1753,13 +1780,24 @@ mod tests {
 
         let mut too_large = proposal("work", &["project_read", "code_run"]);
         too_large.budget = Some(AgentBudget {
-            max_tokens: Some(20_001),
+            max_tokens: Some(32_001),
             ..Default::default()
         });
+        let error = registry.resolve_task(too_large, &host).unwrap_err();
         assert_eq!(
-            registry.resolve_task(too_large, &host).unwrap_err(),
-            ResolutionError::BudgetExceeded
+            error,
+            ResolutionError::BudgetExceeded {
+                field: "max_tokens",
+                requested: "32001".into(),
+                ceiling: 32_000,
+            }
         );
+        // The message must name the triggered limit and both numbers so the
+        // caller knows exactly which ceiling rejected the budget.
+        let message = error.to_string();
+        assert!(message.contains("max_tokens"));
+        assert!(message.contains("32001"));
+        assert!(message.contains("32000"));
     }
 
     #[test]
@@ -2062,7 +2100,7 @@ mod tests {
 
         let mut elevated = proposal("elevated", &["reasoning"]);
         elevated.budget = Some(AgentBudget {
-            max_tokens: Some(9_000),
+            max_tokens: Some(24_000),
             ..Default::default()
         });
         assert!(registry

--- a/crates/wisp-skills/src/portfolio.rs
+++ b/crates/wisp-skills/src/portfolio.rs
@@ -5,6 +5,11 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
 
 const RUNTIME_PARALLEL_LIMIT: usize = 2;
+/// Extra per-node allowance for the sub-Agent loop itself — system prompt,
+/// tool-call round trips, and search results — beyond the rendered Skill body
+/// and the reserved output. Measured Skill nodes consume 15k-22k tokens
+/// overall, so a budget of instruction + output alone deadlocks them.
+const NODE_AGENT_OVERHEAD_TOKENS: u32 = 12_000;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -118,7 +123,9 @@ pub fn plan_portfolio(
             let (score, reasons) = score_candidate(&intent, candidate);
             let instruction_tokens =
                 estimate_tokens(&candidate.rendered_instruction).saturating_add(request_tokens);
-            let node_budget = instruction_tokens.saturating_add(config.node_output_tokens);
+            let node_budget = instruction_tokens
+                .saturating_add(config.node_output_tokens)
+                .saturating_add(NODE_AGENT_OVERHEAD_TOKENS);
             (candidate, score, reasons, instruction_tokens, node_budget)
         })
         .filter(|(_, score, _, _, _)| *score > 0)
@@ -397,8 +404,8 @@ mod tests {
             &candidates,
             PortfolioConfig {
                 tier: PortfolioTier::Deep,
-                total_token_budget: 1_500,
-                synthesis_reserve: 500,
+                total_token_budget: 40_000,
+                synthesis_reserve: 15_000,
                 node_output_tokens: 300,
                 user_parallel_limit: 4,
             },
@@ -406,6 +413,12 @@ mod tests {
         .unwrap();
         assert_eq!(plan.selected.len(), 2);
         assert_eq!(plan.deferred.len(), 6);
+        // Node budgets must cover the Skill body, the sub-Agent loop overhead,
+        // and the reserved output, not just the output.
+        assert_eq!(
+            plan.selected[0].node_budget,
+            plan.selected[0].instruction_tokens + 300 + NODE_AGENT_OVERHEAD_TOKENS
+        );
         assert!(plan
             .deferred
             .iter()

--- a/docs/agent-delegation.md
+++ b/docs/agent-delegation.md
@@ -132,7 +132,8 @@ and descendants that were blocked, then supplies the retained dependency
 results to those descendants. A failed task exposes its current token limit in
 the activity card; changing **Retry max tokens** before retrying revises only
 that task's authorized budget on the same workflow. The new value is still
-checked against capability and host ceilings.
+checked against capability and host ceilings (64k tokens per task); a rejected
+budget names the triggered limit, the requested value, and the ceiling.
 
 Omitting `specialist_id` creates a generic temporary Agent. Selecting a
 Specialist reuses its persona, model preference, skills, and connector
@@ -442,10 +443,11 @@ the coordination paths.
 
 Workflow Studio can generate a draft from the current effective Skill Catalog. The planner
 normalizes the research request, applies deterministic lexical and `wisp` metadata scoring, and
-selects a compact, standard, or deep complementary portfolio. Its preflight uses the rendered
-Skill instruction plus request and node output allowance; it reserves synthesis tokens before
-selecting child nodes and defers lower-ranked optional candidates when the remaining child budget
-is insufficient.
+selects a compact, standard, or deep complementary portfolio. Its preflight budgets each node for
+the rendered Skill instruction plus the request, a fixed sub-Agent loop allowance (system prompt,
+tool round trips, and search results), and the node output allowance; it reserves synthesis tokens
+before selecting child nodes and defers lower-ranked optional candidates when the remaining child
+budget is insufficient.
 
 The confirmation card shows exact Skill sources and reasons, selected and deferred nodes, node and
 total budgets, the synthesis reserve, the runtime maximum of two parallel Agents, and estimated DAG

--- a/src-tauri/src/delegation_runtime.rs
+++ b/src-tauri/src/delegation_runtime.rs
@@ -1500,7 +1500,7 @@ async fn build_dynamic_delegation_policy(
             max_tokens: Some(32_000),
         },
         budget_ceiling: AgentBudget {
-            max_tokens: Some(32_000),
+            max_tokens: Some(64_000),
             max_tool_calls: Some(64),
             max_cost_microunits: Some(1_000_000),
         },

--- a/ui/src/agent_workflows.rs
+++ b/ui/src/agent_workflows.rs
@@ -2912,8 +2912,8 @@ pub(super) fn workflow_studio(
     let portfolio_open = create_rw_signal(false);
     let portfolio_request = create_rw_signal(String::new());
     let portfolio_tier = create_rw_signal("standard".to_string());
-    let portfolio_total = create_rw_signal("16000".to_string());
-    let portfolio_reserve = create_rw_signal("4000".to_string());
+    let portfolio_total = create_rw_signal("96000".to_string());
+    let portfolio_reserve = create_rw_signal("16000".to_string());
     let portfolio_draft = create_rw_signal::<Option<SkillPortfolioDraft>>(None);
     let portfolio_loading = create_rw_signal(false);
 
@@ -2948,7 +2948,7 @@ pub(super) fn workflow_studio(
                     tier: portfolio_tier.get_untracked(),
                     total_token_budget: total,
                     synthesis_reserve: reserve,
-                    node_output_tokens: 2_000,
+                    node_output_tokens: 4_000,
                     user_parallel_limit: 2,
                 }
             }


### PR DESCRIPTION
## Problem

Closes #648. Project workflows with Skill-bound sub-Agent nodes deadlocked:

- The Skill Portfolio Planner budgeted each node for only the rendered Skill body plus a small output allowance (~3k), while loading a Skill and iterating on tool/literature-search results consumes 15k–22k tokens. Every Skill node died with `Agent exceeded its token budget`, blocking the dependent synthesis node.
- Raising the budget at runtime was impossible: capability ceilings (16k–32k) and the host ceiling (32k) rejected 30k–40k requests, and the Agents-card retry path re-resolves through the same policy, so it hit the same wall.
- The rejection error (`requested task budget exceeds the capability or host ceiling`) did not say which limit triggered or what the ceiling was.

## Changes

- `crates/wisp-core/src/delegation_policy.rs` — built-in capability token budgets are now 16k default / 64k ceiling (`DEFAULT_TASK_TOKEN_BUDGET` / `TASK_TOKEN_BUDGET_CEILING`, with the measured-consumption rationale). `ResolutionError::BudgetExceeded` now carries the triggered field, requested value, and ceiling, e.g. `requested task budget exceeds the max_tokens ceiling: requested 32001, but the capability/host policy allows at most 32000`.
- `src-tauri/src/delegation_runtime.rs` — host budget ceiling raised 32k → 64k tokens so `delegate_tasks` and the failed-task retry path accept realistic budgets.
- `crates/wisp-skills/src/portfolio.rs` — node budgets now include a 12k `NODE_AGENT_OVERHEAD_TOKENS` allowance for the sub-Agent loop itself (system prompt, tool round trips, search results).
- `ui/src/agent_workflows.rs` — Skill Portfolio Planner defaults: total 16k → 96k, synthesis reserve 4k → 16k, node output 2k → 4k.
- `docs/agent-delegation.md` — documents the 64k ceiling, the detailed budget error, and the new preflight budget composition.

## Safety

Budgets above the existing 20k elevated threshold still produce a confirmation reason, so raising a task to 40k goes through the normal review flow. Root-wide workflow limits scale from the host ceiling as before.

## Tests

- Updated: `composed_capabilities_use_highest_risk_and_narrowest_budget` (asserts the new error payload and message content), `risky_choices_each_produce_an_explicit_confirmation_reason`, and the portfolio planner test (now asserts node budget = Skill body + agent overhead + output).
- Verified: `cargo fmt --all -- --check`, `cargo test --workspace` (all green), `cd ui && cargo check --target wasm32-unknown-unknown`, and the Playwright `Skill Portfolio Planner` spec.

## Known limitations / follow-ups

- No unlimited-budget mode: a finite 64k ceiling keeps root-wide consumption limits meaningful.
- No automatic per-Skill budget estimation (issue option 4); the measured overhead constant covers the reported cases. Revisit if 64k proves tight.