### PR TITLE
fix(ui): measure completed turn wall time

### DIFF
--- a/ui/src/app_support/transcript.rs
+++ b/ui/src/app_support/transcript.rs
@@ -145,6 +145,12 @@ pub(crate) fn transcript_item_timestamp(
     }
 }
 
+pub(crate) fn turn_duration_ms(sent_at: Option<i64>, response_at: Option<i64>) -> Option<u64> {
+    let sent_at = sent_at.filter(|timestamp| *timestamp > 0)?;
+    let response_at = response_at.filter(|timestamp| *timestamp >= sent_at)?;
+    Some(response_at.saturating_sub(sent_at) as u64 * 1_000)
+}
+
 pub(crate) fn merge_conversation_outline(
     persisted: &[SessionOutlineItem],
     items: &[ChatItem],
@@ -258,7 +264,7 @@ mod transcript_render_window_tests {
 mod conversation_outline_tests {
     use super::{
         conversation_outline_target_is_loaded, merge_conversation_outline,
-        transcript_item_timestamp, user_turn_index,
+        transcript_item_timestamp, turn_duration_ms, user_turn_index,
     };
     use crate::dto::{ChatItem, SessionOutlineItem};
 
@@ -324,6 +330,13 @@ mod conversation_outline_tests {
         assert_eq!(user_turn_index(&items, 2), Some(1));
         assert!(conversation_outline_target_is_loaded(&items, 1, 2));
         assert!(!conversation_outline_target_is_loaded(&items, 1, 0));
+    }
+
+    #[test]
+    fn turn_duration_uses_the_turn_boundaries() {
+        assert_eq!(turn_duration_ms(Some(100), Some(480)), Some(380_000));
+        assert_eq!(turn_duration_ms(Some(100), None), None);
+        assert_eq!(turn_duration_ms(Some(100), Some(99)), None);
     }
 }
 

--- a/ui/src/chat_render.rs
+++ b/ui/src/chat_render.rs
@@ -235,6 +235,7 @@ pub(crate) enum ThreadRow {
     Activity {
         indices: Vec<usize>,
         ui_indices: String,
+        duration_ms: Option<u64>,
     },
 }
 
@@ -322,6 +323,7 @@ pub(crate) fn render_steps_group(
     items: Vec<ChatItem>,
     live: bool,
     completed_turn: bool,
+    turn_duration_ms: Option<u64>,
     group_id: String,
     disclosure_state: RwSignal<HashMap<String, bool>>,
 ) -> impl IntoView {
@@ -331,22 +333,27 @@ pub(crate) fn render_steps_group(
         .filter(|c| matches!(c, ChatItem::Tool { .. } | ChatItem::AcpTool { .. }))
         .count();
     let now = now_ms();
-    let total_ms: u64 = items
-        .iter()
-        .map(|c| match c {
-            ChatItem::Tool {
-                duration_ms: Some(d),
-                ..
-            } => *d,
-            ChatItem::Tool {
-                duration_ms: None,
-                started_at_ms: Some(s),
-                ok: None,
-                ..
-            } if live => now.saturating_sub(*s),
-            _ => 0,
-        })
-        .sum();
+    let total_ms = turn_duration_ms.unwrap_or_else(|| {
+        if completed_turn {
+            return 0;
+        }
+        items
+            .iter()
+            .map(|c| match c {
+                ChatItem::Tool {
+                    duration_ms: Some(d),
+                    ..
+                } => *d,
+                ChatItem::Tool {
+                    duration_ms: None,
+                    started_at_ms: Some(s),
+                    ok: None,
+                    ..
+                } if live => now.saturating_sub(*s),
+                _ => 0,
+            })
+            .sum()
+    });
     let total_label =
         (total_ms > 0 && (!live || n_tools > 0)).then(|| format_duration_ms(total_ms));
     // A settled step-count header reads better with the duration inline; the

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -8030,9 +8030,20 @@ fn App() -> impl IntoView {
                                         .map(|index| index.to_string())
                                         .collect::<Vec<_>>()
                                         .join(" ");
+                                    let user_index = list[..start]
+                                        .iter()
+                                        .filter(|item| matches!(item, ChatItem::User(_)))
+                                        .count()
+                                        .checked_sub(1)
+                                        .map(|index| index + user_offset);
+                                    let duration_ms = user_index
+                                        .and_then(|index| outline.iter().find(|entry| entry.user_index == index))
+                                        .and_then(|entry| turn_duration_ms(entry.sent_at, entry.response_at));
+                                    duration_ms.hash(&mut h);
                                     rows.push((thread_session_id.clone(), start, h.finish(), ThreadRow::Activity {
                                         indices,
                                         ui_indices,
+                                        duration_ms,
                                     }));
                                     i = end;
                                 } else if is_tool_activity(&list[i]) {
@@ -8162,13 +8173,14 @@ fn App() -> impl IntoView {
                                                 group_items,
                                                 live,
                                                 false,
+                                                None,
                                                 group_id,
                                                 step_disclosure_state,
                                             )
                                         }</div>
                                     }.into_view()
                                 },
-                                ThreadRow::Activity { indices, ui_indices } => {
+                                ThreadRow::Activity { indices, ui_indices, duration_ms } => {
                                     let group_id = format!("{session_id}:activity:{start}");
                                     let group_items = items.with_untracked(|list| {
                                         indices.iter().map(|&j| list[j].clone()).collect::<Vec<_>>()
@@ -8179,6 +8191,7 @@ fn App() -> impl IntoView {
                                                 group_items,
                                                 false,
                                                 true,
+                                                duration_ms,
                                                 group_id,
                                                 step_disclosure_state,
                                             )


### PR DESCRIPTION
## Problem

Completed activity summaries derived elapsed time by adding tool durations. This omitted reasoning, text generation, and gaps between tools, so long turns could display implausibly short values such as 14s.

## Changes

- derive completed-turn duration from the persisted user sent time and final response time
- carry that wall-clock duration into the collapsed activity summary
- keep step-level timing unchanged for live/non-completed groups
- add coverage for valid and incomplete turn boundaries

## Verification

- `cargo fmt --all -- --check`
- `cargo check --manifest-path ui/Cargo.toml --target wasm32-unknown-unknown`
- focused UI unit tests
- `cargo test --workspace` was started and passed the suites observed before the local run was stopped; CI will run the complete suite

## Manual smoke

1. Send a prompt that spends time reasoning and generating text around tool calls.
2. Wait for completion.
3. Confirm the collapsed Processed/已处理 duration matches wall-clock time from send to completion.

## Limitations

Historical turns without persisted sent/response timestamps do not show a fabricated aggregate duration.