### PR TITLE
fix(windows): hide subprocess consoles on startup

### DIFF
--- a/crates/wisp-tools/src/process.rs
+++ b/crates/wisp-tools/src/process.rs
@@ -1,7 +1,27 @@
 //! Keep subprocesses from opening a console on Windows GUI builds.
 
+use std::sync::OnceLock;
+use tokio::sync::Mutex;
+
 #[cfg(windows)]
 const CREATE_NO_WINDOW: u32 = 0x08000000;
+
+// Git for Windows can fail during DLL initialization when several windows probe
+// it at once. Serialize every git.exe spawn through this lock.
+static GIT_COMMAND_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+fn git_command_lock() -> &'static Mutex<()> {
+    GIT_COMMAND_LOCK.get_or_init(|| Mutex::new(()))
+}
+
+/// Hold while spawning Git so concurrent startup probes do not overlap.
+pub fn lock_git_command() -> tokio::sync::MutexGuard<'static, ()> {
+    git_command_lock().blocking_lock()
+}
+
+pub async fn lock_git_command_async() -> tokio::sync::MutexGuard<'static, ()> {
+    git_command_lock().lock().await
+}
 
 #[cfg_attr(not(windows), allow(unused_variables))]
 pub fn hide_console(cmd: &mut std::process::Command) {
@@ -16,4 +36,35 @@ pub fn hide_console(cmd: &mut std::process::Command) {
 pub fn hide_console_async(cmd: &mut tokio::process::Command) {
     #[cfg(windows)]
     cmd.creation_flags(CREATE_NO_WINDOW);
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn git_command_lock_is_reentrant_safe_across_threads() {
+        use super::lock_git_command;
+        use std::sync::Arc;
+        use std::thread;
+
+        let started = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let done = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let started_for_thread = Arc::clone(&started);
+        let done_for_thread = Arc::clone(&done);
+        let _guard = lock_git_command();
+        let worker = thread::spawn(move || {
+            started_for_thread.store(true, std::sync::atomic::Ordering::SeqCst);
+            let _guard = lock_git_command();
+            done_for_thread.store(true, std::sync::atomic::Ordering::SeqCst);
+        });
+        while !started.load(std::sync::atomic::Ordering::SeqCst) {
+            thread::yield_now();
+        }
+        assert!(
+            !done.load(std::sync::atomic::Ordering::SeqCst),
+            "git lock must serialize concurrent spawns"
+        );
+        drop(_guard);
+        worker.join().expect("git lock worker");
+        assert!(done.load(std::sync::atomic::Ordering::SeqCst));
+    }
 }

--- a/crates/wisp-tools/src/process.rs
+++ b/crates/wisp-tools/src/process.rs
@@ -1,7 +1,6 @@
 //! Keep subprocesses from opening a console on Windows GUI builds.
 
-use std::sync::OnceLock;
-use tokio::sync::Mutex;
+use std::sync::{Mutex, OnceLock};
 
 #[cfg(windows)]
 const CREATE_NO_WINDOW: u32 = 0x08000000;
@@ -14,13 +13,17 @@ fn git_command_lock() -> &'static Mutex<()> {
     GIT_COMMAND_LOCK.get_or_init(|| Mutex::new(()))
 }
 
-/// Hold while spawning Git so concurrent startup probes do not overlap.
-pub fn lock_git_command() -> tokio::sync::MutexGuard<'static, ()> {
-    git_command_lock().blocking_lock()
+pub struct GitCommandGuard {
+    _guard: std::sync::MutexGuard<'static, ()>,
 }
 
-pub async fn lock_git_command_async() -> tokio::sync::MutexGuard<'static, ()> {
-    git_command_lock().lock().await
+/// Hold only while starting Git; do not keep this guard across `.await`.
+pub fn lock_git_command() -> GitCommandGuard {
+    GitCommandGuard {
+        _guard: git_command_lock()
+            .lock()
+            .unwrap_or_else(|error| error.into_inner()),
+    }
 }
 
 #[cfg_attr(not(windows), allow(unused_variables))]

--- a/src-tauri/src/delegation_isolation.rs
+++ b/src-tauri/src/delegation_isolation.rs
@@ -38,7 +38,6 @@ impl GitCommandRunner for ProcessGitCommandRunner {
         args: Vec<OsString>,
         stdin: Option<Vec<u8>>,
     ) -> anyhow::Result<GitCommandOutput> {
-        let _git = wisp_tools::process::lock_git_command_async().await;
         let mut command = tokio::process::Command::new("git");
         command
             .args(args)
@@ -52,7 +51,10 @@ impl GitCommandRunner for ProcessGitCommandRunner {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
         wisp_tools::process::hide_console_async(&mut command);
-        let mut child = command.spawn()?;
+        let mut child = {
+            let _git = wisp_tools::process::lock_git_command();
+            command.spawn()?
+        };
         if let Some(stdin) = stdin {
             let mut pipe = child
                 .stdin
@@ -900,8 +902,8 @@ mod tests {
 
     #[derive(Default)]
     struct ConcurrentProbeRunner {
-        active: AtomicUsize,
-        max_active: AtomicUsize,
+        in_lock: AtomicUsize,
+        max_in_lock: AtomicUsize,
     }
 
     #[async_trait]
@@ -912,11 +914,13 @@ mod tests {
             _args: Vec<OsString>,
             _stdin: Option<Vec<u8>>,
         ) -> anyhow::Result<GitCommandOutput> {
-            let _git = wisp_tools::process::lock_git_command_async().await;
-            let active = self.active.fetch_add(1, Ordering::SeqCst) + 1;
-            self.max_active.fetch_max(active, Ordering::SeqCst);
+            {
+                let _git = wisp_tools::process::lock_git_command();
+                let active = self.in_lock.fetch_add(1, Ordering::SeqCst) + 1;
+                self.max_in_lock.fetch_max(active, Ordering::SeqCst);
+                self.in_lock.fetch_sub(1, Ordering::SeqCst);
+            }
             tokio::time::sleep(std::time::Duration::from_millis(25)).await;
-            self.active.fetch_sub(1, Ordering::SeqCst);
             anyhow::bail!("git executable was not found")
         }
     }
@@ -940,7 +944,7 @@ mod tests {
 
         assert!(!first_available);
         assert!(!second_available);
-        assert_eq!(runner.max_active.load(Ordering::SeqCst), 1);
+        assert_eq!(runner.max_in_lock.load(Ordering::SeqCst), 1);
         let _ = fs::remove_dir_all(root);
     }
 

--- a/src-tauri/src/delegation_isolation.rs
+++ b/src-tauri/src/delegation_isolation.rs
@@ -9,10 +9,6 @@ use tokio::{io::AsyncWriteExt, sync::Mutex};
 
 const GIT_AUTHOR_NAME: &str = "Wisp Science Agent";
 const GIT_AUTHOR_EMAIL: &str = "wisp-agent@localhost";
-// Git for Windows can fail during DLL initialization when several project
-// windows probe it at once. One app-wide lock keeps capability probes from
-// launching overlapping git.exe processes.
-static GIT_PROBE_LOCK: Mutex<()> = Mutex::const_new(());
 
 #[derive(Debug, Clone)]
 pub(crate) struct GitCommandOutput {
@@ -42,6 +38,7 @@ impl GitCommandRunner for ProcessGitCommandRunner {
         args: Vec<OsString>,
         stdin: Option<Vec<u8>>,
     ) -> anyhow::Result<GitCommandOutput> {
+        let _git = wisp_tools::process::lock_git_command_async().await;
         let mut command = tokio::process::Command::new("git");
         command
             .args(args)
@@ -54,6 +51,7 @@ impl GitCommandRunner for ProcessGitCommandRunner {
             })
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
+        wisp_tools::process::hide_console_async(&mut command);
         let mut child = command.spawn()?;
         if let Some(stdin) = stdin {
             let mut pipe = child
@@ -205,7 +203,6 @@ impl GitWorktreeIsolation {
         if !project_root.is_dir() {
             anyhow::bail!("the project directory does not exist");
         }
-        let _probe = GIT_PROBE_LOCK.lock().await;
         let version = self
             .runner
             .run(project_root, os_args(["--version"]), None)
@@ -915,6 +912,7 @@ mod tests {
             _args: Vec<OsString>,
             _stdin: Option<Vec<u8>>,
         ) -> anyhow::Result<GitCommandOutput> {
+            let _git = wisp_tools::process::lock_git_command_async().await;
             let active = self.active.fetch_add(1, Ordering::SeqCst) + 1;
             self.max_active.fetch_max(active, Ordering::SeqCst);
             tokio::time::sleep(std::time::Duration::from_millis(25)).await;

--- a/src-tauri/src/delegation_runtime.rs
+++ b/src-tauri/src/delegation_runtime.rs
@@ -3112,15 +3112,20 @@ fn parse_agent_result(raw: &str, request: &AgentDelegationRequest) -> Result<Val
 }
 
 async fn reviewer_host_evidence(project_root: &std::path::Path) -> String {
-    let _git = wisp_tools::process::lock_git_command_async().await;
-    let mut command = tokio::process::Command::new("git");
-    command
-        .args(["diff", "--no-ext-diff", "--", "."])
-        .current_dir(project_root);
-    wisp_tools::process::hide_console_async(&mut command);
-    let output = command.output().await;
+    let project_root = project_root.to_path_buf();
+    let output = tokio::task::spawn_blocking(move || {
+        let _git = wisp_tools::process::lock_git_command();
+        let mut command = std::process::Command::new("git");
+        command
+            .args(["diff", "--no-ext-diff", "--", "."])
+            .current_dir(&project_root);
+        wisp_tools::process::hide_console(&mut command);
+        command.output()
+    })
+    .await
+    .ok()
+    .and_then(|result| result.ok());
     let diff = output
-        .ok()
         .filter(|output| output.status.success())
         .map(|output| bounded_text(&String::from_utf8_lossy(&output.stdout), 60_000))
         .unwrap_or_else(|| "Git diff was unavailable; use read on declared outputs.".into());

--- a/src-tauri/src/delegation_runtime.rs
+++ b/src-tauri/src/delegation_runtime.rs
@@ -3112,11 +3112,13 @@ fn parse_agent_result(raw: &str, request: &AgentDelegationRequest) -> Result<Val
 }
 
 async fn reviewer_host_evidence(project_root: &std::path::Path) -> String {
-    let output = tokio::process::Command::new("git")
+    let _git = wisp_tools::process::lock_git_command_async().await;
+    let mut command = tokio::process::Command::new("git");
+    command
         .args(["diff", "--no-ext-diff", "--", "."])
-        .current_dir(project_root)
-        .output()
-        .await;
+        .current_dir(project_root);
+    wisp_tools::process::hide_console_async(&mut command);
+    let output = command.output().await;
     let diff = output
         .ok()
         .filter(|output| output.status.success())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3621,6 +3621,7 @@ async fn connect_mcp(conn: &McpConnection) -> anyhow::Result<wisp_mcp::McpClient
                     cmd.current_dir(dir);
                 }
             }
+            wisp_tools::process::hide_console_async(&mut cmd);
             wisp_mcp::McpClient::launch_with_command(cmd).await
         }
         McpTransport::Http { url, headers, auth } => match auth {
@@ -3985,6 +3986,7 @@ async fn connect_plugin_mcp(
         .envs(&launch.env)
         .env("WISP_PLUGIN_ROOT", &launch.install_root)
         .env("CLAUDE_PLUGIN_ROOT", &launch.install_root);
+    wisp_tools::process::hide_console_async(&mut command);
     wisp_mcp::McpClient::launch_with_command(command).await
 }
 

--- a/src-tauri/src/method_search.rs
+++ b/src-tauri/src/method_search.rs
@@ -286,6 +286,7 @@ impl MethodSearchEvaluator for LocalPythonMethodSearchEvaluator {
         if let Some(path) = &request.final_verification_path {
             command.env("WISP_METHOD_SEARCH_FINAL", path);
         }
+        wisp_tools::process::hide_console_async(&mut command);
         let mut child = command
             .spawn()
             .map_err(|error| format!("Unable to start the configured Python evaluator: {error}"))?;

--- a/src-tauri/src/run_context.rs
+++ b/src-tauri/src/run_context.rs
@@ -1800,10 +1800,14 @@ fn git_code_state(root: Option<&Path>) -> (Option<String>, Option<String>) {
     let Some(root) = root else {
         return (None, None);
     };
-    let commit = std::process::Command::new("git")
+    let _git = wisp_tools::process::lock_git_command();
+    let mut commit_cmd = std::process::Command::new("git");
+    commit_cmd
         .args(["rev-parse", "--verify", "HEAD"])
         .current_dir(root)
-        .env("GIT_OPTIONAL_LOCKS", "0")
+        .env("GIT_OPTIONAL_LOCKS", "0");
+    wisp_tools::process::hide_console(&mut commit_cmd);
+    let commit = commit_cmd
         .output()
         .ok()
         .filter(|output| output.status.success())
@@ -1811,10 +1815,13 @@ fn git_code_state(root: Option<&Path>) -> (Option<String>, Option<String>) {
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty());
     let dirty_patch = commit.as_ref().and_then(|_| {
-        std::process::Command::new("git")
+        let mut diff_cmd = std::process::Command::new("git");
+        diff_cmd
             .args(["diff", "--binary", "--no-ext-diff", "HEAD", "--", "."])
             .current_dir(root)
-            .env("GIT_OPTIONAL_LOCKS", "0")
+            .env("GIT_OPTIONAL_LOCKS", "0");
+        wisp_tools::process::hide_console(&mut diff_cmd);
+        diff_cmd
             .output()
             .ok()
             .filter(|output| output.status.success() && output.stdout.len() <= MAX_PATCH_BYTES)

--- a/src-tauri/src/run_context.rs
+++ b/src-tauri/src/run_context.rs
@@ -1859,7 +1859,12 @@ async fn record_created_run_lineage(
         .map_err(|error| error.to_string())?;
 
     let command = run.command.as_deref().unwrap_or_default();
-    let (git_commit, dirty_patch) = git_code_state(root);
+    let (git_commit, dirty_patch) = match root.map(|path| path.to_path_buf()) {
+        Some(root) => tokio::task::spawn_blocking(move || git_code_state(Some(&root)))
+            .await
+            .map_err(|error| format!("git snapshot task failed: {error}"))?,
+        None => (None, None),
+    };
     store
         .save_run_code_snapshot(&wisp_store::RunCodeSnapshot {
             id: format!("run-code:{}:command", run.id),

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -6,8 +6,8 @@
   "build": {
     "frontendDist": "../ui/dist",
     "devUrl": "http://localhost:1421",
-    "beforeDevCommand": { "script": "powershell -ExecutionPolicy Bypass -File dev.ps1", "cwd": "../ui" },
-    "beforeBuildCommand": { "script": "powershell -ExecutionPolicy Bypass -File build.ps1", "cwd": "../ui" }
+    "beforeDevCommand": { "script": "powershell -WindowStyle Hidden -ExecutionPolicy Bypass -File dev.ps1", "cwd": "../ui" },
+    "beforeBuildCommand": { "script": "powershell -WindowStyle Hidden -ExecutionPolicy Bypass -File build.ps1", "cwd": "../ui" }
   },
   "app": {
     "withGlobalTauri": true,


### PR DESCRIPTION
## Summary
- Apply CREATE_NO_WINDOW to remaining Git, MCP, plugin, and method-search subprocess spawns so GUI builds no longer flash CMD/Git/PowerShell windows.
- Serialize git.exe through an app-wide lock to avoid concurrent startup probes crashing Git for Windows (0xc0000142).
- Hide Tauri dev/build PowerShell windows via -WindowStyle Hidden.

## Test plan
- [x] cargo test -p wisp-tools process::tests
- [x] cargo test -p wisp-tauri delegation_isolation
- [x] Manual: launch wisp-science on Windows with multiple restored project windows; confirm no flashing CMD/Git/PowerShell windows on startup
- [x] Manual: cargo tauri dev on Windows; confirm build/dev PowerShell does not flash visibly

Made with [Cursor](https://cursor.com)