### PR TITLE
Fix interrupted turns being marked complete

### DIFF
--- a/crates/wisp-core/src/agent.rs
+++ b/crates/wisp-core/src/agent.rs
@@ -23,6 +23,7 @@ const STOPPED_BY_USER: &str = "stopped by user";
 const TRUNCATED_OUTPUT_MESSAGE: &str = "模型输出在达到 max_tokens 上限时被截断，任务可能尚未完成——请在设置中调高该模型的 max_tokens，或直接继续对话让我接着做。(output truncated at max_tokens)";
 const STREAM_CUT_MESSAGE: &str = "模型响应流在中途被断开（未收到结束标记），已生成的部分内容不完整、不会计入上下文。常见原因：网络不稳定、代理/中转站切断连接，或同一 API key 的并发请求达到上限（例如多个会话同时使用同一模型）。可重发消息重试；需要并行会话时建议错开请求或使用不同的 API key。(stream cut mid-response, #437)";
 const EMPTY_RESPONSE_MESSAGE: &str = "模型完成了本轮推理，但没有返回可显示的文本或工具调用。对话上下文和已完成的工具结果均已保留；请点击“继续执行”重新生成最终回复。若长对话中反复出现，请先发送 /compact 压缩上下文。(model returned no visible response)";
+const ABNORMAL_FINISH_MESSAGE: &str = "模型服务没有正常完成本轮响应，已生成的部分内容不会作为最终答案提交。已完成的工具结果均已保留；请点击“继续执行”重试。(provider returned an unsuccessful finish reason)";
 /// How many byte-identical tool-call batches within the recent window count as
 /// "stuck". Windowed (not consecutive) so alternating A/B/A/B loops also trip it.
 const STUCK_REPEAT_LIMIT: usize = 5;
@@ -350,6 +351,9 @@ async fn agent_loop_inner(
         }
         if is_truncated(comp.finish_reason.as_deref()) {
             anyhow::bail!(TRUNCATED_OUTPUT_MESSAGE);
+        }
+        if is_unsuccessful_finish(comp.finish_reason.as_deref()) {
+            anyhow::bail!(ABNORMAL_FINISH_MESSAGE);
         }
         // A few reasoning models can terminate cleanly after spending output
         // tokens entirely on `reasoning_content`, leaving neither user-visible
@@ -707,6 +711,13 @@ fn is_truncated(finish_reason: Option<&str>) -> bool {
     matches!(finish_reason, Some("length") | Some("max_tokens"))
 }
 
+fn is_unsuccessful_finish(finish_reason: Option<&str>) -> bool {
+    matches!(
+        finish_reason,
+        Some("incomplete" | "failed" | "cancelled" | "error" | "content_filter")
+    )
+}
+
 /// Signature of a batch of tool calls: each call's name + raw arguments, in
 /// order. Identical signatures on consecutive turns mean the model is stuck
 /// re-issuing the exact same call with no progress.
@@ -742,6 +753,23 @@ mod tests {
         assert!(!is_truncated(Some("stop")));
         assert!(!is_truncated(Some("tool_calls")));
         assert!(!is_truncated(None));
+    }
+
+    #[test]
+    fn unsuccessful_terminal_statuses_are_not_success() {
+        for reason in [
+            "incomplete",
+            "failed",
+            "cancelled",
+            "error",
+            "content_filter",
+        ] {
+            assert!(is_unsuccessful_finish(Some(reason)), "{reason}");
+        }
+        assert!(!is_unsuccessful_finish(Some("stop")));
+        assert!(!is_unsuccessful_finish(Some("tool_calls")));
+        assert!(!is_unsuccessful_finish(Some("completed")));
+        assert!(!is_unsuccessful_finish(None));
     }
 
     #[test]

