### PR TITLE
Fix clipped Windows pet status labels

### DIFF
--- a/docs/pet.md
+++ b/docs/pet.md
@@ -12,7 +12,7 @@ The pet folder must use `spriteVersionNumber: 2` and contain a `1536x2288` PNG o
 
 The app uses the standard animation rows for idle, directional walking, waving, jumping, failure, waiting for user input, active work, review, and 16-direction pointer tracking. Clicking an idle pet makes it wave. Reduced-motion system preferences disable roaming and animated playback.
 
-On Windows, the pet lives in its own transparent always-on-top window instead of inside the main workspace. Drag the pet to move it. While a managed Run is active, the pet shows its title above the sprite; when it finishes, the pet celebrates. When it shows **Needs you**, click it to restore the workspace and open the session waiting for input. Closing the main Wisp Science window hides the workspace to the system tray while the pet and active agent work continue; click the tray icon, choose **Open Wisp Science**, or launch Wisp Science again to restore the existing workspace. Only one desktop app instance runs at a time. Choose **Restart** to restart it or **Quit** to stop it. The pet animation and status badge show when the agent is working, reviewing, waiting for approval, finished, or failed.
+On Windows, the pet lives in its own transparent always-on-top window instead of inside the main workspace. Drag the pet to move it. While a managed Run is active, the pet shows up to two lines of its title above the sprite; when it finishes, the pet celebrates. When it shows **Needs you**, click it to restore the workspace and open the session waiting for input. Closing the main Wisp Science window hides the workspace to the system tray while the pet and active agent work continue; click the tray icon, choose **Open Wisp Science**, or launch Wisp Science again to restore the existing workspace. Only one desktop app instance runs at a time. Choose **Restart** to restart it or **Quit** to stop it. The pet animation and status badge show when the agent is working, reviewing, waiting for approval, finished, or failed.
 
 ## 配置宠物
 
@@ -20,4 +20,4 @@ Wisp Science 只加载一个由用户明确选择的 Codex v2 宠物，默认关
 
 打开 **设置 > 宠物**，选择包含 `pet.json` 和精灵表的安装目录，开启 **显示宠物** 后保存。目录必须使用 `spriteVersionNumber: 2`，精灵表必须是 `1536x2288` 的 PNG 或 WebP 文件。更换配置目录即可更换宠物；关闭开关后，应用不会再加载或显示该目录中的宠物。
 
-在 Windows 上，宠物运行在独立的透明置顶窗口中，而不是嵌在主工作区内，可以拖动到屏幕上的其他位置。托管 Run 执行时会在宠物上方显示任务名称，完成时宠物会跳动提醒。显示 **Needs you** 时，点击宠物会恢复工作区并打开正在等待操作的 session。关闭 Wisp Science 主窗口会把工作区隐藏到系统托盘，宠物和正在执行的 agent 任务会继续工作；点击托盘图标、选择 **Open Wisp Science** 或再次启动 Wisp Science 都会恢复现有工作区。桌面应用全局只运行一个实例；选择 **Restart** 会重启应用，选择 **Quit** 才会真正退出。宠物动画、状态点和文字会显示工作中、review、等待批准、完成或失败状态。
+在 Windows 上，宠物运行在独立的透明置顶窗口中，而不是嵌在主工作区内，可以拖动到屏幕上的其他位置。托管 Run 执行时会在宠物上方显示最多两行任务名称，完成时宠物会跳动提醒。显示 **Needs you** 时，点击宠物会恢复工作区并打开正在等待操作的 session。关闭 Wisp Science 主窗口会把工作区隐藏到系统托盘，宠物和正在执行的 agent 任务会继续工作；点击托盘图标、选择 **Open Wisp Science** 或再次启动 Wisp Science 都会恢复现有工作区。桌面应用全局只运行一个实例；选择 **Restart** 会重启应用，选择 **Quit** 才会真正退出。宠物动画、状态点和文字会显示工作中、review、等待批准、完成或失败状态。

--- a/src-tauri/src/desktop_lifecycle.rs
+++ b/src-tauri/src/desktop_lifecycle.rs
@@ -10,6 +10,16 @@ use tauri::{AppHandle, Emitter, Manager};
 pub(crate) const PET_WINDOW_LABEL: &str = "pet";
 
 #[cfg(any(target_os = "windows", test))]
+pub(crate) const PET_WINDOW_WIDTH: u32 = 128;
+#[cfg(any(target_os = "windows", test))]
+pub(crate) const PET_WINDOW_HEIGHT: u32 = 176;
+
+#[cfg(target_os = "windows")]
+const PET_WINDOW_RIGHT_MARGIN: u32 = 24;
+#[cfg(target_os = "windows")]
+const PET_WINDOW_BOTTOM_MARGIN: u32 = 90;
+
+#[cfg(any(target_os = "windows", test))]
 pub(crate) fn should_hide_workspace_on_close(window_label: &str) -> bool {
     window_label == "main"
 }
