### PR TITLE
feat: add search_models tool and model_id param for skill-to-workflow model binding

### DIFF
--- a/crates/wisp-core/src/system_prompt.rs
+++ b/crates/wisp-core/src/system_prompt.rs
@@ -120,6 +120,7 @@ If a named workflow is disabled or unavailable, follow the same principles direc
             "## Skills Selection Guidelines\n\n\
 {count} {availability} currently configured, enabled, and searchable for this project/session. Their catalog and bodies are not preloaded.\n\n\
 - When a task may match an installed workflow, call `search_skills` with concise task or domain keywords.\n\
+- When a task needs a specific model ability (e.g. image understanding), call `search_models` with a capability keyword like `vision` to find a suitable model, then pass its id to `create_workflow` via `params.model_id`.\n\
 - When the user asks how many Skills are configured, enabled, effective, shadowed, or broken, use `list_skill_catalog` and read its explicitly named count fields.\n\
 - Treat `current_configured_enabled_count` as authoritative for this Agent snapshot. If the user cites a different UI or remembered count, report the discrepancy; do not accept, relabel, or explain the user's number without supporting inventory data.\n\
 - Then call `use_skill` with the exact returned name before proceeding.\n\

--- a/crates/wisp-tools/src/lib.rs
+++ b/crates/wisp-tools/src/lib.rs
@@ -52,6 +52,7 @@ const BUILT_IN_SCHEMA_NAMES: &[&str] = &[
     "attempt_completion",
     "list_skill_catalog",
     "search_skills",
+    "search_models",
     "use_skill",
     "search_memory",
     "append_memory",
@@ -89,6 +90,7 @@ pub const PLAN_MODE_READ_ONLY: &[&str] = &[
     // wisp-core / wisp-skills
     "search_memory",
     "search_skills",
+    "search_models",
     "use_skill",
     // Desktop host tools that only read or retrieve
     "web_scan",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5163,6 +5163,9 @@ async fn send_message_inner(
         agent.add_tool(Box::new(quick_actions::ExplainWorkflowTool::new(
             state.store.clone(),
         )));
+        agent.add_tool(Box::new(quick_actions::SearchModelsTool::new(
+            state.store.clone(),
+        )));
         agent.add_tool(Box::new(quick_actions::CreateWorkflowTool::new(
             state.store.clone(),
             skills.clone(),

--- a/src-tauri/src/quick_actions.rs
+++ b/src-tauri/src/quick_actions.rs
@@ -124,6 +124,117 @@ impl Tool for ExplainWorkflowTool {
     }
 }
 
+/// Search configured model profiles by capability keyword (e.g. "vision",
+/// "reasoning") or browse all with "*". Returns each model's id, label,
+/// provider, supports_vision, max_tokens, context_window, and active status
+/// so the Agent can pick the right model for a task and pass its id to
+/// `create_workflow` via `params.model_id`.
+pub(crate) struct SearchModelsTool {
+    store: Store,
+}
+
+impl SearchModelsTool {
+    pub(crate) fn new(store: Store) -> Self {
+        Self { store }
+    }
+}
+
+#[async_trait::async_trait]
+impl Tool for SearchModelsTool {
+    fn name(&self) -> &str {
+        "search_models"
+    }
+
+    fn schema(&self) -> ToolSchema {
+        ToolSchema::new(
+            "search_models",
+            "Search configured chat model profiles by capability keyword (e.g. 'vision', 'reasoning') or browse all with '*'. Returns each model's id, label, provider, supports_vision flag, max_tokens, context_window, and active status. Use the returned model id as params.model_id when calling create_workflow to bind a specific model to a Workflow node.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Capability keyword ('vision', 'reasoning', etc.), model label fragment, or '*' to browse all configured models"
+                    }
+                },
+                "required": ["query"]
+            }),
+        )
+    }
+
+    fn preview(&self, args: &Value) -> String {
+        args.get("query")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string()
+    }
+
+    fn read_only(&self) -> bool {
+        true
+    }
+
+    async fn run(&self, args: &Value, _env: &dyn ToolEnv) -> ToolResult {
+        let Some(query) = args
+            .get("query")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|query| !query.is_empty())
+        else {
+            return ToolResult::fail("missing required argument 'query'");
+        };
+        let profiles = crate::models::delegation_profiles(&self.store).await;
+        let query_lower = query.to_lowercase();
+        let browse = query == "*";
+        let mut results = Vec::new();
+        for profile in &profiles {
+            let label_lower = profile.label.to_lowercase();
+            let provider_lower = profile.provider.to_lowercase();
+            let model_lower = profile.model.to_lowercase();
+            let score = if browse {
+                1
+            } else if query_lower == "vision" {
+                if profile.supports_vision {
+                    100
+                } else {
+                    0
+                }
+            } else {
+                let mut s = 0;
+                if label_lower.contains(&query_lower)
+                    || model_lower.contains(&query_lower)
+                    || provider_lower.contains(&query_lower)
+                {
+                    s += 10;
+                }
+                if profile.supports_vision && "vision".contains(&query_lower) {
+                    s += 20;
+                }
+                s
+            };
+            if score > 0 {
+                results.push(json!({
+                    "id": profile.id,
+                    "label": profile.label,
+                    "provider": profile.provider,
+                    "model": profile.model,
+                    "supports_vision": profile.supports_vision,
+                    "max_tokens": profile.max_tokens,
+                    "context_window": profile.context_window,
+                    "active": profile.active,
+                    "has_api_key": profile.has_api_key,
+                }));
+            }
+        }
+        ToolResult::ok(
+            serde_json::to_string_pretty(&json!({
+                "results": results,
+                "next": "Pass the desired model's id to create_workflow via params.model_id to bind it to the Workflow node.",
+            }))
+            .unwrap_or_default(),
+        )
+    }
+}
+
 /// Convert an installed Skill into a registered, reusable Workflow template.
 ///
 /// A Skill carries no machine-readable task graph, so the generated template is