--- a/crates/wisp-llm/src/anthropic.rs
+++ b/crates/wisp-llm/src/anthropic.rs
@@ -372,6 +372,13 @@ impl Provider for AnthropicProvider {
                 let Ok(val) = serde_json::from_str::<Value>(&data) else {
                     continue;
                 };
+                // Anthropic emits transport/provider failures as `event: error`
+                // inside an otherwise successful SSE response. Relays may also
+                // omit the event name and leave only `{type:"error"}`. Neither
+                // is a completed model turn, even if a terminal frame follows.
+                if anthropic_stream_event_is_error(&etype, &val) {
+                    return Err(LlmError::Incomplete);
+                }
                 match etype.as_str() {
                     "message_start" => {
                         if let Some(u) = val.pointer("/message/usage").or_else(|| val.get("usage"))
@@ -513,6 +520,12 @@ fn parse_sse_event(event: &str) -> (String, String) {
         }
     }
     (etype, data)
+}
+
+fn anthropic_stream_event_is_error(event_type: &str, value: &Value) -> bool {
+    event_type == "error"
+        || value.get("type").and_then(Value::as_str) == Some("error")
+        || value.get("error").is_some()
 }
 
 #[cfg(test)]
@@ -688,5 +701,21 @@ mod tests {
         assert_eq!(usage.input_tokens, 5500);
         assert_eq!(usage.cached_input_tokens, 5000);
         assert_eq!(usage.output_tokens, 42);
+    }
+
+    #[test]
+    fn identifies_named_and_relayed_stream_errors() {
+        assert!(anthropic_stream_event_is_error(
+            "error",
+            &json!({"type": "error", "error": {"message": "connection reset"}})
+        ));
+        assert!(anthropic_stream_event_is_error(
+            "",
+            &json!({"type": "error", "message": "upstream failed"})
+        ));
+        assert!(!anthropic_stream_event_is_error(
+            "message_stop",
+            &json!({"type": "message_stop"})
+        ));
     }
 }

--- a/crates/wisp-llm/src/openai.rs
+++ b/crates/wisp-llm/src/openai.rs
@@ -483,6 +483,16 @@ impl Provider for OpenAiProvider {
                     let Ok(val) = serde_json::from_str::<Value>(line) else {
                         continue;
                     };
+                    // Some OpenAI-compatible relays keep the HTTP/SSE response
+                    // at 200 after the upstream connection has failed, then
+                    // encode the failure as a normal `data:` payload and may
+                    // still append `[DONE]`. Treating `[DONE]` alone as success
+                    // in that case commits a partial answer and ends the turn.
+                    if val.get("error").is_some()
+                        || val.get("type").and_then(Value::as_str) == Some("error")
+                    {
+                        return Err(LlmError::Incomplete);
+                    }
                     // The final usage chunk carries an empty `choices` array, so
                     // parse usage before the choice guard would `continue` past it.
                     // Non-null so the per-chunk `"usage": null` fields don't wipe it.
@@ -725,6 +735,27 @@ mod tests {
             requests.await.unwrap(),
             ["/chat/completions", "/v1/chat/completions"]
         );
+    }
+
+    #[tokio::test]
+    async fn stream_rejects_in_band_error_even_when_relay_appends_done() {
+        let (base_url, requests) = serve_responses(vec![(
+            "200 OK",
+            "text/event-stream",
+            "data: {\"choices\":[{\"delta\":{\"content\":\"partial\"}}]}\n\ndata: {\"error\":{\"message\":\"upstream connection reset\"}}\n\ndata: [DONE]\n\n",
+        )])
+        .await;
+        let provider = local_provider(&base_url);
+        let mut sink = RecordingSink::default();
+
+        let error = provider
+            .stream(&[Message::user("finish the report")], &[], &mut sink)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, LlmError::Incomplete));
+        assert_eq!(sink.text, ["partial"]);
+        assert_eq!(requests.await.unwrap(), ["/chat/completions"]);
     }
 
     #[tokio::test]

--- a/crates/wisp-llm/src/responses.rs
+++ b/crates/wisp-llm/src/responses.rs
@@ -297,6 +297,7 @@ impl Provider for OpenAiResponsesProvider {
 
     async fn complete(&self, messages: &[Message], tools: &[ToolSchema]) -> Result<Completion> {
         let val = self.request(self.build_body(messages, tools)).await?;
+        ensure_completed_response(&val)?;
         Ok(parse_completion(&val))
     }
 
@@ -315,6 +316,18 @@ impl Provider for OpenAiResponsesProvider {
         }
         sink.on_usage(comp.usage.clone());
         Ok(comp)
+    }
+}
+
+/// A non-streaming Responses request can return HTTP 200 with a terminal
+/// `incomplete`, `failed`, or `cancelled` status and partial output. Only
+/// `completed` is safe to commit as a successful agent iteration. Status-less
+/// responses remain accepted for compatible relays that implement the older
+/// subset of this wire format.
+fn ensure_completed_response(value: &Value) -> Result<()> {
+    match value.get("status").and_then(Value::as_str) {
+        None | Some("completed") => Ok(()),
+        Some(_) => Err(LlmError::Incomplete),
     }
 }
 
