### PR TITLE
fix(ui): keep context menus inside the viewport near window edges

### DIFF
--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -1653,6 +1653,42 @@ test("conversation action button renames, transfers, and deletes sessions (#557)
   )).toBe(true);
 });
 
+test("session context menu near the window bottom stays fully visible (#650)", async ({ page }) => {
+  // Narrow + short window: labels wrap, so real item heights exceed the 38px
+  // estimate the initial placement uses — the menu must re-clamp after measuring.
+  await page.setViewportSize({ width: 180, height: 420 });
+  await page.addInitScript(parallelMock);
+  await page.goto("/");
+  await page.locator(".proj-card-main").first().click();
+  await expect(newSessionButton(page)).toBeVisible();
+
+  await composer(page).fill("ctx-bottom-edge");
+  await page.getByRole("button", { name: "Send" }).click();
+  const session = page.locator(".side-item.ses", { hasText: "ctx-bottom-edge" });
+  await expect(session).toBeVisible({ timeout: 10_000 });
+
+  // Right-click with the pointer at the very bottom edge of the window.
+  await session.evaluate((el) => {
+    const rect = el.getBoundingClientRect();
+    el.dispatchEvent(new MouseEvent("contextmenu", {
+      bubbles: true,
+      cancelable: true,
+      button: 2,
+      clientX: Math.round(rect.left + 20),
+      clientY: window.innerHeight - 12,
+    }));
+  });
+
+  const menu = page.locator(".ctx-menu");
+  await expect(menu).toBeVisible();
+  await expect.poll(() => menu.evaluate((el) => {
+    const rect = el.getBoundingClientRect();
+    return rect.left >= 0 && rect.top >= 0 && rect.right <= innerWidth && rect.bottom <= innerHeight;
+  })).toBe(true);
+  // The last (bottom-most) menu item must remain clickable.
+  await expect(menu.getByRole("button", { name: "Delete", exact: true })).toBeVisible();
+});
+
 test("conversations can be selected and moved or deleted together", async ({ page }) => {
   await page.addInitScript(parallelMock);
   await page.goto("/");

--- a/ui/src/context_menu.rs
+++ b/ui/src/context_menu.rs
@@ -731,6 +731,28 @@ pub fn workspace_entry_action(action: &str, payload: &str) -> Option<WorkspaceEn
     }
 }
 
