### PR TITLE
fix(ui): stabilize chat, paste, and update interactions

### DIFF
--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -3255,9 +3255,14 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
               data: { chunk_length: 25 },
             });
             if (mockUpdateDownloadPending) {
+              (window as any).__mockUpdateProgress = (chunkLength: number) => onEvent?.onmessage?.({
+                event: "progress",
+                data: { chunk_length: chunkLength },
+              });
               await new Promise<void>((resolve) => {
                 resolveMockUpdateDownload = resolve;
               });
+              delete (window as any).__mockUpdateProgress;
               mockUpdateDownloadPending = false;
             }
             if (mockUpdateDownloadError) {

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -3002,17 +3002,7 @@ test("Files creates, renames, deletes, and refreshes local entries", async ({ pa
   await expect.poll(() => lastInvokeArgs(page, "list_dir")).toMatchObject({ path: "." });
 });
 
-test("text-entry context menu pastes into the field that was clicked", async ({ page }) => {
-  await page.addInitScript(() => {
-    let clipboardText = "";
-    Object.defineProperty(navigator, "clipboard", {
-      configurable: true,
-      value: {
-        readText: async () => clipboardText,
-        writeText: async (value: string) => { clipboardText = value; },
-      },
-    });
-  });
+test("text entries keep the native context menu", async ({ page }) => {
   await enterApp(page);
   await page.locator(".proj-switch").click();
   await page.getByRole("button", { name: "Project settings" }).click();
@@ -3020,19 +3010,15 @@ test("text-entry context menu pastes into the field that was clicked", async ({ 
   const modal = page.locator(".proj-settings-modal");
   const name = modal.locator("input").first();
   const description = modal.locator("textarea").first();
-  await description.fill("");
-  await page.evaluate(() => navigator.clipboard.writeText("context-target"));
-  await description.click({ button: "right" });
-  await page.locator(".ctx-menu").getByRole("button", { name: "Paste" }).click();
-  await expect(description).toHaveValue("context-target");
-  await expect(name).not.toHaveValue("context-target");
-
-  await name.fill("");
-  await page.evaluate(() => navigator.clipboard.writeText("name-target"));
-  await name.click({ button: "right" });
-  await page.locator(".ctx-menu").getByRole("button", { name: "Paste" }).click();
-  await expect(name).toHaveValue("name-target");
-  await expect(description).toHaveValue("context-target");
+  for (const entry of [name, description]) {
+    const defaultPrevented = await entry.evaluate((element) => {
+      const event = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });
+      element.dispatchEvent(event);
+      return event.defaultPrevented;
+    });
+    expect(defaultPrevented).toBe(false);
+    await expect(page.locator(".ctx-menu")).toHaveCount(0);
+  }
 });
 
 test("center structure and FASTA previews fill the available height", async ({ page }) => {
@@ -5538,6 +5524,10 @@ test("macOS update download is verified before a separate install confirmation",
   await modal.getByRole("button", { name: "Download update" }).click();
   await expect(modal).toContainText("Downloading Wisp 0.28.0");
   await expect(modal).toContainText("25 B / 100 B");
+  await modal.evaluate((element) => ((window as any).__downloadingModal = element));
+  await page.evaluate(() => (window as any).__mockUpdateProgress(10));
+  await expect(modal).toContainText("35 B / 100 B");
+  expect(await modal.evaluate((element) => element === (window as any).__downloadingModal)).toBe(true);
 
   // An in-flight update owns the top of the Escape stack and keeps Settings open.
   await page.keyboard.press("Escape");
@@ -6297,6 +6287,23 @@ test("chat stays pinned to the bottom while streaming a long reply (#61)", async
       { timeout: 5000 },
     )
     .toBeLessThan(8);
+});
+
+test("chat keeps the user's reading position when streaming finishes (#670)", async ({ page }) => {
+  await enterApp(page);
+  await composer(page).fill("SCROLLTEST");
+  await page.getByRole("button", { name: "Send" }).click();
+  await expect(page.getByText("line 39", { exact: false })).toBeVisible({ timeout: 10_000 });
+
+  const scroller = page.locator("#chat-scroller");
+  await scroller.evaluate((element) => {
+    element.scrollTop = Math.max(80, element.scrollHeight / 3);
+    element.dispatchEvent(new WheelEvent("wheel", { deltaY: -80, bubbles: true }));
+  });
+  const readingTop = await scroller.evaluate((element) => element.scrollTop);
+
+  await expect(page.getByText("line 79", { exact: false })).toBeVisible({ timeout: 10_000 });
+  await expect.poll(() => scroller.evaluate((element) => element.scrollTop)).toBeGreaterThan(readingTop - 40);
 });
 
 test("recent sessions show only title and status badge", async ({ page }) => {

--- a/ui/src/app_support.rs
+++ b/ui/src/app_support.rs
@@ -460,8 +460,8 @@ pub(super) enum UpdateCheckModal {
     },
     Downloading {
         version: String,
-        downloaded_bytes: u64,
-        total_bytes: Option<u64>,
+        downloaded_bytes: RwSignal<u64>,
+        total_bytes: RwSignal<Option<u64>>,
     },
     ReadyToInstall {
         version: String,

--- a/ui/src/context_menu.js
+++ b/ui/src/context_menu.js
@@ -2,48 +2,6 @@ export function isDevMode() {
   return window.__WISP_DEV__ === true;
 }
 
-let contextTextEntry = null;
-
-export function captureTextEntryTarget(el) {
-  contextTextEntry = el;
-}
-
-export function textEntryCommand(kind) {
-  const el = contextTextEntry;
-  if (!el || !(el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement || el.isContentEditable)) return;
-  el.focus();
-  if (kind === "selectAll") {
-    if (typeof el.select === "function") el.select();
-    else document.execCommand("selectAll");
-    return;
-  }
-  if (kind === "cut") {
-    document.execCommand("cut");
-    return;
-  }
-  if (kind === "copy") {
-    document.execCommand("copy");
-    return;
-  }
-  if (kind === "paste") {
-    navigator.clipboard.readText().then((text) => {
-      if (el.isContentEditable) {
-        document.execCommand("insertText", false, text);
-        el.dispatchEvent(new Event("input", { bubbles: true }));
-        return;
-      }
-      const start = el.selectionStart ?? el.value.length;
-      const end = el.selectionEnd ?? start;
-      const v = el.value;
-      el.value = v.slice(0, start) + text + v.slice(end);
-      const pos = start + text.length;
-      el.selectionStart = pos;
-      el.selectionEnd = pos;
-      el.dispatchEvent(new Event("input", { bubbles: true }));
-    }).catch(() => {});
-  }
-}
-
 export async function copyImage(src) {
   const source = await (await fetch(src)).blob();
   let png = source;

--- a/ui/src/context_menu.rs
+++ b/ui/src/context_menu.rs
@@ -8,10 +8,6 @@ use wasm_bindgen::prelude::*;
 #[wasm_bindgen(module = "/src/context_menu.js")]
 extern "C" {
     fn isDevMode() -> bool;
-    #[wasm_bindgen(js_name = captureTextEntryTarget)]
-    fn capture_text_entry_target(target: web_sys::Element);
-    #[wasm_bindgen(js_name = textEntryCommand)]
-    fn text_entry_command(kind: &str);
     #[wasm_bindgen(catch, js_name = copyImage)]
     async fn copy_image_js(src: &str) -> Result<JsValue, JsValue>;
 }
@@ -123,6 +119,12 @@ fn editable_text_entry(el: &web_sys::Element) -> Option<web_sys::Element> {
         }
     }
     Some(entry)
+}
+
+pub(crate) fn uses_native_text_menu(ev: &web_sys::MouseEvent) -> bool {
+    event_target(ev)
+        .and_then(|target| editable_text_entry(&target))
+        .is_some()
 }
 
 pub(crate) fn selection_text() -> Option<String> {
@@ -397,24 +399,6 @@ pub fn build(
         }
     }
 
-    if let Some(entry) = text_entry {
-        capture_text_entry_target(entry);
-        return Some(CtxMenu {
-            x,
-            y,
-            items: vec![
-                item("cut", i18n::t(locale, "ctx.cut"), String::new()),
-                item("copy", i18n::t(locale, "ctx.copy"), String::new()),
-                item("paste", i18n::t(locale, "ctx.paste"), String::new()),
-                item(
-                    "selectAll",
-                    i18n::t(locale, "ctx.select_all"),
-                    String::new(),
-                ),
-            ],
-        });
-    }
-
     if let Some(code) = text_from_code_block(&target) {
         return Some(CtxMenu {
             x,
@@ -604,8 +588,6 @@ pub fn build(
 
 pub fn run_action(action: &str, payload: &str, copy: impl Fn(String)) {
     match action {
-        "cut" | "paste" | "selectAll" => text_entry_command(action),
-        "copy" if payload.is_empty() => text_entry_command("copy"),
         "copy" | "copyCode" | "copyTitle" | "copyName" | "copyMessage" if !payload.is_empty() => {
             copy(payload.to_string());
         }

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -6472,6 +6472,10 @@ fn App() -> impl IntoView {
         })
     };
     let on_context_menu = move |ev: web_sys::MouseEvent| {
+        if context_menu::uses_native_text_menu(&ev) {
+            ctx_menu.set(None);
+            return;
+        }
         let loc = locale.get();
         let center = center_file.get_untracked();
         if let Some(menu) = context_menu::build(
@@ -8151,17 +8155,14 @@ fn App() -> impl IntoView {
                                         on:click=move |_| {
                                             let version = version_for_download.clone();
                                             let release_url = release_for_download.clone();
+                                            let downloaded_bytes = create_rw_signal(0_u64);
+                                            let total_bytes = create_rw_signal(None::<u64>);
                                             update_check_modal.set(Some(UpdateCheckModal::Downloading {
                                                 version: version.clone(),
-                                                downloaded_bytes: 0,
-                                                total_bytes: None,
+                                                downloaded_bytes,
+                                                total_bytes,
                                             }));
                                             spawn_local(async move {
-                                                let downloaded = Rc::new(Cell::new(0_u64));
-                                                let total = Rc::new(Cell::new(None::<u64>));
-                                                let event_downloaded = downloaded.clone();
-                                                let event_total = total.clone();
-                                                let event_version = version.clone();
                                                 let callback = Closure::<dyn FnMut(JsValue)>::wrap(Box::new(
                                                     move |value: JsValue| {
                                                         let Ok(event) = serde_wasm_bindgen::from_value::<UpdateDownloadEvent>(value) else {
@@ -8169,20 +8170,15 @@ fn App() -> impl IntoView {
                                                         };
                                                         match event {
                                                             UpdateDownloadEvent::Started { content_length } => {
-                                                                event_total.set(content_length);
+                                                                total_bytes.set(content_length);
                                                             }
                                                             UpdateDownloadEvent::Progress { chunk_length } => {
-                                                                event_downloaded.set(
-                                                                    event_downloaded.get().saturating_add(chunk_length),
-                                                                );
+                                                                downloaded_bytes.update(|bytes| {
+                                                                    *bytes = bytes.saturating_add(chunk_length);
+                                                                });
                                                             }
                                                             UpdateDownloadEvent::Verified => {}
                                                         }
-                                                        update_check_modal.set(Some(UpdateCheckModal::Downloading {
-                                                            version: event_version.clone(),
-                                                            downloaded_bytes: event_downloaded.get(),
-                                                            total_bytes: event_total.get(),
-                                                        }));
                                                     },
                                                 ));
                                                 let result = download_app_update(
@@ -8232,11 +8228,6 @@ fn App() -> impl IntoView {
                     "update_modal.downloading_title",
                     &[("version", &version)],
                 );
-                let progress = if let Some(total) = total_bytes {
-                    format!("{} / {}", format_bytes(downloaded_bytes), format_bytes(total))
-                } else {
-                    format_bytes(downloaded_bytes)
-                };
                 view! {
                     <div class="overlay">
                         <div class="modal confirm-modal update-check-modal" data-testid="update-check-modal">
@@ -8244,10 +8235,14 @@ fn App() -> impl IntoView {
                             <div class="hint">{move || t(locale.get(), "update_modal.downloading_body")}</div>
                             <div class="update-download-progress" role="status" aria-live="polite">
                                 <progress
-                                    max=total_bytes.unwrap_or(1).to_string()
-                                    value=total_bytes.map(|_| downloaded_bytes.to_string())
+                                    max=move || total_bytes.get().unwrap_or(1).to_string()
+                                    value=move || total_bytes.get().map(|_| downloaded_bytes.get().to_string())
                                 ></progress>
-                                <span>{progress}</span>
+                                <span>{move || if let Some(total) = total_bytes.get() {
+                                    format!("{} / {}", format_bytes(downloaded_bytes.get()), format_bytes(total))
+                                } else {
+                                    format_bytes(downloaded_bytes.get())
+                                }}</span>
                             </div>
                         </div>
                     </div>

--- a/ui/src/scroll.js
+++ b/ui/src/scroll.js
@@ -31,6 +31,7 @@ export function attach_chat_scroll(scrollerId, contentId) {
 
   let follow = true;
   let lastHeight = content.scrollHeight;
+  let readingTop = scroller.scrollTop;
   const setFollow = (value) => {
     follow = value;
     scroller.style.overflowAnchor = value ? "none" : "auto";
@@ -70,6 +71,7 @@ export function attach_chat_scroll(scrollerId, contentId) {
     // happened just now. Reflow-driven scrolls leave `follow` untouched.
     if (performance.now() - lastUserScroll < 500) {
       setFollow(false);
+      readingTop = scroller.scrollTop;
       return;
     }
     // Reflow-driven clamp while following (streaming rebuilds shrink the
@@ -84,6 +86,9 @@ export function attach_chat_scroll(scrollerId, contentId) {
     const grew = h > lastHeight;
     lastHeight = h;
     if (follow && grew) snapBottom(scroller);
+    else if (!follow && grew) {
+      scroller.scrollTop = Math.min(readingTop, scroller.scrollHeight - scroller.clientHeight);
+    }
     syncFollow();
   };
 
@@ -110,6 +115,7 @@ export function attach_chat_scroll(scrollerId, contentId) {
     onGrowth,
     unfollow: () => {
       setFollow(false);
+      readingTop = scroller.scrollTop;
       lastHeight = content.scrollHeight;
     },
     snap: () => {


### PR DESCRIPTION
## Problem

Three macOS-facing UI regressions interrupt ordinary work:

- Streaming completion can reset a user's chat reading position.
- The custom text-entry paste action triggers WebView's second Paste permission button.
- Update download progress rebuilds the entire modal for every chunk and visibly flashes.

## Changes

- Preserve the last intentional chat reading position while a non-following transcript is rebuilt.
- Let input, textarea, and contenteditable elements use the native context menu; keep Wisp menus for structural content and selections.
- Store update byte progress in stable Leptos signals so progress updates do not replace the modal DOM.
- Update the Tauri mock and add regression coverage for all three behaviors.

## Tests

- `cargo fmt --all -- --check`
- `cd ui && cargo check --target wasm32-unknown-unknown`
- `cargo test --workspace` (all code tests passed; the keyring test was rerun outside the filesystem sandbox and passed)
- `cd ui-tests && npm ci && npx playwright test` — 282 passed, 1 optional integration test skipped

## Manual smoke

1. Start a long streaming answer, scroll into history, and confirm completion does not move the viewport.
2. On macOS, right-click the composer and paste once from the native menu.
3. Download an in-app update and confirm the progress modal remains visually stable.

## Known limitations / follow-up

- Native context-menu labels and presentation follow the operating system/WebView locale.
- The real signed-update rendering path still needs a macOS release-build smoke test because automated tests use a mocked Tauri bridge.

Closes #670
Closes #671
Closes #672