@@ -477,6 +490,23 @@ mod tests {
         assert_eq!(comp.tool_calls[0].function.name, "openalex");
         assert_eq!(comp.usage.input_tokens, 3);
         assert_eq!(comp.usage.output_tokens, 5);
+    }
+
+    #[test]
+    fn rejects_partial_terminal_responses() {
+        for status in ["incomplete", "failed", "cancelled", "in_progress"] {
+            let value = json!({
+                "status": status,
+                "output_text": "partial report",
+                "incomplete_details": {"reason": "upstream_error"}
+            });
+            assert!(matches!(
+                ensure_completed_response(&value),
+                Err(LlmError::Incomplete)
+            ));
+        }
+        assert!(ensure_completed_response(&json!({"status": "completed"})).is_ok());
+        assert!(ensure_completed_response(&json!({"output_text": "relay response"})).is_ok());
     }
 
     #[test]

--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -5,7 +5,9 @@ After a completed reply, Wisp uses that conversation's current model to offer
 three optional next questions. That secondary call reads only the four most
 recent user turns, so completing a long, tool-heavy conversation does not load
 and duplicate its full history. The suggestion panel can be hidden per reply,
-or the setting can be turned off to skip the extra model call entirely.
+or the setting can be turned off to skip the extra model call entirely. Wisp
+does not request suggestions for failed, cancelled, paused, or tool-only turns;
+the current turn must contain a visible final answer.
 
 The desktop transcript also treats ordinary tool output as a preview: tool
 results are limited to 4,000 characters and streamed terminal output to 64 KiB
@@ -109,6 +111,12 @@ as silently processed. Completed tool results remain in the conversation; use
 **Resume** to request the missing final reply without replaying those tools. If
 this repeats in a long conversation, send `/compact` before resuming to fold old
 turns while preserving an archive of the full history.
+
+Wisp also treats an SSE `error` payload and a Responses API status other than
+`completed` as a failed, resumable turn, even when a compatible relay keeps the
+HTTP status at 200 or appends a `[DONE]` marker. Partial output is not committed
+as a final answer, completed tool results remain available, and follow-up
+questions are not generated for that interrupted turn.
 
 **Settings → General → Automatically compact long conversations** is enabled by
 default. Following mangopi-cli's model-boundary approach, Wisp checks the

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -3814,6 +3814,18 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
             if (String(msg).includes("POSTSTARTFAIL")) {
               throw new Error("[turn-started] execution failed after turn/start");
             }
