### PR TITLE
fix: keep user turn visible after API failure and resume

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4878,7 +4878,9 @@ async fn send_message_inner(
                         message: error.clone(),
                     },
                 );
-                return Err(error);
+                // ACP prompt submission always accepts the user turn first
+                // (except early validation). Resume is always mid-turn.
+                return Err(client_turn_error(true, &error));
             }
         }
     }
@@ -5667,6 +5669,11 @@ async fn send_message_inner(
             rt.set_last_seq(agent.ctx.messages.len() as i64);
         }
     }
+    // Resume is already mid-turn. A normal send is mid-turn once the loop
+    // accepted the user message (ctx grew past turn_start via on_message).
+    // The UI uses this marker so it keeps the optimistic user bubble instead of
+    // rolling the draft back; the visual Error card stays prefix-free.
+    let turn_started = resume || agent.ctx.messages.len() > turn_start;
     drop(guard);
     // After the persist flush so the seen snapshot covers the final messages.
     mark_seen_if_viewed(&state, &frame_id).await;
@@ -5683,15 +5690,28 @@ async fn send_message_inner(
             Ok(frame_id)
         }
         Err(e) => {
+            let message = format!("{e}");
             emit_agent_event(
                 &app,
                 AgentEvent::Error {
                     frame_id: frame_id.clone(),
-                    message: format!("{e}"),
+                    message: message.clone(),
                 },
             );
-            Err(format!("{e}"))
+            Err(client_turn_error(turn_started, &message))
         }
+    }
+}
+
+/// Invoke-facing failure string for `send_message`. The live Error event carries
+/// the plain message; only the Promise rejection uses the control prefix so the
+/// UI can preserve a started turn's user row without painting `[turn-started]`
+/// into the transcript.
+fn client_turn_error(turn_started: bool, message: &str) -> String {
+    if turn_started {
+        format!("[turn-started] {message}")
+    } else {
+        message.to_string()
     }
 }
 

