### PR TITLE
fix(ui): keep pet status label above sprite

### DIFF
--- a/docs/pet.md
+++ b/docs/pet.md
@@ -12,7 +12,7 @@ The pet folder must use `spriteVersionNumber: 2` and contain a `1536x2288` PNG o
 
 The app uses the standard animation rows for idle, directional walking, waving, jumping, failure, waiting for user input, active work, review, and 16-direction pointer tracking. Clicking an idle pet makes it wave. Reduced-motion system preferences disable roaming and animated playback.
 
-On Windows, the pet lives in its own transparent always-on-top window instead of inside the main workspace. Drag the pet to move it. While a managed Run is active, the pet shows its title; when it finishes, the pet celebrates. When it shows **Needs you**, click it to restore the workspace and open the session waiting for input. Closing the main Wisp Science window hides the workspace to the system tray while the pet and active agent work continue; click the tray icon, choose **Open Wisp Science**, or launch Wisp Science again to restore the existing workspace. Only one desktop app instance runs at a time. Choose **Restart** to restart it or **Quit** to stop it. The pet animation and status badge show when the agent is working, reviewing, waiting for approval, finished, or failed.
+On Windows, the pet lives in its own transparent always-on-top window instead of inside the main workspace. Drag the pet to move it. While a managed Run is active, the pet shows its title above the sprite; when it finishes, the pet celebrates. When it shows **Needs you**, click it to restore the workspace and open the session waiting for input. Closing the main Wisp Science window hides the workspace to the system tray while the pet and active agent work continue; click the tray icon, choose **Open Wisp Science**, or launch Wisp Science again to restore the existing workspace. Only one desktop app instance runs at a time. Choose **Restart** to restart it or **Quit** to stop it. The pet animation and status badge show when the agent is working, reviewing, waiting for approval, finished, or failed.
 
 ## 配置宠物
 
@@ -20,4 +20,4 @@ Wisp Science 只加载一个由用户明确选择的 Codex v2 宠物，默认关
 
 打开 **设置 > 宠物**，选择包含 `pet.json` 和精灵表的安装目录，开启 **显示宠物** 后保存。目录必须使用 `spriteVersionNumber: 2`，精灵表必须是 `1536x2288` 的 PNG 或 WebP 文件。更换配置目录即可更换宠物；关闭开关后，应用不会再加载或显示该目录中的宠物。
 
-在 Windows 上，宠物运行在独立的透明置顶窗口中，而不是嵌在主工作区内，可以拖动到屏幕上的其他位置。托管 Run 执行时会显示任务名称，完成时宠物会跳动提醒。显示 **Needs you** 时，点击宠物会恢复工作区并打开正在等待操作的 session。关闭 Wisp Science 主窗口会把工作区隐藏到系统托盘，宠物和正在执行的 agent 任务会继续工作；点击托盘图标、选择 **Open Wisp Science** 或再次启动 Wisp Science 都会恢复现有工作区。桌面应用全局只运行一个实例；选择 **Restart** 会重启应用，选择 **Quit** 才会真正退出。宠物动画、状态点和文字会显示工作中、review、等待批准、完成或失败状态。
+在 Windows 上，宠物运行在独立的透明置顶窗口中，而不是嵌在主工作区内，可以拖动到屏幕上的其他位置。托管 Run 执行时会在宠物上方显示任务名称，完成时宠物会跳动提醒。显示 **Needs you** 时，点击宠物会恢复工作区并打开正在等待操作的 session。关闭 Wisp Science 主窗口会把工作区隐藏到系统托盘，宠物和正在执行的 agent 任务会继续工作；点击托盘图标、选择 **Open Wisp Science** 或再次启动 Wisp Science 都会恢复现有工作区。桌面应用全局只运行一个实例；选择 **Restart** 会重启应用，选择 **Quit** 才会真正退出。宠物动画、状态点和文字会显示工作中、review、等待批准、完成或失败状态。

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -7617,15 +7617,20 @@ test("desktop pet remains independent and reflects global agent state", async ({
 test("desktop pet shows active Run titles and celebrates completion (#693)", async ({ page }) => {
   await page.addInitScript(() => {
     (window as any).__mockPetActiveRuns = [
-      { id: "run-data", title: "data_analysis.py" },
+      { id: "run-data", title: "siibra atlas query example (with assignment)" },
     ];
   });
   await page.goto("/?pet=desktop&mockPet=1");
 
   const pet = page.getByTestId("wisp-pet");
+  const sprite = pet.locator(".wisp-pet-sprite");
+  const label = pet.locator(".wisp-pet-state-label");
   await expect(pet).toHaveAttribute("data-tauri-drag-region", "deep");
-  await expect(pet.getByText("Running: data_analysis.py")).toBeVisible();
+  await expect(label).toHaveText("Running: siibra atlas query example (with assignment)");
+  await expect(label).toBeVisible();
   await expect(pet).toHaveAttribute("data-state", "running");
+  const [spriteBox, labelBox] = await Promise.all([sprite.boundingBox(), label.boundingBox()]);
+  expect(labelBox!.y + labelBox!.height).toBeLessThanOrEqual(spriteBox!.y);
 
   await page.evaluate(() => {
     (window as any).__mockPetActiveRuns = [];

--- a/ui/src/styles/pet.css
+++ b/ui/src/styles/pet.css
@@ -56,8 +56,10 @@ html.pet-window-shell body {
 .pet-window-root .wisp-pet-state-label {
   position: absolute;
   left: 50%;
-  bottom: -19px;
+  bottom: calc(100% + 6px);
   display: none;
+  width: max-content;
+  max-width: 160px;
   min-width: 52px;
   padding: 2px 7px;
   border: 1px solid rgba(25, 29, 34, .13);
@@ -67,6 +69,7 @@ html.pet-window-shell body {
   color: #34383e;
   font: 600 10px/1.35 "Segoe UI Variable", "Segoe UI", sans-serif;
   text-align: center;
+  white-space: normal;
   transform: translateX(-50%);
   backdrop-filter: blur(8px);
 }


### PR DESCRIPTION
## Problem
Long managed Run titles wrapped upward from the desktop pet status pill and overlapped the pet sprite.

## Changes
- Position the desktop pet status label above the sprite.
- Bound long labels to a readable width while allowing wrapping.
- Extend the Playwright regression to assert that a long Run title does not intersect the sprite.
- Document the status-label placement in English and Chinese.

## Tests
- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cd ui && cargo check --target wasm32-unknown-unknown`
- `cd ui-tests && npm ci && npx playwright test` (292 passed, 1 skipped)

## Manual smoke
1. Enable the desktop pet on Windows.
2. Start a managed Run with a long title such as `siibra atlas query example (with assignment)`.
3. Confirm the title wraps above the pet without covering the sprite.
4. Confirm the pet remains draggable and celebrates when the Run completes.

## Known limitations / follow-up
- The label remains constrained by the small transparent pet window; exceptionally long titles wrap across multiple lines.