### PR TITLE
feat(skills): import ZIP packages

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -34,11 +34,13 @@ Skills that the user explicitly disabled remain disabled. Idle conversation
 Agents are rebuilt on their next turn, so the new index is used without losing
 conversation history or restarting the persistent Python/R runtime.
 
-The **Add skill** action installs or updates a global Skill. A project Skill can
-be managed with the project files under `.wisp/skills` and then loaded with
-**Reload skills**. Only global Skills can be deleted from the Skills settings
-page; project and extra-path files remain owned by their project or source
-directory. Plugin Skills are managed from their plugin card.
+The **Add skill** action installs or updates a global Skill from a `SKILL.md`
+file, a Skill folder, or a ZIP archive. A ZIP may contain `SKILL.md` directly or
+wrap one Skill in a single top-level folder. A project Skill can be managed with
+the project files under `.wisp/skills` and then loaded with **Reload skills**.
+Only global Skills can be deleted from the Skills settings page; project and
+extra-path files remain owned by their project or source directory. Plugin
+Skills are managed from their plugin card.
 
 Tags declared in `SKILL.md` appear automatically. Tags edited in Settings are a
 user override and are also applied to Agent `search_skills` queries after the

--- a/src-tauri/src/plugins.rs
+++ b/src-tauri/src/plugins.rs
@@ -477,64 +477,76 @@ fn validate_plugin_url(value: &str) -> Result<url::Url, String> {
     Ok(parsed)
 }
 
