### PR TITLE
perf(ui): silently unload old live transcript rows

### DIFF
--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -15,6 +15,12 @@ results are limited to 4,000 characters and streamed terminal output to 64 KiB
 and question cards are not clipped. The durable model transcript is unchanged;
 these limits apply to the WebView presentation and its replay data.
 
+Long conversations use the same bounded tail whether they stay open or are
+reopened. After a live transcript grows past 40 completed user turns, the
+WebView unloads older reactive rows and keeps the latest 20; **Load earlier
+messages** restores the durable history from SQLite. This presentation limit
+does not change model context, exports, artifacts, or the saved transcript.
+
 wisp-science calls remote LLM APIs through model profiles. Desktop users
 configure these in **Settings -> Models**. Each row is a model profile with its
 own display name, provider, API URL, model ID, advanced options, and API key.

--- a/src-tauri/src/acp.rs
+++ b/src-tauri/src/acp.rs
@@ -1053,6 +1053,13 @@ async fn run_acp_turn_inner(
                 text: message.to_string(),
             },
         );
+        crate::emit_agent_event(
+            app,
+            AgentEvent::MessageBoundary {
+                frame_id: frame_id.to_string(),
+                seq: next_seq - 1,
+            },
+        );
     }
     let prompt = runtime.handle.prompt(runtime.session_id.clone(), content);
     tokio::pin!(prompt);

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -7258,17 +7258,73 @@ test("long transcript rendering keeps a bounded turn window", async ({ page }) =
     )).toBe(loaded + 1);
   }
 
-  await expect(page.locator(".msg.user")).toHaveCount(40);
+  await expect(page.locator(".msg.user")).toHaveCount(20);
   const oldestRow = new RegExp(`Window page ${pageCount - 1} row 0`);
   await expect(page.getByText(oldestRow)).toBeVisible();
-  const newerSteps = Math.ceil(Math.max(0, pageCount * 10 - 40) / 20);
+  const newerSteps = Math.ceil(Math.max(0, pageCount * 10 - 20) / 20);
   for (let step = 0; step < newerSteps; step += 1) {
     await page.getByRole("button", { name: "Show newer messages" }).click();
   }
-  await expect(page.locator(".msg.user")).toHaveCount(40);
+  await expect(page.locator(".msg.user")).toHaveCount(20);
   await expect(page.getByText(/Window page 0 row 0/)).toBeVisible();
   await expect(page.getByText(oldestRow)).toHaveCount(0);
   await expect(page.getByRole("button", { name: "Show earlier loaded messages" })).toBeVisible();
