### PR TITLE
fix(ui): stop run output panels from jittering each poll

### DIFF
--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -4170,6 +4170,50 @@ test("run monitor output stays pinned to the tail across poll rebuilds (#654)", 
   });
 });
 
+test("a settled run card stops rebuilding itself on every poll (#654)", async ({ page }) => {
+  const longOutput = Array.from(
+    { length: 8 },
+    (_, index) => `settled line ${index} ` + "x".repeat(180),
+  ).join("\n");
+
+  await enterApp(page);
+  // The MONITORRUN turn never resolves, so the agent stays busy and the run
+  // list is polled once a second even though this run is already finished.
+  await page.evaluate((stdout) => {
+    const run = (window as any).__mockRuns.find((item: any) => item.id === "run-local-002");
+    Object.assign(run, {
+      context_id: "local",
+      title: "Settled pipeline",
+      kind: "local",
+      status: "failed",
+      created_at: Math.floor(Date.now() / 1000) - 30,
+      started_at: Math.floor(Date.now() / 1000) - 29,
+      ended_at: Math.floor(Date.now() / 1000) - 5,
+      exit_code: 1,
+      stdout_tail: stdout,
+      progress_json: "{}",
+    });
+  }, longOutput);
+
+  await composer(page).fill("MONITORRUN");
+  await page.getByRole("button", { name: "Send" }).click();
+
+  const output = page.locator('[data-run-id="run-local-002"] .run-monitor-output pre');
+  await expect(output).toBeVisible();
+  const bottomGap = () =>
+    output.evaluate((el) => el.scrollHeight - el.clientHeight - el.scrollTop);
+  await expect.poll(bottomGap, { timeout: 5_000 }).toBeLessThanOrEqual(2);
+
+  // Tag the live node. Identical poll results must leave it in place: replacing
+  // it is what reset the panel to its top edge for a frame, once per second.
+  await output.evaluate((el) => {
+    (el as any).__stableProbe = true;
+  });
+  await page.waitForTimeout(3_000);
+  expect(await output.evaluate((el) => (el as any).__stableProbe === true)).toBe(true);
+  expect(await bottomGap()).toBeLessThanOrEqual(2);
+});
+
 test("reasoning details stays open while more thinking streams in", async ({ page }) => {
   await enterApp(page);
   await composer(page).fill("RZSTREAM");

--- a/ui/src/app_support/runtime.rs
+++ b/ui/src/app_support/runtime.rs
@@ -71,7 +71,16 @@ pub(crate) fn refresh_runs(into: RwSignal<Vec<RunRecord>>, locale: RwSignal<Loca
                 }
                 initialized && added
             });
