### PR TITLE
feat(windows): add tray restart action

### DIFF
--- a/docs/pet.md
+++ b/docs/pet.md
@@ -12,7 +12,7 @@ The pet folder must use `spriteVersionNumber: 2` and contain a `1536x2288` PNG o
 
 The app uses the standard animation rows for idle, directional walking, waving, jumping, failure, waiting for user input, active work, review, and 16-direction pointer tracking. Clicking an idle pet makes it wave. Reduced-motion system preferences disable roaming and animated playback.
 
-On Windows, the pet lives in its own transparent always-on-top window instead of inside the main workspace. Drag the pet to move it. When it shows **Needs you**, click it to restore the workspace and open the session waiting for input. Closing the main Wisp Science window hides the workspace to the system tray while the pet and active agent work continue; click the tray icon, choose **Open Wisp Science**, or launch Wisp Science again to restore the existing workspace. Only one desktop app instance runs at a time. Choose **Quit** to stop the app. The pet animation and status badge show when the agent is working, reviewing, waiting for approval, finished, or failed.
+On Windows, the pet lives in its own transparent always-on-top window instead of inside the main workspace. Drag the pet to move it. When it shows **Needs you**, click it to restore the workspace and open the session waiting for input. Closing the main Wisp Science window hides the workspace to the system tray while the pet and active agent work continue; click the tray icon, choose **Open Wisp Science**, or launch Wisp Science again to restore the existing workspace. Only one desktop app instance runs at a time. Choose **Restart** to restart it or **Quit** to stop it. The pet animation and status badge show when the agent is working, reviewing, waiting for approval, finished, or failed.
 
 ## 配置宠物
 
@@ -20,4 +20,4 @@ Wisp Science 只加载一个由用户明确选择的 Codex v2 宠物，默认关
 
 打开 **设置 > 宠物**，选择包含 `pet.json` 和精灵表的安装目录，开启 **显示宠物** 后保存。目录必须使用 `spriteVersionNumber: 2`，精灵表必须是 `1536x2288` 的 PNG 或 WebP 文件。更换配置目录即可更换宠物；关闭开关后，应用不会再加载或显示该目录中的宠物。
 
-在 Windows 上，宠物运行在独立的透明置顶窗口中，而不是嵌在主工作区内，可以拖动到屏幕上的其他位置。显示 **Needs you** 时，点击宠物会恢复工作区并打开正在等待操作的 session。关闭 Wisp Science 主窗口会把工作区隐藏到系统托盘，宠物和正在执行的 agent 任务会继续工作；点击托盘图标、选择 **Open Wisp Science** 或再次启动 Wisp Science 都会恢复现有工作区。桌面应用全局只运行一个实例，选择 **Quit** 才会真正退出。宠物动画、状态点和文字会显示工作中、review、等待批准、完成或失败状态。
+在 Windows 上，宠物运行在独立的透明置顶窗口中，而不是嵌在主工作区内，可以拖动到屏幕上的其他位置。显示 **Needs you** 时，点击宠物会恢复工作区并打开正在等待操作的 session。关闭 Wisp Science 主窗口会把工作区隐藏到系统托盘，宠物和正在执行的 agent 任务会继续工作；点击托盘图标、选择 **Open Wisp Science** 或再次启动 Wisp Science 都会恢复现有工作区。桌面应用全局只运行一个实例；选择 **Restart** 会重启应用，选择 **Quit** 才会真正退出。宠物动画、状态点和文字会显示工作中、review、等待批准、完成或失败状态。

--- a/src-tauri/src/desktop_lifecycle.rs
+++ b/src-tauri/src/desktop_lifecycle.rs
@@ -18,6 +18,24 @@ pub(crate) fn should_activate_workspace_window(window_label: &str) -> bool {
     window_label != "pet"
 }
 
+#[cfg(any(target_os = "windows", test))]
+#[derive(Debug, PartialEq, Eq)]
+enum TrayAction {
+    Show,
+    Restart,
+    Quit,
+}
+
+#[cfg(any(target_os = "windows", test))]
+fn tray_action(id: &str) -> Option<TrayAction> {
+    match id {
+        "tray-show" => Some(TrayAction::Show),
+        "tray-restart" => Some(TrayAction::Restart),
+        "tray-quit" => Some(TrayAction::Quit),
+        _ => None,
+    }
+}
+
 pub(crate) fn activate_workspace(app: &AppHandle) {
     #[cfg(target_os = "macos")]
     let _ = app.show();
@@ -142,15 +160,17 @@ pub(crate) fn set_pet_window_visible(app: tauri::AppHandle, visible: bool) -> Re
 #[cfg(target_os = "windows")]
 pub(crate) fn install_windows_shell(app: &mut App) -> tauri::Result<()> {
     let show = MenuItemBuilder::with_id("tray-show", "Open Wisp Science").build(app)?;
+    let restart = MenuItemBuilder::with_id("tray-restart", "Restart").build(app)?;
     let quit = MenuItemBuilder::with_id("tray-quit", "Quit").build(app)?;
-    let menu = Menu::with_items(app, &[&show, &quit])?;
+    let menu = Menu::with_items(app, &[&show, &restart, &quit])?;
     let mut tray = TrayIconBuilder::with_id("wisp-tray")
         .menu(&menu)
         .tooltip("Wisp Science")
         .show_menu_on_left_click(false)
-        .on_menu_event(|app, event| match event.id().as_ref() {
-            "tray-show" => activate_workspace(app),
-            "tray-quit" => app.exit(0),
+        .on_menu_event(|app, event| match tray_action(event.id().as_ref()) {
+            Some(TrayAction::Show) => activate_workspace(app),
+            Some(TrayAction::Restart) => app.request_restart(),
+            Some(TrayAction::Quit) => app.exit(0),
             _ => {}
         })
         .on_tray_icon_event(|tray, event| {
@@ -189,4 +209,17 @@ pub(crate) fn install_windows_shell(app: &mut App) -> tauri::Result<()> {
         });
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{tray_action, TrayAction};
+
+    #[test]
+    fn windows_tray_actions_include_restart() {
+        assert_eq!(tray_action("tray-show"), Some(TrayAction::Show));
+        assert_eq!(tray_action("tray-restart"), Some(TrayAction::Restart));
+        assert_eq!(tray_action("tray-quit"), Some(TrayAction::Quit));
+        assert_eq!(tray_action("unknown"), None);
+    }
 }


### PR DESCRIPTION
## Problem

Windows users can quit Wisp Science from the system tray, but cannot restart it directly when troubleshooting or applying a runtime reset.

## Changes

- Add a **Restart** item between **Open Wisp Science** and **Quit** in the Windows tray menu.
- Route the action through Tauri’s native `request_restart()` lifecycle.
- Add a pure unit test for tray action mapping.
- Document the new tray behavior in English and Chinese.

## Tests

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `git diff --check`

## Manual smoke steps

1. Launch the Windows desktop build.
2. Right-click the Wisp Science tray icon.
3. Verify the menu shows **Open Wisp Science**, **Restart**, and **Quit** in that order.
4. Select **Restart** and verify the current process exits and Wisp Science launches again.

## Known limitations

- The tray item is Windows-only, matching the existing tray lifecycle implementation.
- No automated test launches a real Windows tray or process; the event mapping is covered by a platform-independent unit test.