### PR TITLE
ui: visual polish pass — quieter composer, scrollable tabs, compact artifact cards, unified font scale

### DIFF
--- a/ui-tests/tests/visual-polish.spec.ts
+++ b/ui-tests/tests/visual-polish.spec.ts
@@ -1,0 +1,112 @@
+import { test, expect, type Page } from "@playwright/test";
+import { tauriMock } from "./mock-tauri";
+
+// Regression coverage for the visual polish pass: the composer sits flat until
+// focused, right-pane tabs scroll instead of ellipsizing short labels, artifact
+// cards render as compact rows, and follow-up suggestions carry no panel fill.
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(tauriMock);
+});
+
+async function enterApp(page: Page, path = "/") {
+  await page.goto(path);
+  await page.locator(".proj-card-main").first().click();
+  await expect(page.locator(".composer-inner").first()).toBeVisible();
+}
+
+test("composer rests on a hairline border and small shadow until focused", async ({ page }) => {
+  await enterApp(page);
+  const inner = page.locator(".composer-inner").first();
+  const input = page.locator(".composer-inner textarea").first();
+
+  await input.blur();
+  const resting = await inner.evaluate((el) => {
+    const cs = getComputedStyle(el);
+    return { borderColor: cs.borderTopColor, boxShadow: cs.boxShadow };
+  });
+  // --border (rgba(60,55,45,.1) in the paper palette), not --border-strong (#d6d4cc).
+  expect(resting.borderColor).toBe("rgba(60, 55, 45, 0.1)");
+  // Only --shadow-sm; the big --shadow lift (32px blur) is reserved for focus.
+  // Poll past the .15s box-shadow transition, which pads lists with zero layers.
+  await expect.poll(() => inner.evaluate((el) => getComputedStyle(el).boxShadow))
+    .not.toContain("32px");
+
+  await input.focus();
+  await expect.poll(() => inner.evaluate((el) => getComputedStyle(el).boxShadow))
+    .toContain("32px");
+});
+
+test("composer shortcut hint appears only while the composer is focused or hovered", async ({ page }) => {
+  await enterApp(page);
+  const hint = page.locator(".composer-hint").first();
+  const input = page.locator(".composer-inner textarea").first();
+
+  await input.blur();
+  await expect.poll(() => hint.evaluate((el) => getComputedStyle(el).opacity)).toBe("0");
+
+  await input.focus();
+  await expect.poll(() => hint.evaluate((el) => getComputedStyle(el).opacity)).toBe("1");
+
+  await input.blur();
+  await expect.poll(() => hint.evaluate((el) => getComputedStyle(el).opacity)).toBe("0");
+  await hint.hover({ force: true });
+  await expect.poll(() => hint.evaluate((el) => getComputedStyle(el).opacity)).toBe("1");
+});
+
+test("right-pane tabs keep their labels and scroll instead of ellipsizing", async ({ page }) => {
+  await page.setViewportSize({ width: 900, height: 700 });
+  await enterApp(page);
+  await page.getByRole("button", { name: "Toggle panel" }).click();
+
+  const panel = page.locator(".rightpane");
+  const addPanel = panel.getByRole("button", { name: "Add panel" });
+  for (const name of [/^Notebook/, /^Highlights/, /^Provenance/, /^Side chat$/]) {
+    await addPanel.click();
+    await panel.locator(".rp-tab-add-menu").getByRole("button", { name }).click();
+  }
+
+  const tabs = panel.locator(".rp-tab");
+  const tabCount = await tabs.count();
+  expect(tabCount).toBeGreaterThanOrEqual(5);
+  for (let i = 0; i < tabCount; i++) {
+    const tab = tabs.nth(i);
+    // Full label is always available as a tooltip.
+    await expect(tab).toHaveAttribute("title", /.+/);
+    // Short built-in labels never ellipsize; overflow moved to the scroller.
+    const fits = await tab.evaluate((el) => el.scrollWidth <= el.clientWidth + 1);
+    expect(await fits).toBe(true);
+  }
+  const scrollerOverflows = await panel.locator(".rp-tab-scroll")
+    .evaluate((el) => el.scrollWidth > el.clientWidth);
+  expect(scrollerOverflows).toBe(true);
+});
+
+test("generated artifact cards render as compact rows", async ({ page }) => {
+  await enterApp(page);
+  await page.locator(".composer-inner textarea").first().fill("ARTIFACTATTRIBUTION");
+  await page.getByRole("button", { name: "Send" }).click();
+
+  const card = page.locator('.message-artifact-card[data-artifact-name="new.png"]');
+  await expect(card).toBeVisible({ timeout: 10_000 });
+  const metrics = await card.evaluate((el) => {
+    const thumb = el.querySelector(".message-artifact-thumb")!;
+    const cardBox = el.getBoundingClientRect();
+    const thumbBox = thumb.getBoundingClientRect();
+    return { cardHeight: cardBox.height, thumbSize: thumbBox.width };
+  });
+  expect(metrics.thumbSize).toBe(40);
+  // Compact row: thumb + one or two text lines, not the old ~140px tile.
+  expect(metrics.cardHeight).toBeLessThan(72);
+});
+
+test("follow-up suggestions sit on the canvas without a panel fill", async ({ page }) => {
+  await enterApp(page);
+  await page.locator(".composer-inner textarea").first().fill("hello there");
+  await page.getByRole("button", { name: "Send" }).click();
+
+  const followUps = page.getByTestId("follow-up-questions");
+  await expect(followUps.getByRole("button").first()).toBeVisible({ timeout: 10_000 });
+  const background = await followUps.evaluate((el) => getComputedStyle(el).backgroundColor);
+  expect(background).toBe("rgba(0, 0, 0, 0)");
+});

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -11150,6 +11150,9 @@ fn App() -> impl IntoView {
                                             });
                                         }>
                                         <button type="button" class="rp-tab" class:active=is_active
