### PR TITLE
Use AnyDoc for local rich-document parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
 name = "agent-client-protocol"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,6 +104,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anydoc"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d88a76ba2a26a65e133879dee68acd593656e68e306488ebb162b69f37902b"
+dependencies = [
+ "calamine",
+ "cfb 0.14.0",
+ "csv",
+ "encoding_rs",
+ "flate2",
+ "log",
+ "pdf-inspector",
+ "quick-xml 0.41.0",
+ "zip 8.6.0",
 ]
 
 [[package]]
@@ -274,6 +352,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi_simd"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cdb3708a128e559a30fb830e8a77a5022ee6902806925c216658652b452a44"
+dependencies = [
+ "debug_unsafe",
+ "rustversion",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,6 +486,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -508,6 +605,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "calamine"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fa68281b1a76b54a62156474adb06bb380a67e07dd60656e3217152b42183f3"
+dependencies = [
+ "atoi_simd",
+ "byteorder",
+ "chrono",
+ "codepage",
+ "encoding_rs",
+ "fast-float2",
+ "log",
+ "quick-xml 0.41.0",
+ "serde",
+ "zip 8.6.0",
+]
+
+[[package]]
 name = "camino"
 version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -550,6 +665,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -574,6 +698,17 @@ dependencies = [
  "byteorder",
  "fnv",
  "uuid",
+]
+
+[[package]]
+name = "cfb"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a347dcabdae9c31b0825fd6a8bed285ec9c2acb89c47827126d52fa4f59cece3"
+dependencies = [
+ "fnv",
+ "uuid",
+ "web-time",
 ]
 
 [[package]]
@@ -628,10 +763,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.7",
+ "inout",
+]
+
+[[package]]
+name = "codepage"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f68d061bc2828ae826206326e61251aca94c1e4a5305cf52d9138639c918b4"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -779,6 +939,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -839,6 +1018,27 @@ checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -916,6 +1116,43 @@ checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
 dependencies = [
  "dbus",
  "zeroize",
+]
+
+[[package]]
+name = "debug_unsafe"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eed2c4702fa172d1ce21078faa7c5203e69f5394d48cc436d25928394a867a2"
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1149,6 +1386,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecb"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a8bfa975b1aec2145850fcaa1c6fe269a16578c44705a532ae3edc92b8881c7"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1178,6 +1424,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1205,10 +1460,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "env_home"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
+
+[[package]]
+name = "env_logger"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
 
 [[package]]
 name = "equivalent"
@@ -1257,6 +1535,12 @@ dependencies = [
  "event-listener",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fast-float2"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
 
 [[package]]
 name = "fastrand"
@@ -1330,6 +1614,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1665,9 +1950,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2194,6 +2481,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2222,7 +2528,17 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
 dependencies = [
- "cfb",
+ "cfb 0.7.3",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
 ]
 
 [[package]]
@@ -2251,6 +2567,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2277,6 +2599,59 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
 ]
 
 [[package]]
