### PR TITLE
feat(core): support project AGENTS.md instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,11 @@ hosts.
 **Settings → Storage** lists workspace paths per project. Select a project to
 view that workspace's local footprint separately from shared app data.
 
+For project-specific Agent instructions, Wisp reads `AGENTS.md` from the
+project root when a new session starts. Instructions entered in **Project
+Settings → Agent Context** are stored in `.wisp/WISP.md` and applied after
+`AGENTS.md`, so the explicit Wisp setting takes precedence when both exist.
+
 | Variable             | Purpose                                                       |
 |----------------------|---------------------------------------------------------------|
 | `WISP_API_KEY`       | Provider API key (CLI). Desktop uses the keyring instead.     |

--- a/crates/wisp-core/src/context.rs
+++ b/crates/wisp-core/src/context.rs
@@ -128,7 +128,13 @@ fn system_text_weights(text: &str) -> [usize; 5] {
         bucket = if trimmed == "<delegation_capability>" || trimmed.starts_with("## Specialist") {
             SUBAGENT_BUCKET
         } else if trimmed == "<plan_mode>"
-            || matches!(trimmed, "## Safety" | "## Built-in Rules" | "## User Rules")
+            || matches!(
+                trimmed,
+                "## Safety"
+                    | "## Built-in Rules"
+                    | "## Project Instructions (AGENTS.md)"
+                    | "## User Rules"
+            )
         {
             RULES_BUCKET
         } else if matches!(

--- a/crates/wisp-core/src/system_prompt.rs
+++ b/crates/wisp-core/src/system_prompt.rs
@@ -9,6 +9,7 @@ use wisp_skills::SkillIndex;
 pub struct SystemPrompt<'a> {
     project_root: &'a Path,
     skills: &'a SkillIndex,
+    project_instructions: Option<String>,
     user_rules: Option<String>,
     compute_hosts: Option<String>,
 }
@@ -19,12 +20,16 @@ impl<'a> SystemPrompt<'a> {
         skills: &'a SkillIndex,
         compute_hosts: Option<String>,
     ) -> Self {
+        let project_instructions = std::fs::read_to_string(project_root.join("AGENTS.md"))
+            .ok()
+            .filter(|s| !s.trim().is_empty());
         let user_rules = std::fs::read_to_string(project_root.join(".wisp").join("WISP.md"))
             .ok()
             .filter(|s| !s.trim().is_empty());
         Self {
             project_root,
             skills,
+            project_instructions,
             user_rules,
             compute_hosts,
         }
@@ -138,10 +143,17 @@ If a named workflow is disabled or unavailable, follow the same principles direc
     }
 
     fn memory(&self) -> String {
-        match &self.user_rules {
-            Some(rules) => format!("## User Rules\n\n{rules}\n"),
-            None => "## User Rules\n\nNo user-defined rules.\n".into(),
+        let mut sections = Vec::new();
+        if let Some(instructions) = &self.project_instructions {
+            sections.push(format!(
+                "## Project Instructions (AGENTS.md)\n\n{instructions}"
+            ));
         }
+        sections.push(match &self.user_rules {
+            Some(rules) => format!("## User Rules\n\n{rules}"),
+            None => "## User Rules\n\nNo user-defined rules.".into(),
+        });
+        sections.join("\n\n") + "\n"
     }
 
     fn environment(&self) -> String {
@@ -180,6 +192,28 @@ If a named workflow is disabled or unavailable, follow the same principles direc
 mod tests {
     use super::*;
     use wisp_skills::SkillIndex;
+
+    #[test]
+    fn project_agents_md_is_loaded_before_wisp_rules() {
+        let root = std::env::temp_dir().join(format!(
+            "wisp-agents-md-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(root.join(".wisp")).unwrap();
+        std::fs::write(root.join("AGENTS.md"), "Use the repository checks.").unwrap();
+        std::fs::write(root.join(".wisp/WISP.md"), "Prefer the project UI setting.").unwrap();
+
+        let out = SystemPrompt::new(&root, &SkillIndex::default(), None).assemble();
+        let agents = out.find("Use the repository checks.").unwrap();
+        let wisp = out.find("Prefer the project UI setting.").unwrap();
+        assert!(
+            agents < wisp,
+            "WISP.md must remain the later override:\n{out}"
+        );
+
+        std::fs::remove_dir_all(root).ok();
+    }
 
     #[test]
     fn assemble_includes_compute_hosts_when_present() {


### PR DESCRIPTION
## Problem

Wisp built-in Agent only reads `.wisp/WISP.md`, so repositories using `AGENTS.md` must duplicate their instructions.

## Changes

- Read project-root `AGENTS.md` when seeding a new system prompt.
- Apply it before `.wisp/WISP.md`, keeping the explicit Wisp setting authoritative.
- Preserve the stable `## User Rules` prompt boundary.
- Count the new section in Rules context usage.
- Document behavior and precedence.

## Tests

- `cargo fmt --all -- --check`
- `cargo test --workspace`

## Manual smoke

1. Add a distinctive rule to project-root `AGENTS.md`.
2. Start a new session and inspect the debug request system prompt.
3. Confirm it appears under `Project Instructions (AGENTS.md)`.
4. Add a conflicting Project Settings Agent Context rule and confirm it appears later.

## Known limitations / follow-up

- Only project-root `AGENTS.md` is loaded; nested per-directory files are not dynamically selected.
- Changes apply to newly seeded sessions.