+                                            // Labels ellipsize past 180px (long file names);
+                                            // the tooltip keeps the full name one hover away.
+                                            title=label.clone()
                                             on:click=move |_| {
                                                 right_tab.set(tab);
                                                 match tab {

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -418,7 +418,7 @@ body { display: flex; flex-direction: column; overflow: hidden; }
   background: var(--clay);
   color: var(--on-clay);
   border-color: transparent;
-  font-weight: 650;
+  font-weight: 600;
 }
 .btn-primary {
   border: 1px solid transparent;

--- a/ui/src/styles/chat.css
+++ b/ui/src/styles/chat.css
@@ -9,7 +9,7 @@
 .center-tabs { display: flex; align-items: center; gap: 4px; min-width: 0; overflow-x: auto; flex: 1 1 auto; scrollbar-width: none; box-sizing: border-box; }
 .center-tabs::-webkit-scrollbar { display: none; }
 .center-tab-wrap { position: relative; display: flex; min-width: 0; flex: 0 0 auto; border-radius: var(--radius-xs); }
-.center-tab { min-width: 108px; max-width: 220px; height: 32px; padding: 0 30px 0 12px; border: 1px solid transparent; border-radius: var(--radius-xs); background: transparent; color: var(--text-muted); font: inherit; font-size: 12px; font-weight: 520; cursor: pointer; transition: background .16s ease, border-color .16s ease, color .16s ease, box-shadow .2s ease; }
+.center-tab { min-width: 108px; max-width: 220px; height: 32px; padding: 0 30px 0 12px; border: 1px solid transparent; border-radius: var(--radius-xs); background: transparent; color: var(--text-muted); font: inherit; font-size: 12px; font-weight: 500; cursor: pointer; transition: background .16s ease, border-color .16s ease, color .16s ease, box-shadow .2s ease; }
 .center-tabs > .center-tab { min-width: min(260px, 42cqw); max-width: min(520px, 52cqw); padding: 0 14px; color: var(--text-faint); }
 .center-tab:hover { background: var(--surface-hover); color: var(--text); }
 .center-tab.active { border-color: var(--border-active); background: var(--bg-elev); color: var(--text); box-shadow: var(--shadow-sm); }
@@ -52,7 +52,7 @@
 .center-runtime-environment-head > div:first-child > span { display: block; margin-top: 2px; overflow: hidden; color: var(--text-faint); font: 10px/1.3 var(--font-mono); text-overflow: ellipsis; white-space: nowrap; }
 .center-runtime-environment-table-head,
 .center-runtime-environment-row { display: grid; grid-template-columns: minmax(62px, 1fr) minmax(56px, .8fr) minmax(76px, 1.25fr) minmax(44px, auto); align-items: center; gap: 8px; }
-.center-runtime-environment-table-head { flex: 0 0 auto; padding: 7px 10px; border-bottom: 1px solid var(--border); background: var(--bg-sunken); color: var(--text-faint); font-size: 9.5px; font-weight: 650; }
+.center-runtime-environment-table-head { flex: 0 0 auto; padding: 7px 10px; border-bottom: 1px solid var(--border); background: var(--bg-sunken); color: var(--text-faint); font-size: 9.5px; font-weight: 600; }
 .center-runtime-environment-table-head span:last-child { text-align: right; }
 .center-runtime-environment-body { min-height: 0; flex: 1 1 auto; overflow: auto; }
 .center-runtime-environment-rows { min-width: 280px; }
@@ -184,7 +184,7 @@
 /* Specialist is a quiet label, not a status pill. */
 .session-specialist {
   flex: 0 0 auto; max-width: 120px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-  font-size: 11px; font-weight: 550; color: var(--text-faint);
+  font-size: 11px; font-weight: 500; color: var(--text-faint);
 }
 .session-specialist::before { content: "·"; margin-right: 8px; color: var(--border-strong); }
 .topbar .hint {
@@ -220,7 +220,7 @@
 @keyframes review-lens-scan { to { transform: translateX(14px) rotate(-8deg); } }
 @keyframes review-dot-squirm { to { opacity: .9; transform: translateY(-2px); } }
 .context-compaction-live-copy { display: grid; min-width: 0; line-height: 1.15; }
-.context-compaction-live-copy strong { font-size: 11.5px; font-weight: 620; white-space: nowrap; }
+.context-compaction-live-copy strong { font-size: 11.5px; font-weight: 600; white-space: nowrap; }
 .context-compaction-live-copy span { color: var(--text-faint); font-size: 9.5px; white-space: nowrap; }
 .context-compaction-spectrum {
   position: relative; display: flex; align-items: end; gap: 2px; width: 30px; height: 18px;
@@ -315,7 +315,7 @@
 .exploration-banner-copy { display: flex; min-width: 0; flex-direction: column; gap: 2px; }
 .exploration-banner-copy strong { overflow: hidden; color: var(--text); font-size: 13.5px; text-overflow: ellipsis; white-space: nowrap; }
 .exploration-banner-copy > span:last-child { color: var(--text-muted); font-size: 11px; line-height: 1.4; }
-.exploration-banner-eyebrow { color: var(--clay-strong); font-size: 9.5px; font-weight: 750; letter-spacing: .06em; text-transform: uppercase; }
+.exploration-banner-eyebrow { color: var(--clay-strong); font-size: 9.5px; font-weight: 700; letter-spacing: .06em; text-transform: uppercase; }
 .exploration-banner-actions { display: flex; flex: 0 0 auto; flex-wrap: wrap; justify-content: flex-end; gap: 5px; }
 .exploration-banner button {
   flex: 0 0 auto; padding: 5px 8px; border: 1px solid var(--border-strong); border-radius: var(--radius-xs);
@@ -452,7 +452,9 @@
 .msg.assistant .msg-actions { justify-content: flex-start; margin-left: -4px; opacity: 1; }
 .msg:hover .msg-actions, .msg:focus-within .msg-actions { opacity: 1; }
 .msg.assistant .assistant-wrap { display: flex; flex-direction: column; min-width: 0; max-width: 100%; }
-.follow-up-questions { margin-top: 10px; border-top: 1px solid var(--border-strong); background: color-mix(in srgb, var(--bg-panel) 72%, transparent); }
+/* Lightweight list on the canvas: no panel fill, hairline separator only;
+   rows pick up a hover background instead of sitting on a tinted block. */
+.follow-up-questions { margin-top: 10px; border-top: 1px solid var(--border); }
 .follow-up-questions-head { display: flex; align-items: center; gap: 8px; padding: 12px 8px; color: var(--text-muted); }
 .follow-up-questions-head > span { display: inline-flex; }
 .follow-up-questions-head svg { width: 16px; height: 16px; }
@@ -463,18 +465,22 @@
 .follow-up-options button:hover { background: var(--surface-hover); }
 .follow-up-options button > span:first-child { color: var(--text-faint); }
 .message-artifacts { margin-top: 14px; max-width: 100%; }
-.message-artifacts-label { margin-bottom: 7px; color: var(--text-faint); font-size: 10px; font-weight: 650; letter-spacing: .05em; text-transform: uppercase; }
-.message-artifact-cards { display: grid; grid-template-columns: repeat(auto-fill, minmax(132px, 1fr)); gap: 8px; max-width: 620px; }
+.message-artifacts-label { margin-bottom: 7px; color: var(--text-faint); font-size: 10px; font-weight: 600; letter-spacing: .05em; text-transform: uppercase; }
+/* Compact rows instead of large tiles: non-image kinds only carry a type badge,
+   so a 4:3 thumb area was empty weight. Images still show a cropped thumb. */
+.message-artifact-cards { display: grid; grid-template-columns: repeat(auto-fill, minmax(216px, 1fr)); gap: 6px; max-width: 680px; }
 /* Overflow fold: keep the 9 in step with `generated_overflow` in app_support.rs. */
 .message-artifact-cards.collapsed > .message-artifact-card:nth-child(n+9) { display: none; }
-.message-artifact-card { display: flex; min-width: 0; flex-direction: column; gap: 7px; padding: 8px; border: 1px solid var(--border-strong); border-radius: var(--radius-sm); background: var(--bg-panel); color: var(--text); font: inherit; cursor: pointer; text-align: left; }
-.message-artifact-card:hover { border-color: var(--text-faint); background: var(--surface-hover); }
+.message-artifact-card { display: grid; grid-template-columns: 40px minmax(0, 1fr); grid-template-rows: auto auto; column-gap: 10px; align-items: center; padding: 7px 9px; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--bg-elev); color: var(--text); font: inherit; cursor: pointer; text-align: left; transition: border-color .12s ease, background .12s ease; }
+.message-artifact-card:hover { border-color: var(--border-strong); background: var(--surface-hover); }
 .message-artifact-card.superseded { opacity: .52; cursor: default; background: var(--bg-sunken); }
-.message-artifact-card.superseded:hover { border-color: var(--border-strong); }
-.message-artifact-thumb { position: relative; display: flex; aspect-ratio: 4 / 3; align-items: center; justify-content: center; overflow: hidden; border-radius: var(--radius-xs); background: var(--bg-sunken); }
+.message-artifact-card.superseded:hover { border-color: var(--border); }
+.message-artifact-thumb { grid-row: 1 / -1; position: relative; display: flex; width: 40px; height: 40px; align-items: center; justify-content: center; overflow: hidden; border-radius: var(--radius-xs); background: var(--bg-sunken); }
 .message-artifact-thumb img { position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover; background: var(--bg-sunken); }
-.message-artifact-name { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 12px; font-weight: 600; }
-.message-artifact-status { color: var(--text-faint); font-size: 10.5px; }
+.message-artifact-name { grid-column: 2; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 12px; font-weight: 600; }
+/* No status row: let the name span both tracks so it stays vertically centered. */
+.message-artifact-name:last-child { grid-row: 1 / -1; }
+.message-artifact-status { grid-column: 2; color: var(--text-faint); font-size: 10.5px; }
 .message-artifact-more { display: flex; align-items: center; justify-content: center; padding: 8px; border: 1px dashed var(--border-strong); border-radius: var(--radius-sm); background: transparent; color: var(--text-muted); font: inherit; font-size: 12px; font-weight: 600; cursor: pointer; }
 .message-artifact-more:hover { color: var(--text); border-color: var(--text-faint); background: var(--surface-hover); }
 button.msg-btn { background: transparent; color: var(--text-faint); border: none; border-radius: var(--radius-xs); padding: 4px 8px; font: inherit; font-size: 11px; cursor: pointer; line-height: 1; }
@@ -587,7 +593,7 @@ button.tool-btn.card-copy { margin-left: auto; flex: 0 0 auto; padding: 2px 8px;
   border-radius: var(--radius-sm); padding: 14px 16px; box-shadow: 0 8px 28px rgba(15, 23, 42, 0.08);
 }
 .approval-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 10px; }
-.approval-title { font-size: 15px; font-weight: 650; letter-spacing: -0.01em; }
+.approval-title { font-size: 15px; font-weight: 600; letter-spacing: -0.01em; }
 .approval-status {
   display: inline-flex; align-items: center; gap: 6px;
   font-size: 11px; color: var(--text-faint); text-transform: uppercase; letter-spacing: .05em; font-weight: 600;
@@ -930,8 +936,8 @@ details.tool:not([open]) > summary.head .run-dot { animation: tool-pulse 1.1s ea
 .md :is(h1, h2, h3, h4, h5) + :is(ul, ol) { margin-top: 0.2em; }
 
 /* Chinese markdown: calmer hierarchy, more breathing room */
-:lang(zh) .md h1 { font-size: 1.38em; font-weight: 650; }
-:lang(zh) .md h2 { font-size: 1.18em; font-weight: 650; }
+:lang(zh) .md h1 { font-size: 1.38em; font-weight: 600; }
+:lang(zh) .md h2 { font-size: 1.18em; font-weight: 600; }
 :lang(zh) .md h3 { font-size: 1.06em; font-weight: 600; }
 :lang(zh) .md h1, :lang(zh) .md h2, :lang(zh) .md h3, :lang(zh) .md h4, :lang(zh) .md h5 {
   margin: 1.15em 0 0.45em;
@@ -941,7 +947,7 @@ details.tool:not([open]) > summary.head .run-dot { animation: tool-pulse 1.1s ea
 :lang(zh) .md p { margin: 0 0 0.7em; }
 :lang(zh) .md ul > li + li,
 :lang(zh) .md ol > li + li { margin-top: 0.42em; }
-:lang(zh) .md strong { font-weight: 650; }
+:lang(zh) .md strong { font-weight: 600; }
 :lang(zh) .md em { font-style: normal; font-weight: 500; }
 .md img { max-width: 100%; border-radius: var(--radius-sm); }
 .md table { border-collapse: collapse; width: 100%; font-size: 12.5px; margin: 0 0 10px; display: block; overflow: auto; }
@@ -949,7 +955,7 @@ details.tool:not([open]) > summary.head .run-dot { animation: tool-pulse 1.1s ea
 .md .md-table-card table { width: 100%; margin: 0; display: table; overflow: visible; }
 .md .md-table-card .tbl-wrap { margin: 0; }
 .md th, .md td { padding: 6px 10px; border: 1px solid var(--border); text-align: left; white-space: normal; word-break: break-word; vertical-align: top; }
-.md thead th { background: var(--bg-elev); font-weight: 650; position: sticky; top: 0; }
+.md thead th { background: var(--bg-elev); font-weight: 600; position: sticky; top: 0; }
 /* File chips in table cells often arrive as mini-lists ("- `file`"). Hide the
    custom bullets and lay chips out as a wrapping row instead of a dotted list. */
 .md td ul, .md th ul, .md td ol, .md th ol {
@@ -976,11 +982,13 @@ details.tool:not([open]) > summary.head .run-dot { animation: tool-pulse 1.1s ea
 .composer-inner {
   position: relative; display: flex; flex-direction: column;
   max-width: var(--chat-col-max); width: 100%; margin: 0 auto;
-  background: var(--bg-input); border: 1px solid var(--border-strong); border-radius: var(--radius);
+  background: var(--bg-input); border: 1px solid var(--border); border-radius: var(--radius);
   padding: 0 12px 10px 14px;
-  box-shadow: var(--shadow-sm), var(--shadow);
+  box-shadow: var(--shadow-sm);
   transition: border-color .15s ease, box-shadow .15s ease;
 }
+/* Idle composer sits flat on the canvas; only focus lifts it, so the focused
+   input is the one element that clearly "floats". */
 .composer-inner:focus-within, .composer-inner.composer-dragover {
   border-color: color-mix(in srgb, var(--clay) 45%, var(--border-strong));
   box-shadow: var(--shadow-sm), var(--shadow), 0 0 0 3px var(--focus-ring);
@@ -1099,7 +1107,10 @@ details.tool:not([open]) > summary.head .run-dot { animation: tool-pulse 1.1s ea
 }
 .model-menu-config-toggle { flex: 0 0 auto; }
 .composer-footer { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 8px; min-height: 20px; margin-top: 5px; }
-.composer-hint { min-width: 0; padding: 0 2px 0 54px; font-size: 11px; line-height: 1.35; color: var(--text-faint); user-select: none; text-align: center; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+/* Shortcut hint stays hidden until the composer is focused (or hovered), so the
+   idle composer reads as a clean input rather than a help panel. */
+.composer-hint { min-width: 0; padding: 0 2px 0 54px; font-size: 11px; line-height: 1.35; color: var(--text-faint); user-select: none; text-align: center; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; opacity: 0; transition: opacity .15s ease; }
+.composer-inner:focus-within .composer-hint, .composer-inner:hover .composer-hint { opacity: 1; }
 .context-usage-wrap { display: flex; align-items: center; justify-content: flex-end; }
 .context-usage-trigger {
   display: inline-flex; align-items: center; gap: 4px; height: 20px; padding: 0 2px;
@@ -1207,9 +1218,9 @@ details.tool:not([open]) > summary.head .run-dot { animation: tool-pulse 1.1s ea
 .compute-resource-row.enabled .compute-resource-icon { color: var(--clay-strong); }
 .compute-resource-name-wrap { min-width: 0; display: flex; align-items: center; gap: 6px; }
 .compute-resource-name { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.compute-resource-default { flex: 0 0 auto; padding: 0 6px; border-radius: 999px; border: 1px solid var(--clay); color: var(--clay-strong); font-size: 10px; font-weight: 650; line-height: 15px; }
+.compute-resource-default { flex: 0 0 auto; padding: 0 6px; border-radius: 999px; border: 1px solid var(--clay); color: var(--clay-strong); font-size: 10px; font-weight: 600; line-height: 15px; }
 .compute-resource-state { color: var(--text-faint); font-size: 11px; }
-.compute-resource-row.enabled .compute-resource-state { color: var(--clay-strong); font-weight: 650; }
+.compute-resource-row.enabled .compute-resource-state { color: var(--clay-strong); font-weight: 600; }
 .agent-submenu-row.compute-manage-row { flex: 0 0 auto; justify-content: center; min-height: 38px; margin-top: 4px; border-top: 1px solid var(--border); border-radius: 0 0 10px 10px; color: var(--text-muted); font-size: 12.5px; }
 .agent-menu-check { display: inline-flex; flex: 0 0 auto; color: var(--clay); }
 .agent-menu-check svg { width: 16px; height: 16px; }
@@ -1307,13 +1318,13 @@ button.send:disabled { opacity: .45; cursor: default; }
 .send-mode-item:hover:not(:disabled) { background: var(--bg-sunken); }
 .send-mode-item:disabled { opacity: .5; cursor: default; }
 .send-mode-item .compose-item-icon { width: 28px; height: 28px; border-radius: var(--radius-xs); }
-button.stop { display: inline-flex; align-items: center; justify-content: center; height: 32px; padding: 0 14px; background: transparent; color: var(--err); border: 1px solid hsl(0 70% 50% / 0.35); border-radius: 999px; font: inherit; font-weight: 650; font-size: 13px; cursor: pointer; flex: 0 0 auto; }
+button.stop { display: inline-flex; align-items: center; justify-content: center; height: 32px; padding: 0 14px; background: transparent; color: var(--err); border: 1px solid hsl(0 70% 50% / 0.35); border-radius: 999px; font: inherit; font-weight: 600; font-size: 13px; cursor: pointer; flex: 0 0 auto; }
 button.stop:hover:not(:disabled) { background: hsl(0 70% 50% / 0.08); border-color: hsl(0 70% 50% / 0.55); }
 button.stop:disabled { opacity: .6; cursor: default; }
 
 .sidechat-in-pane { flex: 1 1 auto; min-height: 0; display: flex; flex-direction: column; background: var(--bg-elev); }
 .sidechat-head { flex: 0 0 auto; display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 6px 8px 6px 20px; border-bottom: 1px solid var(--border); }
-.sidechat-title { font-size: 12.5px; font-weight: 650; color: var(--text-muted); }
+.sidechat-title { font-size: 12.5px; font-weight: 600; color: var(--text-muted); }
 .sidechat-log { flex: 1 1 auto; min-height: 0; overflow-y: auto; padding: 18px 20px; display: flex; flex-direction: column; gap: 14px; background: var(--bg-elev); }
 .sidechat-empty { margin: auto; max-width: 260px; color: var(--text-faint); font-size: 13px; line-height: 1.5; text-align: center; }
 .sidechat-row { display: flex; flex-direction: column; gap: 4px; }
@@ -1346,8 +1357,8 @@ button.stop:disabled { opacity: .6; cursor: default; }
 .sidechat-model-menu { position: absolute; z-index: 82; left: 0; bottom: calc(100% + 8px); min-width: 220px; max-height: 260px; overflow-y: auto; padding: 6px; background: var(--bg-elev); border: 1px solid var(--border-strong); border-radius: var(--radius-sm); box-shadow: var(--shadow); transform-origin: bottom left; animation: motion-surface-in-soft var(--motion-duration-fast) var(--motion-ease-decelerate) both; }
 .sidechat-model-row { display: flex; align-items: center; justify-content: space-between; gap: 12px; width: 100%; padding: 8px 9px; border: none; border-radius: var(--radius-xs); background: transparent; color: var(--text); font: inherit; font-size: 12.5px; text-align: left; cursor: pointer; }
 .sidechat-model-row:hover, .sidechat-model-row.active { background: var(--bg-sunken); }
-.sidechat-model-group { padding: 8px 9px 4px; font-size: 10.5px; font-weight: 650; letter-spacing: .04em; text-transform: uppercase; color: var(--text-muted); }
-.sidechat-send { height: 30px; padding: 0 13px; border: none; border-radius: 999px; background: var(--clay); color: var(--on-clay); font: inherit; font-size: 12.5px; font-weight: 650; cursor: pointer; }
+.sidechat-model-group { padding: 8px 9px 4px; font-size: 10.5px; font-weight: 600; letter-spacing: .04em; text-transform: uppercase; color: var(--text-muted); }
+.sidechat-send { height: 30px; padding: 0 13px; border: none; border-radius: 999px; background: var(--clay); color: var(--on-clay); font: inherit; font-size: 12.5px; font-weight: 600; cursor: pointer; }
 .sidechat-send:disabled { opacity: .45; cursor: default; }
 .sidechat-send:hover:not(:disabled) { background: var(--clay-strong); }
 
@@ -1366,7 +1377,7 @@ button.stop:disabled { opacity: .6; cursor: default; }
   border: 2px solid hsl(0 70% 50% / 0.25); border-top-color: var(--err);
   animation: stopping-spin 0.7s linear infinite; }
 @keyframes stopping-spin { to { transform: rotate(360deg); } }
-.prov-label { font-size: 11px; font-weight: 650; color: var(--text-faint); text-transform: uppercase; letter-spacing: .04em; margin: 8px 0 4px; }
+.prov-label { font-size: 11px; font-weight: 600; color: var(--text-faint); text-transform: uppercase; letter-spacing: .04em; margin: 8px 0 4px; }
 
 /* Collapsible "steps" panel — folds a thinking + tool-call run into one
    glanceable summary so the process doesn't flood the thread (#82). Built as a

--- a/ui/src/styles/explorer.css
+++ b/ui/src/styles/explorer.css
@@ -72,7 +72,7 @@
 .cap-num { font-size: 22px; font-weight: 700; color: var(--clay); }
 .cap-label { font-size: 11px; color: var(--text-faint); text-transform: uppercase; letter-spacing: .04em; }
 .cap-section { display: flex; flex-direction: column; gap: 8px; }
-.cap-section h3 { margin: 0; font-size: 13px; font-weight: 650; color: var(--text-muted); }
+.cap-section h3 { margin: 0; font-size: 13px; font-weight: 600; color: var(--text-muted); }
 /* ---------- Skill Manager ---------- */
 .skill-tags-filter button {
   background: var(--bg-input); color: var(--text-muted);

--- a/ui/src/styles/modals.css
+++ b/ui/src/styles/modals.css
@@ -19,7 +19,7 @@
 .modal .ps-close:hover:not(:disabled) { color: var(--text); background: var(--surface-hover); }
 .modal .ps-close:disabled { opacity: .45; cursor: default; }
 .modal .ps-close .gi { width: 16px; height: 16px; }
-.modal h2 { margin: 0; font-size: 17px; font-weight: 650; letter-spacing: -0.01em; }
+.modal h2 { margin: 0; font-size: 17px; font-weight: 600; letter-spacing: -0.01em; }
 .modal label { font-size: 12px; color: var(--text-muted); display: flex; flex-direction: column; gap: 5px; font-weight: 500; }
 .modal input, .modal select { background: var(--bg-input); color: var(--text); border: 1px solid var(--border-strong); border-radius: var(--radius-sm); padding: 9px 11px; font: inherit; font-size: 14px; outline: none; transition: border-color .12s ease, box-shadow .12s ease; }
 .modal input:focus, .modal select:focus { border-color: var(--clay); box-shadow: 0 0 0 3px var(--focus-ring); }
@@ -53,7 +53,7 @@
   display: grid; gap: 8px; padding: 12px 13px;
   border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--bg-sunken);
 }
-.portfolio-plan-card strong { color: var(--text); font-size: 13px; font-weight: 650; }
+.portfolio-plan-card strong { color: var(--text); font-size: 13px; font-weight: 600; }
 .portfolio-plan-card p { margin: 0; color: var(--text-muted); font-size: 12px; line-height: 1.45; }
 .portfolio-plan-card ul {
   margin: 0; padding-left: 18px; color: var(--text-muted); font-size: 12px; line-height: 1.5;
@@ -89,7 +89,7 @@
   background: color-mix(in srgb, var(--clay) 7%, var(--bg-input));
 }
 .context-recovery-option:disabled { opacity: .55; cursor: wait; }
-.context-recovery-option-title { font-size: 13.5px; font-weight: 650; }
+.context-recovery-option-title { font-size: 13.5px; font-weight: 600; }
 .context-recovery-option-hint { color: var(--text-muted); font-size: 12px; line-height: 1.45; }
 .context-recovery-error {
   color: var(--err); background: color-mix(in srgb, var(--err) 9%, transparent);
@@ -241,7 +241,7 @@
   border-color: color-mix(in srgb, var(--err) 28%, transparent);
 }
 .turn-undo-section { display: flex; flex-direction: column; gap: 5px; }
-.turn-undo-section h3 { margin: 0; color: var(--text); font-size: 12.5px; font-weight: 650; }
+.turn-undo-section h3 { margin: 0; color: var(--text); font-size: 12.5px; font-weight: 600; }
 .turn-undo-section ul { margin: 0; padding-left: 20px; color: var(--text-muted); font-size: 12px; line-height: 1.55; }
 .turn-undo-section code { color: inherit; overflow-wrap: anywhere; }
 .turn-undo-section.unsupported h3, .turn-undo-section.conflicts h3 { color: var(--warn); }
@@ -282,7 +282,7 @@
   white-space: pre-wrap;
   word-break: break-word;
 }
-.ssh-check-causes-title { font-weight: 650; font-size: 13px; margin-bottom: 4px; color: var(--text); }
+.ssh-check-causes-title { font-weight: 600; font-size: 13px; margin-bottom: 4px; color: var(--text); }
 .ssh-check-causes ul {
   margin: 0;
   padding-left: 1.2em;
@@ -301,7 +301,7 @@
   flex: 0 0 auto;
   font: inherit;
   font-size: 13.5px;
-  font-weight: 550;
+  font-weight: 500;
   padding: 8px 14px;
   border: 1px solid var(--border-strong);
   border-radius: var(--radius-sm);
@@ -365,7 +365,7 @@ textarea.host-input { min-height:64px; resize:vertical; }
 .acp-agent-info button {
   font: inherit;
   font-size: 12px;
-  font-weight: 550;
+  font-weight: 500;
   padding: 5px 11px;
   border: 1px solid var(--border-strong);
   border-radius: 999px;
@@ -411,7 +411,7 @@ textarea.host-input { min-height:64px; resize:vertical; }
 .acp-agents-pane .row button {
   font: inherit;
   font-size: 13.5px;
-  font-weight: 550;
+  font-weight: 500;
   padding: 9px 16px;
   border: 1px solid var(--border-strong);
   border-radius: var(--radius-sm);
@@ -471,8 +471,8 @@ textarea.host-input { min-height:64px; resize:vertical; }
 .artifact-modal.html-preview .am-figure .rp-html {
   flex: 0 0 1200px; width: 1200px; min-width: 1200px; max-width: none;
 }
-.artifact-modal .am-tabs { display: flex; gap: 6px; padding-bottom: 8px; border-bottom: 1px solid var(--border-strong); flex: 0 0 auto; }
-.artifact-modal .am-tab { padding: 6px 10px; border: 1px solid transparent; background: transparent; color: var(--text-faint); font: inherit; font-size: 12px; font-weight: 520; cursor: pointer; border-radius: var(--radius-xs); }
+.artifact-modal .am-tabs { display: flex; gap: 6px; padding-bottom: 8px; border-bottom: 1px solid var(--border); flex: 0 0 auto; }
+.artifact-modal .am-tab { padding: 6px 10px; border: 1px solid transparent; background: transparent; color: var(--text-faint); font: inherit; font-size: 12px; font-weight: 500; cursor: pointer; border-radius: var(--radius-xs); }
 .artifact-modal .am-tab:hover:not(.active) { background: var(--surface-hover); color: var(--text); }
 .artifact-modal .am-tab.active { background: var(--bg-elev); border-color: var(--border-active); color: var(--text); box-shadow: var(--shadow-sm); }
 .artifact-modal .am-panel { max-height: 30vh; overflow: auto; flex: 0 0 auto; min-width: 0; }
@@ -517,7 +517,7 @@ textarea.host-input { min-height:64px; resize:vertical; }
   margin: 0;
   font-family: var(--font-serif);
   font-size: var(--text-lg);
-  font-weight: 550;
+  font-weight: 500;
   letter-spacing: -0.02em;
 }
 .research-graph-heading p {

--- a/ui/src/styles/projects.css
+++ b/ui/src/styles/projects.css
@@ -85,7 +85,7 @@ button.proj-card { width: 100%; padding: 16px 18px; color: var(--text); font: in
 .pc-dot-mark { width: 7px; height: 7px; border-radius: 50%; background: var(--info); flex: 0 0 auto; }
 .pc-dot.running .pc-dot-mark { background: var(--clay); animation: tool-pulse 1s ease-in-out infinite; }
 .pc-dot.ready .pc-dot-mark { background: var(--ok); }
-.pc-dot-n { font-size: 11px; font-weight: 650; color: var(--text-muted); font-variant-numeric: tabular-nums; }
+.pc-dot-n { font-size: 11px; font-weight: 600; color: var(--text-muted); font-variant-numeric: tabular-nums; }
 .sess-status { display: inline-flex; align-items: center; flex: 0 0 auto; padding: 2px 8px; border-radius: 999px; font-size: 11px; font-weight: 600; letter-spacing: .01em; white-space: nowrap; }
 .sess-status-running { color: var(--clay); background: color-mix(in srgb, var(--clay) 12%, transparent); }
 .sess-status-needs-you { color: var(--info); background: var(--info-soft); }
@@ -113,7 +113,7 @@ button.proj-card { width: 100%; padding: 16px 18px; color: var(--text); font: in
   margin: 14px 0 22px; color: var(--text-muted); font-size: 13px; line-height: 1.65;
 }
 .project-sync-code-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 8px; }
-.project-sync-code-head label { color: var(--text); font-size: 12px; font-weight: 650; }
+.project-sync-code-head label { color: var(--text); font-size: 12px; font-weight: 600; }
 .project-sync-guide {
   display: inline-flex; align-items: center; gap: 5px; padding: 3px 0; border: 0; background: transparent;
   color: var(--clay-strong); font: inherit; font-size: 12px; font-weight: 600; cursor: pointer;
@@ -163,7 +163,7 @@ body:has(.window-titlebar) .library-screen { top: 38px; }
 .library-card-icon { width: 36px; height: 36px; flex: 0 0 auto; display: inline-flex; align-items: center; justify-content: center;
   border-radius: var(--radius-xs); background: var(--clay-soft); color: var(--clay-strong); }
 .library-card-body { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 5px; }
-.library-card-title { font-size: 14px; font-weight: 650; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.library-card-title { font-size: 14px; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .library-card pre { max-height: 78px; overflow: hidden; margin: 1px 0; color: var(--text-muted); font: 11.5px/1.45 var(--font-mono); white-space: pre-wrap; }
 .library-card-meta { color: var(--text-faint); font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .library-card-kind { flex: 0 0 auto; margin-left: 10px; padding: 3px 8px; border-radius: 999px; background: var(--bg-sunken); color: var(--text-faint); font: 11px/1.3 var(--font-mono); }
@@ -224,7 +224,7 @@ body:has(.window-titlebar) .project-search-overlay { padding-top: max(12px, min(
 body:has(.window-titlebar) .project-search-dialog { max-height: min(480px, calc(100vh - 96px)); }
 .action-palette { width: min(520px, 92vw); }
 .action-palette-results { padding: 4px 6px 6px; }
-.action-palette-group { padding: 6px 8px 3px; color: var(--text-faint); font-size: 11px; font-weight: 650; }
+.action-palette-group { padding: 6px 8px 3px; color: var(--text-faint); font-size: 11px; font-weight: 600; }
 .action-palette-row { border-radius: var(--radius-xs); min-height: 34px; padding: 5px 10px; gap: 10px; }
 .action-shortcut { flex: 0 0 auto; margin-left: 12px; white-space: nowrap; font-size: 11px; color: var(--text-faint); }
 .project-window-shortcut { visibility: hidden; }
@@ -236,7 +236,7 @@ body:has(.window-titlebar) .project-search-dialog { max-height: min(480px, calc(
 .project-search-input input::placeholder { color: var(--text-faint); }
 .project-search-results { flex: 1 1 auto; min-height: 0; overflow-y: auto; padding: 6px 0; }
 .project-search-section + .project-search-section { margin-top: 4px; }
-.project-search-label { padding: 4px 14px 6px; font-size: 12px; font-weight: 650; color: var(--text-faint); }
+.project-search-label { padding: 4px 14px 6px; font-size: 12px; font-weight: 600; color: var(--text-faint); }
 .project-search-row, .project-search-new { width: 100%; display: flex; align-items: center; gap: 10px; min-height: 40px;
   padding: 6px 14px; border: 0; border-left: 3px solid transparent; background: transparent; color: var(--text);
   font: inherit; text-align: left; cursor: pointer; }
@@ -244,11 +244,11 @@ body:has(.window-titlebar) .project-search-dialog { max-height: min(480px, calc(
 .project-search-row.active, .project-search-new.active { border-left-color: var(--clay); }
 .project-search-row .gi, .project-search-new .gi { width: 15px; height: 15px; flex: 0 0 auto; color: var(--text-faint); }
 .project-search-main { flex: 1 1 auto; min-width: 0; display: flex; flex-direction: column; gap: 1px; }
-.project-search-title { font-size: 13px; font-weight: 560; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.project-search-title { font-size: 13px; font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .project-search-sub { font-size: 11px; color: var(--text-faint); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .project-search-sub:empty { display: none; }
 .project-search-badge { flex: 0 0 auto; max-width: 84px; padding: 1px 6px; border: 1px solid var(--border-strong);
-  border-radius: 999px; color: var(--text-muted); font-size: 10px; font-weight: 650; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  border-radius: 999px; color: var(--text-muted); font-size: 10px; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .project-search-new { color: var(--clay-strong); border-top: 1px solid var(--border); min-height: 42px; }
 .project-search-new .gi { color: var(--clay-strong); }
 .project-search-foot { display: flex; align-items: center; gap: 14px; padding: 7px 14px; border-top: 1px solid var(--border);

--- a/ui/src/styles/right-pane.css
+++ b/ui/src/styles/right-pane.css
@@ -1,15 +1,18 @@
 /* ---------- Resizer + right pane ---------- */
 .resizer { flex: 0 0 auto; width: 5px; cursor: col-resize; background: transparent; position: relative; }
-.resizer::after { content: ""; position: absolute; top: 0; bottom: 0; left: 2px; width: 1px; background: var(--border-strong); transition: background .12s ease; }
+.resizer::after { content: ""; position: absolute; top: 0; bottom: 0; left: 2px; width: 1px; background: var(--border); transition: background .12s ease; }
 .resizer:hover::after { background: var(--clay); }
 .drag-overlay { position: fixed; inset: 0; z-index: 40; cursor: col-resize; }
 .drag-overlay-row { cursor: row-resize; }
 
 .rightpane { flex: 0 0 auto; display: flex; flex-direction: column; background: var(--bg-sunken); border-left: 0; min-width: 0; animation: motion-drawer-in var(--motion-duration-medium) var(--motion-ease-decelerate) both; }
-.rp-tabs { display: flex; align-items: center; gap: 4px; padding: 8px 8px 8px 10px; border-bottom: 1px solid var(--border-strong); flex: 0 0 auto; background: var(--bg-sunken); min-width: 0; overflow: visible; }
+.rp-tabs { display: flex; align-items: center; gap: 4px; padding: 8px 8px 8px 10px; border-bottom: 1px solid var(--border); flex: 0 0 auto; background: var(--bg-sunken); min-width: 0; overflow: visible; }
 .rp-tab-scroll { position: relative; display: flex; align-items: center; gap: 4px; flex: 1 1 auto; min-width: 0; overflow-x: auto; overflow-y: hidden; overscroll-behavior-x: contain; scrollbar-width: none; }
 .rp-tab-scroll::-webkit-scrollbar { display: none; }
-.rp-tab-wrap { position: relative; display: inline-flex; align-items: stretch; flex: 0 1 auto; min-width: 56px; max-width: 180px; border: 1px solid transparent; border-radius: var(--radius-xs); background: transparent; }
+/* Tabs never shrink below their label: overflow scrolls (rp-tab-scroll) instead
+   of ellipsizing two-character labels into unreadable fragments. Long file names
+   still cap at 180px with a title tooltip on the button. */
+.rp-tab-wrap { position: relative; display: inline-flex; align-items: stretch; flex: 0 0 auto; min-width: 0; max-width: 180px; border: 1px solid transparent; border-radius: var(--radius-xs); background: transparent; }
 .rp-tab-wrap.dragging { opacity: .45; }
 .rp-tab-wrap.drop-target { border-color: var(--clay); background: var(--clay-soft); }
 .rp-tab-wrap:has(.rp-tab.active) { border-color: var(--border-active); background: var(--bg-elev); box-shadow: var(--shadow-sm); }
@@ -30,7 +33,7 @@
 .rp-tab-add-item:hover { background: var(--bg-sunken); }
 .rp-tab-add-item.open { color: var(--text-muted); }
 .rp-tabs > .icon-btn, .rp-tabs > .rp-view-modes { flex: 0 0 auto; }
-.rp-tab { padding: 6px 10px; border-radius: var(--radius-xs); color: var(--text-faint); border: none; background: transparent; cursor: pointer; font: inherit; font-size: 12px; font-weight: 520; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.rp-tab { padding: 6px 10px; border-radius: var(--radius-xs); color: var(--text-faint); border: none; background: transparent; cursor: pointer; font: inherit; font-size: 12px; font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .rp-tab.active { background: var(--bg-elev); color: var(--text); box-shadow: var(--shadow-sm); }
 .rp-tab:hover:not(.active) { background: var(--surface-hover); color: var(--text); }
 .rp-doc { flex: 1 1 auto; min-height: 0; overflow: hidden; display: flex; flex-direction: column; background: var(--bg-elev); }
@@ -323,7 +326,7 @@ button.run-status:hover { filter:brightness(0.96); }
 .rp-art-group.collapsed .rp-art-group-items { display: none; }
 .rp-tiles {
   display: flex; flex-direction: column; gap: 6px;
-  padding: 12px; border-bottom: 1px solid var(--border-strong);
+  padding: 12px; border-bottom: 1px solid var(--border);
   flex: 0 0 auto; max-height: min(240px, 34vh); overflow-y: auto;
   background: var(--bg-sunken);
 }
@@ -410,7 +413,7 @@ button.run-status:hover { filter:brightness(0.96); }
 .rp-path { margin: 0; font-family: var(--font-mono); font-size: 11px; word-break: break-all; }
 /* Type labels stay mono + quiet; only tabular data keeps a clay accent. */
 .rp-badge {
-  font-size: 10px; font-weight: 650; text-transform: uppercase; letter-spacing: .04em;
+  font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: .04em;
   padding: 2px 6px; border-radius: var(--radius-xs);
   background: var(--bg-elev); color: var(--text-faint); border: 1px solid var(--border);
 }
@@ -434,7 +437,7 @@ button.run-status:hover { filter:brightness(0.96); }
   color: var(--text-faint); user-select: none; vertical-align: top;
   border-right: 1px solid var(--border-strong); background: var(--bg-sunken);
 }
-.rp-fasta-hdr { padding: 1px 12px 1px 8px; color: var(--clay-strong); font-weight: 650; white-space: pre; }
+.rp-fasta-hdr { padding: 1px 12px 1px 8px; color: var(--clay-strong); font-weight: 600; white-space: pre; }
 .rp-fasta-seq { padding: 1px 12px 1px 8px; color: var(--text-muted); letter-spacing: 0.02em; white-space: pre; }
 .rp-msa-wrap nightingale-msa { display: block; min-height: 420px; }
 
@@ -497,9 +500,9 @@ button.run-status:hover { filter:brightness(0.96); }
 .rp-xlsx-tabs { display: flex; flex: 0 0 auto; gap: 2px; padding: 5px 6px 0; overflow-x: auto; border-bottom: 1px solid var(--border); background: var(--bg-sunken); }
 .rp-xlsx-tabs button { max-width: 180px; padding: 5px 10px; overflow: hidden; border: 1px solid transparent; border-bottom: 0; border-radius: 6px 6px 0 0; background: transparent; color: var(--text-muted); font: inherit; font-size: 11px; text-overflow: ellipsis; white-space: nowrap; cursor: pointer; }
 .rp-xlsx-tabs button:hover { color: var(--text); background: var(--surface-hover); }
-.rp-xlsx-tabs button.active { border-color: var(--border); background: var(--bg-elev); color: var(--text); font-weight: 650; }
+.rp-xlsx-tabs button.active { border-color: var(--border); background: var(--bg-elev); color: var(--text); font-weight: 600; }
 .rp-xlsx-formula { display: flex; min-height: 30px; flex: 0 0 auto; align-items: center; border-bottom: 1px solid var(--border); background: var(--bg-elev); }
-.rp-xlsx-formula > span { align-self: stretch; display: flex; align-items: center; padding: 0 9px; border-right: 1px solid var(--border); color: var(--text-faint); font-size: 10px; font-weight: 650; text-transform: uppercase; }
+.rp-xlsx-formula > span { align-self: stretch; display: flex; align-items: center; padding: 0 9px; border-right: 1px solid var(--border); color: var(--text-faint); font-size: 10px; font-weight: 600; text-transform: uppercase; }
 .rp-xlsx-formula code { min-width: 0; padding: 0 9px; overflow: hidden; color: var(--text-muted); font: 11px/1.4 var(--font-mono); text-overflow: ellipsis; white-space: nowrap; }
 .rp-xlsx-grid { position: relative; min-width: 0; min-height: 180px; flex: 1 1 auto; overflow: auto; background: var(--bg-elev); scrollbar-gutter: stable; }
 .rp-xlsx-content { position: relative; min-width: 100%; min-height: 100%; background-image: linear-gradient(to right, transparent 139px, var(--border) 140px), linear-gradient(to bottom, transparent 27px, var(--border) 28px); background-position: 52px 28px; background-size: 140px 28px; }
@@ -552,7 +555,7 @@ button.run-status:hover { filter:brightness(0.96); }
 .file-preview-crop-layer { position: absolute; inset: 0; z-index: 3; cursor: crosshair; touch-action: none; }
 .file-preview-crop-rect { position: absolute; z-index: 4; border: 1.5px solid var(--clay); background: color-mix(in srgb, var(--clay) 18%, transparent); pointer-events: none; }
 .file-preview-crop-rect.selected { border-width: 2px; box-shadow: 0 0 0 1px color-mix(in srgb, var(--bg-elev) 70%, transparent); }
-.file-preview-crop-label { position: absolute; top: 6px; left: 6px; padding: 3px 7px; border-radius: 5px; background: var(--clay); color: var(--on-clay); font-size: 11px; font-weight: 650; white-space: nowrap; box-shadow: var(--shadow-sm); }
+.file-preview-crop-label { position: absolute; top: 6px; left: 6px; padding: 3px 7px; border-radius: 5px; background: var(--clay); color: var(--on-clay); font-size: 11px; font-weight: 600; white-space: nowrap; box-shadow: var(--shadow-sm); }
 /* Anchored inside the crop layer, not the window: absolute overrides the base
    .selection-popup fixed, and the entrance animation is dropped because its
    fill-mode `to { transform: none }` would cancel the centering translate. */
@@ -606,23 +609,23 @@ button.run-status:hover { filter:brightness(0.96); }
    instead of shattering numbers/headers character-by-character (matches the
    Claude Science CsvPreview approach: nowrap + tabular-nums + scroll). */
 .tbl th, .tbl td { padding: 7px 11px; text-align: left; border-bottom: 1px solid var(--border); border-right: 1px solid var(--border); white-space: nowrap; vertical-align: middle; line-height: 1.45; font-variant-numeric: tabular-nums; }
-.tbl td strong, .tbl th strong { font-weight: 650; }
+.tbl td strong, .tbl th strong { font-weight: 600; }
 .tbl td code, .tbl th code { font-family: var(--font-mono); font-size: 11.5px; background: var(--bg-sunken); border: 1px solid var(--border); border-radius: 4px; padding: 0 4px; }
 .tbl th:last-child, .tbl td:last-child { border-right: none; }
-.tbl thead th { position: sticky; top: 0; background: var(--bg-elev); color: var(--text); font-weight: 650; z-index: 1; }
+.tbl thead th { position: sticky; top: 0; background: var(--bg-elev); color: var(--text); font-weight: 600; z-index: 1; }
 .tbl tbody tr:hover { background: var(--bg-elev); }
 .tbl tbody tr:last-child td { border-bottom: none; }
 
 /* Controlled Agent workflows */
 .agents-pane { flex: 1 1 auto; min-height: 0; overflow-y: auto; padding: 12px; background: var(--bg-sunken); }
 .agents-create { display: grid; gap: 7px; padding: 11px; border: 1px solid var(--border-strong); border-radius: var(--radius-sm); background: var(--bg-elev); box-shadow: var(--shadow-sm); }
-.agents-create label { color: var(--text-muted); font-size: 11.5px; font-weight: 650; }
+.agents-create label { color: var(--text-muted); font-size: 11.5px; font-weight: 600; }
 .agents-create textarea { box-sizing: border-box; width: 100%; min-height: 72px; resize: vertical; padding: 8px 9px; border: 1px solid var(--border-strong); border-radius: var(--radius-xs); background: var(--bg-app); color: var(--text); font: inherit; font-size: 12.5px; line-height: 1.45; }
 .agents-create-actions, .agent-workflow-actions { display: flex; align-items: center; flex-wrap: wrap; gap: 7px; }
 .agents-mode-row { display: flex; align-items: center; gap: 8px; color: var(--text-faint); font-size: 11px; line-height: 1.4; }
 .agents-mode-row select { flex: 0 0 auto; }
 .agents-create select { min-width: 108px; padding: 6px 8px; border: 1px solid var(--border-strong); border-radius: var(--radius-xs); background: var(--bg-elev); color: var(--text); font: inherit; font-size: 12px; }
-.agents-primary, .agents-secondary, .agents-danger { padding: 6px 10px; border: 1px solid var(--border-strong); border-radius: var(--radius-xs); font: inherit; font-size: 11.5px; font-weight: 650; cursor: pointer; }
+.agents-primary, .agents-secondary, .agents-danger { padding: 6px 10px; border: 1px solid var(--border-strong); border-radius: var(--radius-xs); font: inherit; font-size: 11.5px; font-weight: 600; cursor: pointer; }
 .agents-primary { border-color: var(--clay); background: var(--clay); color: var(--on-clay); }
 .agents-primary:hover:not(:disabled) { background: var(--clay-strong); }
 .agents-secondary { background: var(--bg-elev); color: var(--text-muted); }
@@ -633,18 +636,18 @@ button.run-status:hover { filter:brightness(0.96); }
 .agent-delegation-off { margin-bottom: 8px; padding: 7px 9px; border: 1px solid color-mix(in srgb, var(--clay) 22%, var(--border)); border-radius: var(--radius-xs); background: var(--clay-soft); color: var(--text-muted); font-size: 11px; line-height: 1.45; }
 .agent-workflow-card { margin-top: 10px; padding: 11px; border: 1px solid var(--border-strong); border-radius: var(--radius-sm); background: var(--bg-elev); box-shadow: var(--shadow-sm); }
 .agent-workflow-head, .agent-step-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 8px; }
-.agent-workflow-name { color: var(--text); font-size: 13px; font-weight: 680; line-height: 1.35; overflow-wrap: anywhere; }
+.agent-workflow-name { color: var(--text); font-size: 13px; font-weight: 600; line-height: 1.35; overflow-wrap: anywhere; }
 .agent-workflow-meta, .agent-step-meta, .agent-step-limits, .agent-usage { margin-top: 3px; color: var(--text-faint); font-size: 10.5px; line-height: 1.4; overflow-wrap: anywhere; }
 .agent-workflow-goal { margin: 8px 0; color: var(--text-muted); font-size: 12px; line-height: 1.48; }
 .agent-confirm-hint { margin-bottom: 8px; padding: 6px 8px; border-radius: var(--radius-xs); background: var(--clay-soft); color: var(--text-muted); font-size: 10.5px; }
-.agent-workflow-status, .agent-attempt-status { flex: 0 0 auto; padding: 2px 6px; border-radius: var(--radius-xs); background: var(--bg-sunken); color: var(--text-muted); font-size: 10px; font-weight: 650; text-transform: capitalize; }
+.agent-workflow-status, .agent-attempt-status { flex: 0 0 auto; padding: 2px 6px; border-radius: var(--radius-xs); background: var(--bg-sunken); color: var(--text-muted); font-size: 10px; font-weight: 600; text-transform: capitalize; }
 .agent-workflow-status.running, .agent-attempt-status.running { background: color-mix(in srgb, var(--clay) 14%, var(--bg-elev)); color: var(--clay-strong); }
 .agent-workflow-status.succeeded, .agent-attempt-status.succeeded { background: color-mix(in srgb, var(--ok) 12%, var(--bg-elev)); color: var(--ok); }
 .agent-workflow-status.failed, .agent-workflow-status.cancelled, .agent-attempt-status.failed, .agent-attempt-status.cancelled, .agent-attempt-status.blocked { background: color-mix(in srgb, var(--err) 10%, var(--bg-elev)); color: var(--err); }
 .agent-step-list { display: grid; gap: 7px; margin-top: 10px; }
 .agent-step { padding: 8px 9px; border: 1px solid var(--border); border-radius: var(--radius-xs); background: var(--bg-app); }
-.agent-step-name { color: var(--text); font-size: 11.5px; font-weight: 650; text-transform: capitalize; }
-.agent-retry-budget { display: flex; align-items: center; gap: 7px; margin-top: 7px; color: var(--text-muted); font-size: 10.5px; font-weight: 650; }
+.agent-step-name { color: var(--text); font-size: 11.5px; font-weight: 600; text-transform: capitalize; }
+.agent-retry-budget { display: flex; align-items: center; gap: 7px; margin-top: 7px; color: var(--text-muted); font-size: 10.5px; font-weight: 600; }
 .agent-retry-budget input { width: 96px; padding: 4px 6px; border: 1px solid var(--border-strong); border-radius: var(--radius-xs); background: var(--bg-elev); color: var(--text); font: inherit; }
 .agent-attempt-summary { margin: 6px 0 0; color: var(--text-muted); font-size: 11.5px; line-height: 1.45; }
 /* Dynamic temporary Agents */
@@ -674,7 +677,7 @@ button.run-status:hover { filter:brightness(0.96); }
 .dynamic-agent-policy-row { display: grid; grid-template-columns: minmax(130px, .8fr) minmax(140px, 1fr); align-items: end; gap: 9px; }
 .dynamic-agent-policy-row label { display: grid; gap: 4px; }
 .dynamic-agent-policy-row > span { padding-bottom: 4px; color: var(--text-faint); font-size: 10.5px; line-height: 1.4; }
-.dynamic-agent-context > summary, .dynamic-agent-advanced > summary { cursor: pointer; color: var(--text-muted); font-size: 11px; font-weight: 650; }
+.dynamic-agent-context > summary, .dynamic-agent-advanced > summary { cursor: pointer; color: var(--text-muted); font-size: 11px; font-weight: 600; }
 .dynamic-agent-context textarea { margin-top: 7px; min-height: 58px; }
 .dynamic-agent-task { min-width: 0; margin: 0; padding: 9px; border: 1px solid var(--border); border-radius: var(--radius-xs); background: var(--bg-sunken); }
 .dynamic-agent-task-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
@@ -799,7 +802,7 @@ button.run-status:hover { filter:brightness(0.96); }
 
 /* Highlights tab: this session's saved text excerpts. */
 .highlights-list { flex: 1 1 auto; min-height: 0; overflow: auto; background: var(--bg-elev); }
-.highlight-card { display: flex; align-items: flex-start; gap: 6px; padding: 12px; border-bottom: 1px solid var(--border-strong); }
+.highlight-card { display: flex; align-items: flex-start; gap: 6px; padding: 12px; border-bottom: 1px solid var(--border); }
 .highlight-text { flex: 1; min-width: 0; text-align: left; background: none; border: none; margin: 0; padding: 2px 0 2px 10px; border-left: 3px solid var(--clay); color: var(--text); font: inherit; font-size: 13px; line-height: 1.55; cursor: pointer; white-space: pre-wrap; word-break: break-word; }
 .highlight-text:hover { color: var(--clay-strong); }
 .highlight-actions { display: flex; flex-direction: column; gap: 2px; }

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -55,7 +55,7 @@ body:has(.settings-page) .projects-screen { display: none; }
 .settings-nav-title {
   padding: 2px 14px 0;
   font-size: 20px;
-  font-weight: 650;
+  font-weight: 600;
   letter-spacing: -0.02em;
   color: var(--text);
 }
@@ -67,7 +67,7 @@ body:has(.settings-page) .projects-screen { display: none; }
 .settings-nav-label {
   padding: 0 14px 4px;
   font-size: 11px;
-  font-weight: 650;
+  font-weight: 600;
   letter-spacing: .04em;
   text-transform: uppercase;
   color: var(--text-faint);
@@ -91,7 +91,7 @@ body:has(.settings-page) .projects-screen { display: none; }
 .settings-nav button.active {
   background: var(--bg-elev);
   color: var(--text);
-  font-weight: 650;
+  font-weight: 600;
   border-color: var(--border);
   box-shadow: var(--shadow-sm);
 }
@@ -109,7 +109,7 @@ body:has(.settings-page) .projects-screen { display: none; }
   border-bottom: none;
   flex-shrink: 0;
   font-size: 18px;
-  font-weight: 650;
+  font-weight: 600;
   letter-spacing: -0.02em;
 }
 .settings-head {
@@ -168,7 +168,7 @@ body:has(.settings-page) .projects-screen { display: none; }
 .settings-crumb-link:hover { color: var(--text); }
 .settings-crumb-sep { color: var(--text-faint); flex-shrink: 0; }
 .settings-crumb-current {
-  font-weight: 650;
+  font-weight: 600;
   color: var(--text);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -268,7 +268,7 @@ body:has(.settings-page) .projects-screen { display: none; }
 .cred-help-section strong {
   color: var(--text);
   font-size: 11.5px;
-  font-weight: 650;
+  font-weight: 600;
 }
 .cred-setup-note {
   display: flex;
@@ -294,7 +294,7 @@ body:has(.settings-page) .projects-screen { display: none; }
   background: transparent;
   color: var(--clay);
   font: inherit;
-  font-weight: 550;
+  font-weight: 500;
   cursor: pointer;
   text-decoration: underline;
   text-decoration-color: color-mix(in srgb, var(--clay) 45%, transparent);
@@ -687,7 +687,7 @@ body:has(.settings-page) .projects-screen { display: none; }
   color: var(--text-muted);
   font: inherit;
   font-size: 11.5px;
-  font-weight: 550;
+  font-weight: 500;
   white-space: nowrap;
   cursor: pointer;
   box-shadow: var(--shadow-sm);
@@ -756,7 +756,7 @@ body:has(.settings-page) .projects-screen { display: none; }
   background: var(--clay-soft);
   color: var(--clay-strong);
   font-size: 10px;
-  font-weight: 650;
+  font-weight: 600;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -899,7 +899,7 @@ body:has(.settings-page) .projects-screen { display: none; }
   pointer-events: none;
 }
 .workflow-graph-stage-label span {
-  font-weight: 750;
+  font-weight: 700;
   letter-spacing: .04em;
   text-transform: uppercase;
 }
@@ -1041,7 +1041,7 @@ body:has(.settings-page) .projects-screen { display: none; }
   background: color-mix(in srgb, var(--bg-sunken) 88%, var(--bg-elev));
   color: var(--text-muted);
   font-size: 9px;
-  font-weight: 550;
+  font-weight: 500;
   letter-spacing: .01em;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1183,7 +1183,7 @@ button.workflow-graph-port.output.active {
 .workflow-graph-incoming > span {
   color: var(--text-faint);
   font-size: 9.5px;
-  font-weight: 650;
+  font-weight: 600;
   text-transform: uppercase;
 }
 .workflow-graph-inspector-head strong {
@@ -1237,7 +1237,7 @@ button.workflow-graph-port.output.active {
 .workflow-graph-incoming code {
   overflow: hidden;
   font-size: 9.5px;
-  font-weight: 550;
+  font-weight: 500;
   text-overflow: ellipsis;
 }
 .workflow-graph-inspector .dynamic-agent-task {
@@ -1471,7 +1471,7 @@ button.workflow-graph-port.output.active {
   border-radius: var(--radius-xs);
   font-family: var(--font-ui);
   font-size: 11.5px;
-  font-weight: 550;
+  font-weight: 500;
   white-space: nowrap;
 }
 .workflow-studio-editor-actions .agents-primary { font-weight: 600; }
@@ -1607,7 +1607,7 @@ button.workflow-graph-port.output.active {
 .plugin-local-source { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 8px; }
 .plugin-local-source button { padding: 9px 13px; border: 1px solid var(--border-strong); border-radius: var(--radius-sm); background: var(--bg-input); color: var(--text); font: inherit; font-size: 13px; white-space: nowrap; cursor: pointer; }
 .plugin-local-source button:hover { border-color: var(--text-faint); }
-.plugin-install-fields > button { justify-self: end; padding: 9px 15px; border: 1px solid transparent; border-radius: var(--radius-sm); background: var(--clay); color: var(--on-clay); font: inherit; font-size: 13px; font-weight: 650; cursor: pointer; }
+.plugin-install-fields > button { justify-self: end; padding: 9px 15px; border: 1px solid transparent; border-radius: var(--radius-sm); background: var(--clay); color: var(--on-clay); font: inherit; font-size: 13px; font-weight: 600; cursor: pointer; }
 .plugin-install-fields > button:hover:not(:disabled) { background: var(--clay-strong); }
 .plugin-install-fields > button:disabled { opacity: .48; cursor: not-allowed; }
 /* .primary fill comes from shared button primitives in base.css */
@@ -1625,7 +1625,7 @@ button.workflow-graph-port.output.active {
 .plugin-details .plugin-detail-grid { display: grid; grid-template-columns: auto minmax(0, 1fr); gap: 3px 12px; margin: 8px 0 0; font-size: 12px; }
 .plugin-details .plugin-detail-grid dt { color: var(--text-faint); }
 .plugin-details .plugin-detail-grid dd { margin: 0; color: var(--text-muted); word-break: break-word; }
-.appearance-theme-section h3 { margin: 0 0 18px; font-size: 16px; font-weight: 650; }
+.appearance-theme-section h3 { margin: 0 0 18px; font-size: 16px; font-weight: 600; }
 .theme-mode-grid { display: grid; grid-template-columns: repeat(3, 244px); gap: 18px; }
 .theme-mode-card {
   display: flex; flex-direction: column; gap: 9px; align-items: stretch; min-width: 0;
@@ -1664,7 +1664,7 @@ button.workflow-graph-port.output.active {
 .pet-settings-pane { gap: 22px; }
 .pet-settings-hero { display: flex; align-items: center; gap: 24px; min-height: 150px; padding: 18px 24px; overflow: hidden; border: 1px solid color-mix(in srgb, var(--clay) 28%, var(--border)); border-radius: var(--radius); background: radial-gradient(circle at 16% 20%, color-mix(in srgb, var(--clay) 16%, transparent), transparent 36%), linear-gradient(135deg, color-mix(in srgb, var(--bg-elev) 90%, var(--clay-soft)), var(--bg-app)); }
 .pet-settings-preview { display: grid; place-items: center; width: 116px; height: 126px; flex: 0 0 auto; border-radius: 24px; background: color-mix(in srgb, var(--bg-sunken) 76%, transparent); box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--border) 75%, transparent); }
-.pet-settings-preview.empty::after { content: "?"; color: var(--text-faint); font-size: 38px; font-weight: 300; }
+.pet-settings-preview.empty::after { content: "?"; color: var(--text-faint); font-size: 38px; font-weight: 400; }
 .pet-settings-sprite { width: 96px; height: 104px; background-repeat: no-repeat; background-size: 800% 1100%; background-position: 0 0; filter: drop-shadow(0 8px 12px rgba(22,20,16,.16)); }
 .pet-settings-copy { min-width: 0; }
 .pet-settings-copy h3 { margin: 0 0 7px; font-size: 21px; letter-spacing: -.025em; }
@@ -1677,7 +1677,7 @@ button.workflow-graph-port.output.active {
 .pet-directory-row .settings-field-hint { font-weight: 400; }
 .appearance-config-head, .appearance-config-row { display: flex; align-items: center; justify-content: space-between; gap: 24px; min-height: 66px; border-bottom: 1px solid var(--border); }
 .appearance-config-row:last-child { border-bottom: none; }
-.appearance-config-head > strong, .appearance-config-row > strong, .appearance-config-row > div > strong { font-size: 14px; font-weight: 650; }
+.appearance-config-head > strong, .appearance-config-row > strong, .appearance-config-row > div > strong { font-size: 14px; font-weight: 600; }
 .appearance-config-head select { width: 264px; }
 .appearance-config-row > div { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
 .appearance-config-row > div > span { color: var(--text-faint); font-size: 12px; }
@@ -1903,7 +1903,7 @@ button.workflow-graph-port.output.active {
 .settings-toolbar > button {
   font: inherit;
   font-size: 12.5px;
-  font-weight: 550;
+  font-weight: 500;
   padding: 7px 12px;
   border: 1px solid var(--border-strong);
   border-radius: var(--radius-sm);
@@ -1944,7 +1944,7 @@ button.workflow-graph-port.output.active {
 .settings-category-tab {
   font: inherit;
   font-size: 13px;
-  font-weight: 550;
+  font-weight: 500;
   color: var(--text-muted);
   white-space: nowrap;
   padding: 7px 12px;
@@ -1967,7 +1967,7 @@ button.workflow-graph-port.output.active {
 .settings-toolbar-end .settings-add-menu { justify-self: end; }
 .settings-filter {
   font-size: 13px;
-  font-weight: 550;
+  font-weight: 500;
   color: var(--text);
   white-space: nowrap;
   padding: 7px 12px;
@@ -1998,7 +1998,7 @@ button.workflow-graph-port.output.active {
   cursor: pointer;
   font: inherit;
   font-size: 13.5px;
-  font-weight: 550;
+  font-weight: 500;
   padding: 8px 14px;
   border: 1px solid var(--border-strong);
   border-radius: var(--radius-sm);
@@ -2039,7 +2039,7 @@ button.workflow-graph-port.output.active {
 .appearance-config-row > button {
   font: inherit;
   font-size: 13.5px;
-  font-weight: 550;
+  font-weight: 500;
   padding: 8px 14px;
   border: 1px solid var(--border-strong);
   border-radius: var(--radius-sm);
@@ -2074,7 +2074,7 @@ button.workflow-graph-port.output.active {
 .model-preset-btn {
   font: inherit;
   font-size: 12.5px;
-  font-weight: 550;
+  font-weight: 500;
   padding: 4px 12px;
   border: 1px solid var(--border-strong);
   border-radius: 999px;
@@ -2116,7 +2116,7 @@ button.workflow-graph-port.output.active {
   gap: 20px;
 }
 .channel-bind-row > div { min-width: 0; }
-.channel-bind-row strong, .channels-qr strong { color: var(--text); font-size: 13px; font-weight: 620; }
+.channel-bind-row strong, .channels-qr strong { color: var(--text); font-size: 13px; font-weight: 600; }
 .channel-bind-row p, .channels-qr p {
   max-width: 720px;
   margin: 4px 0 0;
@@ -2253,7 +2253,7 @@ button.workflow-graph-port.output.active {
 }
 .settings-list-title {
   font-size: 14px;
-  font-weight: 550;
+  font-weight: 500;
   color: var(--text);
   line-height: 1.35;
 }
@@ -2449,7 +2449,7 @@ button.workflow-graph-port.output.active {
 .memory-clear-btn {
   font: inherit;
   font-size: 13px;
-  font-weight: 550;
+  font-weight: 500;
   padding: 8px 14px;
   border: 1px solid var(--border-strong);
   border-radius: var(--radius-sm);
@@ -2677,18 +2677,18 @@ body { font-size: var(--ui-font-size, 14px); }
 .storage-dot { width: 10px; height: 10px; border-radius: 3px; flex: none; }
 .storage-legend-label { flex: 1; min-width: 0; }
 .storage-legend-bytes { color: var(--text-muted); font-variant-numeric: tabular-nums; }
-.storage-legend-total { font-weight: 650; }
+.storage-legend-total { font-weight: 600; }
 .storage-legend-total .storage-legend-bytes { color: var(--text); }
 
 /* Usage section */
 .settings-usage-pane { padding-bottom: 28px; }
 .usage-summary { display: flex; gap: 10px; flex-wrap: wrap; margin: 12px 0 18px; }
 .usage-tile { flex: 1; min-width: 110px; display: flex; flex-direction: column; gap: 3px; background: var(--bg-sunken); border: 1px solid var(--border); border-radius: var(--radius-sm); padding: 12px 14px; }
-.usage-tile-value { font-size: 20px; font-weight: 650; font-variant-numeric: tabular-nums; }
+.usage-tile-value { font-size: 20px; font-weight: 600; font-variant-numeric: tabular-nums; }
 .usage-tile-label { font-size: 12px; color: var(--text-faint); }
 .usage-card { min-width: 0; padding: 16px; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--bg-elev); }
 .usage-card-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 14px; }
-.usage-card-head h3 { margin: 0; font-size: 15px; font-weight: 650; }
+.usage-card-head h3 { margin: 0; font-size: 15px; font-weight: 600; }
 .usage-card-head p { margin: 3px 0 0; color: var(--text-faint); font-size: 11.5px; }
 .usage-activity-card { margin-bottom: 14px; }
 .usage-mode-tabs { display: inline-flex; flex: none; padding: 2px; border-radius: var(--radius-xs); background: var(--bg-sunken); }
@@ -2722,7 +2722,7 @@ body { font-size: var(--ui-font-size, 14px); }
 .usage-tool-rank-list { display: flex; flex-direction: column; gap: 10px; }
 .usage-tool-rank-row { display: grid; grid-template-columns: 18px auto minmax(0, 1fr); gap: 8px; align-items: start; }
 .usage-tool-rank-index { color: var(--text-faint); font-size: 11px; font-variant-numeric: tabular-nums; line-height: 18px; text-align: right; }
-.usage-tool-rank-badge { display: inline-flex; align-items: center; height: 18px; padding: 0 6px; border-radius: 4px; background: var(--bg-sunken); color: var(--text-muted); font-size: 10px; font-weight: 650; letter-spacing: .02em; line-height: 1; text-transform: uppercase; white-space: nowrap; }
+.usage-tool-rank-badge { display: inline-flex; align-items: center; height: 18px; padding: 0 6px; border-radius: 4px; background: var(--bg-sunken); color: var(--text-muted); font-size: 10px; font-weight: 600; letter-spacing: .02em; line-height: 1; text-transform: uppercase; white-space: nowrap; }
 .usage-tool-rank-badge.kind-skill { color: color-mix(in srgb, var(--clay) 85%, var(--text)); background: color-mix(in srgb, var(--clay) 16%, var(--bg-sunken)); }
 .usage-tool-rank-badge.kind-mcp { color: color-mix(in srgb, #3b82f6 80%, var(--text)); background: color-mix(in srgb, #3b82f6 14%, var(--bg-sunken)); }
 .usage-tool-rank-main { min-width: 0; display: flex; flex-direction: column; gap: 4px; }

--- a/ui/src/styles/sidebar.css
+++ b/ui/src/styles/sidebar.css
@@ -191,7 +191,7 @@ button.side-item.ses.selecting { padding-right: 10px; }
 .side-exploration.active { border-color: var(--border-active); background: var(--clay-soft); color: var(--text); }
 .exploration-branch-mark { flex: 0 0 auto; color: var(--clay); font: 12px/1 var(--font-mono); }
 .side-exploration-copy { display: flex; min-width: 0; flex-direction: column; gap: 1px; }
-.side-exploration-title { overflow: hidden; font-size: 12px; font-weight: 560; text-overflow: ellipsis; white-space: nowrap; }
+.side-exploration-title { overflow: hidden; font-size: 12px; font-weight: 500; text-overflow: ellipsis; white-space: nowrap; }
 .side-exploration-meta { overflow: hidden; color: var(--text-faint); font-size: 9.5px; text-overflow: ellipsis; white-space: nowrap; }
 .side-hint { font-size: 12px; color: var(--text-faint); padding: 6px 10px; }
 .side-load-more { width: 100%; margin-top: 6px; padding: 7px; border: 0; border-radius: var(--radius-xs); background: transparent; color: var(--text-muted); font-size: 12px; cursor: pointer; }

--- a/ui/src/styles/terminal-dock.css
+++ b/ui/src/styles/terminal-dock.css
@@ -18,7 +18,7 @@
   flex: 0 0 auto;
   min-height: 150px;
   overflow: hidden;
-  border-top: 1px solid var(--border-strong);
+  border-top: 1px solid var(--border);
   background: var(--bg-app);
   box-shadow: 0 -8px 28px color-mix(in srgb, var(--shadow-color) 22%, transparent);
   animation: terminal-dock-in var(--motion-duration-medium) var(--motion-ease-emphasized) both;
@@ -153,7 +153,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-weight: 520;
+  font-weight: 500;
 }
 .terminal-dock-meta { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--text-faint); font: 10px/1.2 var(--font-mono); }
 .terminal-dock-spacer { flex: 1; }
@@ -201,7 +201,7 @@
   padding: 5px 8px 7px;
   color: var(--text-faint);
   font-size: 10px;
-  font-weight: 650;
+  font-weight: 600;
   letter-spacing: .04em;
   text-transform: uppercase;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The UI felt visually noisy: everything competed for attention at once. The composer carried a heavy double shadow and strong border at all times, the right-pane tab strip ellipsized two-character CJK labels into unreadable fragments ("产…"), static dividers used the strong border tone everywhere, artifact cards allocated a large 4:3 thumbnail area even for kinds that have no preview, and font weights were scattered across nine different values.

## Changes

**P0 — highest-leverage quieting:**
- `chat.css`: `.composer-inner` now rests on `var(--border)` + `--shadow-sm` only; the strong border and big lift shadow are reserved for `:focus-within`, so the focused input is the one element that floats. The keyboard-shortcut hint (`.composer-hint`) is hidden until the composer is focused or hovered.
- `right-pane.css`: `.rp-tab-wrap` changed from `flex: 0 1 auto` (shrank to a 56px floor, truncating labels) to `flex: 0 0 auto` — overflow now scrolls via `.rp-tab-scroll`, which the strip already supports. `.rp-tab` buttons in `main.rs` carry a `title` tooltip so long file names remain readable.
- Static structural hairlines moved from `--border-strong` to `--border`: `.rp-tabs`, `.rp-tiles`, `.highlight-card`, `.resizer`, `.terminal-dock`, `.am-tabs`, `.follow-up-questions`. `--border-strong` remains on interactive controls (inputs, buttons, menus, modals).

**P1 — component language:**
- `.message-artifact-card` switches from a 4:3 tile (mostly an empty badge area for non-image kinds) to a compact 40px-thumb row; the cards grid moves from `minmax(132px, 1fr)` to `minmax(216px, 1fr)`. Image artifacts still render real cropped thumbnails.
- `.follow-up-questions` drops its tinted panel fill; rows keep only the hover surface.
- Font weights normalized from nine values ({300, 520, 550, 560, 620, 650, 680, 750} + intended) onto the 400/500/600/700 scale (650→600, 550/520/560→500, 620/680→600, 750→700, 300→400).

## Tests

- New `ui-tests/tests/visual-polish.spec.ts` (5 cases): resting vs focused composer border/shadow, hint opacity on blur/focus/hover, tab no-ellipsize + `title` tooltips + scroller overflow, compact artifact row metrics, transparent follow-up block.
- Full Playwright suite: 321 passed, 1 skipped (pre-existing skip).
- `cargo fmt --all -- --check` clean; `cargo check --target wasm32-unknown-unknown` clean.
- `cargo test` passes for all crates that build in a headless Linux container (268 tests). `wisp-tauri` and `wisp-store` fail to *build* in this container (missing system `gdk-3.0` / `libdbus` dev packages); verified identical failure on the base branch — pre-existing environment limitation, unrelated to this change.

## Manual smoke

1. Open a project: composer sits flat; click into it → border/shadow/ring lift, shortcut hint fades in; click away → settles back.
2. Open the right panel and add tabs (Notebook, Highlights, Provenance, Side chat) at a narrow window: tab labels stay intact, the strip scrolls horizontally, hover shows full-name tooltips.
3. Send a message that generates artifacts: cards render as compact rows; image artifacts still show thumbnails.
4. Follow-up suggestions render as a plain list under the reply with hover-only row backgrounds.
5. Toggle dark mode: all of the above resolve through the existing tokens, no per-theme overrides needed.

## Known limitations / follow-ups

- Artifact cards do not yet render real mini-previews for table/code kinds (the original audit's larger suggestion) — that needs a data-flow change and is deliberately out of scope; this PR makes the no-preview state compact instead.
- The reference audit's "three stacked toolbars" claim did not reproduce against current main (titlebar is a single row); no change made there.
- Session title rename UX and dev-metrics tucking (other audit items) are untouched pending product decision.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-341ac143-43a2-42c1-83ad-3a42a2b518db?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-341ac143-43a2-42c1-83ad-3a42a2b518db&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

