### PR TITLE
Fix dismissed run cards reappearing between turns

### DIFF
--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -4516,6 +4516,15 @@ test("monitor_run renders a live Run card from summary polls and on-demand detai
   await card.getByRole("button", { name: "Dismiss completed run card" }).click();
   await expect(card).toHaveCount(0);
   await expect(page.locator(".run-monitor-wrap")).toBeHidden();
+
+  // Starting another turn remounts settled transcript rows. A manual
+  // dismissal must survive that remount instead of flashing back until the
+  // next run-list refresh.
+  await composer(page).fill("continue after dismiss");
+  await page.getByRole("button", { name: "Send" }).click();
+  await expect(card).toHaveCount(0);
+  await page.waitForTimeout(1_500);
+  await expect(card).toHaveCount(0);
 });
 
 test("run monitor output stays pinned to the tail across poll rebuilds (#654)", async ({ page }) => {

--- a/ui/src/chat_render.rs
+++ b/ui/src/chat_render.rs
@@ -8,7 +8,7 @@ use crate::text::{event_target_value, format_duration_ms, md_to_html, tool_card_
 use leptos::*;
 use serde_wasm_bindgen::to_value;
 use std::cell::Cell;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
 /// True for items whose `render_item` produces an empty view, so the thread
@@ -1015,9 +1015,9 @@ pub(crate) fn RunMonitorCard(
     clock: ReadSignal<i64>,
     tool_ok: Option<bool>,
     tool_output: String,
+    dismissed_runs: RwSignal<HashSet<String>>,
 ) -> impl IntoView {
     let locale = use_locale();
-    let dismissed = create_rw_signal(false);
     let fallback = serde_json::from_str::<RunRecord>(&tool_output).ok();
     let detail = create_rw_signal(fallback.clone());
     let lookup_id = run_id.clone();
@@ -1074,7 +1074,7 @@ pub(crate) fn RunMonitorCard(
     let env_open = create_rw_signal(false);
     view! {
         {move || {
-            if dismissed.get() {
+            if dismissed_runs.with(|ids| ids.contains(&run_id)) {
                 return view! {}.into_view();
             }
             let run = selected_run.get();
@@ -1145,7 +1145,7 @@ pub(crate) fn RunMonitorCard(
             let cancel_id = run.id.clone();
             let output_id = run.id.clone();
             view! {
-                <article class="run-monitor-card" data-testid="run-monitor-card" data-run-id=run.id>
+                <article class="run-monitor-card" data-testid="run-monitor-card" data-run-id=run.id.clone()>
                     <div class="run-monitor-head">
                         <span class="run-monitor-icon">{
                             if active {
@@ -1200,11 +1200,14 @@ pub(crate) fn RunMonitorCard(
                         })}
                         {dismissible.then(|| {
                             let tip = t(locale.get(), "runs.dismiss");
+                            let dismiss_id = run.id.clone();
                             view! {
                                 <button type="button" class="icon-btn run-monitor-dismiss"
                                     title=tip.clone()
                                     aria-label=tip
-                                    on:click=move |_| dismissed.set(true)
+                                    on:click=move |_| dismissed_runs.update(|ids| {
+                                        ids.insert(dismiss_id.clone());
+                                    })
                                 >{compose_icon("close")}</button>
                             }
                         })}
@@ -1290,6 +1293,7 @@ pub(crate) fn render_item(
     on_plan_decision: Callback<PlanDecision>,
     on_question_answer: Callback<(usize, Option<String>, String)>,
     on_review_jump: Callback<usize>,
+    dismissed_runs: RwSignal<HashSet<String>>,
 ) -> impl IntoView {
     let locale = use_locale();
     match item {
@@ -1385,6 +1389,7 @@ pub(crate) fn render_item(
                 clock=run_clock
                 tool_ok=*ok
                 tool_output=output.clone()
+                dismissed_runs=dismissed_runs
             />
         }.into_view(),
         ChatItem::Tool { name, ok, input, output, .. } if is_image_generation_tool(name) => view! {

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -285,6 +285,10 @@ fn App() -> impl IntoView {
     let sync_actions_available = create_rw_signal(false);
     let pet_status = create_rw_signal(PetStatus::default());
     let run_records = create_rw_signal::<Vec<RunSummary>>(vec![]);
+    // A transcript row is remounted when a later turn changes its keyed
+    // projection. Keep explicit Run-card dismissals above the card component
+    // so a dismissed terminal Run cannot flash back during that remount.
+    let dismissed_run_cards = create_rw_signal::<HashSet<String>>(HashSet::new());
     // Configured model profiles + the composer's bottom-right picker state.
     let models = create_rw_signal::<Vec<ModelProfile>>(vec![]);
     let active_session = create_rw_signal::<Option<String>>(None);
@@ -9288,6 +9292,7 @@ fn App() -> impl IntoView {
                                             clock=run_clock.read_only()
                                             tool_ok=None
                                             tool_output=String::new()
+                                            dismissed_runs=dismissed_run_cards
                                         />
                                     </div>
                                 }.into_view(),
@@ -9421,6 +9426,7 @@ fn App() -> impl IntoView {
                                                     step_disclosure_state,
                                                     plan_mode_active, plan_compat, on_plan_decision,
                                                     on_question_answer, jump_to_review_message,
+                                                    dismissed_run_cards,
                                                 ).into_view()
                                             }}
                                         </div>


### PR DESCRIPTION
## What changed

- Move dismissed Run-card state out of each `RunMonitorCard` and into shared page-level state keyed by Run ID.
- Pass the shared state to both transcript-backed and automatically anchored Run cards.
- Add a Playwright regression assertion that starts a new turn after dismissal and verifies the card never reappears.

## Why

Manually dismissed completed Run cards could flash back when the next conversation turn started. The new turn rebuilt keyed transcript rows, remounting the card component and resetting its component-local dismissal boolean. The card disappeared again only after subsequent run-list reconciliation.

The shared dismissal set survives those row/component remounts, so a manually closed terminal Run remains hidden for the rest of the page lifecycle.

## Validation

- `cargo fmt --all -- --check`
- `cd ui && cargo check --target wasm32-unknown-unknown`
- `cd ui-tests && npx playwright test tests/ui.spec.ts --grep "monitor_run renders a live Run card"`
- `git diff --check`