-            into.set(list);
+            // The poll runs every second while the agent is busy. Setting the
+            // signal unconditionally rebuilds every run card, which resets the
+            // output panel's scroll to the top for a frame — a finished run
+            // visibly jumped once per poll with nothing to show for it (#654).
+            if into.with_untracked(|current| current != &list) {
+                into.set(list);
+            }
+            // Unconditional: the elapsed-time clock rebuilds active run cards
+            // even when this poll changed nothing, and a rebuilt panel needs
+            // re-pinning either way.
             schedule_run_output_follow();
             RUN_REFRESH_INITIALIZED.with(|ready| ready.set(true));
             if should_toast {

--- a/ui/src/dto.rs
+++ b/ui/src/dto.rs
@@ -3058,7 +3058,7 @@ pub(crate) struct RuntimeSlot {
 /// the always-NULL `script_path`). No blanket `allow(dead_code)`: an unread
 /// field here means the UI is dropping data again, and the warning is the
 /// whole point.
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize, Clone, PartialEq)]
 pub(crate) struct RunRecord {
     pub(crate) id: String,
     pub(crate) frame_id: Option<String>,

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -35,8 +35,8 @@ use bindings::{
     invoke, invoke_checked, invoke_timeout, is_mac, is_windows, jump_chat_to_item,
     jump_chat_to_last_user, jump_chat_to_user, listen, listen_current_window,
     listen_native_file_drop, native_drop_in_composer, open_external_url, pasted_image_count,
-    preserve_chat_prepend_position, preview_selection, schedule_chat_follow, set_saved_marks,
-    CHAT_SCROLLER_ID, CHAT_THREAD_ID,
+    preserve_chat_prepend_position, preview_selection, schedule_chat_follow,
+    schedule_run_output_follow, set_saved_marks, CHAT_SCROLLER_ID, CHAT_THREAD_ID,
 };
 use context_menu::{ContextMenuPortal, CtxMenu};
 use dto::*;
@@ -5430,6 +5430,10 @@ fn App() -> impl IntoView {
         let ticks = Cell::new(0_u8);
         let refresh = Closure::wrap(Box::new(move || {
             run_clock.set(now_secs());
+            // The clock rebuilds every active run card to redraw its elapsed
+            // time, which resets the output panel's scroll. Re-pin it here so
+            // the panel does not depend on a run-list poll landing this tick.
+            schedule_run_output_follow();
             let tick = (ticks.get() + 1) % 5;
             ticks.set(tick);
             let transfer_active = run_records.get_untracked().iter().any(|run| {

--- a/ui/src/scroll.js
+++ b/ui/src/scroll.js
@@ -186,38 +186,43 @@ const runOutputFollow = new Map();
 const attachedRunOutputs = new WeakSet();
 
 export function follow_run_outputs() {
-  requestAnimationFrame(() => {
-    requestAnimationFrame(() => {
-      document.querySelectorAll("[data-run-output-for]").forEach((el) => {
-        const key = el.getAttribute("data-run-output-for");
-        let state = runOutputFollow.get(key);
-        if (!state) {
-          state = { follow: true, top: 0 };
-          runOutputFollow.set(key, state);
-        }
-        if (!attachedRunOutputs.has(el)) {
-          attachedRunOutputs.add(el);
-          // Scroll anchoring would fight the explicit snap on rebuild.
-          el.style.overflowAnchor = "none";
-          el.addEventListener(
-            "scroll",
-            () => {
-              state.top = el.scrollTop;
-              state.follow = atBottom(el);
-            },
-            { passive: true },
-          );
-        }
-        if (state.follow) {
-          snapBottom(el);
-        } else {
-          // A scrolled-up user keeps their place across the rebuild; the tail
-          // buffer may have dropped lines, so clamp instead of trusting `top`.
-          const max = Math.max(0, el.scrollHeight - el.clientHeight);
-          el.scrollTop = Math.min(state.top, max);
-        }
-      });
+  const apply = () => {
+    document.querySelectorAll("[data-run-output-for]").forEach((el) => {
+      const key = el.getAttribute("data-run-output-for");
+      let state = runOutputFollow.get(key);
+      if (!state) {
+        state = { follow: true, top: 0 };
+        runOutputFollow.set(key, state);
+      }
+      if (!attachedRunOutputs.has(el)) {
+        attachedRunOutputs.add(el);
+        // Scroll anchoring would fight the explicit snap on rebuild.
+        el.style.overflowAnchor = "none";
+        el.addEventListener(
+          "scroll",
+          () => {
+            state.top = el.scrollTop;
+            state.follow = atBottom(el);
+          },
+          { passive: true },
+        );
+      }
+      if (state.follow) {
+        snapBottom(el);
+      } else {
+        // A scrolled-up user keeps their place across the rebuild; the tail
+        // buffer may have dropped lines, so clamp instead of trusting `top`.
+        const max = Math.max(0, el.scrollHeight - el.clientHeight);
+        el.scrollTop = Math.min(state.top, max);
+      }
     });
+  };
+  // The first pass runs before the frame is painted, so a rebuilt panel never
+  // shows its top edge. The second is the safety net for a panel whose height
+  // only settles after layout (wrapped lines, late fonts).
+  requestAnimationFrame(() => {
+    apply();
+    requestAnimationFrame(apply);
   });
 }
 


### PR DESCRIPTION
## Problem

A Run card's output panel visibly jumped once per poll — roughly once a second while the agent was busy — even for a Run that had already finished and whose output could no longer change. Reported as a recurrence of #654.

The run list poll called `into.set(list)` unconditionally, so Leptos tore down and rebuilt every run card even when the records were byte-identical. The rebuilt `<pre>` starts at `scrollTop` 0, and `follow_run_outputs` only re-pinned it on the *second* `requestAnimationFrame`, which leaves exactly one painted frame showing the top edge. `.run-monitor-output pre` is capped at 150px with `overflow:auto`, so that frame is plainly visible.

## Changes

- `ui/src/app_support.rs` + `ui/src/dto.rs`: `RunRecord` derives `PartialEq`; `refresh_runs` skips the signal write when the poll returned identical records. A settled Run's card is no longer rebuilt at all.
- `ui/src/scroll.js`: `follow_run_outputs` applies the pin on the first animation frame (before paint) and repeats it on the second as a layout-settling safety net.
- `ui/src/main.rs`: the per-second clock rebuilds *active* run cards on its own to redraw elapsed time, independent of the run list. The re-pin therefore stays unconditional in `refresh_runs` and also runs on the clock tick, so an active panel is not left at its top edge during the 5-second idle poll gap.

## Tests

- New: `a settled run card stops rebuilding itself on every poll (#654)` — tags the live `<pre>` and requires the same node to survive several poll cycles. Verified it fails without the fix (`Expected: true, Received: false`).
- Existing `run monitor output stays pinned to the tail across poll rebuilds (#654)` still passes; it is what caught the intermediate mistake of gating the re-pin behind the dedupe.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo check --target wasm32-unknown-unknown` — clean
- `npx playwright test` — 282/285 passed. The 2 failures are pre-existing and unrelated: `reasoning details stays open while more thinking streams in` fails 2 of 3 runs on an unmodified baseline build, and `opening a long conversation lands at the latest message` passes with `--workers=1` (full-suite parallel interference).
- Run-focused subset with `--repeat-each=2`: 30/30 passed.
- `cargo test --workspace` has 10 pre-existing `wisp-tauri` failures on this Windows box (e.g. `resource_leases` asserting `plot.r` vs `plot.R`), reproduced on the unmodified baseline. This change touches only `ui/`.

## Manual smoke

1. Start a Run that produces more than 8 lines of output and let it fail or finish.
2. Watch the card's 最新输出 panel while the agent is still busy: it should sit still at the tail instead of flicking to the top once a second.
3. Scroll the panel up mid-Run — it must keep your position across polls; scroll back to the bottom to re-engage following.

## Known limitations

Active Run cards are still rebuilt every second by the elapsed-time clock. The flash is gone because the re-pin now happens before paint, but the rebuild itself remains; making the elapsed-time text update without rebuilding the card is a separate follow-up.
