### PR TITLE
Show empty sessions in the sidebar

### DIFF
--- a/docs/workspace-navigation.md
+++ b/docs/workspace-navigation.md
@@ -6,4 +6,6 @@ priority.
 
 To open workspaces on a blank conversation instead, turn off **Resume the last
 conversation when opening a workspace** in **Settings → General**. Starting a
-new conversation manually is always available from the sidebar.
+new conversation manually is always available from the sidebar. A newly
+created conversation appears there immediately as **Untitled session**, even
+before its first message is sent.

--- a/src-tauri/src/session_commands.rs
+++ b/src-tauri/src/session_commands.rs
@@ -10,8 +10,8 @@ pub(super) async fn new_session(
     // Create a fresh frame and hand its id to the UI up front, so the UI can
     // route streamed events to the right transcript *before* the first delta
     // arrives. Does NOT cancel any running turn — parallel conversations keep
-    // running. Empty frames are filtered out of the sidebar until they get a
-    // user message.
+    // running. Persisted history still ignores empty frames; the UI keeps the
+    // currently active draft visible until its first user turn is stored.
     let ap = state.active(window.label());
     let _project_activity = state.begin_project_activity(&ap.id)?;
     let id = create_session_frame(&state.store, &ap.id).await?;

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -1854,6 +1854,21 @@ test("new session focuses the composer", async ({ page }) => {
   await expect(composer(page)).toBeFocused();
 });
 
+test("new session appears in the sidebar before its first message", async ({ page }) => {
+  await enterApp(page);
+  const sessions = page.locator(".side-item.ses");
+  const countBefore = await sessions.count();
+  const sendsBefore = (await invokeArgsList(page, "send_message")).length;
+
+  await newSessionButton(page).click();
+
+  await expect(sessions).toHaveCount(countBefore + 1);
+  const newSession = sessions.filter({ hasText: "Untitled session" }).first();
+  await expect(newSession).toBeVisible();
+  await expect(newSession).toHaveClass(/active/);
+  expect((await invokeArgsList(page, "send_message")).length).toBe(sendsBefore);
+});
+
 test("rename session modal autofocuses so Ctrl+A selects the title", async ({ page }) => {
   await page.addInitScript(parallelMock);
   await page.goto("/");
@@ -7961,7 +7976,7 @@ test("a second conversation can run in parallel without interleaving transcripts
   await expect(page.getByText("echo:alpha")).toHaveCount(0);
 
   // A is still running → its sidebar entry shows the running indicator.
-  await expect(page.locator(".side-item.ses.running")).toBeVisible();
+  await expect(page.locator(".side-item.ses.running", { hasText: "alpha" })).toBeVisible();
 
   // Switch back to A: the cached (live) transcript renders, B's does not.
   await page.locator(".side-item.ses", { hasText: "alpha" }).click();

--- a/ui/src/app_support/sessions.rs
+++ b/ui/src/app_support/sessions.rs
@@ -5,14 +5,37 @@ pub(crate) fn refresh_sessions(
     pending: RwSignal<HashMap<String, usize>>,
     running: RwSignal<HashSet<String>>,
     next_cursor: RwSignal<Option<SessionCursor>>,
+    active_session: RwSignal<Option<String>>,
 ) {
     next_cursor.set(None);
     spawn_local(async move {
         let args = to_value(&serde_json::json!({ "cursor": null })).unwrap();
         let v = invoke("list_sessions_page", args).await;
-        if let Ok(page) = serde_wasm_bindgen::from_value::<SessionPage>(v) {
+        if let Ok(mut page) = serde_wasm_bindgen::from_value::<SessionPage>(v) {
             let set = pending.with_untracked(|m| rebuilt_running_set(&page.running_ids, m));
             running.set(set);
+            let active = active_session.get_untracked();
+            let active_is_listed = active.as_ref().is_none_or(|id| {
+                page.items
+                    .iter()
+                    .any(|session| session.id.as_str() == id.as_str())
+            });
+            if !active_is_listed {
+                let id = active.expect("an unlisted active session has an id");
+                let draft = sessions
+                    .with_untracked(|current| {
+                        current.iter().find(|session| session.id == id).cloned()
+                    })
+                    .unwrap_or(SessionInfo {
+                        id,
+                        title: String::new(),
+                        ts: js_sys::Date::now() as i64,
+                        folder_id: None,
+                        branched_from: None,
+                        pinned: false,
+                    });
+                page.items.insert(0, draft);
+            }
             sessions.set(page.items);
             next_cursor.set(page.next_cursor);
         }

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -569,8 +569,15 @@ fn App() -> impl IntoView {
     // Session history (left sidebar).
     let session_history_cursor = create_rw_signal::<Option<SessionCursor>>(None);
     let session_history_loading = create_rw_signal(false);
-    let refresh_session_history =
-        move || refresh_sessions(sessions, pending_turns, running, session_history_cursor);
+    let refresh_session_history = move || {
+        refresh_sessions(
+            sessions,
+            pending_turns,
+            running,
+            session_history_cursor,
+            active_session,
+        )
+    };
     let folders = create_rw_signal::<Vec<FolderInfo>>(vec![]);
     let collapsed_folders = create_rw_signal::<HashSet<String>>(HashSet::new());
     let drag_session = create_rw_signal::<Option<String>>(None);
@@ -7393,7 +7400,13 @@ fn App() -> impl IntoView {
                             key,
                             &[("n", &summary.message_count.to_string())],
                         ));
-                        refresh_sessions(sessions, pending_turns, running, session_history_cursor);
+                        refresh_sessions(
+                            sessions,
+                            pending_turns,
+                            running,
+                            session_history_cursor,
+                            active_session,
+                        );
                         refresh_folders(folders);
                         if summary.status != "skipped" && !summary.frame_id.is_empty() {
                             open_project_transition
@@ -7648,6 +7661,7 @@ fn App() -> impl IntoView {
                     pending_turns,
                     running,
                     session_history_cursor,
+                    active_session,
                 );
                 refresh_folders(folders);
             })


### PR DESCRIPTION
## Problem

A newly created conversation did not appear in the left sidebar until its first user message was persisted. This made the active blank conversation look detached from session history.

## Root cause

The persisted session-history query intentionally excludes frames without a user turn. The UI replaced its whole local sidebar snapshot with that query result, so the currently active empty frame was dropped during refresh.

## What changed

- Preserve the currently active session as a local **Untitled session** draft when it is absent from the persisted history page.
- Let the normal persisted session record replace the draft after the first user turn is stored.
- Keep the database query unchanged so old empty frames created by demos or abandoned internal flows do not appear in history.
- Pass the active-session signal through every first-page history refresh path.
- Add a Playwright regression proving that a new session appears before any `send_message` call.
- Tighten the parallel-session running-state assertion now that both active conversations can be visible.
- Document the sidebar behavior.

## User impact

Clicking **New session** now immediately creates and selects an **Untitled session** row in the sidebar. Sending the first message transitions it to the normal persisted history entry.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cd ui && cargo check --target wasm32-unknown-unknown`
- Targeted Playwright coverage for empty-session visibility, pagination, empty state, and parallel conversations
- Full Playwright run: 301 passed, 1 conditionally skipped, and 1 unrelated project-page startup timeout; the timed-out test passed on isolated rerun in 1.1s

## Manual smoke steps

1. Open a project and click **New session**.
2. Confirm an active **Untitled session** appears immediately in the sidebar.
3. Send a first message and confirm the row remains available under its persisted title.
4. Start two conversations in parallel and confirm each retains its own transcript and running state.

## Known limitation

An empty draft is intentionally client-side until its first user turn. If the app is closed before that turn, the abandoned empty frame remains excluded from persisted session history.