### PR TITLE
perf(ui): isolate transcript rendering hot paths

### DIFF
--- a/docs/ui-design-principles.md
+++ b/docs/ui-design-principles.md
@@ -34,6 +34,13 @@
 - Long attachment names truncate inside the card; the full value remains available through the control's title.
 - Remove controls live inside the related card and retain an accessible label.
 
+## Transcript rendering
+
+- A live assistant message renders as plain, whitespace-preserving text while tokens arrive. Full Markdown is rendered once the turn settles, so completed answers keep tables, math, lists, and code formatting without reparsing the growing prefix for every token batch.
+- Turn-boundary affordances such as Undo update inside the existing message row; they must not remount or reparse an unchanged historical answer.
+- Collapsed activity summaries, tool details, reasoning, and provenance rows do not keep hidden body DOM. Mount the body when its disclosure opens and remove it when the disclosure closes; headers and status remain available while collapsed.
+- Transcript-derived Inspector data (artifacts, notebook cells, saved highlights, and the conversation outline) refreshes on structural events and settled revisions rather than on every text delta. Live tool status and provenance headers may update independently through compact keyed projections.
+
 ## Topbar and inspector chrome
 
 - The conversation topbar keeps session tabs as the primary signal. Inbox, terminal, and inspector toggles live in `.topbar-actions`.

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -112,6 +112,11 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
   const mockPlanFlow = query.get("mockPlanFlow");
   const mockPublication = query.get("mockPublication");
   const mockLongPages = Number(query.get("mockLongPages") ?? 0);
+  const mockLongRows = Math.min(200, Math.max(20, Number(query.get("mockLongRows") ?? 20)));
+  const mockLongRowBytes = Math.min(
+    64 * 1024,
+    Math.max(256, Number(query.get("mockLongRowBytes") ?? 256)),
+  );
   const mockLongSession = query.get("mockLongSession") === "1" || mockLongPages > 0;
   const mockResourceSession = query.get("mockResourceSession") === "1";
   const mockMcpAppSession = query.get("mockMcpAppSession") === "1";
@@ -1721,9 +1726,9 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
               if (mockLongPages > 0) {
                 const pageIndex = before == null ? 0 : Number(before);
                 return {
-                  items: Array.from({ length: 20 }, (_, index) => ({
+                  items: Array.from({ length: mockLongRows }, (_, index) => ({
                     role: index % 2 === 0 ? "user" : "assistant",
-                    text: `Window page ${pageIndex} row ${index} ${"x".repeat(256)}`,
+                    text: `Window page ${pageIndex} row ${index} ${"x".repeat(mockLongRowBytes)}`,
                     tool_name: null,
                     ok: null,
                   })),
@@ -3635,6 +3640,28 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
                 50,
               );
               return fid;
+            }
+            // Slow stream keeps send_message pending until Done. This mirrors the
+            // native command lifecycle and leaves enough live time to assert that
+            // Markdown/projection work is deferred between token batches.
+            if (String(arg("message") ?? "").includes("MARKDOWNSTREAM")) {
+              return await new Promise<string>((resolve) => {
+                let n = 0;
+                const tick = () => {
+                  if (n < 24) {
+                    emit("agent", { kind: "Text", frame_id: fid, delta: `**stream line ${n}**\n` });
+                    n++;
+                    setTimeout(tick, 50);
+                  } else {
+                    emit("agent", { kind: "Done", frame_id: fid });
+                    resolve(fid);
+                  }
+                };
+                setTimeout(() => {
+                  emit("agent", { kind: "User", frame_id: fid, text: msg });
+                  tick();
+                }, 30);
+              });
             }
             // Long-stream path (#61 regression test): drip many text deltas so the
             // thread re-renders repeatedly and grows well past the viewport.

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -604,7 +604,9 @@ test("background Agent completion appears in its owning conversation", async ({ 
     });
   }, sent.sessionId);
 
-  const card = page.locator(".step", { hasText: "delegate_tasks" }).last();
+  const activity = page.locator(".steps.activity-summary").last();
+  await activity.getByRole("button", { name: /Processed/ }).click();
+  const card = activity.locator(".step", { hasText: "delegate_tasks" }).last();
   await expect(card).toContainText("Background Agent batch completed");
   await expect(card).toContainText("· workflow");
 });
