### PR TITLE
Fix workspace switcher behavior

### DIFF
--- a/docs/workspace-navigation.md
+++ b/docs/workspace-navigation.md
@@ -4,6 +4,10 @@ By default, opening a workspace restores its most recently active conversation.
 Opening a specific conversation from Recent sessions or search still takes
 priority.
 
+Choose another workspace from the sidebar workspace menu to switch the current
+window in place. A separate window is opened only by an action explicitly
+labelled **Open in new window**.
+
 To open workspaces on a blank conversation instead, turn off **Resume the last
 conversation when opening a workspace** in **Settings → General**. Starting a
 new conversation manually is always available from the sidebar. A newly

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -7680,6 +7680,19 @@ test("project switcher does not show a stale fallback name while opening", async
   await expect(page.locator(".proj-name")).toHaveText("wisp-science");
 });
 
+test("project switcher has no caret and switches workspace in the current window", async ({ page }) => {
+  await enterApp(page);
+  const switcher = page.locator(".proj-switch");
+  await expect(switcher.locator(".caret")).toHaveCount(0);
+
+  await switcher.click();
+  await page.locator(".proj-menu").getByRole("button", { name: "Other project" }).click();
+
+  await expect.poll(() => lastInvokeArgs(page, "open_project")).toMatchObject({ id: "other" });
+  await expect.poll(() => lastInvokeArgs(page, "open_project_window")).toBeNull();
+  await expect(page.locator(".proj-name")).toHaveText("Other project");
+});
+
 test("opening a workspace resumes its most recent conversation by default", async ({ page }) => {
   await page.goto("/?mockLongSession=1");
   await page.locator(".proj-card-main").first().click();

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -7257,24 +7257,17 @@ fn App() -> impl IntoView {
     spawn_local(async move {
         let _ = listen_current_window("open-session", &open_session_js).await;
     });
-    // Cross-project opens from inside a workspace go to the target project's
-    // own window (#423). The landing (and a window with no project yet) keeps
-    // repointing the current window — it's the "enter a project here" surface.
+    // Cross-project conversation opens may still target the project's own
+    // window (#423). Choosing a workspace itself always repoints this window.
     let opens_in_project_window = move |project_id: &str| -> bool {
         !show_projects.get_untracked()
             && matches!(project_info.get_untracked(), Some(p) if p.id != project_id)
     };
-    // Switch the active project inline (same guarded flow as the Projects screen).
+    // Workspace pickers always switch the active project in this window. New
+    // windows remain available only through actions explicitly labelled as such.
     let switch_project = {
         let open_project_transition = open_project_transition;
         Callback::new(move |id: String| {
-            if opens_in_project_window(&id) {
-                spawn_local(async move {
-                    let arg = to_value(&serde_json::json!({ "id": id })).unwrap();
-                    let _ = invoke("open_project_window", arg).await;
-                });
-                return;
-            }
             open_project_transition.call((id, None));
         })
     };

--- a/ui/src/sidebar.rs
+++ b/ui/src/sidebar.rs
@@ -187,7 +187,6 @@ pub(super) fn Sidebar(
                     title=move || if demo_mode.get() { t(locale.get(), "projects.example").to_string() } else { project_info.get().map(|p| p.name.clone()).unwrap_or_else(|| t(locale.get(), "projects.opening").into()) }
                     on:click=move |ev| toggle_proj_menu.call(ev)>
                     <span class="proj-name">{move || if demo_mode.get() { t(locale.get(), "projects.example").to_string() } else { project_info.get().map(|p| p.name.clone()).unwrap_or_else(|| t(locale.get(), "projects.opening").into()) }}</span>
-                    <span class="caret">"▾"</span>
                 </button>
                 <button class="icon-btn" title=move || t(locale.get(), "sidebar.collapse") on:click=move |_| show_sidebar.set(false)>{compose_icon("chevron-left")}</button>
             </div>

--- a/ui/src/styles/alignment.css
+++ b/ui/src/styles/alignment.css
@@ -15,7 +15,7 @@
 .side-back .gi { width: 16px; height: 16px; opacity: .85; }
 .side-back:hover .gi { opacity: 1; }
 
-/* --- Project switcher pill (name + caret, opens dropdown) --- */
+/* --- Project switcher pill (name opens dropdown) --- */
 .proj-switch {
   flex: 1 1 auto; min-width: 0; display: flex; align-items: center; gap: 6px;
   text-align: left; background: transparent; border: 1px solid transparent;
@@ -25,7 +25,6 @@
 }
 .proj-switch:hover, .proj-switch.active { background: var(--bg-elev); }
 .proj-switch .proj-name { font-weight: 600; font-size: 14px; letter-spacing: -0.015em; flex: 1 1 auto; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
-.proj-switch .caret { color: var(--text-faint); font-size: 10px; flex: 0 0 auto; }
 
 /* --- Project switcher dropdown --- */
 .proj-menu-backdrop { position: fixed; inset: 0; z-index: 40; }

--- a/ui/src/styles/sidebar.css
+++ b/ui/src/styles/sidebar.css
@@ -253,7 +253,6 @@ button.side-item.ses.selecting { padding-right: 10px; }
   }
   .sidebar-head .icon-btn { display: none; }
   .sidebar .proj-name,
-  .sidebar .caret,
   .sidebar .side-group-title,
   .sidebar .side-sessions-head,
   .sidebar .side-session-search,


### PR DESCRIPTION
## What changed

- Removed the faint caret from the sidebar workspace switcher and cleaned up its unused styles.
- Changed workspace selections to switch the active workspace in the current window.
- Preserved explicitly labelled **Open in new window** actions.
- Added Playwright coverage for the visual and navigation behavior.
- Documented the workspace switching behavior.

## Why

The caret was too subtle to be useful, and selecting another workspace from the sidebar unexpectedly opened a separate window instead of switching the current workspace.

## Root cause

The sidebar switcher reused a callback that routed cross-workspace selections through `open_project_window`. The switcher now always uses the guarded in-place project transition; dedicated new-window actions still invoke `open_project_window` explicitly.

## Impact

Users can switch workspaces from the sidebar without creating extra windows, while intentional new-window workflows continue to work.

## Validation

- `cargo fmt --all -- --check`
- `cd ui && cargo check --target wasm32-unknown-unknown`
- `cargo test --workspace`
- `cd ui-tests && npx playwright test` — 313 passed, 1 skipped