+});
+
+test("a continuously open conversation unloads old live rows after a completed turn", async ({ page }) => {
+  await enterApp(page);
+  await composer(page).fill("seed turn");
+  await page.getByRole("button", { name: "Send" }).click();
+  await expect(page.locator(".msg.assistant")).toContainText("Hello from mock wisp-science.");
+  const sent = await lastInvokeArgs(page, "send_message");
+  const frameId = String(sent?.sessionId ?? "");
+  expect(frameId).not.toBe("");
+
+  await page.evaluate(({ frameId }) => {
+    for (let turn = 0; turn < 41; turn += 1) {
+      (window as any).__tauriEmit("agent", {
+        kind: "User",
+        frame_id: frameId,
+        text: `Live turn ${turn}`,
+      });
+      (window as any).__tauriEmit("agent", {
+        kind: "MessageBoundary",
+        frame_id: frameId,
+        seq: 100 + turn * 2,
+      });
+      (window as any).__tauriEmit("agent", {
+        kind: "Text",
+        frame_id: frameId,
+        delta: `Live answer ${turn}`,
+      });
+    }
+  }, { frameId });
+
+  const thread = page.locator("#chat-thread");
+  const scroller = page.locator("#chat-scroller");
+  await expect(thread.getByText("Live turn 40", { exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Show earlier loaded messages" })).toBeVisible();
+  await expect.poll(() => scroller.evaluate((element) =>
+    element.scrollHeight - element.clientHeight - element.scrollTop,
+  )).toBeLessThan(8);
+
+  await emitTauriEvent(page, "agent", { kind: "Done", frame_id: frameId });
+
+  await expect(page.locator(".msg.user")).toHaveCount(20);
+  await expect(thread.getByText("Live turn 21", { exact: true })).toBeVisible();
+  await expect(thread.getByText("Live turn 40", { exact: true })).toBeVisible();
+  await expect(thread.getByText("Live turn 0", { exact: true })).toHaveCount(0);
+  const loadEarlier = page.getByRole("button", { name: "Load earlier messages" });
+  await expect(loadEarlier).toBeVisible();
+  await expect.poll(() => scroller.evaluate((element) =>
+    element.scrollHeight - element.clientHeight - element.scrollTop,
+  )).toBeLessThan(8);
+
+  await loadEarlier.click();
+  await expect.poll(() => lastInvokeArgs(page, "load_session")).toMatchObject({
+    id: frameId,
+    beforeSeq: 142,
+  });
 });
 
 test("a multi-megabyte transcript stays interactive while an answer streams", async ({ page }) => {

--- a/ui/src/app_support/transcript.rs
+++ b/ui/src/app_support/transcript.rs
@@ -379,9 +379,35 @@ pub(crate) fn transcript_render_window(
     (first_item..last_item, start, total)
 }
 
+/// Find the prefix that can be unloaded after a completed live turn. The
+/// durable transcript remains in SQLite; this only bounds the reactive rows
+/// that otherwise grow for as long as the app stays open.
+pub(crate) fn transcript_tail_trim_point(
+    items: &[ChatItem],
+    trim_above_user_turns: usize,
+    retain_user_turns: usize,
+) -> Option<(usize, usize)> {
+    if items
+        .iter()
+        .any(|item| matches!(item, ChatItem::QueuedUser { .. }))
+    {
+        return None;
+    }
+    let user_rows = items
+        .iter()
+        .enumerate()
+        .filter_map(|(index, item)| matches!(item, ChatItem::User(_)).then_some(index))
+        .collect::<Vec<_>>();
+    if user_rows.len() <= trim_above_user_turns {
+        return None;
+    }
+    let dropped_turns = user_rows.len().saturating_sub(retain_user_turns.max(1));
+    Some((user_rows[dropped_turns], dropped_turns))
+}
+
 #[cfg(test)]
 mod transcript_render_window_tests {
-    use super::transcript_render_window;
+    use super::{transcript_render_window, transcript_tail_trim_point};
     use crate::dto::ChatItem;
 
     #[test]
@@ -405,6 +431,35 @@ mod transcript_render_window_tests {
             (8..12, 4, 6)
         );
         assert_eq!(transcript_render_window(&items, 2, 2), (4..8, 2, 6));
+    }
+
+    #[test]
+    fn trims_completed_live_history_in_page_sized_chunks() {
+        let mut items = (0..5)
+            .flat_map(|turn| {
+                [
+                    ChatItem::User(format!("question {turn}")),
+                    ChatItem::Reasoning(format!("reasoning {turn}")),
+                    ChatItem::Assistant {
+                        text: format!("answer {turn}"),
+                        model: None,
+                        resources: Vec::new(),
+                    },
+                ]
+            })
+            .collect::<Vec<_>>();
+
+        let (first_item, dropped_turns) = transcript_tail_trim_point(&items, 4, 2).unwrap();
+        assert_eq!((first_item, dropped_turns), (9, 3));
+        items.drain(..first_item);
+        assert!(matches!(&items[0], ChatItem::User(text) if text == "question 3"));
+        assert_eq!(transcript_tail_trim_point(&items, 4, 2), None);
+
+        items.push(ChatItem::QueuedUser {
+            id: 1,
+            text: "queued".into(),
+        });
+        assert_eq!(transcript_tail_trim_point(&items, 1, 1), None);
     }
 }
 

--- a/ui/src/dto.rs
+++ b/ui/src/dto.rs
@@ -196,7 +196,10 @@ pub(crate) enum AgentEvent {
         frame_id: String,
         text: String,
     },
-    MessageBoundary {},
+    MessageBoundary {
+        frame_id: String,
+        seq: i64,
+    },
     Resources {
         frame_id: String,
         resources: Vec<MessageResource>,

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -83,8 +83,9 @@ const NO_API_KEY_MARK: &str = "No API key set";
 const HOME_SEARCH_PROJECT_LIMIT: usize = 6;
 const HOME_SEARCH_ARTIFACT_LIMIT: usize = 8;
 const HOME_SEARCH_SESSION_LIMIT: usize = 6;
-const TRANSCRIPT_RENDER_TURNS: usize = 40;
+const TRANSCRIPT_RENDER_TURNS: usize = 20;
 const TRANSCRIPT_WINDOW_STEP: usize = 20;
+const TRANSCRIPT_LIVE_TRIM_TURNS: usize = TRANSCRIPT_RENDER_TURNS + TRANSCRIPT_WINDOW_STEP;
 const CENTER_PANE_MIN_WIDTH: f64 = 360.0;
 const RIGHT_PANE_MIN_WIDTH: f64 = 320.0;
 const RIGHT_PANE_MAX_WIDTH: f64 = 900.0;
@@ -1736,7 +1737,24 @@ fn App() -> impl IntoView {
                 });
                 refresh_transcript_projections(&frame_id);
             }
-            AgentEvent::MessageBoundary { .. } => {}
+            AgentEvent::MessageBoundary { frame_id, seq } => {
+                let needs_seq = conversation_outlines_cb.with_untracked(|outlines| {
+                    outlines
+                        .get(&frame_id)
+                        .and_then(|outline| outline.last())
+                        .is_some_and(|entry| entry.seq.is_none())
+                });
+                if needs_seq {
+                    conversation_outlines_cb.update(|outlines| {
+                        if let Some(entry) = outlines
+                            .get_mut(&frame_id)
+                            .and_then(|outline| outline.last_mut())
+                        {
+                            entry.seq = Some(seq);
+                        }
+                    });
+                }
+            }
             AgentEvent::Resources {
                 frame_id,
                 resources,
@@ -1979,10 +1997,43 @@ fn App() -> impl IntoView {
                     }
                 });
                 notify_desktop(&frame_id, "done", "");
+                let outline = conversation_outlines_cb
+                    .with_untracked(|outlines| outlines.get(&frame_id).cloned())
+                    .unwrap_or_default();
+                let mut page = transcript_pages
+                    .with_untracked(|pages| pages.get(&frame_id).copied())
+                    .unwrap_or_default();
+                let mut trimmed = false;
                 route_items(active_cb, items_cb, transcripts_cb, &frame_id, |items| {
                     strip_approval_pending(items);
                     settle_plan_cards(items);
+                    let Some((first_item, dropped_turns)) = transcript_tail_trim_point(
+                        items,
+                        TRANSCRIPT_LIVE_TRIM_TURNS,
+                        TRANSCRIPT_RENDER_TURNS,
+                    ) else {
+                        return;
+                    };
+                    let user_offset = page.user_offset.saturating_add(dropped_turns);
+                    let Some(before_seq) = outline
+                        .iter()
+                        .find(|entry| entry.user_index == user_offset)
+                        .and_then(|entry| entry.seq)
+                    else {
+                        return;
+                    };
+                    items.drain(..first_item);
+                    page.next_before_seq = Some(before_seq);
+                    page.user_offset = user_offset;
+                    page.loading = false;
+                    page.window_user_start = usize::MAX;
+                    trimmed = true;
                 });
+                if trimmed {
+                    transcript_pages.update(|pages| {
+                        pages.insert(frame_id.clone(), page);
+                    });
+                }
                 refresh_transcript_projections(&frame_id);
                 approval_cb.update(|s| {
                     s.remove(&frame_id);


### PR DESCRIPTION
## Problem

A conversation that stayed open kept every live `ChatItem` in WebView reactive state, even though reopening the same session loaded only the latest page. The supplied 1.0.0 demo contains 81 user turns, 592 messages, and 234 tool calls; its message and tool-call JSON files total about 3.9 MB. This made long, attachment-heavy conversations progressively slower until reload.

## Summary

- Render only the latest 20 loaded user turns at once.
- After a completed live transcript exceeds 40 user turns, silently unload the hidden prefix and retain the latest 20 turns in reactive state.
- Preserve the SQLite page cursor from native and ACP message boundaries, so **Load earlier messages** restores unloaded history normally.
- Keep queued and in-flight turns intact; model context, persisted transcripts, exports, artifacts, and conversation outlines are unchanged.
- Document the behavior and cover trimming, scroll stability, pagination cursor restoration, and the existing multi-megabyte streaming case.

## Tests

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cd ui && cargo test transcript_render_window_tests`
- `cd ui && cargo check --target wasm32-unknown-unknown`
- `cd ui-tests && npm ci`
- `cd ui-tests && npx playwright test` — 326 passed, 1 environment-gated test skipped

## Manual smoke steps

1. Keep one conversation open for more than 40 completed user turns, including tool calls or attachments.
2. Confirm the latest messages remain visible and the scroll position does not jump when a turn finishes.
3. Continue sending messages and confirm the composer and transcript remain responsive.
4. Click **Load earlier messages** and confirm older persisted turns return.
5. Reopen the conversation and confirm it still opens at the latest page.

## Known limitations and follow-up

- The bound is turn-based rather than byte-based. A future byte budget or virtual list should only be added if profiling shows that the latest 20 unusually large turns are still expensive.
- Trimming happens at completed-turn boundaries so the active response and queued follow-ups are never partially unloaded.