@@ -793,7 +795,9 @@ test("ACP turn maps config, overlapping tools, plan, usage, and exact permission
   await page.getByRole("button", { name: "Send" }).click();
 
   await expect(page.getByText("Hello from ACP.")).toBeVisible();
-  await expect(page.getByTestId("acp-tool")).toHaveCount(2);
+  const activity = page.locator(".steps.activity-summary").last();
+  await activity.getByRole("button", { name: /Processed/ }).click();
+  await expect(activity.getByTestId("acp-tool")).toHaveCount(2);
   await expect(page.getByText("Inspect")).toBeVisible();
   await expect(page.getByTestId("acp-session-config")).toHaveCount(0);
   await expect(page.locator(".model-picker-btn")).toContainText("Test ACP Agent");
@@ -4260,11 +4264,14 @@ test("active Run elapsed time advances without waiting for a backend refresh (#6
   await page.goto("/?mockLiveRunClock=1");
   await page.getByTestId("recent-session-card").nth(1).click();
 
-  const meta = page.getByTestId("auto-run-monitor").locator(".run-monitor-meta");
+  const card = page.getByTestId("auto-run-monitor").locator(".run-monitor-card");
+  const meta = card.locator(".run-monitor-meta");
   const elapsed = async () => (await meta.textContent())?.match(/Elapsed ([^·]+)/)?.[1].trim();
   await expect.poll(elapsed).toMatch(/\d+s/);
+  await card.evaluate((element) => ((element as any).__clockStableProbe = true));
   const initial = await elapsed();
   await expect.poll(elapsed, { timeout: 3_000 }).not.toBe(initial);
+  expect(await card.evaluate((element) => (element as any).__clockStableProbe === true)).toBe(true);
 });
 
 test("image generation shows a placeholder and replaces it with the PNG", async ({ page }) => {
@@ -6341,6 +6348,21 @@ test("chat stays pinned to the bottom while streaming a long reply (#61)", async
     .toBeLessThan(8);
 });
 
+test("streaming assistant text defers Markdown until the turn settles", async ({ page }) => {
+  await enterApp(page);
+  await composer(page).fill("MARKDOWNSTREAM");
+  await page.getByRole("button", { name: "Send" }).click();
+
+  await expect(page.getByText("stream line 4", { exact: false })).toBeVisible({ timeout: 10_000 });
+  await expect(page.locator(".msg.assistant .body.streaming")).toBeVisible();
+  await expect(page.locator(".msg.assistant .body.md")).toHaveCount(0);
+
+  await expect(page.getByText("stream line 23", { exact: false })).toBeVisible({ timeout: 10_000 });
+  await expect(page.locator(".msg.assistant .body.md")).toBeVisible();
+  await expect(page.locator(".msg.assistant .body.md strong")).toHaveCount(24);
+  await expect(page.locator(".msg.assistant .body.streaming")).toHaveCount(0);
+});
+
 test("chat keeps the user's reading position when streaming finishes (#670)", async ({ page }) => {
   await enterApp(page);
   await composer(page).fill("SCROLLTEST");
@@ -6634,6 +6656,32 @@ test("long transcript rendering keeps a bounded turn window", async ({ page }) =
   await expect(page.getByText(/Window page 0 row 0/)).toBeVisible();
   await expect(page.getByText(oldestRow)).toHaveCount(0);
   await expect(page.getByRole("button", { name: "Show earlier loaded messages" })).toBeVisible();
+});
+
+test("a multi-megabyte transcript stays interactive while an answer streams", async ({ page }) => {
+  test.setTimeout(45_000);
+  await page.goto(`/?mockLongPages=1&mockLongRows=160&mockLongRowBytes=${32 * 1024}`);
+  await page.locator(".proj-card-main").first().click();
+  await page.getByText("Long transcript", { exact: true }).click();
+  await expect(page.getByText(/Window page 0 row 159/)).toBeVisible({ timeout: 15_000 });
+  const historicAssistant = page.locator(".msg.assistant", {
+    hasText: /Window page 0 row 159/,
+  });
+  await historicAssistant.evaluate((element) => ((element as any).__historicRowProbe = true));
+
+  await composer(page).fill("MARKDOWNSTREAM");
+  await page.getByRole("button", { name: "Send" }).click();
+  await expect(page.getByText("stream line 4", { exact: false })).toBeVisible({ timeout: 10_000 });
+  expect(await historicAssistant.evaluate((element) => (element as any).__historicRowProbe === true)).toBe(true);
+  await expect(historicAssistant.locator(".body.md")).toBeVisible();
+  await page.getByRole("button", { name: "Agent options" }).click({ timeout: 2_000 });
+  const menu = page.getByRole("menu", { name: "Agent options" });
+  await expect(menu).toBeVisible();
+  await menu.evaluate((element) => ((element as any).__largeTranscriptProbe = true));
+
+  await expect(page.getByText("stream line 23", { exact: false })).toBeVisible({ timeout: 10_000 });
+  expect(await historicAssistant.evaluate((element) => (element as any).__historicRowProbe === true)).toBe(true);
+  expect(await menu.evaluate((element) => (element as any).__largeTranscriptProbe === true)).toBe(true);
 });
 
 test("branching from a paged transcript uses the global user-turn index", async ({ page }) => {
@@ -7822,6 +7870,10 @@ test("completed commentary, reasoning, and tools fold into one activity summary"
   await expect(activity).toHaveCount(1);
   expect(browserErrors).toEqual([]);
   await expect(activity).not.toHaveClass(/open/);
+  // A collapsed summary owns no hidden transcript subtree; rows and their
+  // potentially large tool bodies mount only after the corresponding toggle.
+  await expect(activity.locator(".steps-body")).toHaveCount(0);
+  await expect(activity.locator(".step")).toHaveCount(0);
   await expect(page.locator(".step-body:visible")).toHaveCount(0);
   const activityHead = activity.getByRole("button", { name: /Processed/ });
   await expect(activityHead).toHaveAttribute("aria-expanded", "false");
@@ -7833,6 +7885,12 @@ test("completed commentary, reasoning, and tools fold into one activity summary"
   await expect(activity.locator(".step-name")).toContainText([
     "progress", "thinking", "shell", "progress", "thinking", "python", "progress", "write",
   ]);
+  await expect(activity.locator(".step-body")).toHaveCount(0);
+  const shell = activity.locator(".step", { hasText: "shell" });
+  await shell.locator(".step-head").click();
+  await expect(shell.locator(".step-body")).toHaveCount(1);
+  await expect(shell.locator(".tool-output")).toContainText("gene_0");
+  await activityHead.focus();
   await page.keyboard.press("Space");
   await expect(activityHead).toHaveAttribute("aria-expanded", "false");
   await expect(page.locator("details.rz")).toHaveCount(0);
@@ -7869,7 +7927,32 @@ test("live step disclosure choices survive tool updates and completion (#172)", 
   // Completion replaces the live disclosure with a fresh, collapsed summary.
   await expect(steps).toHaveClass(/activity-summary/);
   await expect(steps).not.toHaveClass(/open/);
-  await expect(shell).not.toHaveClass(/open/);
+  await expect(shell).toHaveCount(0);
+});
+
+test("provenance rows and collapsed bodies stay isolated while assistant text streams", async ({ page }) => {
+  await enterApp(page);
+  await composer(page).fill("STEPSDEMO");
+  await page.getByRole("button", { name: "Send" }).click();
+  await expect(page.getByText(/60,675 genes/)).toBeVisible({ timeout: 10_000 });
+
+  await page.getByRole("button", { name: "Toggle panel" }).click();
+  const panel = page.locator(".rightpane");
+  await panel.getByRole("button", { name: "Add panel" }).click();
+  await panel.locator(".rp-tab-add-menu").getByRole("button", { name: /^Provenance/ }).click();
+
+  const first = panel.locator(".prov-item").first();
+  await expect(first).toBeVisible();
+  await expect(first.locator(".prov-body")).toHaveCount(0);
+  await first.locator(".prov-head").click();
+  await expect(first.locator(".prov-body").last()).toContainText("gene_0");
+  await first.evaluate((element) => ((element as any).__streamStableProbe = true));
+
+  await composer(page).fill("SCROLLTEST");
+  await page.getByRole("button", { name: "Send" }).click();
+  await expect(page.getByText("line 40", { exact: false })).toBeVisible({ timeout: 10_000 });
+  expect(await first.evaluate((element) => (element as any).__streamStableProbe === true)).toBe(true);
+  await expect(first).toHaveAttribute("open", "open");
 });
 
 test("completed ACP commentary, reasoning, and tools share one summary", async ({ page }) => {
@@ -8260,6 +8343,24 @@ test("the selection popup saves a highlight into the right pane and library", as
   await expect(page.getByRole("button", { name: "Highlights (1)", exact: true })).toBeVisible();
   await expect(page.locator(".highlight-card .highlight-text")).toContainText(selected.trim().slice(0, 30));
   await expect.poll(() => page.evaluate(() => (CSS as any).highlights?.has("wisp-saved") ?? false)).toBe(true);
+
+  // Saved-mark application is revision-based: token batches in a later turn
+  // must not rebuild the transcript text index once per flush.
+  await composer(page).fill("MARKDOWNSTREAM");
+  await page.getByRole("button", { name: "Send" }).click();
+  await expect(page.getByText("stream line 4", { exact: false })).toBeVisible({ timeout: 10_000 });
+  await page.evaluate(() => {
+    const registry = (CSS as any).highlights;
+    const set = registry.set.bind(registry);
+    (window as any).__savedMarkSetCalls = 0;
+    registry.set = (name: string, value: unknown) => {
+      if (name === "wisp-saved") (window as any).__savedMarkSetCalls += 1;
+      return set(name, value);
+    };
+  });
+  await expect(page.getByText("stream line 18", { exact: false })).toBeVisible({ timeout: 10_000 });
+  expect(await page.evaluate(() => (window as any).__savedMarkSetCalls)).toBe(0);
+  await expect(page.getByText("stream line 23", { exact: false })).toBeVisible({ timeout: 10_000 });
 
   // The global library lists it under the Highlights filter.
   await page.getByRole("button", { name: "Library", exact: true }).click();

--- a/ui/src/app_support/messages.rs
+++ b/ui/src/app_support/messages.rs
@@ -531,7 +531,7 @@ pub(crate) fn AssistantMessage(
     on_artifact: Callback<usize>,
     on_file: Callback<ModalArtifact>,
     on_copy: Callback<String>,
-    can_undo: bool,
+    can_undo: Signal<bool>,
     on_undo: Callback<usize>,
 ) -> impl IntoView {
     let locale = use_locale();
@@ -697,7 +697,7 @@ pub(crate) fn AssistantMessage(
                 >
                     <span class="gi copy" aria-hidden="true"></span>
                 </button>
-                {can_undo.then(|| view! {
+                {move || can_undo.get().then(|| view! {
                     <button
                         type="button"
                         class="msg-icon-btn"
@@ -721,32 +721,34 @@ pub(crate) fn ToolBlock(
     output: String,
 ) -> impl IntoView {
     let locale = use_locale();
-    let open = ok != Some(true);
+    let expanded = create_rw_signal(ok != Some(true));
     let lang = tool_lang(&name).to_string();
     let hid = unique_dom_id("tool");
     let hid_for_effect = hid.clone();
     let has_input = !input.is_empty();
     let has_output = !output.is_empty();
-    let input_track = input.clone();
-    let output_track = output.clone();
-    let lang_track = lang.clone();
+    let (badge_key, title) = tool_card_label(&name, &input);
+    let input = store_value(input);
+    let output = store_value(output);
+    let lang = store_value(lang);
     create_effect(move |_| {
-        let _ = (&input_track, &output_track, &lang_track);
-        schedule_highlight(hid_for_effect.clone());
-    });
-    let name_for_label = name.clone();
-    let input_label = move || {
-        if matches!(name_for_label.as_str(), "python" | "r") {
-            t(locale.get(), "tool.copy_code")
-        } else {
-            t(locale.get(), "tool.copy_input")
+        if expanded.get() {
+            schedule_highlight(hid_for_effect.clone());
         }
+    });
+    let input_label_key = if matches!(name.as_str(), "python" | "r") {
+        "tool.copy_code"
+    } else {
+        "tool.copy_input"
     };
 
-    let (badge_key, title) = tool_card_label(&name, &input);
     view! {
-        <details class="tool" class:ext=badge_key.is_some() open=open>
-            <summary class="head">
+        <details class="tool" class:ext=badge_key.is_some() open=move || expanded.get()>
+            <summary class="head" aria-expanded=move || expanded.get().to_string()
+                on:click=move |event| {
+                    event.prevent_default();
+                    expanded.update(|open| *open = !*open);
+                }>
                 {badge_key.map(|key| view! {
                     <span class="tool-badge">{move || t(locale.get(), key)}</span>
                 })}
@@ -757,30 +759,37 @@ pub(crate) fn ToolBlock(
                     None => view!{ <span class="run"><span class="run-dot"></span>{move || t(locale.get(), "tool.running")}</span> }.into_view(),
                 }}
             </summary>
-            <div class="tool-panel" id=hid.clone()>
-                <div class="tool-actions">
-                    {has_input.then(|| {
-                        let text = input.clone();
-                        view! {
-                            <button type="button" class="tool-btn" on:click=move |_| copy_text(text.clone())>
-                                {input_label}
-                            </button>
-                        }
-                    })}
-                    {has_output.then(|| {
-                        let text = output.clone();
-                        view! {
-                            <button type="button" class="tool-btn" on:click=move |_| copy_text(text.clone())>{move || t(locale.get(), "tool.copy_output")}</button>
-                        }
-                    })}
-                </div>
-                {has_input.then(|| view! {
-                    <pre class="tool-input md-code"><code class=format!("language-{lang}")>{input.clone()}</code></pre>
-                })}
-                {has_output.then(|| view! {
-                    <pre class="tool-output md-code"><code class="language-plaintext">{output.clone()}</code></pre>
-                })}
-            </div>
+            {move || expanded.get().then(|| {
+                let input = input.get_value();
+                let output = output.get_value();
+                let input_for_copy = input.clone();
+                let output_for_copy = output.clone();
+                let language = lang.get_value();
+                view! {
+                    <div class="tool-panel" id=hid.clone()>
+                        <div class="tool-actions">
+                            {has_input.then(|| view! {
+                                <button type="button" class="tool-btn"
+                                    on:click=move |_| copy_text(input_for_copy.clone())>
+                                    {move || t(locale.get(), input_label_key)}
+                                </button>
+                            })}
+                            {has_output.then(|| view! {
+                                <button type="button" class="tool-btn"
+                                    on:click=move |_| copy_text(output_for_copy.clone())>
+                                    {move || t(locale.get(), "tool.copy_output")}
+                                </button>
+                            })}
+                        </div>
+                        {has_input.then(|| view! {
+                            <pre class="tool-input md-code"><code class=format!("language-{language}")>{input}</code></pre>
+                        })}
+                        {has_output.then(|| view! {
+                            <pre class="tool-output md-code"><code class="language-plaintext">{output}</code></pre>
+                        })}
+                    </div>
+                }
+            })}
         </details>
     }
 }

--- a/ui/src/app_support/runtime.rs
+++ b/ui/src/app_support/runtime.rs
@@ -77,11 +77,8 @@ pub(crate) fn refresh_runs(into: RwSignal<Vec<RunRecord>>, locale: RwSignal<Loca
             // visibly jumped once per poll with nothing to show for it (#654).
             if into.with_untracked(|current| current != &list) {
                 into.set(list);
+                schedule_run_output_follow();
             }
-            // Unconditional: the elapsed-time clock rebuilds active run cards
-            // even when this poll changed nothing, and a rebuilt panel needs
-            // re-pinning either way.
-            schedule_run_output_follow();
             RUN_REFRESH_INITIALIZED.with(|ready| ready.set(true));
             if should_toast {
                 show_warning_toast(&t(locale.get_untracked(), "runs.ssh_retry_stopped"));

--- a/ui/src/app_support/transcript.rs
+++ b/ui/src/app_support/transcript.rs
@@ -156,31 +156,47 @@ pub(crate) fn merge_conversation_outline(
     items: &[ChatItem],
     user_offset: usize,
 ) -> Vec<SessionOutlineItem> {
-    let mut outline = persisted.to_vec();
-    let mut local_index = 0usize;
-    for item in items {
-        let text = match item {
-            ChatItem::User(text) | ChatItem::QueuedUser { text, .. } => text,
-            _ => continue,
-        };
-        let user_index = user_offset + local_index;
-        local_index += 1;
-        if let Some(entry) = outline
-            .iter_mut()
-            .find(|entry| entry.user_index == user_index)
-        {
-            entry.text.clone_from(text);
-        } else {
-            outline.push(SessionOutlineItem {
-                user_index,
-                seq: None,
-                text: text.clone(),
-                sent_at: None,
-                response_at: None,
-            });
+    let mut persisted = persisted.to_vec();
+    if !persisted
+        .windows(2)
+        .all(|window| window[0].user_index <= window[1].user_index)
+    {
+        persisted.sort_by_key(|entry| entry.user_index);
+    }
+    let live = items
+        .iter()
+        .filter_map(|item| match item {
+            ChatItem::User(text) | ChatItem::QueuedUser { text, .. } => Some(text),
+            _ => None,
+        })
+        .enumerate()
+        .map(|(local_index, text)| SessionOutlineItem {
+            user_index: user_offset + local_index,
+            seq: None,
+            text: text.clone(),
+            sent_at: None,
+            response_at: None,
+        })
+        .collect::<Vec<_>>();
+
+    // Both inputs are ordered by user index, so merge once instead of finding
+    // every live turn in the growing persisted vector and sorting afterwards.
+    let mut outline = Vec::with_capacity(persisted.len() + live.len());
+    let mut persisted = persisted.into_iter().peekable();
+    let mut live = live.into_iter().peekable();
+    while let (Some(saved), Some(current)) = (persisted.peek(), live.peek()) {
+        match saved.user_index.cmp(&current.user_index) {
+            std::cmp::Ordering::Less => outline.push(persisted.next().unwrap()),
+            std::cmp::Ordering::Greater => outline.push(live.next().unwrap()),
+            std::cmp::Ordering::Equal => {
+                let mut saved = persisted.next().unwrap();
+                saved.text = live.next().unwrap().text;
+                outline.push(saved);
+            }
         }
     }
-    outline.sort_by_key(|entry| entry.user_index);
+    outline.extend(persisted);
+    outline.extend(live);
     outline
 }
 
@@ -337,6 +353,36 @@ mod conversation_outline_tests {
         assert_eq!(turn_duration_ms(Some(100), Some(480)), Some(380_000));
         assert_eq!(turn_duration_ms(Some(100), None), None);
         assert_eq!(turn_duration_ms(Some(100), Some(99)), None);
+    }
+
+    #[test]
+    fn normalizes_an_old_unsorted_directory_before_merging() {
+        let persisted = vec![
+            SessionOutlineItem {
+                user_index: 2,
+                seq: Some(5),
+                text: "third".into(),
+                sent_at: None,
+                response_at: None,
+            },
+            SessionOutlineItem {
+                user_index: 0,
+                seq: Some(1),
+                text: "first".into(),
+                sent_at: None,
+                response_at: None,
+            },
+        ];
+
+        let merged = merge_conversation_outline(&persisted, &[ChatItem::User("second".into())], 1);
+
+        assert_eq!(
+            merged
+                .iter()
+                .map(|entry| (entry.user_index, entry.text.as_str()))
+                .collect::<Vec<_>>(),
+            vec![(0, "first"), (1, "second"), (2, "third")]
+        );
     }
 }
 

--- a/ui/src/bindings.rs
+++ b/ui/src/bindings.rs
@@ -117,7 +117,7 @@ pub(crate) fn attach_chat_autoscroll() {
     attach_chat_scroll(CHAT_SCROLLER_ID, CHAT_THREAD_ID);
 }
 
-/// Nudge the chat view to follow new content (respects the user's scroll-up).
+/// Nudge the chat view after a non-transcript layout change (respects scroll-up).
 pub(crate) fn schedule_chat_follow() {
     notify_chat_scroll(CHAT_SCROLLER_ID);
 }

--- a/ui/src/chat_render.rs
+++ b/ui/src/chat_render.rs
@@ -225,7 +225,6 @@ pub(crate) enum ThreadRow {
         timestamp: Option<i64>,
         commentary: bool,
         compact_assistant: bool,
-        can_undo: bool,
     },
     Steps {
         indices: Vec<usize>,
@@ -320,7 +319,8 @@ mod steps_title_tests {
 }
 
 pub(crate) fn render_steps_group(
-    items: Vec<ChatItem>,
+    indices: Vec<usize>,
+    source: RwSignal<Vec<ChatItem>>,
     live: bool,
     completed_turn: bool,
     turn_duration_ms: Option<u64>,
@@ -328,31 +328,44 @@ pub(crate) fn render_steps_group(
     disclosure_state: RwSignal<HashMap<String, bool>>,
 ) -> impl IntoView {
     let locale = use_locale();
-    let n_tools = items
-        .iter()
-        .filter(|c| matches!(c, ChatItem::Tool { .. } | ChatItem::AcpTool { .. }))
-        .count();
     let now = now_ms();
-    let total_ms = turn_duration_ms.unwrap_or_else(|| {
-        if completed_turn {
-            return 0;
-        }
-        items
-            .iter()
-            .map(|c| match c {
+    let (n_tools, tool_total_ms, now_line) = source.with_untracked(|items| {
+        let selected = || indices.iter().filter_map(|index| items.get(*index));
+        let n_tools = selected()
+            .filter(|item| matches!(item, ChatItem::Tool { .. } | ChatItem::AcpTool { .. }))
+            .count();
+        let total_ms = selected()
+            .map(|item| match item {
                 ChatItem::Tool {
-                    duration_ms: Some(d),
+                    duration_ms: Some(duration),
                     ..
-                } => *d,
+                } => *duration,
                 ChatItem::Tool {
                     duration_ms: None,
-                    started_at_ms: Some(s),
+                    started_at_ms: Some(started),
                     ok: None,
                     ..
-                } if live => now.saturating_sub(*s),
+                } if live => now.saturating_sub(*started),
                 _ => 0,
             })
-            .sum()
+            .sum::<u64>();
+        let now_line = live
+            .then(|| {
+                indices
+                    .iter()
+                    .rev()
+                    .filter_map(|index| items.get(*index))
+                    .find_map(step_now_line)
+            })
+            .flatten();
+        (n_tools, total_ms, now_line)
+    });
+    let total_ms = turn_duration_ms.unwrap_or_else(|| {
+        if completed_turn {
+            0
+        } else {
+            tool_total_ms
+        }
     });
     let total_label =
         (total_ms > 0 && (!live || n_tools > 0)).then(|| format_duration_ms(total_ms));
@@ -372,166 +385,16 @@ pub(crate) fn render_steps_group(
             inline_time.as_deref(),
         )
     };
-    // The group re-renders on every streaming delta (fingerprint-keyed row),
-    // so this static line tracks the in-flight step while collapsed.
-    let now_line = live.then(|| steps_now_line(&items)).flatten();
-    let rows = items.into_iter().enumerate().map(|(position, it)| match it {
-        ChatItem::Assistant { text, .. } => {
-            let step_id = format!("{group_id}:progress:{position}");
-            let class_id = step_id.clone();
-            let aria_id = step_id.clone();
-            let toggle_id = step_id.clone();
-            let detail: String = text
-                .lines()
-                .find(|line| !line.trim().is_empty())
-                .unwrap_or("")
-                .trim()
-                .chars()
-                .take(100)
-                .collect();
-            let html = md_to_html(&text);
-            view! {
-                <div class="step step-progress"
-                    class:open=move || disclosure_open(disclosure_state, &class_id, false)>
-                    <button type="button" class="step-head"
-                        aria-expanded=move || disclosure_open(disclosure_state, &aria_id, false).to_string()
-                        on:click=move |_| toggle_disclosure(disclosure_state, &toggle_id, false)>
-                        <span class="step-icon progress"></span>
-                        <span class="step-name">{move || t(locale.get(), "chat.progress")}</span>
-                        <span class="step-detail">{detail}</span>
-                    </button>
-                    <div class="step-progress-body body md" inner_html=html></div>
-                </div>
-            }.into_view()
-        }
-        ChatItem::Reasoning(text) => {
-            let step_id = format!("{group_id}:reasoning:{position}");
-            let class_id = step_id.clone();
-            let aria_id = step_id.clone();
-            let toggle_id = step_id.clone();
-            view! {
-                <div class="step step-think"
-                    class:open=move || disclosure_open(disclosure_state, &class_id, false)>
-                    <button type="button" class="step-head"
-                        aria-expanded=move || disclosure_open(disclosure_state, &aria_id, false).to_string()
-                        on:click=move |_| toggle_disclosure(disclosure_state, &toggle_id, false)>
-                        <span class="step-icon think"></span>
-                        <span class="step-name">{move || t(locale.get(), "chat.thinking")}</span>
-                    </button>
-                    <div class="step-think-body">{text}</div>
-                </div>
-            }.into_view()
-        }
-        ChatItem::Tool { name, ok, input, output, started_at_ms, duration_ms, .. } => {
-            let step_id = format!("{group_id}:tool:{position}");
-            let automatic = ok.is_none() && live;
-            let class_id = step_id.clone();
-            let aria_id = step_id.clone();
-            let toggle_id = step_id.clone();
-            let (badge_key, title) = tool_card_label(&name, &input);
-            let mut detail: String = input
-                .lines().find(|l| !l.trim().is_empty()).unwrap_or("").trim()
-                .chars().take(80).collect();
-            if detail == title {
-                detail.clear();
-            }
-            let lines = if output.is_empty() { 0 } else { output.lines().count() };
-            let has_body = !input.is_empty() || !output.is_empty();
-            let icon = match ok {
-                Some(true) => view! { <span class="step-icon ok">"✓"</span> }.into_view(),
-                Some(false) => view! { <span class="step-icon fail">"✗"</span> }.into_view(),
-                None => view! { <span class="step-icon run"><span class="run-dot"></span></span> }.into_view(),
-            };
-            let meta_text = step_tool_meta(locale.get(), duration_ms, started_at_ms, ok, lines, now);
-            let meta = meta_text.map(|text| view! { <span class="step-meta">{text}</span> });
-            view! {
-                <div class="step"
-                    class:open=move || disclosure_open(disclosure_state, &class_id, automatic)
-                    class=("no-body", !has_body)>
-                    <button type="button" class="step-head" disabled=!has_body
-                        aria-expanded=move || (has_body && disclosure_open(disclosure_state, &aria_id, automatic)).to_string()
-                        on:click=move |_| {
-                        if has_body {
-                            toggle_disclosure(disclosure_state, &toggle_id, automatic)
-                        }
-                    }>
-                        {icon}
-                        {badge_key.map(|key| view! {
-                            <span class="tool-badge">{move || t(locale.get(), key)}</span>
-                        })}
-                        <span class="step-name">{title}</span>
-                        {(!detail.is_empty()).then(|| view! { <span class="step-detail">{detail}</span> })}
-                        {meta}
-                    </button>
-                    {has_body.then(|| view! {
-                        <div class="step-body">
-                            {(!input.is_empty()).then(|| view! { <pre class="tool-input">{input.clone()}</pre> })}
-                            {(!output.is_empty()).then(|| view! { <pre class="tool-output">{output.clone()}</pre> })}
-                        </div>
-                    })}
-                </div>
-            }.into_view()
-        }
-        ChatItem::AcpTool { call_id, title, kind, status, content, locations, .. } => {
-            let failed = status == "failed";
-            let done = matches!(status.as_str(), "completed" | "failed");
-            let running = !done;
-            let stable_part = if call_id.is_empty() {
-                format!("position-{position}")
-            } else {
-                call_id.clone()
-            };
-            let step_id = format!("{group_id}:acp:{stable_part}");
-            let automatic = running && live;
-            let class_id = step_id.clone();
-            let aria_id = step_id.clone();
-            let toggle_id = step_id.clone();
-            let detail = acp_tool_step_detail(&kind, &content, &locations);
-            let body = acp_tool_step_body(&content, &locations);
-            let has_body = !body.is_empty();
-            let icon = if failed {
-                view! { <span class="step-icon fail">"✗"</span> }.into_view()
-            } else if done {
-                view! { <span class="step-icon ok">"✓"</span> }.into_view()
-            } else {
-                view! { <span class="step-icon run"><span class="run-dot"></span></span> }.into_view()
-            };
-            let meta = (!done).then(|| status.clone());
-            view! {
-                <div class="step acp-tool" data-testid="acp-tool" data-status=status.clone()
-                    class:open=move || disclosure_open(disclosure_state, &class_id, automatic)
-                    class=("no-body", !has_body)>
-                    <button type="button" class="step-head" disabled=!has_body
-                        aria-expanded=move || (has_body && disclosure_open(disclosure_state, &aria_id, automatic)).to_string()
-                        on:click=move |_| {
-                        if has_body {
-                            toggle_disclosure(disclosure_state, &toggle_id, automatic)
-                        }
-                    }>
-                        {icon}
-                        <span class="step-name">{title.clone()}</span>
-                        {(!detail.is_empty()).then(|| view! { <span class="step-detail">{detail.clone()}</span> })}
-                        {meta.map(|text| view! { <span class="step-meta">{text}</span> })}
-                    </button>
-                    {has_body.then(|| view! {
-                        <div class="step-body">
-                            <pre class="tool-output">{body.clone()}</pre>
-                        </div>
-                    })}
-                </div>
-            }.into_view()
-        }
-        _ => view! {}.into_view(),
-    }).collect_view();
     let class_group_id = group_id.clone();
-    let aria_group_id = group_id.clone();
     let toggle_group_id = group_id.clone();
+    let rows_group_id = group_id;
+    let group_open = create_memo(move |_| disclosure_open(disclosure_state, &class_group_id, live));
     view! {
         <div class="steps"
             class=("activity-summary", completed_turn)
-            class:open=move || disclosure_open(disclosure_state, &class_group_id, live)>
+            class:open=move || group_open.get()>
             <button type="button" class="steps-head"
-                aria-expanded=move || disclosure_open(disclosure_state, &aria_group_id, live).to_string()
+                aria-expanded=move || group_open.get().to_string()
                 on:click=move |_| {
                 toggle_disclosure(disclosure_state, &toggle_group_id, live)
             }>
@@ -540,14 +403,284 @@ pub(crate) fn render_steps_group(
                 {now_line.map(|text| view! { <span class="steps-now">{text}</span> })}
                 {meta_label.map(|label| view! { <span class="steps-meta">{label}</span> })}
             </button>
-            <div class="steps-body">{rows}</div>
+            {move || group_open.get().then(|| view! {
+                <div class="steps-body">{
+                    render_step_rows(
+                        &indices,
+                        source,
+                        live,
+                        &rows_group_id,
+                        disclosure_state,
+                        locale,
+                        now,
+                    )
+                }</div>
+            })}
         </div>
     }
 }
 
+fn render_step_rows(
+    indices: &[usize],
+    source: RwSignal<Vec<ChatItem>>,
+    live: bool,
+    group_id: &str,
+    disclosure_state: RwSignal<HashMap<String, bool>>,
+    locale: ReadSignal<Locale>,
+    now: u64,
+) -> View {
+    indices
+        .iter()
+        .copied()
+        .enumerate()
+        .map(|(position, index)| {
+            render_step_row(
+                source,
+                index,
+                position,
+                live,
+                group_id,
+                disclosure_state,
+                locale,
+                now,
+            )
+        })
+        .collect_view()
+}
+
+#[allow(clippy::too_many_arguments)]
+fn render_step_row(
+    source: RwSignal<Vec<ChatItem>>,
+    index: usize,
+    position: usize,
+    live: bool,
+    group_id: &str,
+    disclosure_state: RwSignal<HashMap<String, bool>>,
+    locale: ReadSignal<Locale>,
+    now: u64,
+) -> View {
+    source.with_untracked(|items| match items.get(index) {
+        Some(ChatItem::Assistant { text, .. }) => {
+            let step_id = format!("{group_id}:progress:{position}");
+            let toggle_id = step_id.clone();
+            let detail = text
+                .lines()
+                .find(|line| !line.trim().is_empty())
+                .unwrap_or("")
+                .trim()
+                .chars()
+                .take(100)
+                .collect::<String>();
+            let step_open = create_memo(move |_| {
+                disclosure_open(disclosure_state, &step_id, false)
+            });
+            view! {
+                <div class="step step-progress" class:open=move || step_open.get()>
+                    <button type="button" class="step-head"
+                        aria-expanded=move || step_open.get().to_string()
+                        on:click=move |_| toggle_disclosure(disclosure_state, &toggle_id, false)>
+                        <span class="step-icon progress"></span>
+                        <span class="step-name">{move || t(locale.get(), "chat.progress")}</span>
+                        <span class="step-detail">{detail}</span>
+                    </button>
+                    {move || step_open.get().then(|| {
+                        let text = source.with_untracked(|items| match items.get(index) {
+                            Some(ChatItem::Assistant { text, .. }) => text.clone(),
+                            _ => String::new(),
+                        });
+                        if live {
+                            view! { <div class="step-progress-body body streaming">{text}</div> }.into_view()
+                        } else {
+                            view! { <div class="step-progress-body body md" inner_html=md_to_html(&text)></div> }.into_view()
+                        }
+                    })}
+                </div>
+            }
+            .into_view()
+        }
+        Some(ChatItem::Reasoning(_)) => {
+            let step_id = format!("{group_id}:reasoning:{position}");
+            let toggle_id = step_id.clone();
+            let step_open = create_memo(move |_| {
+                disclosure_open(disclosure_state, &step_id, false)
+            });
+            view! {
+                <div class="step step-think" class:open=move || step_open.get()>
+                    <button type="button" class="step-head"
+                        aria-expanded=move || step_open.get().to_string()
+                        on:click=move |_| toggle_disclosure(disclosure_state, &toggle_id, false)>
+                        <span class="step-icon think"></span>
+                        <span class="step-name">{move || t(locale.get(), "chat.thinking")}</span>
+                    </button>
+                    {move || step_open.get().then(|| {
+                        let text = source.with_untracked(|items| match items.get(index) {
+                            Some(ChatItem::Reasoning(text)) => text.clone(),
+                            _ => String::new(),
+                        });
+                        view! { <div class="step-think-body">{text}</div> }
+                    })}
+                </div>
+            }
+            .into_view()
+        }
+        Some(ChatItem::Tool {
+            name,
+            ok,
+            input,
+            output,
+            started_at_ms,
+            duration_ms,
+        }) => {
+            let step_id = format!("{group_id}:tool:{position}");
+            let automatic = ok.is_none() && live;
+            let toggle_id = step_id.clone();
+            let (badge_key, title) = tool_card_label(name, input);
+            let mut detail = input
+                .lines()
+                .find(|line| !line.trim().is_empty())
+                .unwrap_or("")
+                .trim()
+                .chars()
+                .take(80)
+                .collect::<String>();
+            if detail == title {
+                detail.clear();
+            }
+            // Counting an ever-growing stdout tail per chunk is quadratic. The
+            // final card still reports its settled line count.
+            let lines = if ok.is_some() && !output.is_empty() {
+                output.lines().count()
+            } else {
+                0
+            };
+            let has_input = !input.is_empty();
+            let has_output = !output.is_empty();
+            let has_body = has_input || has_output;
+            let icon = match ok {
+                Some(true) => view! { <span class="step-icon ok">"✓"</span> }.into_view(),
+                Some(false) => view! { <span class="step-icon fail">"✗"</span> }.into_view(),
+                None => view! { <span class="step-icon run"><span class="run-dot"></span></span> }.into_view(),
+            };
+            let meta = step_tool_meta(
+                locale.get(),
+                *duration_ms,
+                *started_at_ms,
+                *ok,
+                lines,
+                now,
+            )
+            .map(|text| view! { <span class="step-meta">{text}</span> });
+            let step_open = create_memo(move |_| {
+                has_body && disclosure_open(disclosure_state, &step_id, automatic)
+            });
+            view! {
+                <div class="step" class:open=move || step_open.get() class=("no-body", !has_body)>
+                    <button type="button" class="step-head" disabled=!has_body
+                        aria-expanded=move || step_open.get().to_string()
+                        on:click=move |_| {
+                            if has_body {
+                                toggle_disclosure(disclosure_state, &toggle_id, automatic)
+                            }
+                        }>
+                        {icon}
+                        {badge_key.map(|key| view! {
+                            <span class="tool-badge">{move || t(locale.get(), key)}</span>
+                        })}
+                        <span class="step-name">{title}</span>
+                        {(!detail.is_empty()).then(|| view! { <span class="step-detail">{detail}</span> })}
+                        {meta}
+                    </button>
+                    {move || step_open.get().then(|| {
+                        let (input, output) = source.with_untracked(|items| match items.get(index) {
+                            Some(ChatItem::Tool { input, output, .. }) => (input.clone(), output.clone()),
+                            _ => (String::new(), String::new()),
+                        });
+                        view! {
+                            <div class="step-body">
+                                {has_input.then(|| view! { <pre class="tool-input">{input}</pre> })}
+                                {has_output.then(|| view! { <pre class="tool-output">{output}</pre> })}
+                            </div>
+                        }
+                    })}
+                </div>
+            }
+            .into_view()
+        }
+        Some(ChatItem::AcpTool {
+            call_id,
+            title,
+            kind,
+            status,
+            content,
+            locations,
+            ..
+        }) => {
+            let failed = status == "failed";
+            let done = matches!(status.as_str(), "completed" | "failed");
+            let stable_part = if call_id.is_empty() {
+                format!("position-{position}")
+            } else {
+                call_id.clone()
+            };
+            let step_id = format!("{group_id}:acp:{stable_part}");
+            let automatic = !done && live;
+            let toggle_id = step_id.clone();
+            let detail = acp_tool_step_detail(kind, content, locations);
+            let has_body = !locations.trim().is_empty()
+                || (!content.trim().is_empty() && !acp_tool_is_terminal_stub(content));
+            let icon = if failed {
+                view! { <span class="step-icon fail">"✗"</span> }.into_view()
+            } else if done {
+                view! { <span class="step-icon ok">"✓"</span> }.into_view()
+            } else {
+                view! { <span class="step-icon run"><span class="run-dot"></span></span> }.into_view()
+            };
+            let meta = (!done).then(|| status.clone());
+            let title = title.clone();
+            let status = status.clone();
+            let step_open = create_memo(move |_| {
+                has_body && disclosure_open(disclosure_state, &step_id, automatic)
+            });
+            view! {
+                <div class="step acp-tool" data-testid="acp-tool" data-status=status
+                    class:open=move || step_open.get() class=("no-body", !has_body)>
+                    <button type="button" class="step-head" disabled=!has_body
+                        aria-expanded=move || step_open.get().to_string()
+                        on:click=move |_| {
+                            if has_body {
+                                toggle_disclosure(disclosure_state, &toggle_id, automatic)
+                            }
+                        }>
+                        {icon}
+                        <span class="step-name">{title}</span>
+                        {(!detail.is_empty()).then(|| view! { <span class="step-detail">{detail}</span> })}
+                        {meta.map(|text| view! { <span class="step-meta">{text}</span> })}
+                    </button>
+                    {move || step_open.get().then(|| {
+                        let body = source.with_untracked(|items| match items.get(index) {
+                            Some(ChatItem::AcpTool { content, locations, .. }) => {
+                                acp_tool_step_body(content, locations)
+                            }
+                            _ => String::new(),
+                        });
+                        view! { <div class="step-body"><pre class="tool-output">{body}</pre></div> }
+                    })}
+                </div>
+            }
+            .into_view()
+        }
+        _ => view! {}.into_view(),
+    })
+}
+
 /// Latest step of a live run as "name · detail", shown in the collapsed
 /// steps header so folding the panel hides detail, not progress.
+#[cfg(test)]
 pub(crate) fn steps_now_line(items: &[ChatItem]) -> Option<String> {
+    items.iter().rev().find_map(step_now_line)
+}
+
+fn step_now_line(item: &ChatItem) -> Option<String> {
     let first_line = |s: &str| -> String {
         s.lines()
             .find(|l| !l.trim().is_empty())
@@ -557,7 +690,7 @@ pub(crate) fn steps_now_line(items: &[ChatItem]) -> Option<String> {
             .take(80)
             .collect()
     };
-    items.iter().rev().find_map(|item| match item {
+    match item {
         ChatItem::Tool { name, input, .. } => {
             let (_, title) = tool_card_label(name, input);
             let detail = first_line(input);
@@ -582,7 +715,7 @@ pub(crate) fn steps_now_line(items: &[ChatItem]) -> Option<String> {
             })
         }
         _ => None,
-    })
+    }
 }
 
 #[cfg(test)]
@@ -671,6 +804,123 @@ pub(crate) fn run_output_preview(run: &RunRecord) -> String {
 }
 
 #[component]
+pub(crate) fn ProvenancePane(
+    items: RwSignal<Vec<ChatItem>>,
+    rows: Memo<Vec<(usize, u64)>>,
+) -> impl IntoView {
+    let locale = use_locale();
+    let expanded = create_rw_signal::<HashMap<usize, bool>>(HashMap::new());
+    let has_rows = create_memo(move |_| rows.with(|rows| !rows.is_empty()));
+    view! {
+        {move || if !has_rows.get() {
+            view! {
+                <div class="rp-empty">
+                    <span class="rp-empty-icon"></span>
+                    <div class="rp-empty-title">{move || t(locale.get(), "right.no_tools.title")}</div>
+                    <p>{move || t(locale.get(), "right.no_tools.body")}</p>
+                </div>
+            }
+            .into_view()
+        } else {
+            view! {
+                <div class="prov-list">
+                    <For
+                        each=move || rows.get()
+                        key=|(index, fingerprint)| (*index, *fingerprint)
+                        children=move |(index, _)| {
+                            let (name, ok, has_input, has_output) = items.with_untracked(|items| {
+                                match items.get(index) {
+                                    Some(ChatItem::Tool { name, ok, input, output, .. }) => {
+                                        (name.clone(), *ok, !input.is_empty(), !output.is_empty())
+                                    }
+                                    _ => (String::new(), None, false, false),
+                                }
+                            });
+                            let automatic = ok != Some(true);
+                            let row_open = create_memo(move |_| {
+                                expanded.with(|rows| rows.get(&index).copied().unwrap_or(automatic))
+                            });
+                            view! {
+                                <details class="prov-item" data-provenance-index=index.to_string()
+                                    open=move || row_open.get()>
+                                    <summary class="prov-head" aria-expanded=move || row_open.get().to_string()
+                                        on:click=move |event| {
+                                            event.prevent_default();
+                                            expanded.update(|rows| {
+                                                rows.insert(index, !row_open.get_untracked());
+                                            });
+                                        }>
+                                        <span class="prov-name">{name}</span>
+                                        {match ok {
+                                            Some(true) => view! { <span class="ok">"✓"</span> }.into_view(),
+                                            Some(false) => view! { <span class="fail">"✗"</span> }.into_view(),
+                                            None => view! { <span class="run">"…"</span> }.into_view(),
+                                        }}
+                                    </summary>
+                                    {move || row_open.get().then(|| {
+                                        let (input, output) = items.with_untracked(|items| {
+                                            match items.get(index) {
+                                                Some(ChatItem::Tool { input, output, .. }) => {
+                                                    (input.clone(), output.clone())
+                                                }
+                                                _ => (String::new(), String::new()),
+                                            }
+                                        });
+                                        view! {
+                                            <div class="prov-detail">
+                                                {has_input.then(|| view! {
+                                                    <div class="prov-label">{move || t(locale.get(), "right.input")}</div>
+                                                    <pre class="prov-body">{input}</pre>
+                                                })}
+                                                {has_output.then(|| view! {
+                                                    <div class="prov-label">{move || t(locale.get(), "right.output")}</div>
+                                                    <pre class="prov-body">{output}</pre>
+                                                })}
+                                            </div>
+                                        }
+                                    })}
+                                </details>
+                            }
+                        }
+                    />
+                </div>
+            }
+            .into_view()
+        }}
+    }
+}
+
+fn run_monitor_meta(
+    locale: Locale,
+    context_id: &str,
+    kind: &str,
+    started: i64,
+    ended_at: Option<i64>,
+    active: bool,
+    last_heartbeat: Option<i64>,
+    timeout_secs: Option<i64>,
+    now: i64,
+) -> String {
+    let ended = ended_at.unwrap_or(now);
+    let elapsed_value = transfer_duration(ended.saturating_sub(started) as u64);
+    let elapsed = tf(locale, "runs.elapsed", &[("time", &elapsed_value)]);
+    let mut meta = format!("{context_id} · {kind} · {elapsed}");
+    if active {
+        if let Some(last_heartbeat) = last_heartbeat {
+            let age = transfer_duration(now.saturating_sub(last_heartbeat) as u64);
+            meta.push_str(" · ");
+            meta.push_str(&tf(locale, "runs.heartbeat", &[("time", &age)]));
+        }
+        if let Some(limit) = timeout_secs.filter(|seconds| *seconds > 0) {
+            let limit = transfer_duration(limit as u64);
+            meta.push_str(" · ");
+            meta.push_str(&tf(locale, "runs.timeout", &[("time", &limit)]));
+        }
+    }
+    meta
+}
+
+#[component]
 pub(crate) fn RunMonitorCard(
     run_id: String,
     runs: RwSignal<Vec<RunRecord>>,
@@ -681,17 +931,27 @@ pub(crate) fn RunMonitorCard(
     let locale = use_locale();
     let fallback = serde_json::from_str::<RunRecord>(&tool_output).ok();
     let lookup_id = run_id.clone();
+    let selected_id = run_id.clone();
+    let fallback_for_selection = fallback.clone();
+    // Polls touch the shared run vector, but this memo only publishes when this
+    // card's record changes. Unrelated run updates therefore leave its DOM and
+    // disclosure state alone.
+    let selected_run = create_memo(move |_| {
+        runs.with(|records| {
+            records
+                .iter()
+                .find(|record| record.id == selected_id)
+                .cloned()
+        })
+        .or_else(|| fallback_for_selection.clone())
+    });
     // Outside the card closure on purpose: the run list refresh re-renders the
     // body every few seconds, which would snap a native `<details>` shut while
     // the user is reading it.
     let env_open = create_rw_signal(false);
     view! {
         {move || {
-            let run = runs
-                .get()
-                .into_iter()
-                .find(|run| run.id == lookup_id)
-                .or_else(|| fallback.clone());
+            let run = selected_run.get();
             let Some(run) = run else {
                 let failed = tool_ok == Some(false);
                 let status = if failed { "failed" } else { "running" };
@@ -727,30 +987,12 @@ pub(crate) fn RunMonitorCard(
                 t(locale.get(), "runs.cancel")
             };
             let started = run.started_at.unwrap_or(run.created_at);
-            let now = if active {
-                clock.get()
-            } else {
-                js_sys::Date::now() as i64 / 1000
-            };
-            let ended = run.ended_at.unwrap_or(now);
-            let elapsed_value = transfer_duration(ended.saturating_sub(started) as u64);
-            let elapsed = tf(locale.get(), "runs.elapsed", &[("time", &elapsed_value)]);
-            let mut meta = format!("{} · {} · {elapsed}", run.context_id, run.kind);
-            if active {
-                if let Some(last_heartbeat) = run.last_polled_at {
-                    let age = now.saturating_sub(last_heartbeat);
-                    let age = transfer_duration(age as u64);
-                    meta.push_str(" · ");
-                    meta.push_str(&tf(locale.get(), "runs.heartbeat", &[("time", &age)]));
-                }
-            }
-            // The wall limit only tells the user anything while the run can still
-            // hit it, so finished runs keep the shorter line.
-            if let Some(limit) = run.timeout_secs.filter(|_| active).filter(|secs| *secs > 0) {
-                let limit = transfer_duration(limit as u64);
-                meta.push_str(" · ");
-                meta.push_str(&tf(locale.get(), "runs.timeout", &[("time", &limit)]));
-            }
+            let meta_context = run.context_id.clone();
+            let meta_kind = run.kind.clone();
+            let ended_at = run.ended_at;
+            let last_heartbeat = run.last_polled_at;
+            let timeout_secs = run.timeout_secs;
+            let settled_now = js_sys::Date::now() as i64 / 1000;
             let progress = run_progress(&run);
             let output = run_output_preview(&run);
             let command = run.command.clone().filter(|value| !value.trim().is_empty());
@@ -817,7 +1059,20 @@ pub(crate) fn RunMonitorCard(
                             }
                         })}
                     </div>
-                    <div class="run-monitor-meta">{meta}</div>
+                    <div class="run-monitor-meta">{move || {
+                        let now = if active { clock.get() } else { settled_now };
+                        run_monitor_meta(
+                            locale.get(),
+                            &meta_context,
+                            &meta_kind,
+                            started,
+                            ended_at,
+                            active,
+                            last_heartbeat,
+                            timeout_secs,
+                            now,
+                        )
+                    }}</div>
                     {progress.map(|progress| run_progress_meter(progress, locale.get()))}
                     {command.map(|command| view! { <div class="run-monitor-command">{command}</div> })}
                     {remote_workdir.map(|workdir| view! {
@@ -866,7 +1121,7 @@ pub(crate) fn render_item(
     busy: ReadSignal<bool>,
     compact_assistant: bool,
     can_modify: bool,
-    can_undo: bool,
+    can_undo: Signal<bool>,
     on_edit: impl Fn(usize) + Clone + 'static,
     on_branch: impl Fn(usize) + Clone + 'static,
     on_undo: Callback<usize>,
@@ -935,7 +1190,7 @@ pub(crate) fn render_item(
         }
         ChatItem::Assistant { text, .. } if compact_assistant => view! {
             <div class="assistant-wrap">
-                <div class="body md" inner_html=md_to_html(text)></div>
+                <div class="body streaming">{text.clone()}</div>
             </div>
         }.into_view(),
         ChatItem::Assistant { text, model, resources } => view! {

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -31,12 +31,11 @@ use app_overlays::{
     UpdateCheckOverlay, UpdateCheckOverlayState,
 };
 use bindings::{
-    attach_chat_autoscroll, clear_selection, close_mcp_app, force_chat_bottom,
-    invoke, invoke_checked, invoke_timeout, is_mac, is_windows, jump_chat_to_item,
-    jump_chat_to_last_user, jump_chat_to_user, listen, listen_current_window,
-    listen_native_file_drop, native_drop_in_composer, open_external_url, pasted_image_count,
-    preserve_chat_prepend_position, preview_selection, schedule_chat_follow,
-    schedule_run_output_follow, set_saved_marks, CHAT_SCROLLER_ID, CHAT_THREAD_ID,
+    attach_chat_autoscroll, clear_selection, close_mcp_app, force_chat_bottom, invoke,
+    invoke_checked, invoke_timeout, is_mac, is_windows, jump_chat_to_item, jump_chat_to_last_user,
+    jump_chat_to_user, listen, listen_current_window, listen_native_file_drop,
+    native_drop_in_composer, open_external_url, pasted_image_count, preserve_chat_prepend_position,
+    preview_selection, schedule_chat_follow, set_saved_marks, CHAT_SCROLLER_ID, CHAT_THREAD_ID,
 };
 use context_menu::{ContextMenuPortal, CtxMenu};
 use dto::*;
@@ -175,6 +174,10 @@ fn App() -> impl IntoView {
     create_effect(move |_| save_send_with_modifier(send_with_modifier.get()));
 
     let items = create_rw_signal::<Vec<ChatItem>>(vec![]);
+    // Expensive transcript projections do not need token-by-token freshness.
+    // This revision advances for ordinary settled edits and for the structural
+    // events explicitly marked in the streaming handlers below.
+    let transcript_projection_epoch = create_rw_signal(0_u64);
     // Disclosure choices belong to the session/step identity, not to a render
     // instance. Content fingerprints intentionally remount changed rows while
     // streaming, so keeping this state here preserves explicit user choices.
@@ -187,7 +190,7 @@ fn App() -> impl IntoView {
             % EMPTY_SUBTITLE_COUNT,
     );
     create_effect(move |_| {
-        if items.get().is_empty() {
+        if items.with(Vec::is_empty) {
             empty_title_idx.set(
                 (js_sys::Math::random() * EMPTY_TITLE_COUNT as f64).floor() as usize
                     % EMPTY_TITLE_COUNT,
@@ -277,18 +280,69 @@ fn App() -> impl IntoView {
     // Configured model profiles + the composer's bottom-right picker state.
     let models = create_rw_signal::<Vec<ModelProfile>>(vec![]);
     let active_session = create_rw_signal::<Option<String>>(None);
+    let sessions = create_rw_signal::<Vec<SessionInfo>>(vec![]);
     let session_has_items = create_memo(move |_| items.with(|rows| !rows.is_empty()));
     let conversation_outline = create_memo(move |_| {
         let Some(id) = active_session.get() else {
             return Vec::new();
         };
+        let _ = transcript_projection_epoch.get();
         let persisted = conversation_outlines
             .with(|outlines| outlines.get(&id).cloned())
             .unwrap_or_default();
         let user_offset = transcript_pages
             .with(|pages| pages.get(&id).copied())
             .map_or(0, |page| page.user_offset);
-        items.with(|rows| merge_conversation_outline(&persisted, rows, user_offset))
+        items.with_untracked(|rows| merge_conversation_outline(&persisted, rows, user_offset))
+    });
+    let center_conversation_title = create_memo(move |_| {
+        let loc = locale.get();
+        let _ = transcript_projection_epoch.get();
+        if let Some(id) = active_session.get() {
+            if let Some(title) = sessions.with(|sessions| {
+                sessions
+                    .iter()
+                    .find(|session| session.id == id)
+                    .and_then(|session| {
+                        let clean = user_message_presentation(&session.title).body;
+                        (!clean.trim().is_empty()).then_some(clean)
+                    })
+            }) {
+                return title;
+            }
+        }
+        items.with_untracked(|items| {
+            items
+                .iter()
+                .find_map(|item| match item {
+                    ChatItem::User(message) => {
+                        let clean = user_message_presentation(message).body;
+                        let title = clean.trim();
+                        if title.is_empty() {
+                            None
+                        } else if title.chars().count() > 48 {
+                            Some(format!("{}…", title.chars().take(48).collect::<String>()))
+                        } else {
+                            Some(title.to_string())
+                        }
+                    }
+                    _ => None,
+                })
+                .unwrap_or_else(|| i18n::t(loc, "center.new_session").into())
+        })
+    });
+    let loaded_conversation_user_range = create_memo(move |_| {
+        let _ = transcript_projection_epoch.get();
+        let user_offset = active_session
+            .get()
+            .and_then(|id| transcript_pages.with(|pages| pages.get(&id).copied()))
+            .map_or(0, |page| page.user_offset);
+        let loaded = items.with_untracked(|rows| {
+            rows.iter()
+                .filter(|item| matches!(item, ChatItem::User(_) | ChatItem::QueuedUser { .. }))
+                .count()
+        });
+        user_offset..user_offset + loaded
     });
     create_effect(move |_| {
         let _ = active_session.get();
@@ -308,7 +362,8 @@ fn App() -> impl IntoView {
         if active_acp_agent_id.get().is_some() {
             acp_context_usage.with(|all| all.get(&session_id).cloned())
         } else {
-            items.with(|rows| latest_context_usage(rows))
+            let _ = transcript_projection_epoch.get();
+            items.with_untracked(|rows| latest_context_usage(rows))
         }
     });
     create_effect(move |_| {
@@ -491,7 +546,6 @@ fn App() -> impl IntoView {
     let proj_settings_busy = create_rw_signal(false);
 
     // Session history (left sidebar).
-    let sessions = create_rw_signal::<Vec<SessionInfo>>(vec![]);
     let session_history_cursor = create_rw_signal::<Option<SessionCursor>>(None);
     let session_history_loading = create_rw_signal(false);
     let refresh_session_history =
@@ -614,6 +668,19 @@ fn App() -> impl IntoView {
             .unwrap_or(false);
         busy.set(b);
     });
+    // Settled transcript edits refresh projections automatically. While a turn
+    // streams, stop subscribing to `items`; structural event handlers advance
+    // the revision explicitly, and the final busy -> idle transition refreshes
+    // once more with the completed assistant text.
+    create_effect(move |_| {
+        if busy.get() {
+            return;
+        }
+        items.with(|_| ());
+        transcript_projection_epoch.update(|revision| {
+            *revision = revision.wrapping_add(1);
+        });
+    });
 
     // Refresh the session's specialist whenever the active session changes
     // (including on load and on "no session").
@@ -682,21 +749,29 @@ fn App() -> impl IntoView {
     // Artifacts and notebook cells are projections of the active transcript.
     let proto_cache = Rc::new(RefCell::new(ProtoCache::new()));
     let artifacts_all = create_memo(move |_| {
-        items.with(|list| collect_artifacts(list, locale.get(), &mut proto_cache.borrow_mut()))
+        let _ = active_session.get();
+        let _ = transcript_projection_epoch.get();
+        items.with_untracked(|list| {
+            collect_artifacts(list, locale.get(), &mut proto_cache.borrow_mut())
+        })
     });
     // File-backed artifacts are scraped from chat text, so a file that was
     // renamed or overwritten still lingers and 404s on click (#41). Ask the
     // backend which referenced files are gone and drop them from the list.
     let missing_paths = create_rw_signal(std::collections::HashSet::<String>::new());
+    let artifact_file_paths = create_memo(move |_| {
+        artifacts_all.with(|artifacts| {
+            artifacts
+                .iter()
+                .filter_map(|artifact| match &artifact.data {
+                    PreviewData::File { path, .. } => Some(path.clone()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>()
+        })
+    });
     create_effect(move |_| {
-        let paths: Vec<String> = artifacts_all
-            .get()
-            .iter()
-            .filter_map(|a| match &a.data {
-                PreviewData::File { path, .. } => Some(path.clone()),
-                _ => None,
-            })
-            .collect();
+        let paths = artifact_file_paths.get();
         if paths.is_empty() {
             missing_paths.set(std::collections::HashSet::new());
             return;
@@ -739,7 +814,43 @@ fn App() -> impl IntoView {
     });
     let notebook_cache = Rc::new(RefCell::new(NotebookCache::new()));
     let notebook_cells = create_memo(move |_| {
-        items.with(|list| collect_notebook_cells(list, &mut notebook_cache.borrow_mut()))
+        let _ = active_session.get();
+        let _ = transcript_projection_epoch.get();
+        items.with_untracked(|list| collect_notebook_cells(list, &mut notebook_cache.borrow_mut()))
+    });
+    let provenance_rows = create_memo(move |_| {
+        let _ = active_session.get();
+        items.with(|rows| {
+            rows.iter()
+                .enumerate()
+                .filter_map(|(index, item)| {
+                    matches!(item, ChatItem::Tool { .. }).then(|| (index, item.fingerprint()))
+                })
+                .collect::<Vec<_>>()
+        })
+    });
+    let artifact_count = create_memo(move |_| artifacts.with(Vec::len));
+    let artifact_render_fingerprint =
+        create_memo(move |_| artifacts.with(|artifacts| artifacts_fingerprint(artifacts)));
+    let notebook_count = create_memo(move |_| notebook_cells.with(Vec::len));
+    let provenance_count = create_memo(move |_| provenance_rows.with(Vec::len));
+    let highlight_count = create_memo(move |_| {
+        let session = active_session.get();
+        library_items.with(|items| session_highlight_count(session, items))
+    });
+    let monitored_run_ids = create_memo(move |_| {
+        let _ = active_session.get();
+        let _ = transcript_projection_epoch.get();
+        items.with_untracked(|rows| {
+            rows.iter()
+                .filter_map(|item| match item {
+                    ChatItem::Tool { name, input, .. } if is_run_monitor_tool(name) => {
+                        Some(input.trim().to_string())
+                    }
+                    _ => None,
+                })
+                .collect::<HashSet<_>>()
+        })
     });
     let sel_artifact = create_rw_signal(0usize);
     let show_art_preview = create_rw_signal(false);
@@ -1296,10 +1407,6 @@ fn App() -> impl IntoView {
     create_effect(move |_| {
         attach_chat_autoscroll();
     });
-    create_effect(move |_| {
-        let _ = items.get();
-        schedule_chat_follow();
-    });
 
     // Wire the agent event stream once. Every event carries the session frame
     // id; route transcript mutations to `items` (active session) or the
@@ -1312,6 +1419,7 @@ fn App() -> impl IntoView {
     let pending_cb = pending_turns;
     let approval_cb = approval_pending;
     let conversation_outlines_cb = conversation_outlines;
+    let transcript_projection_epoch_cb = transcript_projection_epoch;
     // Desktop notification for task status (#327). The backend drops it while
     // any app window is focused or when disabled in settings, so callers just
     // fire on every done/error/approval event.
@@ -1462,6 +1570,13 @@ fn App() -> impl IntoView {
                 });
             }
         };
+        let refresh_transcript_projections = |frame_id: &str| {
+            if active_cb.get_untracked().as_deref() == Some(frame_id) {
+                transcript_projection_epoch_cb.update(|revision| {
+                    *revision = revision.wrapping_add(1);
+                });
+            }
+        };
         match ev {
             AgentEvent::User { frame_id, text } => {
                 set_pet_activity(&frame_id, "running");
@@ -1476,7 +1591,7 @@ fn App() -> impl IntoView {
                     start_user_turn(v, text, model.clone());
                 });
                 conversation_outlines_cb.update(|outlines| {
-                    let outline = outlines.entry(frame_id).or_default();
+                    let outline = outlines.entry(frame_id.clone()).or_default();
                     let user_index = outline
                         .last()
                         .map_or(0, |entry| entry.user_index.saturating_add(1));
@@ -1488,6 +1603,7 @@ fn App() -> impl IntoView {
                         response_at: None,
                     });
                 });
+                refresh_transcript_projections(&frame_id);
             }
             AgentEvent::MessageBoundary { .. } => {}
             AgentEvent::Resources {
@@ -1557,7 +1673,8 @@ fn App() -> impl IntoView {
                             duration_ms: None,
                         },
                     );
-                })
+                });
+                refresh_transcript_projections(&frame_id);
             }
             AgentEvent::ToolResult {
                 frame_id,
@@ -1625,7 +1742,8 @@ fn App() -> impl IntoView {
                     if name == "attempt_completion" && ok {
                         promote_assistant_text(v, &content);
                     }
-                })
+                });
+                refresh_transcript_projections(&frame_id);
             }
             AgentEvent::ToolPresentation {
                 frame_id,
@@ -1666,6 +1784,7 @@ fn App() -> impl IntoView {
                         context_usage,
                     );
                 });
+                refresh_transcript_projections(&frame_id);
             }
             AgentEvent::Compaction {
                 frame_id,
@@ -1731,6 +1850,7 @@ fn App() -> impl IntoView {
                     strip_approval_pending(items);
                     settle_plan_cards(items);
                 });
+                refresh_transcript_projections(&frame_id);
                 approval_cb.update(|s| {
                     s.remove(&frame_id);
                 });
@@ -1794,6 +1914,7 @@ fn App() -> impl IntoView {
                         });
                     });
                 }
+                refresh_transcript_projections(&frame_id);
                 approval_cb.update(|s| {
                     s.remove(&frame_id);
                 });
@@ -1842,6 +1963,7 @@ fn App() -> impl IntoView {
                         },
                     );
                 });
+                refresh_transcript_projections(&frame_id);
                 if active_cb.get().as_deref() == Some(&frame_id) {
                     status_cb.set(label);
                 }
@@ -2386,6 +2508,9 @@ fn App() -> impl IntoView {
                     text: display_message.clone(),
                 });
             });
+            transcript_projection_epoch.update(|revision| {
+                *revision = revision.wrapping_add(1);
+            });
             force_chat_bottom();
             let enqueue_msg = display_message.clone();
             spawn_local(async move {
@@ -2400,6 +2525,9 @@ fn App() -> impl IntoView {
                 if invoke_checked("enqueue_turn", args).await.is_err() {
                     route_items(active_session, items, transcripts, &session, |rows| {
                         remove_optimistic_send_rows(rows, &enqueue_msg);
+                    });
+                    transcript_projection_epoch.update(|revision| {
+                        *revision = revision.wrapping_add(1);
                     });
                     status.set(t(locale.get(), "status.send_failed").into());
                 }
@@ -2458,9 +2586,14 @@ fn App() -> impl IntoView {
             };
             // Mark the turn pending before touching active_session so the
             // session→ACP lookup effect does not clear a just-selected agent
-            // while send_message is still binding the session.
-            begin_pending_turn(pending_turns, running, &id);
-            if active_session.get_untracked().as_deref() != Some(id.as_str()) {
+            // while send_message is still binding a newly activated session.
+            // For the already-active session, insert its optimistic assistant
+            // first so the busy transition cannot briefly mistake the prior
+            // answer for the new live row and remount its Markdown.
+            let activates_session =
+                active_session.get_untracked().as_deref() != Some(id.as_str());
+            if activates_session {
+                begin_pending_turn(pending_turns, running, &id);
                 active_session.set(Some(id.clone()));
             }
             transcript_pages.update(|pages| {
@@ -2483,6 +2616,12 @@ fn App() -> impl IntoView {
                         resources: Vec::new(),
                     });
                 }
+            });
+            if !activates_session {
+                begin_pending_turn(pending_turns, running, &id);
+            }
+            transcript_projection_epoch.update(|revision| {
+                *revision = revision.wrapping_add(1);
             });
             force_chat_bottom();
             // Await the stop before send_message so the running turn is already
@@ -2531,6 +2670,9 @@ fn App() -> impl IntoView {
                         } else {
                             remove_optimistic_send_rows(rows, &display_message);
                         }
+                    });
+                    transcript_projection_epoch.update(|revision| {
+                        *revision = revision.wrapping_add(1);
                     });
                     if !started {
                         if input.get_untracked().is_empty() {
@@ -2943,6 +3085,11 @@ fn App() -> impl IntoView {
                 (id, if up { "move_up" } else { "move_down" }, None)
             }
         };
+        if action != "cutin" {
+            transcript_projection_epoch.update(|revision| {
+                *revision = revision.wrapping_add(1);
+            });
+        }
         spawn_local(async move {
             let args = to_value(&QueuedTurnActionArgs {
                 session_id: sid,
@@ -5430,10 +5577,6 @@ fn App() -> impl IntoView {
         let ticks = Cell::new(0_u8);
         let refresh = Closure::wrap(Box::new(move || {
             run_clock.set(now_secs());
-            // The clock rebuilds every active run card to redraw its elapsed
-            // time, which resets the output panel's scroll. Re-pin it here so
-            // the panel does not depend on a run-list poll landing this tick.
-            schedule_run_output_follow();
             let tick = (ticks.get() + 1) % 5;
             ticks.set(tick);
             let transfer_active = run_records.get_untracked().iter().any(|run| {
@@ -5546,16 +5689,18 @@ fn App() -> impl IntoView {
             focus_and_select_soon("add-host-alias");
         }
     });
-    // Re-underline saved excerpts whenever the transcript or library changes.
+    // Re-underline saved excerpts when a structural/settled transcript revision
+    // or the library changes. Token batches deliberately do not rescan the DOM.
     create_effect(move |_| {
-        let _ = items.get();
+        let _ = transcript_projection_epoch.get();
         let texts = match active_session.get() {
-            Some(session) => library_items
-                .get()
-                .iter()
-                .filter(|item| item.kind == "text" && item.source_session_id == session)
-                .map(|item| item.code.clone())
-                .collect::<Vec<_>>(),
+            Some(session) => library_items.with(|items| {
+                items
+                    .iter()
+                    .filter(|item| item.kind == "text" && item.source_session_id == session)
+                    .map(|item| item.code.clone())
+                    .collect::<Vec<_>>()
+            }),
             None => Vec::new(),
         };
         set_saved_marks(&serde_json::to_string(&texts).unwrap_or_default());
@@ -7148,6 +7293,30 @@ fn App() -> impl IntoView {
         }
     });
 
+    // Undo eligibility changes at turn boundaries, but the assistant Markdown
+    // does not. Publish the one eligible index separately so adding/removing
+    // its button never remounts and reparses the whole message row.
+    let undo_assistant_index = create_memo(move |_| {
+        if busy.get() || active_acp_agent_id.get().is_some() {
+            return None;
+        }
+        items.with(|list| {
+            let queue_start = trailing_queue_start(list);
+            (queue_start == list.len())
+                .then(|| {
+                    list.iter().enumerate().rev().find_map(|(index, item)| {
+                        matches!(
+                            item,
+                            ChatItem::Assistant { text, .. }
+                                if !text.trim().is_empty() && !text.starts_with("Error: ")
+                        )
+                        .then_some(index)
+                    })
+                })
+                .flatten()
+        })
+    });
+
     view! {
         {is_windows().then(|| view! {
             <WindowTitlebar locale=locale has_current_project=has_current_project
@@ -7319,27 +7488,7 @@ fn App() -> impl IntoView {
                 <div class="center-tabs" role="tablist">
                     <button type="button" class="center-tab" class:active=move || center_file.get().is_none()
                         on:click=move |_| center_file.set(None)>
-                        <span class="center-tab-label">{move || {
-                            let loc = locale.get();
-                            if let Some(id) = active_session.get() {
-                                if let Some(s) = sessions.get().iter().find(|s| s.id == id) {
-                                    let clean = user_message_presentation(&s.title).body;
-                                    let title = clean.trim();
-                                    if !title.is_empty() { return clean; }
-                                }
-                            }
-                            items.get().iter().find_map(|i| match i {
-                                ChatItem::User(msg) => {
-                                    let clean = user_message_presentation(msg).body;
-                                    let t = clean.trim();
-                                    if t.is_empty() { None }
-                                    else if t.chars().count() > 48 {
-                                        Some(format!("{}…", t.chars().take(48).collect::<String>()))
-                                    } else { Some(t.to_string()) }
-                                }
-                                _ => None,
-                            }).unwrap_or_else(|| i18n::t(loc, "center.new_session").into())
-                        }}</span>
+                        <span class="center-tab-label">{move || center_conversation_title.get()}</span>
                     </button>
                     <For
                         each=move || center_files.get()
@@ -7956,52 +8105,39 @@ fn App() -> impl IntoView {
                     <For
                         each=move || {
                             use std::hash::{Hash, Hasher};
-                            let arts_fp = artifacts.with(|a| artifacts_fingerprint(a));
+                            let arts_fp = artifact_render_fingerprint.get();
                             let busy_now = busy.get();
-                            let native_session = active_acp_agent_id.get().is_none();
-                            let outline = conversation_outline.get();
                             // `load_session` deliberately swaps the visible rows before
                             // publishing their session id. Carry the id in every keyed row
                             // so that second update rebuilds callbacks which must target the
                             // newly active session (notably background approval cards).
                             let thread_session_id = active_session.get().unwrap_or_default();
                             let user_offset = transcript_pages
-                                .get()
-                                .get(&thread_session_id)
-                                .copied()
+                                .with(|pages| pages.get(&thread_session_id).copied())
                                 .map_or(0, |page| page.user_offset);
                             let requested_start = if busy_now {
                                 usize::MAX
                             } else {
-                                transcript_pages
-                                    .get()
-                                    .get(&thread_session_id)
-                                    .map(|page| page.window_user_start)
-                                    .unwrap_or(usize::MAX)
+                                transcript_pages.with(|pages| {
+                                    pages
+                                        .get(&thread_session_id)
+                                        .map(|page| page.window_user_start)
+                                        .unwrap_or(usize::MAX)
+                                })
                             };
                             // Rows carry message indices, never cloned messages;
                             // `children` clones lazily, so a flush only pays for
                             // rows whose fingerprint key actually changed.
-                            items.with(|list| {
+                            conversation_outline.with(|outline| items.with(|list| {
                             // Queued user turns live after the active turn and
                             // must not make its process group look historical.
                             let queue_start = trailing_queue_start(list);
                             let last = queue_start.saturating_sub(1);
-                            let undo_index = (!busy_now
-                                && native_session
-                                && queue_start == list.len())
-                                .then(|| {
-                                    list.iter().enumerate().rev().find_map(|(index, item)| {
-                                        matches!(
-                                            item,
-                                            ChatItem::Assistant { text, .. }
-                                                if !text.trim().is_empty()
-                                                    && !text.starts_with("Error: ")
-                                        )
-                                        .then_some(index)
-                                    })
-                                })
-                                .flatten();
+                            let live_assistant_index = busy_now.then(|| {
+                                list[..queue_start]
+                                    .iter()
+                                    .rposition(|item| matches!(item, ChatItem::Assistant { .. }))
+                            }).flatten();
                             // Keep process layers separate while the turn runs;
                             // once complete, fold commentary + reasoning + tools
                             // into one activity summary before the final answer.
@@ -8082,9 +8218,7 @@ fn App() -> impl IntoView {
                                     // one cannot strand async markdown effects
                                     // under a disposed Leptos owner.
                                     let compact_assistant = commentary
-                                        || (busy_now
-                                            && matches!(&list[i], ChatItem::Assistant { .. }));
-                                    let can_undo = !compact_assistant && undo_index == Some(i);
+                                        || live_assistant_index == Some(i);
                                     let timestamp = transcript_item_timestamp(
                                         list,
                                         i,
@@ -8096,20 +8230,18 @@ fn App() -> impl IntoView {
                                     if matches!(&list[i], ChatItem::Assistant { .. }) { fp ^= arts_fp; }
                                     fp ^= (commentary as u64) << 63;
                                     fp ^= (compact_assistant as u64) << 62;
-                                    fp ^= (can_undo as u64) << 61;
                                     fp ^= timestamp.unwrap_or_default() as u64;
                                     rows.push((thread_session_id.clone(), i, fp, ThreadRow::Item {
                                         i,
                                         timestamp,
                                         commentary,
                                         compact_assistant,
-                                        can_undo,
                                     }));
                                     i += 1;
                                 }
                             }
                             rows
-                            })
+                            }))
                         }
                         key=|(session_id, start, fp, _)| (session_id.clone(), *start, *fp)
                         children=move |(session_id, start, _, row)| {
@@ -8119,20 +8251,26 @@ fn App() -> impl IntoView {
                                     timestamp,
                                     commentary,
                                     compact_assistant,
-                                    can_undo,
                                 } => {
                                     // Rebuilt only when the fingerprint key changed,
                                     // so this is the one clone that actually pays off.
                                     let item = items.with_untracked(|list| list[i].clone());
-                                    let arts = artifacts.get_untracked();
+                                    let arts = if matches!(&item, ChatItem::Assistant { .. })
+                                        && !compact_assistant
+                                    {
+                                        artifacts.get_untracked()
+                                    } else {
+                                        Vec::new()
+                                    };
                                     let on_resume = Callback::new(resume_turn);
                                     let class = if commentary {
                                         "msg assistant commentary"
                                     } else {
                                         class_for(&item)
                                     };
-                                    let user_index =
-                                        user_turn_index(&items.get_untracked(), i).map(|index| {
+                                    let user_index = items
+                                        .with_untracked(|rows| user_turn_index(rows, i))
+                                        .map(|index| {
                                             index
                                                 + transcript_pages
                                                     .with_untracked(|pages| {
@@ -8142,6 +8280,9 @@ fn App() -> impl IntoView {
                                         });
                                     let data_user_index =
                                         user_index.map(|index| index.to_string());
+                                    let can_undo = Signal::derive(move || {
+                                        !compact_assistant && undo_assistant_index.get() == Some(i)
+                                    });
                                     view! {
                                         <div class=class
                                             class:outline-target=move || user_index.is_some_and(|index| {
@@ -8164,13 +8305,11 @@ fn App() -> impl IntoView {
                                     // ponytail: position-keyed; move to stable
                                     // row ids if mid-list edits ever shift groups.
                                     let group_id = format!("{session_id}:steps:{start}");
-                                    let group_items = items.with_untracked(|list| {
-                                        indices.iter().map(|&j| list[j].clone()).collect::<Vec<_>>()
-                                    });
                                     view! {
                                         <div class="steps-wrap" data-ui-indices=ui_indices>{
                                             render_steps_group(
-                                                group_items,
+                                                indices,
+                                                items,
                                                 live,
                                                 false,
                                                 None,
@@ -8182,13 +8321,11 @@ fn App() -> impl IntoView {
                                 },
                                 ThreadRow::Activity { indices, ui_indices, duration_ms } => {
                                     let group_id = format!("{session_id}:activity:{start}");
-                                    let group_items = items.with_untracked(|list| {
-                                        indices.iter().map(|&j| list[j].clone()).collect::<Vec<_>>()
-                                    });
                                     view! {
                                         <div class="steps-wrap" data-ui-indices=ui_indices>{
                                             render_steps_group(
-                                                group_items,
+                                                indices,
+                                                items,
                                                 false,
                                                 true,
                                                 duration_ms,
@@ -8205,20 +8342,10 @@ fn App() -> impl IntoView {
                         let Some(frame_id) = active_session.get() else {
                             return Vec::<View>::new().into_view();
                         };
-                        let monitored = items.with(|rows| {
-                            rows.iter()
-                                .filter_map(|item| match item {
-                                    ChatItem::Tool { name, input, .. } if is_run_monitor_tool(name) => {
-                                        Some(input.trim().to_string())
-                                    }
-                                    _ => None,
-                                })
-                                .collect::<HashSet<_>>()
-                        });
+                        let monitored = monitored_run_ids.get();
                         let now = js_sys::Date::now() as i64 / 1000;
-                        run_records
-                            .get()
-                            .into_iter()
+                        run_records.with(|runs| runs
+                            .iter()
                             .filter(|run| run.frame_id.as_deref() == Some(frame_id.as_str()))
                             .filter(|run| !monitored.contains(&run.id))
                             .filter(|run| {
@@ -8226,7 +8353,7 @@ fn App() -> impl IntoView {
                                     || run.ended_at.is_some_and(|ended| now.saturating_sub(ended) <= 60)
                             })
                             .map(|run| {
-                                let run_id = run.id;
+                                let run_id = run.id.clone();
                                 view! {
                                     <div class="tool-wrap run-monitor-wrap auto-run-monitor"
                                         data-testid="auto-run-monitor">
@@ -8241,7 +8368,7 @@ fn App() -> impl IntoView {
                                 }
                             })
                             .collect_view()
-                            .into_view()
+                            .into_view())
                     }}
                     {move || (!busy.get()).then(|| active_session.get()).flatten().and_then(|id| {
                         transcript_pages.get().get(&id).copied().and_then(|page| {
@@ -8304,18 +8431,9 @@ fn App() -> impl IntoView {
                                             if !busy.get() {
                                                 return false;
                                             }
-                                            let offset = active_session
+                                            !loaded_conversation_user_range
                                                 .get()
-                                                .and_then(|id| transcript_pages
-                                                    .get()
-                                                    .get(&id)
-                                                    .copied())
-                                                .map_or(0, |page| page.user_offset);
-                                            !conversation_outline_target_is_loaded(
-                                                &items.get(),
-                                                offset,
-                                                target,
-                                            )
+                                                .contains(&target)
                                         }
                                         on:click=move |_| {
                                             jump_to_conversation_outline.call((target, before_seq));
@@ -9952,10 +10070,10 @@ fn App() -> impl IntoView {
                         {move || {
                             let loc = locale.get();
                             let active = right_tab.get();
-                            let art_n = artifacts.get().len();
-                            let notebook_n = notebook_cells.get().len();
-                            let prov_n = items.get().iter().filter(|i| matches!(i, ChatItem::Tool { .. })).count();
-                            let highlight_n = session_highlight_count(active_session.get(), &library_items.get());
+                            let art_n = artifact_count.get();
+                            let notebook_n = notebook_count.get();
+                            let prov_n = provenance_count.get();
+                            let highlight_n = highlight_count.get();
                             open_right_tabs.get().into_iter().map(|tab| {
                                 let label = match tab {
                                     RightTab::Artifacts => tab_count(loc, "right.artifacts", art_n),
@@ -10062,10 +10180,10 @@ fn App() -> impl IntoView {
                                 {move || {
                                     let loc = locale.get();
                                     let open = open_right_tabs.get();
-                                    let art_n = artifacts.get().len();
-                                    let notebook_n = notebook_cells.get().len();
-                                    let prov_n = items.get().iter().filter(|i| matches!(i, ChatItem::Tool { .. })).count();
-                                    let highlight_n = session_highlight_count(active_session.get(), &library_items.get());
+                                    let art_n = artifact_count.get();
+                                    let notebook_n = notebook_count.get();
+                                    let prov_n = provenance_count.get();
+                                    let highlight_n = highlight_count.get();
                                     ALL_RIGHT_TABS.iter().copied().map(|tab| {
                                         let label = match tab {
                                             RightTab::Artifacts => tab_count(loc, "right.artifacts", art_n),
@@ -10755,45 +10873,10 @@ fn App() -> impl IntoView {
                             }.into_view()
                         }
                         RightTab::Provenance => {
-                            let loc = locale.get();
-                            let tools: Vec<_> = items.get().iter().filter_map(|it| match it {
-                                ChatItem::Tool { name, ok, input, output, .. } => Some((name.clone(), *ok, input.clone(), output.clone())),
-                                _ => None,
-                            }).collect();
-                            if tools.is_empty() {
-                                view! {
-                                    <div class="rp-empty">
-                                        <span class="rp-empty-icon"></span>
-                                        <div class="rp-empty-title">{t(loc, "right.no_tools.title")}</div>
-                                        <p>{t(loc, "right.no_tools.body")}</p>
-                                    </div>
-                                }.into_view()
-                            } else {
-                                view! {
-                                    <div class="prov-list">
-                                        {tools.into_iter().map(|(name, ok, input, output)| view! {
-                                            <details class="prov-item" open=ok != Some(true)>
-                                                <summary class="prov-head">
-                                                    <span class="prov-name">{name.clone()}</span>
-                                                    {match ok {
-                                                        Some(true) => view! { <span class="ok">"✓"</span> }.into_view(),
-                                                        Some(false) => view! { <span class="fail">"✗"</span> }.into_view(),
-                                                        None => view! { <span class="run">"…"</span> }.into_view(),
-                                                    }}
-                                                </summary>
-                                                {(!input.is_empty()).then(|| view! {
-                                                    <div class="prov-label">{move || t(locale.get(), "right.input")}</div>
-                                                    <pre class="prov-body">{input.clone()}</pre>
-                                                })}
-                                                {(!output.is_empty()).then(|| view! {
-                                                    <div class="prov-label">{move || t(locale.get(), "right.output")}</div>
-                                                    <pre class="prov-body">{output.clone()}</pre>
-                                                })}
-                                            </details>
-                                        }).collect_view()}
-                                    </div>
-                                }.into_view()
+                            view! {
+                                <ProvenancePane items=items rows=provenance_rows />
                             }
+                            .into_view()
                         }
                         RightTab::Hosts => {
                             let loc = locale.get();

--- a/ui/src/marks.js
+++ b/ui/src/marks.js
@@ -51,11 +51,25 @@ function findRanges(needle, onRange) {
 function apply() {
   if (!("highlights" in CSS)) return;
   const ranges = [];
-  for (const needle of needles) {
-    findRanges(needle, (range) => {
-      ranges.push(range);
-      return false;
-    });
+  // Index each rendered message once, then match every saved excerpt against
+  // that shared text. The previous needle-first loop rebuilt the full
+  // character-to-DOM map once per highlight.
+  for (const body of document.querySelectorAll("#chat-thread .msg .body")) {
+    const { hay, map } = indexBody(body);
+    for (const needle of needles) {
+      if (!needle) continue;
+      let from = 0;
+      let at;
+      while ((at = hay.indexOf(needle, from)) !== -1) {
+        const [startNode, startOffset] = map[at];
+        const [endNode, endOffset] = map[at + needle.length - 1];
+        const range = new Range();
+        range.setStart(startNode, startOffset);
+        range.setEnd(endNode, endOffset + 1);
+        ranges.push(range);
+        from = at + needle.length;
+      }
+    }
   }
   if (ranges.length) CSS.highlights.set(NAME, new Highlight(...ranges));
   else CSS.highlights.delete(NAME);

--- a/ui/src/scroll.js
+++ b/ui/src/scroll.js
@@ -51,6 +51,10 @@ export function attach_chat_scroll(scrollerId, contentId) {
   const syncPill = () => {
     const pill = document.getElementById(JUMP_PILL_ID);
     if (!pill) return;
+    if (follow) {
+      pill.classList.remove("visible");
+      return;
+    }
     let show = false;
     const row = lastUserRow(content);
     if (row && bottomGap(scroller) > 48) {
@@ -62,9 +66,9 @@ export function attach_chat_scroll(scrollerId, contentId) {
   };
 
   const syncFollow = () => {
-    syncPill();
     if (atBottom(scroller)) {
       setFollow(true);
+      syncPill();
       return;
     }
     // Not at bottom: only treat it as an intentional scroll-up if a real gesture
@@ -72,6 +76,7 @@ export function attach_chat_scroll(scrollerId, contentId) {
     if (performance.now() - lastUserScroll < 500) {
       setFollow(false);
       readingTop = scroller.scrollTop;
+      syncPill();
       return;
     }
     // Reflow-driven clamp while following (streaming rebuilds shrink the
@@ -79,14 +84,22 @@ export function attach_chat_scroll(scrollerId, contentId) {
     // paint, so an instant snap here means the clamped position is never
     // painted — without it the view visibly bounces on every thinking delta.
     if (follow) snapBottom(scroller);
+    syncPill();
   };
 
-  const onGrowth = () => {
-    const h = content.scrollHeight;
+  const onGrowth = (observedHeight = content.scrollHeight) => {
+    const h = observedHeight;
     const grew = h > lastHeight;
     lastHeight = h;
-    if (follow && grew) snapBottom(scroller);
-    else if (!follow && grew) {
+    if (follow) {
+      // ResizeObserver already coalesces streaming DOM changes. Keep the hot
+      // path to one bottom snap and skip the row/viewport geometry used only
+      // by the scroll-away pill.
+      snapBottom(scroller);
+      syncPill();
+      return;
+    }
+    if (grew) {
       scroller.scrollTop = Math.min(readingTop, scroller.scrollHeight - scroller.clientHeight);
     }
     syncFollow();
@@ -107,7 +120,7 @@ export function attach_chat_scroll(scrollerId, contentId) {
   scroller.addEventListener("pointerdown", markUser, { passive: true });
   scroller.addEventListener("keydown", markUser, { passive: true });
 
-  const ro = new ResizeObserver(() => onGrowth());
+  const ro = new ResizeObserver((entries) => onGrowth(entries[0]?.contentRect.height));
   ro.observe(content);
 
   hooks.set(scrollerId, {


### PR DESCRIPTION
## Problem

Follow-up to #684. That PR made transcript row identity work O(1), but profiling the same UI path found more token-level work: streaming updates could still rebuild transcript-derived panels, reparse Markdown, retain collapsed output DOM, and wake stable run/scroll surfaces. On a multi-megabyte transcript this made controls visibly sluggish; the 5 MiB regression case timed out beyond 43 seconds before these changes.

## Changes

- Render only the active assistant tail in lightweight streaming mode; keep historical assistant DOM stable and decouple Undo eligibility from Markdown rendering.
- Lazily mount collapsed reasoning, tool, ACP, run-output, and provenance bodies.
- Gate transcript-derived artifacts, notebook, outline, context, highlights, and monitored runs behind a structural projection epoch.
- Merge outline state linearly and index saved highlight needles in one body pass.
- Update run cards and output-follow behavior only when run data changes; trim redundant ResizeObserver geometry work.
- Add large-transcript/DOM-identity regressions and document the rendering invariants.

## Verification

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo test --manifest-path ui/Cargo.toml` — 179 passed
- `cargo check --manifest-path ui/Cargo.toml --target wasm32-unknown-unknown`
- `cd ui-tests && npx playwright test` — 287 passed, 1 environment-gated test skipped
- 5 MiB transcript regression — completed in about 21.4 seconds locally; the pre-fix path timed out beyond 43 seconds in the same environment

## Manual smoke

1. Open a long transcript and start a slow streaming response.
2. While tokens arrive, open the Agent menu and interact with earlier messages.
3. Verify the historical final-answer row keeps its DOM identity, the menu stays open, and follow-scroll still tracks the active tail.
4. Expand and collapse reasoning, tool, run-output, and provenance sections to confirm content mounts on demand.

## Known limitations / follow-up

- The first expansion of a very large settled Markdown message still pays its parse/render cost.
- This PR does not add per-message virtualization; add it only if profiling shows the remaining first-render cost is material.
- The real Motif Playwright case remains skipped when its external environment is unavailable.