### PR TITLE
fix: scope reasoning effort to conversations

### DIFF
--- a/crates/wisp-store/migrations/0000_init.sql
+++ b/crates/wisp-store/migrations/0000_init.sql
@@ -33,6 +33,7 @@ CREATE TABLE IF NOT EXISTS frames (
     branched_from   TEXT,
     pinned          INTEGER NOT NULL DEFAULT 0,
     model           TEXT,
+    reasoning_effort TEXT,
     input_tokens    INTEGER,
     output_tokens   INTEGER,
     created_at      INTEGER NOT NULL,

--- a/crates/wisp-store/src/explorations.rs
+++ b/crates/wisp-store/src/explorations.rs
@@ -472,7 +472,7 @@ impl Store {
         }
         let mut tx = self.begin_write().await?;
         let source = sqlx::query(
-            "SELECT project_id,agent_name,status,model,input_tokens,output_tokens,completed_at,title \
+            "SELECT project_id,agent_name,status,model,reasoning_effort,input_tokens,output_tokens,completed_at,title \
              FROM frames WHERE id=? AND parent_frame_id=id",
         )
         .bind(source_frame_id)
@@ -497,9 +497,9 @@ impl Store {
         let now = chrono::Utc::now().timestamp();
         sqlx::query(
             "INSERT INTO frames(\
-               id,parent_frame_id,root_frame_id,agent_name,status,project_id,branched_from,model,\
+               id,parent_frame_id,root_frame_id,agent_name,status,project_id,branched_from,model,reasoning_effort,\
                input_tokens,output_tokens,created_at,updated_at,completed_at,title\
-             ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+             ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
         )
         .bind(target_frame_id)
         .bind(target_frame_id)
@@ -509,6 +509,7 @@ impl Store {
         .bind(source.try_get::<String, _>("project_id")?)
         .bind(source_frame_id)
         .bind(source.try_get::<Option<String>, _>("model")?)
+        .bind(source.try_get::<Option<String>, _>("reasoning_effort")?)
         .bind(source.try_get::<Option<i64>, _>("input_tokens")?)
         .bind(source.try_get::<Option<i64>, _>("output_tokens")?)
         .bind(now)

--- a/crates/wisp-store/src/lib.rs
+++ b/crates/wisp-store/src/lib.rs
@@ -144,6 +144,7 @@ const PROJECT_STATE_REVISIONS_MIGRATION_SQL: &str =
     include_str!("../migrations/0038_project_state_revisions.sql");
 const GLOBAL_MEMORIES_MIGRATION: &str = "0039_global_memories";
 const GLOBAL_MEMORIES_MIGRATION_SQL: &str = include_str!("../migrations/0039_global_memories.sql");
+const SESSION_REASONING_EFFORT_MIGRATION: &str = "0040_session_reasoning_effort";
 
 #[derive(Clone)]
 pub struct Store {
@@ -541,6 +542,10 @@ impl Store {
         if !Self::migration_applied(pool, GLOBAL_MEMORIES_MIGRATION).await? {
             Self::execute_sql_script(pool, GLOBAL_MEMORIES_MIGRATION_SQL).await?;
             Self::record_migration(pool, GLOBAL_MEMORIES_MIGRATION).await?;
+        }
+        if !Self::migration_applied(pool, SESSION_REASONING_EFFORT_MIGRATION).await? {
+            Self::add_columns_if_missing(pool, "frames", &[("reasoning_effort", "TEXT")]).await?;
+            Self::record_migration(pool, SESSION_REASONING_EFFORT_MIGRATION).await?;
         }
         Ok(())
     }

--- a/crates/wisp-store/src/project_transfer.rs
+++ b/crates/wisp-store/src/project_transfer.rs
@@ -133,8 +133,8 @@ async fn copy_project_children(tx: &mut Transaction<'_, Sqlite>, project_id: &st
     const QUERIES: &[&str] = &[
         "INSERT INTO folders(id,project_id,name,created_at,updated_at) \
          SELECT id,project_id,name,created_at,updated_at FROM transfer.folders WHERE project_id=?",
-        "INSERT INTO frames(id,parent_frame_id,root_frame_id,agent_name,status,project_id,folder_id,model,input_tokens,output_tokens,created_at,updated_at,completed_at,title) \
-         SELECT id,parent_frame_id,root_frame_id,agent_name,status,project_id,folder_id,model,input_tokens,output_tokens,created_at,updated_at,completed_at,title \
+        "INSERT INTO frames(id,parent_frame_id,root_frame_id,agent_name,status,project_id,folder_id,model,reasoning_effort,input_tokens,output_tokens,created_at,updated_at,completed_at,title) \
+         SELECT id,parent_frame_id,root_frame_id,agent_name,status,project_id,folder_id,model,reasoning_effort,input_tokens,output_tokens,created_at,updated_at,completed_at,title \
          FROM transfer.frames WHERE project_id=?",
         "INSERT INTO messages(id,frame_id,seq,role,content,tool_calls,tool_call_id,tool_name,reasoning,ts,model_name) \
          SELECT id,frame_id,seq,role,content,tool_calls,tool_call_id,tool_name,reasoning,ts,model_name FROM transfer.messages \

--- a/crates/wisp-store/src/sessions.rs
+++ b/crates/wisp-store/src/sessions.rs
@@ -772,6 +772,18 @@ impl Store {
         )
     }
 
+    /// Per-conversation reasoning-effort override. `None` inherits the bound
+    /// model profile; an empty string explicitly requests the provider default.
+    pub async fn frame_reasoning_effort(&self, frame_id: &str) -> Result<Option<String>> {
+        Ok(sqlx::query_scalar::<_, Option<String>>(
+            "SELECT reasoning_effort FROM frames WHERE id=?",
+        )
+        .bind(frame_id)
+        .fetch_optional(&self.pool)
+        .await?
+        .flatten())
+    }
+
     /// Overwrite a frame's created/updated timestamps. Used by importers so
     /// external conversations keep their original chronology in the sidebar.
     pub async fn set_frame_timestamps(
@@ -803,6 +815,27 @@ impl Store {
                 .bind(project_id)
                 .execute(&self.pool)
                 .await?;
+        if updated.rows_affected() != 1 {
+            anyhow::bail!("Session not found");
+        }
+        Ok(())
+    }
+
+    pub async fn set_frame_reasoning_effort(
+        &self,
+        frame_id: &str,
+        project_id: &str,
+        reasoning_effort: Option<&str>,
+    ) -> Result<()> {
+        let updated = sqlx::query(
+            "UPDATE frames SET reasoning_effort=?,updated_at=? WHERE id=? AND project_id=?",
+        )
+        .bind(reasoning_effort)
+        .bind(chrono::Utc::now().timestamp())
+        .bind(frame_id)
+        .bind(project_id)
+        .execute(&self.pool)
+        .await?;
         if updated.rows_affected() != 1 {
             anyhow::bail!("Session not found");
         }
@@ -1571,7 +1604,7 @@ impl Store {
         }
 
         let source = sqlx::query(
-            "SELECT agent_name,status,model,input_tokens,output_tokens,completed_at,title \
+            "SELECT agent_name,status,model,reasoning_effort,input_tokens,output_tokens,completed_at,title \
              FROM frames WHERE id=? AND project_id=? AND parent_frame_id=id",
         )
         .bind(frame_id)
@@ -1583,9 +1616,9 @@ impl Store {
         let now = chrono::Utc::now().timestamp();
         sqlx::query(
             "INSERT INTO frames(\
-                id,parent_frame_id,root_frame_id,agent_name,status,project_id,folder_id,model,\
+                id,parent_frame_id,root_frame_id,agent_name,status,project_id,folder_id,model,reasoning_effort,\
                 input_tokens,output_tokens,created_at,updated_at,completed_at,title\
-             ) VALUES(?,?,?,?,?,?,NULL,?,?,?,?,?,?,?)",
+             ) VALUES(?,?,?,?,?,?,NULL,?,?,?,?,?,?,?,?)",
         )
         .bind(new_frame_id)
         .bind(new_frame_id)
@@ -1594,6 +1627,7 @@ impl Store {
         .bind(source.try_get::<String, _>("status")?)
         .bind(target_project_id)
         .bind(source.try_get::<Option<String>, _>("model")?)
+        .bind(source.try_get::<Option<String>, _>("reasoning_effort")?)
         .bind(source.try_get::<Option<i64>, _>("input_tokens")?)
         .bind(source.try_get::<Option<i64>, _>("output_tokens")?)
         .bind(now)

--- a/crates/wisp-store/src/store_tests.rs
+++ b/crates/wisp-store/src/store_tests.rs
@@ -450,6 +450,71 @@ async fn frame_models_are_session_scoped() {
 }
 
 #[tokio::test]
+async fn frame_reasoning_effort_is_session_scoped_and_nullable() {
+    let tmp = std::env::temp_dir().join(format!(
+        "wisp_store_frame_reasoning_{}.sqlite",
+        uuid::Uuid::new_v4()
+    ));
+    let store = Store::open(&tmp).await.unwrap();
+    store.create_project("p", "proj", "").await.unwrap();
+    store
+        .create_frame("first", "p", "OPERON", "m1")
+        .await
+        .unwrap();
+    store
+        .create_frame("second", "p", "OPERON", "m1")
+        .await
+        .unwrap();
+
+    store
+        .set_frame_reasoning_effort("first", "p", Some("high"))
+        .await
+        .unwrap();
+    assert_eq!(
+        store.frame_reasoning_effort("first").await.unwrap(),
+        Some("high".into())
+    );
+    assert_eq!(store.frame_reasoning_effort("second").await.unwrap(), None);
+
+    sqlx::query("INSERT INTO messages(id,frame_id,seq,role,ts) VALUES('msg','first',1,'user',1)")
+        .execute(&store.pool)
+        .await
+        .unwrap();
+    store
+        .clone_exploration_frame("first", "exploration", 1, 0)
+        .await
+        .unwrap();
+    assert_eq!(
+        store.frame_reasoning_effort("exploration").await.unwrap(),
+        Some("high".into()),
+        "an exploration branch must preserve the conversation override"
+    );
+
+    assert!(store
+        .set_frame_reasoning_effort("first", "other", Some("low"))
+        .await
+        .is_err());
+
+    store
+        .set_frame_reasoning_effort("first", "p", Some(""))
+        .await
+        .unwrap();
+    assert_eq!(
+        store.frame_reasoning_effort("first").await.unwrap(),
+        Some(String::new()),
+        "an explicit provider-default override must differ from inheritance"
+    );
+    store
+        .set_frame_reasoning_effort("first", "p", None)
+        .await
+        .unwrap();
+    assert_eq!(store.frame_reasoning_effort("first").await.unwrap(), None);
+
+    store.pool.close().await;
+    let _ = std::fs::remove_file(tmp);
+}
+
+#[tokio::test]
 async fn agent_workflow_and_steps_roundtrip() {
     let tmp = std::env::temp_dir().join(format!(
         "wisp_agent_workflow_{}.sqlite",
@@ -2923,6 +2988,7 @@ async fn store_open_records_migrations_and_seeds_local_context() {
             EXPLORATION_BRANCHES_MIGRATION.to_string(),
             PROJECT_STATE_REVISIONS_MIGRATION.to_string(),
             GLOBAL_MEMORIES_MIGRATION.to_string(),
+            SESSION_REASONING_EFFORT_MIGRATION.to_string(),
         ]
     );
 

--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -33,7 +33,10 @@ The composer model picker binds the selected HTTP model to the current
 conversation. Switching one populated conversation asks for confirmation and
 does not change any other conversation. Empty conversations switch immediately
 without a warning. The active profile in Settings remains the default for new
-conversations.
+conversations. The reasoning-effort selector in the same menu is also scoped to
+the current conversation: changing it overrides that conversation's model
+profile without editing the profile or affecting other conversations. A new
+conversation inherits the reasoning effort configured on its model profile.
 
 Model profiles describe model access and capabilities for the **built-in Wisp
 agent**. External coding agents (Codex / Claude via ACP) are configured under

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3410,24 +3410,26 @@ async fn load_session_settings(
     frame_id: &str,
 ) -> (String, String, String, String, u64, String) {
     let profile_id = models::session_profile_id(store, frame_id).await;
-    let (provider, api_url, model, api_key, max_tokens, reasoning_effort) =
+    let (provider, api_url, model, api_key, max_tokens, profile_reasoning_effort) =
         match models::profile_llm(store, &profile_id).await {
             Some(config) => config,
             None => {
                 let (provider, api_url, model, api_key) = load_settings(store).await;
                 let (max_tokens, reasoning_effort) = models::active_llm_advanced(store).await;
-                return (
+                (
                     provider,
                     api_url,
                     model,
                     api_key,
                     max_tokens,
                     reasoning_effort,
-                );
+                )
             }
         };
     let (provider, api_url, model, api_key) =
         resolve_model_settings(provider, api_url, model, api_key);
+    let reasoning_effort =
+        models::session_reasoning_effort(store, frame_id, &profile_reasoning_effort).await;
     (
         provider,
         api_url,
@@ -7812,10 +7814,12 @@ pub fn run() {
             desktop_lifecycle::set_pet_window_visible,
             models::list_models,
             models::get_session_model,
+            models::get_session_reasoning_effort,
             models::save_model,
             models::remove_model,
             models::reorder_models,
             models::set_active_model,
+            models::set_session_reasoning_effort,
             settings_commands::validate_settings,
             list_dir,
             create_file,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -543,6 +543,19 @@ pub async fn session_label(store: &wisp_store::Store, frame_id: &str) -> String 
         .unwrap_or_default()
 }
 
+/// Effective reasoning effort for a conversation: an explicit frame override
+/// wins, otherwise the bound model profile supplies its configured default.
+pub async fn session_reasoning_effort(
+    store: &wisp_store::Store,
+    frame_id: &str,
+    profile_default: &str,
+) -> String {
+    if let Ok(Some(effort)) = store.frame_reasoning_effort(frame_id).await {
+        return effort;
+    }
+    profile_default.to_string()
+}
+
 /// Key for a profile, falling back to the legacy `api_key` secret for the
 /// migrated "default" profile (so a not-yet-re-saved default still works).
 fn key_for(id: &str) -> String {
@@ -878,6 +891,30 @@ pub async fn get_session_model(
     Ok(session_profile_id(&state.store, &session_id).await)
 }
 
+#[tauri::command]
+pub async fn get_session_reasoning_effort(
+    state: State<'_, crate::AppState>,
+    window: tauri::WebviewWindow,
+    session_id: String,
+) -> Result<Option<String>, String> {
+    let project = state.active(window.label());
+    if state
+        .store
+        .frame_project_id(&session_id)
+        .await
+        .map_err(|error| error.to_string())?
+        .as_deref()
+        != Some(project.id.as_str())
+    {
+        return Err("Session not found".into());
+    }
+    state
+        .store
+        .frame_reasoning_effort(&session_id)
+        .await
+        .map_err(|error| error.to_string())
+}
+
 /// Upsert a profile. An empty `id` creates a new one; a non-empty `key` updates
 /// the keyring (a blank key leaves the stored one untouched).
 #[tauri::command]
@@ -1092,6 +1129,39 @@ pub async fn set_active_model(
     Ok(decorated(&state.store).await)
 }
 
+#[tauri::command]
+pub async fn set_session_reasoning_effort(
+    state: State<'_, crate::AppState>,
+    effort: String,
+    session_id: String,
+) -> Result<(), String> {
+    let effort = effort.trim();
+    if !effort.is_empty()
+        && !matches!(
+            effort,
+            "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | "ultra"
+        )
+    {
+        return Err("Unknown reasoning effort.".into());
+    }
+    let (project, scope) =
+        crate::exploration_commands::working_project_for_frame(&state, &session_id).await?;
+    let _activity = state.begin_project_activity(&project.id)?;
+    let _project_write_locked = crate::exploration_commands::conversation_project_write_locked(
+        &state.store,
+        &scope,
+        Some(&session_id),
+    )
+    .await?;
+    state
+        .store
+        .set_frame_reasoning_effort(&session_id, &project.id, Some(effort))
+        .await
+        .map_err(|error| error.to_string())?;
+    crate::clear_session_agent(&state, &session_id).await;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1192,6 +1262,33 @@ mod tests {
 
         assert_eq!(session_profile_id(&store, "a").await, "m2");
         assert_eq!(session_profile_id(&store, "b").await, "m1");
+        drop(store);
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    #[tokio::test]
+    async fn session_reasoning_override_does_not_change_profile_or_sibling() {
+        let tmp = std::env::temp_dir().join(format!(
+            "wisp_session_reasoning_{}.sqlite",
+            uuid::Uuid::new_v4()
+        ));
+        let store = wisp_store::Store::open(&tmp).await.unwrap();
+        store.create_project("p", "project", "").await.unwrap();
+        let mut profile = test_profile("m1", "reasoner", "model-1");
+        profile.reasoning_effort = "max".into();
+        save_raw(&store, &[profile]).await.unwrap();
+        store.set_setting(ACTIVE_KEY, "m1").await.unwrap();
+        store.create_frame("a", "p", "OPERON", "m1").await.unwrap();
+        store.create_frame("b", "p", "OPERON", "m1").await.unwrap();
+
+        store
+            .set_frame_reasoning_effort("a", "p", Some("high"))
+            .await
+            .unwrap();
+
+        assert_eq!(session_reasoning_effort(&store, "a", "max").await, "high");
+        assert_eq!(session_reasoning_effort(&store, "b", "max").await, "max");
+        assert_eq!(profile_llm(&store, "m1").await.unwrap().5, "max");
         drop(store);
         let _ = std::fs::remove_file(&tmp);
     }

--- a/src-tauri/src/session_commands.rs
+++ b/src-tauri/src/session_commands.rs
@@ -67,6 +67,16 @@ pub(super) async fn branch_session(
             .set_frame_model(&id, &ap.id, &model_id)
             .await
             .map_err(|error| error.to_string())?;
+        let reasoning_effort = state
+            .store
+            .frame_reasoning_effort(source)
+            .await
+            .map_err(|error| error.to_string())?;
+        state
+            .store
+            .set_frame_reasoning_effort(&id, &ap.id, reasoning_effort.as_deref())
+            .await
+            .map_err(|error| error.to_string())?;
         let msgs = state
             .store
             .load_messages(source)

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -671,7 +671,7 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
       active: true,
       max_tokens: 4096,
       context_window: 128000,
-      reasoning_effort: "",
+      reasoning_effort: query.get("mockSessionModels") === "1" ? "low" : "",
       supports_vision: query.get("mockTextOnlyModel") !== "1",
       use_for_vision: query.get("mockTextOnlyModel") !== "1",
       use_for_image_generation: false,
@@ -686,7 +686,7 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
       active: false,
       max_tokens: 4096,
       context_window: 200000,
-      reasoning_effort: "",
+      reasoning_effort: query.get("mockSessionModels") === "1" ? "max" : "",
       supports_vision: true,
       use_for_vision: false,
       use_for_image_generation: false,
@@ -696,6 +696,7 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
   const sessionModels: Record<string, string> = query.get("mockSessionModels") === "1"
     ? { "s-model-a": "default", "s-model-b": "default" }
     : {};
+  const sessionReasoningEfforts: Record<string, string> = {};
   let mockAcpAgents = [
     { id: "acp-test", label: "Test ACP Agent", command: "fake-acp", args: ["--stdio"] },
   ];
@@ -2333,6 +2334,13 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
             const sessionId = String(arg("sessionId") ?? "");
             return sessionModels[sessionId] ?? activeHttpModelId();
           }
+          case "get_session_reasoning_effort": {
+            const sessionId = String(arg("sessionId") ?? "");
+            if (Object.prototype.hasOwnProperty.call(sessionReasoningEfforts, sessionId)) {
+              return sessionReasoningEfforts[sessionId];
+            }
+            return null;
+          }
           case "list_acp_agents":
             return mockAcpAgents;
           case "get_dynamic_agent_options":
@@ -2987,6 +2995,11 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
               mockModels = mockModels.map((m) => ({ ...m, active: m.id === id }));
             }
             return mockModels;
+          }
+          case "set_session_reasoning_effort": {
+            const sessionId = String(arg("sessionId") ?? "");
+            sessionReasoningEfforts[sessionId] = String(arg("effort") ?? "");
+            return null;
           }
           case "get_project_info":
             ((window as any).__projectInfoReads ??= []).push(activeProjectId);
@@ -3764,6 +3777,9 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
             const id = `branch-${Math.random().toString(36).slice(2)}`;
             const source = String(arg("sessionId") ?? "");
             sessionModels[id] = sessionModels[source] ?? activeHttpModelId();
+            if (Object.prototype.hasOwnProperty.call(sessionReasoningEfforts, source)) {
+              sessionReasoningEfforts[id] = sessionReasoningEfforts[source];
+            }
             return id;
           }
           case "compare_session_branches": {

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -888,6 +888,37 @@ test("model selection stays bound to its conversation", async ({ page }) => {
   await expect(page.locator(".model-picker-label")).toHaveText("opus-4.8");
 });
 
+test("reasoning effort stays scoped to the current conversation", async ({ page }) => {
+  await enterApp(page, "/?mockSessionModels=1");
+  await page.locator('[data-session-id="s-model-a"]').click();
+
+  await page.locator(".model-picker-btn").click();
+  await page.getByRole("button", { name: /opus-4\.8/ }).click();
+  await page.getByTestId("model-switch-confirm")
+    .getByRole("button", { name: "Yes, switch" }).click();
+  await expect(page.locator(".model-picker-label")).toHaveText("opus-4.8");
+
+  await page.locator(".model-picker-btn").click();
+  const effort = page.locator(".model-menu-effort-select");
+  await expect(effort).toHaveValue("max");
+  await effort.selectOption("high");
+  await expect.poll(() => lastInvokeArgs(page, "set_session_reasoning_effort")).toMatchObject({
+    sessionId: "s-model-a",
+    effort: "high",
+  });
+  await expect.poll(() => lastInvokeArgs(page, "save_model")).toBeNull();
+  await page.locator(".model-menu-backdrop").click();
+
+  await page.locator('[data-session-id="s-model-b"]').click();
+  await page.locator(".model-picker-btn").click();
+  await expect(page.locator(".model-menu-effort-select")).toHaveValue("low");
+  await page.locator(".model-menu-backdrop").click();
+
+  await page.locator('[data-session-id="s-model-a"]').click();
+  await page.locator(".model-picker-btn").click();
+  await expect(page.locator(".model-menu-effort-select")).toHaveValue("high");
+});
+
 test("Settings Models page can open ACP Agents dialog", async ({ page }) => {
   await enterApp(page);
   await page.getByRole("button", { name: "Settings" }).click();

--- a/ui/src/dto.rs
+++ b/ui/src/dto.rs
@@ -1067,6 +1067,31 @@ pub(crate) fn session_model_label(
     )
 }
 
+/// Effective effort for the active conversation. A value loaded from the
+/// frame wins; before that IPC read completes, fall back to the bound profile.
+pub(crate) fn session_reasoning_effort(
+    models: &[ModelProfile],
+    session_models: &HashMap<String, String>,
+    session_efforts: &HashMap<String, String>,
+    session_id: Option<&str>,
+) -> String {
+    if let Some(effort) = session_id.and_then(|id| session_efforts.get(id)) {
+        return effort.clone();
+    }
+    let bound = session_id.and_then(|id| session_models.get(id));
+    models
+        .iter()
+        .find(|model| model.is_chat_model() && bound == Some(&model.id))
+        .or_else(|| {
+            models
+                .iter()
+                .find(|model| model.active && model.is_chat_model())
+        })
+        .or_else(|| models.iter().find(|model| model.is_chat_model()))
+        .map(|model| model.reasoning_effort.clone())
+        .unwrap_or_default()
+}
+
 /// Mirrors `models::effective_context_window` in src-tauri: a configured
 /// window below 4K counts as "unset" and falls back to 128K.
 pub(crate) fn effective_context_window(value: u64) -> u64 {
@@ -1121,7 +1146,7 @@ mod model_label_tests {
 
 #[cfg(test)]
 mod session_context_window_tests {
-    use super::{session_context_window, ModelProfile};
+    use super::{session_context_window, session_reasoning_effort, ModelProfile};
     use std::collections::HashMap;
 
     fn profile(id: &str, active: bool, context_window: u64) -> ModelProfile {
@@ -1150,6 +1175,24 @@ mod session_context_window_tests {
             session_context_window(&models, &bindings, Some("s1")),
             Some(1_000_000)
         );
+    }
+
+    #[test]
+    fn session_effort_override_wins_without_changing_profile() {
+        let mut active = profile("a", true, 128_000);
+        active.reasoning_effort = "max".into();
+        let mut bound = profile("b", false, 128_000);
+        bound.reasoning_effort = "max".into();
+        let models = vec![active, bound];
+        let bindings = HashMap::from([("s1".to_string(), "b".to_string())]);
+        let efforts = HashMap::from([("s1".to_string(), "high".to_string())]);
+
+        assert_eq!(
+            session_reasoning_effort(&models, &bindings, &efforts, Some("s1")),
+            "high"
+        );
+        assert_eq!(models[0].reasoning_effort, "max");
+        assert_eq!(models[1].reasoning_effort, "max");
     }
 
     #[test]

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -493,6 +493,7 @@ fn App() -> impl IntoView {
         conversation_outline_selected.set(None);
     });
     let session_model_ids = create_rw_signal::<HashMap<String, String>>(HashMap::new());
+    let session_reasoning_efforts = create_rw_signal::<HashMap<String, String>>(HashMap::new());
     let acp_agents = create_rw_signal::<Vec<AcpAgentProfile>>(vec![]);
     let active_acp_agent_id = create_rw_signal::<Option<String>>(None);
     let acp_context_usage =
@@ -737,16 +738,24 @@ fn App() -> impl IntoView {
         };
         spawn_local(async move {
             let args = to_value(&serde_json::json!({ "sessionId": session_id.clone() })).unwrap();
-            let Ok(value) = invoke_checked("get_session_model", args).await else {
-                return;
-            };
-            let Some(model_id) = value.as_string() else {
-                return;
-            };
-            if active_session.get_untracked().as_deref() == Some(session_id.as_str()) {
-                session_model_ids.update(|models| {
-                    models.insert(session_id, model_id);
-                });
+            if let Ok(value) = invoke_checked("get_session_model", args).await {
+                if let Some(model_id) = value.as_string() {
+                    if active_session.get_untracked().as_deref() == Some(session_id.as_str()) {
+                        session_model_ids.update(|models| {
+                            models.insert(session_id.clone(), model_id);
+                        });
+                    }
+                }
+            }
+            let args = to_value(&serde_json::json!({ "sessionId": session_id.clone() })).unwrap();
+            if let Ok(value) = invoke_checked("get_session_reasoning_effort", args).await {
+                if let Some(effort) = value.as_string() {
+                    if active_session.get_untracked().as_deref() == Some(session_id.as_str()) {
+                        session_reasoning_efforts.update(|efforts| {
+                            efforts.insert(session_id, effort);
+                        });
+                    }
+                }
             }
         });
     });
@@ -11409,42 +11418,36 @@ fn App() -> impl IntoView {
                                                         on:change=move |ev| {
                                                             let v = dom_value(&ev);
                                                             let effort = if v == "default" { String::new() } else { v };
-                                                            let Some(m) = models.get_untracked().into_iter().find(|m| m.active) else { return; };
-                                                            let profile = serde_json::json!({
-                                                                "id": m.id,
-                                                                "label": m.label,
-                                                                "provider": m.provider,
-                                                                "api_url": m.api_url,
-                                                                "model": m.model,
-                                                                "max_tokens": m.max_tokens,
-                                                                "reasoning_effort": effort,
-                                                                "supports_vision": m.supports_vision,
-                                                                "use_for_vision": m.use_for_vision,
-                                                                "use_for_image_generation": m.use_for_image_generation,
-                                                            });
-                                                            let use_for_vision = m.use_for_vision;
-                                                            let use_for_image_generation = m.use_for_image_generation;
+                                                            let Some(session_id) = active_session.get_untracked() else { return; };
                                                             spawn_local(async move {
                                                                 let arg = to_value(&serde_json::json!({
-                                                                    "profile": profile,
-                                                                    "key": Option::<String>::None,
-                                                                    "useForVision": use_for_vision,
-                                                                    "useForImageGeneration": use_for_image_generation,
+                                                                    "sessionId": session_id.clone(),
+                                                                    "effort": effort.clone(),
                                                                 })).unwrap();
-                                                                if let Ok(v) = invoke_checked("save_model", arg).await {
-                                                                    if let Ok(list) = serde_wasm_bindgen::from_value::<Vec<ModelProfile>>(v) {
-                                                                        models.set(list);
-                                                                    }
+                                                                if invoke_checked("set_session_reasoning_effort", arg).await.is_ok() {
+                                                                    session_reasoning_efforts.update(|efforts| {
+                                                                        efforts.insert(session_id, effort);
+                                                                    });
                                                                 }
                                                             });
                                                         }>
                                                         <option value="default"
-                                                            prop:selected=move || models.get().iter().find(|m| m.active).map(|m| m.reasoning_effort.is_empty()).unwrap_or(true)>
+                                                            prop:selected=move || session_reasoning_effort(
+                                                                &models.get(),
+                                                                &session_model_ids.get(),
+                                                                &session_reasoning_efforts.get(),
+                                                                active_session.get().as_deref(),
+                                                            ).is_empty()>
                                                             {move || t(locale.get(), "settings.reasoning_effort.default")}
                                                         </option>
                                                         {["none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"].into_iter().map(|lvl| view! {
                                                             <option value=lvl
-                                                                prop:selected=move || models.get().iter().find(|m| m.active).is_some_and(|m| m.reasoning_effort == lvl)>
+                                                                prop:selected=move || session_reasoning_effort(
+                                                                    &models.get(),
+                                                                    &session_model_ids.get(),
+                                                                    &session_reasoning_efforts.get(),
+                                                                    active_session.get().as_deref(),
+                                                                ) == lvl>
                                                                 {lvl}
                                                             </option>
                                                         }).collect_view()}


### PR DESCRIPTION
Fixes #781

## Problem

The composer model picker was already conversation-scoped, but its reasoning-effort selector still searched for the globally active model profile and called `save_model`. Changing reasoning effort could therefore edit the wrong profile, affect other conversations, and persist a global setting instead of a conversation setting.

## Changes

- add a nullable `frames.reasoning_effort` override with an idempotent migration
- resolve runtime reasoning effort from the conversation override first, then the bound model profile
- add project-scoped Tauri commands for reading and updating the override
- update the model menu to read and write reasoning effort for the active conversation without calling `save_model`
- preserve the override across regular branches, exploration branches, cross-project copies, and project transfer
- document conversation-scoped behavior and add store, Tauri, UI-unit, and Playwright regressions

`NULL` means inherit the bound model profile. An empty string is an explicit provider-default override.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p wisp-store` (112 passed)
- targeted `wisp-store`, `wisp-tauri`, and `wisp-ui` regression tests
- `cd ui && cargo check --target wasm32-unknown-unknown`
- Playwright conversation model and reasoning-effort regressions
- full Playwright run: 342 passed, 1 skipped; one unrelated selection-popup timeout passed on isolated retry

The full Rust workspace run reached 600 passed / 10 failed. The failures reproduce independently on Windows and are confined to untouched method-search, resource-lease, and publication test paths (path-root/case assertions and Windows file locking).

## Manual smoke

1. Open two conversations and bind one to a non-active model profile.
2. Change reasoning effort in only that conversation.
3. Switch between conversations and confirm each menu retains its own effective effort.
4. Open model settings and confirm the underlying profiles were not edited.

## Known limitations / follow-up

- Existing conversations have no override and continue to inherit their bound model profile.
- The unrelated Windows full-suite failures above remain outside this issue's scope.
