### PR TITLE
ui: reveal sidebar row actions on hover only; status dots hidden until running

### DIFF
--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -1978,6 +1978,8 @@ test("conversation action button renames, transfers, and deletes sessions (#557)
   const openActions = async () => {
     const row = session.locator("..");
     const actions = row.getByRole("button", { name: "Conversation actions" });
+    // The menu button is hover/focus-revealed: rest at opacity 0.
+    await row.hover();
     await expect.poll(() => actions.evaluate((el) => Number.parseFloat(getComputedStyle(el).opacity))).toBeGreaterThan(0);
     await actions.click();
   };
@@ -2184,6 +2186,8 @@ test("group action button visibly renames and deletes groups", async ({ page }) 
   let folder = page.locator(".side-folder", { hasText: "Figures" });
   await expect(folder).toBeVisible();
   let actions = folder.getByRole("button", { name: "Group actions" });
+  // The group menu button is hover/focus-revealed: rest at opacity 0.
+  await folder.hover();
   await expect.poll(() => actions.evaluate((el) => Number.parseFloat(getComputedStyle(el).opacity))).toBeGreaterThan(0);
   await actions.click();
   await page.getByRole("button", { name: "Rename group" }).click();
@@ -2193,6 +2197,7 @@ test("group action button visibly renames and deletes groups", async ({ page }) 
   folder = page.locator(".side-folder", { hasText: "Results" });
   await expect(folder).toBeVisible();
   actions = folder.getByRole("button", { name: "Group actions" });
+  await folder.hover();
   await actions.click();
   await page.getByRole("button", { name: "Delete group" }).click();
   await page.locator(".confirm-modal").getByRole("button", { name: "Delete group", exact: true }).click();

--- a/ui-tests/tests/visual-polish.spec.ts
+++ b/ui-tests/tests/visual-polish.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page } from "@playwright/test";
-import { tauriMock } from "./mock-tauri";
+import { tauriMock, parallelMock } from "./mock-tauri";
 
 // Regression coverage for the visual polish pass: the composer sits flat until
 // focused, right-pane tabs scroll instead of ellipsizing short labels, artifact
@@ -98,6 +98,57 @@ test("generated artifact cards render as compact rows", async ({ page }) => {
   expect(metrics.thumbSize).toBe(40);
   // Compact row: thumb + one or two text lines, not the old ~140px tile.
   expect(metrics.cardHeight).toBeLessThan(72);
+});
+
+test("session row menu button is hidden until hover or keyboard focus", async ({ page }) => {
+  await page.addInitScript(parallelMock);
+  await enterApp(page);
+  await page.locator(".composer-inner textarea").first().fill("hover-reveal-me");
+  await page.getByRole("button", { name: "Send" }).click();
+  await expect(page.getByText("echo:hover-reveal-me")).toBeVisible({ timeout: 10_000 });
+  const session = page.locator(".side-item.ses", { hasText: "hover-reveal-me" });
+  await expect(session).toBeVisible({ timeout: 10_000 });
+  const row = session.locator("..");
+  const actions = row.getByRole("button", { name: "Conversation actions" });
+
+  const opacity = () => actions.evaluate((el) => getComputedStyle(el).opacity);
+  await page.mouse.move(10, 400); // park the pointer off the sidebar rows
+  await expect.poll(opacity).toBe("0");
+
+  await row.hover();
+  await expect.poll(opacity).toBe("1");
+
+  await page.mouse.move(10, 400);
+  await expect.poll(opacity).toBe("0");
+
+  await actions.focus();
+  await expect.poll(opacity).toBe("1");
+});
+
+test("session status dot is hidden at rest and shimmers while running", async ({ page }) => {
+  await page.addInitScript(parallelMock);
+  await enterApp(page);
+  // parallelMock holds Done for ~5s; the sidebar running indicator shows once the
+  // session is in the background, so start a second conversation to push it there.
+  await page.locator(".composer-inner textarea").first().fill("dot-shimmer");
+  await page.getByRole("button", { name: "Send" }).click();
+  await expect(page.getByText("echo:dot-shimmer")).toBeVisible({ timeout: 10_000 });
+  await page.locator(".sidebar").getByRole("button", { name: "New session" }).click();
+
+  const session = page.locator(".side-item.ses", { hasText: "dot-shimmer" });
+  const dot = session.locator(".dot");
+  await expect(session).toHaveClass(/running/);
+
+  // Running: dot visible with a glow and a sheen overlay.
+  await expect.poll(() => dot.evaluate((el) => getComputedStyle(el).opacity)).toBe("1");
+  const glow = await dot.evaluate((el) => getComputedStyle(el).boxShadow);
+  expect(glow).not.toBe("none");
+  const sheen = await dot.evaluate((el) => getComputedStyle(el, "::after").backgroundImage);
+  expect(sheen).toContain("linear-gradient");
+
+  // Idle again: the dot fades out completely once the turn finishes.
+  await expect(session).not.toHaveClass(/running/, { timeout: 15_000 });
+  await expect.poll(() => dot.evaluate((el) => getComputedStyle(el).opacity)).toBe("0");
 });
 
 test("follow-up suggestions sit on the canvas without a panel fill", async ({ page }) => {

--- a/ui/src/styles/sidebar.css
+++ b/ui/src/styles/sidebar.css
@@ -135,8 +135,10 @@
   font-size: 13px; color: var(--text-muted); white-space: nowrap;
 }
 .side-item:hover { background: var(--bg-elev); color: var(--text); }
-.side-item .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--text-faint); flex: 0 0 auto; }
-.side-item .dot.ok { background: var(--ok); }
+/* Status dots stay hidden at rest; only running/attention sessions light one up,
+   so the idle list reads as plain titles. Opacity (not display) keeps row geometry
+   stable when a run starts or finishes. */
+.side-item .dot { position: relative; width: 6px; height: 6px; border-radius: 50%; background: var(--text-faint); flex: 0 0 auto; overflow: hidden; opacity: 0; transition: opacity .15s ease; }
 button.side-item { width: 100%; text-align: left; background: transparent; border: 1px solid transparent; font: inherit; font-size: 13px; cursor: pointer; }
 button.side-item.ses { cursor: pointer; user-select: none; padding-right: 34px; }
 button.side-item.ses.selecting { padding-right: 10px; }
@@ -150,6 +152,9 @@ button.side-item.ses.selecting { padding-right: 10px; }
 .side-item.ses.selected { background: var(--clay-soft); border-color: var(--clay); color: var(--text); }
 .side-item.ses.selected .session-select-mark { background: var(--clay); border-color: var(--clay); color: var(--on-clay); }
 .side-item-wrap { position: relative; min-width: 0; }
+/* Row menus are revealed only on hover/keyboard focus — including the active
+   session — so the list reads as plain titles at rest. Opacity (not display)
+   keeps the button tabbable; :focus-within lights it up on keyboard focus. */
 .session-actions, .folder-actions {
   position: absolute; z-index: 1; top: 50%; right: 5px; transform: translateY(-50%);
   display: inline-flex; align-items: center; justify-content: center;
@@ -157,22 +162,41 @@ button.side-item.ses.selecting { padding-right: 10px; }
   border: 1px solid transparent; border-radius: var(--radius-xs);
   background: color-mix(in srgb, var(--bg-elev) 92%, transparent);
   color: var(--text-faint); font: inherit; font-size: 18px; line-height: 1;
-  cursor: pointer; opacity: .58;
+  cursor: pointer; opacity: 0;
   transition: opacity .12s ease, color .12s ease, background .12s ease;
 }
 .side-item-wrap:hover .session-actions,
 .side-item-wrap:focus-within .session-actions,
-.side-item.active + .session-actions,
 .side-folder:hover .folder-actions,
 .side-folder:focus-within .folder-actions { opacity: 1; }
 .session-actions:hover, .session-actions:focus-visible,
 .folder-actions:hover, .folder-actions:focus-visible { color: var(--text); background: var(--bg-input); }
 .session-actions.selection-hidden { display: none; }
 .side-item.active { background: var(--bg-elev); color: var(--text); box-shadow: var(--shadow-sm); }
-.side-item.active .dot { background: var(--clay); }
-.side-item.ses.running .dot { background: var(--clay); animation: tool-pulse 1s ease-in-out infinite; }
-/* Awaiting user approval/confirmation (#327) — outranks running. */
-.side-item.ses.attention .dot { background: var(--warn); animation: tool-pulse 1s ease-in-out infinite; }
+/* Working indicator: glowing dot with a traveling sheen (reference: Claude's
+   shimmering "thinking" light). Attention (awaiting approval #327) shares the
+   motion in warning color and outranks running. */
+.side-item.ses.running .dot, .side-item.ses.attention .dot { opacity: 1; animation: dot-breathe 1.6s ease-in-out infinite; }
+.side-item.ses.running .dot { background: var(--ok); box-shadow: 0 0 6px color-mix(in srgb, var(--ok) 55%, transparent); }
+.side-item.ses.attention .dot { background: var(--warn); box-shadow: 0 0 6px color-mix(in srgb, var(--warn) 55%, transparent); }
+.side-item.ses.running .dot::after, .side-item.ses.attention .dot::after {
+  content: ""; position: absolute; inset: -1px;
+  background: linear-gradient(105deg, transparent 25%, rgba(255, 255, 255, .9) 50%, transparent 75%);
+  background-size: 250% 100%;
+  animation: dot-sheen 1.25s linear infinite;
+}
+@keyframes dot-breathe {
+  0%, 100% { transform: scale(.86); }
+  50% { transform: scale(1.08); }
+}
+@keyframes dot-sheen {
+  from { background-position: 120% 0; }
+  to { background-position: -90% 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .side-item.ses.running .dot, .side-item.ses.attention .dot { animation: none; }
+  .side-item.ses.running .dot::after, .side-item.ses.attention .dot::after { display: none; }
+}
 .ses-title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
 .side-exploration-group {
   display: grid; gap: 2px; margin: 2px 0 5px 14px; padding: 5px 0 2px 9px;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In the session sidebar, every row's "⋯" (Conversation actions) button was always visible — 58% opacity at rest and fully opaque on the active session — and every row carried a gray status dot even when nothing was happening. The list read as cluttered chrome instead of plain titles.

## Changes (`ui/src/styles/sidebar.css` only, plus tests)

- **Row menus on demand**: `.session-actions` / `.folder-actions` now rest at `opacity: 0` and reveal on row hover or keyboard focus (`:focus-within`, so Tab still reaches the button). The active-session exception (`.side-item.active + .session-actions`) is removed. Opacity rather than `display` keeps the button tabbable and avoids layout shifts.
- **Status dots hidden at rest**: `.side-item .dot` rests at `opacity: 0`. The idle list keeps identical geometry (no title shift when a run starts/ends).
- **Working indicator**: running sessions show a glowing green (`--ok`) dot with a traveling sheen — `dot-breathe` (scale 0.86→1.08) plus a `dot-sheen` linear-gradient sweep on `::after`, per the reference animation. Awaiting-approval (#327) shares the motion in `--warn` and still outranks running. `prefers-reduced-motion` gets a static dot with no sheen.
- Removed the dead `.dot.ok` rule and the active-session dot tint.

## Tests

- `ui-tests/tests/visual-polish.spec.ts` gains two cases:
  - menu button is opacity 0 at rest, 1 on row hover, 0 after leaving, 1 on keyboard focus;
  - status dot is hidden at rest, visible with glow + sheen while running, hidden again after `Done` (uses `parallelMock`'s ~5s delayed Done, with a second session pushing the first to the background where the sidebar running indicator applies).
- Existing `conversation action button …` and `group action button …` tests updated to hover the row before asserting/clicking the button, matching real user behavior.
- Full Playwright suite: **323 passed**, 1 skipped (pre-existing skip).
- CSS + test-only change; no Rust code touched.

## Manual smoke

1. Session list at rest: no "⋯" buttons, no dots — just titles.
2. Hover a row (or Tab to its button): "⋯" fades in; click opens the context menu as before.
3. Send a message, then switch to another session: the first session's row shows the shimmering green dot until the reply finishes, then it fades out.
4. Repeat in dark mode: dot glow and sheen resolve through tokens.

## Known limitations

- While a row's context menu is open, the "⋯" button itself may fade if the pointer leaves the row (the open menu owns focus). The menu stays fully functional; keeping the button lit would require per-row open-state plumbing, deferred as unnecessary.
- Folder rows share the same hover-reveal behavior for consistency.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-341ac143-43a2-42c1-83ad-3a42a2b518db?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-341ac143-43a2-42c1-83ad-3a42a2b518db&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

