### PR TITLE
fix(ui): show message actions only on latest reply

### DIFF
--- a/ui-tests/tests/exploration.spec.ts
+++ b/ui-tests/tests/exploration.spec.ts
@@ -66,20 +66,17 @@ test("latest completed turn creates an isolated exploration and freezes mainline
   await expect(page.locator("button.send")).toBeDisabled();
 });
 
-test("only the current completed turn can start an exploration", async ({ page }) => {
+test("only the latest completed turn shows message actions and can start an exploration", async ({ page }) => {
   await page.goto("/?mockExplorations=1&mockHistoricalExploration=1");
   await page.locator(".proj-card-main").first().click();
   await page.locator('[data-session-id="exploration-mainline"]').click();
 
   const actions = page.getByTestId("start-exploration");
-  await expect(actions).toHaveCount(3);
-  await expect(actions.nth(0)).toBeDisabled();
-  await expect(actions.nth(1)).toBeDisabled();
-  await expect(actions.nth(0)).toHaveAttribute("title", /current completed turn/i);
-  await expect(actions.nth(1)).toHaveAttribute("title", /current completed turn/i);
-  await expect(actions.nth(2)).toBeEnabled();
+  await expect(page.locator(".assistant-wrap > .msg-actions")).toHaveCount(1);
+  await expect(actions).toHaveCount(1);
+  await expect(actions).toBeEnabled();
 
-  await actions.nth(2).click();
+  await actions.click();
   await page.getByTestId("exploration-name").fill("From latest turn");
   await page.getByTestId("exploration-create").click();
   await expect.poll(async () => page.evaluate(() => (window as any).__startExplorationCalls)).toEqual([

--- a/ui/src/app_support/messages.rs
+++ b/ui/src/app_support/messages.rs
@@ -695,6 +695,7 @@ pub(crate) fn AssistantMessage(
     on_copy: Callback<String>,
     on_memory: Callback<()>,
     on_review: Callback<()>,
+    show_actions: Signal<bool>,
     can_undo: Signal<bool>,
     on_undo: Callback<usize>,
     show_explore: Signal<bool>,
@@ -854,7 +855,10 @@ pub(crate) fn AssistantMessage(
                     </div>
                 </div>
             })}
-            <div class="msg-actions">
+            {move || {
+                let text_for_disabled = text_for_disabled.clone();
+                let text_for_click_copy = text_for_click_copy.clone();
+                show_actions.get().then(move || view! { <div class="msg-actions">
                 {move || show_explore.get().then(|| view! {
                     <button
                         type="button"
@@ -918,7 +922,7 @@ pub(crate) fn AssistantMessage(
                         <span class="gi undo" aria-hidden="true"></span>
                     </button>
                 })}
-            </div>
+            </div> })}}
         </div>
     }
 }

--- a/ui/src/chat_render.rs
+++ b/ui/src/chat_render.rs
@@ -1274,6 +1274,7 @@ pub(crate) fn render_item(
     busy: ReadSignal<bool>,
     compact_assistant: bool,
     can_modify: bool,
+    show_actions: Signal<bool>,
     can_undo: Signal<bool>,
     show_explore: Signal<bool>,
     can_explore: Signal<bool>,
@@ -1377,6 +1378,7 @@ pub(crate) fn render_item(
                     move |_| on_memory.call((session_id.clone(), explore_turn_index))
                 })
                 on_review=Callback::new(move |_| on_review.call(session_id.clone()))
+                show_actions=show_actions
                 can_undo=can_undo
                 on_undo=on_undo
                 show_explore=show_explore

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -9575,6 +9575,14 @@ fn App() -> impl IntoView {
                                     let can_undo = Signal::derive(move || {
                                         !compact_assistant && undo_assistant_index.get() == Some(i)
                                     });
+                                    let show_actions = Signal::derive(move || {
+                                        !busy.get()
+                                            && items.with(|rows| {
+                                                rows.iter().rposition(|item| {
+                                                    matches!(item, ChatItem::Assistant { text, .. } if !text.trim().is_empty())
+                                                }) == Some(i)
+                                            })
+                                    });
                                     let show_explore = Signal::derive(move || {
                                         if compact_assistant
                                             || active_acp_agent_id.get().is_some()
@@ -9647,7 +9655,7 @@ fn App() -> impl IntoView {
                                             } else {
                                                 render_item(
                                                     i, &item, timestamp, &arts, on_artifact_select, on_file_link,
-                                                    run_records, run_clock.read_only(), busy.read_only(), compact_assistant, active_acp_agent_id.get().is_none(), can_undo, show_explore, can_explore, edit_message, branch_message, undo_message, explore_turn_index.unwrap_or_default(), start_exploration_from_head, session_id,
+                                                    run_records, run_clock.read_only(), busy.read_only(), compact_assistant, active_acp_agent_id.get().is_none(), show_actions, can_undo, show_explore, can_explore, edit_message, branch_message, undo_message, explore_turn_index.unwrap_or_default(), start_exploration_from_head, session_id,
                                                     request_turn_memory, request_session_review, respond_confirm, on_resume, on_queue,
                                                     step_disclosure_state,
                                                     plan_mode_active, plan_compat, on_plan_decision,


### PR DESCRIPTION
## Problem
Assistant actions (Start exploration, Remember, Review, and Copy) were rendered below every completed assistant reply, cluttering historical turns and implying that old turns were still actionable.

## Changes
- Render the assistant action row only for the latest non-empty assistant reply.
- Hide the action row while the conversation is busy.
- Keep existing exploration eligibility checks for the latest reply.
- Update the exploration UI test to assert that historical replies have no action row.

## Tests
- `cd ui && cargo check --target wasm32-unknown-unknown`
- `cd ui-tests && npx playwright test tests/exploration.spec.ts --grep "only the latest completed turn" --reporter=line`

`cargo fmt --all -- --check` remains blocked by pre-existing formatting drift across unrelated UI files; no unrelated formatting changes are included.

## Manual smoke
1. Open a conversation containing several completed assistant replies.
2. Confirm only the final reply shows Start exploration / Remember / Review / Copy.
3. Send another message and confirm the old action row disappears while the reply is running, then appears under the new final reply.

## Known limitations / follow-up
- Error cards and compact assistant views keep their existing specialized controls.