### PR TITLE
perf(ui): make transcript row keys O(1) and clone rows lazily

### DIFF
--- a/ui/src/chat_render.rs
+++ b/ui/src/chat_render.rs
@@ -213,23 +213,27 @@ mod token_format_tests {
 }
 
 /// One thread render unit: either a single message, or a coalesced steps panel.
+///
+/// Rows store message indices, not cloned messages: the keyed `<For>` rebuilds
+/// a row only when its fingerprint key changes, so cloning the message lazily
+/// inside `children` (via `items.with_untracked`) turns per-flush deep clones
+/// of the whole render window into one clone per actually-changed row.
 #[derive(Clone)]
 pub(crate) enum ThreadRow {
     Item {
         i: usize,
-        item: ChatItem,
         timestamp: Option<i64>,
         commentary: bool,
         compact_assistant: bool,
         can_undo: bool,
     },
     Steps {
-        items: Vec<ChatItem>,
+        indices: Vec<usize>,
         live: bool,
         ui_indices: String,
     },
     Activity {
-        items: Vec<ChatItem>,
+        indices: Vec<usize>,
         ui_indices: String,
     },
 }

--- a/ui/src/dto.rs
+++ b/ui/src/dto.rs
@@ -409,6 +409,25 @@ pub(crate) enum ReviewTransitionPhase {
     Passed,
 }
 
