### PR TITLE
fix: stop orphan bullets and mid-token code breaks in chat markdown

### DIFF
--- a/ui-tests/tests/visual-polish.spec.ts
+++ b/ui-tests/tests/visual-polish.spec.ts
@@ -161,3 +161,27 @@ test("follow-up suggestions sit on the canvas without a panel fill", async ({ pa
   const background = await followUps.evaluate((el) => getComputedStyle(el).backgroundColor);
   expect(background).toBe("rgba(0, 0, 0, 0)");
 });
+
+test("assistant markdown rejoins bare list markers and wraps at word boundaries", async ({ page }) => {
+  await page.addInitScript(parallelMock);
+  await enterApp(page);
+  // `- ` alone on a line with the item text on the next line used to render an
+  // orphan bullet dot above a flush-left paragraph.
+  const payload = "coords:\n\n- 450 = x\n- \nTb1 15,248,784 y\n";
+  await page.locator(".composer-inner textarea").first().fill(payload);
+  await page.getByRole("button", { name: "Send" }).click();
+
+  const body = page.locator(".msg.assistant .body.md").last();
+  await expect(body).toContainText("Tb1 15,248,784 y", { timeout: 10_000 });
+  await expect(body.locator("li", { hasText: "Tb1 15,248,784 y" })).toHaveCount(1);
+  await expect(body.locator("li:empty")).toHaveCount(0);
+
+  // `overflow-wrap: anywhere` from `.msg .body` must not win on markdown bodies:
+  // it splits inline code chips mid-token (`file.p|y`) even at normal break points.
+  const wrap = await body.evaluate((el) => {
+    const cs = getComputedStyle(el);
+    return { overflowWrap: cs.overflowWrap, wordBreak: cs.wordBreak };
+  });
+  expect(wrap.overflowWrap).toBe("break-word");
+  expect(wrap.wordBreak).toBe("normal");
+});

--- a/ui/src/styles/chat.css
+++ b/ui/src/styles/chat.css
@@ -546,6 +546,11 @@ button.msg-review-btn span { font-size: 11px; }
 .msg.assistant .body { color: var(--text); font-family: var(--font-response); }
 .msg.assistant .body.md { display: block; font-size: calc(var(--ui-font-size, 14px) + 1px); line-height: 1.55; letter-spacing: -0.004em; white-space: normal; }
 .msg.assistant .body.md:empty { display: none; }
+/* `.msg .body` above sets `overflow-wrap: anywhere` for plain-text bodies, but
+   in Markdown that splits inline code chips mid-token (`file.p|y`) even when
+   normal break points exist. `break-word` only breaks a token that overflows
+   on its own. (Ties `.msg .body` in specificity and wins by source order.) */
+.body.md { overflow-wrap: break-word; word-break: normal; }
 .msg.assistant .streaming-markdown { white-space: normal; }
 .streaming-markdown-prefix:empty { display: none; }
 .streaming-markdown-tail {
@@ -832,6 +837,9 @@ details.tool:not([open]) > summary.head .run-dot { animation: tool-pulse 1.1s ea
 }
 .md ul > li + li,
 .md ol > li + li { margin-top: 0.35em; }
+/* Residual empty items (e.g. `- ` followed by a blank line) must not draw an
+   orphan bullet dot. */
+.md li:empty { display: none; }
 .md ul > li::before {
   content: "";
   position: static;
@@ -954,7 +962,7 @@ details.tool:not([open]) > summary.head .run-dot { animation: tool-pulse 1.1s ea
 .md .md-table-card { margin: 0 0 10px; }
 .md .md-table-card table { width: 100%; margin: 0; display: table; overflow: visible; }
 .md .md-table-card .tbl-wrap { margin: 0; }
-.md th, .md td { padding: 6px 10px; border: 1px solid var(--border); text-align: left; white-space: normal; word-break: break-word; vertical-align: top; }
+.md th, .md td { padding: 6px 10px; border: 1px solid var(--border); text-align: left; white-space: normal; vertical-align: top; }
 .md thead th { background: var(--bg-elev); font-weight: 600; position: sticky; top: 0; }
 /* File chips in table cells often arrive as mini-lists ("- `file`"). Hide the
    custom bullets and lay chips out as a wrapping row instead of a dotted list. */

--- a/ui/src/text.rs
+++ b/ui/src/text.rs
@@ -196,7 +196,11 @@ pub(crate) fn md_document_to_html(src: &str) -> String {
 
 fn preprocess_markdown(src: &str) -> std::borrow::Cow<'_, str> {
     let src = rewrite_image_tags(src);
-    match normalize_math_delimiters(src.as_ref()) {
+    let src = match normalize_math_delimiters(src.as_ref()) {
+        std::borrow::Cow::Borrowed(_) => src,
+        std::borrow::Cow::Owned(s) => std::borrow::Cow::Owned(s),
+    };
+    match rejoin_empty_list_markers(src.as_ref()) {
         std::borrow::Cow::Borrowed(_) => src,
         std::borrow::Cow::Owned(s) => std::borrow::Cow::Owned(s),
     }
@@ -310,6 +314,124 @@ fn find_backtick_run(s: &str, n: usize) -> Option<usize> {
         from = at + run;
     }
     None
+}
+
+/// Models sometimes drop the item text onto the line after a bare list marker
+/// (`- \nTb1 ...`). CommonMark reads that as an empty item plus a paragraph,
+/// which renders as an orphan bullet dot followed by flush-left text. Rejoin
+/// the two lines when the next line is plain prose at the marker's indent;
+/// indented continuations already attach correctly, and real block starts
+/// (fences, headings, quotes, tables, other list items, thematic breaks) are
+/// left alone, as is anything inside fenced code.
+fn rejoin_empty_list_markers(src: &str) -> std::borrow::Cow<'_, str> {
+    let mut out = String::with_capacity(src.len());
+    let mut changed = false;
+    let mut fence: Option<(char, usize)> = None;
+    let mut lines = src.split_inclusive('\n').peekable();
+    while let Some(chunk) = lines.next() {
+        let line = chunk.trim_end_matches(['\r', '\n']);
+        let stripped = line.trim_start();
+        let mark = stripped.chars().next().filter(|c| matches!(c, '`' | '~'));
+        let run = mark.map_or(0, |m| stripped.chars().take_while(|&c| c == m).count());
+        match fence {
+            Some((m, n)) => {
+                out.push_str(chunk);
+                if mark == Some(m) && run >= n && stripped[run..].trim().is_empty() {
+                    fence = None;
+                }
+                continue;
+            }
+            None if run >= 3 => {
+                out.push_str(chunk);
+                fence = Some((mark.unwrap(), run));
+                continue;
+            }
+            None => {}
+        }
+        let Some(indent) = bare_list_marker_indent(line) else {
+            out.push_str(chunk);
+            continue;
+        };
+        let Some(next) = lines.peek() else {
+            out.push_str(chunk);
+            continue;
+        };
+        let next_line = next.trim_end_matches(['\r', '\n']);
+        if !is_plain_continuation(next_line, indent) {
+            out.push_str(chunk);
+            continue;
+        }
+        changed = true;
+        out.push_str(line.trim_end_matches([' ', '\t']));
+        out.push(' ');
+        out.push_str(next_line.trim_start());
+        out.push_str(&next[next_line.len()..]);
+        lines.next();
+    }
+    if changed {
+        std::borrow::Cow::Owned(out)
+    } else {
+        std::borrow::Cow::Borrowed(src)
+    }
+}
+
+/// Indent of a line holding only a list marker (`-`, `*`, `+`, `1.`, `1)`) plus
+/// trailing whitespace, or None. Indents past three spaces are code blocks.
+fn bare_list_marker_indent(line: &str) -> Option<usize> {
+    let stripped = line.trim_start_matches(' ');
+    let indent = line.len() - stripped.len();
+    if indent > 3 {
+        return None;
+    }
+    let marker = stripped.trim_end_matches([' ', '\t']);
+    let bare_bullet = matches!(marker, "-" | "*" | "+");
+    let bare_enum = marker.strip_suffix(['.', ')']).is_some_and(|digits| {
+        !digits.is_empty() && digits.len() <= 9 && digits.bytes().all(|b| b.is_ascii_digit())
+    });
+    (bare_bullet || bare_enum).then_some(indent)
+}
+
+/// True when `line` is plain prose that belongs to a preceding bare list
+/// marker, not a block start of its own.
+fn is_plain_continuation(line: &str, marker_indent: usize) -> bool {
+    if line.starts_with('\t') {
+        return false;
+    }
+    let stripped = line.trim_start_matches(' ');
+    if stripped.is_empty() || line.len() - stripped.len() > marker_indent {
+        return false;
+    }
+    let t = line.trim_start();
+    if t.is_empty() {
+        return false; // whitespace-only line
+    }
+    if t.starts_with("```") || t.starts_with("~~~") {
+        return false; // fenced code
+    }
+    let first = t.chars().next().unwrap();
+    if matches!(first, '#' | '>' | '|' | '<') {
+        return false; // heading / blockquote / table row / raw HTML
+    }
+    if matches!(first, '-' | '*' | '+') {
+        let rest = &t[1..];
+        if rest.is_empty() || rest.starts_with([' ', '\t']) {
+            return false; // another list item
+        }
+    }
+    if first.is_ascii_digit() {
+        let digits = t.bytes().take_while(|b| b.is_ascii_digit()).count();
+        let rest = &t[digits..];
+        if rest.starts_with(['.', ')']) && rest[1..].starts_with([' ', '\t']) {
+            return false; // ordered list item
+        }
+    }
+    if matches!(first, '-' | '*' | '_') {
+        let compact: String = t.chars().filter(|c| !matches!(c, ' ' | '\t')).collect();
+        if compact.len() >= 3 && compact.chars().all(|c| c == first) {
+            return false; // thematic break
+        }
+    }
+    true
 }
 
 /// Treat leading YAML front matter like normal Markdown tooling does: metadata
@@ -1221,6 +1343,47 @@ mod md_catalog_tests {
         runtime_language, strip_ansi, tool_card_label, user_message_presentation, NbOutput,
         MAX_NB_OUTPUT_BYTES, MAX_NB_TOTAL_OUTPUT_BYTES,
     };
+
+    #[test]
+    fn rejoins_text_dropped_after_a_bare_list_marker() {
+        // The screenshot case: `- ` alone on a line, item text on the next.
+        let html = md_to_html("- 450 = x\n- \nTb1 15,248,784 y\n");
+        assert!(html.contains("<li>Tb1 15,248,784 y</li>"), "{html}");
+        assert!(!html.contains("<li></li>"), "{html}");
+    }
+
+    #[test]
+    fn rejoins_bare_ordered_markers_and_keeps_lazy_continuation() {
+        let html = md_to_html("1. a\n2.\nb\n");
+        assert!(html.contains("<li>b</li>"), "{html}");
+        assert!(!html.contains("<li></li>"), "{html}");
+        // A wrapped line after the rejoined item stays inside the item.
+        let html = md_to_html("- \nlong item\ntail\n");
+        assert!(html.contains("<li>long item\ntail</li>"), "{html}");
+    }
+
+    #[test]
+    fn leaves_block_starts_and_code_fences_untouched() {
+        // Indented continuations already attach to the item; do not rejoin.
+        let src = "- a\n- \n  b\n";
+        assert_eq!(md_to_html(src), "<ul>\n<li>a</li>\n<li>b</li>\n</ul>\n");
+        // A bare marker followed by another item keeps its (empty) meaning.
+        let html = md_to_html("- a\n-\n- b\n");
+        assert!(html.contains("<li></li>"), "{html}");
+        // Blank and whitespace-only lines do not rejoin either.
+        for next in ["", "  ", " \t"] {
+            let html = md_to_html(&format!("- \n{next}\nb\n"));
+            assert!(html.contains("<li></li>"), "{next:?}: {html}");
+        }
+        // Thematic breaks, headings, quotes and tables are not item text.
+        for next in ["---", "# h", "> q", "| a | b |"] {
+            let html = md_to_html(&format!("- \n{next}\n"));
+            assert!(html.contains("<li></li>"), "{next}: {html}");
+        }
+        // Bare markers inside fenced code are data, not list syntax.
+        let src = "```\n-\nfoo\n```\n";
+        assert_eq!(md_to_html(src), "<pre><code>-\nfoo\n</code></pre>\n");
+    }
 
     #[test]
     fn decodes_percent_encoded_windows_href() {


### PR DESCRIPTION
## Problem

Two rendering defects in assistant chat markdown, both visible in one message (screenshot below):

1. **Orphan bullet + broken list**: when the model writes a bare list marker alone on a line (`- `) with the item text flush-left on the next line, CommonMark emits an empty `<li></li>` plus a paragraph *outside* the list. The custom `::before` bullet CSS then drew a lone dot, and the item text escaped the list indentation entirely.
2. **Inline code split mid-token**: `.msg .body` sets `overflow-wrap: anywhere` (specificity 0-2-0), which silently beats `.md`'s `overflow-wrap: break-word` (0-1-0) on the shared `<div class="body md">`. `anywhere` introduces wrap points inside any token even when normal break points exist, so inline code chips broke in half — e.g. `create_synteny_with_bed.p` / `y`. Table cells made it worse via the legacy `word-break: break-word` (equivalent to `anywhere`).

## Changes

- `ui/src/text.rs`: new `rejoin_empty_list_markers` in the `preprocess_markdown` chain. A line holding only a list marker (`-`/`*`/`+`/`1.`/`1)`) is rejoined with a following flush-left prose line. Fence-aware; leaves indented continuations (already correct per CommonMark), other list items, headings, quotes, tables, thematic breaks, blank lines, and fenced code untouched.
- `ui/src/styles/chat.css`:
  - `.body.md { overflow-wrap: break-word; word-break: normal }` — ties `.msg .body` in specificity and wins by source order; tokens now only break when they overflow a line on their own.
  - Removed legacy `word-break: break-word` from `.md th, .md td` (cells inherit `break-word` from `.md`; genuinely wide tables still scroll via `.tbl-wrap`'s `overflow: auto`).
  - `.md li:empty { display: none }` as a fallback for residual empty items (e.g. `- ` followed by a blank line).
- `ui-tests/tests/visual-polish.spec.ts`: new e2e regression test — bare marker rejoins into the list, no `li:empty` remains, and the computed style of markdown bodies is `overflow-wrap: break-word` / `word-break: normal`.

## Tests

- `cargo test` (wisp-ui): 219 passed, incl. 3 new unit tests for the rejoin (basic case, ordered markers + lazy continuation, block-start/fence/blank-line guards).
- `cargo test --workspace`: all suites ok, 0 failed.
- `cargo check --target wasm32-unknown-unknown`: clean.
- `npx playwright test tests/visual-polish.spec.ts`: 8/8 passed.
- `cargo fmt --check`: clean for the touched files (the repo has pre-existing formatting drift on main in unrelated files, not touched here).

## Manual smoke

Rendered the original message shape (CN prose + table with long filename code spans + the broken list) in the mocked-UI dev server and screenshot-compared: list structure intact, no orphan dot, code chips no longer split mid-token.

## Known limitations / follow-ups

- Deliberately out of scope (design decisions, happy to follow up): table column squeezing under `table-layout: auto`, the always-visible "复制表格" toolbar bar, bold-only paragraphs reading as headings, and the intentional 82%-ink color of single-paragraph list items.
- Pre-existing repo-wide `cargo fmt` drift on main is left alone; if wanted, a separate formatting-only commit can settle it.