### PR TITLE
Keep the stopping modal scoped to its conversation

### DIFF
--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -3756,6 +3756,9 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
             if ((window as any).__failStopAgent) {
               throw new Error("stop command unavailable");
             }
+            if ((window as any).__holdStopAgent) {
+              return null;
+            }
             setTimeout(() => {
               const frameId = String(arg("id") ?? arg("sessionId") ?? "");
               emit("agent", { kind: "Done", frame_id: frameId, stop_reason: "cancelled" });

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -1216,6 +1216,29 @@ test("ACP cancellation is scoped to the active bound frame", async ({ page }) =>
   await expect(page.getByRole("button", { name: "Send" })).toBeVisible();
 });
 
+test("switching conversations dismisses the previous conversation's stopping modal", async ({ page }) => {
+  await enterApp(page, "/?mockPlanFlow=acp");
+  await expect(page.locator('[data-session-id="s1"]')).toBeVisible();
+  // Keep the seeded session as the navigation target, then run and stop work
+  // in a fresh conversation.
+  await newSessionButton(page).click();
+  const runningSessionId = await page.locator(".side-item.ses.active").getAttribute("data-session-id");
+  expect(runningSessionId).toBeTruthy();
+
+  await page.locator(".model-picker-btn").click();
+  await page.getByRole("button", { name: /Test ACP Agent/ }).click();
+  await composer(page).fill("ACP LONG");
+  await page.getByRole("button", { name: "Send" }).click();
+  await page.evaluate(() => { (window as any).__holdStopAgent = true; });
+  await page.getByRole("button", { name: "Stop" }).click();
+  await expect(page.locator(".stopping-toast")).toBeVisible();
+
+  const otherSession = page.locator(`.side-item.ses:not([data-session-id="${runningSessionId}"])`).first();
+  await expect(otherSession).toBeVisible();
+  await otherSession.click();
+  await expect(page.locator(".stopping-toast")).toHaveCount(0);
+});
+
 test("failed stop command restores the Stop control instead of staying in Stopping", async ({ page }) => {
   await enterApp(page);
   await newSessionButton(page).click();

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -292,6 +292,17 @@ fn App() -> impl IntoView {
     // Configured model profiles + the composer's bottom-right picker state.
     let models = create_rw_signal::<Vec<ModelProfile>>(vec![]);
     let active_session = create_rw_signal::<Option<String>>(None);
+    // The stopping toast is foreground UI owned by the session where Stop was
+    // clicked. The backend cancellation may continue after navigation, but its
+    // modal state must not follow the user into another conversation or block
+    // that conversation's own Stop action.
+    create_effect(move |_| {
+        let active = active_session.get();
+        let stopping = stopping_session.get();
+        if stopping.is_some() && active != stopping {
+            stopping_session.set(None);
+        }
+    });
     let sessions = create_rw_signal::<Vec<SessionInfo>>(vec![]);
     let explorations = create_rw_signal::<Vec<ExplorationSummary>>(vec![]);
     let mainline_frozen = create_memo(move |_| {
@@ -9734,7 +9745,8 @@ fn App() -> impl IntoView {
                         {t(locale.get(), "projects.example_read_only")}
                     </div>
                 })}
-                {move || stopping_session.get().is_some().then(|| view! {
+                {move || (active_session.get().is_some()
+                    && active_session.get() == stopping_session.get()).then(|| view! {
                     <div class="stopping-toast">
                         <span class="stopping-spinner"></span>
                         <div class="stopping-text">


### PR DESCRIPTION
## What changed

- Treat the stopping toast as foreground state owned by the conversation where Stop was clicked.
- Clear that foreground stopping state when the active conversation changes.
- Require the active conversation ID to match the stopping conversation before rendering the toast.
- Extend the mocked Stop command so the regression test can hold cancellation in progress.
- Add a Playwright test that clicks Stop in conversation A, switches directly to conversation B, and verifies the stopping modal disappears.

## Why

The composer rendered the stopping modal whenever the global `stopping_session` value was non-empty. After switching conversations, that value still referred to conversation A, so its modal followed the user into conversation B. The same stale state could also prevent conversation B from initiating its own Stop action.

Backend cancellation remains scoped to conversation A and may continue after navigation; only the foreground modal state is dismissed.

## User impact

Switching away from a conversation whose turn is stopping no longer leaves an unrelated stopping modal visible in the newly selected conversation.

## Validation

- `cargo fmt --all -- --check`
- `cd ui && cargo check --target wasm32-unknown-unknown`
- `cd ui-tests && UI_TEST_PORT=1443 npx playwright test tests/ui.spec.ts --grep "ACP cancellation|switching conversations dismisses|failed stop command"` (3 passed)
- `git diff --check`