+fn viewport_size() -> Option<(f64, f64)> {
+    let window = web_sys::window()?;
+    Some((
+        window.inner_width().ok()?.as_f64()?,
+        window.inner_height().ok()?.as_f64()?,
+    ))
+}
+
+fn clamp_to_viewport(
+    x: f64,
+    y: f64,
+    width: f64,
+    height: f64,
+    viewport_width: f64,
+    viewport_height: f64,
+) -> (f64, f64) {
+    (
+        x.max(8.0).min((viewport_width - width - 8.0).max(8.0)),
+        y.max(8.0).min((viewport_height - height - 8.0).max(8.0)),
+    )
+}
+
 #[component]
 pub fn ContextMenuPortal(
     menu: ReadSignal<Option<CtxMenu>>,
@@ -738,12 +760,70 @@ pub fn ContextMenuPortal(
     on_pick: Callback<(String, String)>,
 ) -> impl IntoView {
     let submenu_anchor = create_rw_signal(None::<SubmenuAnchor>);
+    let menu_el = create_node_ref::<html::Div>();
+    let submenu_el = create_node_ref::<html::Div>();
+    // The initial position is based on a 38px-per-item estimate, but real item
+    // heights vary with fonts, locales, and label wrapping — so after render we
+    // measure the true size and re-clamp the menu into the viewport (issue #650).
+    // Each fix is tagged with the position it was computed for so a stale fix is
+    // never applied to a newly opened menu.
+    let menu_fix = create_rw_signal(None::<(f64, f64, f64, f64)>);
+    let submenu_fix = create_rw_signal(None::<(SubmenuAnchor, f64, f64)>);
     window_capture_escape(move || {
         if submenu_anchor.get_untracked().is_none() {
             return false;
         }
         submenu_anchor.set(None);
         true
+    });
+
+    create_effect(move |_| {
+        let Some(m) = menu.get() else {
+            menu_fix.set(None);
+            return;
+        };
+        request_animation_frame(move || {
+            let Some(el) = menu_el.get() else { return };
+            let Some((viewport_width, viewport_height)) = viewport_size() else {
+                return;
+            };
+            let (left, top) = clamp_to_viewport(
+                m.x,
+                m.y,
+                f64::from(el.offset_width()),
+                f64::from(el.offset_height()),
+                viewport_width,
+                viewport_height,
+            );
+            menu_fix.set(Some((m.x, m.y, left, top)));
+        });
+    });
+
+    create_effect(move |_| {
+        if menu.get().is_none() {
+            submenu_fix.set(None);
+            return;
+        }
+        let Some(anchor) = submenu_anchor.get() else {
+            submenu_fix.set(None);
+            return;
+        };
+        request_animation_frame(move || {
+            let Some(el) = submenu_el.get() else { return };
+            let Some((viewport_width, viewport_height)) = viewport_size() else {
+                return;
+            };
+            let width = f64::from(el.offset_width());
+            let height = f64::from(el.offset_height());
+            let left = if anchor.right + width <= viewport_width - 8.0 {
+                anchor.right
+            } else {
+                (anchor.left - width).max(8.0)
+            };
+            let (_, top) =
+                clamp_to_viewport(left, anchor.top, width, height, viewport_width, viewport_height);
+            submenu_fix.set(Some((anchor, left, top)));
+        });
     });
 
     view! {
@@ -754,13 +834,22 @@ pub fn ContextMenuPortal(
             }
             let items = m.items.clone();
             let item_count = items.len() as f64;
-            let (viewport_width, viewport_height) = web_sys::window()
-                .and_then(|window| Some((window.inner_width().ok()?.as_f64()?, window.inner_height().ok()?.as_f64()?)))
+            let (viewport_width, viewport_height) = viewport_size()
                 .unwrap_or((m.x + 280.0, m.y + item_count * 38.0 + 12.0));
             let estimated_width = 280.0_f64.min((viewport_width - 16.0).max(168.0));
             let estimated_height = (item_count * 38.0 + 12.0).min((viewport_height - 16.0).max(50.0));
-            let left = m.x.max(8.0).min((viewport_width - estimated_width - 8.0).max(8.0));
-            let top = m.y.max(8.0).min((viewport_height - estimated_height - 8.0).max(8.0));
+            let (estimated_left, estimated_top) = clamp_to_viewport(
+                m.x,
+                m.y,
+                estimated_width,
+                estimated_height,
+                viewport_width,
+                viewport_height,
+            );
+            let (left, top) = match menu_fix.get() {
+                Some((x, y, left, top)) if x == m.x && y == m.y => (left, top),
+                _ => (estimated_left, estimated_top),
+            };
             Some(view! {
                 <div
                     class="ctx-backdrop"
@@ -773,6 +862,7 @@ pub fn ContextMenuPortal(
                 <div
                     class="ctx-menu"
                     role="menu"
+                    node_ref=menu_el
                     style=format!("left:{left}px;top:{top}px")
                     on:click=|ev: web_sys::MouseEvent| ev.stop_propagation()
                 >
@@ -832,8 +922,7 @@ pub fn ContextMenuPortal(
                     }
                     let items = parent.children.clone();
                     let item_count = items.len() as f64;
-                    let (viewport_width, viewport_height) = web_sys::window()
-                        .and_then(|window| Some((window.inner_width().ok()?.as_f64()?, window.inner_height().ok()?.as_f64()?)))
+                    let (viewport_width, viewport_height) = viewport_size()
                         .unwrap_or((anchor.right + 280.0, anchor.top + item_count * 38.0 + 12.0));
                     let estimated_width = 280.0_f64.min((viewport_width - 16.0).max(168.0));
                     let estimated_height = (item_count * 38.0 + 12.0).min((viewport_height - 16.0).max(50.0));
@@ -843,11 +932,16 @@ pub fn ContextMenuPortal(
                         (anchor.left - estimated_width).max(8.0)
                     };
                     let top = anchor.top.max(8.0).min((viewport_height - estimated_height - 8.0).max(8.0));
+                    let (left, top) = match submenu_fix.get() {
+                        Some((a, left, top)) if a == anchor => (left, top),
+                        _ => (left, top),
+                    };
                     Some(view! {
                         <div
                             class="ctx-menu ctx-submenu-menu"
                             role="menu"
                             aria-label=parent.label.clone()
+                            node_ref=submenu_el
                             style=format!("left:{left}px;top:{top}px;width:{estimated_width}px")
                             on:click=|ev: web_sys::MouseEvent| ev.stop_propagation()
                         >


### PR DESCRIPTION
## Problem

Fixes #650 — right-clicking a session near the bottom of the window opens a context menu that overflows the window's bottom edge, leaving bottom items like "Delete" clipped and unclickable.

Root cause: `ContextMenuPortal` clamped the menu position against a hard-coded **estimate** of 38px per item. Real item heights vary with label wrapping (narrow windows), font metrics (macOS PingFang vs others), and translations, so the rendered menu can be taller than the estimate. Reproduced in Playwright: menu bottom at 430px in a 420px viewport.

## Fix

After the menu renders at its estimated position, measure the real `offsetWidth`/`offsetHeight` in a `requestAnimationFrame` and re-clamp into the viewport using the measured size. Same treatment for the hover submenu. Each correction is tagged with the position it was computed for, so a stale fix is never applied to a newly opened menu. The existing CSS `max-height: calc(100vh - 16px)` + `overflow-y: auto` still covers windows shorter than the whole menu.

Verified: same scenario now clamps to bottom 418 ≤ 420.

## Changes

- `ui/src/context_menu.rs`: measured re-clamp for `.ctx-menu` and `.ctx-submenu-menu`; shared `clamp_to_viewport`/`viewport_size` helpers.
- `ui-tests/tests/ui.spec.ts`: regression test — right-click a session at the bottom edge of a narrow 180×420 window (labels wrap, actual height > estimate), assert the menu stays fully inside the viewport and "Delete" is visible.

## Verification

- New regression test fails before the fix, passes after.
- Context-menu Playwright subset (5 tests incl. #557 containment test): pass.
- `cargo check --target wasm32-unknown-unknown`: pass.
- `cargo fmt --all -- --check`: pass.
- `cargo test --workspace`: pass.

## Known limitations

- The menu briefly renders at the estimated position for one frame before the measured correction applies; both positions are in-bounds, so this is at most a 1-frame nudge.