### PR TITLE
fix(ui): keep run output panels pinned to the tail across poll rebuilds (#654)

### DIFF
--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -3771,6 +3771,72 @@ test("monitor_run renders a live Run card inline without get_run polling", async
   await expect(card).toContainText("Cancelled");
 });
 
+test("run monitor output stays pinned to the tail across poll rebuilds (#654)", async ({ page }) => {
+  // Eight long logical lines wrap far past the 150px pre, so it scrolls.
+  const longOutput = (tag: string) =>
+    Array.from({ length: 8 }, (_, index) => `${tag} line ${index} ` + "x".repeat(180)).join("\n");
+  const setOutput = (tag: string) =>
+    page.evaluate((stdout) => {
+      const run = (window as any).__mockRuns.find((item: any) => item.id === "run-local-002");
+      run.stdout_tail = stdout;
+    }, longOutput(tag));
+  const bottomGap = () =>
+    page
+      .locator('[data-run-id="run-local-002"] .run-monitor-output pre')
+      .evaluate((el) => el.scrollHeight - el.clientHeight - el.scrollTop);
+
+  await enterApp(page);
+  await page.evaluate(() => {
+    const run = (window as any).__mockRuns.find((item: any) => item.id === "run-local-002");
+    Object.assign(run, {
+      context_id: "local",
+      title: "Scrolling pipeline",
+      kind: "local",
+      status: "running",
+      created_at: Math.floor(Date.now() / 1000) - 30,
+      started_at: Math.floor(Date.now() / 1000) - 29,
+      // Non-empty progress keeps the one-second run refresh active.
+      progress_json: "{\"tick\":1}",
+    });
+  });
+  await setOutput("batch-1");
+
+  await composer(page).fill("MONITORRUN");
+  await page.getByRole("button", { name: "Send" }).click();
+
+  const output = page.locator('[data-run-id="run-local-002"] .run-monitor-output pre');
+  await expect(output).toBeVisible();
+  await expect.poll(bottomGap, { timeout: 5_000 }).toBeLessThanOrEqual(2);
+
+  // Fresh output on the next poll rebuilds the card; the panel must re-pin.
+  await setOutput("batch-2");
+  await expect(output).toContainText("batch-2");
+  await expect.poll(bottomGap, { timeout: 5_000 }).toBeLessThanOrEqual(2);
+
+  // A scrolled-up user keeps their place instead of being yanked back down.
+  await output.evaluate((el) => {
+    el.scrollTop = 0;
+  });
+  await setOutput("batch-3");
+  await expect(output).toContainText("batch-3");
+  await page.waitForTimeout(1_500);
+  expect(await output.evaluate((el) => el.scrollTop)).toBeLessThanOrEqual(2);
+
+  // Scrolling back to the bottom re-engages follow.
+  await output.evaluate((el) => {
+    el.scrollTop = el.scrollHeight;
+  });
+  await setOutput("batch-4");
+  await expect(output).toContainText("batch-4");
+  await expect.poll(bottomGap, { timeout: 5_000 }).toBeLessThanOrEqual(2);
+
+  // Leave the run settled so its one-second refresh stops with this page.
+  await page.evaluate(() => {
+    const run = (window as any).__mockRuns.find((item: any) => item.id === "run-local-002");
+    Object.assign(run, { status: "succeeded", ended_at: Math.floor(Date.now() / 1000), exit_code: 0 });
+  });
+});
+
 test("reasoning details stays open while more thinking streams in", async ({ page }) => {
   await enterApp(page);
   await composer(page).fill("RZSTREAM");

--- a/ui/src/app_support.rs
+++ b/ui/src/app_support.rs
@@ -4,7 +4,8 @@ use super::{
 };
 use crate::bindings::{
     attach_cropped_region, crop_region_to_upload, invoke, invoke_checked, is_mac, mount_preview,
-    open_external_url, schedule_highlight, upload_files, upload_input_files, upload_pasted_images,
+    open_external_url, schedule_highlight, schedule_run_output_follow, upload_files,
+    upload_input_files, upload_pasted_images,
 };
 use crate::dto::*;
 use crate::i18n::{localize_backend, t, tf, use_locale, Locale};
@@ -1076,6 +1077,7 @@ pub(super) fn refresh_runs(into: RwSignal<Vec<RunRecord>>, locale: RwSignal<Loca
                 initialized && added
             });
             into.set(list);
+            schedule_run_output_follow();
             RUN_REFRESH_INITIALIZED.with(|ready| ready.set(true));
             if should_toast {
                 show_warning_toast(&t(locale.get_untracked(), "runs.ssh_retry_stopped"));
@@ -3046,7 +3048,7 @@ pub(super) fn ContextDetailsOverlay(
                                                     {(!output.is_empty()).then(|| view! {
                                                         <details class="run-output">
                                                             <summary>{t(locale.get(), "runs.output")}</summary>
-                                                            <pre>{output}</pre>
+                                                            <pre data-run-output-for=run.id.clone()>{output}</pre>
                                                         </details>
                                                     })}
                                                     {(!produced.is_empty()).then(|| view! {

--- a/ui/src/bindings.rs
+++ b/ui/src/bindings.rs
@@ -91,6 +91,7 @@ extern "C" {
     fn preserve_chat_scroll_on_prepend(scroller_id: &str, content_id: &str);
     fn jump_chat_scroll(scroller_id: &str, selector: &str);
     fn jump_chat_scroll_last_user(scroller_id: &str);
+    fn follow_run_outputs();
 }
 
 #[wasm_bindgen(module = "/src/marks.js")]
@@ -124,6 +125,12 @@ pub(crate) fn schedule_chat_follow() {
 /// Force the chat view to jump to the bottom (e.g. after switching sessions).
 pub(crate) fn force_chat_bottom() {
     force_chat_scroll_bottom(CHAT_SCROLLER_ID);
+}
+
+/// Re-pin every run output panel to the bottom after a run-list refresh
+/// rebuilt the cards (unless the user scrolled that panel up).
+pub(crate) fn schedule_run_output_follow() {
+    follow_run_outputs();
 }
 
 /// Keep the first previously visible transcript row in place after older rows

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -13687,6 +13687,7 @@ fn RunMonitorCard(
             // (old rows, transfer runs) yield no pairs, so the block disappears.
             let env_pairs = research::metadata_pairs(&run.env_snapshot_json);
             let cancel_id = run.id.clone();
+            let output_id = run.id.clone();
             view! {
                 <article class="run-monitor-card" data-testid="run-monitor-card" data-run-id=run.id>
                     <div class="run-monitor-head">
@@ -13754,7 +13755,7 @@ fn RunMonitorCard(
                     {(!output.is_empty()).then(|| view! {
                         <div class="run-monitor-output">
                             <span>{t(locale.get(), "runs.output")}</span>
-                            <pre>{output}</pre>
+                            <pre data-run-output-for=output_id.clone()>{output}</pre>
                         </div>
                     })}
                     {(!env_pairs.is_empty()).then(|| view! {

--- a/ui/src/scroll.js
+++ b/ui/src/scroll.js
@@ -153,6 +153,49 @@ export function preserve_chat_scroll_on_prepend(scrollerId, contentId) {
   });
 }
 
+// Run output panels (chat monitor card, Runs modal) are rebuilt from scratch
+// on every poll, so any per-element scroll state is lost and the view can
+// never stay pinned to the latest output (#654). Keep the follow state here,
+// keyed by run id, and re-apply it to each fresh element after a refresh.
+const runOutputFollow = new Map();
+const attachedRunOutputs = new WeakSet();
+
+export function follow_run_outputs() {
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      document.querySelectorAll("[data-run-output-for]").forEach((el) => {
+        const key = el.getAttribute("data-run-output-for");
+        let state = runOutputFollow.get(key);
+        if (!state) {
+          state = { follow: true, top: 0 };
+          runOutputFollow.set(key, state);
+        }
+        if (!attachedRunOutputs.has(el)) {
+          attachedRunOutputs.add(el);
+          // Scroll anchoring would fight the explicit snap on rebuild.
+          el.style.overflowAnchor = "none";
+          el.addEventListener(
+            "scroll",
+            () => {
+              state.top = el.scrollTop;
+              state.follow = atBottom(el);
+            },
+            { passive: true },
+          );
+        }
+        if (state.follow) {
+          snapBottom(el);
+        } else {
+          // A scrolled-up user keeps their place across the rebuild; the tail
+          // buffer may have dropped lines, so clamp instead of trusting `top`.
+          const max = Math.max(0, el.scrollHeight - el.clientHeight);
+          el.scrollTop = Math.min(state.top, max);
+        }
+      });
+    });
+  });
+}
+
 /** Scroll the latest user turn into view (the floating jump pill).
  * @param {string} scrollerId */
 export function jump_chat_scroll_last_user(scrollerId) {


### PR DESCRIPTION
## Problem

Fixes #654. In v0.33.0 the Run monitor card (and the Runs modal output panel) cannot stay pinned to the latest output: on every run-list refresh the view jumps away from the bottom and the user has to scroll manually to see progress. Regression from v0.29.0.

## Root cause

v0.33.0 moved run output from synchronous streaming to async polling. `RunMonitorCard`'s entire body is one `{ move || ... }` closure over the `runs` signal (and the Runs modal rows follow the same pattern), so **every poll rebuilds the whole card DOM**. The new `<pre>` loses its scroll position each cycle — with wrapped long lines the panel visibly jumps back to the middle and never follows the tail.

## Change

Keep the scroll-follow state outside the disposable DOM, keyed by run id, and re-apply it after every refresh:

- `ui/src/scroll.js` — new `follow_run_outputs()`: a per-run-id `{ follow, top }` state map plus a `WeakSet` for already-attached elements. While following it snaps the panel to the bottom; after a user scroll-up it restores (clamped) their position across rebuilds; scrolling back to the bottom re-engages follow. `overflow-anchor` is disabled on the panel so the browser's scroll anchoring can't fight the snap.
- `ui/src/app_support.rs` — `refresh_runs` (the single choke point after every poll) schedules the follow pass; the Runs modal output `<pre>` carries `data-run-output-for` so it participates.
- `ui/src/main.rs` — the Run monitor card output `<pre>` carries the same attribute.
- `ui/src/bindings.rs` — wasm binding + wrapper for the new JS entry.

## Tests

New Playwright regression `run monitor output stays pinned to the tail across poll rebuilds (#654)`:

- pins to the tail once the output overflows the panel,
- stays pinned across poll rebuilds with fresh output,
- preserves a scroll-up position instead of yanking the user back down,
- re-engages follow after scrolling back to the bottom,
- ends by settling the run so its 1s refresh stops with the page.

Verified the test **fails without the fix** (bottom gap 285px at the first assertion).

- `cd ui && cargo check --target wasm32-unknown-unknown` ✓
- `cd ui && cargo test` ✓ (171)
- `cd ui-tests && npx playwright test` ✓ (267 passed, 1 skipped)

## Manual smoke

1. Start a long local Run (e.g. a Python analysis that prints progress lines).
2. Attach `monitor_run` — the output panel stays pinned to the newest line as polls arrive.
3. Scroll up inside the panel to read earlier output — position is preserved across polls; scroll back to the bottom to resume following.
4. Runs modal → expand **Output** for the same run — same following behavior.

## Notes

- The neighboring `reasoning details stays open while more thinking streams in` spec is timing-sensitive under CPU contention from a cold `trunk` build; it failed twice during bisection on unmodified code paths and passed 3/3 with a warm build, including the full-suite run above. Not related to this change.
- Rebased onto latest `main` (includes #655).