+            if (String(msg).includes("TOOLONLYDONE")) {
+              setTimeout(() => {
+                emit("agent", { kind: "User", frame_id: fid, text: msg });
+                emit("agent", { kind: "Text", frame_id: fid, delta: "I will record the decision first." });
+                emit("agent", { kind: "ToolCall", frame_id: fid, name: "research_graph", preview: "record_decision" });
+                emit("agent", { kind: "ToolResult", frame_id: fid, name: "research_graph", ok: true, content: '{"node_id":"decision-1"}' });
+                // Regression fixture: an old/buggy backend mislabeled the
+                // provider cut after this tool as a successful turn.
+                emit("agent", { kind: "Done", frame_id: fid });
+              }, 30);
+              return fid;
+            }
             if (String(msg).includes("MONITORRUN")) {
               return await new Promise<string>((resolve) => {
                 monitorRunFrameId = fid;

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -268,6 +268,21 @@ test("send streams a mocked assistant reply", async ({ page, context }) => {
   await expect(page.locator(".copy-toast")).toHaveText("Copied");
 });
 
+test("tool-only turn endings do not generate follow-up questions", async ({ page }) => {
+  await enterApp(page);
+  await composer(page).fill("TOOLONLYDONE finish the report");
+  await page.getByRole("button", { name: "Send" }).click();
+
+  await expect(page.getByRole("button", { name: "Processed" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Send" })).toBeVisible();
+  await page.waitForTimeout(100);
+  await expect(page.getByTestId("follow-up-questions")).toHaveCount(0);
+  expect(await page.evaluate(() =>
+    ((window as any).__skillInvokeLog ?? [])
+      .filter((call: any) => call.cmd === "generate_follow_up_questions").length,
+  )).toBe(0);
+});
+
 test("manual review blocks sending and shows a playful progress animation", async ({ page }) => {
   await page.addInitScript(() => {
     (window as any).__reviewDelayMs = 800;

--- a/ui/src/app_support/chat_stream.rs
+++ b/ui/src/app_support/chat_stream.rs
@@ -98,6 +98,25 @@ pub(crate) fn is_error_assistant(item: &ChatItem) -> bool {
     matches!(item, ChatItem::Assistant { text, .. } if text.starts_with("Error: "))
 }
 
+/// Follow-up suggestions belong only to a turn that actually produced a final
+/// answer. In particular, assistant commentary before a tool is not a final
+/// answer: if the provider drops after that tool, a stray `Done` event must not
+/// make the interrupted task look complete by offering next questions.
+pub(crate) fn latest_turn_has_final_answer(items: &[ChatItem]) -> bool {
+    let turn_start = items
+        .iter()
+        .rposition(|item| matches!(item, ChatItem::User(_) | ChatItem::QueuedUser { .. }))
+        .map_or(0, |index| index.saturating_add(1));
+    items
+        .iter()
+        .enumerate()
+        .skip(turn_start)
+        .any(|(index, item)| {
+            matches!(item, ChatItem::Assistant { text, .. } if !text.trim().is_empty() && !text.starts_with("Error: "))
+                && !is_commentary_at(items, index)
+        })
+}
+
 pub(crate) fn strip_error_at(items: &mut Vec<ChatItem>, idx: usize) {
     if idx < items.len() && is_error_assistant(&items[idx]) {
         items.remove(idx);

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -1988,7 +1988,18 @@ fn App() -> impl IntoView {
                     stopping_session.set(None);
                 }
                 refresh_session_history();
-                if settings.get_untracked().follow_up_questions {
+                let has_final_answer = if active_cb.get_untracked().as_deref()
+                    == Some(frame_id.as_str())
+                {
+                    items_cb.with_untracked(|items| latest_turn_has_final_answer(items))
+                } else {
+                    transcripts_cb.with_untracked(|transcripts| {
+                        transcripts
+                            .get(&frame_id)
+                            .is_some_and(|items| latest_turn_has_final_answer(items))
+                    })
+                };
+                if settings.get_untracked().follow_up_questions && has_final_answer {
                     let generation = follow_up_generation.try_update(|generations| {
                         let generation = generations.entry(frame_id.clone()).or_default();
                         *generation += 1;


### PR DESCRIPTION
## Problem

A provider or compatible relay can lose its upstream connection midway through an agent turn while keeping the HTTP response at 200 and sometimes appending a terminal marker. Wisp could then treat the partial/tool-only turn as successfully completed, collapse it as **Processed**, and generate follow-up questions even though no final answer was produced.

## Root cause

The provider adapters trusted terminal framing too broadly:

- OpenAI-compatible streams accepted `[DONE]` even when an earlier SSE payload contained `error`.
- Anthropic streams ignored `event: error` payloads.
- Responses API results accepted terminal statuses other than `completed`.
- The UI generated follow-up questions from any `Done` event without confirming that the latest turn contained a visible final answer.

## Changes

- Reject in-band OpenAI-compatible and Anthropic stream errors as incomplete turns.
- Require `completed` for Responses API results while preserving compatibility with status-less relays.
- Reject known unsuccessful finish reasons before committing assistant/tool output as a successful iteration.
- Generate follow-up questions only when the latest turn contains a non-commentary final answer.
- Add provider, agent, and Playwright regression coverage.
- Document interrupted-turn and follow-up behavior.

Completed tool results remain in the conversation, and the interrupted turn is resumable instead of being presented as successful.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cd ui && cargo check --target wasm32-unknown-unknown`
- `cd ui-tests && npm ci && npx playwright test` — 314 passed, 1 environment-gated test skipped

## Manual smoke

1. Start a native-agent turn that executes at least one tool.
2. Interrupt the next provider response through a relay that emits an SSE error while retaining HTTP 200 / `[DONE]`.
3. Verify the turn shows a resumable failure rather than a successful completion.
4. Verify completed tool results remain visible and no follow-up question panel appears.
5. Resume and verify the model can produce the missing final answer without replaying completed tools.

## Known limitations

Partially emitted model streams are not automatically replayed after an in-stream failure. Wisp stops resumably to avoid duplicating streamed output or repeating side effects; the user must choose **Resume**.