--- a/src-tauri/src/lib_tests.rs
+++ b/src-tauri/src/lib_tests.rs
@@ -3,8 +3,8 @@ use super::app_updates::{update_check_from_release, GithubRelease};
 use super::desktop_lifecycle::{should_activate_workspace_window, should_hide_workspace_on_close};
 use super::session_commands::transcript_page_items;
 use super::{
-    begin_queued_cutin, branch_title, coalesce_live_agent_events, copy_dir_recursive,
-    enable_referenced_contexts, events_to_items, merge_pending_ui_event,
+    begin_queued_cutin, branch_title, client_turn_error, coalesce_live_agent_events,
+    copy_dir_recursive, enable_referenced_contexts, events_to_items, merge_pending_ui_event,
     message_uses_resource_bindings, messages_to_items, parse_disabled_skills,
     parse_enabled_skill_names, parse_follow_up_questions, parse_skill_tags, persist_ui_events,
     receive_confirm_decision, reclaim_unconsumed_cutin, resolve_acp_artifact_references,
@@ -32,6 +32,15 @@ async fn native_confirmation_waits_for_an_explicit_response() {
     );
     sender.send(wisp_tools::ConfirmDecision::Approved).unwrap();
     assert_eq!(decision.await, wisp_tools::ConfirmDecision::Approved);
+}
+
+#[test]
+fn client_turn_error_prefixes_only_started_turns() {
+    assert_eq!(client_turn_error(false, "no model"), "no model");
+    assert_eq!(
+        client_turn_error(true, "api: 400 max tokens"),
+        "[turn-started] api: 400 max tokens"
+    );
 }
 
 #[test]

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -3494,10 +3494,10 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
             }, 0);
             return null;
           case "send_message": {
-            const fid = (args && (args.sessionId ?? args.session_id)) || "t1";
-            const msg = (args && args.message) || "";
+            const fid = String(arg("sessionId") ?? arg("session_id") ?? "") || "t1";
+            const msg = String(arg("message") ?? "");
             sessionModels[fid] ??= activeHttpModelId();
-            const acpAgentId = args?.acpAgentId ?? acpBindings[fid];
+            const acpAgentId = arg("acpAgentId") ?? acpBindings[fid];
             if (acpAgentId && String(msg).includes("ACPTHINK")) {
               // Codex-style ordering: visible commentary streams first, then
               // reasoning, then tool activity. The UI must preserve those as
@@ -3550,6 +3550,25 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
             }
             if (String(msg).includes("PRESTARTFAIL")) {
               throw new Error("No model profile is available");
+            }
+            if (String(msg).includes("POSTSTARTFAIL_EVENT")) {
+              // Mirrors the real backend: live Error event + turn-started
+              // rejection (plain message only on the event card).
+              return await new Promise<string>((_resolve, reject) => {
+                setTimeout(() => {
+                  emit("agent", { kind: "User", frame_id: fid, text: msg });
+                  emit("agent", {
+                    kind: "Error",
+                    frame_id: fid,
+                    message: 'api: 400 {"error":{"message":"max_tokens too high"}}',
+                  });
+                  reject(
+                    new Error(
+                      '[turn-started] api: 400 {"error":{"message":"max_tokens too high"}}',
+                    ),
+                  );
+                }, 30);
+              });
             }
             if (String(msg).includes("POSTSTARTFAIL")) {
               throw new Error("[turn-started] execution failed after turn/start");

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -1169,6 +1169,18 @@ test("post-start send failures keep the persisted user row and hide the phase pr
   await expect(composer(page)).toHaveValue("");
 });
 
+test("post-start API errors keep the user bubble when an Error event lands first", async ({ page }) => {
+  await enterApp(page);
+  await composer(page).fill("POSTSTARTFAIL_EVENT keep question A");
+  await page.getByRole("button", { name: "Send" }).click();
+  await expect(page.locator(".user-bubble")).toContainText("POSTSTARTFAIL_EVENT keep question A");
+  await expect(page.locator(".finding.err")).toContainText("max_tokens too high");
+  await expect(page.locator(".finding.err")).not.toContainText("[turn-started]");
+  await expect(composer(page)).toHaveValue("");
+  // Resume must still see the original question in the transcript.
+  await expect(page.getByRole("button", { name: /Resume|继续执行/ })).toBeVisible();
+});
+
 test("automatic reviewer resolves its finding and jumps past UI-only rows (#550)", async ({ page }) => {
   await enterApp(page);
   await composer(page).fill("REVIEWBASE");

--- a/ui/src/acp.rs
+++ b/ui/src/acp.rs
@@ -212,6 +212,29 @@ pub(crate) fn acp_select_options(option: &serde_json::Value) -> Vec<(String, Str
     result
 }
 
+/// True once the turn has left the pure optimistic "user + blank assistant"
+/// shape: a streamed error card, reasoning, tools, or real answer means the
+/// user row is already durable and must not be rolled back with the draft.
+pub(crate) fn turn_activity_after_user(rows: &[ChatItem], user_index: usize) -> bool {
+    rows.get(user_index + 1..).is_some_and(|tail| {
+        tail.iter().any(|item| match item {
+            ChatItem::Assistant { text, .. } => !text.trim().is_empty(),
+            ChatItem::Reasoning(_)
+            | ChatItem::Tool { .. }
+            | ChatItem::AcpTool { .. }
+            | ChatItem::ApprovalPending { .. }
+            | ChatItem::AcpPermission { .. }
+            | ChatItem::Usage { .. }
+            | ChatItem::Compaction { .. }
+            | ChatItem::ReviewTransition { .. }
+            | ChatItem::Review(_)
+            | ChatItem::Plan(_)
+            | ChatItem::Question(_) => true,
+            ChatItem::User(_) | ChatItem::QueuedUser { .. } => false,
+        })
+    })
+}
+
 pub(crate) fn remove_optimistic_send_rows(rows: &mut Vec<ChatItem>, display_message: &str) {
     let Some(index) = rows.iter().rposition(|item| {
         matches!(item, ChatItem::User(value) if value == display_message)
@@ -221,6 +244,12 @@ pub(crate) fn remove_optimistic_send_rows(rows: &mut Vec<ChatItem>, display_mess
     };
     if matches!(rows.get(index), Some(ChatItem::QueuedUser { .. })) {
         rows.remove(index);
+        return;
+    }
+    // A live Error/Reasoning/Tool event often arrives before send_message's
+    // Result. Rolling the optimistic pair back then drops the only visible
+    // copy of the user's question until a later reload (#resume ghost).
+    if turn_activity_after_user(rows, index) {
         return;
     }
     if matches!(rows.get(index + 1), Some(ChatItem::Assistant { text, .. }) if text.is_empty()) {
@@ -251,10 +280,29 @@ pub(crate) fn mark_optimistic_send_failed(
         );
         return;
     }
+    let has_error_card = rows[index + 1..].iter().any(|item| {
+        matches!(item, ChatItem::Assistant { text, .. } if text.starts_with("Error: "))
+    });
     if let Some(ChatItem::Assistant { text, .. }) = rows.get_mut(index + 1) {
         if text.is_empty() {
-            *text = format!("Error: {error}");
+            if has_error_card {
+                // AgentEvent::Error already landed a card; drop the blank slot.
+                rows.remove(index + 1);
+            } else {
+                *text = format!("Error: {error}");
+            }
         }
+        return;
+    }
+    if !has_error_card {
+        rows.insert(
+            index + 1,
+            ChatItem::Assistant {
+                text: format!("Error: {error}"),
+                model: None,
+                resources: Vec::new(),
+            },
+        );
     }
 }
 
@@ -262,4 +310,106 @@ pub(crate) fn split_turn_started_error(error: &str) -> (bool, &str) {
     error
         .strip_prefix("[turn-started] ")
         .map_or((false, error), |message| (true, message))
+}
+
+/// Resolve whether `send_message` failed after the turn was accepted, using
+/// both the explicit backend marker and whatever is already on the transcript
+/// (events can finish before the invoke Promise rejects).
+pub(crate) fn send_failed_after_start<'a>(
+    rows: &[ChatItem],
+    display_message: &str,
+    raw: &'a str,
+) -> (bool, &'a str) {
+    let (prefixed, message) = split_turn_started_error(raw);
+    if prefixed {
+        return (true, message);
+    }
+    let started = rows
+        .iter()
+        .rposition(|item| {
+            matches!(item, ChatItem::User(value) if value == display_message)
+                || matches!(item, ChatItem::QueuedUser { text, .. } if text == display_message)
+        })
+        .is_some_and(|index| turn_activity_after_user(rows, index));
+    (started, message)
+}
+
+#[cfg(test)]
+mod optimistic_send_tests {
+    use super::{
+        mark_optimistic_send_failed, remove_optimistic_send_rows, send_failed_after_start,
+        split_turn_started_error,
+    };
+    use crate::dto::ChatItem;
+
+    fn empty_assistant() -> ChatItem {
+        ChatItem::Assistant {
+            text: String::new(),
+            model: None,
+            resources: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn prestart_failure_strips_the_optimistic_pair() {
+        let mut rows = vec![
+            ChatItem::User("question A".into()),
+            empty_assistant(),
+        ];
+        remove_optimistic_send_rows(&mut rows, "question A");
+        assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn poststart_prefix_keeps_the_user_row() {
+        let mut rows = vec![
+            ChatItem::User("question A".into()),
+            empty_assistant(),
+        ];
+        let (started, message) =
+            send_failed_after_start(&rows, "question A", "[turn-started] max tokens");
+        assert!(started);
+        assert_eq!(message, "max tokens");
+        mark_optimistic_send_failed(&mut rows, "question A", message);
+        assert!(matches!(&rows[0], ChatItem::User(text) if text == "question A"));
+        assert!(matches!(
+            &rows[1],
+            ChatItem::Assistant { text, .. } if text == "Error: max tokens"
+        ));
+    }
+
+    #[test]
+    fn error_event_before_invoke_rejection_keeps_the_user_row() {
+        let mut rows = vec![
+            ChatItem::User("question A".into()),
+            empty_assistant(),
+            ChatItem::Assistant {
+                text: "Error: api: 400 max tokens".into(),
+                model: None,
+                resources: Vec::new(),
+            },
+        ];
+        let (started, message) =
+            send_failed_after_start(&rows, "question A", "api: 400 max tokens");
+        assert!(started);
+        assert_eq!(message, "api: 400 max tokens");
+        // Rollback path must not erase the durable user bubble.
+        remove_optimistic_send_rows(&mut rows, "question A");
+        mark_optimistic_send_failed(&mut rows, "question A", message);
+        assert!(matches!(&rows[0], ChatItem::User(text) if text == "question A"));
+        assert_eq!(rows.len(), 2);
+        assert!(matches!(
+            &rows[1],
+            ChatItem::Assistant { text, .. } if text == "Error: api: 400 max tokens"
+        ));
+    }
+
+    #[test]
+    fn split_turn_started_error_strips_only_the_control_prefix() {
+        assert_eq!(
+            split_turn_started_error("[turn-started] boom"),
+            (true, "boom")
+        );
+        assert_eq!(split_turn_started_error("boom"), (false, "boom"));
+    }
 }

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -2005,11 +2005,23 @@ fn App() -> impl IntoView {
                     route_items(active_cb, items_cb, transcripts_cb, &frame_id, |v| {
                         strip_approval_pending(v);
                         settle_plan_cards(v);
-                        v.push(ChatItem::Assistant {
-                            text: format!("Error: {message}"),
-                            model,
-                            resources: Vec::new(),
-                        });
+                        // Prefer filling the optimistic blank assistant so a later
+                        // invoke rejection does not see "user + empty" and roll the
+                        // durable user bubble back into the draft.
+                        let error_text = format!("Error: {message}");
+                        if let Some(ChatItem::Assistant { text, .. }) = v
+                            .iter_mut()
+                            .rev()
+                            .find(|item| matches!(item, ChatItem::Assistant { text, .. } if text.is_empty()))
+                        {
+                            *text = error_text;
+                        } else {
+                            v.push(ChatItem::Assistant {
+                                text: error_text,
+                                model,
+                                resources: Vec::new(),
+                            });
+                        }
                     });
                 }
                 refresh_transcript_projections(&frame_id);
@@ -2773,18 +2785,43 @@ fn App() -> impl IntoView {
                 }
                 Err(error) => {
                     let raw = js_error_text(error);
-                    let (started, message_text) = split_turn_started_error(&raw);
+                    // Prefer transcript evidence: Error/Reasoning/Tool events can
+                    // finish before invoke rejects, and a bare string must not
+                    // treat an already-started turn as a pre-start rollback.
+                    // Draft restore must follow whether the bubble was actually
+                    // removed — not a prior snapshot of "started" that races
+                    // the live agent bus.
+                    let (_, status_message) = split_turn_started_error(&raw);
+                    let rolled_back = Rc::new(Cell::new(false));
+                    let rolled_back_flag = rolled_back.clone();
                     route_items(active_session, items, transcripts, &id, |rows| {
+                        let (started, message_text) =
+                            send_failed_after_start(rows, &display_message, &raw);
+                        let had_user = rows.iter().any(|item| {
+                            matches!(item, ChatItem::User(value) if value == &display_message)
+                                || matches!(
+                                    item,
+                                    ChatItem::QueuedUser { text, .. } if text == &display_message
+                                )
+                        });
                         if started {
                             mark_optimistic_send_failed(rows, &display_message, message_text);
                         } else {
                             remove_optimistic_send_rows(rows, &display_message);
                         }
+                        let kept_user = rows.iter().any(|item| {
+                            matches!(item, ChatItem::User(value) if value == &display_message)
+                                || matches!(
+                                    item,
+                                    ChatItem::QueuedUser { text, .. } if text == &display_message
+                                )
+                        });
+                        rolled_back_flag.set(had_user && !kept_user);
                     });
                     transcript_projection_epoch.update(|revision| {
                         *revision = revision.wrapping_add(1);
                     });
-                    if !started {
+                    if rolled_back.get() {
                         if input.get_untracked().is_empty() {
                             input.set(message);
                         }
@@ -2805,7 +2842,7 @@ fn App() -> impl IntoView {
                     status.set(tf(
                         locale.get(),
                         "status.send_failed",
-                        &[("msg", &localize_backend(locale.get(), message_text))],
+                        &[("msg", &localize_backend(locale.get(), status_message))],
                     ));
                 }
             }


### PR DESCRIPTION
## Summary
- Mid-turn API failures (e.g. max_tokens 400) no longer roll back the optimistic user bubble as if send never started, so Continue/resume no longer hides question A while still executing it.
- Backend tags invoke errors that happen after the turn accepted the user message with `[turn-started]`; the Error event card stays prefix-free.
- Frontend keeps durable transcript rows when Error/tool/reasoning already landed, restores the composer draft only when the user bubble is actually removed, and adds unit + Playwright coverage.

## Test plan
- [x] `cargo test` (client_turn_error + optimistic_send)
- [x] Playwright: pre-start rollback, post-start keep user, Error event + resume-ready path
- [x] Manual: send a turn that fails with token ceiling error → confirm user message stays → fix settings → Continue → user message stays while tools run