-fn extract_zip(archive_path: &Path, destination: &Path) -> Result<(), String> {
-    let file = File::open(archive_path).map_err(|error| format!("open plugin ZIP: {error}"))?;
+pub(crate) fn extract_zip(archive_path: &Path, destination: &Path) -> Result<(), String> {
+    let metadata =
+        std::fs::metadata(archive_path).map_err(|error| format!("stat ZIP archive: {error}"))?;
+    if metadata.len() > MAX_ARCHIVE_BYTES {
+        return Err(format!(
+            "ZIP archive exceeds {} MiB",
+            MAX_ARCHIVE_BYTES / 1024 / 1024
+        ));
+    }
+    let file = File::open(archive_path).map_err(|error| format!("open ZIP archive: {error}"))?;
     let mut archive =
-        zip::ZipArchive::new(file).map_err(|error| format!("read plugin ZIP: {error}"))?;
+        zip::ZipArchive::new(file).map_err(|error| format!("read ZIP archive: {error}"))?;
     if archive.len() > MAX_FILES {
-        return Err(format!("plugin ZIP contains more than {MAX_FILES} entries"));
+        return Err(format!(
+            "ZIP archive contains more than {MAX_FILES} entries"
+        ));
     }
     let mut seen = HashSet::new();
     let mut expanded = 0u64;
     for index in 0..archive.len() {
         let mut entry = archive
             .by_index(index)
-            .map_err(|error| format!("read plugin ZIP entry: {error}"))?;
+            .map_err(|error| format!("read ZIP archive entry: {error}"))?;
         let Some(enclosed) = entry.enclosed_name() else {
             return Err(format!(
-                "plugin ZIP entry '{}' escapes the package",
+                "ZIP archive entry '{}' escapes the package",
                 entry.name()
             ));
         };
         let normalized = enclosed.to_string_lossy().replace('\\', "/");
         if normalized.is_empty() || normalized.len() > MAX_PATH_BYTES {
-            return Err("plugin ZIP contains an empty or overly long path".into());
+            return Err("ZIP archive contains an empty or overly long path".into());
         }
         if !seen.insert(normalized.clone()) {
-            return Err(format!("plugin ZIP contains duplicate path '{normalized}'"));
+            return Err(format!(
+                "ZIP archive contains duplicate path '{normalized}'"
+            ));
         }
         if entry
             .unix_mode()
             .is_some_and(|mode| mode & 0o170000 == 0o120000)
         {
-            return Err(format!("plugin ZIP contains symbolic link '{normalized}'"));
+            return Err(format!("ZIP archive contains symbolic link '{normalized}'"));
         }
         let size = entry.size();
         if size > MAX_FILE_BYTES {
-            return Err(format!("plugin ZIP entry '{normalized}' is too large"));
+            return Err(format!("ZIP archive entry '{normalized}' is too large"));
         }
         expanded = expanded.saturating_add(size);
         if expanded > MAX_EXPANDED_BYTES {
-            return Err("plugin ZIP expanded size exceeds safety limit".into());
+            return Err("ZIP archive expanded size exceeds safety limit".into());
         }
         let output = destination.join(&enclosed);
         if entry.is_dir() {
             std::fs::create_dir_all(&output)
-                .map_err(|error| format!("create plugin directory: {error}"))?;
+                .map_err(|error| format!("create ZIP archive directory: {error}"))?;
             continue;
         }
         let parent = output
             .parent()
-            .ok_or_else(|| "plugin ZIP entry has no parent".to_string())?;
+            .ok_or_else(|| "ZIP archive entry has no parent".to_string())?;
         std::fs::create_dir_all(parent)
-            .map_err(|error| format!("create plugin directory: {error}"))?;
+            .map_err(|error| format!("create ZIP archive directory: {error}"))?;
         let mut target = File::create(&output)
-            .map_err(|error| format!("create plugin file '{}': {error}", output.display()))?;
+            .map_err(|error| format!("create extracted file '{}': {error}", output.display()))?;
         std::io::copy(&mut entry, &mut target)
-            .map_err(|error| format!("extract plugin file '{}': {error}", output.display()))?;
+            .map_err(|error| format!("extract ZIP file '{}': {error}", output.display()))?;
         target
             .flush()
-            .map_err(|error| format!("flush plugin file '{}': {error}", output.display()))?;
+            .map_err(|error| format!("flush extracted file '{}': {error}", output.display()))?;
     }
     Ok(())
 }

--- a/src-tauri/src/skill_commands.rs
+++ b/src-tauri/src/skill_commands.rs
@@ -167,11 +167,10 @@ pub(super) async fn set_skills_enabled(
 pub(super) async fn pick_skill_source(app: AppHandle) -> Result<Option<String>, String> {
     use tauri_plugin_dialog::DialogExt;
     let (tx, rx) = tokio::sync::oneshot::channel();
-    // Let the user pick a SKILL.md; folder picking is offered via a second button
-    // in the UI that calls pick_directory (existing command).
+    // Folder picking is offered via a second button in the UI.
     app.dialog()
         .file()
-        .add_filter("SKILL.md", &["md"])
+        .add_filter("Wisp skill", &["md", "zip"])
         .pick_file(move |p| {
             let _ = tx.send(p);
         });
@@ -213,46 +212,103 @@ pub(super) async fn install_skill(
     src_path: String,
 ) -> Result<String, String> {
     let src = PathBuf::from(&src_path);
-    // Resolve the skill's source dir + the SKILL.md path.
-    let (skill_dir, skill_md) = if src.is_dir() {
+    let skills_dir = user_skills_dir()?;
+    // ZIP extraction, recursive copy, and the atomic directory swap run off
+    // the async runtime. Existing user-added skills are replaced so importing
+    // an updated package is a normal upgrade path.
+    let skill_name = tokio::task::spawn_blocking(move || install_skill_source(&src, &skills_dir))
+        .await
+        .map_err(|e| format!("{e}"))??;
+    reload_host_skill_index(&state, window.label());
+    let ap = state.active(window.label());
+    if let Some(mut enabled) = load_enabled_skill_names(&state.store, &ap.id).await {
+        enabled.insert(skill_name.clone());
+        save_enabled_skill_names(&state.store, &ap.id, &enabled).await?;
+    }
+    clear_idle_agents(&state).await;
+    Ok(skill_name)
+}
+
+struct SkillImportTempDir(PathBuf);
+
+impl Drop for SkillImportTempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+fn install_skill_source(src: &Path, skills_dir: &Path) -> Result<String, String> {
+    let (_temp_dir, skill_dir, skill_md) = if src.is_dir() {
         let md = src.join("SKILL.md");
         if !md.is_file() {
             return Err("selected folder has no SKILL.md".into());
         }
-        (src.clone(), md)
-    } else if src.file_name().map(|n| n == "SKILL.md").unwrap_or(false) {
+        (None, src.to_path_buf(), md)
+    } else if src.file_name().is_some_and(|name| name == "SKILL.md") {
         (
+            None,
             src.parent().map(PathBuf::from).unwrap_or_default(),
-            src.clone(),
+            src.to_path_buf(),
         )
+    } else if src
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("zip"))
+    {
+        let temp_root =
+            std::env::temp_dir().join(format!("wisp-skill-import-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir(&temp_root)
+            .map_err(|error| format!("create skill ZIP staging directory: {error}"))?;
+        let temp_dir = SkillImportTempDir(temp_root.clone());
+        let fallback = src
+            .file_stem()
+            .and_then(|name| name.to_str())
+            .filter(|name| validate_skill_name(name).is_ok())
+            .unwrap_or("skill");
+        let unpacked = temp_root.join(fallback);
+        std::fs::create_dir(&unpacked)
+            .map_err(|error| format!("create skill ZIP extraction directory: {error}"))?;
+        crate::plugins::extract_zip(src, &unpacked)?;
+        let skill_dir = find_archived_skill_dir(&unpacked)?;
+        let skill_md = skill_dir.join("SKILL.md");
+        (Some(temp_dir), skill_dir, skill_md)
     } else {
-        return Err("select a skill folder or a SKILL.md file".into());
+        return Err("select a skill folder, a SKILL.md file, or a ZIP archive".into());
     };
-    // Parse name from frontmatter (fall back to dir name), validate description.
+
     let skill = wisp_skills::parse_skill_file(&skill_md)?;
     if skill.description.trim().is_empty() {
         return Err("SKILL.md is missing a description".into());
     }
     validate_skill_name(&skill.name)?;
-    let dest = user_skills_dir()?.join(&skill.name);
-    {
-        // Recursive copy and the atomic directory swap run off the async
-        // runtime: a skill folder can be large. Existing user-added skills are
-        // replaced so importing an updated copy is a normal upgrade path.
-        let (skill_dir, dest) = (skill_dir.clone(), dest.clone());
-        tokio::task::spawn_blocking(move || install_skill_dir(&skill_dir, &dest))
-            .await
-            .map_err(|e| format!("{e}"))?
-            .map_err(|e| format!("install skill: {e}"))?;
-    }
-    reload_host_skill_index(&state, window.label());
-    let ap = state.active(window.label());
-    if let Some(mut enabled) = load_enabled_skill_names(&state.store, &ap.id).await {
-        enabled.insert(skill.name.clone());
-        save_enabled_skill_names(&state.store, &ap.id, &enabled).await?;
-    }
-    clear_idle_agents(&state).await;
+    let dest = skills_dir.join(&skill.name);
+    install_skill_dir(&skill_dir, &dest).map_err(|error| format!("install skill: {error}"))?;
     Ok(skill.name)
+}
+
+fn find_archived_skill_dir(root: &Path) -> Result<PathBuf, String> {
+    if root.join("SKILL.md").is_file() {
+        return Ok(root.to_path_buf());
+    }
+    let mut candidates = Vec::new();
+    for entry in
+        std::fs::read_dir(root).map_err(|error| format!("read skill ZIP contents: {error}"))?
+    {
+        let entry = entry.map_err(|error| format!("read skill ZIP entry: {error}"))?;
+        if entry
+            .file_type()
+            .map_err(|error| format!("inspect skill ZIP entry: {error}"))?
+            .is_dir()
+            && entry.path().join("SKILL.md").is_file()
+        {
+            candidates.push(entry.path());
+        }
+    }
+    match candidates.len() {
+        1 => Ok(candidates.remove(0)),
+        0 => Err("skill ZIP has no SKILL.md at its root or in a top-level folder".into()),
+        _ => Err("skill ZIP contains more than one skill folder".into()),
+    }
 }
 
 #[tauri::command]
@@ -377,6 +433,7 @@ fn install_skill_dir(from: &Path, to: &Path) -> Result<bool, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
 
     struct TestDir(PathBuf);
 
@@ -429,6 +486,66 @@ mod tests {
             std::fs::read_to_string(destination.join("SKILL.md")).unwrap(),
             "old instructions"
         );
+    }
+
+    #[test]
+    fn zip_skill_import_installs_a_single_top_level_skill_folder() {
+        let temp = TestDir::new();
+        let archive_path = temp.0.join("ggtree-visualization.zip");
+        let file = std::fs::File::create(&archive_path).unwrap();
+        let mut archive = zip::ZipWriter::new(file);
+        archive
+            .start_file(
+                "ggtree-visualization/SKILL.md",
+                zip::write::SimpleFileOptions::default(),
+            )
+            .unwrap();
+        archive
+            .write_all(b"---\nname: ggtree-visualization\ndescription: Draw trees\n---\n# Skill")
+            .unwrap();
+        archive
+            .start_file(
+                "ggtree-visualization/assets/template.R",
+                zip::write::SimpleFileOptions::default(),
+            )
+            .unwrap();
+        archive.write_all(b"plot(tree)").unwrap();
+        archive.finish().unwrap();
+
+        let installed = temp.0.join("installed");
+        assert_eq!(
+            install_skill_source(&archive_path, &installed),
+            Ok("ggtree-visualization".into())
+        );
+        assert!(installed.join("ggtree-visualization/SKILL.md").is_file());
+        assert_eq!(
+            std::fs::read_to_string(installed.join("ggtree-visualization/assets/template.R"))
+                .unwrap(),
+            "plot(tree)"
+        );
+    }
+
+    #[test]
+    fn zip_skill_import_rejects_multiple_skill_folders() {
+        let temp = TestDir::new();
+        let archive_path = temp.0.join("skills.zip");
+        let file = std::fs::File::create(&archive_path).unwrap();
+        let mut archive = zip::ZipWriter::new(file);
+        for name in ["one", "two"] {
+            archive
+                .start_file(
+                    format!("{name}/SKILL.md"),
+                    zip::write::SimpleFileOptions::default(),
+                )
+                .unwrap();
+            archive
+                .write_all(format!("---\nname: {name}\ndescription: Test\n---\n").as_bytes())
+                .unwrap();
+        }
+        archive.finish().unwrap();
+
+        let error = install_skill_source(&archive_path, &temp.0.join("installed")).unwrap_err();
+        assert_eq!(error, "skill ZIP contains more than one skill folder");
     }
 
     #[test]

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -2707,7 +2707,7 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
           }
           case "pick_skill_source":
             return query.get("mockSkillImport") === "1"
-              ? "/downloads/paper-narrative/SKILL.md"
+              ? "/downloads/paper-narrative.zip"
               : null;
           case "install_skill":
             return "paper-narrative";

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -5436,9 +5436,15 @@ test("skill manager updates and deletes user-added skills", async ({ page }) => 
   await openSettingsSection(page, "Skills");
 
   await page.getByText("Add skill", { exact: true }).click();
-  await page.getByRole("button", { name: "Add SKILL.md" }).click();
+  const addFile = page.getByRole("button", { name: "Add SKILL.md or ZIP" });
+  await page.keyboard.press("Escape");
+  await expect(addFile).not.toBeVisible();
+  await expect(page.locator(".settings-page")).toBeVisible();
+
+  await page.getByText("Add skill", { exact: true }).click();
+  await addFile.click();
   await expect.poll(() => lastInvokeArgs(page, "install_skill")).toMatchObject({
-    srcPath: "/downloads/paper-narrative/SKILL.md",
+    srcPath: "/downloads/paper-narrative.zip",
   });
   await expect(page.getByText("Skill added or updated.")).toBeVisible();
 

--- a/ui/src/i18n.rs
+++ b/ui/src/i18n.rs
@@ -1229,7 +1229,7 @@ fn lookup(locale: Locale, key: &str) -> Option<&'static str> {
         (Locale::En, "err.cred_env_duplicate") => Some("A credential already uses environment variable {env}."),
         (Locale::En, "settings.applies_new_session") => Some("Changes apply to new sessions."),
         (Locale::En, "settings.auto_saved_new_session") => Some("Saved automatically. Changes apply to new sessions."),
-        (Locale::En, "skills.add_file") => Some("Add SKILL.md"),
+        (Locale::En, "skills.add_file") => Some("Add SKILL.md or ZIP"),
         (Locale::En, "skills.add_folder") => Some("Add folder"),
         (Locale::En, "skills.add") => Some("Add skill"),
         (Locale::En, "skills.manage") => Some("Manage skills"),
@@ -1487,7 +1487,9 @@ fn lookup(locale: Locale, key: &str) -> Option<&'static str> {
         (Locale::En, "err.validation_timeout") => Some("Validation timed out after 30s"),
         (Locale::En, "err.vision_probe_failed") => Some(" This check sent a test image because \"supports images\" is on. If the model has no vision support, turn that off and validate again."),
         (Locale::En, "err.skill_no_md") => Some("The selected folder has no SKILL.md."),
-        (Locale::En, "err.skill_pick") => Some("Select a skill folder or a SKILL.md file."),
+        (Locale::En, "err.skill_pick") => Some("Select a skill folder, a SKILL.md file, or a ZIP archive."),
+        (Locale::En, "err.skill_zip_no_md") => Some("The ZIP archive has no SKILL.md at its root or in a top-level folder."),
+        (Locale::En, "err.skill_zip_multiple") => Some("The ZIP archive contains more than one skill folder."),
         (Locale::En, "err.skill_no_frontmatter") => Some("SKILL.md has no frontmatter (--- block)."),
         (Locale::En, "err.skill_frontmatter_unclosed") => Some("SKILL.md frontmatter is not closed with ---."),
         (Locale::En, "err.skill_no_description") => Some("SKILL.md is missing a description."),
@@ -3043,7 +3045,7 @@ Do not leave generated files in the project root.",
         (Locale::Zh, "err.cred_env_duplicate") => Some("环境变量 {env} 已被其他凭据使用。"),
         (Locale::Zh, "settings.applies_new_session") => Some("改动对新会话生效。"),
         (Locale::Zh, "settings.auto_saved_new_session") => Some("已自动保存；改动对新会话生效。"),
-        (Locale::Zh, "skills.add_file") => Some("添加 SKILL.md"),
+        (Locale::Zh, "skills.add_file") => Some("添加 SKILL.md 或 ZIP"),
         (Locale::Zh, "skills.add_folder") => Some("添加文件夹"),
         (Locale::Zh, "skills.add") => Some("添加技能"),
         (Locale::Zh, "skills.manage") => Some("管理技能"),
@@ -3294,7 +3296,9 @@ Do not leave generated files in the project root.",
         (Locale::Zh, "status.demo") => Some("示例：{title}"),
         (Locale::Zh, "err.api_url_required") => Some("API 地址不能为空。"),
         (Locale::Zh, "err.skill_no_md") => Some("所选文件夹中没有 SKILL.md。"),
-        (Locale::Zh, "err.skill_pick") => Some("请选择技能文件夹或 SKILL.md 文件。"),
+        (Locale::Zh, "err.skill_pick") => Some("请选择技能文件夹、SKILL.md 文件或 ZIP 压缩包。"),
+        (Locale::Zh, "err.skill_zip_no_md") => Some("ZIP 压缩包根目录或其第一层文件夹中没有 SKILL.md。"),
+        (Locale::Zh, "err.skill_zip_multiple") => Some("ZIP 压缩包中包含多个技能文件夹。"),
         (Locale::Zh, "err.skill_no_frontmatter") => Some("SKILL.md 缺少 frontmatter（--- 块）。"),
         (Locale::Zh, "err.skill_frontmatter_unclosed") => Some("SKILL.md 的 frontmatter 没有以 --- 结束。"),
         (Locale::Zh, "err.skill_no_description") => Some("SKILL.md 缺少 description。"),
@@ -3820,7 +3824,15 @@ pub fn localize_backend(locale: Locale, msg: &str) -> String {
         }
         "kernel worker closed protocol stdout" => t(locale, "runtime.worker_closed"),
         "selected folder has no SKILL.md" => t(locale, "err.skill_no_md"),
-        "select a skill folder or a SKILL.md file" => t(locale, "err.skill_pick"),
+        "select a skill folder, a SKILL.md file, or a ZIP archive" => {
+            t(locale, "err.skill_pick")
+        }
+        "skill ZIP has no SKILL.md at its root or in a top-level folder" => {
+            t(locale, "err.skill_zip_no_md")
+        }
+        "skill ZIP contains more than one skill folder" => {
+            t(locale, "err.skill_zip_multiple")
+        }
         "SKILL.md has no frontmatter (--- block)" => t(locale, "err.skill_no_frontmatter"),
         "SKILL.md frontmatter is not closed with ---" => {
             t(locale, "err.skill_frontmatter_unclosed")


### PR DESCRIPTION
## Problem

Skills could only be installed from a SKILL.md file or an unpacked folder. Downloaded skill packages such as ggtree-visualization.zip had to be extracted manually before Wisp could import them.

## Summary

- Accept Markdown and ZIP files in the native Add skill picker.
- Extract ZIP packages in a temporary directory, locate one Skill at the archive root or in one top-level folder, then reuse the existing atomic install/update path.
- Reuse the existing bounded ZIP extractor and its traversal, symlink, duplicate-path, file-count, per-file, compressed-size, and expanded-size checks.
- Add localized English and Chinese labels/errors and document ZIP package support.
- Add Rust coverage for a wrapped skill package and ambiguous multi-skill rejection, plus UI coverage for ZIP selection and the window-level Escape stack.

## Tests

- cargo fmt --all -- --check
- cargo test --workspace
- cd ui && cargo check --target wasm32-unknown-unknown
- cd ui-tests && npm ci
- cd ui-tests && npx playwright test (266 passed, 1 skipped)

## Manual smoke

1. Open Settings > Skills > Add skill.
2. Choose Add SKILL.md or ZIP.
3. Select ggtree-visualization.zip.
4. Confirm ggtree-visualization appears as an enabled global Skill and its assets, references, and scripts are present in the installed package.
5. Open Add skill again and press Escape immediately; confirm only the menu closes and Settings remains open.

## Known limitations / follow-up

- One ZIP installs exactly one Skill. SKILL.md must be at the archive root or inside one top-level folder; archives containing multiple candidate Skill folders are rejected.
- Importing a Skill ZIP from a remote URL is not included; the source must be a local file.