### PR TITLE
Fix long-session UI freezes

### DIFF
--- a/crates/wisp-store/src/sessions.rs
+++ b/crates/wisp-store/src/sessions.rs
@@ -75,6 +75,14 @@ pub struct SessionTranscriptPage {
     pub latest_seq: i64,
 }
 
+/// Maximum stdout characters returned for one tool activity group when a
+/// transcript page is replayed. The Tauri/UI layer applies its byte ceiling as
+/// a second guard; this database-side cap prevents legacy event logs from
+/// being materialized in full before that guard can run.
+pub(crate) const SESSION_UI_STDOUT_REPLAY_MAX_CHARS: usize = 64 * 1024;
+const RECENT_TURN_PREVIEW_MAX_CHARS: usize = 20_000;
+pub(crate) const RECENT_TURN_TOOL_PREVIEW_MAX_CHARS: usize = 4_000;
+
 /// Delete every database row owned by a conversation. Legacy databases do not
 /// consistently enable SQLite foreign keys, so the cascade must be explicit.
 /// Runs are project-level records and survive, but their stale frame reference
@@ -623,6 +631,65 @@ impl Store {
             .collect())
     }
 
+    /// Load only the newest complete user turns as bounded text previews,
+    /// without UI events, reviews, resources, reasoning, image data, or full
+    /// tool-call arguments. This is for secondary model calls (for example
+    /// follow-up suggestions), not transcript rendering or agent recovery.
+    pub async fn load_recent_turn_preview_messages(
+        &self,
+        frame_id: &str,
+        turn_limit: usize,
+    ) -> Result<Vec<Message>> {
+        let rows = sqlx::query(
+            "WITH recent_user_turns AS (\
+                 SELECT seq FROM messages \
+                 WHERE frame_id=? AND role='user' AND tool_name IS NULL \
+                 ORDER BY seq DESC LIMIT ?\
+             ), start_seq AS (SELECT MIN(seq) AS seq FROM recent_user_turns) \
+             SELECT seq,role,json_quote(substr(\
+                 CASE json_type(content) \
+                     WHEN 'text' THEN json_extract(content,'$') \
+                     WHEN 'array' THEN COALESCE((\
+                         SELECT group_concat(json_extract(part.value,'$.text'),'\n') \
+                         FROM json_each(content) AS part \
+                         WHERE json_extract(part.value,'$.type')='text'\
+                     ),'') ELSE '' END,1,\
+                 CASE WHEN role='tool' AND COALESCE(tool_name,'') NOT IN \
+                     ('attempt_completion','propose_plan','ask_user') THEN ? ELSE ? END\
+             )) AS content,NULL AS tool_calls,tool_call_id,tool_name,NULL AS reasoning,ts,model_name \
+             FROM messages WHERE frame_id=? \
+             AND seq>=COALESCE((SELECT seq FROM start_seq), 0) ORDER BY seq ASC",
+        )
+        .bind(frame_id)
+        .bind(turn_limit.max(1) as i64)
+        .bind(RECENT_TURN_TOOL_PREVIEW_MAX_CHARS as i64)
+        .bind(RECENT_TURN_PREVIEW_MAX_CHARS as i64)
+        .bind(frame_id)
+        .fetch_all(&self.pool)
+        .await?;
+        let mut messages = Vec::with_capacity(rows.len());
+        for row in rows {
+            let role: String = row.try_get("role")?;
+            let content_json: String = row.try_get("content")?;
+            let content: wisp_llm::Content =
+                serde_json::from_str(&content_json).unwrap_or(wisp_llm::Content::text(""));
+            let tool_calls_json: Option<String> = row.try_get("tool_calls")?;
+            messages.push(Message {
+                role: parse_role(&role),
+                content,
+                tool_calls: tool_calls_json
+                    .and_then(|value| serde_json::from_str(&value).ok())
+                    .unwrap_or_default(),
+                tool_call_id: row.try_get("tool_call_id")?,
+                tool_name: row.try_get("tool_name")?,
+                reasoning: row.try_get("reasoning")?,
+                ts: row.try_get("ts")?,
+                model_name: row.try_get("model_name")?,
+            });
+        }
+        Ok(messages)
+    }
+
     /// Load the durable user-authored turns used by the conversation outline,
     /// including when each question was sent and its final assistant reply.
     pub async fn load_session_user_messages(
@@ -813,13 +880,32 @@ impl Store {
             i64::MAX
         };
         let event_rows = sqlx::query(
-            "SELECT event_json FROM session_ui_events WHERE frame_id=? AND seq>? AND seq<=? \
-             AND json_extract(event_json,'$.kind')<>'ToolPresentation' \
-             ORDER BY seq",
+            "WITH page_events AS (\
+                 SELECT seq,event_json,json_extract(event_json,'$.kind') AS kind \
+                 FROM session_ui_events WHERE frame_id=? AND seq>? AND seq<=? \
+                 AND json_extract(event_json,'$.kind')<>'ToolPresentation'\
+             ), grouped_events AS (\
+                 SELECT *,SUM(CASE WHEN kind IN ('ToolCall','User') THEN 1 ELSE 0 END) \
+                     OVER (ORDER BY seq) AS stdout_group \
+                 FROM page_events\
+             ), budgeted_events AS (\
+                 SELECT *,COALESCE(SUM(CASE WHEN kind='Stdout' \
+                         THEN length(json_extract(event_json,'$.chunk')) ELSE 0 END) \
+                     OVER (PARTITION BY stdout_group ORDER BY seq \
+                           ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING),0) AS stdout_before \
+                 FROM grouped_events\
+             ) \
+             SELECT CASE WHEN kind='Stdout' THEN json_set(\
+                         event_json,'$.chunk',substr(json_extract(event_json,'$.chunk'),1,? - stdout_before)\
+                     ) ELSE event_json END AS event_json \
+             FROM budgeted_events \
+             WHERE kind<>'Stdout' OR stdout_before<? ORDER BY seq",
         )
         .bind(frame_id)
         .bind(start_event_seq)
         .bind(end_event_seq)
+        .bind(SESSION_UI_STDOUT_REPLAY_MAX_CHARS as i64)
+        .bind(SESSION_UI_STDOUT_REPLAY_MAX_CHARS as i64)
         .fetch_all(&self.pool)
         .await?;
         let ui_events = event_rows

--- a/crates/wisp-store/src/store_tests.rs
+++ b/crates/wisp-store/src/store_tests.rs
@@ -1792,6 +1792,122 @@ async fn transcript_pages_keep_complete_user_turns_and_matching_events() {
 }
 
 #[tokio::test]
+async fn recent_turn_preview_messages_are_turn_and_content_bounded() {
+    let tmp = std::env::temp_dir().join(format!(
+        "wisp_store_recent_turns_{}.sqlite",
+        uuid::Uuid::new_v4()
+    ));
+    let store = Store::open(&tmp).await.unwrap();
+    store.create_project("p", "proj", "").await.unwrap();
+    store.create_frame("f", "p", "OPERON", "m").await.unwrap();
+    let mut background = Message::user("background completion");
+    background.tool_name = Some(AGENT_WORKFLOW_COMPLETION_TOOL.into());
+    let large_tool = Message::tool(
+        "call-shell",
+        "shell",
+        "z".repeat(super::sessions::RECENT_TURN_TOOL_PREVIEW_MAX_CHARS + 500),
+    );
+    let messages = [
+        Message::system("sys"),
+        Message::user("one"),
+        Message::assistant("answer one"),
+        Message::user("two"),
+        Message::assistant("answer two"),
+        large_tool,
+        background,
+        Message::user("three"),
+        Message::assistant("answer three"),
+    ];
+    for (seq, message) in messages.iter().enumerate() {
+        store
+            .append_message("f", seq as i64, message)
+            .await
+            .unwrap();
+    }
+
+    let recent = store
+        .load_recent_turn_preview_messages("f", 2)
+        .await
+        .unwrap();
+    assert_eq!(recent.first().unwrap().content.as_text(), "two");
+    assert_eq!(recent.last().unwrap().content.as_text(), "answer three");
+    assert!(recent
+        .iter()
+        .any(|message| message.content.as_text() == "background completion"));
+    assert!(recent
+        .iter()
+        .all(|message| message.content.as_text() != "one"));
+    let tool = recent
+        .iter()
+        .find(|message| message.tool_name.as_deref() == Some("shell"))
+        .unwrap();
+    assert_eq!(
+        tool.content.as_text().chars().count(),
+        super::sessions::RECENT_TURN_TOOL_PREVIEW_MAX_CHARS
+    );
+    assert!(recent.iter().all(|message| message.tool_calls.is_empty()));
+    assert!(recent.iter().all(|message| message.reasoning.is_none()));
+
+    let _ = std::fs::remove_file(tmp);
+}
+
+#[tokio::test]
+async fn transcript_page_caps_legacy_stdout_before_returning_event_json() {
+    let tmp = std::env::temp_dir().join(format!(
+        "wisp_store_stdout_replay_{}.sqlite",
+        uuid::Uuid::new_v4()
+    ));
+    let store = Store::open(&tmp).await.unwrap();
+    store.create_project("p", "proj", "").await.unwrap();
+    store.create_frame("f", "p", "OPERON", "m").await.unwrap();
+    store
+        .append_message("f", 1, &Message::user("run it"))
+        .await
+        .unwrap();
+    store
+        .append_message("f", 2, &Message::assistant("done"))
+        .await
+        .unwrap();
+    let events = [
+        serde_json::json!({"kind":"ToolCall","frame_id":"f","name":"shell","preview":"run"}),
+        serde_json::json!({"kind":"Stdout","frame_id":"f","chunk":"a".repeat(40_000)}),
+        serde_json::json!({"kind":"Stdout","frame_id":"f","chunk":"b".repeat(40_000)}),
+        serde_json::json!({"kind":"Stdout","frame_id":"f","chunk":"c".repeat(40_000)}),
+        serde_json::json!({"kind":"ToolResult","frame_id":"f","name":"shell","ok":true,"content":"done","duration_ms":1}),
+        serde_json::json!({"kind":"ToolCall","frame_id":"f","name":"shell","preview":"next"}),
+        serde_json::json!({"kind":"Stdout","frame_id":"f","chunk":"next"}),
+        serde_json::json!({"kind":"MessageBoundary","frame_id":"f","seq":2}),
+    ];
+    for (seq, event) in events.iter().enumerate() {
+        store
+            .append_session_ui_event("f", seq as i64 + 1, &event.to_string())
+            .await
+            .unwrap();
+    }
+
+    let page = store
+        .load_session_transcript_page("f", None, 1)
+        .await
+        .unwrap();
+    let stdout = page
+        .ui_events
+        .iter()
+        .filter_map(|event| serde_json::from_str::<serde_json::Value>(event).ok())
+        .filter(|event| event["kind"] == "Stdout")
+        .map(|event| event["chunk"].as_str().unwrap().to_string())
+        .collect::<Vec<_>>();
+    assert_eq!(stdout.len(), 3, "the fully over-budget chunk is omitted");
+    assert_eq!(stdout[0].len(), 40_000);
+    assert_eq!(
+        stdout[1].len(),
+        super::sessions::SESSION_UI_STDOUT_REPLAY_MAX_CHARS - 40_000
+    );
+    assert_eq!(stdout[2], "next", "a new tool receives a fresh budget");
+
+    let _ = std::fs::remove_file(tmp);
+}
+
+#[tokio::test]
 async fn global_composer_search_carries_project_and_session_metadata() {
     let tmp = std::env::temp_dir().join(format!(
         "wisp_store_composer_search_{}.sqlite",

--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -2,8 +2,16 @@
 
 In General settings, **Suggest follow-up questions** is enabled by default.
 After a completed reply, Wisp uses that conversation's current model to offer
-three optional next questions. The suggestion panel can be hidden per reply,
+three optional next questions. That secondary call reads only the four most
+recent user turns, so completing a long, tool-heavy conversation does not load
+and duplicate its full history. The suggestion panel can be hidden per reply,
 or the setting can be turned off to skip the extra model call entirely.
+
+The desktop transcript also treats ordinary tool output as a preview: tool
+results are limited to 4,000 characters and streamed terminal output to 64 KiB
+(with carriage-return progress updates folded in place). Complete answer, plan,
+and question cards are not clipped. The durable model transcript is unchanged;
+these limits apply to the WebView presentation and its replay data.
 
 wisp-science calls remote LLM APIs through model profiles. Desktop users
 configure these in **Settings -> Models**. Each row is a model profile with its

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -814,6 +814,10 @@ struct SessionInfo {
 
 const SESSION_HISTORY_PAGE_SIZE: usize = 100;
 const SESSION_TRANSCRIPT_PAGE_TURNS: usize = 20;
+/// Follow-up suggestions only need the conversational tail. Reading the full
+/// history here used to duplicate every saved tool dump immediately after a
+/// turn completed, exactly when the WebView was settling its projections.
+const FOLLOW_UP_TRANSCRIPT_TURNS: usize = 4;
 
 #[derive(Serialize, Deserialize, Clone)]
 struct SessionCursor {
@@ -1038,7 +1042,7 @@ fn messages_to_items(msgs: &[wisp_llm::Message]) -> Vec<UiItem> {
                 "monitor_run" | "wisp_monitor_run" => args.get("run_id").and_then(|v| v.as_str()),
                 _ => None,
             }?;
-            Some((call.id.as_str(), input.to_owned()))
+            Some((call.id.as_str(), bounded_ui_tool_input(input)))
         })
         .collect();
     let mut out = vec![];
@@ -1177,7 +1181,7 @@ fn messages_to_items(msgs: &[wisp_llm::Message]) -> Vec<UiItem> {
                 {
                     out.push(UiItem {
                         role: "acp_tool".into(),
-                        text: envelope.content,
+                        text: bounded_ui_text(&envelope.content, UI_TOOL_RESULT_MAX_CHARS),
                         tool_name: Some(envelope.title),
                         ok: Some(matches!(envelope.status.as_str(), "completed" | "failed")),
                         duration_ms: None,
@@ -1192,7 +1196,7 @@ fn messages_to_items(msgs: &[wisp_llm::Message]) -> Vec<UiItem> {
                 } else {
                     out.push(UiItem {
                         role: "tool".into(),
-                        text,
+                        text: bounded_ui_tool_result(m.tool_name.as_deref().unwrap_or(""), &text),
                         tool_name: m.tool_name.clone(),
                         ok: Some(true),
                         duration_ms: None,
@@ -1214,6 +1218,89 @@ fn messages_to_items(msgs: &[wisp_llm::Message]) -> Vec<UiItem> {
         }
     }
     out
+}
+
+/// Tool cards need their complete JSON bodies, but ordinary tool output is a
+/// transcript preview. Keep that preview bounded on every path (live events,
+/// modern replay, and the message-only fallback used by legacy sessions).
+const UI_TOOL_RESULT_MAX_CHARS: usize = 4_000;
+const UI_TOOL_INPUT_MAX_CHARS: usize = 64 * 1024;
+const UI_OUTPUT_TRUNCATED_MARKER: &str = "\n… output truncated …";
+
+fn bounded_ui_text(value: &str, max_chars: usize) -> String {
+    let mut chars = value.chars();
+    let mut bounded: String = chars.by_ref().take(max_chars).collect();
+    if chars.next().is_none() {
+        return bounded;
+    }
+    let marker_chars = UI_OUTPUT_TRUNCATED_MARKER.chars().count();
+    for _ in 0..marker_chars.min(max_chars) {
+        bounded.pop();
+    }
+    bounded.push_str(UI_OUTPUT_TRUNCATED_MARKER);
+    bounded
+}
+
+fn bounded_ui_tool_input(value: &str) -> String {
+    bounded_ui_text(value, UI_TOOL_INPUT_MAX_CHARS)
+}
+
+fn bounded_ui_tool_result(name: &str, value: &str) -> String {
+    if matches!(
+        name,
+        "attempt_completion" | wisp_tools::plan::PROPOSE_PLAN | wisp_tools::ask_user::ASK_USER
+    ) {
+        value.to_string()
+    } else {
+        bounded_ui_text(value, UI_TOOL_RESULT_MAX_CHARS)
+    }
+}
+
+/// Replay uses the same terminal semantics and memory ceiling as live stdout.
+/// This is intentionally byte-based because it bounds the actual IPC/String
+/// allocation while preserving UTF-8 boundaries.
+const UI_STREAM_OUTPUT_MAX_BYTES: usize = 64 * 1024;
+
+fn push_bounded_terminal_chunk(output: &mut String, chunk: &str) {
+    let mut rest = chunk;
+    if output.ends_with('\r') && !rest.is_empty() {
+        output.pop();
+        if let Some(stripped) = rest.strip_prefix('\n') {
+            output.push('\n');
+            rest = stripped;
+        } else {
+            truncate_ui_terminal_line(output);
+        }
+    }
+    while let Some(pos) = rest.find('\r') {
+        output.push_str(&rest[..pos]);
+        let after = &rest[pos + 1..];
+        if after.is_empty() {
+            output.push('\r');
+            rest = after;
+            break;
+        }
+        if let Some(stripped) = after.strip_prefix('\n') {
+            output.push('\n');
+            rest = stripped;
+        } else {
+            truncate_ui_terminal_line(output);
+            rest = after;
+        }
+    }
+    output.push_str(rest);
+    if output.len() > UI_STREAM_OUTPUT_MAX_BYTES {
+        let mut cut = output.len() - UI_STREAM_OUTPUT_MAX_BYTES;
+        while !output.is_char_boundary(cut) {
+            cut += 1;
+        }
+        output.drain(..cut);
+    }
+}
+
+fn truncate_ui_terminal_line(output: &mut String) {
+    let line_start = output.rfind('\n').map_or(0, |index| index + 1);
+    output.truncate(line_start);
 }
 
 fn background_completion_ok(raw: &str) -> Option<bool> {
@@ -1339,7 +1426,7 @@ fn events_to_items(events: &[AgentEvent]) -> (Vec<UiItem>, HashMap<i64, usize>) 
                 tool_name: Some(name.clone()),
                 ok: None,
                 duration_ms: None,
-                input: Some(preview.clone()),
+                input: Some(bounded_ui_tool_input(preview)),
                 model_name: None,
                 call_id: None,
                 kind: None,
@@ -1393,7 +1480,7 @@ fn events_to_items(events: &[AgentEvent]) -> (Vec<UiItem>, HashMap<i64, usize>) 
                         && item.ok.is_none()
                 }) {
                     item.ok = Some(*ok);
-                    item.text = content.clone();
+                    item.text = bounded_ui_tool_result(name, content);
                     item.duration_ms = (*duration_ms > 0).then_some(*duration_ms);
                 }
                 if name == "attempt_completion" && *ok && !content.trim().is_empty() {
@@ -1431,11 +1518,13 @@ fn events_to_items(events: &[AgentEvent]) -> (Vec<UiItem>, HashMap<i64, usize>) 
             }
             AgentEvent::Stdout { chunk, .. } => {
                 if let Some(item) = items.iter_mut().rev().find(|item| item.role == "tool") {
-                    item.text.push_str(chunk);
+                    push_bounded_terminal_chunk(&mut item.text, chunk);
                 } else {
+                    let mut text = String::new();
+                    push_bounded_terminal_chunk(&mut text, chunk);
                     items.push(UiItem {
                         role: "tool".into(),
-                        text: chunk.clone(),
+                        text,
                         tool_name: Some("stdout".into()),
                         ok: None,
                         duration_ms: None,
@@ -1497,6 +1586,36 @@ fn usage_item(
 const MAX_PENDING_UI_EVENT_BYTES: usize = 64 * 1024;
 const UI_EVENT_FLUSH_INTERVAL: std::time::Duration = std::time::Duration::from_millis(250);
 
+/// Keep future session event logs bounded as well as their replay. Completed
+/// tools have a separate `ToolResult` preview, so persisted stdout is only the
+/// recoverable in-progress tail and never needs to grow without limit.
+fn limit_persisted_ui_event(mut event: AgentEvent, stdout_bytes: &mut usize) -> Option<AgentEvent> {
+    match &mut event {
+        AgentEvent::ToolCall { .. } | AgentEvent::ToolResult { .. } | AgentEvent::User { .. } => {
+            *stdout_bytes = 0;
+        }
+        AgentEvent::Stdout { chunk, .. } => {
+            let remaining = UI_STREAM_OUTPUT_MAX_BYTES.saturating_sub(*stdout_bytes);
+            if remaining == 0 {
+                return None;
+            }
+            if chunk.len() > remaining {
+                let mut end = remaining;
+                while end > 0 && !chunk.is_char_boundary(end) {
+                    end -= 1;
+                }
+                chunk.truncate(end);
+            }
+            if chunk.is_empty() {
+                return None;
+            }
+            *stdout_bytes += chunk.len();
+        }
+        _ => {}
+    }
+    Some(event)
+}
+
 fn merge_pending_ui_event(
     pending: &mut Option<AgentEvent>,
     event: AgentEvent,
@@ -1542,6 +1661,7 @@ async fn persist_ui_events(
     flush_interval: std::time::Duration,
 ) {
     let mut pending = None;
+    let mut persisted_stdout_bytes = 0usize;
     let mut ticker = tokio::time::interval(flush_interval);
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     ticker.tick().await;
@@ -1549,8 +1669,10 @@ async fn persist_ui_events(
         tokio::select! {
             event = rx.recv() => match event {
                 Some(event) => {
-                    if let Some(event) = merge_pending_ui_event(&mut pending, event) {
-                        append_ui_event(&store, &frame_id, &mut seq, event).await;
+                    if let Some(event) = limit_persisted_ui_event(event, &mut persisted_stdout_bytes) {
+                        if let Some(event) = merge_pending_ui_event(&mut pending, event) {
+                            append_ui_event(&store, &frame_id, &mut seq, event).await;
+                        }
                     }
                 }
                 None => break,
@@ -2493,26 +2615,15 @@ impl Output for TauriOutput {
         self.emit(AgentEvent::ToolCall {
             frame_id: self.frame_id.clone(),
             name: name.into(),
-            preview: preview.into(),
+            preview: bounded_ui_tool_input(preview),
         });
     }
     fn tool_result(&self, name: &str, ok: bool, content: &str, duration_ms: u64) {
-        // ponytail: some tool results ARE the card the UI renders, not a preview
-        // of one — attempt_completion is the final answer bubble, propose_plan
-        // and ask_user are card JSON bodies. A clip would truncate them into junk.
-        let clipped: String = if matches!(
-            name,
-            "attempt_completion" | wisp_tools::plan::PROPOSE_PLAN | wisp_tools::ask_user::ASK_USER
-        ) {
-            content.to_string()
-        } else {
-            content.chars().take(4000).collect()
-        };
         self.emit(AgentEvent::ToolResult {
             frame_id: self.frame_id.clone(),
             name: name.into(),
             ok,
-            content: clipped,
+            content: bounded_ui_tool_result(name, content),
             duration_ms,
         });
     }
@@ -6509,7 +6620,7 @@ async fn generate_follow_up_questions(
     }
     let messages = state
         .store
-        .load_messages(&session_id)
+        .load_recent_turn_preview_messages(&session_id, FOLLOW_UP_TRANSCRIPT_TURNS)
         .await
         .map_err(|error| error.to_string())?;
     let specialist = specialists::session_specialist(&state.store, &session_id).await;

--- a/src-tauri/src/lib_tests.rs
+++ b/src-tauri/src/lib_tests.rs
@@ -4,15 +4,16 @@ use super::desktop_lifecycle::{should_activate_workspace_window, should_hide_wor
 use super::session_commands::transcript_page_items;
 use super::{
     begin_queued_cutin, branch_title, client_turn_error, coalesce_live_agent_events,
-    copy_dir_recursive, enable_referenced_contexts, events_to_items, merge_pending_ui_event,
-    message_uses_resource_bindings, messages_to_items, parse_disabled_skills,
-    parse_enabled_skill_names, parse_follow_up_questions, parse_skill_tags, persist_ui_events,
-    receive_confirm_decision, reclaim_unconsumed_cutin, resolve_acp_artifact_references,
-    resolve_composer_references, resolve_reader_references, resolve_review_backend,
-    resolve_workspace, session_runtime_status, should_hide_app_on_macos_close,
-    should_persist_ui_event, side_chat_prompt, user_message_start, AgentEvent,
-    ComposerReferenceArg, McpConnection, McpHttpAuth, McpTransport, QueuedItem, SessionRuntime,
-    SkillInfo, StartupReport, StartupTimeline, MAX_PENDING_UI_EVENT_BYTES,
+    copy_dir_recursive, enable_referenced_contexts, events_to_items, limit_persisted_ui_event,
+    merge_pending_ui_event, message_uses_resource_bindings, messages_to_items,
+    parse_disabled_skills, parse_enabled_skill_names, parse_follow_up_questions, parse_skill_tags,
+    persist_ui_events, receive_confirm_decision, reclaim_unconsumed_cutin,
+    resolve_acp_artifact_references, resolve_composer_references, resolve_reader_references,
+    resolve_review_backend, resolve_workspace, session_runtime_status,
+    should_hide_app_on_macos_close, should_persist_ui_event, side_chat_prompt, user_message_start,
+    AgentEvent, ComposerReferenceArg, McpConnection, McpHttpAuth, McpTransport, QueuedItem,
+    SessionRuntime, SkillInfo, StartupReport, StartupTimeline, MAX_PENDING_UI_EVENT_BYTES,
+    UI_STREAM_OUTPUT_MAX_BYTES, UI_TOOL_RESULT_MAX_CHARS,
 };
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
@@ -375,6 +376,28 @@ fn reloaded_tool_items_keep_notebook_source() {
 }
 
 #[test]
+fn legacy_tool_replay_is_bounded_but_complete_cards_are_not_truncated() {
+    let ordinary = wisp_llm::Message::tool(
+        "call-shell",
+        "shell",
+        "x".repeat(UI_TOOL_RESULT_MAX_CHARS + 500),
+    );
+    let completion_body = "y".repeat(UI_TOOL_RESULT_MAX_CHARS + 500);
+    let completion = wisp_llm::Message::tool(
+        "call-completion",
+        "attempt_completion",
+        completion_body.clone(),
+    );
+
+    let items = messages_to_items(&[ordinary, completion]);
+
+    assert_eq!(items[0].text.chars().count(), UI_TOOL_RESULT_MAX_CHARS);
+    assert!(items[0].text.ends_with("… output truncated …"));
+    assert_eq!(items[1].role, "assistant");
+    assert_eq!(items[1].text, completion_body);
+}
+
+#[test]
 fn reloaded_propose_plan_result_rebuilds_the_plan_card() {
     let plan = wisp_llm::Message::tool(
         "call-plan",
@@ -485,6 +508,79 @@ fn persisted_ui_events_keep_live_step_order_and_boundaries() {
     );
     assert_eq!(items[3].text, "/tmp");
     assert_eq!(boundaries.get(&2), Some(&4));
+}
+
+#[test]
+fn persisted_stdout_replay_folds_progress_and_stays_bounded() {
+    let frame_id = "f".to_string();
+    let events = vec![
+        AgentEvent::ToolCall {
+            frame_id: frame_id.clone(),
+            name: "shell".into(),
+            preview: "run".into(),
+        },
+        AgentEvent::Stdout {
+            frame_id: frame_id.clone(),
+            chunk: "10%\r90%\n".into(),
+        },
+        AgentEvent::Stdout {
+            frame_id,
+            chunk: "x".repeat(UI_STREAM_OUTPUT_MAX_BYTES + 1_000),
+        },
+    ];
+
+    let (items, _) = events_to_items(&events);
+    assert_eq!(items.len(), 1);
+    assert!(items[0].text.len() <= UI_STREAM_OUTPUT_MAX_BYTES);
+    assert!(!items[0].text.contains("10%"));
+    assert!(items[0].text.ends_with('x'));
+}
+
+#[test]
+fn persisted_stdout_budget_caps_each_tool_and_resets_at_boundaries() {
+    let mut bytes = 0usize;
+    let first = limit_persisted_ui_event(
+        AgentEvent::Stdout {
+            frame_id: "f".into(),
+            chunk: "a".repeat(UI_STREAM_OUTPUT_MAX_BYTES - 2),
+        },
+        &mut bytes,
+    )
+    .unwrap();
+    assert!(matches!(first, AgentEvent::Stdout { .. }));
+    let clipped = limit_persisted_ui_event(
+        AgentEvent::Stdout {
+            frame_id: "f".into(),
+            chunk: "界界".into(),
+        },
+        &mut bytes,
+    );
+    assert!(
+        clipped.is_none(),
+        "a partial UTF-8 scalar must not be saved"
+    );
+    assert_eq!(bytes, UI_STREAM_OUTPUT_MAX_BYTES - 2);
+    assert!(limit_persisted_ui_event(
+        AgentEvent::ToolResult {
+            frame_id: "f".into(),
+            name: "shell".into(),
+            ok: true,
+            content: "done".into(),
+            duration_ms: 1,
+        },
+        &mut bytes,
+    )
+    .is_some());
+    assert_eq!(bytes, 0);
+    assert!(limit_persisted_ui_event(
+        AgentEvent::Stdout {
+            frame_id: "f".into(),
+            chunk: "next".into(),
+        },
+        &mut bytes,
+    )
+    .is_some());
+    assert_eq!(bytes, 4);
 }
 
 #[test]

--- a/ui/src/app_support/artifacts.rs
+++ b/ui/src/app_support/artifacts.rs
@@ -44,9 +44,9 @@ pub(crate) fn split_segments(text: &str) -> Vec<Seg> {
 /// `assemble_artifacts`, so this half is cacheable per item and streaming only
 /// re-extracts the tail message instead of rescanning the whole transcript.
 pub(crate) enum ProtoArtifact {
-    Table(TableData),
-    Csv(TableData),
-    Fasta(String),
+    Table(Rc<TableData>),
+    Csv(Rc<TableData>),
+    Fasta(Rc<str>),
     Latex(String),
     File { path: String, kind: &'static str },
 }
@@ -80,7 +80,7 @@ pub(crate) struct ArtifactScan {
 pub(crate) fn extract_markdown_protos(out: &mut Vec<ProtoArtifact>, s: &str) {
     for seg in split_segments(s) {
         if let Seg::Table(t) = seg {
-            out.push(ProtoArtifact::Table(t));
+            out.push(ProtoArtifact::Table(Rc::new(t)));
         }
     }
     for (lang, body) in fenced_blocks(s) {
@@ -89,10 +89,10 @@ pub(crate) fn extract_markdown_protos(out: &mut Vec<ProtoArtifact>, s: &str) {
             if let Some(header) = lines.first() {
                 let headers = parse_csv_line(header);
                 let rows = lines[1..].iter().map(|line| parse_csv_line(line)).collect();
-                out.push(ProtoArtifact::Csv(TableData { headers, rows }));
+                out.push(ProtoArtifact::Csv(Rc::new(TableData { headers, rows })));
             }
         } else if lang == "fasta" || lang == "fa" {
-            out.push(ProtoArtifact::Fasta(body));
+            out.push(ProtoArtifact::Fasta(Rc::from(body)));
         }
     }
     let lines: Vec<&str> = s.lines().collect();
@@ -710,6 +710,33 @@ mod artifact_scan_tests {
 
     fn fresh(items: &[ChatItem], locale: Locale) -> Vec<Artifact> {
         collect_artifacts(items, locale, &mut ProtoCache::new())
+    }
+
+    #[test]
+    fn cached_table_payload_is_shared_across_artifact_projections() {
+        let item = ChatItem::Assistant {
+            text: "| sample | value |\n| --- | --- |\n| a | 1 |".into(),
+            model: None,
+            resources: Vec::new(),
+        };
+        let protos = Rc::new(extract_protos(&item));
+        let proto_table = match &protos[0] {
+            ProtoArtifact::Table(table) => table,
+            _ => panic!("expected a table proto"),
+        };
+        let artifacts = assemble_artifacts(&[Rc::clone(&protos)], Locale::En);
+        let artifact_table = match &artifacts[0].data {
+            PreviewData::Table(table) => table,
+            _ => panic!("expected a table artifact"),
+        };
+        assert!(Rc::ptr_eq(proto_table, artifact_table));
+
+        let current = current_artifacts(&artifacts, &[], "", &HashSet::new());
+        let current_table = match &current[0].data {
+            PreviewData::Table(table) => table,
+            _ => panic!("expected a current table artifact"),
+        };
+        assert!(Rc::ptr_eq(artifact_table, current_table));
     }
 
     /// #307 made .R/.py previewable, which must not also turn every source path

--- a/ui/src/app_support/previews.rs
+++ b/ui/src/app_support/previews.rs
@@ -89,7 +89,7 @@ pub(crate) fn artifact_meta(a: &Artifact, locale: Locale) -> String {
         PreviewData::Fasta(s) => tf(
             locale,
             "artifact.meta.fasta",
-            &[("seqs", &fasta_seq_count(s).max(1).to_string())],
+            &[("seqs", &fasta_seq_count(s.as_ref()).max(1).to_string())],
         ),
         PreviewData::Smiles(s) => s.chars().take(28).collect(),
         PreviewData::Text(s) | PreviewData::Markdown(s) => tf(
@@ -1244,7 +1244,7 @@ pub(crate) fn FilePreview(dom_id: String, path: String, kind: String) -> impl In
 
 pub(crate) fn artifact_preview(a: &Artifact, dom_id: String, locale: Locale) -> impl IntoView {
     match &a.data {
-        PreviewData::Table(t) => table_view(t, locale).into_view(),
+        PreviewData::Table(t) => table_view(t.as_ref(), locale).into_view(),
         PreviewData::Text(s) => view! { <pre class="rp-pre">{s.clone()}</pre> }.into_view(),
         PreviewData::Markdown(s) => {
             let hid_for_effect = dom_id.clone();
@@ -1258,7 +1258,7 @@ pub(crate) fn artifact_preview(a: &Artifact, dom_id: String, locale: Locale) -> 
                 .into_view()
         }
         PreviewData::Fasta(text) => {
-            let payload = serde_json::json!({ "text": text }).to_string();
+            let payload = serde_json::json!({ "text": text.as_ref() }).to_string();
             view! { <HeavyPreview dom_id=dom_id kind="fasta".to_string() payload=payload /> }
                 .into_view()
         }

--- a/ui/src/dto.rs
+++ b/ui/src/dto.rs
@@ -10,6 +10,7 @@
 use crate::i18n::Locale;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::rc::Rc;
 
 #[derive(Deserialize, Serialize, Clone, Copy, Debug, Default, Hash, PartialEq, Eq)]
 pub(crate) struct ContextUsage {
@@ -2023,13 +2024,13 @@ pub(crate) struct TableData {
 #[derive(Clone, PartialEq)]
 #[allow(dead_code)]
 pub(crate) enum PreviewData {
-    Table(TableData),
+    Table(Rc<TableData>),
     Text(String),
     Markdown(String),
     Latex { tex: String, display: bool },
     File { path: String, kind: String },
     Smiles(String),
-    Fasta(String),
+    Fasta(Rc<str>),
 }
 
 #[derive(Clone, PartialEq)]

--- a/ui/src/notebook.rs
+++ b/ui/src/notebook.rs
@@ -17,9 +17,9 @@ enum NotebookOrigin {
 
 #[derive(Clone, PartialEq)]
 pub(super) struct NotebookProto {
-    language: String,
-    source: String,
-    output: String,
+    language: Rc<str>,
+    source: Rc<str>,
+    output: Rc<str>,
     ok: Option<bool>,
     origin: NotebookOrigin,
 }
@@ -27,9 +27,9 @@ pub(super) struct NotebookProto {
 #[derive(Clone, PartialEq)]
 pub(super) struct NotebookCell {
     index: usize,
-    language: String,
-    source: String,
-    output: String,
+    language: Rc<str>,
+    source: Rc<str>,
+    output: Rc<str>,
     ok: Option<bool>,
     origin: NotebookOrigin,
 }
@@ -42,13 +42,13 @@ fn item_notebook_protos(item: &ChatItem) -> Vec<NotebookProto> {
             .into_iter()
             .filter(|(language, _)| !matches!(language.as_str(), "csv" | "tsv" | "fasta" | "fa"))
             .map(|(language, source)| NotebookProto {
-                language: if language.is_empty() {
-                    "text".into()
+                language: Rc::from(if language.is_empty() {
+                    "text".to_string()
                 } else {
                     language
-                },
-                source,
-                output: String::new(),
+                }),
+                source: Rc::from(source),
+                output: Rc::from(""),
                 ok: None,
                 origin: NotebookOrigin::Assistant,
             })
@@ -71,13 +71,13 @@ fn item_notebook_protos(item: &ChatItem) -> Vec<NotebookProto> {
                 input.clone()
             };
             vec![NotebookProto {
-                language: match name.as_str() {
-                    "python" => "python".into(),
-                    "r" => "r".into(),
-                    _ => "bash".into(),
-                },
-                source,
-                output: output.clone(),
+                language: Rc::from(match name.as_str() {
+                    "python" => "python",
+                    "r" => "r",
+                    _ => "bash",
+                }),
+                source: Rc::from(source),
+                output: Rc::from(output.as_str()),
                 ok: *ok,
                 origin: if matches!(name.as_str(), "python" | "r") {
                     NotebookOrigin::Repl
@@ -110,25 +110,25 @@ pub(super) fn collect_notebook_cells(
 
     // A code fence that is subsequently executed is one cell, not two. Keep
     // every actual execution so intentionally repeated REPL calls remain visible.
-    let executed: HashSet<String> = per_item
+    let executed: HashSet<&str> = per_item
         .iter()
         .flat_map(|protos| protos.iter())
         .filter(|proto| proto.origin != NotebookOrigin::Assistant)
-        .map(|proto| proto.source.trim().to_string())
+        .map(|proto| proto.source.trim())
         .collect();
 
     per_item
-        .into_iter()
-        .flat_map(|protos| protos.iter().cloned().collect::<Vec<_>>())
+        .iter()
+        .flat_map(|protos| protos.iter())
         .filter(|proto| {
             proto.origin != NotebookOrigin::Assistant || !executed.contains(proto.source.trim())
         })
         .enumerate()
         .map(|(index, proto)| NotebookCell {
             index,
-            language: proto.language,
-            source: proto.source,
-            output: proto.output,
+            language: Rc::clone(&proto.language),
+            source: Rc::clone(&proto.source),
+            output: Rc::clone(&proto.output),
             ok: proto.ok,
             origin: proto.origin,
         })
@@ -157,11 +157,11 @@ pub(super) fn NotebookView(
     view! {
         <div class="notebook-cells">
             {cells.into_iter().map(|cell| {
-                let copy = cell.source.clone();
-                let language = cell.language.clone();
-                let source = cell.source.clone();
-                let star_language = cell.language.clone();
-                let star_source = cell.source.clone();
+                let copy = cell.source.to_string();
+                let language = cell.language.to_string();
+                let source = cell.source.to_string();
+                let star_language = cell.language.to_string();
+                let star_source = cell.source.to_string();
                 let starred = create_memo(move |_| {
                     active_session.get().is_some_and(|session| {
                         library_items.get().iter().any(|item| {
@@ -169,10 +169,10 @@ pub(super) fn NotebookView(
                         })
                     })
                 });
-                let click_language = cell.language.clone();
-                let click_source = cell.source.clone();
+                let click_language = cell.language.to_string();
+                let click_source = cell.source.to_string();
                 let has_output = !cell.output.is_empty();
-                let output = cell.output.clone();
+                let output = cell.output.to_string();
                 let output_open = cell.ok == Some(false);
                 let runtime = match cell.origin {
                     NotebookOrigin::Assistant => t(locale, "notebook.assistant"),
@@ -272,11 +272,21 @@ mod tests {
             },
         ];
 
-        let cells = collect_notebook_cells(&items, &mut NotebookCache::new());
+        let mut cache = NotebookCache::new();
+        let cells = collect_notebook_cells(&items, &mut cache);
         assert_eq!(cells.len(), 2);
-        assert_eq!(cells[0].language, "rust");
-        assert_eq!(cells[1].language, "python");
-        assert_eq!(cells[1].output, "1");
+        assert_eq!(cells[0].language.as_ref(), "rust");
+        assert_eq!(cells[1].language.as_ref(), "python");
+        assert_eq!(cells[1].output.as_ref(), "1");
+        let executed_proto = cache
+            .values()
+            .flat_map(|protos| protos.iter())
+            .find(|proto| {
+                proto.origin != NotebookOrigin::Assistant && proto.source.as_ref() == "print(1)"
+            })
+            .unwrap();
+        assert!(Rc::ptr_eq(&cells[1].source, &executed_proto.source));
+        assert!(Rc::ptr_eq(&cells[1].output, &executed_proto.output));
     }
 
     #[test]
@@ -291,7 +301,7 @@ mod tests {
         }];
         let cells = collect_notebook_cells(&items, &mut NotebookCache::new());
         assert_eq!(cells.len(), 1);
-        assert_eq!(cells[0].language, "r");
-        assert_eq!(cells[0].source, "summary(dataset)");
+        assert_eq!(cells[0].language.as_ref(), "r");
+        assert_eq!(cells[0].source.as_ref(), "summary(dataset)");
     }
 }


### PR DESCRIPTION
## Problem

Long, tool-heavy conversations could leave the desktop UI unresponsive when a turn completed or a saved session was reopened. The WebView replay path rebuilt unbounded persisted stdout, the follow-up-question request loaded the full conversation, and artifact/notebook projections still deep-copied large cached payloads.

## Changes

- Bound ordinary tool-result previews, tool inputs, and terminal stdout on live and replay paths while preserving complete answer, plan, and question cards.
- Cap legacy stdout in the SQLite transcript-page query before event JSON reaches Tauri or the WebView, and bound newly persisted stdout per tool activity.
- Generate follow-up questions from four recent, size-bounded textual turns instead of loading the entire session, images, reasoning, and full tool arguments.
- Share cached table, FASTA, notebook source, and notebook output payloads with `Rc` so artifact/notebook projections no longer deep-copy large values.
- Document the presentation limits and add regression coverage for legacy replay, UTF-8 boundaries, recent-turn loading, and shared projection payloads.

## User impact

Completing, reopening, and continuing large scientific sessions should remain responsive. Full durable agent transcripts remain unchanged; only the desktop presentation/replay and secondary follow-up prompt are bounded.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cd ui && cargo check --target wasm32-unknown-unknown`
- Targeted UI unit tests for shared artifact and notebook payloads
- `cd ui-tests && npm ci && npx playwright test` — 301 passed, 1 optional real-MCP test skipped