### PR TITLE
fix(ui-tests): deflake reasoning stream and long-scroll tests

### DIFF
--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -3836,6 +3836,10 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
             if (String(arg("message") ?? "").includes("RZSTREAM")) {
               // Staggered reasoning deltas keep rebuilding the fingerprint-keyed
               // chat row; the expanded thinking block must not snap shut.
+              // `Done` settles the turn and moves the reasoning into the steps
+              // group (details.rz disappears), so it stays far out: on slow CI
+              // runners the click+assert chain itself can take several seconds,
+              // and the test must finish it inside the live window.
               return await new Promise<string>((resolve) => {
                 setTimeout(() => {
                   emit("agent", { kind: "User", frame_id: fid, text: msg });
@@ -3843,12 +3847,12 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
                 }, 30);
                 setTimeout(() => {
                   emit("agent", { kind: "Reasoning", frame_id: fid, delta: " More reasoning arrives." });
-                }, 1_200);
+                }, 3_000);
                 setTimeout(() => {
                   emit("agent", { kind: "Text", frame_id: fid, delta: "Stream done." });
                   emit("agent", { kind: "Done", frame_id: fid });
                   resolve(fid);
-                }, 1_500);
+                }, 12_000);
               });
             }
             if (String(arg("message") ?? "").includes("RNOTEBOOK")) {

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -6497,6 +6497,12 @@ test("opening a long conversation lands at the latest message and stays stable o
   await expect.poll(() => scroller.evaluate((element) => element.scrollTop)).toBeGreaterThan(before - 240);
 
   const readingPosition = await scroller.evaluate((element) => element.scrollTop);
+  // Unfollow flips overflow-anchor back to auto, but Chromium only picks a
+  // scroll anchor at layout time. Wait for a frame so the anchor is armed —
+  // otherwise a same-frame prepend is never compensated (#663).
+  await page.evaluate(
+    () => new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve))),
+  );
   await page.evaluate(() => {
     const thread = document.getElementById("chat-thread");
     const spacer = document.createElement("div");


### PR DESCRIPTION
## Problem

Two e2e tests fail intermittently on CI (and reproduce locally on `main`), making the `ui-e2e` check red at random — most recently on PR #683, where both failures were unrelated to that PR's changes:

- `reasoning details stays open while more thinking streams in` — failed 3 times in recent `main` CI runs.
- `opening a long conversation lands at the latest message and stays stable on scroll (#663)` — reproduced locally on `main` at ~1/10 failure rate.

## Root causes

**reasoning-details**: the mock sends `Done` 1.5s after send. `Done` settles the turn and the reasoning row moves from its streaming shape (`details.rz`) into the steps group — the element disappears. On slow CI runners the test's own click + assert chain can take several seconds, so by the time it polls for the streamed text, `details.rz` is already gone (`element(s) not found`, seen in CI error contexts).

**long-scroll**: `#chat-scroller` sets `overflow-anchor: none` while following; the wheel gesture unfollows and flips it back to `auto` (scroll.js `setFollow`). But Chromium only picks a scroll anchor at layout time. When the test's `prepend` lands in the same frame as the flip, no anchor exists yet and the 480px insertion is never compensated — `scrollTop` stays put for the full 10s poll (error context: expected > 3370, received 2970).

## Changes

- `ui-tests/tests/mock-tauri.ts` (RZSTREAM): move `Done` from 1.5s to 12s out. The second delta stays at 3s; the test finishes its assertions inside the live window regardless of runner speed. Test duration is unchanged in practice (assertions complete right after the 3s delta).
- `ui-tests/tests/ui.spec.ts` (#663): wait one frame (double rAF) between reading the scroll position and the prepend, so Chromium has armed the scroll anchor before the insertion. The product path is unaffected — real "load earlier" prepends always cross frame boundaries.

No production code changes.

## Verification

- Both tests `--repeat-each=20`, two rounds: **80/80 passed** (previously ~10-50% failure depending on load).
- Full suite: **283 passed, 1 skipped, 0 failed** (7.8m).

## Notes

Other tests in this suite have shown similar timing sensitivity in `main` CI history (`Example project shows bundled demos`, `Ctrl+P command palette`, `runtime inspector`, `dynamic tasks`). Left as-is here; can address separately if they keep flaking.
