### PR TITLE
Remove beta label from project landing

### DIFF
--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -7497,7 +7497,7 @@ test("projects landing stays centered on wide windows", async ({ page }) => {
   await page.goto("/");
   await expect(page.locator(".projects-head")).toBeVisible();
   await expect(page.locator(".projects-brand-mark")).toBeVisible();
-  await expect(page.locator(".projects-title")).toContainText("Wisp Science");
+  await expect(page.locator(".projects-title")).toHaveText("Wisp Science");
   await expect.poll(async () => page.locator(".projects-head").evaluate((el) => {
     const rect = el.getBoundingClientRect();
     return Math.round(rect.width);

--- a/ui/src/app_support/projects.rs
+++ b/ui/src/app_support/projects.rs
@@ -396,7 +396,7 @@ pub(crate) fn ProjectsScreen(
             <div class="projects-head">
                 <div class="projects-brand">
                     <span class="projects-brand-mark" aria-hidden="true"></span>
-                    <div class="projects-title">"Wisp Science"<span class="beta">"Beta"</span></div>
+                    <div class="projects-title">"Wisp Science"</div>
                 </div>
                 <div class="projects-actions">
                     <button type="button" class="projects-icon-btn"

--- a/ui/src/styles/projects.css
+++ b/ui/src/styles/projects.css
@@ -38,7 +38,6 @@ body:has(.window-titlebar) .projects-screen { top: 38px; }
   box-shadow: 0 10px 28px color-mix(in srgb, var(--clay) 22%, transparent);
 }
 .projects-title { font-family: var(--font-serif); font-size: var(--text-display); line-height: 1.1; color: var(--text); letter-spacing: -0.02em; }
-.projects-title .beta { font-size: var(--text-sm); color: var(--text-faint); display: block; margin-top: 2px; font-family: var(--font-ui); letter-spacing: 0; }
 .projects-actions { display: flex; align-items: center; gap: var(--space-2); flex: 0 0 auto; }
 .project-open-error { width: min(100%, 1200px); margin: -16px 0 20px; padding: 10px 13px;
   border: 1px solid color-mix(in srgb, var(--err) 32%, var(--border)); border-radius: var(--radius-sm);


### PR DESCRIPTION
## What changed

- Removed the `Beta` label beneath the Wisp Science project landing title.
- Removed the now-unused `.beta` styling.
- Tightened the existing UI assertion so the title must exactly equal `Wisp Science`.

## Why

Wisp Science is no longer presented as beta, so the landing-page branding should no longer show that status.

## User impact

The project landing header now displays only `Wisp Science`.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `npx playwright test tests/ui.spec.ts --grep "projects landing stays centered on wide windows"` (1 passed)