### PR TITLE
fix(ui): keep agent options stable while streaming

### DIFF
--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -6306,6 +6306,21 @@ test("chat keeps the user's reading position when streaming finishes (#670)", as
   await expect.poll(() => scroller.evaluate((element) => element.scrollTop)).toBeGreaterThan(readingTop - 40);
 });
 
+test("agent options stay mounted while chat content streams (#678)", async ({ page }) => {
+  await enterApp(page);
+  await composer(page).fill("SCROLLTEST");
+  await page.getByRole("button", { name: "Send" }).click();
+  await expect(page.getByText("line 10", { exact: false })).toBeVisible({ timeout: 10_000 });
+
+  await page.getByRole("button", { name: "Agent options" }).click();
+  const menu = page.getByRole("menu", { name: "Agent options" });
+  await expect(menu).toBeVisible();
+  await menu.evaluate((element) => ((window as any).__streamingAgentMenu = element));
+
+  await expect(page.getByText("line 79", { exact: false })).toBeVisible({ timeout: 10_000 });
+  expect(await menu.evaluate((element) => element === (window as any).__streamingAgentMenu)).toBe(true);
+});
+
 test("recent sessions show only title and status badge", async ({ page }) => {
   await page.setViewportSize({ width: 900, height: 700 });
   await page.goto("/");

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -851,6 +851,7 @@ fn App() -> impl IntoView {
     // Configured model profiles + the composer's bottom-right picker state.
     let models = create_rw_signal::<Vec<ModelProfile>>(vec![]);
     let active_session = create_rw_signal::<Option<String>>(None);
+    let session_has_items = create_memo(move |_| items.with(|rows| !rows.is_empty()));
     let conversation_outline = create_memo(move |_| {
         let Some(id) = active_session.get() else {
             return Vec::new();
@@ -9988,7 +9989,7 @@ fn App() -> impl IntoView {
                                 {compose_icon("controls")}
                             </button>
                             {move || agent_menu_open.get().then(|| {
-                                let locked = items.with(|rows| !rows.is_empty());
+                                let locked = session_has_items.get();
                                 view! {
                                 <div class="compose-backdrop" on:click=move |_| {
                                     agent_menu_open.set(false);
@@ -10511,7 +10512,7 @@ fn App() -> impl IntoView {
                                                     session_model_ids.with(|models| models.get(&session_id).cloned())
                                                 });
                                                 let acp_selected = active_acp_agent_id.get().is_some();
-                                                let acp_locked = acp_selected && items.with(|rows| !rows.is_empty());
+                                                let acp_locked = acp_selected && session_has_items.get();
                                                 list.into_iter().filter(ModelProfile::is_chat_model).map(|m| {
                                                     let pick_id = m.id.clone();
                                                     let pick_label = m.label.clone();
@@ -10558,7 +10559,7 @@ fn App() -> impl IntoView {
                                                 {acp_agents.get().into_iter().map(|agent| {
                                                     let id = agent.id.clone();
                                                     let active = active_acp_agent_id.get().as_deref() == Some(agent.id.as_str());
-                                                    let starts_new_session = items.with(|rows| !rows.is_empty()) && !active;
+                                                    let starts_new_session = session_has_items.get() && !active;
                                                     view! {
                                                         <div class="model-menu-row" class:active=active>
                                                             <button type="button" class="model-menu-pick"


### PR DESCRIPTION
## Problem

The Agent options popover was rebuilt for every streamed chat delta because its outer reactive view subscribed to the complete transcript. This made the popover visibly flash while a response was running, as reported in #678 after the streaming stability changes in #673.

## Changes

- Derive a memoized `session_has_items` boolean so transcript updates only notify menu consumers when the session changes between empty and non-empty.
- Reuse that state for Agent option locking and model/ACP switching rules.
- Add a Playwright regression test that verifies the Agent options menu keeps the same DOM node throughout a long streamed response.

## Tests

- `cargo fmt --all -- --check`
- `cargo check --target wasm32-unknown-unknown` in `ui/`
- `cargo test --workspace`
- `npm ci` in `ui-tests/`
- `npx playwright test --grep "agent options stay mounted while chat content streams"`
- `npx playwright test` — 283 passed, 1 optional integration test skipped

## Manual smoke

1. Start a response that streams for several seconds.
2. Open Agent options from the composer while the response is still streaming.
3. Confirm the menu stays open and does not flash as new content arrives.

## Known limitations / follow-up

- This fixes the transcript-driven rebuild identified in #678; no unrelated menu rendering was changed.

Closes #678