### PR TITLE
perf(ui): render Markdown during streaming

### DIFF
--- a/docs/ui-design-principles.md
+++ b/docs/ui-design-principles.md
@@ -36,7 +36,7 @@
 
 ## Transcript rendering
 
-- A live assistant message renders as plain, whitespace-preserving text while tokens arrive. Full Markdown is rendered once the turn settles, so completed answers keep tables, math, lists, and code formatting without reparsing the growing prefix for every token batch.
+- A live assistant message keeps a throttled Markdown prefix plus an immediate, whitespace-preserving plain-text tail. The Markdown budget adapts from 50 ms for short answers to 150 ms above 8,000 bytes and 300 ms above 32,000 bytes; once the turn settles, the remaining tail is rendered once as full Markdown.
 - Turn-boundary affordances such as Undo update inside the existing message row; they must not remount or reparse an unchanged historical answer.
 - Collapsed activity summaries, tool details, reasoning, and provenance rows do not keep hidden body DOM. Mount the body when its disclosure opens and remove it when the disclosure closes; headers and status remain available while collapsed.
 - Transcript-derived Inspector data (artifacts, notebook cells, saved highlights, and the conversation outline) refreshes on structural events and settled revisions rather than on every text delta. Live tool status and provenance headers may update independently through compact keyed projections.

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -3649,7 +3649,13 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
                 let n = 0;
                 const tick = () => {
                   if (n < 24) {
-                    emit("agent", { kind: "Text", frame_id: fid, delta: `**stream line ${n}**\n` });
+                    // Cross both adaptive Markdown thresholds so the browser
+                    // test observes a formatted prefix and a cheap live tail.
+                    emit("agent", {
+                      kind: "Text",
+                      frame_id: fid,
+                      delta: `**stream line ${n}** ${"x".repeat(1_500)}\n`,
+                    });
                     n++;
                     setTimeout(tick, 50);
                   } else {

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -6349,14 +6349,21 @@ test("chat stays pinned to the bottom while streaming a long reply (#61)", async
     .toBeLessThan(8);
 });
 
-test("streaming assistant text defers Markdown until the turn settles", async ({ page }) => {
+test("streaming assistant keeps formatted Markdown with a lightweight live tail", async ({ page }) => {
   await enterApp(page);
   await composer(page).fill("MARKDOWNSTREAM");
   await page.getByRole("button", { name: "Send" }).click();
 
   await expect(page.getByText("stream line 4", { exact: false })).toBeVisible({ timeout: 10_000 });
-  await expect(page.locator(".msg.assistant .body.streaming")).toBeVisible();
-  await expect(page.locator(".msg.assistant .body.md")).toHaveCount(0);
+  const live = page.locator(".msg.assistant .streaming-markdown");
+  await expect(live).toBeVisible();
+  await expect(live.locator(".streaming-markdown-prefix strong").first()).toBeVisible();
+  await live.evaluate((element) => ((element as any).__liveMarkdownProbe = true));
+
+  await expect(page.getByText("stream line 18", { exact: false })).toBeVisible({ timeout: 10_000 });
+  await expect.poll(async () => Number(await live.getAttribute("data-pending-bytes") ?? 0))
+    .toBeGreaterThan(0);
+  expect(await live.evaluate((element) => (element as any).__liveMarkdownProbe === true)).toBe(true);
 
   await expect(page.getByText("stream line 23", { exact: false })).toBeVisible({ timeout: 10_000 });
   await expect(page.locator(".msg.assistant .body.md")).toBeVisible();

--- a/ui/src/app_support/messages.rs
+++ b/ui/src/app_support/messages.rs
@@ -1,4 +1,137 @@
 use super::*;
+use leptos::leptos_dom::helpers::TimeoutHandle;
+use std::{cell::Cell, rc::Rc};
+
+const STREAMING_MARKDOWN_TAIL_THRESHOLD_BYTES: usize = 8_000;
+
+pub(crate) fn streaming_markdown_commit_interval_ms(text_len: usize) -> u64 {
+    if text_len >= 32_000 {
+        300
+    } else if text_len >= STREAMING_MARKDOWN_TAIL_THRESHOLD_BYTES {
+        150
+    } else {
+        50
+    }
+}
+
+fn assistant_text_at(items: RwSignal<Vec<ChatItem>>, source_item: usize) -> String {
+    items.with_untracked(|rows| match rows.get(source_item) {
+        Some(ChatItem::Assistant { text, .. }) => text.clone(),
+        _ => String::new(),
+    })
+}
+
+/// Keep completed Markdown readable while an append-only assistant stream grows.
+/// Parsing is throttled by answer size; once the answer is large, the unparsed
+/// suffix remains visible as a cheap whitespace-preserving text tail.
+#[component]
+pub(crate) fn StreamingAssistantMessage(
+    items: RwSignal<Vec<ChatItem>>,
+    source_item: usize,
+    on_artifact: Callback<usize>,
+    on_file: Callback<ModalArtifact>,
+) -> impl IntoView {
+    let locale = use_locale();
+    let rendered_text = create_rw_signal(assistant_text_at(items, source_item));
+    let commit_handle = Rc::new(Cell::new(None::<TimeoutHandle>));
+    let active = Rc::new(Cell::new(true));
+
+    create_render_effect({
+        let commit_handle = Rc::clone(&commit_handle);
+        let active = Rc::clone(&active);
+        move |_| {
+            let (changed, text_len) = items.with(|rows| match rows.get(source_item) {
+                Some(ChatItem::Assistant { text, .. }) => (
+                    rendered_text.with_untracked(|rendered| rendered != text),
+                    text.len(),
+                ),
+                _ => (false, 0),
+            });
+            if !changed || commit_handle.get().is_some() {
+                return;
+            }
+
+            let delay =
+                std::time::Duration::from_millis(streaming_markdown_commit_interval_ms(text_len));
+            let callback_handle = Rc::clone(&commit_handle);
+            let callback_active = Rc::clone(&active);
+            match leptos::set_timeout_with_handle(
+                move || {
+                    callback_handle.set(None);
+                    if !callback_active.get() {
+                        return;
+                    }
+                    let latest = assistant_text_at(items, source_item);
+                    if rendered_text.get_untracked() != latest {
+                        rendered_text.set(latest);
+                    }
+                },
+                delay,
+            ) {
+                Ok(handle) => commit_handle.set(Some(handle)),
+                Err(_) => rendered_text.set(assistant_text_at(items, source_item)),
+            }
+        }
+    });
+
+    on_cleanup({
+        let commit_handle = Rc::clone(&commit_handle);
+        move || {
+            active.set(false);
+            if let Some(handle) = commit_handle.take() {
+                handle.clear();
+            }
+        }
+    });
+
+    let html = create_memo(move |_| {
+        enrich_md_html(md_to_html(&rendered_text.get()), &[], &[], locale.get())
+    });
+    let pending_text = create_memo(move |_| {
+        let rendered = rendered_text.get();
+        items.with(|rows| match rows.get(source_item) {
+            Some(ChatItem::Assistant { text, .. })
+                if text.len() >= STREAMING_MARKDOWN_TAIL_THRESHOLD_BYTES =>
+            {
+                text.strip_prefix(rendered.as_str())
+                    .unwrap_or_default()
+                    .to_string()
+            }
+            _ => String::new(),
+        })
+    });
+    let hid = unique_dom_id("stream-md");
+    let hid_for_effect = hid.clone();
+    create_render_effect(move |_| {
+        let _ = html.get();
+        schedule_highlight(hid_for_effect.clone());
+    });
+
+    view! {
+        <div class="assistant-wrap">
+            <div
+                class="body streaming streaming-markdown"
+                data-rendered-bytes=move || rendered_text.with(|text| text.len().to_string())
+                data-pending-bytes=move || pending_text.with(|text| text.len().to_string())
+            >
+                <div
+                    class="streaming-markdown-prefix md"
+                    id=hid
+                    inner_html=move || html.get()
+                    on:click=move |ev: web_sys::MouseEvent| {
+                        handle_md_click(&ev, &[], &[], &on_artifact, &on_file)
+                    }
+                ></div>
+                {move || {
+                    let tail = pending_text.get();
+                    (!tail.is_empty()).then(|| view! {
+                        <div class="streaming-markdown-tail">{tail}</div>
+                    })
+                }}
+            </div>
+        </div>
+    }
+}
 
 #[component]
 pub(crate) fn SessionStatusBadge(
@@ -1037,6 +1170,19 @@ mod layout_block_tests {
             "Counts are in GEO."
         );
         assert_eq!(apply_layout_block("", BLOCK, false), "");
+    }
+}
+
+#[cfg(test)]
+mod streaming_markdown_tests {
+    use super::streaming_markdown_commit_interval_ms;
+
+    #[test]
+    fn parsing_budget_slows_as_the_live_answer_grows() {
+        assert_eq!(streaming_markdown_commit_interval_ms(7_999), 50);
+        assert_eq!(streaming_markdown_commit_interval_ms(8_000), 150);
+        assert_eq!(streaming_markdown_commit_interval_ms(31_999), 150);
+        assert_eq!(streaming_markdown_commit_interval_ms(32_000), 300);
     }
 }
 

--- a/ui/src/chat_render.rs
+++ b/ui/src/chat_render.rs
@@ -225,6 +225,7 @@ pub(crate) enum ThreadRow {
         timestamp: Option<i64>,
         commentary: bool,
         compact_assistant: bool,
+        streaming_assistant: bool,
     },
     Steps {
         indices: Vec<usize>,

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -8141,7 +8141,7 @@ fn App() -> impl IntoView {
                             // Keep process layers separate while the turn runs;
                             // once complete, fold commentary + reasoning + tools
                             // into one activity summary before the final answer.
-                            let mut rows: Vec<(String, usize, u64, ThreadRow)> = Vec::new();
+                            let mut rows: Vec<(String, usize, bool, u64, ThreadRow)> = Vec::new();
                             let (window, _, _) = transcript_render_window(
                                 list,
                                 requested_start,
@@ -8176,7 +8176,7 @@ fn App() -> impl IntoView {
                                         .and_then(|index| outline.iter().find(|entry| entry.user_index == index))
                                         .and_then(|entry| turn_duration_ms(entry.sent_at, entry.response_at));
                                     duration_ms.hash(&mut h);
-                                    rows.push((thread_session_id.clone(), start, h.finish(), ThreadRow::Activity {
+                                    rows.push((thread_session_id.clone(), start, false, h.finish(), ThreadRow::Activity {
                                         indices,
                                         ui_indices,
                                         duration_ms,
@@ -8204,7 +8204,7 @@ fn App() -> impl IntoView {
                                         .map(|index| index.to_string())
                                         .collect::<Vec<_>>()
                                         .join(" ");
-                                    rows.push((thread_session_id.clone(), start, h.finish(), ThreadRow::Steps {
+                                    rows.push((thread_session_id.clone(), start, false, h.finish(), ThreadRow::Steps {
                                         indices,
                                         live,
                                         ui_indices,
@@ -8212,11 +8212,17 @@ fn App() -> impl IntoView {
                                     i = j;
                                 } else {
                                     let commentary = is_commentary_at(list, i);
-                                    // A text row can become commentary when the
-                                    // next tool event arrives. Keep streaming
-                                    // assistant rows lightweight so replacing
-                                    // one cannot strand async markdown effects
-                                    // under a disposed Leptos owner.
+                                    // A live assistant row keeps one stable owner while
+                                    // its Markdown prefix advances on a separate budget.
+                                    // A following tool turns it into settled commentary
+                                    // and deliberately remounts the compact row.
+                                    let streaming_assistant = live_assistant_index == Some(i)
+                                        && !commentary
+                                        && matches!(
+                                            &list[i],
+                                            ChatItem::Assistant { text, .. }
+                                                if !text.starts_with("Error: ")
+                                        );
                                     let compact_assistant = commentary
                                         || live_assistant_index == Some(i);
                                     let timestamp = transcript_item_timestamp(
@@ -8225,17 +8231,26 @@ fn App() -> impl IntoView {
                                         user_offset,
                                         &outline,
                                     );
-                                    let mut fp = list[i].fingerprint();
+                                    let mut fp = if streaming_assistant {
+                                        0
+                                    } else {
+                                        list[i].fingerprint()
+                                    };
                                     // Assistant markdown embeds artifact chips (index + label).
-                                    if matches!(&list[i], ChatItem::Assistant { .. }) { fp ^= arts_fp; }
+                                    if !streaming_assistant
+                                        && matches!(&list[i], ChatItem::Assistant { .. })
+                                    {
+                                        fp ^= arts_fp;
+                                    }
                                     fp ^= (commentary as u64) << 63;
                                     fp ^= (compact_assistant as u64) << 62;
                                     fp ^= timestamp.unwrap_or_default() as u64;
-                                    rows.push((thread_session_id.clone(), i, fp, ThreadRow::Item {
+                                    rows.push((thread_session_id.clone(), i, streaming_assistant, fp, ThreadRow::Item {
                                         i,
                                         timestamp,
                                         commentary,
                                         compact_assistant,
+                                        streaming_assistant,
                                     }));
                                     i += 1;
                                 }
@@ -8243,14 +8258,17 @@ fn App() -> impl IntoView {
                             rows
                             }))
                         }
-                        key=|(session_id, start, fp, _)| (session_id.clone(), *start, *fp)
-                        children=move |(session_id, start, _, row)| {
+                        key=|(session_id, start, streaming, fp, _)| {
+                            (session_id.clone(), *start, *streaming, *fp)
+                        }
+                        children=move |(session_id, start, _, _, row)| {
                             match row {
                                 ThreadRow::Item {
                                     i,
                                     timestamp,
                                     commentary,
                                     compact_assistant,
+                                    streaming_assistant,
                                 } => {
                                     // Rebuilt only when the fingerprint key changed,
                                     // so this is the one clone that actually pays off.
@@ -8290,14 +8308,25 @@ fn App() -> impl IntoView {
                                             })
                                             data-ui-index=i.to_string()
                                             data-user-index=data_user_index>
-                                            {render_item(
-                                                i, &item, timestamp, &arts, on_artifact_select, on_file_link,
-                                                run_records, run_clock.read_only(), busy.read_only(), compact_assistant, active_acp_agent_id.get().is_none(), can_undo, edit_message, branch_message, undo_message, session_id,
-                                                respond_confirm, on_resume, on_queue,
-                                                step_disclosure_state,
-                                                plan_mode_active, plan_compat, on_plan_decision,
-                                                on_question_answer, jump_to_review_message,
-                                            )}
+                                            {if streaming_assistant {
+                                                view! {
+                                                    <StreamingAssistantMessage
+                                                        items=items
+                                                        source_item=i
+                                                        on_artifact=on_artifact_select
+                                                        on_file=on_file_link
+                                                    />
+                                                }.into_view()
+                                            } else {
+                                                render_item(
+                                                    i, &item, timestamp, &arts, on_artifact_select, on_file_link,
+                                                    run_records, run_clock.read_only(), busy.read_only(), compact_assistant, active_acp_agent_id.get().is_none(), can_undo, edit_message, branch_message, undo_message, session_id,
+                                                    respond_confirm, on_resume, on_queue,
+                                                    step_disclosure_state,
+                                                    plan_mode_active, plan_compat, on_plan_decision,
+                                                    on_question_answer, jump_to_review_message,
+                                                ).into_view()
+                                            }}
                                         </div>
                                     }.into_view()
                                 }

--- a/ui/src/styles/chat.css
+++ b/ui/src/styles/chat.css
@@ -450,6 +450,12 @@ button.msg-icon-btn .gi { width: 14px; height: 14px; }
 .msg.assistant .body { color: var(--text); font-family: var(--font-response); }
 .msg.assistant .body.md { display: block; font-size: 15px; line-height: 1.55; letter-spacing: -0.004em; white-space: normal; }
 .msg.assistant .body.md:empty { display: none; }
+.msg.assistant .streaming-markdown { white-space: normal; }
+.streaming-markdown-prefix:empty { display: none; }
+.streaming-markdown-tail {
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
 .msg.reasoning .body { color: var(--text-faint); font-style: italic; font-size: 13.5px; border-left: 2px solid var(--border-strong); padding-left: 12px; font-family: var(--font-ui); }
 .msg.assistant.commentary { margin-bottom: -8px; }
 .msg.assistant.commentary .role,


### PR DESCRIPTION
## Problem

PR #690 intentionally rendered live assistant output as plain text until the turn settled, avoiding a full Markdown parse for every token batch. That keeps streaming efficient, but long or multi-step answers remain visually unformatted until the entire turn finishes.

## Changes

- Keep the active assistant row mounted with a stable transcript key while text grows.
- Render a throttled Markdown prefix at an adaptive 50/150/300 ms cadence, while showing the newest suffix immediately as a whitespace-preserving plain-text tail for answers above 8 KB.
- Return to the existing full Markdown renderer when the turn settles, preserving tables, math, code-copy controls, links, and artifact interactions.
- Cancel pending commits safely when an apparent answer becomes commentary at a tool boundary.
- Document the rendering policy and add unit/browser coverage for thresholds, progressive formatting, live-tail visibility, stable DOM identity, and final rendering.

## Tests

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --workspace`
- `cargo test --manifest-path ui/Cargo.toml`
- `cargo check --manifest-path ui/Cargo.toml --target wasm32-unknown-unknown`
- `cd ui-tests && npm ci && npx playwright test` — 287 passed, 1 skipped

## Manual smoke

1. Start a long response containing headings, lists, emphasis, and fenced code.
2. Confirm completed portions gain Markdown formatting during streaming while the newest text remains visible immediately.
3. Open or interact with earlier transcript/activity controls while the response continues and confirm they remain stable.
4. Let the turn finish and confirm the complete answer uses normal Markdown rendering and scroll position remains correct.

## Known limitations / follow-up

- This does not add Reasonix-style semantic section splitting or idle-callback scheduling; the committed prefix is still reparsed at the adaptive cadence.
- Settling a large answer still performs one full parse through the existing final renderer.
- Commentary/activity rows retain their existing compact presentation. If profiling shows a need, semantic section caching can be added separately.
