### PR TITLE
Fix composer picker for Windows IME punctuation

### DIFF
--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -1489,6 +1489,22 @@ test("composer picker follows manual caret insertions and ignores pasted text", 
   await enterApp(page);
   const composerInput = composer(page);
 
+  // Windows Chinese IMEs can commit punctuation through the composition path
+  // without exposing the committed character as InputEvent.data (#733).
+  await composerInput.evaluate((element) => {
+    const textarea = element as HTMLTextAreaElement;
+    textarea.focus();
+    textarea.value = "#";
+    textarea.setSelectionRange(1, 1);
+    textarea.dispatchEvent(new InputEvent("input", {
+      bubbles: true,
+      inputType: "insertCompositionText",
+    }));
+  });
+  await expect(page.locator(".mention-menu")).toBeVisible();
+  await page.keyboard.press("Escape");
+  await composerInput.fill("");
+
   await composerInput.fill("已有文字");
   await composerInput.evaluate((element) => {
     const textarea = element as HTMLTextAreaElement;

--- a/ui/src/app_support/composer.rs
+++ b/ui/src/app_support/composer.rs
@@ -587,6 +587,28 @@ pub(crate) fn active_composer_trigger(
     Some((at, end, mode, query.to_string()))
 }
 
+/// Whether an input edit should keep or open the picker for the active token.
+///
+/// Windows IMEs may report punctuation such as `@` and `#` as composition
+/// input, with `InputEvent.data` absent or different from the committed text.
+/// The textarea value and caret have already established which trigger was
+/// entered, so opening must depend on the insertion kind rather than `data`.
+pub(crate) fn composer_picker_accepts_edit(
+    input_type: &str,
+    prior_mode: Option<ComposerPickerMode>,
+    prior_start: Option<usize>,
+    start: usize,
+    query_is_empty: bool,
+) -> bool {
+    let continues_token = prior_mode.is_some() && prior_start == Some(start);
+    let inserts_trigger = query_is_empty
+        && matches!(
+            input_type,
+            "insertText" | "insertCompositionText" | "insertFromComposition"
+        );
+    continues_token || inserts_trigger
+}
+
 pub(crate) fn scroll_picker_item(selector: &str, index: usize) {
     let Some(document) = web_sys::window().and_then(|window| window.document()) else {
         return;
@@ -601,7 +623,9 @@ pub(crate) fn scroll_picker_item(selector: &str, index: usize) {
 
 #[cfg(test)]
 mod mention_tests {
-    use super::{active_composer_trigger, ComposerPickerMode};
+    use super::{
+        active_composer_trigger, composer_picker_accepts_edit, ComposerPickerMode,
+    };
 
     #[test]
     fn detects_trigger_at_the_caret() {
@@ -645,6 +669,48 @@ mod mention_tests {
             active_composer_trigger(text, text.encode_utf16().count()),
             None
         );
+    }
+
+    #[test]
+    fn opens_picker_for_direct_and_ime_trigger_input() {
+        for input_type in [
+            "insertText",
+            "insertCompositionText",
+            "insertFromComposition",
+        ] {
+            assert!(composer_picker_accepts_edit(
+                input_type,
+                None,
+                None,
+                3,
+                true
+            ));
+        }
+        assert!(!composer_picker_accepts_edit(
+            "deleteContentBackward",
+            None,
+            None,
+            3,
+            true
+        ));
+    }
+
+    #[test]
+    fn keeps_picker_open_while_editing_its_active_token() {
+        assert!(composer_picker_accepts_edit(
+            "deleteContentBackward",
+            Some(ComposerPickerMode::Artifact),
+            Some(3),
+            3,
+            false
+        ));
+        assert!(!composer_picker_accepts_edit(
+            "insertText",
+            Some(ComposerPickerMode::Artifact),
+            Some(1),
+            3,
+            false
+        ));
     }
 }
 

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -9218,13 +9218,13 @@ fn App() -> impl IntoView {
                                 };
                                 let v = textarea.value();
                                 let input_type = input_event.input_type();
-                                let data = input_event.data();
                                 let prior_mode = picker_mode.get_untracked();
                                 let prior_range = picker_token_range.get_untracked();
                                 let manual_edit = matches!(
                                     input_type.as_str(),
                                     "insertText"
                                         | "insertCompositionText"
+                                        | "insertFromComposition"
                                         | "deleteCompositionText"
                                         | "deleteContentBackward"
                                         | "deleteContentForward"
@@ -9237,15 +9237,13 @@ fn App() -> impl IntoView {
                                 match active {
                                     Some((start, end, mode, query))
                                         if manual_edit
-                                            && (prior_mode == Some(mode)
-                                                && prior_range.is_some_and(|(prior_start, _)| prior_start == start)
-                                                || input_type == "insertText"
-                                                    && query.is_empty()
-                                                    && data.as_deref() == Some(match mode {
-                                                        ComposerPickerMode::Artifact => "@",
-                                                        ComposerPickerMode::Session => "#",
-                                                        ComposerPickerMode::Skill => "/",
-                                                    })) =>
+                                            && composer_picker_accepts_edit(
+                                                &input_type,
+                                                (prior_mode == Some(mode)).then_some(mode),
+                                                prior_range.map(|(prior_start, _)| prior_start),
+                                                start,
+                                                query.is_empty(),
+                                            ) =>
                                     {
                                         picker_token_range.set(Some((start, end)));
                                         picker_query.set(query);


### PR DESCRIPTION
## Problem

Typing `@` or `#` with a Windows Chinese IME did not open the composer reference picker. Enabling Caps Lock made it work because the characters then followed the direct text-input path.

Fixes #733.

## Root cause

The picker required `InputEvent.data` to exactly equal the trigger character on its first edit. Windows IMEs can deliver punctuation through composition events with absent or different `data`, even though the textarea value and caret contain the correct committed trigger.

## Changes

- Detect picker triggers from the textarea value, caret position, and insertion type instead of relying on `InputEvent.data`.
- Support `insertCompositionText` and `insertFromComposition` while retaining paste and deletion safeguards.
- Add unit coverage for direct and composition input.
- Add a Playwright regression test that simulates the Windows IME event shape.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --manifest-path ui/Cargo.toml mention_tests` (5 passed)
- `cargo check --manifest-path ui/Cargo.toml --target wasm32-unknown-unknown`
- `npx playwright test tests/ui.spec.ts --grep "composer picker follows manual caret insertions"` (1 passed)

The full workspace suite was also run before rebasing. The changed UI tests passed; `wisp-tauri` had 10 unrelated existing Windows failures involving path case normalization, temporary-file sharing, and method-search project-root checks.