+/// Hashes a string in O(1): short strings hash whole, long ones hash their
+/// length plus a head/tail sample. Full-text hashing made every streaming
+/// flush re-hash megabytes of transcript in long sessions, saturating the
+/// WebView main thread. Streaming appends always change the tail sample, so
+/// row keys still track content; a same-length edit confined to the middle of
+/// a long message could miss a rebuild, which we accept for the O(1) cost.
+fn hash_text_sampled<H: std::hash::Hasher>(h: &mut H, s: &str) {
+    use std::hash::Hash;
+    const SAMPLE: usize = 128;
+    let bytes = s.as_bytes();
+    bytes.len().hash(h);
+    if bytes.len() <= 2 * SAMPLE {
+        bytes.hash(h);
+    } else {
+        bytes[..SAMPLE].hash(h);
+        bytes[bytes.len() - SAMPLE..].hash(h);
+    }
+}
+
 impl ChatItem {
     /// Content hash used as the keyed-list key in the chat thread: a row is
     /// rebuilt only when this changes, so streaming updates to one message
@@ -417,14 +436,26 @@ impl ChatItem {
         use std::hash::{Hash, Hasher};
         let mut h = std::collections::hash_map::DefaultHasher::new();
         match self {
-            Self::User(s) => (0u8, s).hash(&mut h),
-            Self::QueuedUser { id, text } => (1u8, id, text).hash(&mut h),
+            Self::User(s) => {
+                0u8.hash(&mut h);
+                hash_text_sampled(&mut h, s);
+            }
+            Self::QueuedUser { id, text } => {
+                (1u8, id).hash(&mut h);
+                hash_text_sampled(&mut h, text);
+            }
             Self::Assistant {
                 text,
                 model,
                 resources,
-            } => (2u8, text, model, resources).hash(&mut h),
-            Self::Reasoning(s) => (3u8, s).hash(&mut h),
+            } => {
+                (2u8, model, resources).hash(&mut h);
+                hash_text_sampled(&mut h, text);
+            }
+            Self::Reasoning(s) => {
+                3u8.hash(&mut h);
+                hash_text_sampled(&mut h, s);
+            }
             Self::Tool {
                 name,
                 ok,
@@ -432,12 +463,20 @@ impl ChatItem {
                 output,
                 duration_ms,
                 ..
-            } => (4u8, name, ok, input, output, duration_ms).hash(&mut h),
+            } => {
+                (4u8, name, ok, duration_ms).hash(&mut h);
+                hash_text_sampled(&mut h, input);
+                hash_text_sampled(&mut h, output);
+            }
             Self::ApprovalPending {
                 tool,
                 preview,
                 message,
-            } => (6u8, tool, preview, message).hash(&mut h),
+            } => {
+                (6u8, tool).hash(&mut h);
+                hash_text_sampled(&mut h, preview);
+                hash_text_sampled(&mut h, message);
+            }
             Self::AcpPermission {
                 request_id,
                 tool,
@@ -450,7 +489,11 @@ impl ChatItem {
                 status,
                 content,
                 locations,
-            } => (10u8, call_id, title, kind, status, content, locations).hash(&mut h),
+            } => {
+                (10u8, call_id, title, kind, status).hash(&mut h);
+                hash_text_sampled(&mut h, content);
+                hash_text_sampled(&mut h, locations);
+            }
             Self::Usage {
                 input,
                 output,
@@ -481,6 +524,72 @@ impl ChatItem {
             Self::Question(question) => (12u8, question).hash(&mut h),
         }
         h.finish()
+    }
+}
+
+#[cfg(test)]
+mod fingerprint_tests {
+    use super::*;
+
+    fn assistant(text: String) -> ChatItem {
+        ChatItem::Assistant {
+            text,
+            model: None,
+            resources: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn same_content_same_fingerprint() {
+        let text = "a".repeat(1000);
+        assert_eq!(assistant(text.clone()).fingerprint(), assistant(text).fingerprint());
+    }
+
+    #[test]
+    fn streaming_append_changes_fingerprint() {
+        let base = "partial answer ".repeat(100);
+        let mut appended = base.clone();
+        appended.push_str("next delta");
+        assert_ne!(
+            assistant(base).fingerprint(),
+            assistant(appended).fingerprint()
+        );
+    }
+
+    #[test]
+    fn short_text_edit_changes_fingerprint() {
+        assert_ne!(
+            ChatItem::User("run the analysis".into()).fingerprint(),
+            ChatItem::User("run the other analysis".into()).fingerprint()
+        );
+    }
+
+    #[test]
+    fn long_text_head_or_tail_edit_changes_fingerprint() {
+        let middle = "x".repeat(1000);
+        let head_edit = format!("EDIT{middle}");
+        let tail_edit = format!("{middle}EDIT");
+        assert_ne!(
+            ChatItem::Reasoning(middle.clone()).fingerprint(),
+            ChatItem::Reasoning(head_edit).fingerprint()
+        );
+        assert_ne!(
+            ChatItem::Reasoning(middle.clone()).fingerprint(),
+            ChatItem::Reasoning(tail_edit).fingerprint()
+        );
+    }
+
+    /// Accepted tradeoff of sampled hashing: a same-length edit confined to
+    /// the middle of a long message keeps the old fingerprint, so a keyed row
+    /// would not rebuild. Streaming appends and typical edits always touch the
+    /// length, head, or tail, so this does not occur in practice.
+    #[test]
+    fn middle_only_same_length_edit_is_not_detected() {
+        let mut a = "y".repeat(1000);
+        let mut b = a.clone();
+        a.replace_range(500..503, "foo");
+        b.replace_range(500..503, "bar");
+        assert_eq!(ChatItem::User(a).fingerprint(), ChatItem::User(b).fingerprint());
     }
 }
 

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -7975,8 +7975,9 @@ fn App() -> impl IntoView {
                                     .map(|page| page.window_user_start)
                                     .unwrap_or(usize::MAX)
                             };
-                            // `with` avoids deep-cloning every message per flush;
-                            // only rows being built clone their item below.
+                            // Rows carry message indices, never cloned messages;
+                            // `children` clones lazily, so a flush only pays for
+                            // rows whose fingerprint key actually changed.
                             items.with(|list| {
                             // Queued user turns live after the active turn and
                             // must not make its process group look historical.
@@ -8011,33 +8012,32 @@ fn App() -> impl IntoView {
                                 if renders_nothing(&list[i]) { i += 1; continue; }
                                 if let Some(end) = completed_activity_end(list, i, busy_now) {
                                     let start = i;
-                                    let mut run: Vec<(usize, ChatItem)> = Vec::new();
+                                    let mut indices: Vec<usize> = Vec::new();
                                     for j in i..end {
                                         if is_turn_activity_at(list, j) {
-                                            run.push((j, list[j].clone()));
+                                            indices.push(j);
                                         }
                                     }
                                     let mut h = std::collections::hash_map::DefaultHasher::new();
-                                    for (idx, it) in &run { (idx, it.fingerprint()).hash(&mut h); }
+                                    for idx in &indices { (idx, list[*idx].fingerprint()).hash(&mut h); }
                                     true.hash(&mut h);
-                                    let ui_indices = run
+                                    let ui_indices = indices
                                         .iter()
-                                        .map(|(index, _)| index.to_string())
+                                        .map(|index| index.to_string())
                                         .collect::<Vec<_>>()
                                         .join(" ");
-                                    let items_only = run.into_iter().map(|(_, item)| item).collect();
                                     rows.push((thread_session_id.clone(), start, h.finish(), ThreadRow::Activity {
-                                        items: items_only,
+                                        indices,
                                         ui_indices,
                                     }));
                                     i = end;
                                 } else if is_tool_activity(&list[i]) {
                                     let start = i;
-                                    let mut run: Vec<(usize, ChatItem)> = Vec::new();
+                                    let mut indices: Vec<usize> = Vec::new();
                                     let mut j = i;
                                     while j < window.end {
                                         if renders_nothing(&list[j]) { j += 1; continue; }
-                                        if is_tool_activity(&list[j]) { run.push((j, list[j].clone())); j += 1; }
+                                        if is_tool_activity(&list[j]) { indices.push(j); j += 1; }
                                         else { break; }
                                     }
                                     // Usage is metadata for the whole reply, not
@@ -8046,16 +8046,15 @@ fn App() -> impl IntoView {
                                         renders_nothing(item) || matches!(item, ChatItem::Usage { .. })
                                     }));
                                     let mut h = std::collections::hash_map::DefaultHasher::new();
-                                    for (idx, it) in &run { (idx, it.fingerprint()).hash(&mut h); }
+                                    for idx in &indices { (idx, list[*idx].fingerprint()).hash(&mut h); }
                                     live.hash(&mut h);
-                                    let ui_indices = run
+                                    let ui_indices = indices
                                         .iter()
-                                        .map(|(index, _)| index.to_string())
+                                        .map(|index| index.to_string())
                                         .collect::<Vec<_>>()
                                         .join(" ");
-                                    let items_only: Vec<ChatItem> = run.into_iter().map(|(_, c)| c).collect();
                                     rows.push((thread_session_id.clone(), start, h.finish(), ThreadRow::Steps {
-                                        items: items_only,
+                                        indices,
                                         live,
                                         ui_indices,
                                     }));
@@ -8086,7 +8085,6 @@ fn App() -> impl IntoView {
                                     fp ^= timestamp.unwrap_or_default() as u64;
                                     rows.push((thread_session_id.clone(), i, fp, ThreadRow::Item {
                                         i,
-                                        item: list[i].clone(),
                                         timestamp,
                                         commentary,
                                         compact_assistant,
@@ -8103,12 +8101,14 @@ fn App() -> impl IntoView {
                             match row {
                                 ThreadRow::Item {
                                     i,
-                                    item,
                                     timestamp,
                                     commentary,
                                     compact_assistant,
                                     can_undo,
                                 } => {
+                                    // Rebuilt only when the fingerprint key changed,
+                                    // so this is the one clone that actually pays off.
+                                    let item = items.with_untracked(|list| list[i].clone());
                                     let arts = artifacts.get_untracked();
                                     let on_resume = Callback::new(resume_turn);
                                     let class = if commentary {
@@ -8145,14 +8145,17 @@ fn App() -> impl IntoView {
                                         </div>
                                     }.into_view()
                                 }
-                                ThreadRow::Steps { items, live, ui_indices } => {
+                                ThreadRow::Steps { indices, live, ui_indices } => {
                                     // ponytail: position-keyed; move to stable
                                     // row ids if mid-list edits ever shift groups.
                                     let group_id = format!("{session_id}:steps:{start}");
+                                    let group_items = items.with_untracked(|list| {
+                                        indices.iter().map(|&j| list[j].clone()).collect::<Vec<_>>()
+                                    });
                                     view! {
                                         <div class="steps-wrap" data-ui-indices=ui_indices>{
                                             render_steps_group(
-                                                items,
+                                                group_items,
                                                 live,
                                                 false,
                                                 group_id,
@@ -8161,12 +8164,15 @@ fn App() -> impl IntoView {
                                         }</div>
                                     }.into_view()
                                 },
-                                ThreadRow::Activity { items, ui_indices } => {
+                                ThreadRow::Activity { indices, ui_indices } => {
                                     let group_id = format!("{session_id}:activity:{start}");
+                                    let group_items = items.with_untracked(|list| {
+                                        indices.iter().map(|&j| list[j].clone()).collect::<Vec<_>>()
+                                    });
                                     view! {
                                         <div class="steps-wrap" data-ui-indices=ui_indices>{
                                             render_steps_group(
-                                                items,
+                                                group_items,
                                                 false,
                                                 true,
                                                 group_id,


### PR DESCRIPTION
## Problem

On Windows, long sessions (2M+ tokens) froze the whole UI: clicking question-card options, the answer/send buttons, and even the window close button did nothing; only the tray Quit worked. The WebView main thread was saturated — every `items` signal write re-hashed the full text of every visible row (`ChatItem::fingerprint`, full-text SipHash) and deep-cloned every row in the render window inside the keyed `<For>` `each` closure. With megabytes of transcript, each streaming flush queued seconds of work, so click events were never processed. The window close button is an HTML button inside the WebView (frameless window on Windows), so it froze together with the page.

## Changes

- `ui/src/dto.rs`: `ChatItem::fingerprint()` now hashes `length + head/tail samples` (128 bytes each) for long strings instead of the full text, via a new `hash_text_sampled` helper. Short strings (<= 256 bytes) still hash whole. Streaming appends always change the tail sample, so row keys still track content changes.
- `ui/src/main.rs`: `ThreadRow` now stores message indices instead of cloned `ChatItem`s. The `<For>` children closure clones lazily via `items.with_untracked(...)`, so a flush only pays for rows whose fingerprint key actually changed, instead of deep-cloning the entire render window on every signal write.

## Tests

- `cargo fmt --all -- --check`
- `cargo check --target wasm32-unknown-unknown` (ui)
- `cargo test --bin wisp-ui` — 177 passed, including 5 new `fingerprint_tests` covering same-content stability, streaming appends, short-text edits, head/tail edits, and the documented middle-edit tradeoff
- `npx playwright test` — 281 passed, 2 flaky failures (`reasoning details stays open`, `scroll stability #663`) that both pass on isolated rerun with this change applied

## Manual smoke steps

1. Open a long session (hundreds of thousands of tokens) in the desktop app.
2. While the agent streams, click a question-card option or type into the composer and send.
3. Verify clicks respond promptly and the transcript keeps rendering the streaming tail.

## Known limitations

- Accepted tradeoff: a same-length edit confined to the middle of a long message (>256 bytes from both ends) keeps the old fingerprint, so that row would not rebuild. Streaming appends and typical edits always touch length, head, or tail; a unit test (`middle_only_same_length_edit_is_not_detected`) locks in this behavior deliberately.
- Other O(conversation) hot spots remain and are follow-ups, not blockers for this fix: `merge_conversation_outline` rescans all items per write, and live Steps groups re-run `md_to_html` per delta.
- The frameless-window close button still depends on a live WebView; a native-side force-close fallback for a hung renderer is a separate follow-up.