@@ -2526,6 +2901,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "lopdf"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67513274c50a2b51e5f75d9e682fcf4ab064a8a9c9ae2c3c59309084882bb24d"
+dependencies = [
+ "aes",
+ "bitflags 2.13.0",
+ "cbc",
+ "chrono",
+ "ecb",
+ "encoding_rs",
+ "flate2",
+ "getrandom 0.4.3",
+ "indexmap 2.14.0",
+ "itoa",
+ "jiff",
+ "log",
+ "md-5",
+ "nom",
+ "rand 0.10.2",
+ "rangemap",
+ "rayon",
+ "sha2",
+ "stringprep",
+ "thiserror 2.0.18",
+ "time",
+ "ttf-parser",
+ "weezl",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2570,6 +2976,16 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "memchr"
@@ -2690,6 +3106,15 @@ dependencies = [
  "cfg-if",
  "cfg_aliases 0.1.1",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2967,6 +3392,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "open"
 version = "5.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3065,6 +3496,24 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "pdf-inspector"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7475018de0880b394b7cc50f871fac0c010aa411dcd14c64074a3e640a4c05c"
+dependencies = [
+ "env_logger",
+ "include_dir",
+ "log",
+ "lopdf",
+ "once_cell",
+ "rayon",
+ "regex",
+ "thiserror 2.0.18",
+ "ttf-parser",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -3177,7 +3626,7 @@ checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml",
+ "quick-xml 0.39.4",
  "serde",
  "time",
 ]
@@ -3220,6 +3669,21 @@ dependencies = [
  "pin-project-lite",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]
@@ -3374,6 +3838,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+dependencies = [
+ "encoding_rs",
+ "memchr",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3496,10 +3970,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rangemap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
+
+[[package]]
 name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -4474,6 +4974,17 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
+]
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
 ]
 
 [[package]]
@@ -5511,6 +6022,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+
+[[package]]
 name = "tungstenite"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5527,6 +6044,12 @@ dependencies = [
  "sha1",
  "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typeid"
@@ -5599,10 +6122,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -5664,6 +6208,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
@@ -6766,6 +7316,7 @@ dependencies = [
 name = "wisp-tools"
 version = "0.34.0"
 dependencies = [
+ "anydoc",
  "async-trait",
  "base64 0.22.1",
  "dunce",
@@ -7071,6 +7622,26 @@ dependencies = [
  "indexmap 2.14.0",
  "memchr",
 ]
+
+[[package]]
+name = "zip"
+version = "8.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "indexmap 2.14.0",
+ "memchr",
+ "typed-path",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ desktop app or a headless CLI.
   [feature plugins](docs/feature-plugins.md) that package Skills and MCP servers.
 - Fully offline previews for Jupyter notebooks, PDF, DOCX/XLSX/PPTX, and
   images — including region cropping straight into the composer.
+- Local Markdown extraction for Word, PowerPoint, Excel, OpenDocument, RTF,
+  EPUB, and text-based PDF files, so agents can read documents without Python
+  or an external conversion service.
 - A [Publication Workspace](docs/publication-evidence.md) that freezes
   manuscript revisions and exports verifiable, deterministic Evidence Capsules.
 

--- a/crates/wisp-tools/Cargo.toml
+++ b/crates/wisp-tools/Cargo.toml
@@ -15,4 +15,5 @@ walkdir = { workspace = true }
 dunce = { workspace = true }
 base64 = "0.22"
 image = { version = "0.25", default-features = false, features = ["gif", "jpeg", "png", "webp"] }
+anydoc = "0.1.6"
 wisp-llm = { workspace = true }

--- a/crates/wisp-tools/src/read.rs
+++ b/crates/wisp-tools/src/read.rs
@@ -11,9 +11,20 @@ const MAX_READ_BYTES: u64 = 50 * 1024 * 1024;
 const MAX_OUTPUT_BYTES: usize = 1024 * 1024;
 
 const BINARY_EXTS: &[&str] = &[
-    "pdf", "docx", "xlsx", "pptx", "zip", "gz", "7z", "tar", "exe", "dll", "so", "dylib", "wasm",
-    "sqlite", "db",
+    "pdf", "doc", "docx", "docm", "odt", "rtf", "epub", "ppt", "pps", "pot", "pptx", "pptm",
+    "ppsx", "ppsm", "xls", "xlsx", "xlsm", "xlsb", "ods", "odp", "zip", "gz", "7z", "tar", "exe",
+    "dll", "so", "dylib", "wasm", "sqlite", "db",
 ];
+
+/// Convert rich documents before the ordinary text/binary split. CSV stays raw:
+/// scientific workflows generally need its exact delimiter and quoting semantics.
+pub fn document_markdown(path: &std::path::Path, bytes: &[u8]) -> Option<Result<String, String>> {
+    let format = anydoc::Format::from_path(path)?;
+    if format == anydoc::Format::Csv {
+        return None;
+    }
+    Some(anydoc::to_markdown_bytes(bytes, format).map_err(|error| error.to_string()))
+}
 
 fn looks_binary(path: &std::path::Path, bytes: &[u8]) -> bool {
     let by_ext = path
@@ -53,11 +64,11 @@ impl Tool for ReadTool {
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(
             "read",
-            "Read a local file. Text sources are limited to 50 MiB and returned text to 1 MiB; images use the configured vision model.",
+            "Read a local text or document file. Office, OpenDocument, RTF, EPUB, and text-based PDF files are converted locally to Markdown. Sources are limited to 50 MiB and returned text to 1 MiB; images use the configured vision model.",
             json!({
                 "type": "object",
                 "properties": {
-                    "path": { "type": "string", "description": "Path to the file to read (text, or image: png/jpg/jpeg/gif/webp)" },
+                    "path": { "type": "string", "description": "Path to a text, document, or image file" },
                     "offset": { "type": "integer", "description": "Line number to start reading from (0-indexed, default 0)" },
                     "limit": { "type": "integer", "description": "Maximum number of lines to read (default: all lines)" }
                 },
@@ -108,12 +119,13 @@ impl Tool for ReadTool {
             }
             Err(e) => return ToolResult::fail(format!("read {requested_path} error: {e}")),
         }
-        if looks_binary(&path, &bytes) {
+        let converted = document_markdown(&path, &bytes).and_then(Result::ok);
+        if converted.is_none() && looks_binary(&path, &bytes) {
             return ToolResult::fail(format!(
-                "read {requested_path} error: binary file; use the python tool (pypdfium2/pypdf for PDFs) to extract text, or view_image for images"
+                "read {requested_path} error: document has no locally extractable text; use OCR or a vision-capable model for scanned pages"
             ));
         }
-        let text = String::from_utf8_lossy(&bytes);
+        let text = converted.unwrap_or_else(|| String::from_utf8_lossy(&bytes).into_owned());
         let offset = arg_int_opt(args, "offset").unwrap_or(0).max(0) as usize;
         let limit = arg_int_opt(args, "limit")
             .map(|l| l.max(0) as usize)
@@ -180,8 +192,34 @@ mod tests {
             )
             .await;
         assert!(!result.success);
-        assert!(result.content.contains("python"));
+        assert!(result.content.contains("no locally extractable text"));
         std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[tokio::test]
+    async fn rich_text_documents_are_read_as_markdown() {
+        let tmp = std::env::temp_dir().join(format!("wisp_read_rtf_{}", std::process::id()));
+        std::fs::remove_dir_all(&tmp).ok();
+        std::fs::create_dir_all(&tmp).unwrap();
+        let rtf = tmp.join("protocol.rtf");
+        std::fs::write(
+            &rtf,
+            br#"{\rtf1\ansi{\fonttbl{\f0 Arial;}}\b Experimental protocol\b0\par Centrifuge at 12000 g.}"#,
+        )
+        .unwrap();
+
+        let result = ReadTool
+            .run(
+                &json!({ "path": rtf.to_string_lossy() }),
+                &TestEnv(tmp.clone()),
+            )
+            .await;
+
+        assert!(result.success, "{}", result.content);
+        assert!(result.content.contains("**Experimental protocol**"));
+        assert!(result.content.contains("Centrifuge at 12000 g."));
+        assert!(!result.content.contains("\\rtf1"));
+        std::fs::remove_dir_all(tmp).ok();
     }
 
     #[tokio::test]

--- a/docs/remote-file-browser.md
+++ b/docs/remote-file-browser.md
@@ -35,6 +35,10 @@ Remote PDF, DOCX, XLSX, and PPTX previews use the same raw-byte IPC and bounded
 OOXML validation as local previews. The remote size check runs before transfer;
 Office archives are then checked locally for entry count, expanded size,
 compression ratio, unsafe paths, macros, ActiveX, and embedded OLE content.
+Other supported rich-document formats (legacy Word/PowerPoint/Excel,
+OpenDocument, RTF, and EPUB) are converted locally to Markdown with AnyDoc for
+preview and agent reading. Text-based PDFs are extractable by the agent; scanned
+PDFs still require OCR or a vision-capable model.
 
 Large text, code, CSV, and log previews (local or remote) load only a bounded
 head — about 1 MiB by default, and at most 8 000 rendered lines in the UI —

--- a/src-tauri/src/file_browser.rs
+++ b/src-tauri/src/file_browser.rs
@@ -132,9 +132,17 @@ pub(super) fn mime_for_path(path: &Path) -> &'static str {
         Some("webp") => "image/webp",
         Some("svg") => "image/svg+xml",
         Some("pdf") => "application/pdf",
+        Some("doc" | "docm") => "application/msword",
         Some("docx") => "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        Some("xls" | "xlsm" | "xlsb") => "application/vnd.ms-excel",
         Some("xlsx") => "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        Some("ppt" | "pps" | "pot" | "pptm" | "ppsx" | "ppsm") => "application/vnd.ms-powerpoint",
         Some("pptx") => "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        Some("odt") => "application/vnd.oasis.opendocument.text",
+        Some("ods") => "application/vnd.oasis.opendocument.spreadsheet",
+        Some("odp") => "application/vnd.oasis.opendocument.presentation",
+        Some("rtf") => "application/rtf",
+        Some("epub") => "application/epub+zip",
         Some("bib") => "text/x-bibtex",
         Some("csv") => "text/csv",
         Some("tsv") => "text/tab-separated-values",
@@ -995,6 +1003,16 @@ fn read_remote_file_with_runner(
             return Err(format!("remote file exceeds {cap} byte limit"));
         }
         let full = read_remote_file_bytes_with_runner(context, path, Some(cap), runner)?;
+        if let Some(Ok(markdown)) = wisp_tools::read::document_markdown(Path::new(path), &full) {
+            return Ok(FileContent {
+                path: path.to_string(),
+                mime: mime.into(),
+                text: Some(markdown),
+                base64: None,
+                truncated: false,
+                total_bytes: Some(total),
+            });
+        }
         return Ok(file_content_from_bytes(
             path.to_string(),
             mime,
@@ -1107,6 +1125,16 @@ pub(super) fn read_file_at(
     } else {
         std::fs::read(&real).map_err(|e| format!("{e}"))?
     };
+    if let Some(Ok(markdown)) = wisp_tools::read::document_markdown(&real, &bytes) {
+        return Ok(FileContent {
+            path: real.to_string_lossy().into_owned(),
+            mime: mime.into(),
+            text: Some(markdown),
+            base64: None,
+            truncated: false,
+            total_bytes: Some(total),
+        });
+    }
     Ok(file_content_from_bytes(
         real.to_string_lossy().into_owned(),
         mime,
@@ -1336,6 +1364,25 @@ mod tests {
             mime_for_path(Path::new("talk.pptx")),
             "application/vnd.openxmlformats-officedocument.presentationml.presentation"
         );
+        assert_eq!(mime_for_path(Path::new("notes.rtf")), "application/rtf");
+    }
+
+    #[test]
+    fn rich_document_preview_uses_anydoc_markdown() {
+        let base =
+            std::env::temp_dir().join(format!("wisp-anydoc-preview-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&base).unwrap();
+        std::fs::write(
+            base.join("protocol.rtf"),
+            br#"{\rtf1\ansi\b Experimental protocol\b0\par Centrifuge at 12000 g.}"#,
+        )
+        .unwrap();
+
+        let content = read_file_at(&base, "protocol.rtf".into(), None).unwrap();
+        assert_eq!(content.mime, "application/rtf");
+        assert!(content.text.unwrap().contains("**Experimental protocol**"));
+        assert!(content.base64.is_none());
+        std::fs::remove_dir_all(base).ok();
     }
 
     #[test]

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -298,6 +298,7 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
     { path: "pixi.toml", is_dir: false, size: 64 },
     { path: "analysis.ipynb", is_dir: false, size: 4096 },
     { path: "analysis.unknown", is_dir: false, size: 128 },
+    { path: "protocol.rtf", is_dir: false, size: 256 },
     { path: "manuscript.docx", is_dir: false, size: 11351 },
     { path: "office-preview.xlsx", is_dir: false, size: 3600 },
     { path: "office-preview.pptx", is_dir: false, size: 8600 },
@@ -3143,6 +3144,9 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
             }
             if (path.toLowerCase().endsWith(".unknown")) {
               return { path, mime: "application/octet-stream", text: null, base64: "AA==" };
+            }
+            if (path.toLowerCase().endsWith(".rtf")) {
+              return { path, mime: "application/rtf", text: "# Experimental protocol\n\nCentrifuge at **12000 g**.", base64: null };
             }
             if (path.toLowerCase().includes(".pdf")) {
               return { path, mime: "application/pdf", text: null, base64: pdfBase64 };

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -3064,6 +3064,13 @@ test("script previews show source while unknown file types are explicitly unsupp
   await expect(page.locator(".center-file-preview .rp-code-body code")).toHaveClass(/language-ini/);
   await expect(page.locator(".center-file-preview")).toContainText("[project]");
 
+  await openInCenter("protocol.rtf");
+  await expect(page.locator('.center-file-preview[data-preview-kind="document"]')).toContainText(
+    "Experimental protocol",
+  );
+  await expect(page.locator('.center-file-preview[data-preview-kind="document"] strong')).toHaveText("12000 g");
+  await expect.poll(() => lastInvokeArgs(page, "read_file")).toMatchObject({ path: "protocol.rtf" });
+
   // Genuinely binary payloads stay explicitly unsupported.
   await openInCenter("analysis.unknown");
   await expect(page.locator(".center-file-preview .rp-error")).toHaveText(

--- a/ui/src/app_support/previews.rs
+++ b/ui/src/app_support/previews.rs
@@ -1168,7 +1168,7 @@ pub(crate) fn FilePreview(dom_id: String, path: String, kind: String) -> impl In
             }
             // Images need a full under-budget payload; text-ish kinds only pull a
             // head so multi-GB logs never enter the WebView (#large-text-preview).
-            let budget = if kind == "image" {
+            let budget = if matches!(kind.as_str(), "image" | "document") {
                 Some(32 * 1024 * 1024)
             } else {
                 Some(TEXT_PREVIEW_MAX_BYTES)
@@ -1190,7 +1190,7 @@ pub(crate) fn FilePreview(dom_id: String, path: String, kind: String) -> impl In
                 }
                 return;
             }
-            if kind == "markdown" {
+            if matches!(kind.as_str(), "markdown" | "document") {
                 if let Some(el) = el {
                     let raw = fc.text.as_deref().unwrap_or("");
                     let (clipped, shown) = clip_preview_text(raw);

--- a/ui/src/text.rs
+++ b/ui/src/text.rs
@@ -1124,6 +1124,8 @@ pub(crate) fn file_kind(path: &str) -> Option<&'static str> {
         "docx" => "docx",
         "xlsx" => "xlsx",
         "pptx" => "pptx",
+        "doc" | "docm" | "odt" | "rtf" | "epub" | "xls" | "xlsm" | "xlsb" | "ods"
+        | "ppt" | "pps" | "pot" | "pptm" | "ppsx" | "ppsm" | "odp" => "document",
         // ponytail: LaTeX sources open as plain text, not code. The vendored
         // highlight.js is the common bundle with no `latex` grammar, and asking
         // it for one throws; the `latex` preview kind is KaTeX for inline
@@ -1441,6 +1443,8 @@ mod md_catalog_tests {
         assert_eq!(file_kind("analysis.Rmd"), Some("markdown"));
         assert_eq!(file_kind("analysis.qmd"), Some("markdown"));
         assert_eq!(file_kind("analysis.ipynb"), Some("notebook"));
+        assert_eq!(file_kind("protocol.rtf"), Some("document"));
+        assert_eq!(file_kind("supplement.odt"), Some("document"));
     }
 
     #[test]


### PR DESCRIPTION
## User-facing problem

Agents previously rejected Office and PDF files as binary, while several rich-document formats had no local preview. Researchers had to install Python tooling or use an external conversion service just to extract document text.

## Changes

- Add AnyDoc 0.1.6 to the built-in read tool.
- Convert Word, PowerPoint, Excel, OpenDocument, RTF, EPUB, and text-based PDF files to Markdown locally before the normal binary check.
- Reuse the same conversion path for local and SSH file previews.
- Render legacy Office, OpenDocument, RTF, and EPUB previews as Markdown.
- Preserve the existing richer DOCX, XLSX, PPTX, and visual PDF previews.
- Keep CSV reads byte-faithful instead of silently converting scientific data into Markdown tables.
- Fall back to the existing binary path with an OCR/vision hint when no text can be extracted.
- Document the new offline parsing behavior.

## Package impact

A release-profile measurement estimated roughly 4-5 MiB of additional executable size and about 2-3 MiB in a compressed installer. AnyDoc is pure Rust and adds no runtime download, Python environment, or external service.

## Tests

- cargo fmt --all -- --check
- cargo test --workspace
- cd ui && cargo check --target wasm32-unknown-unknown
- cd ui-tests && npm ci && npx playwright test

Playwright result: 292 passed, 1 existing optional integration test skipped.

## Manual smoke steps

1. Open a local or SSH RTF, ODT, EPUB, or legacy Office file and confirm the center preview renders Markdown.
2. Ask the Agent to read a DOCX, XLSX, PPTX, or text-based PDF and confirm it receives line-numbered Markdown.
3. Open a DOCX/XLSX/PPTX directly and confirm its existing rich preview remains unchanged.
4. Read an image-only PDF and confirm Wisp recommends OCR or a vision-capable model instead of returning garbage.
5. Read a CSV and confirm the original delimiter and quoting are preserved.

## Known limitations and follow-up

- AnyDoc does not OCR image-only or scanned PDFs.
- Agent reads retain the existing 50 MiB source and 1 MiB returned-text limits; rich previews retain the existing 32 MiB transfer limit.
- The first version uses AnyDoc 0.1.6 and keeps the existing fallback path while the dependency matures.