### PR TITLE
fix(llm): send valid JSON in replayed tool-call arguments

### DIFF
--- a/crates/wisp-llm/src/openai.rs
+++ b/crates/wisp-llm/src/openai.rs
@@ -131,6 +131,8 @@ impl OpenAiProvider {
                         .cloned()
                         .map(|mut tc| {
                             tc.function.name = openai_wire_tool_name(&tc.function.name).into();
+                            tc.function.arguments =
+                                crate::provider::valid_json_tool_arguments(&tc.function.arguments);
                             tc
                         })
                         .collect();
@@ -880,6 +882,44 @@ mod tests {
         let out = OpenAiProvider::sanitize(&msgs);
         assert_eq!(out[0]["tool_calls"].as_array().unwrap().len(), 1);
         assert_eq!(out[1]["tool_call_id"], "a");
+    }
+
+    // Context compaction truncates oversized arguments mid-string, and a
+    // `finish_reason: "length"` turn can persist a half-written call. Strict
+    // gateways re-parse history arguments and 400 ("Unterminated string") on
+    // such values, so the wire format must replace them with valid JSON.
+    #[test]
+    fn replaces_invalid_tool_arguments_with_empty_object() {
+        let mut truncated = call("a");
+        truncated.function.arguments =
+            "{\"path\":\"/tmp/long...[... tool arguments archived ...]".into();
+        let mut empty = call("b");
+        empty.function.arguments = String::new();
+        let mut asst = Message::assistant("");
+        asst.tool_calls = vec![truncated, empty];
+        let msgs = vec![
+            asst,
+            Message::tool("a", "read", "ok"),
+            Message::tool("b", "read", "ok"),
+        ];
+        let out = OpenAiProvider::sanitize(&msgs);
+        let kept = out[0]["tool_calls"].as_array().unwrap();
+        assert_eq!(kept[0]["function"]["arguments"], "{}");
+        assert_eq!(kept[1]["function"]["arguments"], "{}");
+    }
+
+    #[test]
+    fn keeps_valid_tool_arguments_verbatim() {
+        let mut valid = call("a");
+        valid.function.arguments = "{\"path\":\"/tmp/x\"}".into();
+        let mut asst = Message::assistant("");
+        asst.tool_calls = vec![valid];
+        let msgs = vec![asst, Message::tool("a", "read", "ok")];
+        let out = OpenAiProvider::sanitize(&msgs);
+        assert_eq!(
+            out[0]["tool_calls"][0]["function"]["arguments"],
+            "{\"path\":\"/tmp/x\"}"
+        );
     }
 
     #[test]

--- a/crates/wisp-llm/src/provider.rs
+++ b/crates/wisp-llm/src/provider.rs
@@ -21,6 +21,21 @@ pub(crate) fn openai_internal_tool_name(name: &str) -> &str {
     }
 }
 
+/// OpenAI-compatible history must carry `tool_calls[].function.arguments` as
+/// a *valid* JSON string: strict gateways re-parse it and 400 with Python
+/// `json` errors like "Unterminated string" when the value is broken. Ours
+/// can be: context compaction cuts oversized arguments mid-string
+/// (`wisp-core` `bounded_latest_turn`), and a `finish_reason: "length"` turn
+/// can persist a half-written call. Replace anything that doesn't parse with
+/// an empty object, matching the Anthropic provider's stance.
+pub(crate) fn valid_json_tool_arguments(arguments: &str) -> String {
+    let trimmed = arguments.trim();
+    if !trimmed.is_empty() && serde_json::from_str::<serde_json::Value>(trimmed).is_ok() {
+        return arguments.to_string();
+    }
+    "{}".to_string()
+}
+
 /// reqwest's Display hides the useful part ("connection refused", "proxy
 /// unreachable", dns errors) in `source()`; walk the chain so users see it (#77).
 fn error_chain(e: &reqwest::Error) -> String {

--- a/crates/wisp-llm/src/responses.rs
+++ b/crates/wisp-llm/src/responses.rs
@@ -158,7 +158,7 @@ fn message_to_input(m: &Message) -> Vec<Value> {
                     "type": "function_call",
                     "call_id": tc.id,
                     "name": openai_wire_tool_name(&tc.function.name),
-                    "arguments": tc.function.arguments,
+                    "arguments": crate::provider::valid_json_tool_arguments(&tc.function.arguments),
                 }));
             }
             items
@@ -384,6 +384,27 @@ mod tests {
             output["call_id"], "call_abc",
             "output must match the emitted call_id"
         );
+    }
+
+    /// History arguments can be invalid JSON (compaction truncates oversized
+    /// arguments mid-string; a `finish_reason: "length"` turn can persist a
+    /// half-written call). Strict gateways re-parse them and 400, so the wire
+    /// format must replace them with valid JSON.
+    #[test]
+    fn replaces_invalid_arguments_with_empty_object() {
+        let messages = vec![
+            Message::user("run the skill"),
+            assistant_with_call("", "call_bad", "openalex", "{\"q\":\"x...[ archived ...]"),
+            Message::tool("call_bad", "openalex", "result body"),
+        ];
+
+        let input = wire_input(&messages);
+
+        let call = input
+            .iter()
+            .find(|v| v.get("type").and_then(|t| t.as_str()) == Some("function_call"))
+            .expect("function_call item present");
+        assert_eq!(call["arguments"], "{}");
     }
 
     /// Interrupted turn: assistant emitted a call, then the user resumed before


### PR DESCRIPTION
Closes #775

## Problem

Strict OpenAI-compatible gateways (LiteLLM / one-api style Python relays) reject our requests with:

```
api: 400 {"error":{"message":"Unterminated string starting at: line 1 column 1378 (char 1377)","type":"BadRequestError","param":null,"code":400}}
```

The top-level request body is always valid JSON, but these gateways re-parse each history `tool_calls[].function.arguments` value, and wisp can persist non-JSON arguments:

1. **Context compaction** truncates oversized arguments mid-string and splices in an `[... tool arguments archived ...]` marker (`bounded_latest_turn` in `wisp-core`), mutating the live messages that get replayed.
2. **Length-truncated generations** (`finish_reason: "length"` mid-tool-call) persist half-written arguments.

The official OpenAI endpoint never re-parses history arguments, so this only surfaced behind strict relays.

## Changes

- `crates/wisp-llm/src/provider.rs` — new `valid_json_tool_arguments()`: returns arguments unchanged when they parse as JSON, otherwise `{}` (also for empty strings).
- `crates/wisp-llm/src/openai.rs` — `sanitize()` routes replayed tool calls through it.
- `crates/wisp-llm/src/responses.rs` — `message_to_input()` routes `function_call` items through it.
- The Anthropic provider already degraded gracefully (`unwrap_or(json!({}))`); unchanged.

Validating at the wire boundary means no matter which upstream stage produced bad data, the request can no longer be rejected for malformed history arguments.

## Tests

- `openai.rs`: truncated/empty arguments become `{}`; valid arguments pass through verbatim.
- `responses.rs`: invalid arguments become `{}` in `function_call` items.
- `cargo fmt --all -- --check` clean; `cargo test --workspace` all green (41 passed in wisp-llm, 0 failures workspace-wide).

## Known limitations / follow-up

- Context compaction could replace oversized arguments with a valid-JSON placeholder at the source (e.g. `{"_archived": true}`) instead of splicing text; optional hardening, not required with the boundary validation in place.