@@ -196,6 +307,10 @@ impl Tool for CreateWorkflowTool {
                             "output_schema": {
                                 "type": "object",
                                 "description": "JSON object schema describing the task output"
+                            },
+                            "model_id": {
+                                "type": "string",
+                                "description": "Model profile id to bind to this Workflow node, as returned by search_models. Use this when the task needs a specific model ability (e.g. a vision-capable model for image understanding). Defaults to the session's active model."
                             }
                         }
                     }
@@ -409,9 +524,12 @@ fn apply_workflow_params(
                 }
                 proposal.tasks[0].output_schema = Some(value.clone());
             }
+            "model_id" => {
+                proposal.tasks[0].model_id = Some(required_string(value, "model_id")?);
+            }
             other => {
                 return Err(format!(
-                    "unknown params key '{other}'; supported keys: goal, context, instruction, capabilities, approval_policy, output_schema"
+                    "unknown params key '{other}'; supported keys: goal, context, instruction, capabilities, approval_policy, output_schema, model_id"
                 ));
             }
         }


### PR DESCRIPTION
## Problem

The `create_workflow` tool generates Workflow nodes with `model_id: None`, meaning every node falls back to the session default model. When a task needs a specific model ability (e.g. a vision-capable model for image understanding), the Agent has no way to discover which configured models support that ability, and no way to bind a specific model to the node.

The data is already there -- `models::delegation_profiles()` returns full `ModelProfile` records with `supports_vision`, `max_tokens`, `context_window`, etc. But the Agent tool layer has no way to reach it. This is asymmetric with Skills, where `search_skills` lets the Agent discover and select installed skills.

## Changes

### 1. New `search_models` tool (`src-tauri/src/quick_actions.rs`)
- Accepts a capability keyword (`"vision"`, `"reasoning"`) or `"*"` to browse all configured chat models
- Returns each model's `id`, `label`, `provider`, `supports_vision`, `max_tokens`, `context_window`, `active`, and `has_api_key`
- Uses existing `models::delegation_profiles()` data source -- no new storage or API
- Registered alongside `create_workflow` in `lib.rs` (line 5166)

### 2. `model_id` param in `create_workflow` (`src-tauri/src/quick_actions.rs`)
- `params` object now accepts `"model_id"` (string)
- `apply_workflow_params` writes it to `proposal.tasks[0].model_id`
- Schema description references `search_models` for discovery

### 3. System prompt guidance (`crates/wisp-core/src/system_prompt.rs`)
- `skills_guidance()` now includes a line directing the Agent to call `search_models` when a task needs a specific model ability, and to pass the returned id to `create_workflow` via `params.model_id`

### 4. Tool registry lists (`crates/wisp-tools/src/lib.rs`)
- `BUILT_IN_SCHEMA_NAMES`: added `"search_models"`
- `PLAN_MODE_READ_ONLY`: added `"search_models"` (read-only tool, safe in plan mode)

## After this PR

The Agent can complete the full skill + model matching loop:

`
user: "read figures from this paper"
Agent: search_skills("figure analysis") -> cangjie-skill
Agent: search_models("vision")          -> kimi3 (supports_vision: true)
Agent: create_workflow(
         skill_name: "cangjie-skill",
         params: { model_id: "m1" }
       )
`

No manual `Advanced execution controls` configuration needed.

## Files changed

| File | Lines |
|------|-------|
| `src-tauri/src/quick_actions.rs` | +119 -1 (SearchModelsTool + model_id param) |
| `src-tauri/src/lib.rs` | +3 (tool registration) |
| `crates/wisp-core/src/system_prompt.rs` | +1 (guidance line) |
| `crates/wisp-tools/src/lib.rs` | +2 (schema names) |
| **Total** | **+125 -1** |