### PR TITLE
fix(ui): widen runs modal and restyle publication action

### DIFF
--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -3816,7 +3816,10 @@ test("Run surface binds an exact publication evidence source", async ({ page }) 
   await page.locator(".context-card", { hasText: "ssh:gpu-server" })
     .getByRole("button", { name: "View runs" }).click();
 
+  const runsModal = page.locator(".context-details-modal.runs-details");
+  await expect(runsModal).toBeVisible();
   const run = page.locator(".run-card", { hasText: "Kinase screen QC" });
+  await expect(run.locator(".run-use-publication")).toBeVisible();
   await run.getByRole("button", { name: "Use in publication" }).click();
   const dialog = page.getByTestId("publication-binding-dialog");
   await expect(dialog).toContainText("run-kinase-001");

--- a/ui/src/app_support/runtime.rs
+++ b/ui/src/app_support/runtime.rs
@@ -1834,7 +1834,9 @@ pub(crate) fn ContextDetailsOverlay(
 
         view! {
             <div class="overlay context-details-overlay" role="presentation">
-                <div class="modal context-details-modal" class:runtime-details=kind == ContextModalKind::Runtimes
+                <div class="modal context-details-modal"
+                    class:runtime-details=kind == ContextModalKind::Runtimes
+                    class:runs-details=kind == ContextModalKind::Runs
                     class:environment-open=move || {
                         runtime_environment.get().is_some() && !runtime_environment_pinned.get()
                     }
@@ -1993,33 +1995,39 @@ pub(crate) fn ContextDetailsOverlay(
                                             view! {
                                                 <div class="run-card" class:method-search=method_search>
                                                     <div class="run-card-head">
-                                                        <span class="run-title">{title}</span>
-                                                        <span class=status_class>{run.status.clone()}</span>
-                                                        <button type="button" class="secondary run-use-publication"
-                                                            on:click=move |_| {
-                                                                on_use_in_publication.call(publication_source.clone());
-                                                            }>
-                                                            {t(locale.get(), "publication.use")}
-                                                        </button>
-                                                        {cancellable.then(|| {
-                                                            let run_id = cancel_id.clone();
-                                                            let tip = cancel_label.clone();
-                                                            view! {
-                                                                <button type="button" class="icon-btn run-cancel"
-                                                                    title=tip.clone()
-                                                                    aria-label=tip
-                                                                    on:click=move |_| {
-                                                                        let run_id = run_id.clone();
-                                                                        spawn_local(async move {
-                                                                            let arg = to_value(&serde_json::json!({ "runId": run_id })).unwrap();
-                                                                            let _ = invoke("cancel_run", arg).await;
-                                                                            refresh_runs(runs, locale);
-                                                                        });
-                                                                    }>{compose_icon("close")}</button>
-                                                            }
-                                                        })}
+                                                        <div class="run-card-main">
+                                                            <div class="run-card-title-row">
+                                                                <span class="run-title" title=title.clone()>{title}</span>
+                                                                <span class=status_class>{run.status.clone()}</span>
+                                                            </div>
+                                                            <div class="run-meta">{meta}</div>
+                                                        </div>
+                                                        <div class="run-card-actions">
+                                                            <button type="button" class="run-use-publication"
+                                                                on:click=move |_| {
+                                                                    on_use_in_publication.call(publication_source.clone());
+                                                                }>
+                                                                {t(locale.get(), "publication.use")}
+                                                            </button>
+                                                            {cancellable.then(|| {
+                                                                let run_id = cancel_id.clone();
+                                                                let tip = cancel_label.clone();
+                                                                view! {
+                                                                    <button type="button" class="icon-btn run-cancel"
+                                                                        title=tip.clone()
+                                                                        aria-label=tip
+                                                                        on:click=move |_| {
+                                                                            let run_id = run_id.clone();
+                                                                            spawn_local(async move {
+                                                                                let arg = to_value(&serde_json::json!({ "runId": run_id })).unwrap();
+                                                                                let _ = invoke("cancel_run", arg).await;
+                                                                                refresh_runs(runs, locale);
+                                                                            });
+                                                                        }>{compose_icon("close")}</button>
+                                                                }
+                                                            })}
+                                                        </div>
                                                     </div>
-                                                    <div class="run-meta">{meta}</div>
                                                     {progress.map(|progress| run_progress_meter(progress, locale.get()))}
                                                     {method_progress.map(|progress| view! {
                                                         <div class="method-search-card-progress">

--- a/ui/src/styles/right-pane.css
+++ b/ui/src/styles/right-pane.css
@@ -71,21 +71,29 @@
 .context-card-select { display:block; width:100%; padding:0; border:0; background:transparent; color:inherit; font:inherit; text-align:left; cursor:pointer; }
 .context-card-select:focus-visible { outline:2px solid var(--clay); outline-offset:4px; border-radius:4px; }
 .context-card-actions { display:flex; justify-content:flex-end; margin-top:8px; padding-top:8px; border-top:1px solid var(--border); }
-.context-card-head, .run-card-head { display:flex; align-items:center; justify-content:space-between; gap:8px; min-width:0; }
+.context-card-head { display:flex; align-items:center; justify-content:space-between; gap:8px; min-width:0; }
+.run-card { display:flex; flex-direction:column; gap:0; padding:12px 14px; }
+.run-card-head { display:flex; align-items:flex-start; justify-content:space-between; gap:12px; min-width:0; }
+.run-card-main { flex:1 1 auto; min-width:0; display:flex; flex-direction:column; gap:4px; }
+.run-card-title-row { display:flex; align-items:center; gap:8px; min-width:0; }
+.run-card-actions { display:flex; align-items:center; gap:6px; flex:0 0 auto; }
 .context-card-tools { display:flex; align-items:center; gap:6px; width:100%; }
 .context-runtime-config { margin-left:auto; }
 .context-terminal { display:inline-flex; align-items:center; justify-content:center; width:26px; height:26px; padding:0; border:1px solid var(--border); border-radius: var(--radius-xs); background:var(--bg-sunken); color:var(--text-muted); cursor:pointer; }
 .context-terminal:hover { border-color:color-mix(in srgb, var(--clay-strong) 30%, var(--border)); background:var(--clay-soft); color:var(--clay-strong); }
 .context-terminal svg { width:14px; height:14px; }
 .context-id, .run-title { min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; font-size:13px; font-weight:650; }
-.context-label, .context-meta, .run-meta, .run-command { margin-top:4px; min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; font-size:11.5px; color:var(--text-muted); }
-.context-meta, .run-command { font-family:var(--font-mono); }
+.run-title { flex:1 1 auto; }
+.context-label, .context-meta { margin-top:4px; min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; font-size:11.5px; color:var(--text-muted); }
+.run-meta { margin:0; min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; font-size:11.5px; color:var(--text-muted); }
+.run-command { margin-top:6px; min-width:0; overflow:hidden; color:var(--text-muted); font:11.5px/1.45 var(--font-mono); white-space:pre-wrap; overflow-wrap:anywhere; }
+.context-meta { font-family:var(--font-mono); }
 .run-remote { display:flex; align-items:baseline; gap:6px; margin-top:6px; min-width:0; color:var(--text-faint); font-size:11px; }
 .run-remote code { min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; color:var(--text-muted); }
-.run-output { margin-top:7px; font-size:11.5px; color:var(--text-muted); }
-.run-output summary { cursor:pointer; }
-.run-output pre { max-height:180px; margin:6px 0 0; padding:8px; overflow:auto; border:1px solid var(--border); border-radius:var(--radius-sm); background:var(--bg-sunken); color:var(--text); font:11px/1.45 var(--font-mono); white-space:pre-wrap; overflow-wrap:anywhere; }
-.run-artifacts { display:flex; flex-wrap:wrap; align-items:center; gap:6px; margin-top:7px; }
+.run-output { margin-top:8px; font-size:11.5px; color:var(--text-muted); }
+.run-output summary { cursor:pointer; user-select:none; }
+.run-output pre { max-height:220px; margin:6px 0 0; padding:9px 10px; overflow:auto; border:1px solid var(--border); border-radius:var(--radius-xs); background:var(--bg-sunken); color:var(--text); font:11px/1.45 var(--font-mono); white-space:pre-wrap; overflow-wrap:anywhere; }
+.run-artifacts { display:flex; flex-wrap:wrap; align-items:center; gap:6px; margin-top:8px; }
 .run-artifacts-label { font-size:11px; color:var(--text-faint); }
 .run-artifact { max-width:100%; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; padding:2px 8px; border:1px solid var(--border); border-radius:999px; background:var(--bg-elev); color:var(--text); font:11.5px/1.5 var(--font-mono); cursor:pointer; }
 .run-artifact:hover { border-color:var(--clay-strong); color:var(--clay-strong); }
@@ -98,7 +106,20 @@ button.run-status:hover { filter:brightness(0.96); }
 .run-status.running, .run-status.submitted, .run-status.cancelling { background:var(--clay-soft); color:var(--clay-strong); }
 .run-status.paused { background:color-mix(in srgb, var(--text-muted) 12%, transparent); color:var(--text-muted); }
 .run-status.draft { background:color-mix(in srgb, var(--warn) 13%, transparent); color:var(--warn); }
-.run-cancel { margin-left:-4px; }
+.run-use-publication {
+  flex:0 0 auto; white-space:nowrap; height:26px; padding:0 10px;
+  border:1px solid color-mix(in srgb, var(--clay-strong) 22%, var(--border-strong));
+  border-radius:var(--radius-xs); background:var(--clay-soft); color:var(--clay-strong);
+  font:inherit; font-size:11px; font-weight:650; letter-spacing:.01em; cursor:pointer;
+  transition:background .12s ease, border-color .12s ease, color .12s ease;
+}
+.run-use-publication:hover {
+  background:color-mix(in srgb, var(--clay) 18%, var(--bg-elev));
+  border-color:color-mix(in srgb, var(--clay-strong) 42%, var(--border-strong));
+  color:var(--clay-strong);
+}
+.run-use-publication:focus-visible { outline:2px solid var(--clay); outline-offset:2px; }
+.run-cancel { width:26px; height:26px; }
 .run-card.method-search { border-color:color-mix(in srgb, var(--ok) 32%, var(--border-strong)); }
 .method-search-card-progress { display:grid; grid-template-columns:1fr auto auto; gap:8px; align-items:center; margin-top:7px; padding:6px 8px; border-radius:var(--radius-xs); background:color-mix(in srgb, var(--ok) 6%, var(--bg-sunken)); font:10.5px/1.4 var(--font-mono); color:var(--text-muted); }
 .method-search-card-progress strong { color:var(--text); font-weight:650; }
@@ -191,6 +212,29 @@ button.run-status:hover { filter:brightness(0.96); }
 .context-details-modal { max-width:680px; user-select:text; }
 .context-details-modal.runtime-details { position:relative; min-height:min(620px, calc(100vh - 40px)); overflow:hidden; transition:max-width .18s var(--motion-ease-standard); }
 .context-details-modal.runtime-details.environment-open { max-width:min(1080px, calc(100vw - 40px)); }
+.context-details-modal.runs-details {
+  width:min(1040px, calc(100vw - 48px));
+  max-width:min(1040px, calc(100vw - 48px));
+  min-height:min(620px, calc(100vh - 40px));
+  padding:0;
+  gap:0;
+  overflow:hidden;
+}
+.context-details-modal.runs-details > .ps-head {
+  flex:0 0 auto;
+  padding:16px 18px 12px;
+  border-bottom:1px solid var(--border);
+}
+.context-details-modal.runs-details > .context-modal-section {
+  flex:1 1 auto;
+  min-height:0;
+  overflow-y:auto;
+  padding:12px 14px 16px;
+  background:var(--bg-sunken);
+  gap:10px;
+}
+.context-details-modal.runs-details .control-section-head { padding:0 2px; }
+.context-details-modal.runs-details .control-empty { background:var(--bg-elev); }
 .context-modal-title { min-width:0; }
 .context-modal-title h2 { overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
 .context-modal-title span { display:block; margin-top:3px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; color:var(--text-faint); font:11px/1.4 var(--font-mono); }


### PR DESCRIPTION
## Summary
- Widen the context runs dialog (~1040px) with a sunken scroll list so long titles, commands, and status badges have room.
- Restructure each run card so title/status sit left and actions sit right; commands wrap instead of truncating poorly.
- Replace the unstyled "Use in publication" control with a clay-tinted chip and cover the layout markers in the publication-binding UI test.

## Test plan
- [ ] Open Environment → View runs on a context with many long-titled runs; confirm modal width and scroll feel match other dense panels.
- [ ] Confirm "用于论文" / "Use in publication" stays single-line, aligns right, and opens the binding dialog.
- [ ] Confirm failed/succeed status chips and cancel still read correctly on cramped window sizes.
- [ ] `cd ui-tests && npx playwright test -g "Run surface binds an exact publication evidence source"` (or full suite if preferred).
