### PR TITLE
Normalize and link project paths in conversations

### DIFF
--- a/crates/wisp-core/src/system_prompt.rs
+++ b/crates/wisp-core/src/system_prompt.rs
@@ -47,7 +47,11 @@ tell them the underlying model is whatever is set in wisp-science's Settings (pr
 read the exact version from inside a turn, and point them to Settings — never guess \"Claude\" or any other name.\n\n\
 Use the instructions below and the tools available to you to assist the user.\n\
 IMPORTANT: Never generate or guess URLs unless you are confident they help the user with their work. \
-For file paths, prefer absolute paths when possible. If you need to read a directory, use the `shell` tool \
+In user-facing prose and final answers, always refer to files inside the current project with project-relative paths \
+using forward slashes (for example `analysis/results/figure.png`). Never expose the absolute project-root prefix or \
+use Windows backslashes in those displayed project paths. Format mentioned project files as Markdown links whenever \
+possible so users can open them directly. Tool arguments may still use absolute or native paths when \
+the tool requires them. If you need to read a directory, use the `shell` tool \
 with the current platform's directory-listing command because the `read` tool cannot read directories.".into()
     }
 
@@ -214,6 +218,20 @@ mod tests {
         );
 
         std::fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn user_facing_project_paths_are_portable_and_relative() {
+        let out = SystemPrompt::new(
+            std::path::Path::new("/tmp/project"),
+            &SkillIndex::default(),
+            None,
+        )
+        .assemble();
+        assert!(out.contains("project-relative paths"));
+        assert!(out.contains("using forward slashes"));
+        assert!(out.contains("Never expose the absolute project-root prefix"));
+        assert!(!out.contains("prefer absolute paths"));
     }
 
     #[test]

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -4262,7 +4262,7 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
                 emit("agent", {
                   kind: "Text",
                   frame_id: fid,
-                  delta: "I inspected `old.csv` and created the requested output.",
+                  delta: "I inspected `old.csv` and created the requested output. See `notes/FIGURE_LEGEND.md`.",
                 });
                 emit("agent", { kind: "Done", frame_id: fid });
               }, 30);

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -3066,6 +3066,24 @@ test("Generated artifacts survive follow-up tool commentary and ignore mentioned
   await expect(reply.locator('.message-artifact-card[data-artifact-name="old.csv"]')).toHaveCount(0);
   await expect(reply.locator('.message-artifact-card[data-artifact-name="old.png"]')).toHaveCount(0);
   await expect(reply.locator('.message-artifact-card[data-artifact-name="old-report.md"]')).toHaveCount(0);
+  const pathLink = reply.locator('a.workspace-path-link[href="notes/FIGURE_LEGEND.md"]');
+  await expect(pathLink).toHaveText("notes/FIGURE_LEGEND.md");
+  await pathLink.click();
+  const linkedPreview = page.locator('.center-file-preview[data-file-path="notes/FIGURE_LEGEND.md"]');
+  await expect(linkedPreview).toBeVisible();
+  await expect(linkedPreview.locator(".center-file-head > span").first())
+    .toHaveText("notes/FIGURE_LEGEND.md");
+  await page.locator(".center-tabs > .center-tab").click();
+
+  // The backing artifact path remains absolute for loading, but project UI
+  // must present the portable project-relative form.
+  await reply.locator('.message-artifact-card[data-artifact-name="new.png"]').click();
+  const modal = page.locator(".artifact-modal");
+  await expect(modal).toBeVisible();
+  await modal.getByRole("button", { name: "Open in center" }).click();
+  const preview = page.locator('.center-file-preview[data-file-path="/mock/root/results/new.png"]');
+  await expect(preview).toBeVisible();
+  await expect(preview.locator(".center-file-head > span").first()).toHaveText("results/new.png");
 });
 
 test("artifact category headers collapse and expand their tiles", async ({ page }) => {

--- a/ui/src/app_support/markdown.rs
+++ b/ui/src/app_support/markdown.rs
@@ -376,16 +376,17 @@ fn html_attr(tag: &str, name: &str) -> Option<String> {
     Some(tag[start..end].to_string())
 }
 
+fn decode_html_attribute(value: &str) -> String {
+    value
+        .replace("&#x27;", "'")
+        .replace("&#39;", "'")
+        .replace("&quot;", "\"")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&amp;", "&")
+}
+
 fn resource_reference_matches(rendered: &str, original: &str) -> bool {
-    fn decode_html_attribute(value: &str) -> String {
-        value
-            .replace("&#x27;", "'")
-            .replace("&#39;", "'")
-            .replace("&quot;", "\"")
-            .replace("&lt;", "<")
-            .replace("&gt;", ">")
-            .replace("&amp;", "&")
-    }
     normalize_path(&decode_href(&decode_html_attribute(rendered)))
         == normalize_path(&decode_href(original))
 }
@@ -471,6 +472,7 @@ pub(crate) fn enrich_md_html(
     arts: &[Artifact],
     resources: &[MessageResource],
     locale: Locale,
+    project_root: Option<&str>,
 ) -> String {
     html = replace_bound_resource_tags(html, resources);
     html = replace_artifact_tokens(html, arts);
@@ -481,11 +483,55 @@ pub(crate) fn enrich_md_html(
         html = html.replace(&marker, &chip);
     }
     html = wrap_code_filenames_as_art_refs(html, arts);
+    html = wrap_inline_workspace_paths(html, project_root);
     html = strip_list_markers_before_art_refs(&html);
     html = html.replace("<pre><code", "<pre class=\"md-code\"><code");
     html = wrap_markdown_code_blocks_with_copy_controls(html, locale);
     html = wrap_markdown_tables_with_copy_controls(html, locale);
     html
+}
+
+/// Turn inline-code project paths into ordinary Markdown-style file links.
+/// The href remains the portable relative path that `handle_md_click` resolves,
+/// while an absolute in-project path is shortened for display. Code blocks,
+/// artifact chips, URLs, commands, and paths outside the project are untouched.
+fn wrap_inline_workspace_paths(html: String, project_root: Option<&str>) -> String {
+    let mut out = String::with_capacity(html.len());
+    let mut rest = html.as_str();
+    while let Some(start) = rest.find("<code>") {
+        let before = &rest[..start];
+        out.push_str(before);
+        let code_rest = &rest[start + "<code>".len()..];
+        let Some(end) = code_rest.find("</code>") else {
+            out.push_str(&rest[start..]);
+            return out;
+        };
+        let encoded = &code_rest[..end];
+        let candidate = decode_html_attribute(encoded);
+        let relative = workspace_relative_path(project_root.unwrap_or_default(), &candidate);
+        let linked = relative
+            .filter(|path| !path.is_empty() && !path.chars().any(char::is_whitespace))
+            .filter(|path| file_kind(path).is_some())
+            .filter(|_| !code_is_inside_art_ref(before) && !code_is_inside_link(before));
+        if let Some(path) = linked {
+            let escaped = html_escape(&path);
+            out.push_str(&format!(
+                r#"<a class="workspace-path-link" href="{escaped}"><code>{escaped}</code></a>"#
+            ));
+        } else {
+            out.push_str("<code>");
+            out.push_str(encoded);
+            out.push_str("</code>");
+        }
+        rest = &code_rest[end + "</code>".len()..];
+    }
+    out.push_str(rest);
+    out
+}
+
+fn code_is_inside_link(before: &str) -> bool {
+    matches!((before.rfind("<a "), before.rfind("</a>")), (Some(open), Some(close)) if open > close)
+        || (before.rfind("<a ").is_some() && before.rfind("</a>").is_none())
 }
 
 #[cfg(test)]
@@ -554,6 +600,7 @@ mod art_ref_marker_tests {
             &[],
             &[message_resource("D:/work/report.md'", "markdown", true)],
             Locale::En,
+            None,
         );
         assert!(out.contains(r#"data-resource-status="ready""#));
         assert!(!out.contains("D:/work/report.md"));
@@ -617,6 +664,24 @@ mod art_ref_marker_tests {
             "<code>x.csv</code>",
             r#"<button type="button" class="art-ref" data-art-idx="1" title="x.csv"><code>x.csv</code></button>"#,
         );
+        assert_eq!(out, html);
+    }
+
+    #[test]
+    fn inline_project_paths_are_relative_clickable_links() {
+        let html = r#"<p>Saved <code>D:\Wisp-Science\合作项目\analysis\figures\FIGURE_LEGEND.md</code> and <code>figures/plot.png</code>.</p>"#;
+        let out = wrap_inline_workspace_paths(html.into(), Some(r"D:\Wisp-Science\合作项目"));
+        assert!(out.contains(
+            r#"href="analysis/figures/FIGURE_LEGEND.md"><code>analysis/figures/FIGURE_LEGEND.md</code>"#
+        ));
+        assert!(out.contains(r#"href="figures/plot.png"><code>figures/plot.png</code>"#));
+        assert!(!out.contains(r"D:\Wisp-Science"));
+    }
+
+    #[test]
+    fn inline_commands_and_foreign_absolute_paths_stay_plain_code() {
+        let html = r#"<p><code>monitor_run</code> <code>/usr/bin/python3</code> <code>D:\Other\secret.md</code></p>"#;
+        let out = wrap_inline_workspace_paths(html.into(), Some(r"D:\Project"));
         assert_eq!(out, html);
     }
 

--- a/ui/src/app_support/messages.rs
+++ b/ui/src/app_support/messages.rs
@@ -49,6 +49,7 @@ pub(crate) fn StreamingAssistantMessage(
     let commit_handle = Rc::new(Cell::new(None::<TimeoutHandle>));
     let active = Rc::new(Cell::new(true));
     let recent_parse_cost_ms = Rc::new(Cell::new(None::<f64>));
+    let project = use_context::<ReadSignal<Option<ProjectInfo>>>();
 
     create_render_effect({
         let commit_handle = Rc::clone(&commit_handle);
@@ -104,7 +105,14 @@ pub(crate) fn StreamingAssistantMessage(
         let recent_parse_cost_ms = Rc::clone(&recent_parse_cost_ms);
         move |_| {
             let started_at = js_sys::Date::now();
-            let html = enrich_md_html(md_to_html(&rendered_text.get()), &[], &[], locale.get());
+            let project_root = project.and_then(|project| project.get().map(|project| project.root));
+            let html = enrich_md_html(
+                md_to_html(&rendered_text.get()),
+                &[],
+                &[],
+                locale.get(),
+                project_root.as_deref(),
+            );
             let elapsed = (js_sys::Date::now() - started_at).max(0.0);
             let smoothed = recent_parse_cost_ms
                 .get()
@@ -704,12 +712,16 @@ pub(crate) fn AssistantMessage(
     let arts_for_html = artifacts.clone();
     let resources_for_html = resources.clone();
     let text_for_html = text.clone();
+    let project = use_context::<ReadSignal<Option<ProjectInfo>>>();
     let html = create_memo(move |_| {
+        let project_root = project
+            .and_then(|project| project.get().map(|project| project.root));
         enrich_md_html(
             md_to_html(&text_for_html),
             &arts_for_html,
             &resources_for_html,
             locale.get(),
+            project_root.as_deref(),
         )
     });
     let hid = unique_dom_id("md");

--- a/ui/src/chat_render.rs
+++ b/ui/src/chat_render.rs
@@ -1348,7 +1348,15 @@ pub(crate) fn render_item(
             }.into_view()
         }
         ChatItem::Assistant { text, .. } if compact_assistant => {
-            let html = enrich_md_html(md_to_html(text), &[], &[], locale.get());
+            let project_root = use_context::<ReadSignal<Option<ProjectInfo>>>()
+                .and_then(|project| project.get().map(|project| project.root));
+            let html = enrich_md_html(
+                md_to_html(text),
+                &[],
+                &[],
+                locale.get(),
+                project_root.as_deref(),
+            );
             view! {
                 <div class="assistant-wrap">
                     <div class="body md compact-markdown"

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -461,6 +461,7 @@ fn App() -> impl IntoView {
         refresh_session_library(session_library_items, active_session.read_only());
     });
     let project_info = create_rw_signal::<Option<ProjectInfo>>(None);
+    provide_context(project_info.read_only());
     let demo_mode = create_rw_signal(false); // true = the synthetic "Example project" is open
     let scratch_open = create_rw_signal(false); // ephemeral scratch chat overlay
     let feedback_context = create_rw_signal::<Option<String>>(None);
@@ -8520,6 +8521,10 @@ fn App() -> impl IntoView {
                 center_files.get().into_iter().find(|file| file.path == path)
             }).map(|file| {
                 let path = file.path.clone();
+                let display_path = project_info
+                    .get()
+                    .and_then(|project| workspace_relative_path(&project.root, &path))
+                    .unwrap_or_else(|| path.replace('\\', "/"));
                 let revision = center_file_revisions.with(|revisions| {
                     revisions.get(&path).copied().unwrap_or_default()
                 });
@@ -8551,7 +8556,7 @@ fn App() -> impl IntoView {
                         data-preview-kind=kind.clone()
                         data-file-path=path.clone()>
                         <div class="center-file-head">
-                            <span>{if is_mcp_app { label } else { path.clone() }}</span>
+                            <span>{if is_mcp_app { label } else { display_path }}</span>
                             <div class="spacer"></div>
                             // Bind this script to a runtime. Whole-file execution
                             // and direct editing deliberately stay out of this


### PR DESCRIPTION
## What changed

- Change Agent guidance so user-facing project file references use project-relative paths with forward slashes instead of absolute native paths.
- Ask the Agent to format mentioned project files as Markdown links whenever possible.
- Promote inline-code file paths in assistant Markdown into clickable workspace links.
- Convert absolute in-project Windows paths to portable relative display paths at render time, including historical assistant messages.
- Leave commands, URLs, foreign absolute paths, code blocks, and artifact chips untouched.
- Show project-relative forward-slash paths in center preview headers while preserving the real backing path for file loading.
- Add unit and Playwright coverage for Windows path normalization, clickable inline paths, center opening, and absolute backing-path preservation.

## Why

Project files were presented in two incompatible forms: portable paths such as `analysis/450_genome_scan/figures/450_MITE_rich_gene_structure.png` and machine-specific paths such as `D:\\Wisp-Science\\合作项目\\analysis\\450_genome_scan\\figures\\FIGURE_LEGEND.md`. The system prompt explicitly preferred absolute paths, and the center preview displayed its internal load path directly.

Absolute paths leak machine/project-root details, use platform-specific separators, and become invalid when switching or transferring projects. Plain inline-code paths were also not consistently clickable.

## User impact

Conversation prose and file preview headers now consistently show paths like `analysis/450_genome_scan/figures/FIGURE_LEGEND.md`. Recognized project file paths in assistant prose are clickable and open the existing in-app preview, while internal file operations continue using the correct real path.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p wisp-core system_prompt --lib` (14 passed)
- `cd ui && cargo test inline_project_paths_are_relative_clickable_links`
- `cd ui && cargo check --target wasm32-unknown-unknown`
- `cd ui-tests && UI_TEST_PORT=1446 npx playwright test tests/ui.spec.ts --grep "Generated artifacts survive"` (1 passed)
- `git diff --check`