### PR TITLE
fix(ui): reveal feedback conversation

### DIFF
--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -427,9 +427,24 @@ test("storage separates project paths and filters usage when a project is clicke
     .toContainText("120.0 MB");
 });
 
-test("sidebar Report a problem starts an AI-guided issue chat (#596)", async ({ page }) => {
+test("sidebar Feedback leaves a workspace file and starts an AI-guided issue chat (#596)", async ({ page }) => {
   await enterApp(page);
+  await page.setInputFiles("#composer-file-input", {
+    name: "counts.csv",
+    mimeType: "text/csv",
+    buffer: Buffer.from("a,b\n1,2"),
+  });
+  await page.getByRole("button", { name: "Send" }).click();
+  await expect(page.getByText("Hello from mock wisp-science.")).toBeVisible();
+  await page.getByRole("button", { name: "Toggle panel" }).click();
+  const tile = page.locator('.rp-tile[data-artifact-name="counts.csv"]');
+  await tile.click({ button: "right" });
+  await page.locator(".ctx-menu").getByRole("button", { name: "Open in center" }).click();
+  await expect(page.locator(".center-tab.active")).toContainText("counts.csv");
+
   await page.getByTestId("report-problem-entry").click();
+  await expect(page.locator(".center-tabs > .center-tab")).toHaveClass(/active/);
+  await expect(page.locator(".center-file-preview")).toHaveCount(0);
   await expect.poll(() => lastInvokeArgs(page, "new_session")).not.toBeNull();
   await expect.poll(() => lastInvokeArgs(page, "send_message")).toMatchObject({
     message: expect.stringContaining("GitHub issue"),

--- a/ui/src/i18n.rs
+++ b/ui/src/i18n.rs
@@ -1405,7 +1405,7 @@ fn lookup(locale: Locale, key: &str) -> Option<&'static str> {
         (Locale::En, "settings.notifications_hint") => Some("Notify when a background task finishes, fails, or waits for approval. Its conversation opens only in the window that started the task."),
         (Locale::En, "settings.update_check") => Some("Check for updates"),
         (Locale::En, "settings.update_check_hint") => Some("Check GitHub Releases on startup and show a prompt in the sidebar when a newer version is available."),
-        (Locale::En, "issue_report.sidebar") => Some("Report a problem"),
+        (Locale::En, "issue_report.sidebar") => Some("Feedback"),
         (Locale::En, "issue_report.session_title") => Some("Bug report"),
         (Locale::En, "issue_report.chat_prompt") => Some(
             "Help me file a GitHub issue for {repo}.\n\n\
@@ -3310,7 +3310,7 @@ Do not leave generated files in the project root.",
         (Locale::Zh, "settings.notifications_hint") => Some("窗口不在前台时，任务完成、失败或等待确认会发送系统通知；对应会话只会在启动任务的窗口打开。"),
         (Locale::Zh, "settings.update_check") => Some("检查更新"),
         (Locale::Zh, "settings.update_check_hint") => Some("启动时检查 GitHub Releases，有新版本时在侧边栏显示提示。"),
-        (Locale::Zh, "issue_report.sidebar") => Some("报告问题"),
+        (Locale::Zh, "issue_report.sidebar") => Some("反馈"),
         (Locale::Zh, "issue_report.session_title") => Some("问题报告"),
         (Locale::Zh, "issue_report.chat_prompt") => Some(
             "请帮我向 {repo} 提交一个 GitHub issue。\n\n\

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -4341,6 +4341,7 @@ fn App() -> impl IntoView {
         let status = status;
         let locale = locale;
         let demo_mode = demo_mode;
+        let center_file = center_file;
         let active_session = active_session;
         let sel_artifact = sel_artifact;
         let right_tab = right_tab;
@@ -4353,6 +4354,7 @@ fn App() -> impl IntoView {
                 return;
             }
             demo_mode.set(false);
+            center_file.set(None);
             if let Some(old) = active_session.get() {
                 transcripts.update(|m| {
                     m.insert(old, items.get());

--- a/ui/src/sidebar.rs
+++ b/ui/src/sidebar.rs
@@ -654,7 +654,7 @@ pub(super) fn Sidebar(
                     </div>
                 }})}
                 <button class="side-btn" title=move || t(locale.get(), "sidebar.capabilities") on:click=move |ev| open_capabilities.call(ev)><span class="gi grid"></span>{move || t(locale.get(), "sidebar.capabilities")}</button>
-                <button class="side-btn" data-testid="report-problem-entry" title=move || t(locale.get(), "issue_report.sidebar") on:click=move |ev| open_issue_report.call(ev)><span class="gi doc"></span>{move || t(locale.get(), "issue_report.sidebar")}</button>
+                <button class="side-btn" data-testid="report-problem-entry" title=move || t(locale.get(), "issue_report.sidebar") on:click=move |ev| open_issue_report.call(ev)>{compose_icon("chat")}{move || t(locale.get(), "issue_report.sidebar")}</button>
                 <button class="side-btn" title=move || t(locale.get(), "sidebar.settings") on:click=move |ev| open_settings.call(ev)><span class="gi gear"></span>{move || t(locale.get(), "sidebar.settings")}</button>
             </div>
         </aside>


### PR DESCRIPTION
## Problem

Starting Feedback while a workspace file was open created and sent the issue-report conversation behind the active file preview, making the action appear unresponsive.

## Changes

- Switch the center view back to the conversation before starting Feedback
- Rename the sidebar entry from Report a problem to Feedback / 反馈
- Replace the document icon with the existing chat-bubble icon
- Add a Playwright regression covering Feedback from an open workspace file

## Verification

- `cargo fmt --all -- --check`
- `cargo check --target wasm32-unknown-unknown` (from `ui/`)
- `cargo test --workspace`
- `npx playwright test` (292 passed, 1 skipped)

## Manual smoke

1. Open a workspace file in the center view.
2. Click Feedback in the sidebar.
3. Verify the conversation becomes visible immediately and the feedback prompt is sent.

## Known limitations

- Feedback remains the existing AI-guided GitHub issue flow; this change only fixes its visibility and sidebar presentation.