### PR TITLE
feat: default delegated Agent budgets to unlimited

### DIFF
--- a/crates/wisp-core/src/delegation.rs
+++ b/crates/wisp-core/src/delegation.rs
@@ -165,6 +165,11 @@ impl ContextPolicy {
     }
 }
 
+/// Resource limits for one delegated Agent run. Every dimension is optional:
+/// `None` (or `Some(0)`, normalized to `None` at resolution time) means the
+/// dimension is unlimited. Budgets are an advanced tuning knob — delegated
+/// tasks run unlimited by default, and a finite value is only checked after
+/// the run as a policy guard, never as a mid-run abort.
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct AgentBudget {
     #[serde(default)]
@@ -402,12 +407,8 @@ impl AgentSpec {
                 }
             }
         }
-        if self.context_policy.max_tokens == Some(0)
-            || self.budget.max_tokens == Some(0)
-            || self.budget.max_tool_calls == Some(0)
-            || self.budget.max_cost_microunits == Some(0)
-        {
-            anyhow::bail!("agent budgets must be positive");
+        if self.context_policy.max_tokens == Some(0) {
+            anyhow::bail!("context token limits must be positive");
         }
         Ok(())
     }
@@ -927,7 +928,7 @@ fn budget_violation(usage: &AgentUsage, budget: &AgentBudget) -> Option<String> 
     let total_tokens = usage.input_tokens.saturating_add(usage.output_tokens);
     if budget
         .max_tokens
