### PR TITLE
Fix Generated artifact attribution after follow-up tools

### DIFF
--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -4174,11 +4174,11 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
                   ok: true,
                   content: "old.csv\nplots/old.png\nnotes/old-report.md",
                 });
-                emit("agent", { kind: "ToolCall", frame_id: fid, name: "write", preview: "results/new.csv" });
+                emit("agent", { kind: "ToolCall", frame_id: fid, name: "write", preview: "results/new.png" });
                 emit("agent", {
                   kind: "FileChanged",
                   frame_id: fid,
-                  path: "/mock/root/results/new.csv",
+                  path: "/mock/root/results/new.png",
                 });
                 emit("agent", {
                   kind: "ToolResult",
@@ -4186,6 +4186,24 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
                   name: "write",
                   ok: true,
                   content: "write completed",
+                });
+                emit("agent", {
+                  kind: "Text",
+                  frame_id: fid,
+                  delta: "I will verify the generated output first.",
+                });
+                emit("agent", {
+                  kind: "ToolCall",
+                  frame_id: fid,
+                  name: "view_image",
+                  preview: "results/new.png",
+                });
+                emit("agent", {
+                  kind: "ToolResult",
+                  frame_id: fid,
+                  name: "view_image",
+                  ok: true,
+                  content: "output verified",
                 });
                 emit("agent", {
                   kind: "Text",

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -2965,7 +2965,7 @@ test("uploaded file shows up in the artifacts panel after send", async ({ page }
   await expect.poll(() => lastInvokeArgs(page, "download_file")).toMatchObject({ path: "uploads/counts.csv" });
 });
 
-test("Generated artifacts require FileChanged evidence instead of mentioned paths", async ({ page }) => {
+test("Generated artifacts survive follow-up tool commentary and ignore mentioned paths", async ({ page }) => {
   await enterApp(page);
   await composer(page).fill("ARTIFACTATTRIBUTION");
   await page.getByRole("button", { name: "Send" }).click();
@@ -2975,7 +2975,7 @@ test("Generated artifacts require FileChanged evidence instead of mentioned path
   });
   await expect(reply).toBeVisible({ timeout: 10_000 });
   await expect(reply.locator(".message-artifacts-label")).toHaveText("Generated · 1");
-  await expect(reply.locator('.message-artifact-card[data-artifact-name="new.csv"]')).toBeVisible();
+  await expect(reply.locator('.message-artifact-card[data-artifact-name="new.png"]')).toBeVisible();
   await expect(reply.locator('.message-artifact-card[data-artifact-name="old.csv"]')).toHaveCount(0);
   await expect(reply.locator('.message-artifact-card[data-artifact-name="old.png"]')).toHaveCount(0);
   await expect(reply.locator('.message-artifact-card[data-artifact-name="old-report.md"]')).toHaveCount(0);

--- a/ui/src/app_support/artifacts.rs
+++ b/ui/src/app_support/artifacts.rs
@@ -576,18 +576,22 @@ pub(crate) fn collect_artifacts(
             items.get(artifact.source_item),
             Some(ChatItem::FileChanged(_))
         ) {
-            let next_assistant = items
+            let next_final_assistant = items
                 .iter()
                 .enumerate()
                 .skip(artifact.source_item + 1)
                 .find_map(|(index, item)| match item {
-                    ChatItem::Assistant { .. } => Some(Some(index)),
+                    ChatItem::Assistant { text, .. }
+                        if !text.trim().is_empty() && !is_commentary_at(items, index) =>
+                    {
+                        Some(Some(index))
+                    }
                     ChatItem::User(_) => Some(None),
                     _ => None,
                 })
                 .flatten();
-            if let Some(next_assistant) = next_assistant {
-                artifact.source_item = next_assistant;
+            if let Some(next_final_assistant) = next_final_assistant {
+                artifact.source_item = next_final_assistant;
             }
         }
     }
@@ -828,6 +832,48 @@ mod artifact_scan_tests {
         let artifacts = fresh(&items, Locale::En);
         assert_eq!(artifacts.len(), 1);
         assert_eq!(artifacts[0].source_item, 2);
+    }
+
+    #[test]
+    fn structured_file_writes_skip_tool_call_commentary_for_the_final_reply() {
+        let items = vec![
+            ChatItem::Tool {
+                name: "python".into(),
+                ok: Some(true),
+                input: "save comparison images".into(),
+                output: "five images written".into(),
+                started_at_ms: None,
+                duration_ms: None,
+            },
+            ChatItem::FileChanged("evidence/one.png".into()),
+            ChatItem::FileChanged("evidence/two.png".into()),
+            ChatItem::FileChanged("evidence/three.png".into()),
+            ChatItem::FileChanged("evidence/four.png".into()),
+            ChatItem::FileChanged("evidence/five.png".into()),
+            ChatItem::Assistant {
+                text: "I will inspect the comparison images first.".into(),
+                model: None,
+                resources: Vec::new(),
+            },
+            ChatItem::Tool {
+                name: "view_image".into(),
+                ok: Some(true),
+                input: "evidence/one.png".into(),
+                output: "image is legible".into(),
+                started_at_ms: None,
+                duration_ms: None,
+            },
+            ChatItem::Assistant {
+                text: "The five comparison images are ready.".into(),
+                model: None,
+                resources: Vec::new(),
+            },
+        ];
+
+        assert!(is_commentary_at(&items, 6));
+        let artifacts = fresh(&items, Locale::En);
+        assert_eq!(artifacts.len(), 5);
+        assert!(artifacts.iter().all(|artifact| artifact.source_item == 8));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

PR #735 added structured `FileChanged` evidence for Generated artifacts, but it attributed each write to the next assistant message. When the agent generated files, announced a self-check, called another tool such as `view_image`, and only then produced its final answer, that next assistant message was intermediate commentary. The transcript folded the commentary into the completed activity panel, where inline Generated cards are not rendered, so the final answer showed clickable links but no `Generated · N` cards.

## Changes

- Attribute a structured file write to the next non-empty, non-commentary assistant reply in the same user turn.
- Keep the existing user-turn boundary so a write cannot leak into a later request.
- Add a unit regression matching five Python-generated PNGs followed by self-check commentary and a `view_image` call.
- Extend the Playwright attribution scenario to prove the Generated card remains on the final reply after a follow-up tool.

## User impact

Python/PIL outputs and other structured writes now stay visible as Generated artifacts even when the agent validates them with another tool before answering.

## Validation

- `cargo fmt --all -- --check`
- UI unit tests: 208 passed
- `cd ui && cargo check --target wasm32-unknown-unknown`
- Full Playwright suite: 313 passed, 1 skipped
- `cargo test --workspace`: 586 wisp-tauri tests passed; 10 pre-existing Windows path/case and temporary SQLite lock failures remain in method-search, publication-command, and resource-lease tests

## Manual smoke

1. Ask the agent to generate several PNGs with Python.
2. Have it call `view_image` to validate one or more outputs before the final answer.
3. Confirm the final answer displays `Generated · N` and each PNG card opens correctly.
4. Reload the conversation and confirm the cards remain attached to that final answer.

## Known limitations

- Historical turns that never persisted structured `FileChanged` evidence cannot be retroactively reconstructed.
- This PR fixes reply ownership for existing evidence; it does not change workspace diff discovery.