### PR TITLE
fix: preserve delegated task deliveries as degraded results instead of discarding them

### DIFF
--- a/crates/wisp-core/src/delegation.rs
+++ b/crates/wisp-core/src/delegation.rs
@@ -844,6 +844,22 @@ fn matches_json_contract_at_depth(value: &Value, contract: &Value, depth: usize)
     true
 }
 
+/// Marker stored under `output.delivery` when the host preserved a completed
+/// sub-agent result whose final message failed strict delivery parsing or
+/// whose value did not satisfy the task `output_contract`. Consumers must
+/// treat such output as raw evidence rather than contract-shaped data.
+pub fn degraded_delivery_marker(reason: &str) -> Value {
+    serde_json::json!({"degraded": true, "reason": reason})
+}
+
+pub fn is_degraded_delivery(output: &Value) -> bool {
+    output
+        .get("delivery")
+        .and_then(|delivery| delivery.get("degraded"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
 fn task_output_envelope(data: Value, response: &AgentDelegationResponse) -> Value {
     let summary = data
         .get("summary")
@@ -851,14 +867,21 @@ fn task_output_envelope(data: Value, response: &AgentDelegationResponse) -> Valu
         .filter(|summary| !summary.trim().is_empty())
         .unwrap_or("Structured task output is available in data.")
         .to_string();
-    serde_json::json!({
+    let degraded_delivery = is_degraded_delivery(&data)
+        .then(|| data.get("delivery").cloned())
+        .flatten();
+    let mut envelope = serde_json::json!({
         "summary": summary,
         "data": data,
         "artifacts": response.artifacts.clone(),
         "evidence": response.evidence.clone(),
         "tests": [],
         "risks": [],
-    })
+    });
+    if let Some(delivery) = degraded_delivery {
+        envelope["delivery"] = delivery;
+    }
+    envelope
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -894,15 +917,25 @@ pub trait AgentDelegator: Send + Sync {
             response.output = Value::Object(Default::default());
             response.error = Some(reason);
         }
-        if response.status == DelegationStatus::Succeeded
-            && !matches_json_contract(&response.output, &output_contract)
-        {
-            response.status = DelegationStatus::Failed;
-            response.output = Value::Object(Default::default());
-            response.error = Some("delegation output does not satisfy output_contract".into());
-        } else if response.status == DelegationStatus::Succeeded && task_output {
-            let data = std::mem::take(&mut response.output);
-            response.output = task_output_envelope(data, &response);
+        if response.status == DelegationStatus::Succeeded {
+            // A delivery the host already degraded advertises that it is not
+            // contract-shaped; re-checking it would discard preserved work.
+            let contract_met = is_degraded_delivery(&response.output)
+                || matches_json_contract(&response.output, &output_contract);
+            if task_output {
+                let data = std::mem::take(&mut response.output);
+                response.output = task_output_envelope(data, &response);
+            }
+            if !contract_met {
+                if let Value::Object(object) = &mut response.output {
+                    object.insert(
+                        "delivery".into(),
+                        degraded_delivery_marker(
+                            "The output did not satisfy the task output_contract; the non-conforming value is preserved.",
+                        ),
+                    );
+                }
+            }
         }
         response.validate()?;
         Ok(response)
@@ -1279,5 +1312,92 @@ mod tests {
         };
         assert!(spec.validate().is_ok());
         assert!(spec.validate_dynamic_metadata().is_err());
+    }
+
+    struct FixedOutputDelegator(Value);
+
+    #[async_trait]
+    impl AgentDelegator for FixedOutputDelegator {
+        async fn delegate_validated(
+            &self,
+            request: ValidatedAgentDelegationRequest,
+        ) -> anyhow::Result<AgentDelegationResponse> {
+            Ok(AgentDelegationResponse {
+                request_id: request.as_request().request_id.clone(),
+                status: DelegationStatus::Succeeded,
+                output: self.0.clone(),
+                artifact_ids: vec![],
+                artifacts: vec![],
+                evidence: vec![],
+                usage: AgentUsage::default(),
+                agent_session_id: None,
+                child_frame_id: None,
+                error: None,
+                nested_results: vec![],
+            })
+        }
+    }
+
+    fn task_request(output_contract: Value) -> ValidatedAgentDelegationRequest {
+        ValidatedAgentDelegationRequest {
+            inner: AgentDelegationRequest {
+                request_id: "request".into(),
+                workflow_id: "workflow".into(),
+                step_id: "step".into(),
+                spec: AgentSpec {
+                    role: AgentRole::Custom("worker".into()),
+                    output_contract,
+                    output_schema_source: AgentOutputSchemaSource::Task,
+                    ..test_spec("structured")
+                },
+                input: serde_json::json!({}),
+                lineage: None,
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn conforming_task_output_is_delivered_without_degradation() {
+        let contract = serde_json::json!({"type": "object", "required": ["rows"]});
+        let delegator = FixedOutputDelegator(serde_json::json!({"rows": [1]}));
+        let response = delegator
+            .delegate_authorized(task_request(contract))
+            .await
+            .unwrap();
+        assert_eq!(response.status, DelegationStatus::Succeeded);
+        assert_eq!(response.output["data"]["rows"], serde_json::json!([1]));
+        assert!(!is_degraded_delivery(&response.output));
+    }
+
+    #[tokio::test]
+    async fn contract_mismatch_preserves_the_output_as_degraded_delivery() {
+        let contract = serde_json::json!({"type": "object", "required": ["rows"]});
+        let delegator = FixedOutputDelegator(serde_json::json!({"count": 3}));
+        let response = delegator
+            .delegate_authorized(task_request(contract))
+            .await
+            .unwrap();
+        assert_eq!(response.status, DelegationStatus::Succeeded);
+        assert_eq!(response.error, None);
+        assert_eq!(response.output["data"]["count"], 3);
+        assert!(is_degraded_delivery(&response.output));
+        assert!(response.output["delivery"]["reason"].is_string());
+    }
+
+    #[tokio::test]
+    async fn already_degraded_deliveries_skip_the_contract_check() {
+        let contract = serde_json::json!({"type": "object", "required": ["rows"]});
+        let delegator = FixedOutputDelegator(serde_json::json!({
+            "summary": "raw narrative text",
+            "delivery": degraded_delivery_marker("parse fallback"),
+        }));
+        let response = delegator
+            .delegate_authorized(task_request(contract))
+            .await
+            .unwrap();
+        assert_eq!(response.status, DelegationStatus::Succeeded);
+        assert_eq!(response.output["summary"], "raw narrative text");
+        assert_eq!(response.output["data"]["summary"], "raw narrative text");
+        assert!(is_degraded_delivery(&response.output));
     }
 }

--- a/crates/wisp-core/src/lib.rs
+++ b/crates/wisp-core/src/lib.rs
@@ -18,13 +18,13 @@ pub mod system_prompt;
 pub use agent::{agent_loop, agent_loop_continue, GuidanceQueue};
 pub use context::ContextManager;
 pub use delegation::{
-    AgentArtifact, AgentAuthorizationSnapshot, AgentBackend, AgentBudget, AgentDelegationLineage,
-    AgentDelegationRequest, AgentDelegationResponse, AgentDelegator, AgentEvidence,
-    AgentExecutorRef, AgentOrigin, AgentOutputSchemaSource, AgentRequestPreferences, AgentRole,
-    AgentSessionPolicy, AgentSkillBinding, AgentSpec, AgentUsage, AgentWorkspacePolicy,
-    CapabilityRevision, ContextPolicy, DelegationStatus, PermissionSet, SpecialistSnapshot,
-    UnconfiguredAgentDelegator, ValidatedAgentDelegationRequest, MAX_AGENT_DELEGATION_DEPTH,
-    MAX_AGENT_OUTPUT_SCHEMA_BYTES,
+    degraded_delivery_marker, is_degraded_delivery, AgentArtifact, AgentAuthorizationSnapshot,
+    AgentBackend, AgentBudget, AgentDelegationLineage, AgentDelegationRequest,
+    AgentDelegationResponse, AgentDelegator, AgentEvidence, AgentExecutorRef, AgentOrigin,
+    AgentOutputSchemaSource, AgentRequestPreferences, AgentRole, AgentSessionPolicy,
+    AgentSkillBinding, AgentSpec, AgentUsage, AgentWorkspacePolicy, CapabilityRevision,
+    ContextPolicy, DelegationStatus, PermissionSet, SpecialistSnapshot, UnconfiguredAgentDelegator,
+    ValidatedAgentDelegationRequest, MAX_AGENT_DELEGATION_DEPTH, MAX_AGENT_OUTPUT_SCHEMA_BYTES,
 };
 pub use delegation_policy::{
     CapabilityDefinition, CapabilityRegistry, CapabilityRisk, DelegatedTaskProposal,

--- a/docs/agent-delegation.md
+++ b/docs/agent-delegation.md
@@ -129,6 +129,19 @@ boundary.
    result was truncated, `get_delegated_result` reads that task's full persisted
    result for the same conversation.
 
+Delivery parsing is tolerant. A child's final message may wrap the requested
+JSON in a Markdown fence or narrative text; Wisp extracts the embedded JSON
+payload. When a non-reviewer child finishes but its final message still cannot
+be parsed as the requested shape, or its parsed value does not satisfy the
+task's output schema, the completed work is preserved instead of discarded:
+the raw text (or non-conforming value) is delivered with a
+`delivery: {degraded, reason}` marker, the task counts as succeeded, and
+dependent tasks receive the degraded result rather than being blocked.
+Consumers must treat a degraded delivery as raw evidence, not contract-shaped
+data. Reviewer verdicts are exempt: a reviewer result that is not a JSON
+object with a summary (and, for standard reviews, a findings array) still
+fails, because review gates must not be satisfiable by unparseable output.
+
 Failed and cancelled workflows are resumable. **Retry** keeps the persisted
 workflow and every successful task result, reruns only failed/cancelled tasks
 and descendants that were blocked, then supplies the retained dependency

--- a/src-tauri/src/delegation_runtime.rs
+++ b/src-tauri/src/delegation_runtime.rs
@@ -3082,11 +3082,33 @@ fn delegation_result_instructions(request: &AgentDelegationRequest) -> anyhow::R
 }
 
 fn parse_agent_result(raw: &str, request: &AgentDelegationRequest) -> Result<Value, String> {
-    if request.spec.output_schema_source == AgentOutputSchemaSource::Task {
-        return serde_json::from_str(raw.trim())
-            .map_err(|error| format!("Agent returned invalid task JSON: {error}"));
+    if raw.trim().is_empty() {
+        return Err("Agent returned an empty final message".into());
     }
-    parse_result_object(raw)
+    let reviewer = is_reviewer(request);
+    let candidates = extract_json_candidates(raw);
+    if request.spec.output_schema_source == AgentOutputSchemaSource::Task {
+        if let Some(value) = largest_candidate(candidates) {
+            return Ok(value);
+        }
+        if reviewer {
+            return Err("Reviewer returned no parseable JSON task result".into());
+        }
+        return Ok(degraded_result_envelope(
+            raw,
+            "The final message contained no parseable JSON value; the raw text is preserved in summary.",
+        ));
+    }
+    if let Some(object) = envelope_candidate(candidates) {
+        return Ok(normalize_result_envelope(object));
+    }
+    if reviewer {
+        return Err("Reviewer returned no JSON result object with a summary string".into());
+    }
+    Ok(degraded_result_envelope(
+        raw,
+        "The final message contained no JSON object with a summary string; the raw text is preserved in summary.",
+    ))
 }
 
 async fn reviewer_host_evidence(project_root: &std::path::Path) -> String {
@@ -4352,31 +4374,92 @@ fn delegation_prompt(request: &AgentDelegationRequest) -> anyhow::Result<String>
     ))
 }
 
-fn parse_result_object(raw: &str) -> Result<Value, String> {
-    let start = raw
-        .find('{')
-        .ok_or_else(|| "Agent returned no JSON object".to_string())?;
-    let end = raw
-        .rfind('}')
-        .filter(|end| *end >= start)
-        .ok_or_else(|| "Agent returned an incomplete JSON object".to_string())?;
-    let value: Value = serde_json::from_str(&raw[start..=end])
-        .map_err(|error| format!("Agent returned invalid JSON: {error}"))?;
-    let object = value
-        .as_object()
-        .ok_or_else(|| "Agent result must be an object".to_string())?;
-    if !object.get("summary").is_some_and(Value::is_string) {
-        return Err("Agent result is missing the summary string".into());
+/// Every JSON value that can be recovered from the Agent's final message.
+/// Models frequently wrap the requested JSON in Markdown fences or narrative
+/// text, so after a strict whole-message parse this scans for embedded
+/// balanced JSON values and skips past each recovered one.
+fn extract_json_candidates(raw: &str) -> Vec<Value> {
+    let trimmed = raw.trim();
+    if let Ok(value) = serde_json::from_str::<Value>(trimmed) {
+        return vec![value];
     }
+    let mut candidates = Vec::new();
+    let bytes = trimmed.as_bytes();
+    let mut index = 0;
+    let mut failed_attempts = 0;
+    while index < bytes.len() {
+        if bytes[index] != b'{' && bytes[index] != b'[' {
+            index += 1;
+            continue;
+        }
+        let mut stream = serde_json::Deserializer::from_str(&trimmed[index..]).into_iter::<Value>();
+        match stream.next() {
+            Some(Ok(value)) => {
+                index += stream.byte_offset().max(1);
+                candidates.push(value);
+            }
+            _ => {
+                // Bound quadratic rescans of pathological brace-heavy text.
+                failed_attempts += 1;
+                if failed_attempts > 1_000 {
+                    break;
+                }
+                index += 1;
+            }
+        }
+    }
+    candidates
+}
+
+fn largest_candidate(candidates: Vec<Value>) -> Option<Value> {
+    candidates.into_iter().max_by_key(|value| {
+        serde_json::to_string(value)
+            .map(|serialized| serialized.len())
+            .unwrap_or(0)
+    })
+}
+
+fn envelope_candidate(candidates: Vec<Value>) -> Option<Map<String, Value>> {
+    largest_candidate(
+        candidates
+            .into_iter()
+            .filter(|value| value.get("summary").is_some_and(Value::is_string))
+            .collect(),
+    )
+    .and_then(|value| match value {
+        Value::Object(object) => Some(object),
+        _ => None,
+    })
+}
+
+/// Fill optional envelope fields so downstream consumers can rely on their
+/// presence; only the summary string is required from the Agent itself.
+fn normalize_result_envelope(mut object: Map<String, Value>) -> Value {
     if !object.get("diff_summary").is_some_and(Value::is_string) {
-        return Err("Agent result is missing the diff_summary string".into());
+        object.insert("diff_summary".into(), json!(""));
     }
     for field in ["files_changed", "artifacts", "evidence", "tests", "risks"] {
         if !object.get(field).is_some_and(Value::is_array) {
-            return Err(format!("Agent result is missing the {field} array"));
+            object.insert(field.into(), json!([]));
         }
     }
-    Ok(value)
+    Value::Object(object)
+}
+
+/// Preserve the Agent's completed work instead of discarding it when the
+/// final message is not the requested JSON shape. The raw text becomes the
+/// summary and the delivery marker records why the result was degraded.
+fn degraded_result_envelope(raw: &str, reason: &str) -> Value {
+    json!({
+        "summary": bounded_text(raw.trim(), 60_000),
+        "files_changed": [],
+        "diff_summary": "",
+        "artifacts": [],
+        "evidence": [],
+        "tests": [],
+        "risks": [],
+        "delivery": wisp_core::degraded_delivery_marker(reason),
+    })
 }
 
 fn evidence_from_output(output: &Value) -> Vec<AgentEvidence> {
@@ -5342,36 +5425,127 @@ mod tests {
         let _ = std::fs::remove_dir_all(root);
     }
 
-    #[test]
-    fn structured_result_parser_rejects_prose_and_incomplete_results() {
-        assert!(parse_result_object("done").is_err());
-        assert!(parse_result_object(r#"{"summary":"done"}"#).is_err());
-        assert!(parse_result_object(r#"{"summary":"done","files_changed":[],"diff_summary":"","artifacts":[],"evidence":[],"tests":[],"risks":[]}"#)
-        .is_ok());
-
-        let request = AgentDelegationRequest {
+    fn parse_request(spec: Value) -> AgentDelegationRequest {
+        AgentDelegationRequest {
             request_id: "request".into(),
             workflow_id: "workflow".into(),
             step_id: "step".into(),
-            spec: serde_json::from_value(json!({
-                "agent_id": "structured",
-                "name": "Structured Agent",
-                "goal": "Return rows",
-                "role": "temporary",
-                "backend": "local",
-                "prompt_template": "Return structured data.",
-                "output_contract": {"type": "array"},
-                "output_schema_source": "task"
-            }))
-            .unwrap(),
+            spec: serde_json::from_value(spec).unwrap(),
             input: json!({}),
             lineage: None,
-        };
+        }
+    }
+
+    fn standard_parse_request() -> AgentDelegationRequest {
+        parse_request(json!({
+            "agent_id": "worker",
+            "name": "Worker Agent",
+            "goal": "Do the work",
+            "role": "temporary",
+            "backend": "local",
+            "prompt_template": "Work."
+        }))
+    }
+
+    fn task_parse_request() -> AgentDelegationRequest {
+        parse_request(json!({
+            "agent_id": "structured",
+            "name": "Structured Agent",
+            "goal": "Return rows",
+            "role": "temporary",
+            "backend": "local",
+            "prompt_template": "Return structured data.",
+            "output_contract": {"type": "array"},
+            "output_schema_source": "task"
+        }))
+    }
+
+    fn reviewer_parse_request() -> AgentDelegationRequest {
+        parse_request(json!({
+            "agent_id": "temporary-reviewer",
+            "name": "Independent reviewer",
+            "goal": "Review the work",
+            "role": "reviewer",
+            "backend": "local",
+            "prompt_template": "Review only."
+        }))
+    }
+
+    #[test]
+    fn result_parser_tolerates_fences_and_narrative_around_the_payload() {
+        let request = task_parse_request();
         assert_eq!(
             parse_agent_result("[1,2]", &request).unwrap(),
             json!([1, 2])
         );
-        assert!(parse_agent_result("not JSON", &request).is_err());
+        assert_eq!(
+            parse_agent_result("```json\n{\"rows\":[1]}\n```", &request).unwrap(),
+            json!({"rows": [1]})
+        );
+        assert_eq!(
+            parse_agent_result(
+                "Here is the final result you asked for:\n{\"rows\":[1,2]}\nDone.",
+                &request
+            )
+            .unwrap(),
+            json!({"rows": [1, 2]})
+        );
+
+        let request = standard_parse_request();
+        let envelope = r#"{"summary":"done","files_changed":[],"diff_summary":"","artifacts":[],"evidence":[],"tests":[],"risks":[]}"#;
+        assert_eq!(
+            parse_agent_result(envelope, &request).unwrap()["summary"],
+            "done"
+        );
+        // Stray braces in surrounding prose must not break payload extraction.
+        let noisy = format!("I produced {{almost}} everything requested.\n{envelope}");
+        assert_eq!(
+            parse_agent_result(&noisy, &request).unwrap()["summary"],
+            "done"
+        );
+        // Optional envelope fields are normalized instead of rejected.
+        let minimal = parse_agent_result(r#"{"summary":"done"}"#, &request).unwrap();
+        assert_eq!(minimal["summary"], "done");
+        assert_eq!(minimal["files_changed"], json!([]));
+        assert_eq!(minimal["diff_summary"], "");
+        assert!(minimal.get("delivery").is_none());
+    }
+
+    #[test]
+    fn result_parser_degrades_unparseable_deliveries_instead_of_discarding_them() {
+        let request = standard_parse_request();
+        let narrative = "A long narrative report without any JSON envelope.";
+        let degraded = parse_agent_result(narrative, &request).unwrap();
+        assert_eq!(degraded["summary"], narrative);
+        assert_eq!(degraded["delivery"]["degraded"], true);
+        assert!(degraded["delivery"]["reason"].is_string());
+
+        // A JSON object without the required summary keeps the raw text too.
+        let custom = r#"{"skill_source":"bear-review","findings":[],"limitations":[]}"#;
+        let degraded = parse_agent_result(custom, &request).unwrap();
+        assert_eq!(degraded["delivery"]["degraded"], true);
+        assert_eq!(degraded["summary"], custom);
+
+        let request = task_parse_request();
+        let degraded = parse_agent_result("not JSON", &request).unwrap();
+        assert_eq!(degraded["summary"], "not JSON");
+        assert_eq!(degraded["delivery"]["degraded"], true);
+
+        assert!(parse_agent_result("  \n ", &request).is_err());
+    }
+
+    #[test]
+    fn result_parser_keeps_reviewer_deliveries_strict() {
+        let request = reviewer_parse_request();
+        assert!(is_reviewer(&request));
+        assert_eq!(
+            parse_agent_result("plain prose verdict", &request).unwrap_err(),
+            "Reviewer returned no JSON result object with a summary string"
+        );
+        let envelope = r#"{"summary":"ok","findings":[]}"#;
+        let parsed = parse_agent_result(envelope, &request).unwrap();
+        assert_eq!(parsed["summary"], "ok");
+        assert_eq!(parsed["findings"], json!([]));
     }
 
     #[test]

--- a/src-tauri/src/delegation_tool.rs
+++ b/src-tauri/src/delegation_tool.rs
@@ -891,7 +891,7 @@ pub(crate) fn compact_execution_result(
                 .output
                 .get("data")
                 .unwrap_or(&response.output);
-            json!({
+            let mut entry = json!({
                 "id": id,
                 "status": response.status,
                 "summary": summary,
@@ -910,7 +910,11 @@ pub(crate) fn compact_execution_result(
                     "workflow_id": execution.workflow_id,
                     "task_id": id,
                 }
-            })
+            });
+            if wisp_core::is_degraded_delivery(&response.output) {
+                entry["delivery"] = response.output["delivery"].clone();
+            }
+            entry
         })
         .collect::<Vec<_>>();
     let resumable = execution.status != wisp_core::DelegationExecutionStatus::Succeeded;
@@ -2103,7 +2107,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn task_output_schema_is_enforced_and_full_result_can_be_loaded() {
+    async fn task_output_schema_violations_degrade_and_full_result_can_be_loaded() {
         let (store, project, root) = fixture().await;
         enable_delegation(&store).await;
         let delegator = Arc::new(FakeDelegator::new(&[], &["invalid"]));
@@ -2143,8 +2147,13 @@ mod tests {
         let results = value["results"].as_array().unwrap();
         assert_eq!(results[0]["status"], "succeeded");
         assert_eq!(results[0]["data"]["score"], 7);
-        assert_eq!(results[1]["status"], "failed");
-        assert!(results[1]["error"]
+        assert!(results[0].get("delivery").is_none());
+        // A schema violation preserves the completed output as a degraded
+        // delivery instead of discarding it.
+        assert_eq!(results[1]["status"], "succeeded");
+        assert_eq!(results[1]["data"]["score"], "invalid");
+        assert_eq!(results[1]["delivery"]["degraded"], true);
+        assert!(results[1]["delivery"]["reason"]
             .as_str()
             .unwrap()
             .contains("output_contract"));


### PR DESCRIPTION
## Summary

Fixes #659.

**User-facing problem.** `delegate_tasks` sub-agents that finished their work (4,300–5,600 output tokens in the reported workflows) still failed at the delivery step whenever their final message was not byte-exact JSON, with three inconsistent error messages ("Agent returned invalid task JSON", "Agent result is missing the summary string", "Agent returned no JSON object"). The completed content was discarded (`data` empty) and dependent synthesis tasks were blocked with "dependency ... did not succeed".

**Root causes.**

- `parse_agent_result` (task-schema path) did a strict whole-string `serde_json::from_str`, so a Markdown fence or narrative prefix failed parsing.
- `parse_result_object` (standard path) sliced from the first `{` to the last `}`, so prose without braces, prose containing stray braces, or a JSON object without `summary` each failed on a different branch.
- Every parse failure and every `output_contract` mismatch (in `AgentDelegator::delegate_authorized`) replaced the output with `{}`, dropping the completed work.

**Changes.**

- `src-tauri/src/delegation_runtime.rs`: new tolerant extraction (`extract_json_candidates`) scans the final message for embedded balanced JSON values, tolerating fences and surrounding narrative, and picks the largest candidate (standard path: largest object with a `summary` string, then normalizes optional envelope fields). When no usable JSON remains, non-reviewer deliveries degrade into a standard envelope that preserves the raw text in `summary` with a `delivery: {degraded, reason}` marker and count as succeeded, so dependents unblock. Reviewer deliveries stay strict (stable error wording) so review gates cannot be satisfied by unparseable output.
- `crates/wisp-core/src/delegation.rs`: `delegate_authorized` no longer clears the output on `output_contract` mismatch; it preserves the non-conforming value and attaches the degraded-delivery marker. Already-degraded deliveries skip the contract check. `task_output_envelope` hoists the marker so inline consumers can see it. New helpers `degraded_delivery_marker` / `is_degraded_delivery` are exported.
- `src-tauri/src/delegation_tool.rs`: compact per-task results now include the `delivery` marker when a delivery was degraded.
- `docs/agent-delegation.md`: documents tolerant delivery parsing, the degraded-delivery marker, and the reviewer exemption.

## Tests

- `wisp-tauri`: replaced `structured_result_parser_rejects_prose_and_incomplete_results` with three tests covering fence/narrative tolerance, degradation of unparseable deliveries (including the exact custom-envelope case from the issue), and reviewer strictness. Updated `task_output_schema_violations_degrade_and_full_result_can_be_loaded` for the new contract-mismatch behavior.
- `wisp-core`: three new `delegate_authorized` tests (conforming output unchanged, contract mismatch preserved as degraded delivery, already-degraded deliveries skip the contract check).
- `cargo fmt --all -- --check` clean; `cargo test --workspace` passes except 10 pre-existing environment-specific failures (`method_search*`, `publication_commands`, `resource_leases`) that fail identically on unmodified `main` on this Windows machine (temp-path canonicalization, file locking, filesystem case-insensitivity) and are unrelated to this change.

## Known limitations / follow-ups

- Tasks that fail for real reasons (budget violations, provider errors, cancellation) still block their descendants; a broader degraded path for failed dependencies is intentionally out of scope here.
- For task-schema outputs whose parsed value merely violates the schema, the degradation marker lives at the envelope level; the inline `data` payload itself is delivered unmarked (the compact result carries the `delivery` field alongside it).
- Degraded raw text is bounded to 60,000 characters in the preserved summary; the full transcript remains in the child conversation.
