### PR TITLE
Fix run card placement, cut-in delivery, and browser tab closing

### DIFF
--- a/src-tauri/src/browser_bridge.rs
+++ b/src-tauri/src/browser_bridge.rs
@@ -724,7 +724,7 @@ impl Tool for WebExecuteJsTool {
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(
             self.name(),
-            "Execute JavaScript in a tab from the user's real, persistent Chrome/Chromium session. Call web_scan first and do not guess selectors. If web_scan reports human_intervention.required=true, do not automate the challenge; wait for the user to complete it and confirm before continuing. For a task that will trigger multiple file downloads, first tell the user how to allow automatic multiple downloads for the trusted target site at chrome://settings/content/automaticDownloads or edge://settings/content/automaticDownloads, then wait for confirmation; until confirmed, trigger at most one file download. A JSON script with cmd='cdp' may call one Chrome DevTools Protocol method for trusted input or other advanced browser actions.",
+            "Execute JavaScript in a tab from the user's real, persistent Chrome/Chromium session. Call web_scan first and do not guess selectors. To close tabs, never call window.close(); send {\"cmd\":\"tabs\",\"method\":\"close\",\"tabIds\":[...]} using ids returned by web_open_tab/web_scan. If web_scan reports human_intervention.required=true, do not automate the challenge; wait for the user to complete it and confirm before continuing. For a task that will trigger multiple file downloads, first tell the user how to allow automatic multiple downloads for the trusted target site at chrome://settings/content/automaticDownloads or edge://settings/content/automaticDownloads, then wait for confirmation; until confirmed, trigger at most one file download. A JSON script with cmd='cdp' may call one Chrome DevTools Protocol method for trusted input or other advanced browser actions.",
             json!({
                 "type": "object",
                 "properties": {
@@ -764,6 +764,11 @@ impl Tool for WebExecuteJsTool {
                 "browser script is {} bytes (maximum {MAX_SCRIPT_BYTES})",
                 script.len()
             ));
+        }
+        if script.starts_with("window.close()") {
+            return ToolResult::fail(
+                "window.close() cannot close ordinary browser tabs. Use the browser-use skill's tab command: {\"cmd\":\"tabs\",\"method\":\"close\",\"tabIds\":[...]} with tab ids returned by web_open_tab/web_scan.",
+            );
         }
         let tab_id = match tab_id_arg(args) {
             Ok(tab_id) => tab_id,
@@ -942,6 +947,21 @@ mod tests {
     use base64::Engine;
     use sha2::{Digest, Sha256};
 
+    struct NoEnv(PathBuf);
+
+    #[async_trait]
+    impl ToolEnv for NoEnv {
+        fn project_root(&self) -> &std::path::Path {
+            &self.0
+        }
+
+        async fn confirm(&self, _message: &str) -> bool {
+            true
+        }
+
+        async fn emit(&self, _event: wisp_tools::ToolEvent) {}
+    }
+
     #[test]
     fn manifest_key_matches_the_only_accepted_extension_origin() {
         let manifest_path = wisp_paths::browser_extension_dir()
@@ -990,6 +1010,20 @@ mod tests {
             WebScreenshotTool::new(bridge).minimum_approval(),
             Approval::Ask
         );
+    }
+
+    #[tokio::test]
+    async fn execute_js_rejects_window_close_with_the_tab_command() {
+        let bridge = Arc::new(BrowserBridge::new(PathBuf::from("extension")));
+        let result = WebExecuteJsTool::new(bridge)
+            .run(
+                &json!({ "script": "window.close(); 'close-requested'" }),
+                &NoEnv(PathBuf::from(".")),
+            )
+            .await;
+        assert!(!result.success);
+        assert!(result.content.contains("\"method\":\"close\""));
+        assert!(result.content.contains("tabIds"));
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5789,9 +5789,41 @@ async fn enqueue_turn(
 /// - `cancel` → drop it from the queue.
 /// - `cutin`  → pull it out and fold it into the *running* turn via the guide
 ///   path (#410); if nothing is running it stays queued and runs normally.
+fn begin_queued_cutin(rt: &SessionRuntime, id: u64) -> Option<(u64, QueuedItem)> {
+    let item = {
+        let mut queued = rt.queued.lock().unwrap();
+        queued
+            .iter()
+            .position(|item| item.id == id)
+            .map(|index| queued.remove(index))?
+    };
+    let guidance_id = rt
+        .guidance_seq
+        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    rt.pending_guidance
+        .lock()
+        .unwrap()
+        .push((guidance_id, item.message.clone()));
+    Some((guidance_id, item))
+}
+
+fn reclaim_unconsumed_cutin(rt: &SessionRuntime, guidance_id: u64, item: QueuedItem) -> bool {
+    let mut pending = rt.pending_guidance.lock().unwrap();
+    let before = pending.len();
+    pending.retain(|(pending_id, _)| *pending_id != guidance_id);
+    let unconsumed = pending.len() != before;
+    drop(pending);
+    if unconsumed {
+        rt.queued.lock().unwrap().insert(0, item);
+    }
+    unconsumed
+}
+
 #[tauri::command]
 async fn queued_turn_action(
     state: State<'_, AppState>,
+    app: AppHandle,
+    window: tauri::WebviewWindow,
     session_id: String,
     id: u64,
     action: String,
@@ -5819,19 +5851,25 @@ async fn queued_turn_action(
         "cutin" => {
             let running = state.running_turns.lock().await.contains(&session_id);
             if running {
-                let text = {
-                    let mut q = rt.queued.lock().unwrap();
-                    q.iter()
-                        .position(|it| it.id == id)
-                        .map(|i| q.remove(i).message)
-                };
                 // ponytail: cut-in folds only text into the turn, matching the
                 // guide path; attachments on a cut-in item are dropped.
-                if let Some(text) = text {
-                    let gid = rt
-                        .guidance_seq
-                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                    rt.pending_guidance.lock().unwrap().push((gid, text));
+                if let Some((guidance_id, item)) = begin_queued_cutin(&rt, id) {
+                    // Wait until the running turn reaches an iteration boundary
+                    // or ends. If it ended without consuming the guidance, put
+                    // the item back at the front and let the normal driver run it.
+                    let guard = rt.workflow.clone().lock_owned().await;
+                    let unconsumed = reclaim_unconsumed_cutin(&rt, guidance_id, item);
+                    drop(guard);
+                    if unconsumed {
+                        if !rt.draining.swap(true, Ordering::SeqCst) {
+                            spawn_queue_driver(
+                                app,
+                                rt.clone(),
+                                session_id,
+                                window.label().to_string(),
+                            );
+                        }
+                    }
                 }
             }
         }

--- a/src-tauri/src/lib_tests.rs
+++ b/src-tauri/src/lib_tests.rs
@@ -3,10 +3,11 @@ use super::app_updates::{update_check_from_release, GithubRelease};
 use super::desktop_lifecycle::{should_activate_workspace_window, should_hide_workspace_on_close};
 use super::session_commands::transcript_page_items;
 use super::{
-    branch_title, coalesce_live_agent_events, copy_dir_recursive, enable_referenced_contexts,
-    events_to_items, merge_pending_ui_event, message_uses_resource_bindings, messages_to_items,
-    parse_disabled_skills, parse_enabled_skill_names, parse_follow_up_questions, parse_skill_tags,
-    persist_ui_events, receive_confirm_decision, resolve_acp_artifact_references,
+    begin_queued_cutin, branch_title, coalesce_live_agent_events, copy_dir_recursive,
+    enable_referenced_contexts, events_to_items, merge_pending_ui_event,
+    message_uses_resource_bindings, messages_to_items, parse_disabled_skills,
+    parse_enabled_skill_names, parse_follow_up_questions, parse_skill_tags, persist_ui_events,
+    receive_confirm_decision, reclaim_unconsumed_cutin, resolve_acp_artifact_references,
     resolve_composer_references, resolve_reader_references, resolve_review_backend,
     resolve_workspace, session_runtime_status, should_hide_app_on_macos_close,
     should_persist_ui_event, side_chat_prompt, user_message_start, AgentEvent,
@@ -1669,6 +1670,39 @@ fn queue_driver_claim_is_single_and_reclaimable() {
         !rt.draining.swap(true, Ordering::SeqCst),
         "post-drain enqueue re-claims the driver"
     );
+}
+
+#[test]
+fn unconsumed_cutin_returns_to_the_front_of_the_queue() {
+    let rt = SessionRuntime::new();
+    rt.queued.lock().unwrap().push(QueuedItem {
+        id: 7,
+        message: "close tabs".into(),
+        attachments: vec![],
+        references: vec![],
+    });
+
+    let (guidance_id, item) = begin_queued_cutin(&rt, 7).unwrap();
+    assert!(rt.queued.lock().unwrap().is_empty());
+    assert!(reclaim_unconsumed_cutin(&rt, guidance_id, item));
+    assert_eq!(rt.queued.lock().unwrap()[0].message, "close tabs");
+    assert!(rt.pending_guidance.lock().unwrap().is_empty());
+}
+
+#[test]
+fn consumed_cutin_is_not_queued_again() {
+    let rt = SessionRuntime::new();
+    rt.queued.lock().unwrap().push(QueuedItem {
+        id: 8,
+        message: "use tab.close".into(),
+        attachments: vec![],
+        references: vec![],
+    });
+
+    let (guidance_id, item) = begin_queued_cutin(&rt, 8).unwrap();
+    rt.pending_guidance.lock().unwrap().clear();
+    assert!(!reclaim_unconsumed_cutin(&rt, guidance_id, item));
+    assert!(rt.queued.lock().unwrap().is_empty());
 }
 
 // Reorder (#433): move swaps with the neighbour and clamps at both ends, so the

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -4262,6 +4262,17 @@ test("active session Runs appear automatically with elapsed time and heartbeat (
   await expect(automatic).toContainText("Elapsed 1m");
   await expect(automatic).toContainText("Heartbeat");
   await expect(automatic).toContainText("2 of 3 stages complete");
+
+  await composer(page).fill("MDLIST later turn");
+  await page.getByRole("button", { name: "Send" }).click();
+  await expect(page.locator(".msg.user", { hasText: "MDLIST later turn" })).toBeVisible();
+  await expect.poll(() => page.evaluate(() => {
+    const card = document.querySelector('[data-testid="auto-run-monitor"]');
+    const laterTurn = [...document.querySelectorAll(".msg.user")]
+      .find((element) => element.textContent?.includes("MDLIST later turn"));
+    return !!card && !!laterTurn
+      && !!(card.compareDocumentPosition(laterTurn) & Node.DOCUMENT_POSITION_FOLLOWING);
+  })).toBe(true);
 });
 
 test("active Run elapsed time advances without waiting for a backend refresh (#663)", async ({ page }) => {

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -4941,13 +4941,13 @@ test("DOCX artifacts render offline with headings, tables, and equations", async
   await enterApp(page);
   await composer(page).fill("open manuscript.docx");
   await page.getByRole("button", { name: "Send" }).click();
+  // Opening the artifact while its streaming turn still owns the artifact
+  // projection can replace the clicked tile before the selection signal lands.
+  await expect(page.getByRole("button", { name: "Send" })).toBeVisible();
   await page.getByRole("button", { name: "Toggle panel" }).click();
-  // This test targets rendering, not pointer behavior. Invoke the visible
-  // tile directly because the artifact panel replaces its DOM while the turn
-  // streams, which can otherwise detach Playwright's click target mid-action.
   const manuscriptTile = page.locator('.rp-tile[data-artifact-name="manuscript.docx"] .rp-tile-main');
   await expect(manuscriptTile).toBeVisible();
-  await manuscriptTile.evaluate((element: HTMLElement) => element.click());
+  await manuscriptTile.click();
 
   // docx-preview renders a `.docx-wrapper` of `section.docx` pages, fully offline.
   const docx = page.locator(".rp-docx");

--- a/ui/src/chat_render.rs
+++ b/ui/src/chat_render.rs
@@ -220,6 +220,9 @@ mod token_format_tests {
 /// of the whole render window into one clone per actually-changed row.
 #[derive(Clone)]
 pub(crate) enum ThreadRow {
+    AutoRun {
+        run_id: String,
+    },
     Item {
         i: usize,
         timestamp: Option<i64>,

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -280,6 +280,7 @@ fn App() -> impl IntoView {
     // from `settings`, which also holds unsaved edits while Settings is open.
     let sync_actions_available = create_rw_signal(false);
     let pet_status = create_rw_signal(PetStatus::default());
+    let run_records = create_rw_signal::<Vec<RunRecord>>(vec![]);
     // Configured model profiles + the composer's bottom-right picker state.
     let models = create_rw_signal::<Vec<ModelProfile>>(vec![]);
     let active_session = create_rw_signal::<Option<String>>(None);
@@ -858,6 +859,28 @@ fn App() -> impl IntoView {
                 })
                 .collect::<HashSet<_>>()
         })
+    });
+    let automatic_session_runs = create_memo(move |_| {
+        let Some(frame_id) = active_session.get() else {
+            return Vec::new();
+        };
+        let monitored = monitored_run_ids.get();
+        let now = js_sys::Date::now() as i64 / 1000;
+        let mut runs = run_records.with(|runs| {
+            runs.iter()
+                .filter(|run| run.frame_id.as_deref() == Some(frame_id.as_str()))
+                .filter(|run| !monitored.contains(&run.id))
+                .filter(|run| {
+                    matches!(run.status.as_str(), "submitted" | "running" | "cancelling")
+                        || run
+                            .ended_at
+                            .is_some_and(|ended| now.saturating_sub(ended) <= 60)
+                })
+                .map(|run| (run.id.clone(), run.created_at))
+                .collect::<Vec<_>>()
+        });
+        runs.sort_by_key(|(_, created_at)| *created_at);
+        runs
     });
     let sel_artifact = create_rw_signal(0usize);
     let show_art_preview = create_rw_signal(false);
@@ -5500,7 +5523,6 @@ fn App() -> impl IntoView {
     let runtime_infos = create_rw_signal::<Vec<RuntimeInfo>>(vec![]);
     let runtime_object_states =
         create_rw_signal::<HashMap<String, RuntimeObjectState>>(HashMap::new());
-    let run_records = create_rw_signal::<Vec<RunRecord>>(vec![]);
     let run_clock = create_rw_signal(now_secs());
     let show_add_host = create_rw_signal(false);
     let host_alias = create_rw_signal(String::new());
@@ -8477,7 +8499,47 @@ fn App() -> impl IntoView {
                                     i += 1;
                                 }
                             }
-                            rows
+                            // Runs without an inline `monitor_run` tool row only carry a
+                            // session id. Use their persisted creation time to put the
+                            // fallback card before the next user turn instead of always
+                            // appending it to the live end of the conversation.
+                            let automatic_runs = automatic_session_runs.get();
+                            let mut automatic_runs = automatic_runs.into_iter().peekable();
+                            let mut anchored = Vec::with_capacity(rows.len() + automatic_runs.len());
+                            let mut synthetic_start = list.len();
+                            for row in rows {
+                                let next_user_at = match &row.4 {
+                                    ThreadRow::Item { i, timestamp, .. }
+                                        if matches!(list[*i], ChatItem::User(_)) => *timestamp,
+                                    _ => None,
+                                };
+                                if let Some(next_user_at) = next_user_at {
+                                    while automatic_runs
+                                        .peek()
+                                        .is_some_and(|(_, created_at)| *created_at < next_user_at)
+                                    {
+                                        let (run_id, _) = automatic_runs.next().unwrap();
+                                        let mut h = std::collections::hash_map::DefaultHasher::new();
+                                        run_id.hash(&mut h);
+                                        anchored.push((
+                                            thread_session_id.clone(), synthetic_start, false, h.finish(),
+                                            ThreadRow::AutoRun { run_id },
+                                        ));
+                                        synthetic_start += 1;
+                                    }
+                                }
+                                anchored.push(row);
+                            }
+                            for (run_id, _) in automatic_runs {
+                                let mut h = std::collections::hash_map::DefaultHasher::new();
+                                run_id.hash(&mut h);
+                                anchored.push((
+                                    thread_session_id.clone(), synthetic_start, false, h.finish(),
+                                    ThreadRow::AutoRun { run_id },
+                                ));
+                                synthetic_start += 1;
+                            }
+                            anchored
                             }))
                         }
                         key=|(session_id, start, streaming, fp, _)| {
@@ -8485,6 +8547,18 @@ fn App() -> impl IntoView {
                         }
                         children=move |(session_id, start, _, _, row)| {
                             match row {
+                                ThreadRow::AutoRun { run_id } => view! {
+                                    <div class="tool-wrap run-monitor-wrap auto-run-monitor"
+                                        data-testid="auto-run-monitor">
+                                        <RunMonitorCard
+                                            run_id=run_id
+                                            runs=run_records
+                                            clock=run_clock.read_only()
+                                            tool_ok=None
+                                            tool_output=String::new()
+                                        />
+                                    </div>
+                                }.into_view(),
                                 ThreadRow::Item {
                                     i,
                                     timestamp,
@@ -8624,38 +8698,6 @@ fn App() -> impl IntoView {
                             }
                         })
                     })}
-                    {move || {
-                        let Some(frame_id) = active_session.get() else {
-                            return Vec::<View>::new().into_view();
-                        };
-                        let monitored = monitored_run_ids.get();
-                        let now = js_sys::Date::now() as i64 / 1000;
-                        run_records.with(|runs| runs
-                            .iter()
-                            .filter(|run| run.frame_id.as_deref() == Some(frame_id.as_str()))
-                            .filter(|run| !monitored.contains(&run.id))
-                            .filter(|run| {
-                                matches!(run.status.as_str(), "submitted" | "running" | "cancelling")
-                                    || run.ended_at.is_some_and(|ended| now.saturating_sub(ended) <= 60)
-                            })
-                            .map(|run| {
-                                let run_id = run.id.clone();
-                                view! {
-                                    <div class="tool-wrap run-monitor-wrap auto-run-monitor"
-                                        data-testid="auto-run-monitor">
-                                        <RunMonitorCard
-                                            run_id=run_id
-                                            runs=run_records
-                                            clock=run_clock.read_only()
-                                            tool_ok=None
-                                            tool_output=String::new()
-                                        />
-                                    </div>
-                                }
-                            })
-                            .collect_view()
-                            .into_view())
-                    }}
                     {move || (!busy.get()).then(|| active_session.get()).flatten().and_then(|id| {
                         transcript_pages.get().get(&id).copied().and_then(|page| {
                             let (_, start, total) = items.with(|rows| {


### PR DESCRIPTION
## Problem

- Automatic Run cards were appended after the whole transcript, so an older Run appeared beneath newer conversation turns.
- A queued message moved into the running turn could be lost if that turn ended before draining mid-turn guidance.
- Browser automation could repeatedly try `window.close()`, which cannot close ordinary user tabs, instead of using the browser-use tab command.
- The DOCX UI test could click an artifact while streaming projection replaced its DOM.

## Changes

- Add automatic Run cards to the transcript row sequence and anchor them using the persisted Run creation time.
- Requeue an unconsumed cut-in at the front and restart the queue driver; retain consumed cut-ins without duplication.
- Reject `window.close()` immediately with the supported `tabs.close` JSON command and include that command in the tool schema.
- Wait for the streaming turn to settle before the DOCX rendering test opens its artifact.

## Tests

- `cargo fmt --all -- --check`
- `cargo check --manifest-path ui/Cargo.toml --target wasm32-unknown-unknown`
- `cargo test --workspace` (575 wisp-tauri tests passed)
- `npx playwright test` (295 passed, 1 skipped before the final DOCX test stabilization)
- `npx playwright test --grep "DOCX artifacts render offline" --repeat-each=3` (3 passed)

## Manual smoke

1. Start a Run, send a later user turn, and confirm the Run card remains above that later turn.
2. Queue a follow-up during a running turn and choose Cut in; confirm it is consumed by the turn or runs next rather than disappearing.
3. Ask the browser agent to close tabs it opened; confirm it uses the tabs close command and does not retry `window.close()`.

## Known limitations

- Automatic Run anchoring uses existing persisted timestamps because Runs currently have session-level, not message-level, ownership. A durable message/turn id can replace this inference if exact linkage is added later.
- Mid-turn cut-in remains iteration-boundary guidance; an in-flight tool is not forcibly cancelled.