### PR TITLE
feat(ui): move manual project sync from general to remote access settings

### DIFF
--- a/src-tauri/src/lib_tests.rs
+++ b/src-tauri/src/lib_tests.rs
@@ -178,8 +178,7 @@ fn configured_image_generation_tool_is_available_without_a_specialist() {
 #[test]
 fn live_agent_settings_refresh_max_iter_on_reused_agent() {
     // Mid-session Settings changes must not stay stuck at construction time.
-    let root =
-        std::env::temp_dir().join(format!("wisp_live_max_iter_{}", uuid::Uuid::new_v4()));
+    let root = std::env::temp_dir().join(format!("wisp_live_max_iter_{}", uuid::Uuid::new_v4()));
     std::fs::create_dir_all(&root).unwrap();
     let skills = Arc::new(wisp_skills::SkillIndex::load(&[]));
     let memory = Arc::new(wisp_core::MemoryManager::new(&root));

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -7364,7 +7364,7 @@ test("projects sync manually, copy a device code, and join on another device", a
 
   await expect(page.getByRole("button", { name: "Join synced project" })).toHaveCount(0);
   await page.getByRole("button", { name: "Settings" }).click();
-  await page.getByRole("button", { name: "General", exact: true }).click();
+  await page.getByRole("button", { name: "Remote Access", exact: true }).click();
   await page.getByRole("button", { name: "Join synced project" }).click();
   const joinDialog = page.getByRole("dialog", { name: "Join a synced project" });
   const deviceCode = page.getByTestId("sync-device-code");
@@ -7400,7 +7400,7 @@ test("project sync actions appear only after a sync backend is configured", asyn
   await expect(projectCard.getByRole("button", { name: "Sync now" })).toHaveCount(0);
   await expect(projectCard.getByRole("button", { name: "Copy device code" })).toHaveCount(0);
 
-  await openSettingsSection(page, "General");
+  await openSettingsSection(page, "Remote Access");
   await page.getByTestId("sync-relay-url").fill("https://relay.example.test");
   await page.getByTestId("sync-relay-token").fill("secret-token");
   await page.locator(".settings-footer").getByRole("button", { name: "Save" }).click();
@@ -7409,9 +7409,9 @@ test("project sync actions appear only after a sync backend is configured", asyn
   await expect(projectCard.getByRole("button", { name: "Copy device code" })).toBeVisible();
 });
 
-test("general settings configure a cloud-drive sync folder", async ({ page }) => {
+test("remote access settings configure a cloud-drive sync folder", async ({ page }) => {
   await page.goto("/");
-  await openSettingsSection(page, "General");
+  await openSettingsSection(page, "Remote Access");
   await page.getByTestId("sync-backend").selectOption("folder");
   await page.locator(".settings-path-row").getByRole("button", { name: "Choose folder" }).click();
   await expect(page.getByTestId("sync-folder")).toHaveValue("/mock/root/new-project");

--- a/ui/src/settings_view.rs
+++ b/ui/src/settings_view.rs
@@ -1265,71 +1265,6 @@ pub(super) fn SettingsView(
                                 <span class="toggle-track" aria-hidden="true"></span>
                             </label>
                         </div>
-                        <div class="span-2 settings-sync-block">
-                            <h3>{move || t(locale.get(), "settings.sync.title")}</h3>
-                            <p class="settings-field-hint">{move || t(locale.get(), "settings.sync.hint")}</p>
-                            <label>{move || t(locale.get(), "settings.sync.backend")}
-                                <select data-testid="sync-backend"
-                                    prop:value=move || settings.get().sync_backend
-                                    on:change=move |ev| settings.update(|current| current.sync_backend = dom_value(&ev))>
-                                    <option value="relay">{move || t(locale.get(), "settings.sync.relay")}</option>
-                                    <option value="folder">{move || t(locale.get(), "settings.sync.folder")}</option>
-                                </select>
-                            </label>
-                            {move || if settings.get().sync_backend == "folder" {
-                                view! {
-                                    <label>{move || t(locale.get(), "settings.sync.folder_path")}
-                                        <div class="settings-path-row">
-                                            <input class="settings-path-input" data-testid="sync-folder"
-                                                prop:value=move || settings.get().sync_folder
-                                                on:input=move |ev| settings.update(|current| current.sync_folder = event_target_input(&ev).value()) />
-                                            <button type="button" class="settings-add-btn" data-testid="sync-choose-folder"
-                                                on:click=choose_sync_folder>
-                                                {move || t(locale.get(), "projects.choose_dir")}
-                                            </button>
-                                        </div>
-                                        <span class="settings-field-hint">{move || t(locale.get(), "settings.sync.folder_hint")}</span>
-                                    </label>
-                                }.into_view()
-                            } else {
-                                view! {
-                                    <label>{move || t(locale.get(), "settings.sync.relay_url")}
-                                        <input data-testid="sync-relay-url" type="url"
-                                            prop:value=move || settings.get().sync_relay_url
-                                            placeholder="https://sync.example.com"
-                                            on:input=move |ev| settings.update(|current| current.sync_relay_url = event_target_input(&ev).value()) />
-                                    </label>
-                                    <label>{move || t(locale.get(), "settings.sync.relay_token")}
-                                        <input data-testid="sync-relay-token" type="password"
-                                            prop:value=move || settings.get().sync_relay_token
-                                            placeholder=move || if settings.get().has_sync_relay_token {
-                                                t(locale.get(), "settings.key_stored")
-                                            } else {
-                                                t(locale.get(), "settings.sync.token_placeholder")
-                                            }
-                                            on:input=move |ev| settings.update(|current| current.sync_relay_token = event_target_input(&ev).value()) />
-                                        <span class="settings-field-hint">{move || t(locale.get(), "settings.sync.relay_hint")}</span>
-                                    </label>
-                                }.into_view()
-                            }}
-                            <p class="settings-field-hint">
-                                {move || t(locale.get(), "settings.sync.join_hint")}
-                            </p>
-                            <div class="row settings-sync-actions">
-                                <button type="button" on:click=open_sync_guide>
-                                    {compose_icon("doc")}
-                                    <span>{move || t(locale.get(), "projects.sync.guide")}</span>
-                                </button>
-                                <button type="button" class="primary"
-                                    on:click=move |_| {
-                                        join_error.set(None);
-                                        joining.set(true);
-                                    }>
-                                    {compose_icon("link")}
-                                    <span>{move || t(locale.get(), "projects.sync.join")}</span>
-                                </button>
-                            </div>
-                        </div>
                         </div>
                         {move || settings_message.get().map(|(ok, text)| view! {
                             <div class="settings-status"
@@ -4240,6 +4175,81 @@ pub(super) fn SettingsView(
                                     }
                                 });
                             }>{move || t(locale.get(), "settings.save")}</button>
+                        </div>
+                    </div>
+                }.into_view())}
+                {move || (settings_section.get() == "channels" && channels_open.get().is_none()).then(|| view! {
+                    <div class="settings-pane">
+                        <div class="settings-form-grid">
+                            <div class="span-2 settings-sync-block">
+                                <h3>{move || t(locale.get(), "settings.sync.title")}</h3>
+                                <p class="settings-field-hint">{move || t(locale.get(), "settings.sync.hint")}</p>
+                                <label>{move || t(locale.get(), "settings.sync.backend")}
+                                    <select data-testid="sync-backend"
+                                        prop:value=move || settings.get().sync_backend
+                                        on:change=move |ev| settings.update(|current| current.sync_backend = dom_value(&ev))>
+                                        <option value="relay">{move || t(locale.get(), "settings.sync.relay")}</option>
+                                        <option value="folder">{move || t(locale.get(), "settings.sync.folder")}</option>
+                                    </select>
+                                </label>
+                                {move || if settings.get().sync_backend == "folder" {
+                                    view! {
+                                        <label>{move || t(locale.get(), "settings.sync.folder_path")}
+                                            <div class="settings-path-row">
+                                                <input class="settings-path-input" data-testid="sync-folder"
+                                                    prop:value=move || settings.get().sync_folder
+                                                    on:input=move |ev| settings.update(|current| current.sync_folder = event_target_input(&ev).value()) />
+                                                <button type="button" class="settings-add-btn" data-testid="sync-choose-folder"
+                                                    on:click=choose_sync_folder>
+                                                    {move || t(locale.get(), "projects.choose_dir")}
+                                                </button>
+                                            </div>
+                                            <span class="settings-field-hint">{move || t(locale.get(), "settings.sync.folder_hint")}</span>
+                                        </label>
+                                    }.into_view()
+                                } else {
+                                    view! {
+                                        <label>{move || t(locale.get(), "settings.sync.relay_url")}
+                                            <input data-testid="sync-relay-url" type="url"
+                                                prop:value=move || settings.get().sync_relay_url
+                                                placeholder="https://sync.example.com"
+                                                on:input=move |ev| settings.update(|current| current.sync_relay_url = event_target_input(&ev).value()) />
+                                        </label>
+                                        <label>{move || t(locale.get(), "settings.sync.relay_token")}
+                                            <input data-testid="sync-relay-token" type="password"
+                                                prop:value=move || settings.get().sync_relay_token
+                                                placeholder=move || if settings.get().has_sync_relay_token {
+                                                    t(locale.get(), "settings.key_stored")
+                                                } else {
+                                                    t(locale.get(), "settings.sync.token_placeholder")
+                                                }
+                                                on:input=move |ev| settings.update(|current| current.sync_relay_token = event_target_input(&ev).value()) />
+                                            <span class="settings-field-hint">{move || t(locale.get(), "settings.sync.relay_hint")}</span>
+                                        </label>
+                                    }.into_view()
+                                }}
+                                <p class="settings-field-hint">
+                                    {move || t(locale.get(), "settings.sync.join_hint")}
+                                </p>
+                                <div class="row settings-sync-actions">
+                                    <button type="button" on:click=open_sync_guide>
+                                        {compose_icon("doc")}
+                                        <span>{move || t(locale.get(), "projects.sync.guide")}</span>
+                                    </button>
+                                    <button type="button" class="primary"
+                                        on:click=move |_| {
+                                            join_error.set(None);
+                                            joining.set(true);
+                                        }>
+                                        {compose_icon("link")}
+                                        <span>{move || t(locale.get(), "projects.sync.join")}</span>
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="row settings-footer">
+                            <button type="button" disabled=move || settings_busy.get() on:click=move |_| show_settings.set(false)>{move || t(locale.get(), "settings.cancel")}</button>
+                            <button type="button" class="primary" disabled=move || settings_busy.get() on:click=move |ev| save_settings.call(ev)>{move || t(locale.get(), "settings.save")}</button>
                         </div>
                     </div>
                 }.into_view())}


### PR DESCRIPTION
## 变更摘要

将「手动项目同步」设置从「常规」页面迁移至「远程接入」页面，使所有远程连接相关配置集中管理。

## 变更内容

- `ui/src/settings_view.rs`
  - 从 **常规** (`settings.nav.general`) 页面移除：
    - 同步后端
    - 中继地址 / 令牌
    - 共享文件夹路径
    - 「加入同步项目」按钮
  - 在 **远程接入** (`settings.nav.channels`) 页面顶部新增同步设置区域。
  - 当进入飞书、微信或 StickS3 子页面时，自动隐藏同步设置；返回远程接入主页后恢复显示。
  - 为同步设置新增独立的「取消」和「保存」按钮。

- `src-tauri/src/lib_tests.rs`
  - `cargo fmt --all` 自动修复的既有格式调整，无功能变更。

## 验证

- ✅ `cargo fmt --all -- --check`
- ✅ `cd ui && cargo check --target wasm32-unknown-unknown`
- ⚠️ `cargo test --workspace`
  - **552** 个测试通过
  - **10** 个测试失败
  - 失败项均为已有问题，与本次 UI 调整无关。

## 后续验证

建议在实际界面中检查以下流程：

1. 打开 **设置 → 远程接入**，确认同步设置显示在页面顶部。
2. 进入飞书、微信或 StickS3 页面，确认同步设置自动隐藏。
3. 返回远程接入主页，确认同步设置恢复显示。
4. 验证同步配置的保存与取消操作是否正常。