-        .is_some_and(|limit| total_tokens > u64::from(limit))
+        .is_some_and(|limit| limit > 0 && total_tokens > u64::from(limit))
     {
         return Some(format!(
             "Agent exceeded its token budget ({total_tokens} tokens)"
@@ -935,7 +936,7 @@ fn budget_violation(usage: &AgentUsage, budget: &AgentBudget) -> Option<String> 
     }
     if budget
         .max_tool_calls
-        .is_some_and(|limit| usage.tool_calls > u64::from(limit))
+        .is_some_and(|limit| limit > 0 && usage.tool_calls > u64::from(limit))
     {
         return Some(format!(
             "Agent exceeded its tool-call budget ({} calls)",
@@ -944,7 +945,7 @@ fn budget_violation(usage: &AgentUsage, budget: &AgentBudget) -> Option<String> 
     }
     if budget
         .max_cost_microunits
-        .is_some_and(|limit| usage.cost_microunits > limit)
+        .is_some_and(|limit| limit > 0 && usage.cost_microunits > limit)
     {
         return Some(format!(
             "Agent exceeded its cost budget ({} microunits)",
@@ -1049,6 +1050,33 @@ mod tests {
             ..test_spec("a")
         };
         assert!(spec.validate().is_err());
+    }
+
+    #[test]
+    fn zero_budget_dimensions_are_valid_and_mean_unlimited() {
+        let spec = AgentSpec {
+            budget: AgentBudget {
+                max_tokens: Some(0),
+                max_tool_calls: Some(0),
+                max_cost_microunits: Some(0),
+            },
+            ..test_spec("a")
+        };
+        assert!(spec.validate().is_ok());
+
+        let usage = AgentUsage {
+            input_tokens: 900_000,
+            output_tokens: 100_000,
+            tool_calls: 10_000,
+            cost_microunits: u64::MAX,
+        };
+        assert_eq!(budget_violation(&usage, &spec.budget), None);
+        assert_eq!(budget_violation(&usage, &AgentBudget::default()), None);
+        let capped = AgentBudget {
+            max_tokens: Some(50_000),
+            ..AgentBudget::default()
+        };
+        assert!(budget_violation(&usage, &capped).is_some());
     }
 
     #[test]

--- a/crates/wisp-core/src/delegation_policy.rs
+++ b/crates/wisp-core/src/delegation_policy.rs
@@ -20,12 +20,11 @@ use thiserror::Error;
 
 const ELEVATED_TOKEN_THRESHOLD: u32 = 20_000;
 const ELEVATED_COST_THRESHOLD_MICROUNITS: u64 = 1_000_000;
-/// Default per-task token budget and the highest token budget a delegated task
-/// may request. Skill-bound literature/review tasks routinely consume
-/// 15k-25k tokens while loading the Skill and iterating on tool results, so
-/// the ceiling must leave comfortable room above that.
-const DEFAULT_TASK_TOKEN_BUDGET: u32 = 16_000;
-const TASK_TOKEN_BUDGET_CEILING: u32 = 64_000;
+/// Ceiling on how much conversation context a delegated task may ingest. This
+/// bounds the prompt, not the run: run budgets (tokens/tool calls/cost) are
+/// unlimited by default and only constrained when the user explicitly sets
+/// them, so skill-bound tasks are never failed mid-work by a budget guess.
+const CONTEXT_TOKEN_CEILING: u32 = 64_000;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -370,8 +369,13 @@ impl CapabilityRegistry {
             &grant.budget_ceiling,
         )?;
         let timeout_secs = select_timeout(host)?;
-        let mut approval_reasons =
-            approval_reasons(&grant, model, &executor, workspace_policy, &budget);
+        let mut approval_reasons = approval_reasons(
+            &grant,
+            model,
+            &executor,
+            workspace_policy,
+            proposal.budget.as_ref(),
+        );
         approval_reasons.sort();
         approval_reasons.dedup();
 
@@ -993,48 +997,53 @@ fn select_budget(
     ceiling: &AgentBudget,
 ) -> Result<AgentBudget, ResolutionError> {
     let selected = AgentBudget {
-        max_tokens: requested
-            .and_then(|value| value.max_tokens)
-            .or(defaults.max_tokens),
-        max_tool_calls: requested
-            .and_then(|value| value.max_tool_calls)
-            .or(defaults.max_tool_calls),
-        max_cost_microunits: requested
-            .and_then(|value| value.max_cost_microunits)
-            .or(defaults.max_cost_microunits),
+        max_tokens: clamp_budget_limit(
+            "max_tokens",
+            requested
+                .and_then(|value| value.max_tokens)
+                .or(defaults.max_tokens),
+            ceiling.max_tokens,
+        )?,
+        max_tool_calls: clamp_budget_limit(
+            "max_tool_calls",
+            requested
+                .and_then(|value| value.max_tool_calls)
+                .or(defaults.max_tool_calls),
+            ceiling.max_tool_calls,
+        )?,
+        max_cost_microunits: clamp_budget_limit(
+            "max_cost_microunits",
+            requested
+                .and_then(|value| value.max_cost_microunits)
+                .or(defaults.max_cost_microunits),
+            ceiling.max_cost_microunits,
+        )?,
     };
-    check_budget_limit("max_tokens", selected.max_tokens, ceiling.max_tokens)?;
-    check_budget_limit(
-        "max_tool_calls",
-        selected.max_tool_calls,
-        ceiling.max_tool_calls,
-    )?;
-    check_budget_limit(
-        "max_cost_microunits",
-        selected.max_cost_microunits,
-        ceiling.max_cost_microunits,
-    )?;
     Ok(selected)
 }
 
-fn check_budget_limit<T: Ord + Copy + Into<u64>>(
+/// Resolve one budget dimension against its ceiling. `Some(0)` is normalized
+/// to `None` (unlimited) so users can opt back out of a finite budget. An
+/// unlimited selection under a finite ceiling clamps down to the ceiling; a
+/// finite selection above the ceiling is rejected with the field named.
+fn clamp_budget_limit<T: Ord + Copy + Into<u64>>(
     field: &'static str,
     selected: Option<T>,
     ceiling: Option<T>,
-) -> Result<(), ResolutionError> {
-    let exceeded = match (selected, ceiling) {
-        (_, None) => false,
-        (Some(selected), Some(ceiling)) => selected > ceiling,
-        (None, Some(_)) => true,
-    };
-    if exceeded {
-        return Err(ResolutionError::BudgetExceeded {
-            field,
-            requested: selected.map_or_else(|| "unset".into(), |value| value.into().to_string()),
-            ceiling: ceiling.map_or(0, Into::into),
-        });
+) -> Result<Option<T>, ResolutionError> {
+    let selected = selected.filter(|value| (*value).into() != 0);
+    match (selected, ceiling) {
+        (Some(selected), Some(ceiling)) if selected > ceiling => {
+            Err(ResolutionError::BudgetExceeded {
+                field,
+                requested: selected.into().to_string(),
+                ceiling: ceiling.into(),
+            })
+        }
+        (Some(selected), Some(_)) => Ok(Some(selected)),
+        (None, ceiling) => Ok(ceiling),
+        (selected, None) => Ok(selected),
     }
-    Ok(())
 }
 
 fn select_timeout(host: &DelegationHostPolicy) -> Result<Option<u64>, ResolutionError> {
@@ -1051,7 +1060,7 @@ fn approval_reasons(
     model: Option<&ModelProfilePolicy>,
     executor: &AgentExecutorRef,
     workspace: AgentWorkspacePolicy,
-    budget: &AgentBudget,
+    requested_budget: Option<&AgentBudget>,
 ) -> Vec<String> {
     let mut reasons = grant.approval_reasons.clone();
     if grant.permissions.write {
@@ -1081,20 +1090,26 @@ fn approval_reasons(
                 .into(),
         );
     }
-    if budget_is_elevated(budget, &grant.default_budget) {
+    if budget_is_elevated(requested_budget, &grant.default_budget) {
         reasons.push("Task requests an elevated resource budget".into());
     }
     reasons
 }
 
-fn budget_is_elevated(selected: &AgentBudget, defaults: &AgentBudget) -> bool {
-    limit_greater(selected.max_tokens, defaults.max_tokens)
-        || limit_greater(selected.max_tool_calls, defaults.max_tool_calls)
-        || limit_greater(selected.max_cost_microunits, defaults.max_cost_microunits)
-        || selected
+/// Elevation is judged on what the task explicitly requested, not on the
+/// resolved budget: an unset or zero dimension is the unlimited default and
+/// must not turn a host ceiling clamp into a confirmation prompt.
+fn budget_is_elevated(requested: Option<&AgentBudget>, defaults: &AgentBudget) -> bool {
+    let Some(requested) = requested else {
+        return false;
+    };
+    limit_greater(requested.max_tokens, defaults.max_tokens)
+        || limit_greater(requested.max_tool_calls, defaults.max_tool_calls)
+        || limit_greater(requested.max_cost_microunits, defaults.max_cost_microunits)
+        || requested
             .max_tokens
             .is_some_and(|value| value > ELEVATED_TOKEN_THRESHOLD)
-        || selected
+        || requested
             .max_cost_microunits
             .is_some_and(|value| value > ELEVATED_COST_THRESHOLD_MICROUNITS)
 }
@@ -1286,8 +1301,7 @@ fn builtin_capabilities() -> Vec<CapabilityDefinition> {
             &[],
             &[],
             AgentWorkspacePolicy::SharedReadOnly,
-            DEFAULT_TASK_TOKEN_BUDGET,
-            TASK_TOKEN_BUDGET_CEILING,
+            CONTEXT_TOKEN_CEILING,
         ),
         capability(
             "project_read",
@@ -1302,8 +1316,7 @@ fn builtin_capabilities() -> Vec<CapabilityDefinition> {
             &[],
             &[],
             AgentWorkspacePolicy::SharedReadOnly,
-            DEFAULT_TASK_TOKEN_BUDGET,
-            TASK_TOKEN_BUDGET_CEILING,
+            CONTEXT_TOKEN_CEILING,
         ),
         capability(
             "project_write",
@@ -1318,8 +1331,7 @@ fn builtin_capabilities() -> Vec<CapabilityDefinition> {
             &[],
             &[],
             AgentWorkspacePolicy::SerializedMutation,
-            DEFAULT_TASK_TOKEN_BUDGET,
-            TASK_TOKEN_BUDGET_CEILING,
+            CONTEXT_TOKEN_CEILING,
         ),
         capability(
             "code_run",
@@ -1342,8 +1354,7 @@ fn builtin_capabilities() -> Vec<CapabilityDefinition> {
             &[],
             &[],
             AgentWorkspacePolicy::SerializedMutation,
-            DEFAULT_TASK_TOKEN_BUDGET,
-            TASK_TOKEN_BUDGET_CEILING,
+            CONTEXT_TOKEN_CEILING,
         ),
         capability(
             "literature_search",
@@ -1361,8 +1372,7 @@ fn builtin_capabilities() -> Vec<CapabilityDefinition> {
             &[],
             &["literature"],
             AgentWorkspacePolicy::SharedReadOnly,
-            DEFAULT_TASK_TOKEN_BUDGET,
-            TASK_TOKEN_BUDGET_CEILING,
+            CONTEXT_TOKEN_CEILING,
         ),
         capability(
             "external_research",
@@ -1377,8 +1387,7 @@ fn builtin_capabilities() -> Vec<CapabilityDefinition> {
             &[],
             &["web"],
             AgentWorkspacePolicy::SharedReadOnly,
-            DEFAULT_TASK_TOKEN_BUDGET,
-            TASK_TOKEN_BUDGET_CEILING,
+            CONTEXT_TOKEN_CEILING,
         ),
         capability(
             "visualization",
@@ -1397,8 +1406,7 @@ fn builtin_capabilities() -> Vec<CapabilityDefinition> {
             &[],
             &[],
             AgentWorkspacePolicy::SerializedMutation,
-            DEFAULT_TASK_TOKEN_BUDGET,
-            TASK_TOKEN_BUDGET_CEILING,
+            CONTEXT_TOKEN_CEILING,
         ),
         capability(
             "review",
@@ -1413,8 +1421,7 @@ fn builtin_capabilities() -> Vec<CapabilityDefinition> {
             &[],
             &[],
             AgentWorkspacePolicy::SharedReadOnly,
-            DEFAULT_TASK_TOKEN_BUDGET,
-            TASK_TOKEN_BUDGET_CEILING,
+            CONTEXT_TOKEN_CEILING,
         ),
         delegation_capability(),
         capability_with_model(
@@ -1425,8 +1432,7 @@ fn builtin_capabilities() -> Vec<CapabilityDefinition> {
             &["read", "view_image"],
             &[ExecutorFeature::ProjectRead, ExecutorFeature::Vision],
             &[ModelFeature::Vision],
-            DEFAULT_TASK_TOKEN_BUDGET,
-            TASK_TOKEN_BUDGET_CEILING,
+            CONTEXT_TOKEN_CEILING,
         ),
     ]
 }
@@ -1445,8 +1451,7 @@ fn delegation_capability() -> CapabilityDefinition {
         &[],
         &[],
         AgentWorkspacePolicy::SharedReadOnly,
-        DEFAULT_TASK_TOKEN_BUDGET,
-        TASK_TOKEN_BUDGET_CEILING,
+        CONTEXT_TOKEN_CEILING,
     );
     definition.approval_reason =
         Some("Task may create a bounded nested Agent batch within root-wide limits".into());
@@ -1467,8 +1472,7 @@ fn capability(
     skills: &[&str],
     connectors: &[&str],
     workspace_policy: AgentWorkspacePolicy,
-    default_tokens: u32,
-    max_tokens: u32,
+    context_tokens: u32,
 ) -> CapabilityDefinition {
     CapabilityDefinition {
         id: id.into(),
@@ -1494,18 +1498,13 @@ fn capability(
         context_ceiling: ContextPolicy {
             include_history: false,
             include_artifacts: true,
-            max_tokens: Some(max_tokens),
+            max_tokens: Some(context_tokens),
         },
-        default_budget: AgentBudget {
-            max_tokens: Some(default_tokens),
-            max_tool_calls: Some(32),
-            max_cost_microunits: Some(500_000),
-        },
-        budget_ceiling: AgentBudget {
-            max_tokens: Some(max_tokens),
-            max_tool_calls: Some(64),
-            max_cost_microunits: Some(1_000_000),
-        },
+        // Run budgets default to unlimited on every dimension; they remain an
+        // advanced per-task override validated against these (also unlimited)
+        // ceilings rather than a planner guess that can fail finished work.
+        default_budget: AgentBudget::default(),
+        budget_ceiling: AgentBudget::default(),
         workspace_policy,
         approval_reason: None,
     }
@@ -1520,8 +1519,7 @@ fn capability_with_model(
     tools: &[&str],
     executor_features: &[ExecutorFeature],
     model_features: &[ModelFeature],
-    default_tokens: u32,
-    max_tokens: u32,
+    context_tokens: u32,
 ) -> CapabilityDefinition {
     let mut definition = capability(
         id,
@@ -1536,8 +1534,7 @@ fn capability_with_model(
         &[],
         &[],
         AgentWorkspacePolicy::SharedReadOnly,
-        default_tokens,
-        max_tokens,
+        context_tokens,
     );
     definition.required_model_features = model_features.to_vec();
     definition
@@ -1798,6 +1795,41 @@ mod tests {
         assert!(message.contains("max_tokens"));
         assert!(message.contains("32001"));
         assert!(message.contains("32000"));
+    }
+
+    #[test]
+    fn budgets_default_to_unlimited_and_zero_dimensions_normalize() {
+        let registry = CapabilityRegistry::builtins();
+
+        // With an unlimited host ceiling a task that asks for nothing gets no
+        // budget at all — and no confirmation prompt.
+        let mut open_host = host_policy();
+        open_host.budget_ceiling = AgentBudget::default();
+        let resolved = registry
+            .resolve_task(proposal("free", &["project_read"]), &open_host)
+            .unwrap();
+        assert_eq!(resolved.spec().budget, AgentBudget::default());
+        assert!(!resolved
+            .spec()
+            .approval_reasons
+            .iter()
+            .any(|reason| reason.contains("budget")));
+
+        // Zero dimensions are an explicit unlimited: they normalize away,
+        // then clamp to the ceiling when the host still sets a finite one.
+        let mut zeroed = proposal("zeroed", &["project_read"]);
+        zeroed.budget = Some(AgentBudget {
+            max_tokens: Some(0),
+            max_tool_calls: Some(0),
+            max_cost_microunits: Some(0),
+        });
+        let resolved = registry.resolve_task(zeroed, &host_policy()).unwrap();
+        assert_eq!(resolved.spec().budget.max_tokens, Some(32_000));
+        assert!(!resolved
+            .spec()
+            .approval_reasons
+            .iter()
+            .any(|reason| reason.contains("budget")));
     }
 
     #[test]

--- a/crates/wisp-skills/src/portfolio.rs
+++ b/crates/wisp-skills/src/portfolio.rs
@@ -60,6 +60,9 @@ pub struct PortfolioCandidate {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PortfolioConfig {
     pub tier: PortfolioTier,
+    /// Total token allowance shared by the selected nodes. `0` (the default
+    /// stance) means unlimited — per-node budgets are then only estimates
+    /// shown in the plan, not enforced limits.
     pub total_token_budget: u32,
     pub synthesis_reserve: u32,
     pub node_output_tokens: u32,
@@ -109,13 +112,21 @@ pub fn plan_portfolio(
     config: PortfolioConfig,
 ) -> Result<PortfolioPlan, String> {
     normalize_intent(&mut intent);
-    if config.total_token_budget <= config.synthesis_reserve {
+    // A total budget of 0 means unlimited: budgets are an advanced tuning
+    // knob, so by default the planner must not defer skills over a guessed
+    // allowance. Bounded mode still requires room for the synthesis reserve.
+    let bounded = config.total_token_budget > 0;
+    if bounded && config.total_token_budget <= config.synthesis_reserve {
         return Err("total token budget must exceed the synthesis reserve".into());
     }
     if config.node_output_tokens == 0 {
         return Err("node output token budget must be greater than zero".into());
     }
-    let child_token_budget = config.total_token_budget - config.synthesis_reserve;
+    let child_token_budget = if bounded {
+        config.total_token_budget - config.synthesis_reserve
+    } else {
+        0
+    };
     let request_tokens = estimate_tokens(&intent.request);
     let mut ranked = candidates
         .iter()
@@ -154,7 +165,7 @@ pub fn plan_portfolio(
         let adjusted_score = score - if duplicate_role { 2 } else { 0 };
         if selected.len() >= config.tier.skill_limit() {
             deferred.push(deferral(candidate, adjusted_score, "tier_limit"));
-        } else if used.saturating_add(node_budget) > child_token_budget {
+        } else if bounded && used.saturating_add(node_budget) > child_token_budget {
             deferred.push(deferral(
                 candidate,
                 adjusted_score,
@@ -426,5 +437,42 @@ mod tests {
         assert_eq!(plan.max_parallel, 2);
         assert_eq!(plan.estimated_batches, 2);
         assert!(plan.requires_confirmation);
+    }
+
+    #[test]
+    fn zero_total_budget_means_unlimited_and_never_defers_on_tokens() {
+        let candidates = (0..4)
+            .map(|index| candidate(&format!("skill-{index}"), "analyst", 400))
+            .collect::<Vec<_>>();
+        let plan = plan_portfolio(
+            ResearchIntent {
+                request: "oncology omics analysis".into(),
+                domains: vec!["oncology".into()],
+                research_stages: vec!["analysis".into()],
+                roles: vec!["analyst".into()],
+                evidence_types: vec!["omics".into()],
+                outputs: vec!["analysis-module".into()],
+            },
+            &candidates,
+            PortfolioConfig {
+                tier: PortfolioTier::Deep,
+                total_token_budget: 0,
+                synthesis_reserve: 0,
+                node_output_tokens: 300,
+                user_parallel_limit: 4,
+            },
+        )
+        .unwrap();
+        assert_eq!(plan.child_token_budget, 0);
+        assert!(plan
+            .deferred
+            .iter()
+            .all(|item| item.reason != "insufficient_token_budget"));
+        assert_eq!(plan.selected.len(), 4);
+        // Node budgets stay as estimates for display even when unbounded.
+        assert_eq!(
+            plan.selected[0].node_budget,
+            plan.selected[0].instruction_tokens + 300 + NODE_AGENT_OVERHEAD_TOKENS
+        );
     }
 }

--- a/docs/agent-delegation.md
+++ b/docs/agent-delegation.md
@@ -109,14 +109,17 @@ boundary.
 3. The call describes an overall goal, bounded shared context, and up to eight
    tasks. Each task has its own instruction, dependency IDs, capability IDs,
    optional Specialist, optional JSON output schema, optional isolation
-   request, and optional per-task token/tool/cost budget.
+   request, and optional per-task token/tool/cost budget. Budgets are an
+   advanced tuning knob: tasks run unlimited by default, and an omitted or
+   zero dimension stays unlimited.
 4. Wisp resolves every capability through host policy into an exact model,
    executor, tool set, project scope, workspace policy, budget, and timeout.
    The model cannot grant raw tools or permissions to a child.
 5. Safe read-only tasks run immediately. A batch that can write, execute code,
-   use an external service, request isolation, or exceed normal budgets uses
-   the existing approval prompt. Rejecting it starts no child and returns the
-   feedback to the main Agent so it can revise the batch.
+   use an external service, request isolation, or explicitly request an
+   elevated budget uses the existing approval prompt. Rejecting it starts no
+   child and returns the feedback to the main Agent so it can revise the
+   batch.
 6. Independent tasks run concurrently up to the batch limit. A dependent task
    starts only after its direct dependencies succeed and receives their
    structured results. An unrelated branch continues after another branch
@@ -131,9 +134,10 @@ workflow and every successful task result, reruns only failed/cancelled tasks
 and descendants that were blocked, then supplies the retained dependency
 results to those descendants. A failed task exposes its current token limit in
 the activity card; changing **Retry max tokens** before retrying revises only
-that task's authorized budget on the same workflow. The new value is still
-checked against capability and host ceilings (64k tokens per task); a rejected
-budget names the triggered limit, the requested value, and the ceiling.
+that task's authorized budget on the same workflow (0 makes the task
+unlimited). A finite value is still checked against capability and host
+ceilings; a rejected budget names the triggered limit, the requested value,
+and the ceiling.
 
 Omitting `specialist_id` creates a generic temporary Agent. Selecting a
 Specialist reuses its persona, model preference, skills, and connector
@@ -443,11 +447,13 @@ the coordination paths.
 
 Workflow Studio can generate a draft from the current effective Skill Catalog. The planner
 normalizes the research request, applies deterministic lexical and `wisp` metadata scoring, and
-selects a compact, standard, or deep complementary portfolio. Its preflight budgets each node for
-the rendered Skill instruction plus the request, a fixed sub-Agent loop allowance (system prompt,
-tool round trips, and search results), and the node output allowance; it reserves synthesis tokens
-before selecting child nodes and defers lower-ranked optional candidates when the remaining child
-budget is insufficient.
+selects a compact, standard, or deep complementary portfolio. Budgets are an advanced override: a
+total budget of 0 (the default) leaves every node unlimited, and the preflight numbers are shown
+as estimates only. With a bounded total, preflight budgets each node for the rendered Skill
+instruction plus the request, a fixed sub-Agent loop allowance (system prompt, tool round trips,
+and search results), and the node output allowance; it reserves synthesis tokens before selecting
+child nodes and defers lower-ranked optional candidates when the remaining child budget is
+insufficient.
 
 The confirmation card shows exact Skill sources and reasons, selected and deferred nodes, node and
 total budgets, the synthesis reserve, the runtime maximum of two parallel Agents, and estimated DAG

--- a/src-tauri/src/delegation_runtime.rs
+++ b/src-tauri/src/delegation_runtime.rs
@@ -1499,11 +1499,9 @@ async fn build_dynamic_delegation_policy(
             include_artifacts: true,
             max_tokens: Some(32_000),
         },
-        budget_ceiling: AgentBudget {
-            max_tokens: Some(64_000),
-            max_tool_calls: Some(64),
-            max_cost_microunits: Some(1_000_000),
-        },
+        // Run budgets are unlimited by default: the host does not cap tokens,
+        // tool calls, or cost unless the user sets a per-task budget.
+        budget_ceiling: AgentBudget::default(),
         default_timeout_secs: Some(600),
         timeout_ceiling_secs: Some(1_800),
         auto_safe: true,
@@ -3916,12 +3914,12 @@ impl AcpUsage {
     }
 
     fn missing_budget_dimension(&self, budget: &AgentBudget) -> Option<String> {
-        if budget.max_tokens.is_some() && !self.tokens_reported {
+        if budget.max_tokens.is_some_and(|limit| limit > 0) && !self.tokens_reported {
             return Some(
                 "ACP Agent did not report usage required to enforce its token budget".into(),
             );
         }
-        if budget.max_cost_microunits.is_some() && !self.cost_reported {
+        if budget.max_cost_microunits.is_some_and(|limit| limit > 0) && !self.cost_reported {
             return Some(
                 "ACP Agent did not report cost required to enforce its cost budget".into(),
             );
@@ -3934,7 +3932,7 @@ fn runtime_budget_violation(usage: &AgentUsage, budget: &AgentBudget) -> Option<
     let total_tokens = usage.input_tokens.saturating_add(usage.output_tokens);
     if budget
         .max_tokens
-        .is_some_and(|limit| total_tokens > u64::from(limit))
+        .is_some_and(|limit| limit > 0 && total_tokens > u64::from(limit))
     {
         return Some(format!(
             "Agent exceeded its token budget ({total_tokens} tokens)"
@@ -3942,7 +3940,7 @@ fn runtime_budget_violation(usage: &AgentUsage, budget: &AgentBudget) -> Option<
     }
     if budget
         .max_tool_calls
-        .is_some_and(|limit| usage.tool_calls > u64::from(limit))
+        .is_some_and(|limit| limit > 0 && usage.tool_calls > u64::from(limit))
     {
         return Some(format!(
             "Agent exceeded its tool-call budget ({} calls)",
@@ -3951,7 +3949,7 @@ fn runtime_budget_violation(usage: &AgentUsage, budget: &AgentBudget) -> Option<
     }
     if budget
         .max_cost_microunits
-        .is_some_and(|limit| usage.cost_microunits > limit)
+        .is_some_and(|limit| limit > 0 && usage.cost_microunits > limit)
     {
         return Some(format!(
             "Agent exceeded its cost budget ({} microunits)",
@@ -6930,6 +6928,26 @@ mod tests {
             &budget
         )
         .is_some());
+    }
+
+    #[test]
+    fn runtime_budget_checks_treat_zero_dimensions_as_unlimited() {
+        let budget = AgentBudget {
+            max_tokens: Some(0),
+            max_tool_calls: Some(0),
+            max_cost_microunits: Some(0),
+        };
+        let usage = AgentUsage {
+            input_tokens: 900_000,
+            output_tokens: 100_000,
+            tool_calls: 10_000,
+            cost_microunits: u64::MAX,
+        };
+        assert_eq!(runtime_budget_violation(&usage, &budget), None);
+        assert_eq!(
+            runtime_budget_violation(&usage, &AgentBudget::default()),
+            None
+        );
     }
 
     struct SuccessfulDelegator;

--- a/src-tauri/src/delegation_tool.rs
+++ b/src-tauri/src/delegation_tool.rs
@@ -318,11 +318,11 @@ fn build_delegate_tasks_schema(
                                 "type": "object",
                                 "additionalProperties": false,
                                 "properties": {
-                                    "max_tokens": {"type": "integer", "minimum": 1},
-                                    "max_tool_calls": {"type": "integer", "minimum": 1},
-                                    "max_cost_microunits": {"type": "integer", "minimum": 1}
+                                    "max_tokens": {"type": "integer", "minimum": 0},
+                                    "max_tool_calls": {"type": "integer", "minimum": 0},
+                                    "max_cost_microunits": {"type": "integer", "minimum": 0}
                                 },
-                                "description": "Optional per-task limits. Values are validated against capability and host ceilings; omit a dimension to use its capability default."
+                                "description": "Optional per-task limits for advanced tuning. Tasks run unlimited by default; omit a dimension or set it to 0 to leave it unlimited. Positive values are validated against capability and host ceilings."
                             }
                         },
                         "required": ["id", "instruction", "capabilities"]

--- a/src-tauri/src/dynamic_workflow.rs
+++ b/src-tauri/src/dynamic_workflow.rs
@@ -914,14 +914,8 @@ pub(crate) fn validate_proposal(proposal: &DynamicAgentWorkflowProposal) -> Resu
                 task.id
             ));
         }
-        if let Some(budget) = &task.budget {
-            if budget.max_tokens == Some(0)
-                || budget.max_tool_calls == Some(0)
-                || budget.max_cost_microunits == Some(0)
-            {
-                return Err(format!("task {} budget limits must be positive", task.id));
-            }
-        }
+        // Budget dimensions accept 0 as an explicit unlimited (normalized at
+        // policy resolution); omitting the budget leaves the task unlimited.
     }
     for task in &proposal.tasks {
         let mut dependencies = HashSet::new();

--- a/src-tauri/src/native_delegation.rs
+++ b/src-tauri/src/native_delegation.rs
@@ -212,12 +212,13 @@ pub(crate) async fn run_native_agent(
         .spec
         .context_policy
         .max_tokens
-        .or(request.spec.budget.max_tokens)
+        .or(request.spec.budget.max_tokens.filter(|limit| *limit > 0))
         .unwrap_or(32_000) as usize;
     let max_iterations = request
         .spec
         .budget
         .max_tool_calls
+        .filter(|limit| *limit > 0)
         .map(|limit| limit as usize + 1)
         .unwrap_or(100);
     let mut context = ContextManager::new(max_context.max(1));

--- a/src-tauri/src/quick_actions.rs
+++ b/src-tauri/src/quick_actions.rs
@@ -535,11 +535,7 @@ fn literature_base_proposal() -> dynamic_workflow::DynamicAgentWorkflowProposal 
                 isolated: false,
                 model_id: None,
                 executor: None,
-                budget: Some(dynamic_workflow::AgentBudgetProposal {
-                    max_tokens: Some(32_000),
-                    max_tool_calls: Some(8),
-                    max_cost_microunits: None,
-                }),
+                budget: None,
             },
             dynamic_workflow::DynamicAgentTaskProposal {
                 id: "challenging_evidence".into(),
@@ -558,11 +554,7 @@ fn literature_base_proposal() -> dynamic_workflow::DynamicAgentWorkflowProposal 
                 isolated: false,
                 model_id: None,
                 executor: None,
-                budget: Some(dynamic_workflow::AgentBudgetProposal {
-                    max_tokens: Some(32_000),
-                    max_tool_calls: Some(8),
-                    max_cost_microunits: None,
-                }),
+                budget: None,
             },
             dynamic_workflow::DynamicAgentTaskProposal {
                 id: "synthesize".into(),
@@ -582,11 +574,7 @@ fn literature_base_proposal() -> dynamic_workflow::DynamicAgentWorkflowProposal 
                 isolated: false,
                 model_id: None,
                 executor: None,
-                budget: Some(dynamic_workflow::AgentBudgetProposal {
-                    max_tokens: Some(16_000),
-                    max_tool_calls: Some(2),
-                    max_cost_microunits: None,
-                }),
+                budget: None,
             },
         ],
     }
@@ -611,13 +599,6 @@ fn roundtable_base_proposal() -> dynamic_workflow::DynamicAgentWorkflowProposal 
     let review = "Review both opening positions supplied as dependency results. Compare them, \
         identify agreements, conflicts, missing evidence, and failure modes, then give a revised \
         recommendation. Preserve meaningful disagreement instead of forcing consensus.";
-    let budget = || {
-        Some(dynamic_workflow::AgentBudgetProposal {
-            max_tokens: Some(16_000),
-            max_tool_calls: Some(16),
-            max_cost_microunits: None,
-        })
-    };
     dynamic_workflow::DynamicAgentWorkflowProposal {
         goal: "Run a two-perspective roundtable and chair synthesis".into(),
         context: String::new(),
@@ -638,7 +619,7 @@ fn roundtable_base_proposal() -> dynamic_workflow::DynamicAgentWorkflowProposal 
                 isolated: false,
                 model_id: None,
                 executor: None,
-                budget: budget(),
+                budget: None,
             },
             dynamic_workflow::DynamicAgentTaskProposal {
                 id: "seat_2_opening".into(),
@@ -653,7 +634,7 @@ fn roundtable_base_proposal() -> dynamic_workflow::DynamicAgentWorkflowProposal 
                 isolated: false,
                 model_id: None,
                 executor: None,
-                budget: budget(),
+                budget: None,
             },
             dynamic_workflow::DynamicAgentTaskProposal {
                 id: "seat_1_review".into(),
@@ -668,7 +649,7 @@ fn roundtable_base_proposal() -> dynamic_workflow::DynamicAgentWorkflowProposal 
                 isolated: false,
                 model_id: None,
                 executor: None,
-                budget: budget(),
+                budget: None,
             },
             dynamic_workflow::DynamicAgentTaskProposal {
                 id: "seat_2_review".into(),
@@ -683,7 +664,7 @@ fn roundtable_base_proposal() -> dynamic_workflow::DynamicAgentWorkflowProposal 
                 isolated: false,
                 model_id: None,
                 executor: None,
-                budget: budget(),
+                budget: None,
             },
             dynamic_workflow::DynamicAgentTaskProposal {
                 id: "chair_synthesis".into(),
@@ -702,7 +683,7 @@ fn roundtable_base_proposal() -> dynamic_workflow::DynamicAgentWorkflowProposal 
                 isolated: false,
                 model_id: None,
                 executor: None,
-                budget: budget(),
+                budget: None,
             },
         ],
     }
@@ -774,11 +755,7 @@ fn research_design_base_proposal() -> dynamic_workflow::DynamicAgentWorkflowProp
             isolated: false,
             model_id: None,
             executor: None,
-            budget: Some(dynamic_workflow::AgentBudgetProposal {
-                max_tokens: Some(12_000),
-                max_tool_calls: Some(12),
-                max_cost_microunits: None,
-            }),
+            budget: None,
         }
     };
     dynamic_workflow::DynamicAgentWorkflowProposal {
@@ -811,7 +788,7 @@ fn research_design_base_proposal() -> dynamic_workflow::DynamicAgentWorkflowProp
                 isolated: false,
                 model_id: None,
                 executor: None,
-                budget: Some(dynamic_workflow::AgentBudgetProposal { max_tokens: Some(12_000), max_tool_calls: Some(3), max_cost_microunits: None }),
+                budget: None,
             },
         ],
     }
@@ -897,11 +874,7 @@ fn method_search_agent_task(
         isolated: false,
         model_id: None,
         executor: None,
-        budget: Some(dynamic_workflow::AgentBudgetProposal {
-            max_tokens: Some(16_000),
-            max_tool_calls: Some(16),
-            max_cost_microunits: None,
-        }),
+        budget: None,
     }
 }
 
@@ -1736,16 +1709,13 @@ mod tests {
             ["literature_search".to_string()]
         );
         assert_eq!(proposal.tasks[2].capabilities, ["reasoning".to_string()]);
+        // Built-in templates ship unlimited budgets; per-task limits stay an
+        // advanced user override.
+        assert!(proposal.tasks.iter().all(|task| task.budget.is_none()));
         for task in &proposal.tasks[..2] {
-            let budget = task.budget.as_ref().expect("search budget");
-            assert_eq!(budget.max_tokens, Some(32_000));
-            assert_eq!(budget.max_tool_calls, Some(8));
             assert!(task.instruction.contains("at most 8"));
             assert!(task.instruction.contains("return the required JSON"));
         }
-        let synthesis_budget = proposal.tasks[2].budget.as_ref().expect("synthesis budget");
-        assert_eq!(synthesis_budget.max_tokens, Some(16_000));
-        assert_eq!(synthesis_budget.max_tool_calls, Some(2));
         assert!(proposal.context.contains("notes/claim.md"));
         assert!(proposal.context.contains("A testable biological claim."));
     }
@@ -1754,11 +1724,7 @@ mod tests {
     fn roundtable_template_has_parallel_openings_reviews_and_chair() {
         let proposal = roundtable_base_proposal();
         assert_eq!(proposal.tasks.len(), 5);
-        assert!(proposal.tasks.iter().all(|task| {
-            task.budget.as_ref().is_some_and(|budget| {
-                budget.max_tokens == Some(16_000) && budget.max_tool_calls == Some(16)
-            })
-        }));
+        assert!(proposal.tasks.iter().all(|task| task.budget.is_none()));
         assert!(proposal.tasks[0].depends_on.is_empty());
         assert!(proposal.tasks[1].depends_on.is_empty());
         assert_eq!(

--- a/src-tauri/src/skill_portfolio.rs
+++ b/src-tauri/src/skill_portfolio.rs
@@ -57,6 +57,9 @@ pub(crate) async fn plan_skill_portfolio(
 }
 
 fn workflow_draft(plan: &PortfolioPlan) -> dynamic_workflow::DynamicAgentWorkflowProposal {
+    // Budgets are an advanced override: an unbounded plan (total budget 0)
+    // leaves every task unlimited instead of enforcing estimated allowances.
+    let bounded = plan.total_token_budget > 0;
     let mut tasks = plan
         .selected
         .iter()
@@ -87,7 +90,7 @@ fn workflow_draft(plan: &PortfolioPlan) -> dynamic_workflow::DynamicAgentWorkflo
             isolated: false,
             model_id: None,
             executor: None,
-            budget: Some(dynamic_workflow::AgentBudgetProposal {
+            budget: bounded.then_some(dynamic_workflow::AgentBudgetProposal {
                 max_tokens: Some(selection.node_budget),
                 max_tool_calls: Some(12),
                 max_cost_microunits: None,
@@ -116,7 +119,7 @@ fn workflow_draft(plan: &PortfolioPlan) -> dynamic_workflow::DynamicAgentWorkflo
         isolated: false,
         model_id: None,
         executor: None,
-        budget: Some(dynamic_workflow::AgentBudgetProposal {
+        budget: bounded.then_some(dynamic_workflow::AgentBudgetProposal {
             max_tokens: Some(plan.synthesis_reserve),
             max_tool_calls: Some(4),
             max_cost_microunits: None,
@@ -192,5 +195,38 @@ mod tests {
             draft.approval_policy,
             dynamic_workflow::AgentApprovalPolicy::ReviewAll
         );
+    }
+
+    #[test]
+    fn unbounded_plan_leaves_task_budgets_unset() {
+        let plan = PortfolioPlan {
+            intent: ResearchIntent {
+                request: "design a study".into(),
+                ..Default::default()
+            },
+            tier: PortfolioTier::Standard,
+            selected: vec![PortfolioSelection {
+                skill_id: "analysis-workflow".into(),
+                name: "Analysis".into(),
+                scope: "bundled".into(),
+                path: "/skill/SKILL.md".into(),
+                skill_md_sha256: "abc".into(),
+                score: 9,
+                reasons: vec!["stage: analysis".into()],
+                instruction_tokens: 200,
+                node_budget: 1_200,
+                side_effects: SkillSideEffects::ReadOnly,
+            }],
+            deferred: Vec::<PortfolioDeferral>::new(),
+            total_token_budget: 0,
+            child_token_budget: 0,
+            selected_node_budget: 1_200,
+            synthesis_reserve: 0,
+            max_parallel: 1,
+            estimated_batches: 2,
+            requires_confirmation: false,
+        };
+        let draft = workflow_draft(&plan);
+        assert!(draft.tasks.iter().all(|task| task.budget.is_none()));
     }
 }

--- a/ui/src/agent_workflows.rs
+++ b/ui/src/agent_workflows.rs
@@ -161,9 +161,9 @@ impl DynamicTaskForm {
                     .map_err(|error| format!("Task {} output schema: {error}", self.id))?,
             )
         };
-        let max_tokens = parse_optional_u32(&self.max_tokens, "token budget")?;
-        let max_tool_calls = parse_optional_u32(&self.max_tool_calls, "tool-call budget")?;
-        let max_cost_microunits = parse_optional_u64(&self.max_cost_microunits, "cost budget")?;
+        let max_tokens = parse_budget_u32(&self.max_tokens, "token budget")?;
+        let max_tool_calls = parse_budget_u32(&self.max_tool_calls, "tool-call budget")?;
+        let max_cost_microunits = parse_budget_u64(&self.max_cost_microunits, "cost budget")?;
         let budget =
             (max_tokens.is_some() || max_tool_calls.is_some() || max_cost_microunits.is_some())
                 .then_some(AgentBudgetProposal {
@@ -527,8 +527,6 @@ impl DynamicWorkflowForm {
             let mut task = DynamicTaskForm::blank(next_key, id.clone());
             next_key += 1;
             task.instruction.clone_from(&opening_instruction);
-            task.max_tokens = "16000".into();
-            task.max_tool_calls = "16".into();
             template.participants[index].apply_to(&mut task);
             tasks.push(task);
         }
@@ -538,8 +536,6 @@ impl DynamicWorkflowForm {
             next_key += 1;
             task.instruction.clone_from(&review_instruction);
             task.depends_on.clone_from(&opening_ids);
-            task.max_tokens = "16000".into();
-            task.max_tool_calls = "16".into();
             template.participants[index].apply_to(&mut task);
             tasks.push(task);
         }
@@ -548,8 +544,6 @@ impl DynamicWorkflowForm {
         next_key += 1;
         chair.instruction = chair_instruction;
         chair.depends_on = review_ids;
-        chair.max_tokens = "16000".into();
-        chair.max_tool_calls = "16".into();
         template.chair.apply_to(&mut chair);
         tasks.push(chair);
 
@@ -871,6 +865,28 @@ fn parse_optional_u32(value: &str, label: &str) -> Result<Option<u32>, String> {
                 .ok()
                 .filter(|value| *value > 0)
                 .ok_or_else(|| format!("{label} must be a positive whole number"))
+        })
+        .transpose()
+}
+
+/// Budget fields accept 0 as an explicit "unlimited" (normalized downstream);
+/// empty stays unset, which is also unlimited.
+fn parse_budget_u32(value: &str, label: &str) -> Result<Option<u32>, String> {
+    nonempty(value)
+        .map(|value| {
+            value
+                .parse::<u32>()
+                .map_err(|_| format!("{label} must be a whole number (0 = unlimited)"))
+        })
+        .transpose()
+}
+
+fn parse_budget_u64(value: &str, label: &str) -> Result<Option<u64>, String> {
+    nonempty(value)
+        .map(|value| {
+            value
+                .parse::<u64>()
+                .map_err(|_| format!("{label} must be a whole number (0 = unlimited)"))
         })
         .transpose()
 }
@@ -2903,8 +2919,8 @@ pub(super) fn workflow_studio(
     let portfolio_open = create_rw_signal(false);
     let portfolio_request = create_rw_signal(String::new());
     let portfolio_tier = create_rw_signal("standard".to_string());
-    let portfolio_total = create_rw_signal("96000".to_string());
-    let portfolio_reserve = create_rw_signal("16000".to_string());
+    let portfolio_total = create_rw_signal("0".to_string());
+    let portfolio_reserve = create_rw_signal("0".to_string());
     let portfolio_draft = create_rw_signal::<Option<SkillPortfolioDraft>>(None);
     let portfolio_loading = create_rw_signal(false);
 
@@ -2923,9 +2939,12 @@ pub(super) fn workflow_studio(
             .get_untracked()
             .parse::<u32>()
             .unwrap_or(0);
-        if request_text.is_empty() || total == 0 || reserve == 0 {
+        // Budgets are an advanced override: 0 means unlimited. A bounded
+        // total still has to leave room for the synthesis reserve.
+        if request_text.is_empty() || (total > 0 && (reserve == 0 || reserve >= total)) {
             state.error.set(Some(
-                "Research request and positive budgets are required.".into(),
+                "Research request is required; a bounded total budget must exceed the synthesis reserve (0 = unlimited)."
+                    .into(),
             ));
             return;
         }
@@ -3395,10 +3414,10 @@ pub(super) fn workflow_studio(
                                     <option value="deep">{"Deep"}</option>
                                 </select>
                             </label>
-                            <label><span>{"Total tokens"}</span><input data-testid="portfolio-total" type="number"
+                            <label><span>{"Total tokens (0 = unlimited)"}</span><input data-testid="portfolio-total" type="number" min="0"
                                 prop:value=move || portfolio_total.get()
                                 on:input=move |event| portfolio_total.set(event_target_value(&event)) /></label>
-                            <label><span>{"Synthesis reserve"}</span><input data-testid="portfolio-reserve" type="number"
+                            <label><span>{"Synthesis reserve"}</span><input data-testid="portfolio-reserve" type="number" min="0"
                                 prop:value=move || portfolio_reserve.get()
                                 on:input=move |event| portfolio_reserve.set(event_target_value(&event)) /></label>
                         </div>
@@ -3412,7 +3431,11 @@ pub(super) fn workflow_studio(
                             view! {
                                 <section data-testid="portfolio-plan-card">
                                     <strong>{format!("{} Skills · {} batches · max {} parallel", plan.selected.len(), plan.estimated_batches, plan.max_parallel)}</strong>
-                                    <p>{format!("{} total · {} node tokens · {} synthesis reserve", plan.total_token_budget, plan.selected_node_budget, plan.synthesis_reserve)}</p>
+                                    <p>{if plan.total_token_budget == 0 {
+                                        format!("unlimited budget · est. {} node tokens", plan.selected_node_budget)
+                                    } else {
+                                        format!("{} total · {} node tokens · {} synthesis reserve", plan.total_token_budget, plan.selected_node_budget, plan.synthesis_reserve)
+                                    }}</p>
                                     <ul>{plan.selected.into_iter().map(|item| view! {
                                         <li><code>{format!("{}:{}", item.scope, item.skill_id)}</code>
                                             {format!(" · {} tokens · {}", item.node_budget, item.reasons.join("; "))}</li>
@@ -3467,10 +3490,8 @@ fn retry_workflow(snapshot: AgentWorkflowSnapshot, state: AgentPanelState) {
                 let max_tokens = raw
                     .trim()
                     .parse::<u32>()
-                    .ok()
-                    .filter(|value| *value > 0)
-                    .ok_or_else(|| {
-                        "Retry token budget must be a positive whole number".to_string()
+                    .map_err(|_| {
+                        "Retry token budget must be a whole number (0 = unlimited)".to_string()
                     })?;
                 if task.budget.max_tokens != Some(max_tokens) {
                     overrides.insert(
@@ -4511,11 +4532,9 @@ mod tests {
             proposal.tasks[4].depends_on,
             ["seat_1_review", "seat_2_review"]
         );
-        assert!(proposal.tasks.iter().all(|task| {
-            task.budget.as_ref().is_some_and(|budget| {
-                budget.max_tokens == Some(16_000) && budget.max_tool_calls == Some(16)
-            })
-        }));
+        // Budgets are an advanced override: the template leaves them unset,
+        // which resolves to unlimited at planning time.
+        assert!(proposal.tasks.iter().all(|task| task.budget.is_none()));
 
         for task in [&proposal.tasks[0], &proposal.tasks[2]] {
             assert_eq!(task.specialist_id.as_deref(), Some("reader"));
@@ -4720,5 +4739,14 @@ mod tests {
         assert!(parse_optional_u32("0", "token budget").is_err());
         assert!(parse_optional_u64("0", "cost budget").is_err());
         assert_eq!(parse_optional_u32("42", "token budget").unwrap(), Some(42));
+    }
+
+    #[test]
+    fn task_budget_fields_accept_zero_as_unlimited() {
+        assert_eq!(parse_budget_u32("0", "token budget").unwrap(), Some(0));
+        assert_eq!(parse_budget_u64("0", "cost budget").unwrap(), Some(0));
+        assert_eq!(parse_budget_u32("", "token budget").unwrap(), None);
+        assert_eq!(parse_budget_u32("42", "token budget").unwrap(), Some(42));
+        assert!(parse_budget_u32("nope", "token budget").is_err());
     }
 }


### PR DESCRIPTION
## Problem

Follow-up to #649. Even after raising the per-task budgets (16k default / 64k ceiling), Skill-bound workflow nodes still failed with `Agent exceeded its token budget`. The failure mode was structural, not a matter of picking better numbers:

- The **post-run** budget check (`budget_violation`) discarded a finished, contract-satisfying result after its tokens were already spent — the worst of both worlds.
- The native **mid-run** enforcement (`BudgetedProvider`) killed sub-Agents mid-loop on planner-guessed limits (e.g. a 32k literature node that simply needed 40k).
- Raising a budget at runtime required fighting capability/host ceilings.

## Change

Budgets become an **advanced tuning knob that is unlimited by default**. `None` and `0` both mean unlimited on every `AgentBudget` dimension.

| Layer | Before | After |
|---|---|---|
| Built-in capability default/ceiling | 16k / 64k tokens, 32/64 tool calls, cost caps | unlimited |
| Host `budget_ceiling` | 64k tokens | unlimited |
| Unlimited selection under a finite ceiling | `BudgetExceeded("unset")` error | clamps to the ceiling |
| Explicit `0` in a budget field | rejected ("must be positive") | normalized to unlimited |
| Elevated-budget confirmation | triggered by the *resolved* budget (incl. ceiling clamps) | judged only on the *explicitly requested* budget |
| Skill Portfolio planner | total 96k default, deferred nodes on `insufficient_token_budget` | total 0 (unlimited) default; node budgets are display-only estimates |
| Built-in templates (literature, roundtable, research design, method search) | prefilled 12k-32k budgets | no budget (unlimited) |
| Workflow Studio fields, `delegate_tasks` schema, retry path | positive integers only | accept `0` = unlimited |

Ceilings still work when a host deliberately sets them (clamp), and explicit over-ceiling requests still fail with the field name and both numbers. ACP-side checks (`runtime_budget_violation`, `missing_budget_dimension`) and the native iteration/context fallbacks skip zero dimensions.

Runaway protection is preserved where it actually helps: stuck-loop detection, the 100-iteration loop cap, timeouts, root depth/task/wall-time limits, and context-window ceilings (32k/64k — a prompt-size bound, not a run budget).

## Files

- `crates/wisp-core/src/delegation.rs` — `AgentBudget` doc + `budget_violation`/validate accept 0 = unlimited
- `crates/wisp-core/src/delegation_policy.rs` — unlimited capability defaults/ceilings; `select_budget` clamp+normalize; request-based elevation
- `crates/wisp-skills/src/portfolio.rs` — `total_token_budget == 0` = unlimited planning
- `src-tauri/src/delegation_runtime.rs` — unlimited host ceiling; ACP zero-dimension guards
- `src-tauri/src/native_delegation.rs` — zero budgets don't shrink iteration/context fallbacks
- `src-tauri/src/quick_actions.rs` — built-in templates ship unlimited
- `src-tauri/src/delegation_tool.rs`, `dynamic_workflow.rs`, `skill_portfolio.rs` — schema/validation/draft alignment
- `ui/src/agent_workflows.rs` — portfolio defaults 0, budget fields accept 0, retry allows 0, template prefills removed
- `docs/agent-delegation.md` — budget semantics + portfolio planner docs

## Tests

Added/updated: policy resolution (unlimited default, zero normalization, finite-ceiling clamp, over-ceiling error), `budget_violation` and ACP `runtime_budget_violation` zero-dimension cases, portfolio unlimited planning (no budget deferrals), unlimited portfolio draft, UI budget parsing (0 accepted), template budget assertions.

- `cargo fmt --all -- --check` ✓
- `cargo test --workspace` ✓
- `cd ui && cargo check --target wasm32-unknown-unknown` ✓
- `cd ui && cargo test` ✓ (171)
- `cd ui-tests && npx playwright test` ✓ (266 passed, 1 skipped)

## Manual smoke

1. Agents panel → run the built-in Literature evidence review on a long passage — nodes now run to completion without token-budget failures.
2. Workflow Studio → Skill Portfolio Planner → leave **Total tokens** at 0 → plan card shows "unlimited budget"; generated tasks carry no budget.
3. Fail a task, set **Retry max tokens** to 0 → retry runs unlimited; set a positive value → still validated and honored.

## Known limitations / follow-ups

- Budget enforcement remains post-hoc for ACP agents whose usage is only reported at completion; with defaults unlimited this path is inert unless the user sets a budget.
- Root delegation limits (depth/task/wall-time, and accounting of *declared* budgets) are unchanged — unlimited per-task budgets sum to zero reservation by design.
- A runtime "budget reached → pause and request an extension" escalation was discussed and deliberately deferred: with unlimited defaults it only matters for user-imposed budgets, where failing is the requested behavior. If wanted, it needs a mid-loop escalation channel and is a separate PR.