@@ -87,8 +97,16 @@ fn default_pet_position(app: &AppHandle) -> Option<(f64, f64)> {
     let origin = monitor.position();
     let size = monitor.size();
     Some((
-        f64::from(origin.x) + f64::from(size.width.saturating_sub(152)),
-        f64::from(origin.y) + f64::from(size.height.saturating_sub(230)),
+        f64::from(origin.x)
+            + f64::from(
+                size.width
+                    .saturating_sub(PET_WINDOW_WIDTH + PET_WINDOW_RIGHT_MARGIN),
+            ),
+        f64::from(origin.y)
+            + f64::from(
+                size.height
+                    .saturating_sub(PET_WINDOW_HEIGHT + PET_WINDOW_BOTTOM_MARGIN),
+            ),
     ))
 }
 
@@ -100,7 +118,7 @@ fn ensure_pet_window(app: &AppHandle) -> Result<(), String> {
     let url = WebviewUrl::App("index.html?pet=desktop".into());
     let mut builder = WebviewWindowBuilder::new(app, PET_WINDOW_LABEL, url)
         .title("Wisp pet")
-        .inner_size(128.0, 140.0)
+        .inner_size(f64::from(PET_WINDOW_WIDTH), f64::from(PET_WINDOW_HEIGHT))
         .resizable(false)
         .maximizable(false)
         .minimizable(false)

--- a/src-tauri/src/lib_tests.rs
+++ b/src-tauri/src/lib_tests.rs
@@ -1,6 +1,9 @@
 use super::app_commands::parse_ssh_artifact_uri;
 use super::app_updates::{update_check_from_release, GithubRelease};
-use super::desktop_lifecycle::{should_activate_workspace_window, should_hide_workspace_on_close};
+use super::desktop_lifecycle::{
+    should_activate_workspace_window, should_hide_workspace_on_close, PET_WINDOW_HEIGHT,
+    PET_WINDOW_WIDTH,
+};
 use super::session_commands::transcript_page_items;
 use super::{
     begin_queued_cutin, branch_title, client_turn_error, coalesce_live_agent_events,
@@ -1572,6 +1575,11 @@ fn windows_close_to_tray_applies_only_to_the_main_window() {
     assert!(should_hide_workspace_on_close("main"));
     assert!(!should_hide_workspace_on_close("proj-default"));
     assert!(!should_hide_workspace_on_close("pet"));
+}
+
+#[test]
+fn windows_pet_window_uses_the_label_safe_viewport() {
+    assert_eq!((PET_WINDOW_WIDTH, PET_WINDOW_HEIGHT), (128, 176));
 }
 
 #[test]

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from "@playwright/test";
+import { test, expect, type Locator, type Page } from "@playwright/test";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { tauriMock, parallelMock } from "./mock-tauri";
@@ -11,6 +11,15 @@ const motifAppHtmlPath = process.env.WISP_MOTIF_APP_HTML;
 
 function providerSelect(page: Page) {
   return page.getByTestId("settings-provider");
+}
+
+async function expectInsideViewport(locator: Locator, width: number, height: number) {
+  const box = await locator.boundingBox();
+  expect(box).not.toBeNull();
+  expect(box!.x).toBeGreaterThanOrEqual(0);
+  expect(box!.y).toBeGreaterThanOrEqual(0);
+  expect(box!.x + box!.width).toBeLessThanOrEqual(width);
+  expect(box!.y + box!.height).toBeLessThanOrEqual(height);
 }
 
 async function openModelsSettings(page: Page) {
@@ -8106,6 +8115,7 @@ test("pet stays off until the user explicitly configures its directory", async (
 });
 
 test("desktop pet remains independent and reflects global agent state", async ({ page }) => {
+  await page.setViewportSize({ width: 128, height: 176 });
   await page.goto("/?pet=desktop&mockPet=1");
 
   const pet = page.getByTestId("wisp-pet");
@@ -8118,13 +8128,17 @@ test("desktop pet remains independent and reflects global agent state", async ({
     (window as any).__tauriEmit("agent", { kind: "User", frame_id: "pet-frame", text: "run" });
   });
   await expect(pet).toHaveAttribute("data-state", "running");
-  await expect(pet.getByText("Working")).toBeVisible();
+  const workingLabel = pet.getByText("Working");
+  await expect(workingLabel).toBeVisible();
+  await expectInsideViewport(workingLabel, 128, 176);
 
   await page.evaluate(() => {
     (window as any).__tauriEmit("confirm-request", { frame_id: "pet-frame", message: "Approve?" });
   });
   await expect(pet).toHaveAttribute("data-state", "waiting");
-  await expect(pet.getByText("Needs you")).toBeVisible();
+  const waitingLabel = pet.getByText("Needs you");
+  await expect(waitingLabel).toBeVisible();
+  await expectInsideViewport(waitingLabel, 128, 176);
   await pet.click();
   await expect.poll(() => lastInvokeArgs(page, "open_pet_session")).toMatchObject({
     sessionId: "pet-frame",
@@ -8150,6 +8164,7 @@ test("desktop pet remains independent and reflects global agent state", async ({
 });
 
 test("desktop pet shows active Run titles and celebrates completion (#693)", async ({ page }) => {
+  await page.setViewportSize({ width: 128, height: 176 });
   await page.addInitScript(() => {
     (window as any).__mockPetActiveRuns = [
       { id: "run-data", title: "siibra atlas query example (with assignment)" },
@@ -8165,6 +8180,7 @@ test("desktop pet shows active Run titles and celebrates completion (#693)", asy
   await expect(label).toBeVisible();
   await expect(pet).toHaveAttribute("data-state", "running");
   const [spriteBox, labelBox] = await Promise.all([sprite.boundingBox(), label.boundingBox()]);
+  await expectInsideViewport(label, 128, 176);
   expect(labelBox!.y + labelBox!.height).toBeLessThanOrEqual(spriteBox!.y);
 
   await page.evaluate(() => {

--- a/ui/src/styles/pet.css
+++ b/ui/src/styles/pet.css
@@ -59,7 +59,8 @@ html.pet-window-shell body {
   bottom: calc(100% + 6px);
   display: none;
   width: max-content;
-  max-width: 160px;
+  max-width: min(160px, calc(100vw - 16px));
+  max-height: 33px;
   min-width: 52px;
   padding: 2px 7px;
   border: 1px solid rgba(25, 29, 34, .13);
@@ -68,16 +69,20 @@ html.pet-window-shell body {
   box-shadow: 0 3px 10px rgba(20, 23, 28, .13);
   color: #34383e;
   font: 600 10px/1.35 "Segoe UI Variable", "Segoe UI", sans-serif;
+  overflow: hidden;
+  overflow-wrap: anywhere;
   text-align: center;
   white-space: normal;
   transform: translateX(-50%);
   backdrop-filter: blur(8px);
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
 }
 .pet-window-root .wisp-pet[data-state="running"] .wisp-pet-state-label,
 .pet-window-root .wisp-pet[data-state="review"] .wisp-pet-state-label,
 .pet-window-root .wisp-pet[data-state="waiting"] .wisp-pet-state-label,
 .pet-window-root .wisp-pet[data-state="jumping"] .wisp-pet-state-label,
-.pet-window-root .wisp-pet[data-state="failed"] .wisp-pet-state-label { display: block; }
+.pet-window-root .wisp-pet[data-state="failed"] .wisp-pet-state-label { display: -webkit-box; }
 
 @keyframes pet-arrive { from { opacity: 0; transform: translateX(var(--pet-x)) translateY(12px) scale(.92); } to { opacity: 1; transform: translateX(var(--pet-x)) translateY(0) scale(1); } }
 @keyframes pet-status-pulse { 50% { box-shadow: 0 0 0 5px color-mix(in srgb, var(--warn) 20%, transparent); } }


### PR DESCRIPTION
## Problem

On Windows, the desktop pet's status text could be clipped by the transparent native window. Labels such as **Working** and **Needs you** were no longer readable, and long managed Run titles could extend beyond the viewport.

Closes #750.

## Root cause

The status label was moved above the pet sprite, but the native pet window remained 128×140 CSS pixels. The label therefore rendered above the top edge of the WebView and was clipped by the window boundary.

## What changed

- Increase the Windows pet viewport from 128×140 to 128×176.
- Derive the default window position from named size and margin constants so the sprite stays in its previous screen position.
- Keep labels within the viewport width and clamp long Run titles to two lines.
- Test **Working**, **Needs you**, and a long Run title at the exact native viewport size.
- Document the two-line Run title behavior in English and Chinese.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cd ui && cargo check --target wasm32-unknown-unknown`
- `cd ui-tests && npm ci && npx playwright test` — 316 passed, 1 optional integration test skipped

## Manual smoke steps

1. Start a Windows build with a configured desktop pet.
2. Trigger an agent turn and confirm **Working** is fully visible above the sprite.
3. Trigger a confirmation or permission request and confirm **Needs you** is fully visible and still opens the waiting session when clicked.
4. Start a managed Run with a long title and confirm it stays above the sprite within two lines.

## Known limitations and follow-up

Long Run titles are intentionally limited to two visible lines so the transparent pet window remains compact. No follow-up is required for this fix.