### PR TITLE
fix: apply max_iter on reused session agents

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1769,6 +1769,17 @@ fn log_dev_llm_dispatch(
     );
 }
 
+/// Push settings that must stay live on a reused session agent.
+///
+/// Session runtimes cache one `Agent` across turns. Construction-time knobs
+/// (especially `max_iter`) are re-read from Settings before every turn so a
+/// mid-session change — e.g. 100 → 0 for unlimited monitoring — takes effect
+/// without waiting for an unrelated agent rebuild.
+fn apply_live_agent_settings(agent: &mut wisp_core::Agent, max_iter: usize, auto_compact: bool) {
+    agent.max_iter = max_iter;
+    agent.set_auto_compact(auto_compact);
+}
+
 fn default_locale() -> String {
     "en".into()
 }
@@ -5247,6 +5258,11 @@ async fn send_message_inner(
         *guard = Some(agent);
     }
     let agent = guard.as_mut().unwrap();
+    apply_live_agent_settings(
+        agent,
+        max_iter,
+        load_auto_compact_enabled(&state.store).await,
+    );
     // InterruptReplace (#410): the user stopped the previous turn because it
     // went the wrong way — drop that turn (its user message included) from the
     // model context before running the replacement. Mirrors /compact: only the

--- a/src-tauri/src/lib_tests.rs
+++ b/src-tauri/src/lib_tests.rs
@@ -176,6 +176,35 @@ fn configured_image_generation_tool_is_available_without_a_specialist() {
 }
 
 #[test]
+fn live_agent_settings_refresh_max_iter_on_reused_agent() {
+    // Mid-session Settings changes must not stay stuck at construction time.
+    let root =
+        std::env::temp_dir().join(format!("wisp_live_max_iter_{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&root).unwrap();
+    let skills = Arc::new(wisp_skills::SkillIndex::load(&[]));
+    let memory = Arc::new(wisp_core::MemoryManager::new(&root));
+    let mut agent = wisp_core::Agent::new(
+        wisp_llm::ProviderConfig::openai("http://127.0.0.1:9/v1", "sk-chat-test", "chat-model"),
+        skills,
+        memory,
+        root.clone(),
+        128_000,
+        100,
+        false,
+        None,
+    );
+    assert_eq!(agent.max_iter, 100);
+
+    super::apply_live_agent_settings(&mut agent, 0, true);
+    assert_eq!(agent.max_iter, 0);
+
+    super::apply_live_agent_settings(&mut agent, 50, false);
+    assert_eq!(agent.max_iter, 50);
+
+    let _ = std::fs::remove_dir_all(root);
+}
+
+#[test]
 fn llm_dispatch_debug_detects_cached_model_mismatch() {
     assert!(!super::llm_model_mismatch("glm-5.2", "GLM-5.2"));
     assert!(super::llm_model_mismatch("gpt-5.6-luna", "glm-5.2"));


### PR DESCRIPTION
## Summary
- Session runtimes reuse one cached `Agent` across turns, so construction-time `max_iter` (and auto-compact) stayed stale after mid-session Settings changes.
- Refresh those live knobs from store before every turn via `apply_live_agent_settings`, so setting max iterations to `0` (unlimited) takes effect on the next message/resume without requiring an agent rebuild.
- Add a unit test covering `max_iter` refresh on a reused agent.

## Test plan
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib live_agent_settings_refresh_max_iter -- --nocapture`
- [x] Start a long session with default max_iter 100, change Settings to 0 and Save, click Continue — turn should no longer stop silently at 100 tool rounds
- [x] Confirm newly created sessions still honor the saved max_iter from the first turn
