### PR TITLE
Agent 运行时事件协议：工具草稿流、结构化结果、队列收口

### DIFF
--- a/crates/wisp-core/src/agent.rs
+++ b/crates/wisp-core/src/agent.rs
@@ -6,6 +6,7 @@ use crate::archive::{prune_dir, ArchiveRetention};
 use crate::context::{image_content, ContextManager};
 use crate::output::{StreamSinkAdapter, ToolEnvAdapter};
 use crate::provenance;
+use crate::runtime_event::{AgentRuntimeEvent, RunOutcome, ToolInvocationKey};
 use crate::Output;
 use anyhow::Result;
 use std::collections::VecDeque;
@@ -257,6 +258,52 @@ async fn agent_loop_inner(
     cancel: Option<&AtomicBool>,
     guidance: Option<&GuidanceQueue>,
 ) -> Result<()> {
+    output.runtime_event(&AgentRuntimeEvent::RunStarted);
+    let result = agent_loop_run(
+        ctx,
+        provider,
+        vision_provider,
+        tools,
+        root,
+        output,
+        max_iter,
+        cancel,
+        guidance,
+    )
+    .await;
+    // Exactly one RunFinished per run, however the run ended.
+    let outcome = match &result {
+        Ok(()) => RunOutcome::Completed,
+        Err(error) if is_user_cancel(error) => RunOutcome::Cancelled,
+        Err(error) => RunOutcome::Failed(error.to_string()),
+    };
+    output.runtime_event(&AgentRuntimeEvent::RunFinished { outcome });
+    result
+}
+
+fn is_user_cancel(error: &anyhow::Error) -> bool {
+    error.to_string().contains(STOPPED_BY_USER)
+}
+
+/// Whether the run needs another model request after this round.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RoundFlow {
+    Continue,
+    Done,
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn agent_loop_run(
+    ctx: &mut ContextManager,
+    provider: &dyn Provider,
+    vision_provider: Option<&dyn Provider>,
+    tools: &Registry,
+    root: &Path,
+    output: &dyn Output,
+    max_iter: usize,
+    cancel: Option<&AtomicBool>,
+    guidance: Option<&GuidanceQueue>,
+) -> Result<()> {
     let env = match cancel {
         Some(c) => ToolEnvAdapter::with_cancel(root.to_path_buf(), output, c),
         None => ToolEnvAdapter::new(root.to_path_buf(), output),
@@ -280,260 +327,22 @@ async fn agent_loop_inner(
             }
         }
         iteration += 1;
-        let (schemas, schema_origins) = tools.schemas_with_origins();
-        let fixed_request_tokens = ContextManager::estimated_tool_tokens(&schemas);
-        // Match the long-context behaviour used by mangopi-cli: check the
-        // budget at every model boundary, not only when the user first sends a
-        // turn. Wisp's archive-first compactor preserves the full transcript
-        // on disk before folding old turns, so automatic recovery has the same
-        // retrievability contract as manual `/compact`.
-        if ctx.needs_auto_compact_with_reserve(fixed_request_tokens) {
-            let (archive, archive_reference) = context_archive(root);
-            output.compaction_started("auto");
-            match ctx
-                .compact_with_reserve_reference(
-                    provider,
-                    &archive,
-                    fixed_request_tokens,
-                    &archive_reference,
-                )
-                .await
-            {
-                Ok((before, after)) => output.compaction(before, after, "auto"),
-                Err(error) => {
-                    tracing::warn!(
-                        archive = %archive.display(),
-                        "automatic context compaction failed: {error}"
-                    );
-                }
-            }
-        }
-        let mut sink = match cancel {
-            Some(c) => StreamSinkAdapter::with_cancel(output, c),
-            None => StreamSinkAdapter::new(output),
-        };
-        let mut overflow_recovery_used = false;
-        let comp = loop {
-            let messages = ctx.prepare_for_api_with_reserve(output, fixed_request_tokens);
-            match stream_with_retry(provider, &messages, &schemas, &mut sink, cancel).await {
-                Ok(comp) => break comp,
-                Err(LlmError::Incomplete) => anyhow::bail!(STREAM_CUT_MESSAGE),
-                Err(error) if error.is_context_overflow() && !overflow_recovery_used => {
-                    overflow_recovery_used = true;
-                    let (archive, archive_reference) = context_archive(root);
-                    output.compaction_started("overflow");
-                    match ctx
-                        .compact_with_reserve_reference(
-                            provider,
-                            &archive,
-                            fixed_request_tokens,
-                            &archive_reference,
-                        )
-                        .await
-                    {
-                        Ok((before, after)) => output.compaction(before, after, "overflow"),
-                        Err(compact_error) => {
-                            anyhow::bail!(
-                                "context overflow recovery failed: {compact_error} (original: {error})"
-                            );
-                        }
-                    }
-                    continue;
-                }
-                Err(error) => return Err(error.into()),
-            }
-        };
-        if comp.usage.input_tokens > 0 {
-            ctx.calibrate(comp.usage.input_tokens, ctx.last_request_estimated_tokens());
-        }
-        if cancel.is_some_and(|c| c.load(Ordering::Relaxed)) {
-            anyhow::bail!("stopped by user");
-        }
-        if is_truncated(comp.finish_reason.as_deref()) {
-            anyhow::bail!(TRUNCATED_OUTPUT_MESSAGE);
-        }
-        if is_unsuccessful_finish(comp.finish_reason.as_deref()) {
-            anyhow::bail!(ABNORMAL_FINISH_MESSAGE);
-        }
-        // A few reasoning models can terminate cleanly after spending output
-        // tokens entirely on `reasoning_content`, leaving neither user-visible
-        // text nor a tool call. Treating that as success produces a bare
-        // "Processed" row and, worse, persists an empty assistant turn. Fail
-        // resumably instead: tool results already appended to the context stay
-        // intact, so Resume asks only for the missing final response.
-        if comp.content.trim().is_empty() && comp.tool_calls.is_empty() {
-            let context_usage = ctx.context_usage(&schemas, &schema_origins);
-            let context_tokens = context_usage.total();
-            debug_assert_eq!(
-                context_tokens,
-                ctx.request_tokens_with_reserve(fixed_request_tokens)
-            );
-            output.usage(
-                iteration,
-                comp.usage.input_tokens,
-                comp.usage.output_tokens,
-                comp.usage.reasoning_tokens,
-                comp.usage.cached_input_tokens,
-                context_tokens,
-                ctx.max_context,
-                context_usage,
-            );
-            anyhow::bail!(EMPTY_RESPONSE_MESSAGE);
-        }
-
-        ctx.append_assistant(
-            comp.content.clone(),
-            comp.tool_calls.clone(),
-            comp.reasoning.clone(),
-        );
-        if let Some(m) = ctx.messages.last() {
-            output.on_message(m);
-        }
-        let context_usage = ctx.context_usage(&schemas, &schema_origins);
-        let context_tokens = context_usage.total();
-        debug_assert_eq!(
-            context_tokens,
-            ctx.request_tokens_with_reserve(fixed_request_tokens)
-        );
-        output.usage(
+        output.runtime_event(&AgentRuntimeEvent::RoundStarted { round: iteration });
+        let flow = run_round(
+            ctx,
+            provider,
+            vision_provider,
+            tools,
+            output,
+            &env,
             iteration,
-            comp.usage.input_tokens,
-            comp.usage.output_tokens,
-            comp.usage.reasoning_tokens,
-            comp.usage.cached_input_tokens,
-            context_tokens,
-            ctx.max_context,
-            context_usage,
-        );
-
-        if comp.tool_calls.is_empty() {
-            break;
-        }
-
-        // Stuck-loop guard: a degenerate model re-issues the exact same call
-        // (same name + args), each returning the same result, making no
-        // progress. max_iter only caps the waste; this cuts it off early.
-        // Scans a recent window rather than only consecutive turns, so an
-        // interspersed loop (A/B/A/B, or bouncing among a few calls) trips it
-        // too — not just a byte-for-byte repeat run.
-        let sig = tool_call_signature(&comp.tool_calls);
-        let repeats = recent_sigs.iter().filter(|s| *s == &sig).count() + 1;
-        recent_sigs.push_back(sig);
-        if recent_sigs.len() > STUCK_WINDOW {
-            recent_sigs.pop_front();
-        }
-        if repeats >= STUCK_REPEAT_LIMIT {
-            anyhow::bail!(STUCK_LOOP_MESSAGE);
-        }
-
-        let mut batch_control = ToolControl::Continue;
-        for (index, tc) in comp.tool_calls.iter().enumerate() {
-            let name = tc.function.name.clone();
-            let args = tc.args_value();
-            let producing = provenance::is_producing(&name);
-            let root = producing.then(|| env.project_root().to_path_buf());
-            let source = provenance::source_of(&name, &args);
-            let before = if let Some(root) = root.clone() {
-                tokio::task::spawn_blocking(move || provenance::snapshot(&root))
-                    .await
-                    .unwrap_or_default()
-            } else {
-                Default::default()
-            };
-            let preimages = if let Some(root) = root.clone() {
-                let before = before.clone();
-                let source = source.clone();
-                tokio::task::spawn_blocking(move || {
-                    provenance::capture_text_preimages(&before, &root, &source)
-                })
-                .await
-                .unwrap_or_default()
-            } else {
-                Default::default()
-            };
-            let t0 = std::time::Instant::now();
-            let result = tools.run(&name, &args, &env).await;
-            let control = result.control;
-            let duration_ms = t0.elapsed().as_millis() as u64;
-            if let Some(root) = &root {
-                let root2 = root.clone();
-                let after = tokio::task::spawn_blocking(move || provenance::snapshot(&root2))
-                    .await
-                    .unwrap_or_default();
-                let (mut written, mut read) = provenance::diff(&before, &after, root, &source);
-                provenance::augment_written_paths(
-                    &name,
-                    root,
-                    &source,
-                    result.success,
-                    &preimages,
-                    &mut written,
-                );
-                read.retain(|path| !written.contains(path));
-                if !written.is_empty() {
-                    let file_changes =
-                        provenance::undo_file_changes(&before, root, &written, &preimages);
-                    output.provenance(&provenance::ProvenanceRecord {
-                        tool: name.clone(),
-                        language: provenance::language_of(&name),
-                        source,
-                        output: result.content.clone(),
-                        success: result.success,
-                        files_written: written,
-                        files_read: read,
-                        file_changes,
-                    });
-                }
-            }
-            let (content, tool_text, ok) = if let Some(img) = &result.image {
-                match vision_provider {
-                    Some(vision) => match describe_image(vision, img, &name, &args).await {
-                        Ok(text) => (Content::text(text.clone()), text, true),
-                        Err(e) => {
-                            let text = format!("{name} error: vision model failed: {e}");
-                            (Content::text(text.clone()), text, false)
-                        }
-                    },
-                    None => {
-                        let text = format!("{name} error: no vision model is configured. Mark an API model as vision-capable in Settings -> Models and set it for image analysis.");
-                        (Content::text(text.clone()), text, false)
-                    }
-                }
-            } else {
-                (
-                    Content::text(result.content.clone()),
-                    result.content.clone(),
-                    result.success,
-                )
-            };
-            output.tool_result(&tools.event_name(&name, &args), ok, &tool_text, duration_ms);
-            ctx.append_tool(
-                &tc.id,
-                &name,
-                budget_tool_result(env.project_root(), &name, content),
-            );
-            if let Some(m) = ctx.messages.last() {
-                output.on_message(m);
-            }
-
-            if control != ToolControl::Continue {
-                // A user decision invalidates calls the model optimistically
-                // placed later in the same batch. Do not execute them, but do
-                // persist a synthetic result for each one: providers require
-                // every assistant tool call to have a matching tool message.
-                append_skipped_tool_results(
-                    ctx,
-                    tools,
-                    output,
-                    &comp.tool_calls[index + 1..],
-                    &name,
-                    control,
-                );
-                batch_control = control;
-                break;
-            }
-        }
-        if batch_control == ToolControl::StopTurn {
+            cancel,
+            &mut recent_sigs,
+        )
+        .await;
+        // RoundStarted/Finished always pair, even when the round failed.
+        output.runtime_event(&AgentRuntimeEvent::RoundFinished { round: iteration });
+        if flow? == RoundFlow::Done {
             break;
         }
         if iteration_limit_reached(iteration, max_iter) {
@@ -548,10 +357,310 @@ async fn agent_loop_inner(
     Ok(())
 }
 
+/// One model request plus the tool batch it triggers.
+#[allow(clippy::too_many_arguments)]
+async fn run_round(
+    ctx: &mut ContextManager,
+    provider: &dyn Provider,
+    vision_provider: Option<&dyn Provider>,
+    tools: &Registry,
+    output: &dyn Output,
+    env: &ToolEnvAdapter<'_>,
+    round: usize,
+    cancel: Option<&AtomicBool>,
+    recent_sigs: &mut VecDeque<String>,
+) -> Result<RoundFlow> {
+    let (schemas, schema_origins) = tools.schemas_with_origins();
+    let fixed_request_tokens = ContextManager::estimated_tool_tokens(&schemas);
+    // Match the long-context behaviour used by mangopi-cli: check the
+    // budget at every model boundary, not only when the user first sends a
+    // turn. Wisp's archive-first compactor preserves the full transcript
+    // on disk before folding old turns, so automatic recovery has the same
+    // retrievability contract as manual `/compact`.
+    if ctx.needs_auto_compact_with_reserve(fixed_request_tokens) {
+        let (archive, archive_reference) = context_archive(env.project_root());
+        output.compaction_started("auto");
+        match ctx
+            .compact_with_reserve_reference(
+                provider,
+                &archive,
+                fixed_request_tokens,
+                &archive_reference,
+            )
+            .await
+        {
+            Ok((before, after)) => output.compaction(before, after, "auto"),
+            Err(error) => {
+                tracing::warn!(
+                    archive = %archive.display(),
+                    "automatic context compaction failed: {error}"
+                );
+            }
+        }
+    }
+    let mut sink = match cancel {
+        Some(c) => StreamSinkAdapter::with_cancel(output, c).for_round(round),
+        None => StreamSinkAdapter::new(output).for_round(round),
+    };
+    let mut overflow_recovery_used = false;
+    output.runtime_event(&AgentRuntimeEvent::AssistantMessageStarted { round });
+    let comp = loop {
+        let messages = ctx.prepare_for_api_with_reserve(output, fixed_request_tokens);
+        match stream_with_retry(provider, &messages, &schemas, &mut sink, cancel).await {
+            Ok(comp) => break comp,
+            Err(LlmError::Incomplete) => anyhow::bail!(STREAM_CUT_MESSAGE),
+            Err(error) if error.is_context_overflow() && !overflow_recovery_used => {
+                overflow_recovery_used = true;
+                let (archive, archive_reference) = context_archive(env.project_root());
+                output.compaction_started("overflow");
+                match ctx
+                    .compact_with_reserve_reference(
+                        provider,
+                        &archive,
+                        fixed_request_tokens,
+                        &archive_reference,
+                    )
+                    .await
+                {
+                    Ok((before, after)) => output.compaction(before, after, "overflow"),
+                    Err(compact_error) => {
+                        anyhow::bail!(
+                            "context overflow recovery failed: {compact_error} (original: {error})"
+                        );
+                    }
+                }
+                continue;
+            }
+            Err(error) => return Err(error.into()),
+        }
+    };
+    if comp.usage.input_tokens > 0 {
+        ctx.calibrate(comp.usage.input_tokens, ctx.last_request_estimated_tokens());
+    }
+    if cancel.is_some_and(|c| c.load(Ordering::Relaxed)) {
+        anyhow::bail!("stopped by user");
+    }
+    if is_truncated(comp.finish_reason.as_deref()) {
+        anyhow::bail!(TRUNCATED_OUTPUT_MESSAGE);
+    }
+    if is_unsuccessful_finish(comp.finish_reason.as_deref()) {
+        anyhow::bail!(ABNORMAL_FINISH_MESSAGE);
+    }
+    output.runtime_event(&AgentRuntimeEvent::AssistantMessageFinished { round });
+    // A few reasoning models can terminate cleanly after spending output
+    // tokens entirely on `reasoning_content`, leaving neither user-visible
+    // text nor a tool call. Treating that as success produces a bare
+    // "Processed" row and, worse, persists an empty assistant turn. Fail
+    // resumably instead: tool results already appended to the context stay
+    // intact, so Resume asks only for the missing final response.
+    if comp.content.trim().is_empty() && comp.tool_calls.is_empty() {
+        let context_usage = ctx.context_usage(&schemas, &schema_origins);
+        let context_tokens = context_usage.total();
+        debug_assert_eq!(
+            context_tokens,
+            ctx.request_tokens_with_reserve(fixed_request_tokens)
+        );
+        output.usage(
+            round,
+            comp.usage.input_tokens,
+            comp.usage.output_tokens,
+            comp.usage.reasoning_tokens,
+            comp.usage.cached_input_tokens,
+            context_tokens,
+            ctx.max_context,
+            context_usage,
+        );
+        anyhow::bail!(EMPTY_RESPONSE_MESSAGE);
+    }
+
+    ctx.append_assistant(
+        comp.content.clone(),
+        comp.tool_calls.clone(),
+        comp.reasoning.clone(),
+    );
+    if let Some(m) = ctx.messages.last() {
+        output.on_message(m);
+    }
+    let context_usage = ctx.context_usage(&schemas, &schema_origins);
+    let context_tokens = context_usage.total();
+    debug_assert_eq!(
+        context_tokens,
+        ctx.request_tokens_with_reserve(fixed_request_tokens)
+    );
+    output.usage(
+        round,
+        comp.usage.input_tokens,
+        comp.usage.output_tokens,
+        comp.usage.reasoning_tokens,
+        comp.usage.cached_input_tokens,
+        context_tokens,
+        ctx.max_context,
+        context_usage,
+    );
+
+    if comp.tool_calls.is_empty() {
+        return Ok(RoundFlow::Done);
+    }
+
+    // Stuck-loop guard: a degenerate model re-issues the exact same call
+    // (same name + args), each returning the same result, making no
+    // progress. max_iter only caps the waste; this cuts it off early.
+    // Scans a recent window rather than only consecutive turns, so an
+    // interspersed loop (A/B/A/B, or bouncing among a few calls) trips it
+    // too — not just a byte-for-byte repeat run.
+    let sig = tool_call_signature(&comp.tool_calls);
+    let repeats = recent_sigs.iter().filter(|s| *s == &sig).count() + 1;
+    recent_sigs.push_back(sig);
+    if recent_sigs.len() > STUCK_WINDOW {
+        recent_sigs.pop_front();
+    }
+    if repeats >= STUCK_REPEAT_LIMIT {
+        anyhow::bail!(STUCK_LOOP_MESSAGE);
+    }
+
+    // Arguments are final now: every call in the batch is ready, even the
+    // ones a later user decision will skip (those end up Blocked, never
+    // Started).
+    for (index, tc) in comp.tool_calls.iter().enumerate() {
+        output.runtime_event(&AgentRuntimeEvent::ToolCallReady {
+            key: ToolInvocationKey::ready(round, index, tc.id.clone()),
+            name: tc.function.name.clone(),
+        });
+    }
+
+    for (index, tc) in comp.tool_calls.iter().enumerate() {
+        let key = ToolInvocationKey::ready(round, index, tc.id.clone());
+        let name = tc.function.name.clone();
+        let args = tc.args_value();
+        let producing = provenance::is_producing(&name);
+        let root = producing.then(|| env.project_root().to_path_buf());
+        let source = provenance::source_of(&name, &args);
+        let before = if let Some(root) = root.clone() {
+            tokio::task::spawn_blocking(move || provenance::snapshot(&root))
+                .await
+                .unwrap_or_default()
+        } else {
+            Default::default()
+        };
+        let preimages = if let Some(root) = root.clone() {
+            let before = before.clone();
+            let source = source.clone();
+            tokio::task::spawn_blocking(move || {
+                provenance::capture_text_preimages(&before, &root, &source)
+            })
+            .await
+            .unwrap_or_default()
+        } else {
+            Default::default()
+        };
+        output.runtime_event(&AgentRuntimeEvent::ToolExecutionStarted {
+            key: key.clone(),
+            name: name.clone(),
+        });
+        let t0 = std::time::Instant::now();
+        let result = tools.run(&name, &args, env).await;
+        let control = result.control;
+        let duration_ms = t0.elapsed().as_millis() as u64;
+        if let Some(root) = &root {
+            let root2 = root.clone();
+            let after = tokio::task::spawn_blocking(move || provenance::snapshot(&root2))
+                .await
+                .unwrap_or_default();
+            let (mut written, mut read) = provenance::diff(&before, &after, root, &source);
+            provenance::augment_written_paths(
+                &name,
+                root,
+                &source,
+                result.success,
+                &preimages,
+                &mut written,
+            );
+            read.retain(|path| !written.contains(path));
+            if !written.is_empty() {
+                let file_changes =
+                    provenance::undo_file_changes(&before, root, &written, &preimages);
+                output.provenance(&provenance::ProvenanceRecord {
+                    tool: name.clone(),
+                    language: provenance::language_of(&name),
+                    source,
+                    output: result.content.clone(),
+                    success: result.success,
+                    files_written: written,
+                    files_read: read,
+                    file_changes,
+                });
+            }
+        }
+        let (content, tool_text, ok) = if let Some(img) = &result.image {
+            match vision_provider {
+                Some(vision) => match describe_image(vision, img, &name, &args).await {
+                    Ok(text) => (Content::text(text.clone()), text, true),
+                    Err(e) => {
+                        let text = format!("{name} error: vision model failed: {e}");
+                        (Content::text(text.clone()), text, false)
+                    }
+                },
+                None => {
+                    let text = format!("{name} error: no vision model is configured. Mark an API model as vision-capable in Settings -> Models and set it for image analysis.");
+                    (Content::text(text.clone()), text, false)
+                }
+            }
+        } else {
+            (
+                Content::text(result.content.clone()),
+                result.content.clone(),
+                result.success,
+            )
+        };
+        let event_name = tools.event_name(&name, &args);
+        output.tool_result(&event_name, ok, &tool_text, duration_ms);
+        output.runtime_event(&AgentRuntimeEvent::ToolExecutionFinished {
+            key,
+            name: event_name,
+            ok,
+            duration_ms,
+        });
+        ctx.append_tool(
+            &tc.id,
+            &name,
+            budget_tool_result(env.project_root(), &name, content),
+        );
+        if let Some(m) = ctx.messages.last() {
+            output.on_message(m);
+        }
+
+        if control != ToolControl::Continue {
+            // A user decision invalidates calls the model optimistically
+            // placed later in the same batch. Do not execute them, but do
+            // persist a synthetic result for each one: providers require
+            // every assistant tool call to have a matching tool message.
+            append_skipped_tool_results(
+                ctx,
+                tools,
+                output,
+                round,
+                index + 1,
+                &comp.tool_calls[index + 1..],
+                &name,
+                control,
+            );
+            return Ok(if control == ToolControl::StopTurn {
+                RoundFlow::Done
+            } else {
+                RoundFlow::Continue
+            });
+        }
+    }
+    Ok(RoundFlow::Continue)
+}
+
+#[allow(clippy::too_many_arguments)]
 fn append_skipped_tool_results(
     ctx: &mut ContextManager,
     tools: &Registry,
     output: &dyn Output,
+    round: usize,
+    start_index: usize,
     skipped: &[ToolCall],
     boundary_name: &str,
     control: ToolControl,
@@ -565,10 +674,15 @@ fn append_skipped_tool_results(
         ),
         ToolControl::Continue => return,
     };
-    for tc in skipped {
+    for (offset, tc) in skipped.iter().enumerate() {
         let name = &tc.function.name;
         let args = tc.args_value();
         let event_name = tools.event_name(name, &args);
+        output.runtime_event(&AgentRuntimeEvent::ToolExecutionBlocked {
+            key: ToolInvocationKey::ready(round, start_index + offset, tc.id.clone()),
+            name: event_name.clone(),
+            reason: reason.clone(),
+        });
         output.tool_call(&event_name, &reason);
         output.tool_result(&event_name, false, &reason, 0);
         ctx.append_tool(&tc.id, name, Content::text(reason.clone()));
@@ -2191,5 +2305,442 @@ mod tests {
             "unexpected error: {err}"
         );
         std::fs::remove_dir_all(root).ok();
+    }
+
+    // --- AgentRuntimeEvent lifecycle tests ---
+
+    #[derive(Default)]
+    struct EventLog(Mutex<Vec<AgentRuntimeEvent>>);
+
+    impl Output for EventLog {
+        fn runtime_event(&self, event: &AgentRuntimeEvent) {
+            self.0.lock().unwrap().push(event.clone());
+        }
+    }
+
+    impl EventLog {
+        fn events(&self) -> Vec<AgentRuntimeEvent> {
+            self.0.lock().unwrap().clone()
+        }
+    }
+
+    fn assert_rounds_paired(events: &[AgentRuntimeEvent]) {
+        let started: Vec<usize> = events
+            .iter()
+            .filter_map(|e| match e {
+                AgentRuntimeEvent::RoundStarted { round } => Some(*round),
+                _ => None,
+            })
+            .collect();
+        let finished: Vec<usize> = events
+            .iter()
+            .filter_map(|e| match e {
+                AgentRuntimeEvent::RoundFinished { round } => Some(*round),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(started, finished, "RoundStarted/Finished must pair up");
+    }
+
+    fn assert_exactly_one_run_finished(events: &[AgentRuntimeEvent]) -> RunOutcome {
+        let outcomes: Vec<RunOutcome> = events
+            .iter()
+            .filter_map(|e| match e {
+                AgentRuntimeEvent::RunFinished { outcome } => Some(outcome.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(outcomes.len(), 1, "exactly one RunFinished per run");
+        outcomes.into_iter().next().unwrap()
+    }
+
+    #[tokio::test]
+    async fn plain_text_answer_emits_the_full_lifecycle_sequence() {
+        let provider = SequenceProvider::new([Completion {
+            content: "final answer".into(),
+            finish_reason: Some("stop".into()),
+            ..Completion::default()
+        }]);
+        let tools = Registry::builtins().filtered(&[]);
+        let mut ctx = ContextManager::new(100_000);
+        let output = EventLog::default();
+
+        agent_loop(
+            &mut ctx,
+            &provider,
+            None,
+            &tools,
+            Path::new("."),
+            &output,
+            "hi",
+            0,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            output.events(),
+            vec![
+                AgentRuntimeEvent::RunStarted,
+                AgentRuntimeEvent::RoundStarted { round: 1 },
+                AgentRuntimeEvent::AssistantMessageStarted { round: 1 },
+                AgentRuntimeEvent::AssistantMessageFinished { round: 1 },
+                AgentRuntimeEvent::RoundFinished { round: 1 },
+                AgentRuntimeEvent::RunFinished {
+                    outcome: RunOutcome::Completed
+                },
+            ]
+        );
+    }
+
+    struct StreamingTextProvider;
+
+    #[async_trait]
+    impl Provider for StreamingTextProvider {
+        fn name(&self) -> &str {
+            "streaming-text"
+        }
+        fn model(&self) -> &str {
+            "streaming-text"
+        }
+        async fn complete(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSchema],
+        ) -> wisp_llm::Result<Completion> {
+            Err(LlmError::Config("complete is not used".into()))
+        }
+        async fn stream(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSchema],
+            sink: &mut dyn wisp_llm::StreamSink,
+        ) -> wisp_llm::Result<Completion> {
+            sink.on_reasoning("thinking");
+            sink.on_text("Hello");
+            sink.on_text(" world");
+            Ok(Completion {
+                content: "Hello world".into(),
+                finish_reason: Some("stop".into()),
+                ..Completion::default()
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn streamed_deltas_are_stamped_with_their_round() {
+        let provider = StreamingTextProvider;
+        let tools = Registry::builtins().filtered(&[]);
+        let mut ctx = ContextManager::new(100_000);
+        let output = EventLog::default();
+
+        agent_loop(
+            &mut ctx,
+            &provider,
+            None,
+            &tools,
+            Path::new("."),
+            &output,
+            "hi",
+            0,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let events = output.events();
+        let deltas: Vec<&AgentRuntimeEvent> = events
+            .iter()
+            .filter(|e| {
+                matches!(
+                    e,
+                    AgentRuntimeEvent::AssistantTextDelta { .. }
+                        | AgentRuntimeEvent::AssistantReasoningDelta { .. }
+                )
+            })
+            .collect();
+        assert_eq!(
+            deltas,
+            vec![
+                &AgentRuntimeEvent::AssistantReasoningDelta {
+                    round: 1,
+                    delta: "thinking".into()
+                },
+                &AgentRuntimeEvent::AssistantTextDelta {
+                    round: 1,
+                    delta: "Hello".into()
+                },
+                &AgentRuntimeEvent::AssistantTextDelta {
+                    round: 1,
+                    delta: " world".into()
+                },
+            ]
+        );
+        assert_eq!(
+            assert_exactly_one_run_finished(&events),
+            RunOutcome::Completed
+        );
+    }
+
+    #[tokio::test]
+    async fn tool_calls_move_through_ready_started_finished_states() {
+        let provider = SequenceProvider::new([
+            Completion {
+                tool_calls: vec![call("work-1", "work", serde_json::json!({}))],
+                finish_reason: Some("tool_calls".into()),
+                ..Completion::default()
+            },
+            Completion {
+                content: "done".into(),
+                finish_reason: Some("stop".into()),
+                ..Completion::default()
+            },
+        ]);
+        let mut tools = Registry::builtins().filtered(&[]);
+        tools.add(Box::new(CountingTool {
+            name: "work",
+            runs: Arc::new(AtomicUsize::new(0)),
+        }));
+        let mut ctx = ContextManager::new(100_000);
+        let output = EventLog::default();
+
+        agent_loop(
+            &mut ctx,
+            &provider,
+            None,
+            &tools,
+            Path::new("."),
+            &output,
+            "do work",
+            0,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let events = output.events();
+        let key = ToolInvocationKey::ready(1, 0, "work-1");
+        let pos = |pred: &dyn Fn(&AgentRuntimeEvent) -> bool| {
+            events.iter().position(|e| pred(e)).unwrap()
+        };
+        let ready = pos(
+            &|e| matches!(e, AgentRuntimeEvent::ToolCallReady { key: k, name } if *k == key && name == "work"),
+        );
+        let started = pos(
+            &|e| matches!(e, AgentRuntimeEvent::ToolExecutionStarted { key: k, name } if *k == key && name == "work"),
+        );
+        let finished = pos(
+            &|e| matches!(e, AgentRuntimeEvent::ToolExecutionFinished { key: k, ok: true, .. } if *k == key),
+        );
+        assert!(ready < started && started < finished);
+        // The tool result leads into round 2, which closes the run.
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, AgentRuntimeEvent::RoundStarted { round: 2 })));
+        assert_rounds_paired(&events);
+        assert_eq!(
+            assert_exactly_one_run_finished(&events),
+            RunOutcome::Completed
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_run_pairs_rounds_and_finishes_exactly_once() {
+        let provider = SequenceProvider::new([]); // empty → LlmError::Incomplete
+        let tools = Registry::builtins().filtered(&[]);
+        let mut ctx = ContextManager::new(100_000);
+        let output = EventLog::default();
+
+        let err = agent_loop(
+            &mut ctx,
+            &provider,
+            None,
+            &tools,
+            Path::new("."),
+            &output,
+            "hi",
+            0,
+            None,
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("stream cut"), "{err}");
+
+        let events = output.events();
+        assert_rounds_paired(&events);
+        match assert_exactly_one_run_finished(&events) {
+            RunOutcome::Failed(message) => assert!(message.contains("stream cut"), "{message}"),
+            other => panic!("expected Failed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn cancelled_run_finishes_with_the_cancelled_outcome() {
+        let provider = SequenceProvider::new([Completion {
+            content: "never reached".into(),
+            finish_reason: Some("stop".into()),
+            ..Completion::default()
+        }]);
+        let tools = Registry::builtins().filtered(&[]);
+        let mut ctx = ContextManager::new(100_000);
+        let output = EventLog::default();
+        let cancel = AtomicBool::new(true);
+
+        let err = agent_loop(
+            &mut ctx,
+            &provider,
+            None,
+            &tools,
+            Path::new("."),
+            &output,
+            "hi",
+            0,
+            Some(&cancel),
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains(STOPPED_BY_USER), "{err}");
+
+        let events = output.events();
+        assert_eq!(
+            events,
+            vec![
+                AgentRuntimeEvent::RunStarted,
+                AgentRuntimeEvent::RunFinished {
+                    outcome: RunOutcome::Cancelled
+                },
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn skipped_sibling_is_blocked_not_started() {
+        let provider = SequenceProvider::new([Completion {
+            tool_calls: vec![
+                call(
+                    "ask-1",
+                    ASK_USER,
+                    serde_json::json!({
+                        "question": "Which reference genome?",
+                        "options": [{ "label": "GRCh38" }]
+                    }),
+                ),
+                call("later-1", "later", serde_json::json!({})),
+            ],
+            finish_reason: Some("tool_calls".into()),
+            ..Completion::default()
+        }]);
+        let mut tools = Registry::builtins();
+        tools.add(Box::new(wisp_tools::ask_user::AskUserTool));
+        tools.add(Box::new(CountingTool {
+            name: "later",
+            runs: Arc::new(AtomicUsize::new(0)),
+        }));
+        let mut ctx = ContextManager::new(100_000);
+        let output = EventLog::default();
+
+        agent_loop(
+            &mut ctx,
+            &provider,
+            None,
+            &tools,
+            Path::new("."),
+            &output,
+            "prepare the analysis",
+            0,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let events = output.events();
+        let blocked = events.iter().any(|e| {
+            matches!(e, AgentRuntimeEvent::ToolExecutionBlocked { key, name, .. } if *key == ToolInvocationKey::ready(1, 1, "later-1") && name == "later")
+        });
+        assert!(blocked, "skipped sibling must be Blocked: {events:?}");
+        let started = events.iter().any(|e| {
+            matches!(e, AgentRuntimeEvent::ToolExecutionStarted { key, .. } if *key == ToolInvocationKey::ready(1, 1, "later-1"))
+        });
+        assert!(!started, "skipped sibling must never start: {events:?}");
+        assert_eq!(
+            assert_exactly_one_run_finished(&events),
+            RunOutcome::Completed
+        );
+    }
+
+    struct FailOnceProvider {
+        stream_calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl Provider for FailOnceProvider {
+        fn name(&self) -> &str {
+            "fail-once"
+        }
+        fn model(&self) -> &str {
+            "fail-once"
+        }
+        async fn complete(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSchema],
+        ) -> wisp_llm::Result<Completion> {
+            Err(LlmError::Config("complete is not used".into()))
+        }
+        async fn stream(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSchema],
+            _sink: &mut dyn wisp_llm::StreamSink,
+        ) -> wisp_llm::Result<Completion> {
+            if self.stream_calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                return Err(LlmError::Api {
+                    status: 503,
+                    body: "overloaded".into(),
+                });
+            }
+            Ok(Completion {
+                content: "recovered".into(),
+                finish_reason: Some("stop".into()),
+                ..Completion::default()
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn retried_round_emits_one_message_lifecycle_and_completes() {
+        let provider = FailOnceProvider {
+            stream_calls: AtomicUsize::new(0),
+        };
+        let tools = Registry::builtins().filtered(&[]);
+        let mut ctx = ContextManager::new(100_000);
+        let output = EventLog::default();
+
+        agent_loop(
+            &mut ctx,
+            &provider,
+            None,
+            &tools,
+            Path::new("."),
+            &output,
+            "hi",
+            0,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let events = output.events();
+        let starts = events
+            .iter()
+            .filter(|e| matches!(e, AgentRuntimeEvent::AssistantMessageStarted { round: 1 }))
+            .count();
+        assert_eq!(starts, 1, "a retried request reuses the same round");
+        assert_rounds_paired(&events);
+        assert_eq!(
+            assert_exactly_one_run_finished(&events),
+            RunOutcome::Completed
+        );
     }
 }

--- a/crates/wisp-core/src/agent.rs
+++ b/crates/wisp-core/src/agent.rs
@@ -2972,4 +2972,140 @@ mod tests {
             RunOutcome::Completed
         );
     }
+
+    // Guide (#410): steering parked via AgentControl while a tool is running
+    // folds into the context as a real user message at the next iteration
+    // boundary.
+    struct NoFollowUps;
+
+    impl crate::control::FollowUpItem for NoFollowUps {
+        fn id(&self) -> u64 {
+            0
+        }
+    }
+
+    struct SteerTool {
+        control: crate::control::AgentControl<NoFollowUps>,
+    }
+
+    #[async_trait]
+    impl Tool for SteerTool {
+        fn name(&self) -> &str {
+            "steer"
+        }
+
+        fn schema(&self) -> ToolSchema {
+            ToolSchema::new(
+                "steer",
+                "push mid-turn steering while the turn runs",
+                serde_json::json!({"type": "object"}),
+            )
+        }
+
+        async fn run(&self, _args: &serde_json::Value, _env: &dyn ToolEnv) -> ToolResult {
+            self.control.push_steering("use the other endpoint");
+            ToolResult::ok("steered")
+        }
+    }
+
+    #[tokio::test]
+    async fn steering_pushed_during_a_tool_run_is_folded_at_the_next_boundary() {
+        let control = crate::control::AgentControl::<NoFollowUps>::new();
+        let provider = SequenceProvider::new([
+            Completion {
+                tool_calls: vec![call("steer-1", "steer", serde_json::json!({}))],
+                finish_reason: Some("tool_calls".into()),
+                ..Completion::default()
+            },
+            Completion {
+                content: "switched endpoints".into(),
+                finish_reason: Some("stop".into()),
+                ..Completion::default()
+            },
+        ]);
+        let mut tools = Registry::builtins().filtered(&[]);
+        tools.add(Box::new(SteerTool {
+            control: control.clone(),
+        }));
+        let mut ctx = ContextManager::new(100_000);
+
+        agent_loop_with_images(
+            &mut ctx,
+            &provider,
+            None,
+            &tools,
+            Path::new("."),
+            &NullOutput,
+            "hit the search endpoint",
+            &[],
+            false,
+            0,
+            None,
+            Some(control.steering_queue()),
+        )
+        .await
+        .unwrap();
+
+        let steering_at = ctx
+            .messages
+            .iter()
+            .position(|message| {
+                message.role == wisp_llm::Role::User
+                    && message.content.as_text() == "use the other endpoint"
+            })
+            .expect("steering became a user message");
+        let answer_at = ctx
+            .messages
+            .iter()
+            .rposition(|message| {
+                message.role == wisp_llm::Role::Assistant
+                    && message.content.as_text() == "switched endpoints"
+            })
+            .expect("final answer present");
+        assert!(
+            steering_at < answer_at,
+            "the steering message precedes the answer that reacted to it"
+        );
+        assert!(
+            control.steering_queue().lock().unwrap().is_empty(),
+            "the loop drained the steering queue"
+        );
+    }
+
+    #[tokio::test]
+    async fn steering_unconsumed_by_a_cancelled_run_can_be_reclaimed() {
+        let control = crate::control::AgentControl::<NoFollowUps>::new();
+        let id = control.push_steering("never seen");
+        let cancel = AtomicBool::new(true);
+        let provider = SequenceProvider::new([]);
+        let tools = Registry::builtins().filtered(&[]);
+        let mut ctx = ContextManager::new(100_000);
+
+        let error = agent_loop_with_images(
+            &mut ctx,
+            &provider,
+            None,
+            &tools,
+            Path::new("."),
+            &NullOutput,
+            "start",
+            &[],
+            false,
+            0,
+            Some(&cancel),
+            Some(control.steering_queue()),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(error.to_string().contains(STOPPED_BY_USER));
+        assert!(
+            control.reclaim_steering(id),
+            "a cancelled run never drained the steering message"
+        );
+        assert!(
+            !control.reclaim_steering(id),
+            "a second reclaim observes it as consumed"
+        );
+    }
 }

--- a/crates/wisp-core/src/agent.rs
+++ b/crates/wisp-core/src/agent.rs
@@ -558,7 +558,12 @@ async fn run_round(
             name: name.clone(),
         });
         let t0 = std::time::Instant::now();
-        let result = tools.run(&name, &args, env).await;
+        // The loop (not the tool) injects the invocation identity so any
+        // ToolEvent::Progress the tool emits is stamped with this call's key;
+        // progress emitted after the call returns is dropped.
+        let invocation_env = env.for_invocation(key.clone());
+        let result = tools.run(&name, &args, &invocation_env).await;
+        invocation_env.finish_invocation();
         let control = result.control;
         let duration_ms = t0.elapsed().as_millis() as u64;
         if let Some(root) = &root {
@@ -614,11 +619,18 @@ async fn run_round(
         };
         let event_name = tools.event_name(&name, &args);
         output.tool_result(&event_name, ok, &tool_text, duration_ms);
+        // Structured details ride the Finished event only — bounded, and never
+        // appended to the model context below (content keeps flowing through
+        // budget_tool_result exactly as before).
         output.runtime_event(&AgentRuntimeEvent::ToolExecutionFinished {
             key,
             name: event_name,
             ok,
             duration_ms,
+            details: result
+                .details
+                .clone()
+                .map(crate::runtime_event::bound_tool_details),
         });
         ctx.append_tool(
             &tc.id,
@@ -2542,6 +2554,223 @@ mod tests {
         assert_eq!(
             assert_exactly_one_run_finished(&events),
             RunOutcome::Completed
+        );
+    }
+
+    /// Records every provider request so tests can assert what never reaches
+    /// the model context.
+    struct RecordingSequenceProvider {
+        completions: Mutex<VecDeque<Completion>>,
+        requests: Mutex<Vec<Vec<Message>>>,
+    }
+
+    impl RecordingSequenceProvider {
+        fn new(completions: impl IntoIterator<Item = Completion>) -> Self {
+            Self {
+                completions: Mutex::new(completions.into_iter().collect()),
+                requests: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Provider for RecordingSequenceProvider {
+        fn name(&self) -> &str {
+            "recording-sequence"
+        }
+        fn model(&self) -> &str {
+            "recording-sequence"
+        }
+        async fn complete(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSchema],
+        ) -> wisp_llm::Result<Completion> {
+            Err(LlmError::Config("complete is not used".into()))
+        }
+        async fn stream(
+            &self,
+            messages: &[Message],
+            _tools: &[ToolSchema],
+            _sink: &mut dyn wisp_llm::StreamSink,
+        ) -> wisp_llm::Result<Completion> {
+            self.requests.lock().unwrap().push(messages.to_vec());
+            self.completions
+                .lock()
+                .unwrap()
+                .pop_front()
+                .ok_or(LlmError::Incomplete)
+        }
+    }
+
+    struct DetailsTool;
+
+    #[async_trait]
+    impl Tool for DetailsTool {
+        fn name(&self) -> &str {
+            "details_tool"
+        }
+        fn schema(&self) -> ToolSchema {
+            ToolSchema::new(
+                "details_tool",
+                "returns structured details",
+                serde_json::json!({"type": "object"}),
+            )
+        }
+        async fn run(&self, _args: &serde_json::Value, _env: &dyn ToolEnv) -> ToolResult {
+            ToolResult::ok("human summary").with_details(serde_json::json!({
+                "run_id": "r1",
+                "marker": "STRUCTURED-ONLY-MARKER",
+            }))
+        }
+    }
+
+    #[tokio::test]
+    async fn tool_details_ride_the_finished_event_and_never_enter_model_context() {
+        let provider = RecordingSequenceProvider::new([
+            Completion {
+                tool_calls: vec![call("d1", "details_tool", serde_json::json!({}))],
+                finish_reason: Some("tool_calls".into()),
+                ..Completion::default()
+            },
+            Completion {
+                content: "done".into(),
+                finish_reason: Some("stop".into()),
+                ..Completion::default()
+            },
+        ]);
+        let mut tools = Registry::builtins().filtered(&[]);
+        tools.add(Box::new(DetailsTool));
+        let mut ctx = ContextManager::new(100_000);
+        let output = EventLog::default();
+
+        agent_loop(
+            &mut ctx,
+            &provider,
+            None,
+            &tools,
+            Path::new("."),
+            &output,
+            "run it",
+            0,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let key = ToolInvocationKey::ready(1, 0, "d1");
+        let events = output.events();
+        let finished = events
+            .iter()
+            .find_map(|e| match e {
+                AgentRuntimeEvent::ToolExecutionFinished {
+                    key: k, details, ..
+                } if *k == key => Some(details.clone()),
+                _ => None,
+            })
+            .expect("the call must finish");
+        assert_eq!(
+            finished,
+            Some(serde_json::json!({"run_id": "r1", "marker": "STRUCTURED-ONLY-MARKER"}))
+        );
+        // The model only ever sees the human summary: no provider request may
+        // contain the structured marker, and the persisted tool message is the
+        // summary text.
+        for request in provider.requests.lock().unwrap().iter() {
+            let serialized = serde_json::to_string(request).unwrap();
+            assert!(
+                !serialized.contains("STRUCTURED-ONLY-MARKER"),
+                "details leaked into a provider request: {serialized}"
+            );
+        }
+        let tool_message = ctx
+            .messages
+            .iter()
+            .find(|m| m.tool_call_id.as_deref() == Some("d1"))
+            .expect("tool result message is persisted");
+        assert_eq!(tool_message.content.as_text(), "human summary");
+    }
+
+    struct ProgressTool;
+
+    #[async_trait]
+    impl Tool for ProgressTool {
+        fn name(&self) -> &str {
+            "progress_tool"
+        }
+        fn schema(&self) -> ToolSchema {
+            ToolSchema::new(
+                "progress_tool",
+                "emits structured progress",
+                serde_json::json!({"type": "object"}),
+            )
+        }
+        async fn run(&self, _args: &serde_json::Value, env: &dyn ToolEnv) -> ToolResult {
+            env.emit(wisp_tools::ToolEvent::Progress {
+                details: serde_json::json!({"pct": 10}),
+            })
+            .await;
+            env.emit(wisp_tools::ToolEvent::Progress {
+                details: serde_json::json!({"pct": 90}),
+            })
+            .await;
+            ToolResult::ok("done")
+        }
+    }
+
+    #[tokio::test]
+    async fn progress_events_are_ordered_between_started_and_finished() {
+        let provider = RecordingSequenceProvider::new([
+            Completion {
+                tool_calls: vec![call("p1", "progress_tool", serde_json::json!({}))],
+                finish_reason: Some("tool_calls".into()),
+                ..Completion::default()
+            },
+            Completion {
+                content: "done".into(),
+                finish_reason: Some("stop".into()),
+                ..Completion::default()
+            },
+        ]);
+        let mut tools = Registry::builtins().filtered(&[]);
+        tools.add(Box::new(ProgressTool));
+        let mut ctx = ContextManager::new(100_000);
+        let output = EventLog::default();
+
+        agent_loop(
+            &mut ctx,
+            &provider,
+            None,
+            &tools,
+            Path::new("."),
+            &output,
+            "run it",
+            0,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let key = ToolInvocationKey::ready(1, 0, "p1");
+        let events = output.events();
+        let pos = |pred: &dyn Fn(&AgentRuntimeEvent) -> bool| {
+            events.iter().position(|e| pred(e)).unwrap()
+        };
+        let started = pos(
+            &|e| matches!(e, AgentRuntimeEvent::ToolExecutionStarted { key: k, .. } if *k == key),
+        );
+        let first = pos(
+            &|e| matches!(e, AgentRuntimeEvent::ToolExecutionUpdated { key: k, details } if *k == key && details["pct"] == 10),
+        );
+        let second = pos(
+            &|e| matches!(e, AgentRuntimeEvent::ToolExecutionUpdated { key: k, details } if *k == key && details["pct"] == 90),
+        );
+        let finished = pos(
+            &|e| matches!(e, AgentRuntimeEvent::ToolExecutionFinished { key: k, .. } if *k == key),
+        );
+        assert!(
+            started < first && first < second && second < finished,
+            "progress must stream between Started and Finished: {events:?}"
         );
     }
 

--- a/crates/wisp-core/src/agent.rs
+++ b/crates/wisp-core/src/agent.rs
@@ -150,6 +150,42 @@ pub async fn agent_loop_with_images(
     cancel: Option<&AtomicBool>,
     guidance: Option<&GuidanceQueue>,
 ) -> Result<()> {
+    // RunStarted wraps the WHOLE run — including vision pre-processing — so
+    // every failure path below still pairs with exactly one RunFinished.
+    output.runtime_event(&AgentRuntimeEvent::RunStarted);
+    let result = agent_loop_turn(
+        ctx,
+        provider,
+        vision_provider,
+        tools,
+        root,
+        output,
+        user_input,
+        images,
+        provider_supports_vision,
+        max_iter,
+        cancel,
+        guidance,
+    )
+    .await;
+    finish_run(output, result)
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn agent_loop_turn(
+    ctx: &mut ContextManager,
+    provider: &dyn Provider,
+    vision_provider: Option<&dyn Provider>,
+    tools: &Registry,
+    root: &Path,
+    output: &dyn Output,
+    user_input: &str,
+    images: &[ImageData],
+    provider_supports_vision: bool,
+    max_iter: usize,
+    cancel: Option<&AtomicBool>,
+    guidance: Option<&GuidanceQueue>,
+) -> Result<()> {
     let observations = if images.is_empty() || provider_supports_vision {
         None
     } else {
@@ -233,33 +269,8 @@ pub async fn agent_loop_continue(
     cancel: Option<&AtomicBool>,
     guidance: Option<&GuidanceQueue>,
 ) -> Result<()> {
-    agent_loop_inner(
-        ctx,
-        provider,
-        vision_provider,
-        tools,
-        root,
-        output,
-        max_iter,
-        cancel,
-        guidance,
-    )
-    .await
-}
-
-async fn agent_loop_inner(
-    ctx: &mut ContextManager,
-    provider: &dyn Provider,
-    vision_provider: Option<&dyn Provider>,
-    tools: &Registry,
-    root: &Path,
-    output: &dyn Output,
-    max_iter: usize,
-    cancel: Option<&AtomicBool>,
-    guidance: Option<&GuidanceQueue>,
-) -> Result<()> {
     output.runtime_event(&AgentRuntimeEvent::RunStarted);
-    let result = agent_loop_run(
+    let result = agent_loop_inner(
         ctx,
         provider,
         vision_provider,
@@ -271,7 +282,11 @@ async fn agent_loop_inner(
         guidance,
     )
     .await;
-    // Exactly one RunFinished per run, however the run ended.
+    finish_run(output, result)
+}
+
+/// Exactly one RunFinished per run, however the run ended.
+fn finish_run(output: &dyn Output, result: Result<()>) -> Result<()> {
     let outcome = match &result {
         Ok(()) => RunOutcome::Completed,
         Err(error) if is_user_cancel(error) => RunOutcome::Cancelled,
@@ -292,8 +307,11 @@ enum RoundFlow {
     Done,
 }
 
+/// The inner driver: model request → tool batch, round by round, until the
+/// model stops or an error ends the turn. Emits no run-boundary events; the
+/// public entry points own RunStarted/RunFinished.
 #[allow(clippy::too_many_arguments)]
-async fn agent_loop_run(
+async fn agent_loop_inner(
     ctx: &mut ContextManager,
     provider: &dyn Provider,
     vision_provider: Option<&dyn Provider>,
@@ -553,10 +571,10 @@ async fn run_round(
         } else {
             Default::default()
         };
-        output.runtime_event(&AgentRuntimeEvent::ToolExecutionStarted {
-            key: key.clone(),
-            name: name.clone(),
-        });
+        // No ToolExecutionStarted here: the registry emits the call card only
+        // after the non-interactive policy checks pass, and the per-invocation
+        // ToolEnvAdapter projects that card into Started. A refusal before it
+        // (write lock, plan mode, explicit Deny) surfaces as Blocked below.
         let t0 = std::time::Instant::now();
         // The loop (not the tool) injects the invocation identity so any
         // ToolEvent::Progress the tool emits is stamped with this call's key;
@@ -619,19 +637,28 @@ async fn run_round(
         };
         let event_name = tools.event_name(&name, &args);
         output.tool_result(&event_name, ok, &tool_text, duration_ms);
-        // Structured details ride the Finished event only — bounded, and never
-        // appended to the model context below (content keeps flowing through
-        // budget_tool_result exactly as before).
-        output.runtime_event(&AgentRuntimeEvent::ToolExecutionFinished {
-            key,
-            name: event_name,
-            ok,
-            duration_ms,
-            details: result
-                .details
-                .clone()
-                .map(crate::runtime_event::bound_tool_details),
-        });
+        if result.blocked {
+            // A policy or user-decision refusal: Blocked, never Finished.
+            output.runtime_event(&AgentRuntimeEvent::ToolExecutionBlocked {
+                key,
+                name: event_name,
+                reason: result.content.clone(),
+            });
+        } else {
+            // Structured details ride the Finished event only — bounded, and
+            // never appended to the model context below (content keeps flowing
+            // through budget_tool_result exactly as before).
+            output.runtime_event(&AgentRuntimeEvent::ToolExecutionFinished {
+                key,
+                name: event_name,
+                ok,
+                duration_ms,
+                details: result
+                    .details
+                    .clone()
+                    .map(crate::runtime_event::bound_tool_details),
+            });
+        }
         ctx.append_tool(
             &tc.id,
             &name,
@@ -1911,6 +1938,7 @@ mod tests {
         let primary = RecordingProvider::new("text-primary", "done");
         let mut ctx = ContextManager::new(100_000);
         let tools = Registry::builtins();
+        let output = EventLog::default();
 
         let error = agent_loop_with_images(
             &mut ctx,
@@ -1918,7 +1946,7 @@ mod tests {
             None,
             &tools,
             Path::new("."),
-            &NullOutput,
+            &output,
             "Explain the chart",
             &[test_image()],
             false,
@@ -1932,6 +1960,21 @@ mod tests {
         assert!(error.to_string().contains("no vision model is configured"));
         assert!(ctx.messages.is_empty());
         assert!(primary.stream_messages.lock().unwrap().is_empty());
+        // The vision pre-processing failure happens before any model request,
+        // yet the run lifecycle contract still holds: RunStarted pairs with
+        // exactly one RunFinished(Failed).
+        let events = output.events();
+        assert_eq!(events.first(), Some(&AgentRuntimeEvent::RunStarted));
+        match assert_exactly_one_run_finished(&events) {
+            RunOutcome::Failed(message) => {
+                assert!(
+                    message.contains("no vision model is configured"),
+                    "{message}"
+                )
+            }
+            other => panic!("expected Failed, got {other:?}"),
+        }
+        assert_eq!(events.len(), 2, "no round events precede the failure");
     }
 
     static SPY_RAN: AtomicBool = AtomicBool::new(false);
@@ -2892,6 +2935,267 @@ mod tests {
             matches!(e, AgentRuntimeEvent::ToolExecutionStarted { key, .. } if *key == ToolInvocationKey::ready(1, 1, "later-1"))
         });
         assert!(!started, "skipped sibling must never start: {events:?}");
+        assert_eq!(
+            assert_exactly_one_run_finished(&events),
+            RunOutcome::Completed
+        );
+    }
+
+    /// EventLog with a per-tool approval policy and a canned confirm answer,
+    /// for asserting how policy/user refusals map onto the tool lifecycle.
+    struct PolicyEventLog {
+        events: EventLog,
+        gated_tool: &'static str,
+        mode: Approval,
+        confirm_ok: bool,
+    }
+
+    impl Output for PolicyEventLog {
+        fn runtime_event(&self, event: &AgentRuntimeEvent) {
+            self.events.runtime_event(event);
+        }
+
+        fn approval_mode(&self, tool: &str) -> Approval {
+            if tool == self.gated_tool {
+                self.mode
+            } else {
+                Approval::Allow
+            }
+        }
+
+        fn confirm(&self, _message: &str) -> bool {
+            self.confirm_ok
+        }
+    }
+
+    fn lifecycle_positions(
+        events: &[AgentRuntimeEvent],
+        key: &ToolInvocationKey,
+    ) -> (Option<usize>, Option<usize>, Option<usize>) {
+        let pos = |pred: &dyn Fn(&AgentRuntimeEvent) -> bool| events.iter().position(|e| pred(e));
+        let started = pos(
+            &|e| matches!(e, AgentRuntimeEvent::ToolExecutionStarted { key: k, .. } if k == key),
+        );
+        let blocked = pos(
+            &|e| matches!(e, AgentRuntimeEvent::ToolExecutionBlocked { key: k, .. } if k == key),
+        );
+        let finished = pos(
+            &|e| matches!(e, AgentRuntimeEvent::ToolExecutionFinished { key: k, .. } if k == key),
+        );
+        (started, blocked, finished)
+    }
+
+    // A policy refusal (explicit Deny) never reaches the call card: Blocked,
+    // with no Started and no Finished for the same key.
+    #[tokio::test]
+    async fn policy_denied_call_is_blocked_without_started_or_finished() {
+        let provider = SequenceProvider::new([
+            Completion {
+                tool_calls: vec![call("deny-1", "gated_tool", serde_json::json!({}))],
+                finish_reason: Some("tool_calls".into()),
+                ..Completion::default()
+            },
+            Completion {
+                content: "understood".into(),
+                finish_reason: Some("stop".into()),
+                ..Completion::default()
+            },
+        ]);
+        let mut tools = Registry::builtins().filtered(&[]);
+        tools.add(Box::new(CountingTool {
+            name: "gated_tool",
+            runs: Arc::new(AtomicUsize::new(0)),
+        }));
+        let mut ctx = ContextManager::new(100_000);
+        let output = PolicyEventLog {
+            events: EventLog::default(),
+            gated_tool: "gated_tool",
+            mode: Approval::Deny,
+            confirm_ok: true,
+        };
+
+        agent_loop(
+            &mut ctx,
+            &provider,
+            None,
+            &tools,
+            Path::new("."),
+            &output,
+            "run the gated tool",
+            0,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let key = ToolInvocationKey::ready(1, 0, "deny-1");
+        let events = output.events.events();
+        let (started, blocked, finished) = lifecycle_positions(&events, &key);
+        assert_eq!(started, None, "policy refusal must not start: {events:?}");
+        assert!(blocked.is_some(), "policy refusal is Blocked: {events:?}");
+        assert_eq!(finished, None, "Blocked is never Finished: {events:?}");
+        let blocked_reason = events.iter().find_map(|e| match e {
+            AgentRuntimeEvent::ToolExecutionBlocked { key: k, reason, .. } if *k == key => {
+                Some(reason.clone())
+            }
+            _ => None,
+        });
+        assert!(
+            blocked_reason
+                .as_deref()
+                .is_some_and(|r| r.contains("blocked by the approval policy")),
+            "{blocked_reason:?}"
+        );
+        assert_eq!(tool_result_ids(&ctx), vec!["deny-1"]);
+        assert_eq!(
+            assert_exactly_one_run_finished(&events),
+            RunOutcome::Completed
+        );
+    }
+
+    // A denial at the interactive confirm prompt happens after the call card
+    // is up: Started first, then Blocked — never Finished.
+    #[tokio::test]
+    async fn user_denied_at_confirm_is_started_then_blocked() {
+        let provider = SequenceProvider::new([
+            Completion {
+                tool_calls: vec![call("ask-1", "gated_tool", serde_json::json!({}))],
+                finish_reason: Some("tool_calls".into()),
+                ..Completion::default()
+            },
+            Completion {
+                content: "understood".into(),
+                finish_reason: Some("stop".into()),
+                ..Completion::default()
+            },
+        ]);
+        let mut tools = Registry::builtins().filtered(&[]);
+        tools.add(Box::new(CountingTool {
+            name: "gated_tool",
+            runs: Arc::new(AtomicUsize::new(0)),
+        }));
+        let mut ctx = ContextManager::new(100_000);
+        let output = PolicyEventLog {
+            events: EventLog::default(),
+            gated_tool: "gated_tool",
+            mode: Approval::Ask,
+            confirm_ok: false,
+        };
+
+        agent_loop(
+            &mut ctx,
+            &provider,
+            None,
+            &tools,
+            Path::new("."),
+            &output,
+            "run the gated tool",
+            0,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let key = ToolInvocationKey::ready(1, 0, "ask-1");
+        let events = output.events.events();
+        let (started, blocked, finished) = lifecycle_positions(&events, &key);
+        let (started, blocked) = (started.unwrap(), blocked.unwrap());
+        assert!(
+            started < blocked,
+            "interactive denial is Started then Blocked: {events:?}"
+        );
+        assert_eq!(finished, None, "Blocked is never Finished: {events:?}");
+        assert_eq!(
+            assert_exactly_one_run_finished(&events),
+            RunOutcome::Completed
+        );
+    }
+
+    struct DeferredMcpTool;
+
+    #[async_trait]
+    impl Tool for DeferredMcpTool {
+        fn name(&self) -> &str {
+            "pubmed_search"
+        }
+
+        fn schema(&self) -> ToolSchema {
+            ToolSchema::new(
+                "pubmed_search",
+                "deferred MCP tool",
+                serde_json::json!({"type": "object"}),
+            )
+        }
+
+        fn defer_schema(&self) -> bool {
+            true
+        }
+
+        async fn run(&self, _args: &serde_json::Value, _env: &dyn ToolEnv) -> ToolResult {
+            ToolResult::ok("papers")
+        }
+    }
+
+    // A deferred MCP tool is reached through the use_mcp_tool gateway, but its
+    // call card carries the canonical `mcp:<target>` event name — so Started
+    // (projected from the card) uses that name too, matching Finished and the
+    // tool row. (The model's raw `use_mcp_tool` name must never appear.)
+    #[tokio::test]
+    async fn deferred_mcp_tool_started_carries_the_mcp_event_name() {
+        let provider = SequenceProvider::new([
+            Completion {
+                tool_calls: vec![call(
+                    "mcp-1",
+                    "use_mcp_tool",
+                    serde_json::json!({
+                        "tool_name": "pubmed_search",
+                        "tool_input": { "query": "tp53" }
+                    }),
+                )],
+                finish_reason: Some("tool_calls".into()),
+                ..Completion::default()
+            },
+            Completion {
+                content: "done".into(),
+                finish_reason: Some("stop".into()),
+                ..Completion::default()
+            },
+        ]);
+        let mut tools = Registry::builtins().filtered(&[]);
+        tools.add(Box::new(DeferredMcpTool));
+        let mut ctx = ContextManager::new(100_000);
+        let output = EventLog::default();
+
+        agent_loop(
+            &mut ctx,
+            &provider,
+            None,
+            &tools,
+            Path::new("."),
+            &output,
+            "search pubmed",
+            0,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let key = ToolInvocationKey::ready(1, 0, "mcp-1");
+        let events = output.events();
+        let started_name = events.iter().find_map(|e| match e {
+            AgentRuntimeEvent::ToolExecutionStarted { key: k, name } if *k == key => {
+                Some(name.clone())
+            }
+            _ => None,
+        });
+        assert_eq!(started_name.as_deref(), Some("mcp:pubmed_search"));
+        let finished_name = events.iter().find_map(|e| match e {
+            AgentRuntimeEvent::ToolExecutionFinished { key: k, name, .. } if *k == key => {
+                Some(name.clone())
+            }
+            _ => None,
+        });
+        assert_eq!(finished_name.as_deref(), Some("mcp:pubmed_search"));
         assert_eq!(
             assert_exactly_one_run_finished(&events),
             RunOutcome::Completed

--- a/crates/wisp-core/src/control.rs
+++ b/crates/wisp-core/src/control.rs
@@ -1,0 +1,490 @@
+//! Shared per-session agent control: cancellation, mid-turn steering, and the
+//! parked follow-up queue. [`AgentControl`] is the single ownership point the
+//! agent loop and the host both clone, so the host can steer or enqueue
+//! follow-ups even while it holds the agent's run lock.
+
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use crate::agent::GuidanceQueue;
+
+/// Identity for items parked in a [`FollowUpQueue`]. The host's queued-item
+/// type implements this so Core can match items by id without naming host
+/// types (attachments, composer references, ...).
+pub trait FollowUpItem {
+    fn id(&self) -> u64;
+}
+
+/// Host-agnostic FIFO queue of parked follow-up turns (#433) plus the driver
+/// claim/release protocol. Clone shares the same underlying queue.
+///
+/// No lost wakeup: `enqueue` pushes and claims the driver slot in one lock
+/// acquisition, and `driver_pop` releases the slot only when it observes an
+/// empty queue under that same lock — so an enqueue can never strand behind a
+/// driver that is exiting on an empty queue.
+///
+/// ponytail: the queue is in-memory only — items are lost on app restart,
+/// same as the optimistic bubbles, which are never persisted either. This is
+/// intentional for now.
+pub struct FollowUpQueue<T> {
+    state: Arc<Mutex<FollowUpState<T>>>,
+}
+
+struct FollowUpState<T> {
+    items: VecDeque<T>,
+    /// True while a driver task owns draining `items`. Flipped only under
+    /// this lock, which is what makes the enqueue-vs-exit race safe.
+    draining: bool,
+}
+
+impl<T> Clone for FollowUpQueue<T> {
+    fn clone(&self) -> Self {
+        Self {
+            state: self.state.clone(),
+        }
+    }
+}
+
+impl<T> Default for FollowUpQueue<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> FollowUpQueue<T> {
+    pub fn new() -> Self {
+        Self {
+            state: Arc::new(Mutex::new(FollowUpState {
+                items: VecDeque::new(),
+                draining: false,
+            })),
+        }
+    }
+
+    /// Park a follow-up at the back. Returns true when the caller must spawn
+    /// a driver: the push and the driver-slot claim happen atomically, and
+    /// the slot is only released by `driver_pop` on an empty queue.
+    pub fn enqueue(&self, item: T) -> bool {
+        let mut state = self.state.lock().unwrap();
+        state.items.push_back(item);
+        Self::claim_driver_locked(&mut state)
+    }
+
+    /// Claim the driver slot without pushing. Returns true when no driver was
+    /// active, i.e. the caller now owns draining and must spawn one. Used when
+    /// an item re-enters the queue outside `enqueue` (cut-in reclaim).
+    pub fn claim_driver(&self) -> bool {
+        Self::claim_driver_locked(&mut self.state.lock().unwrap())
+    }
+
+    fn claim_driver_locked(state: &mut FollowUpState<T>) -> bool {
+        !std::mem::replace(&mut state.draining, true)
+    }
+
+    /// Driver-side pop: takes the next item FIFO, or — when the queue is
+    /// empty — releases the driver slot under the same lock and returns None
+    /// so the driver exits. An enqueue after that point re-claims the slot.
+    pub fn driver_pop(&self) -> Option<T> {
+        let mut state = self.state.lock().unwrap();
+        match state.items.pop_front() {
+            Some(item) => Some(item),
+            None => {
+                state.draining = false;
+                None
+            }
+        }
+    }
+
+    /// Plain front pop without driver semantics.
+    pub fn pop_front(&self) -> Option<T> {
+        self.state.lock().unwrap().items.pop_front()
+    }
+
+    /// Put an item back at the front (reclaim of an unconsumed cut-in).
+    pub fn insert_front(&self, item: T) {
+        self.state.lock().unwrap().items.push_front(item);
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.state.lock().unwrap().items.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.state.lock().unwrap().items.len()
+    }
+
+    /// True while a driver task owns draining this queue.
+    pub fn driver_active(&self) -> bool {
+        self.state.lock().unwrap().draining
+    }
+
+    pub fn snapshot(&self) -> Vec<T>
+    where
+        T: Clone,
+    {
+        self.state.lock().unwrap().items.iter().cloned().collect()
+    }
+}
+
+impl<T: FollowUpItem> FollowUpQueue<T> {
+    /// Replace part of a parked item in place (e.g. its text). Returns false
+    /// when no item with `id` is parked.
+    pub fn edit(&self, id: u64, edit: impl FnOnce(&mut T)) -> bool {
+        let mut state = self.state.lock().unwrap();
+        match state.items.iter_mut().find(|item| item.id() == id) {
+            Some(item) => {
+                edit(item);
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Drop a parked item. Returns false when no item with `id` was parked.
+    pub fn cancel(&self, id: u64) -> bool {
+        let mut state = self.state.lock().unwrap();
+        let before = state.items.len();
+        state.items.retain(|item| item.id() != id);
+        state.items.len() != before
+    }
+
+    /// Pull an item out of the queue (cut-in into the running turn).
+    pub fn take(&self, id: u64) -> Option<T> {
+        let mut state = self.state.lock().unwrap();
+        state
+            .items
+            .iter()
+            .position(|item| item.id() == id)
+            .and_then(|index| state.items.remove(index))
+    }
+
+    /// Swap with the previous neighbour; a no-op when already first.
+    pub fn move_up(&self, id: u64) -> bool {
+        self.swap_toward(id, true)
+    }
+
+    /// Swap with the next neighbour; a no-op when already last.
+    pub fn move_down(&self, id: u64) -> bool {
+        self.swap_toward(id, false)
+    }
+
+    fn swap_toward(&self, id: u64, up: bool) -> bool {
+        let mut state = self.state.lock().unwrap();
+        let Some(index) = state.items.iter().position(|item| item.id() == id) else {
+            return false;
+        };
+        let target = if up {
+            index.checked_sub(1)
+        } else {
+            (index + 1 < state.items.len()).then_some(index + 1)
+        };
+        match target {
+            Some(other) => {
+                state.items.swap(index, other);
+                true
+            }
+            None => false,
+        }
+    }
+}
+
+/// Shared control state for one agent session. Clone freely — every clone
+/// points at the same cancel flag, steering queue, and follow-up queue, so the
+/// host can steer or enqueue while the agent loop is running.
+pub struct AgentControl<T> {
+    inner: Arc<AgentControlInner<T>>,
+}
+
+struct AgentControlInner<T> {
+    cancel: Arc<AtomicBool>,
+    // TODO(agent-message): the steering payload stays `(u64, String)` until the
+    // structured AgentMessage migration; this queue is where it slots in.
+    steering: GuidanceQueue,
+    steering_seq: AtomicU64,
+    follow_ups: FollowUpQueue<T>,
+}
+
+impl<T> Clone for AgentControl<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl<T> Default for AgentControl<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> AgentControl<T> {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(AgentControlInner {
+                cancel: Arc::new(AtomicBool::new(false)),
+                steering: GuidanceQueue::default(),
+                steering_seq: AtomicU64::new(0),
+                follow_ups: FollowUpQueue::new(),
+            }),
+        }
+    }
+
+    /// Borrow the cancel flag (e.g. `Some(control.cancel_flag())` for the
+    /// agent loop).
+    pub fn cancel_flag(&self) -> &AtomicBool {
+        &self.inner.cancel
+    }
+
+    /// Share the cancel flag with a component that outlives this handle.
+    pub fn cancel_arc(&self) -> Arc<AtomicBool> {
+        self.inner.cancel.clone()
+    }
+
+    pub fn request_cancel(&self) {
+        self.inner.cancel.store(true, Ordering::Relaxed);
+    }
+
+    pub fn reset_cancel(&self) {
+        self.inner.cancel.store(false, Ordering::SeqCst);
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.inner.cancel.load(Ordering::SeqCst)
+    }
+
+    /// The queue the agent loop drains at each iteration boundary; pass it as
+    /// `Some(control.steering_queue())` to the agent loop.
+    pub fn steering_queue(&self) -> &GuidanceQueue {
+        &self.inner.steering
+    }
+
+    /// Park a steering message for the running loop. Returns its id so the
+    /// sender can later tell whether the loop consumed it.
+    pub fn push_steering(&self, text: impl Into<String>) -> u64 {
+        let id = self.inner.steering_seq.fetch_add(1, Ordering::Relaxed);
+        self.inner.steering.lock().unwrap().push((id, text.into()));
+        id
+    }
+
+    /// Remove a steering message the loop has not consumed yet. Returns true
+    /// when it was still parked (caller must run it as a normal turn); false
+    /// means the loop already folded it into the running turn.
+    pub fn reclaim_steering(&self, id: u64) -> bool {
+        let mut steering = self.inner.steering.lock().unwrap();
+        let before = steering.len();
+        steering.retain(|(steering_id, _)| *steering_id != id);
+        steering.len() != before
+    }
+
+    pub fn follow_ups(&self) -> &FollowUpQueue<T> {
+        &self.inner.follow_ups
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Clone)]
+    struct Item {
+        id: u64,
+        text: String,
+    }
+
+    impl FollowUpItem for Item {
+        fn id(&self) -> u64 {
+            self.id
+        }
+    }
+
+    fn item(id: u64) -> Item {
+        Item {
+            id,
+            text: format!("m{id}"),
+        }
+    }
+
+    fn ids(queue: &FollowUpQueue<Item>) -> Vec<u64> {
+        queue.snapshot().iter().map(|item| item.id).collect()
+    }
+
+    #[test]
+    fn enqueue_claims_one_driver_and_drains_fifo() {
+        let queue = FollowUpQueue::new();
+        assert!(queue.enqueue(item(1)), "first enqueue claims the driver");
+        assert!(
+            !queue.enqueue(item(2)),
+            "a driver is already running for later enqueues"
+        );
+        assert!(!queue.enqueue(item(3)));
+
+        assert_eq!(queue.driver_pop().map(|item| item.id), Some(1));
+        assert_eq!(queue.driver_pop().map(|item| item.id), Some(2));
+        assert_eq!(queue.driver_pop().map(|item| item.id), Some(3));
+        assert!(
+            queue.driver_pop().is_none(),
+            "empty queue releases the slot"
+        );
+        assert!(!queue.driver_active());
+    }
+
+    #[test]
+    fn driver_slot_is_reclaimable_after_the_queue_empties() {
+        let queue = FollowUpQueue::new();
+        assert!(queue.enqueue(item(1)));
+        assert_eq!(queue.driver_pop().map(|item| item.id), Some(1));
+        assert!(queue.driver_pop().is_none());
+
+        // A post-drain enqueue re-claims the slot rather than stranding.
+        assert!(queue.enqueue(item(2)));
+        assert_eq!(queue.driver_pop().map(|item| item.id), Some(2));
+    }
+
+    #[test]
+    fn edit_by_id_replaces_in_place() {
+        let queue = FollowUpQueue::new();
+        queue.enqueue(item(1));
+        queue.enqueue(item(2));
+        assert!(queue.edit(2, |item| item.text = "edited".into()));
+        assert!(!queue.edit(9, |item| item.text = "nope".into()));
+        let snapshot = queue.snapshot();
+        assert_eq!(snapshot[0].text, "m1");
+        assert_eq!(snapshot[1].text, "edited");
+    }
+
+    #[test]
+    fn cancel_by_id_removes_only_that_item() {
+        let queue = FollowUpQueue::new();
+        queue.enqueue(item(1));
+        queue.enqueue(item(2));
+        queue.enqueue(item(3));
+        assert!(queue.cancel(2));
+        assert!(!queue.cancel(2), "already gone");
+        assert_eq!(ids(&queue), [1, 3]);
+    }
+
+    #[test]
+    fn take_removes_and_insert_front_reclaims() {
+        let queue = FollowUpQueue::new();
+        queue.enqueue(item(1));
+        queue.enqueue(item(2));
+        let taken = queue.take(1).expect("item 1 is parked");
+        assert_eq!(taken.text, "m1");
+        assert_eq!(ids(&queue), [2]);
+        queue.insert_front(taken);
+        assert_eq!(ids(&queue), [1, 2]);
+        assert!(queue.take(9).is_none());
+    }
+
+    #[test]
+    fn move_swaps_with_neighbour_and_clamps_at_the_ends() {
+        let queue = FollowUpQueue::new();
+        queue.enqueue(item(1));
+        queue.enqueue(item(2));
+        queue.enqueue(item(3)); // A, B, C
+        assert!(queue.move_up(3)); // C up → A, C, B
+        assert_eq!(ids(&queue), [1, 3, 2]);
+        assert!(queue.move_down(1)); // A down → C, A, B
+        assert_eq!(ids(&queue), [3, 1, 2]);
+        assert!(!queue.move_up(3), "already first — clamped");
+        assert_eq!(ids(&queue), [3, 1, 2]);
+        assert!(!queue.move_down(2), "already last — clamped");
+        assert_eq!(ids(&queue), [3, 1, 2]);
+        assert!(!queue.move_up(9), "unknown id");
+    }
+
+    /// The no-lost-wakeup invariant under real concurrency: enqueues from many
+    /// threads race a driver that exits as soon as it sees an empty queue.
+    /// Every enqueue that claims the slot spawns a fresh driver; at the end
+    /// every item must have been consumed exactly once.
+    #[test]
+    fn concurrent_enqueue_never_strands_an_item_without_a_driver() {
+        fn spawn_driver(
+            queue: &FollowUpQueue<Item>,
+            consumed: &Arc<Mutex<Vec<u64>>>,
+            drivers: &Arc<Mutex<Vec<std::thread::JoinHandle<()>>>>,
+        ) {
+            let queue = queue.clone();
+            let consumed = consumed.clone();
+            drivers.lock().unwrap().push(std::thread::spawn(move || {
+                while let Some(item) = queue.driver_pop() {
+                    consumed.lock().unwrap().push(item.id);
+                }
+            }));
+        }
+
+        let queue = FollowUpQueue::new();
+        let consumed = Arc::new(Mutex::new(Vec::new()));
+        let drivers = Arc::new(Mutex::new(Vec::new()));
+        const PRODUCERS: u64 = 4;
+        const PER_PRODUCER: u64 = 50;
+
+        let producers: Vec<_> = (0..PRODUCERS)
+            .map(|producer| {
+                let queue = queue.clone();
+                let consumed = consumed.clone();
+                let drivers = drivers.clone();
+                std::thread::spawn(move || {
+                    for i in 0..PER_PRODUCER {
+                        if queue.enqueue(item(producer * PER_PRODUCER + i)) {
+                            spawn_driver(&queue, &consumed, &drivers);
+                        }
+                    }
+                })
+            })
+            .collect();
+        for producer in producers {
+            producer.join().unwrap();
+        }
+        // No more enqueues past this point, so the driver set is final and
+        // each one exits once it drains the queue.
+        for driver in std::mem::take(&mut *drivers.lock().unwrap()) {
+            driver.join().unwrap();
+        }
+
+        let mut consumed = std::mem::take(&mut *consumed.lock().unwrap());
+        consumed.sort_unstable();
+        assert_eq!(
+            consumed,
+            (0..PRODUCERS * PER_PRODUCER).collect::<Vec<_>>(),
+            "every enqueued item was consumed exactly once"
+        );
+        assert!(queue.is_empty());
+        assert!(!queue.driver_active());
+    }
+
+    #[test]
+    fn steering_ids_are_unique_and_reclaim_reports_consumption() {
+        let control = AgentControl::<Item>::new();
+        let first = control.push_steering("one");
+        let second = control.push_steering("two");
+        assert_ne!(first, second);
+
+        assert!(control.reclaim_steering(first), "still parked — reclaimed");
+        assert!(
+            !control.reclaim_steering(first),
+            "already removed — treated as consumed"
+        );
+        // Consumed by the loop draining the queue.
+        control.steering_queue().lock().unwrap().clear();
+        assert!(!control.reclaim_steering(second));
+    }
+
+    #[test]
+    fn clones_share_one_control_state() {
+        let control = AgentControl::<Item>::new();
+        let clone = control.clone();
+        control.push_steering("shared");
+        clone.follow_ups().enqueue(item(1));
+        clone.request_cancel();
+
+        assert_eq!(control.steering_queue().lock().unwrap().len(), 1);
+        assert_eq!(control.follow_ups().len(), 1);
+        assert!(control.is_cancelled());
+        control.reset_cancel();
+        assert!(!clone.is_cancelled());
+        assert!(std::ptr::eq(control.cancel_flag(), clone.cancel_flag()));
+    }
+}

--- a/crates/wisp-core/src/lib.rs
+++ b/crates/wisp-core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod method_search;
 pub mod orchestration;
 pub mod output;
 pub mod provenance;
+pub mod runtime_event;
 pub mod subagent;
 pub mod system_prompt;
 
@@ -43,6 +44,7 @@ pub use orchestration::{
 };
 pub use output::{NullOutput, Output, OutputFuture, StreamSinkAdapter, ToolEnvAdapter};
 pub use provenance::ProvenanceRecord;
+pub use runtime_event::{AgentRuntimeEvent, RunOutcome, ToolCallDraft, ToolInvocationKey};
 pub use subagent::ExploreTool;
 pub use system_prompt::SystemPrompt;
 

--- a/crates/wisp-core/src/lib.rs
+++ b/crates/wisp-core/src/lib.rs
@@ -4,6 +4,7 @@
 pub mod agent;
 pub mod archive;
 pub mod context;
+pub mod control;
 pub mod delegation;
 pub mod delegation_policy;
 pub mod execution;
@@ -18,6 +19,7 @@ pub mod system_prompt;
 
 pub use agent::{agent_loop, agent_loop_continue, GuidanceQueue};
 pub use context::{ContextManager, ContextToolDetail, ContextUsage, ContextUsageDetails};
+pub use control::{AgentControl, FollowUpItem, FollowUpQueue};
 pub use delegation::{
     degraded_delivery_marker, is_degraded_delivery, AgentArtifact, AgentAuthorizationSnapshot,
     AgentBackend, AgentBudget, AgentDelegationLineage, AgentDelegationRequest,

--- a/crates/wisp-core/src/lib.rs
+++ b/crates/wisp-core/src/lib.rs
@@ -46,9 +46,7 @@ pub use orchestration::{
 };
 pub use output::{NullOutput, Output, OutputFuture, StreamSinkAdapter, ToolEnvAdapter};
 pub use provenance::ProvenanceRecord;
-pub use runtime_event::{
-    bound_tool_details, AgentRuntimeEvent, RunOutcome, ToolCallDraft, ToolInvocationKey,
-};
+pub use runtime_event::{bound_tool_details, AgentRuntimeEvent, RunOutcome, ToolInvocationKey};
 pub use subagent::ExploreTool;
 pub use system_prompt::SystemPrompt;
 

--- a/crates/wisp-core/src/lib.rs
+++ b/crates/wisp-core/src/lib.rs
@@ -44,7 +44,9 @@ pub use orchestration::{
 };
 pub use output::{NullOutput, Output, OutputFuture, StreamSinkAdapter, ToolEnvAdapter};
 pub use provenance::ProvenanceRecord;
-pub use runtime_event::{AgentRuntimeEvent, RunOutcome, ToolCallDraft, ToolInvocationKey};
+pub use runtime_event::{
+    bound_tool_details, AgentRuntimeEvent, RunOutcome, ToolCallDraft, ToolInvocationKey,
+};
 pub use subagent::ExploreTool;
 pub use system_prompt::SystemPrompt;
 

--- a/crates/wisp-core/src/output.rs
+++ b/crates/wisp-core/src/output.rs
@@ -102,6 +102,12 @@ pub trait Output: Send + Sync {
     fn project_write_locked(&self) -> bool {
         false
     }
+    /// Structured run/round/tool lifecycle event. Default no-op keeps
+    /// CLI/test outputs unchanged; hosts that render live tool state (the
+    /// Tauri shell) override it and project the event onto their own
+    /// protocol. Existing granular callbacks (`assistant_text`, `tool_call`,
+    /// ...) keep firing alongside it during the compatibility period.
+    fn runtime_event(&self, _event: &crate::runtime_event::AgentRuntimeEvent) {}
     /// Fired once per message appended to the context during a turn (user,
     /// assistant, tool). Lets the host persist incrementally so a crash or a
     /// mid-turn "new session" doesn't lose the whole turn. Default: no-op.
@@ -219,10 +225,17 @@ impl<'a> wisp_tools::ToolEnv for ToolEnvAdapter<'a> {
 pub struct StreamSinkAdapter<'a> {
     out: &'a dyn Output,
     cancel: Option<&'a std::sync::atomic::AtomicBool>,
+    /// Round (agent-loop iteration) this sink streams; stamped onto the
+    /// runtime events forwarded with each delta.
+    round: usize,
 }
 impl<'a> StreamSinkAdapter<'a> {
     pub fn new(out: &'a dyn Output) -> Self {
-        Self { out, cancel: None }
+        Self {
+            out,
+            cancel: None,
+            round: 0,
+        }
     }
     /// Like `new`, but the streaming loop can poll `is_cancelled()` to stop
     /// token generation mid-stream when the user hits Stop.
@@ -230,15 +243,33 @@ impl<'a> StreamSinkAdapter<'a> {
         Self {
             out,
             cancel: Some(cancel),
+            round: 0,
         }
+    }
+    /// Stamp runtime events with the agent-loop round being streamed.
+    pub fn for_round(mut self, round: usize) -> Self {
+        self.round = round;
+        self
     }
 }
 impl<'a> wisp_llm::StreamSink for StreamSinkAdapter<'a> {
     fn on_text(&mut self, delta: &str) {
         self.out.assistant_text(delta);
+        self.out.runtime_event(
+            &crate::runtime_event::AgentRuntimeEvent::AssistantTextDelta {
+                round: self.round,
+                delta: delta.to_string(),
+            },
+        );
     }
     fn on_reasoning(&mut self, delta: &str) {
         self.out.reasoning(delta);
+        self.out.runtime_event(
+            &crate::runtime_event::AgentRuntimeEvent::AssistantReasoningDelta {
+                round: self.round,
+                delta: delta.to_string(),
+            },
+        );
     }
     fn on_tool_call(&mut self, _i: usize, _name: &str, _args: &str) {}
     fn on_usage(&mut self, _u: wisp_llm::Usage) {}

--- a/crates/wisp-core/src/output.rs
+++ b/crates/wisp-core/src/output.rs
@@ -132,6 +132,11 @@ pub struct ToolEnvAdapter<'a> {
     root: std::path::PathBuf,
     out: &'a dyn Output,
     cancel: Option<&'a std::sync::atomic::AtomicBool>,
+    /// Invocation identity injected by the agent loop (never by the tool) via
+    /// [`ToolEnvAdapter::for_invocation`]. Structured progress is forwarded
+    /// only while this is set and the invocation is still active.
+    invocation: Option<crate::runtime_event::ToolInvocationKey>,
+    invocation_active: std::sync::Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl<'a> ToolEnvAdapter<'a> {
@@ -140,6 +145,8 @@ impl<'a> ToolEnvAdapter<'a> {
             root,
             out,
             cancel: None,
+            invocation: None,
+            invocation_active: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         }
     }
     /// Like `new`, but tools can poll `is_cancelled()` to stop mid-execution.
@@ -152,7 +159,28 @@ impl<'a> ToolEnvAdapter<'a> {
             root,
             out,
             cancel: Some(cancel),
+            invocation: None,
+            invocation_active: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         }
+    }
+    /// Per-call clone carrying the invocation key the agent loop assigned, so
+    /// `ToolEvent::Progress` can be projected onto the runtime-event stream
+    /// with a stable identity. Progress is forwarded only until
+    /// [`ToolEnvAdapter::finish_invocation`] runs.
+    pub fn for_invocation(&self, key: crate::runtime_event::ToolInvocationKey) -> Self {
+        Self {
+            root: self.root.clone(),
+            out: self.out,
+            cancel: self.cancel,
+            invocation: Some(key),
+            invocation_active: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
+        }
+    }
+    /// Mark the invocation finished: progress emitted afterwards (e.g. by a
+    /// detached task the tool spawned) is silently ignored.
+    pub fn finish_invocation(&self) {
+        self.invocation_active
+            .store(false, std::sync::atomic::Ordering::Relaxed);
     }
 }
 
@@ -213,6 +241,24 @@ impl<'a> wisp_tools::ToolEnv for ToolEnvAdapter<'a> {
             wisp_tools::ToolEvent::Stdout { chunk } => self.out.stdout_chunk(&chunk),
             wisp_tools::ToolEvent::Presentation { kind, payload } => {
                 self.out.tool_presentation(&kind, &payload)
+            }
+            wisp_tools::ToolEvent::Progress { details } => {
+                // Structured progress rides the runtime-event stream only while
+                // the owning invocation is live; anything emitted after the
+                // tool finished (or without an invocation key) is dropped.
+                let active = self
+                    .invocation_active
+                    .load(std::sync::atomic::Ordering::Relaxed);
+                if active {
+                    if let Some(key) = &self.invocation {
+                        self.out.runtime_event(
+                            &crate::runtime_event::AgentRuntimeEvent::ToolExecutionUpdated {
+                                key: key.clone(),
+                                details: crate::runtime_event::bound_tool_details(details),
+                            },
+                        );
+                    }
+                }
             }
             wisp_tools::ToolEvent::Result { ok: _ } => {}
         }
@@ -409,5 +455,84 @@ mod tests {
             !output.sync_called.load(Ordering::SeqCst),
             "the adapter must not fall back to the runtime-blocking sync hook"
         );
+    }
+
+    #[tokio::test]
+    async fn progress_is_forwarded_only_for_an_active_invocation() {
+        use crate::runtime_event::{AgentRuntimeEvent, ToolInvocationKey};
+
+        struct Recorder(Mutex<Vec<AgentRuntimeEvent>>);
+        impl Output for Recorder {
+            fn runtime_event(&self, event: &AgentRuntimeEvent) {
+                self.0.lock().unwrap().push(event.clone());
+            }
+        }
+
+        let out = Recorder(Mutex::new(Vec::new()));
+        let env = ToolEnvAdapter::new(std::path::PathBuf::from("."), &out);
+        // No invocation key: progress has nowhere to land and is dropped.
+        wisp_tools::ToolEnv::emit(
+            &env,
+            wisp_tools::ToolEvent::Progress {
+                details: serde_json::json!({"pct": 1}),
+            },
+        )
+        .await;
+        assert!(out.0.lock().unwrap().is_empty());
+
+        let key = ToolInvocationKey::ready(1, 0, "call-1");
+        let invocation = env.for_invocation(key.clone());
+        wisp_tools::ToolEnv::emit(
+            &invocation,
+            wisp_tools::ToolEvent::Progress {
+                details: serde_json::json!({"pct": 50}),
+            },
+        )
+        .await;
+        // Once the invocation is finished, late progress is silently ignored.
+        invocation.finish_invocation();
+        wisp_tools::ToolEnv::emit(
+            &invocation,
+            wisp_tools::ToolEvent::Progress {
+                details: serde_json::json!({"pct": 100}),
+            },
+        )
+        .await;
+
+        let events = out.0.lock().unwrap();
+        assert_eq!(
+            events.as_slice(),
+            &[AgentRuntimeEvent::ToolExecutionUpdated {
+                key,
+                details: serde_json::json!({"pct": 50}),
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn oversized_progress_details_are_bounded() {
+        use crate::runtime_event::{AgentRuntimeEvent, ToolInvocationKey};
+
+        struct Recorder(Mutex<Vec<AgentRuntimeEvent>>);
+        impl Output for Recorder {
+            fn runtime_event(&self, event: &AgentRuntimeEvent) {
+                self.0.lock().unwrap().push(event.clone());
+            }
+        }
+
+        let out = Recorder(Mutex::new(Vec::new()));
+        let env = ToolEnvAdapter::new(std::path::PathBuf::from("."), &out)
+            .for_invocation(ToolInvocationKey::ready(1, 0, "call-1"));
+        let big = serde_json::json!({"blob": "x".repeat(32 * 1024)});
+        wisp_tools::ToolEnv::emit(&env, wisp_tools::ToolEvent::Progress { details: big }).await;
+
+        let events = out.0.lock().unwrap();
+        let [AgentRuntimeEvent::ToolExecutionUpdated { details, .. }] = events.as_slice() else {
+            panic!("expected one progress event, got {events:?}");
+        };
+        assert_eq!(details["truncated"], serde_json::json!(true));
+        let original = details["original_bytes"].as_u64().unwrap() as usize;
+        assert!(original > crate::runtime_event::TOOL_DETAILS_MAX_BYTES);
+        assert!(serde_json::to_string(details).unwrap().len() <= 256);
     }
 }

--- a/crates/wisp-core/src/output.rs
+++ b/crates/wisp-core/src/output.rs
@@ -271,7 +271,18 @@ impl<'a> wisp_llm::StreamSink for StreamSinkAdapter<'a> {
             },
         );
     }
-    fn on_tool_call(&mut self, _i: usize, _name: &str, _args: &str) {}
+    fn on_tool_call(&mut self, snapshot: &wisp_llm::ToolCallSnapshot) {
+        self.out.runtime_event(
+            &crate::runtime_event::AgentRuntimeEvent::AssistantToolCallUpdated(
+                crate::runtime_event::ToolCallDraft {
+                    key: crate::runtime_event::ToolInvocationKey::draft(self.round, snapshot.index),
+                    id: snapshot.id.clone(),
+                    name: snapshot.name.clone(),
+                    arguments_so_far: snapshot.arguments_so_far.clone(),
+                },
+            ),
+        );
+    }
     fn on_usage(&mut self, _u: wisp_llm::Usage) {}
     fn is_cancelled(&self) -> bool {
         self.cancel
@@ -302,6 +313,53 @@ mod tests {
         );
         // A sink built without a cancel flag never reports cancelled.
         assert!(!StreamSinkAdapter::new(&out).is_cancelled());
+    }
+
+    #[test]
+    fn tool_call_snapshots_become_live_draft_events() {
+        use crate::runtime_event::{AgentRuntimeEvent, ToolInvocationKey};
+        use wisp_llm::ToolCallSnapshot;
+
+        struct Recorder(Mutex<Vec<AgentRuntimeEvent>>);
+        impl Output for Recorder {
+            fn runtime_event(&self, event: &AgentRuntimeEvent) {
+                self.0.lock().unwrap().push(event.clone());
+            }
+        }
+
+        let out = Recorder(Mutex::new(Vec::new()));
+        let mut sink = StreamSinkAdapter::new(&out).for_round(3);
+        // Fragments arrive; each emission is a full snapshot keyed by
+        // (round, index). The id appears once the stream reveals it.
+        sink.on_tool_call(&ToolCallSnapshot {
+            index: 1,
+            id: None,
+            name: "read".into(),
+            arguments_so_far: "{\"pa".into(),
+        });
+        sink.on_tool_call(&ToolCallSnapshot {
+            index: 1,
+            id: Some("call-9".into()),
+            name: "read".into(),
+            arguments_so_far: "{\"path\":\"a.txt\"}".into(),
+        });
+
+        let events = out.0.lock().unwrap();
+        assert_eq!(events.len(), 2);
+        let mut drafts = events.iter().map(|event| {
+            let AgentRuntimeEvent::AssistantToolCallUpdated(draft) = event else {
+                panic!("expected a draft event, got {event:?}");
+            };
+            assert_eq!(draft.key, ToolInvocationKey::draft(3, 1));
+            assert_eq!(draft.name, "read");
+            draft
+        });
+        let first = drafts.next().unwrap();
+        assert_eq!(first.id, None);
+        assert_eq!(first.arguments_so_far, "{\"pa");
+        let second = drafts.next().unwrap();
+        assert_eq!(second.id.as_deref(), Some("call-9"));
+        assert_eq!(second.arguments_so_far, "{\"path\":\"a.txt\"}");
     }
 
     struct AsyncConfirmOutput {

--- a/crates/wisp-core/src/output.rs
+++ b/crates/wisp-core/src/output.rs
@@ -235,7 +235,24 @@ impl<'a> wisp_tools::ToolEnv for ToolEnvAdapter<'a> {
     }
     async fn emit(&self, event: wisp_tools::ToolEvent) {
         match event {
-            wisp_tools::ToolEvent::Call { name, preview } => self.out.tool_call(&name, &preview),
+            wisp_tools::ToolEvent::Call { name, preview } => {
+                // The registry only emits Call after the non-interactive
+                // policy checks (write lock, plan mode, explicit Deny) pass,
+                // so this is where execution actually begins. Emit Started
+                // first: hosts announce it just before the tool's own call
+                // card so the card can consume the invocation key. `name` is
+                // the canonical event name (`mcp:`-prefixed for deferred MCP
+                // tools), so it matches Finished/Blocked.
+                if let Some(key) = &self.invocation {
+                    self.out.runtime_event(
+                        &crate::runtime_event::AgentRuntimeEvent::ToolExecutionStarted {
+                            key: key.clone(),
+                            name: name.clone(),
+                        },
+                    );
+                }
+                self.out.tool_call(&name, &preview);
+            }
             wisp_tools::ToolEvent::Diff { path, old, new } => self.out.diff(&path, &old, &new),
             wisp_tools::ToolEvent::FileChanged { path } => self.out.file_changed(&path),
             wisp_tools::ToolEvent::Stdout { chunk } => self.out.stdout_chunk(&chunk),
@@ -266,8 +283,9 @@ impl<'a> wisp_tools::ToolEnv for ToolEnvAdapter<'a> {
     }
 }
 
-/// Adapter exposing `Output` as a `wisp_llm::StreamSink` (text + reasoning
-/// deltas only; usage/tool-call deltas are handled by the agent loop).
+/// Adapter exposing `Output` as a `wisp_llm::StreamSink`: text, reasoning,
+/// and tool-call fragments are forwarded as runtime events; usage is handled
+/// by the agent loop.
 pub struct StreamSinkAdapter<'a> {
     out: &'a dyn Output,
     cancel: Option<&'a std::sync::atomic::AtomicBool>,
@@ -317,16 +335,16 @@ impl<'a> wisp_llm::StreamSink for StreamSinkAdapter<'a> {
             },
         );
     }
-    fn on_tool_call(&mut self, snapshot: &wisp_llm::ToolCallSnapshot) {
+    fn on_tool_call(&mut self, delta: &wisp_llm::ToolCallDelta) {
+        // Forward the fragment as-is: accumulation happens once, host-side.
         self.out.runtime_event(
-            &crate::runtime_event::AgentRuntimeEvent::AssistantToolCallUpdated(
-                crate::runtime_event::ToolCallDraft {
-                    key: crate::runtime_event::ToolInvocationKey::draft(self.round, snapshot.index),
-                    id: snapshot.id.clone(),
-                    name: snapshot.name.clone(),
-                    arguments_so_far: snapshot.arguments_so_far.clone(),
-                },
-            ),
+            &crate::runtime_event::AgentRuntimeEvent::AssistantToolCallDelta {
+                key: crate::runtime_event::ToolInvocationKey::draft(self.round, delta.index),
+                id: delta.id.clone(),
+                name: delta.name.clone(),
+                arguments_delta: delta.arguments_delta.clone(),
+                reset: delta.reset,
+            },
         );
     }
     fn on_usage(&mut self, _u: wisp_llm::Usage) {}
@@ -362,9 +380,9 @@ mod tests {
     }
 
     #[test]
-    fn tool_call_snapshots_become_live_draft_events() {
+    fn tool_call_deltas_become_live_draft_events_without_accumulating() {
         use crate::runtime_event::{AgentRuntimeEvent, ToolInvocationKey};
-        use wisp_llm::ToolCallSnapshot;
+        use wisp_llm::ToolCallDelta;
 
         struct Recorder(Mutex<Vec<AgentRuntimeEvent>>);
         impl Output for Recorder {
@@ -375,37 +393,58 @@ mod tests {
 
         let out = Recorder(Mutex::new(Vec::new()));
         let mut sink = StreamSinkAdapter::new(&out).for_round(3);
-        // Fragments arrive; each emission is a full snapshot keyed by
-        // (round, index). The id appears once the stream reveals it.
-        sink.on_tool_call(&ToolCallSnapshot {
-            index: 1,
-            id: None,
-            name: "read".into(),
-            arguments_so_far: "{\"pa".into(),
-        });
-        sink.on_tool_call(&ToolCallSnapshot {
+        // Fragments arrive keyed by (round, index): a reset carrying id/name,
+        // then pure argument fragments. The adapter forwards them verbatim —
+        // it never concatenates arguments itself.
+        sink.on_tool_call(&ToolCallDelta {
             index: 1,
             id: Some("call-9".into()),
-            name: "read".into(),
-            arguments_so_far: "{\"path\":\"a.txt\"}".into(),
+            name: Some("read".into()),
+            arguments_delta: String::new(),
+            reset: true,
+        });
+        sink.on_tool_call(&ToolCallDelta {
+            index: 1,
+            id: None,
+            name: None,
+            arguments_delta: "{\"pa".into(),
+            reset: false,
+        });
+        sink.on_tool_call(&ToolCallDelta {
+            index: 1,
+            id: None,
+            name: None,
+            arguments_delta: "th\":\"a.txt\"}".into(),
+            reset: false,
         });
 
         let events = out.0.lock().unwrap();
-        assert_eq!(events.len(), 2);
-        let mut drafts = events.iter().map(|event| {
-            let AgentRuntimeEvent::AssistantToolCallUpdated(draft) = event else {
-                panic!("expected a draft event, got {event:?}");
-            };
-            assert_eq!(draft.key, ToolInvocationKey::draft(3, 1));
-            assert_eq!(draft.name, "read");
-            draft
-        });
-        let first = drafts.next().unwrap();
-        assert_eq!(first.id, None);
-        assert_eq!(first.arguments_so_far, "{\"pa");
-        let second = drafts.next().unwrap();
-        assert_eq!(second.id.as_deref(), Some("call-9"));
-        assert_eq!(second.arguments_so_far, "{\"path\":\"a.txt\"}");
+        assert_eq!(
+            events.as_slice(),
+            &[
+                AgentRuntimeEvent::AssistantToolCallDelta {
+                    key: ToolInvocationKey::draft(3, 1),
+                    id: Some("call-9".into()),
+                    name: Some("read".into()),
+                    arguments_delta: String::new(),
+                    reset: true,
+                },
+                AgentRuntimeEvent::AssistantToolCallDelta {
+                    key: ToolInvocationKey::draft(3, 1),
+                    id: None,
+                    name: None,
+                    arguments_delta: "{\"pa".into(),
+                    reset: false,
+                },
+                AgentRuntimeEvent::AssistantToolCallDelta {
+                    key: ToolInvocationKey::draft(3, 1),
+                    id: None,
+                    name: None,
+                    arguments_delta: "th\":\"a.txt\"}".into(),
+                    reset: false,
+                },
+            ]
+        );
     }
 
     struct AsyncConfirmOutput {

--- a/crates/wisp-core/src/runtime_event.rs
+++ b/crates/wisp-core/src/runtime_event.rs
@@ -11,14 +11,22 @@
 //! tell "the model is still typing arguments" apart from "the tool is
 //! actually running":
 //!
-//! - [`AgentRuntimeEvent::AssistantToolCallUpdated`]: argument draft, still
-//!   streaming. Live-only; never persisted.
+//! - [`AgentRuntimeEvent::AssistantToolCallDelta`]: argument draft, still
+//!   streaming. Live-only; never persisted. Deltas append per key; a provider
+//!   retry replaces prior state via `reset`, and a cancel/truncate clears
+//!   drafts via the round/run boundary events as before.
 //! - [`AgentRuntimeEvent::ToolCallReady`]: the assistant message is complete
 //!   and the call's arguments are final.
-//! - [`AgentRuntimeEvent::ToolExecutionStarted`] / `Updated` / `Finished`:
-//!   the tool is executing.
+//! - [`AgentRuntimeEvent::ToolExecutionStarted`]: the call actually began —
+//!   it fires once the registry's non-interactive policy checks (project
+//!   write lock, plan-mode gate, explicit `Deny`) have passed and the call
+//!   card is up. An interactive denial afterwards (confirm prompt, resource
+//!   conflict) is Started→Blocked.
+//! - [`AgentRuntimeEvent::ToolExecutionUpdated`] / `Finished`: the tool is
+//!   executing / done.
 //! - [`AgentRuntimeEvent::ToolExecutionBlocked`]: the call was rejected by a
-//!   policy or user decision instead of running.
+//!   policy or user decision instead of running. A policy refusal is Blocked
+//!   with no Started; a skipped sibling is likewise Blocked only.
 //!
 //! Exactly one [`AgentRuntimeEvent::RunFinished`] is emitted per run, whether
 //! the run completes, fails, is truncated, or is cancelled.
@@ -79,19 +87,6 @@ pub fn bound_tool_details(details: serde_json::Value) -> serde_json::Value {
     })
 }
 
-/// Snapshot of a tool call whose arguments are still streaming. Always a
-/// full snapshot (never a delta): a retry replaces the previous snapshot for
-/// the same `(round, index)` instead of appending to it.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ToolCallDraft {
-    pub key: ToolInvocationKey,
-    /// Provider-assigned call id, once the stream has revealed it.
-    pub id: Option<String>,
-    pub name: String,
-    /// Raw arguments received so far — possibly not yet valid JSON.
-    pub arguments_so_far: String,
-}
-
 #[derive(Debug, Clone, PartialEq)]
 pub enum AgentRuntimeEvent {
     RunStarted,
@@ -109,10 +104,22 @@ pub enum AgentRuntimeEvent {
         round: usize,
         delta: String,
     },
-    /// A tool-call argument draft updated. Live-only: hosts must not persist
-    /// `arguments_so_far` (it may be incomplete or sensitive); render only
-    /// what the tool's `preview()` produces from it.
-    AssistantToolCallUpdated(ToolCallDraft),
+    /// One fragment of a tool-call argument draft, still streaming. Live-only:
+    /// hosts accumulate `arguments_delta` per key (applying `reset` first) and
+    /// must never persist the raw text (it may be incomplete or sensitive);
+    /// render only what the tool's `preview()` produces from the accumulation.
+    AssistantToolCallDelta {
+        key: ToolInvocationKey,
+        /// Provider-assigned call id fragment, when this chunk carries it.
+        id: Option<String>,
+        /// Tool name fragment, when this chunk carries it.
+        name: Option<String>,
+        /// New argument text to append to the host-side accumulator for `key`.
+        arguments_delta: String,
+        /// First fragment of this call — or of a retried attempt reusing the
+        /// index: drop previously accumulated state for `key` before applying.
+        reset: bool,
+    },
     AssistantMessageFinished {
         round: usize,
     },
@@ -121,6 +128,13 @@ pub enum AgentRuntimeEvent {
         key: ToolInvocationKey,
         name: String,
     },
+    /// The call actually began executing: the registry's non-interactive
+    /// policy checks (project write lock, plan-mode gate, explicit `Deny`)
+    /// have passed and the call card is up. A refusal at those checks is
+    /// [`AgentRuntimeEvent::ToolExecutionBlocked`] with no Started; an
+    /// interactive denial afterwards (confirm prompt, resource conflict) is
+    /// Started→Blocked. `name` is the canonical event name (`mcp:`-prefixed
+    /// for deferred MCP tools), matching Finished/Blocked.
     ToolExecutionStarted {
         key: ToolInvocationKey,
         name: String,
@@ -141,7 +155,9 @@ pub enum AgentRuntimeEvent {
         details: Option<serde_json::Value>,
     },
     /// The call did not run: a user decision on a sibling call invalidated
-    /// it, or a policy refused it.
+    /// it, a policy (write lock, plan mode, explicit `Deny`) refused it, or
+    /// the user denied it at a confirm/resource prompt. Never paired with
+    /// Finished for the same key.
     ToolExecutionBlocked {
         key: ToolInvocationKey,
         name: String,

--- a/crates/wisp-core/src/runtime_event.rs
+++ b/crates/wisp-core/src/runtime_event.rs
@@ -59,6 +59,26 @@ pub enum RunOutcome {
     Failed(String),
 }
 
+/// Serialized-size cap for structured tool details/progress payloads. Tool
+/// output is an unbounded external payload; details forwarded to hosts must
+/// stay small enough to persist and stream per tool call.
+pub const TOOL_DETAILS_MAX_BYTES: usize = 16 * 1024;
+
+/// Bound one structured details payload for event forwarding. Values whose
+/// serialized form exceeds [`TOOL_DETAILS_MAX_BYTES`] are replaced by a small
+/// marker object — large details must be capped (or converted to a reference
+/// by the tool itself), never forwarded unbounded.
+pub fn bound_tool_details(details: serde_json::Value) -> serde_json::Value {
+    let serialized = serde_json::to_string(&details).unwrap_or_default();
+    if serialized.len() <= TOOL_DETAILS_MAX_BYTES {
+        return details;
+    }
+    serde_json::json!({
+        "truncated": true,
+        "original_bytes": serialized.len(),
+    })
+}
+
 /// Snapshot of a tool call whose arguments are still streaming. Always a
 /// full snapshot (never a delta): a retry replaces the previous snapshot for
 /// the same `(round, index)` instead of appending to it.
@@ -115,6 +135,10 @@ pub enum AgentRuntimeEvent {
         name: String,
         ok: bool,
         duration_ms: u64,
+        /// The tool's final structured details (bounded via
+        /// [`bound_tool_details`]). Host/UI only; never enters the model
+        /// context.
+        details: Option<serde_json::Value>,
     },
     /// The call did not run: a user decision on a sibling call invalidated
     /// it, or a policy refused it.
@@ -129,4 +153,24 @@ pub enum AgentRuntimeEvent {
     RunFinished {
         outcome: RunOutcome,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn small_details_pass_through_untouched() {
+        let details = serde_json::json!({"run_id": "r1", "status": "running"});
+        assert_eq!(bound_tool_details(details.clone()), details);
+    }
+
+    #[test]
+    fn oversized_details_collapse_to_a_marker() {
+        let details = serde_json::json!({"blob": "x".repeat(TOOL_DETAILS_MAX_BYTES + 1)});
+        let bounded = bound_tool_details(details);
+        assert_eq!(bounded["truncated"], serde_json::json!(true));
+        assert!(bounded["original_bytes"].as_u64().unwrap() as usize > TOOL_DETAILS_MAX_BYTES);
+        assert!(serde_json::to_string(&bounded).unwrap().len() <= TOOL_DETAILS_MAX_BYTES);
+    }
 }

--- a/crates/wisp-core/src/runtime_event.rs
+++ b/crates/wisp-core/src/runtime_event.rs
@@ -1,0 +1,132 @@
+//! Structured lifecycle events for one agent run.
+//!
+//! The agent loop emits these through [`crate::Output::runtime_event`]. They
+//! are host-agnostic: the Tauri shell projects them onto its own UI event
+//! protocol and headless hosts can ignore them entirely. Terminology:
+//!
+//! - **Run**: one `agent_loop` / `agent_loop_continue` invocation.
+//! - **Round**: one model request together with the tool batch it triggers.
+//!
+//! Tool lifecycle is deliberately split into distinct states so a host can
+//! tell "the model is still typing arguments" apart from "the tool is
+//! actually running":
+//!
+//! - [`AgentRuntimeEvent::AssistantToolCallUpdated`]: argument draft, still
+//!   streaming. Live-only; never persisted.
+//! - [`AgentRuntimeEvent::ToolCallReady`]: the assistant message is complete
+//!   and the call's arguments are final.
+//! - [`AgentRuntimeEvent::ToolExecutionStarted`] / `Updated` / `Finished`:
+//!   the tool is executing.
+//! - [`AgentRuntimeEvent::ToolExecutionBlocked`]: the call was rejected by a
+//!   policy or user decision instead of running.
+//!
+//! Exactly one [`AgentRuntimeEvent::RunFinished`] is emitted per run, whether
+//! the run completes, fails, is truncated, or is cancelled.
+
+/// Stable identity of one tool invocation within a run. The draft phase keys
+/// on `(round, index)` only; `call_id` is bound once the assistant message
+/// finishes and the provider-assigned id is known.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ToolInvocationKey {
+    pub round: usize,
+    pub index: usize,
+    pub call_id: Option<String>,
+}
+
+impl ToolInvocationKey {
+    pub fn draft(round: usize, index: usize) -> Self {
+        Self {
+            round,
+            index,
+            call_id: None,
+        }
+    }
+
+    pub fn ready(round: usize, index: usize, call_id: impl Into<String>) -> Self {
+        Self {
+            round,
+            index,
+            call_id: Some(call_id.into()),
+        }
+    }
+}
+
+/// How a run ended. `Failed` carries the user-facing error message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RunOutcome {
+    Completed,
+    Cancelled,
+    Failed(String),
+}
+
+/// Snapshot of a tool call whose arguments are still streaming. Always a
+/// full snapshot (never a delta): a retry replaces the previous snapshot for
+/// the same `(round, index)` instead of appending to it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolCallDraft {
+    pub key: ToolInvocationKey,
+    /// Provider-assigned call id, once the stream has revealed it.
+    pub id: Option<String>,
+    pub name: String,
+    /// Raw arguments received so far — possibly not yet valid JSON.
+    pub arguments_so_far: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum AgentRuntimeEvent {
+    RunStarted,
+    RoundStarted {
+        round: usize,
+    },
+    AssistantMessageStarted {
+        round: usize,
+    },
+    AssistantTextDelta {
+        round: usize,
+        delta: String,
+    },
+    AssistantReasoningDelta {
+        round: usize,
+        delta: String,
+    },
+    /// A tool-call argument draft updated. Live-only: hosts must not persist
+    /// `arguments_so_far` (it may be incomplete or sensitive); render only
+    /// what the tool's `preview()` produces from it.
+    AssistantToolCallUpdated(ToolCallDraft),
+    AssistantMessageFinished {
+        round: usize,
+    },
+    /// The assistant message is complete; this call's arguments are final.
+    ToolCallReady {
+        key: ToolInvocationKey,
+        name: String,
+    },
+    ToolExecutionStarted {
+        key: ToolInvocationKey,
+        name: String,
+    },
+    /// Structured mid-execution progress. Never enters the model context.
+    ToolExecutionUpdated {
+        key: ToolInvocationKey,
+        details: serde_json::Value,
+    },
+    ToolExecutionFinished {
+        key: ToolInvocationKey,
+        name: String,
+        ok: bool,
+        duration_ms: u64,
+    },
+    /// The call did not run: a user decision on a sibling call invalidated
+    /// it, or a policy refused it.
+    ToolExecutionBlocked {
+        key: ToolInvocationKey,
+        name: String,
+        reason: String,
+    },
+    RoundFinished {
+        round: usize,
+    },
+    RunFinished {
+        outcome: RunOutcome,
+    },
+}

--- a/crates/wisp-llm/src/anthropic.rs
+++ b/crates/wisp-llm/src/anthropic.rs
@@ -435,7 +435,12 @@ impl Provider for AnthropicProvider {
                                 if let Some(p) = delta.get("partial_json").and_then(|v| v.as_str())
                                 {
                                     b.input.push_str(p);
-                                    sink.on_tool_call(i, &b.name, &b.input);
+                                    sink.on_tool_call(&crate::provider::ToolCallSnapshot {
+                                        index: i,
+                                        id: (!b.id.is_empty()).then(|| b.id.clone()),
+                                        name: b.name.clone(),
+                                        arguments_so_far: b.input.clone(),
+                                    });
                                 }
                             }
                             Some("thinking_delta") => {

--- a/crates/wisp-llm/src/anthropic.rs
+++ b/crates/wisp-llm/src/anthropic.rs
@@ -349,6 +349,14 @@ impl Provider for AnthropicProvider {
         // index -> (type, id, name, input_json_accumulator, text_accumulator)
         let mut blocks: std::collections::BTreeMap<usize, BlockAcc> =
             std::collections::BTreeMap::new();
+        // content_block.index -> tool-call ordinal. Anthropic numbers *all*
+        // content blocks (text, thinking, tool_use), but the final tool_calls
+        // vector keeps only tool_use blocks and re-enumerates from 0 — and
+        // downstream consumers key drafts by that tool ordinal. Assign the
+        // ordinal when each tool_use block starts so draft and final keys
+        // agree even when text/thinking blocks precede a call.
+        let mut tool_ordinals: std::collections::HashMap<usize, usize> =
+            std::collections::HashMap::new();
         let mut content = String::new();
         let mut finish_reason: Option<String> = None;
         let mut usage = Usage::default();
@@ -407,13 +415,27 @@ impl Provider for AnthropicProvider {
                         blocks.insert(
                             i,
                             BlockAcc {
-                                kind,
+                                kind: kind.clone(),
                                 id,
                                 name,
                                 input: String::new(),
                                 text: String::new(),
                             },
                         );
+                        if kind == "tool_use" {
+                            let b = blocks.get(&i).expect("block just inserted");
+                            let ordinal = tool_ordinals.len();
+                            tool_ordinals.insert(i, ordinal);
+                            // First fragment of the call: reset any prior
+                            // accumulator state and carry the id/name.
+                            sink.on_tool_call(&crate::provider::ToolCallDelta {
+                                index: ordinal,
+                                id: (!b.id.is_empty()).then(|| b.id.clone()),
+                                name: (!b.name.is_empty()).then(|| b.name.clone()),
+                                arguments_delta: String::new(),
+                                reset: true,
+                            });
+                        }
                     }
                     "content_block_delta" => {
                         let i = val.get("index").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
@@ -435,12 +457,15 @@ impl Provider for AnthropicProvider {
                                 if let Some(p) = delta.get("partial_json").and_then(|v| v.as_str())
                                 {
                                     b.input.push_str(p);
-                                    sink.on_tool_call(&crate::provider::ToolCallSnapshot {
-                                        index: i,
-                                        id: (!b.id.is_empty()).then(|| b.id.clone()),
-                                        name: b.name.clone(),
-                                        arguments_so_far: b.input.clone(),
-                                    });
+                                    if let Some(&ordinal) = tool_ordinals.get(&i) {
+                                        sink.on_tool_call(&crate::provider::ToolCallDelta {
+                                            index: ordinal,
+                                            id: None,
+                                            name: None,
+                                            arguments_delta: p.to_string(),
+                                            reset: false,
+                                        });
+                                    }
                                 }
                             }
                             Some("thinking_delta") => {
@@ -536,6 +561,136 @@ fn anthropic_stream_event_is_error(event_type: &str, value: &Value) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::provider::ToolCallDelta;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    /// Serve one canned SSE response body over a local HTTP connection.
+    async fn serve_sse(body: &'static str) -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = vec![0; 16 * 1024];
+            let _ = socket.read(&mut request).await.unwrap();
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            socket.write_all(response.as_bytes()).await.unwrap();
+        });
+        format!("http://{address}")
+    }
+
+    #[derive(Default)]
+    struct RecordingSink {
+        tool_deltas: Vec<ToolCallDelta>,
+    }
+
+    impl StreamSink for RecordingSink {
+        fn on_text(&mut self, _: &str) {}
+        fn on_reasoning(&mut self, _: &str) {}
+        fn on_tool_call(&mut self, delta: &ToolCallDelta) {
+            self.tool_deltas.push(delta.clone());
+        }
+        fn on_usage(&mut self, _: Usage) {}
+    }
+
+    // Anthropic indexes ALL content blocks (text, thinking, tool_use) while
+    // the final tool_calls vector keeps only tool_use blocks and re-enumerates
+    // from 0. Draft fragments must use that same tool ordinal, or a text block
+    // in front of a call leaves a ghost draft keyed by the raw block index.
+    #[tokio::test]
+    async fn mixed_text_thinking_tool_stream_keys_drafts_by_tool_ordinal() {
+        let sse = concat!(
+            "event: message_start\n",
+            "data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":10,\"output_tokens\":1}}}\n\n",
+            "event: content_block_start\n",
+            "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\n",
+            "event: content_block_delta\n",
+            "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"checking\"}}\n\n",
+            "event: content_block_start\n",
+            "data: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"thinking\",\"thinking\":\"\"}}\n\n",
+            "event: content_block_delta\n",
+            "data: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"hmm\"}}\n\n",
+            "event: content_block_start\n",
+            "data: {\"type\":\"content_block_start\",\"index\":2,\"content_block\":{\"type\":\"tool_use\",\"id\":\"tu_1\",\"name\":\"read\",\"input\":{}}}\n\n",
+            "event: content_block_delta\n",
+            "data: {\"type\":\"content_block_delta\",\"index\":2,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"path\\\":\"}}\n\n",
+            "event: content_block_delta\n",
+            "data: {\"type\":\"content_block_delta\",\"index\":2,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"\\\"a.txt\\\"}\"}}\n\n",
+            "event: content_block_start\n",
+            "data: {\"type\":\"content_block_start\",\"index\":3,\"content_block\":{\"type\":\"tool_use\",\"id\":\"tu_2\",\"name\":\"write\",\"input\":{}}}\n\n",
+            "event: content_block_delta\n",
+            "data: {\"type\":\"content_block_delta\",\"index\":3,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{}\"}}\n\n",
+            "event: message_delta\n",
+            "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\"},\"usage\":{\"output_tokens\":20}}\n\n",
+            "event: message_stop\n",
+            "data: {\"type\":\"message_stop\"}\n\n",
+        );
+        let base_url = serve_sse(sse).await;
+        let mut cfg = crate::ProviderConfig::anthropic(&base_url, "test-key", "claude-test");
+        cfg.proxy = Some("none".into());
+        let provider = AnthropicProvider::new(cfg);
+        let mut sink = RecordingSink::default();
+
+        let completion = provider
+            .stream(&[Message::user("read then write")], &[], &mut sink)
+            .await
+            .unwrap();
+
+        // Final calls: only the two tool_use blocks, re-enumerated 0 and 1.
+        assert_eq!(completion.tool_calls.len(), 2);
+        assert_eq!(completion.tool_calls[0].id, "tu_1");
+        assert_eq!(completion.tool_calls[0].function.name, "read");
+        assert_eq!(
+            completion.tool_calls[0].function.arguments,
+            "{\"path\":\"a.txt\"}"
+        );
+        assert_eq!(completion.tool_calls[1].id, "tu_2");
+
+        // Draft fragments must key on those same ordinals — never on the raw
+        // content_block.index (2 and 3) — and stream as reset + deltas.
+        assert_eq!(
+            sink.tool_deltas,
+            vec![
+                ToolCallDelta {
+                    index: 0,
+                    id: Some("tu_1".into()),
+                    name: Some("read".into()),
+                    arguments_delta: String::new(),
+                    reset: true,
+                },
+                ToolCallDelta {
+                    index: 0,
+                    id: None,
+                    name: None,
+                    arguments_delta: "{\"path\":".into(),
+                    reset: false,
+                },
+                ToolCallDelta {
+                    index: 0,
+                    id: None,
+                    name: None,
+                    arguments_delta: "\"a.txt\"}".into(),
+                    reset: false,
+                },
+                ToolCallDelta {
+                    index: 1,
+                    id: Some("tu_2".into()),
+                    name: Some("write".into()),
+                    arguments_delta: String::new(),
+                    reset: true,
+                },
+                ToolCallDelta {
+                    index: 1,
+                    id: None,
+                    name: None,
+                    arguments_delta: "{}".into(),
+                    reset: false,
+                },
+            ]
+        );
+    }
 
     fn assistant_with_call(text: &str, call_id: &str, name: &str, args: &str) -> Message {
         let mut m = Message::assistant(text);

--- a/crates/wisp-llm/src/lib.rs
+++ b/crates/wisp-llm/src/lib.rs
@@ -21,6 +21,7 @@ pub use message::{
 };
 pub use provider::{
     build, is_retriable, NullSink, Provider, ProviderConfig, ProviderKind, StreamSink,
+    ToolCallSnapshot,
 };
 pub use provider::{LlmError, Result};
 pub use routed::RoutedProvider;

--- a/crates/wisp-llm/src/lib.rs
+++ b/crates/wisp-llm/src/lib.rs
@@ -21,7 +21,7 @@ pub use message::{
 };
 pub use provider::{
     build, is_retriable, NullSink, Provider, ProviderConfig, ProviderKind, StreamSink,
-    ToolCallSnapshot,
+    ToolCallDelta,
 };
 pub use provider::{LlmError, Result};
 pub use routed::RoutedProvider;

--- a/crates/wisp-llm/src/openai.rs
+++ b/crates/wisp-llm/src/openai.rs
@@ -520,7 +520,12 @@ impl Provider for OpenAiProvider {
                                 .entry(i)
                                 .or_insert_with(|| (String::new(), String::new(), String::new()));
                             merge_stream_tool_call_delta(entry, tc);
-                            sink.on_tool_call(i, &entry.1, &entry.2);
+                            sink.on_tool_call(&crate::provider::ToolCallSnapshot {
+                                index: i,
+                                id: (!entry.0.is_empty()).then(|| entry.0.clone()),
+                                name: entry.1.clone(),
+                                arguments_so_far: entry.2.clone(),
+                            });
                         }
                     }
                     if let Some(fr) = choice.get("finish_reason").and_then(|v| v.as_str()) {
@@ -622,7 +627,7 @@ mod tests {
             self.reasoning.push(delta.into());
         }
 
-        fn on_tool_call(&mut self, _: usize, _: &str, _: &str) {}
+        fn on_tool_call(&mut self, _: &crate::provider::ToolCallSnapshot) {}
 
         fn on_usage(&mut self, _: Usage) {}
     }

--- a/crates/wisp-llm/src/openai.rs
+++ b/crates/wisp-llm/src/openai.rs
@@ -329,14 +329,14 @@ fn normalize_tool_calls(msg: &Value) -> Vec<ToolCall> {
     out
 }
 
-fn merge_stream_tool_call_delta(entry: &mut (String, String, String), tc: &Value) {
-    if let Some(id) = tc
+/// Extract the id/name/arguments fragments one `tool_calls[]` delta chunk
+/// carries. Any of the three may be absent from a given chunk.
+fn stream_tool_call_fragments(tc: &Value) -> (Option<String>, Option<String>, Option<String>) {
+    let id = tc
         .get("id")
         .and_then(|v| v.as_str())
         .filter(|s| !s.is_empty())
-    {
-        entry.0 = id.to_string();
-    }
+        .map(str::to_string);
     let function = tc.get("function").and_then(|v| v.as_object());
     let name = function
         .and_then(|f| f.get("name"))
@@ -346,17 +346,27 @@ fn merge_stream_tool_call_delta(entry: &mut (String, String, String), tc: &Value
             tc.get("name")
                 .and_then(|v| v.as_str())
                 .filter(|s| !s.is_empty())
-        });
-    if let Some(name) = name {
-        entry.1 = openai_internal_tool_name(name).to_string();
-    }
+        })
+        .map(|name| openai_internal_tool_name(name).to_string());
     let arguments = function
         .and_then(|f| f.get("arguments"))
         .and_then(|v| v.as_str())
         .filter(|s| !s.is_empty())
-        .or_else(|| tc.get("arguments").and_then(|v| v.as_str()));
+        .or_else(|| tc.get("arguments").and_then(|v| v.as_str()))
+        .map(str::to_string);
+    (id, name, arguments)
+}
+
+fn merge_stream_tool_call_delta(entry: &mut (String, String, String), tc: &Value) {
+    let (id, name, arguments) = stream_tool_call_fragments(tc);
+    if let Some(id) = id {
+        entry.0 = id;
+    }
+    if let Some(name) = name {
+        entry.1 = name;
+    }
     if let Some(arguments) = arguments {
-        entry.2.push_str(arguments);
+        entry.2.push_str(&arguments);
     }
 }
 
@@ -458,6 +468,10 @@ impl Provider for OpenAiProvider {
         // index -> (id, name, arguments)
         let mut tool_calls: std::collections::BTreeMap<usize, (String, String, String)> =
             std::collections::BTreeMap::new();
+        // Indices already seen in this stream attempt: their first chunk
+        // carries `reset` so a retry reusing an index restarts accumulation.
+        let mut seen_tool_call_indices: std::collections::HashSet<usize> =
+            std::collections::HashSet::new();
         let mut finish_reason: Option<String> = None;
         let mut usage = Usage::default();
         let mut saw_done = false;
@@ -516,15 +530,20 @@ impl Provider for OpenAiProvider {
                     if let Some(tcs) = delta.get("tool_calls").and_then(|v| v.as_array()) {
                         for tc in tcs {
                             let i = tc.get("index").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+                            // First chunk of this call (or of a retried attempt
+                            // reusing the index) resets downstream accumulators.
+                            let reset = seen_tool_call_indices.insert(i);
+                            let (id, name, arguments) = stream_tool_call_fragments(tc);
                             let entry = tool_calls
                                 .entry(i)
                                 .or_insert_with(|| (String::new(), String::new(), String::new()));
                             merge_stream_tool_call_delta(entry, tc);
-                            sink.on_tool_call(&crate::provider::ToolCallSnapshot {
+                            sink.on_tool_call(&crate::provider::ToolCallDelta {
                                 index: i,
-                                id: (!entry.0.is_empty()).then(|| entry.0.clone()),
-                                name: entry.1.clone(),
-                                arguments_so_far: entry.2.clone(),
+                                id,
+                                name,
+                                arguments_delta: arguments.unwrap_or_default(),
+                                reset,
                             });
                         }
                     }
@@ -616,6 +635,7 @@ mod tests {
     struct RecordingSink {
         text: Vec<String>,
         reasoning: Vec<String>,
+        tool_deltas: Vec<crate::provider::ToolCallDelta>,
     }
 
     impl StreamSink for RecordingSink {
@@ -627,7 +647,9 @@ mod tests {
             self.reasoning.push(delta.into());
         }
 
-        fn on_tool_call(&mut self, _: &crate::provider::ToolCallSnapshot) {}
+        fn on_tool_call(&mut self, delta: &crate::provider::ToolCallDelta) {
+            self.tool_deltas.push(delta.clone());
+        }
 
         fn on_usage(&mut self, _: Usage) {}
     }
@@ -762,6 +784,62 @@ mod tests {
 
         assert!(matches!(error, LlmError::Incomplete));
         assert_eq!(sink.text, ["partial"]);
+        assert_eq!(requests.await.unwrap(), ["/chat/completions"]);
+    }
+
+    #[tokio::test]
+    async fn stream_emits_argument_fragments_as_deltas_without_accumulating() {
+        let (base_url, requests) = serve_responses(vec![(
+            "200 OK",
+            "text/event-stream",
+            concat!(
+                "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"read\",\"arguments\":\"\"}}]}}]}\n\n",
+                "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"pa\"}}]}}]}\n\n",
+                "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"th\\\":\\\"a\\\"}\"}}]}}]}\n\n",
+                "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n",
+                "data: [DONE]\n\n",
+            ),
+        )])
+        .await;
+        let provider = local_provider(&base_url);
+        let mut sink = RecordingSink::default();
+
+        let completion = provider
+            .stream(&[Message::user("read a file")], &[], &mut sink)
+            .await
+            .unwrap();
+
+        assert_eq!(completion.tool_calls.len(), 1);
+        assert_eq!(
+            completion.tool_calls[0].function.arguments,
+            "{\"path\":\"a\"}"
+        );
+        assert_eq!(
+            sink.tool_deltas,
+            vec![
+                crate::provider::ToolCallDelta {
+                    index: 0,
+                    id: Some("call_1".into()),
+                    name: Some("read".into()),
+                    arguments_delta: String::new(),
+                    reset: true,
+                },
+                crate::provider::ToolCallDelta {
+                    index: 0,
+                    id: None,
+                    name: None,
+                    arguments_delta: "{\"pa".into(),
+                    reset: false,
+                },
+                crate::provider::ToolCallDelta {
+                    index: 0,
+                    id: None,
+                    name: None,
+                    arguments_delta: "th\":\"a\"}".into(),
+                    reset: false,
+                },
+            ]
+        );
         assert_eq!(requests.await.unwrap(), ["/chat/completions"]);
     }
 

--- a/crates/wisp-llm/src/provider.rs
+++ b/crates/wisp-llm/src/provider.rs
@@ -214,27 +214,34 @@ impl ProviderConfig {
     }
 }
 
-/// A tool call accumulated so far while its arguments are still streaming.
-/// Always a full snapshot, never a delta: consumers replace their previous
-/// state for `index` instead of appending (so a provider retry that restarts
-/// the stream cannot duplicate argument fragments).
+/// One incremental fragment of a streaming tool call. Providers emit only the
+/// new text (`arguments_delta`), never the arguments-so-far, so the per-chunk
+/// cost stays O(fragment) instead of O(call). Consumers keep their own
+/// accumulator per `index`: append `arguments_delta`, applying `reset` first.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ToolCallSnapshot {
+pub struct ToolCallDelta {
+    /// Tool-call ordinal within the completion (matches the position in the
+    /// final `Completion::tool_calls`).
     pub index: usize,
-    /// Provider-assigned call id, once the stream has revealed it.
+    /// Provider-assigned call id fragment, when this chunk carries it.
     pub id: Option<String>,
-    pub name: String,
-    /// Raw arguments received so far — possibly not yet valid JSON.
-    pub arguments_so_far: String,
+    /// Tool name fragment, when this chunk carries it.
+    pub name: Option<String>,
+    /// New argument text to append — possibly not yet valid JSON.
+    pub arguments_delta: String,
+    /// First fragment of this call — or of a retried attempt reusing the same
+    /// index. Accumulators must drop previous state for `index` before
+    /// applying, so a restarted stream cannot duplicate argument fragments.
+    pub reset: bool,
 }
 
 /// Callbacks the agent loop receives while a streamed completion is in flight.
 pub trait StreamSink: Send {
     fn on_text(&mut self, delta: &str);
     fn on_reasoning(&mut self, delta: &str);
-    /// A tool call accumulated so far. Called as argument fragments arrive so
-    /// the UI can render an in-progress call.
-    fn on_tool_call(&mut self, snapshot: &ToolCallSnapshot);
+    /// One fragment of an in-progress tool call. Called as argument fragments
+    /// arrive so the UI can render the call while it streams.
+    fn on_tool_call(&mut self, delta: &ToolCallDelta);
     fn on_usage(&mut self, usage: crate::Usage);
     /// Whether the user requested cancellation. Streaming loops poll this each
     /// chunk so a Stop interrupts token generation mid-stream, not only between
@@ -249,7 +256,7 @@ pub struct NullSink;
 impl StreamSink for NullSink {
     fn on_text(&mut self, _: &str) {}
     fn on_reasoning(&mut self, _: &str) {}
-    fn on_tool_call(&mut self, _: &ToolCallSnapshot) {}
+    fn on_tool_call(&mut self, _: &ToolCallDelta) {}
     fn on_usage(&mut self, _: crate::Usage) {}
 }
 

--- a/crates/wisp-llm/src/provider.rs
+++ b/crates/wisp-llm/src/provider.rs
@@ -214,13 +214,27 @@ impl ProviderConfig {
     }
 }
 
+/// A tool call accumulated so far while its arguments are still streaming.
+/// Always a full snapshot, never a delta: consumers replace their previous
+/// state for `index` instead of appending (so a provider retry that restarts
+/// the stream cannot duplicate argument fragments).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolCallSnapshot {
+    pub index: usize,
+    /// Provider-assigned call id, once the stream has revealed it.
+    pub id: Option<String>,
+    pub name: String,
+    /// Raw arguments received so far — possibly not yet valid JSON.
+    pub arguments_so_far: String,
+}
+
 /// Callbacks the agent loop receives while a streamed completion is in flight.
 pub trait StreamSink: Send {
     fn on_text(&mut self, delta: &str);
     fn on_reasoning(&mut self, delta: &str);
-    /// A tool call accumulated so far (index, name, arguments-so-far). Called
-    /// as argument fragments arrive so the UI can render an in-progress call.
-    fn on_tool_call(&mut self, index: usize, name: &str, arguments_so_far: &str);
+    /// A tool call accumulated so far. Called as argument fragments arrive so
+    /// the UI can render an in-progress call.
+    fn on_tool_call(&mut self, snapshot: &ToolCallSnapshot);
     fn on_usage(&mut self, usage: crate::Usage);
     /// Whether the user requested cancellation. Streaming loops poll this each
     /// chunk so a Stop interrupts token generation mid-stream, not only between
@@ -235,7 +249,7 @@ pub struct NullSink;
 impl StreamSink for NullSink {
     fn on_text(&mut self, _: &str) {}
     fn on_reasoning(&mut self, _: &str) {}
-    fn on_tool_call(&mut self, _: usize, _: &str, _: &str) {}
+    fn on_tool_call(&mut self, _: &ToolCallSnapshot) {}
     fn on_usage(&mut self, _: crate::Usage) {}
 }
 

--- a/crates/wisp-llm/src/responses.rs
+++ b/crates/wisp-llm/src/responses.rs
@@ -312,7 +312,12 @@ impl Provider for OpenAiResponsesProvider {
             sink.on_text(&comp.content);
         }
         for (i, tc) in comp.tool_calls.iter().enumerate() {
-            sink.on_tool_call(i, &tc.function.name, &tc.function.arguments);
+            sink.on_tool_call(&crate::provider::ToolCallSnapshot {
+                index: i,
+                id: Some(tc.id.clone()),
+                name: tc.function.name.clone(),
+                arguments_so_far: tc.function.arguments.clone(),
+            });
         }
         sink.on_usage(comp.usage.clone());
         Ok(comp)

--- a/crates/wisp-llm/src/responses.rs
+++ b/crates/wisp-llm/src/responses.rs
@@ -312,11 +312,14 @@ impl Provider for OpenAiResponsesProvider {
             sink.on_text(&comp.content);
         }
         for (i, tc) in comp.tool_calls.iter().enumerate() {
-            sink.on_tool_call(&crate::provider::ToolCallSnapshot {
+            // Non-streaming endpoint: the whole call arrives at once, so one
+            // resetting delta carries the full arguments.
+            sink.on_tool_call(&crate::provider::ToolCallDelta {
                 index: i,
                 id: Some(tc.id.clone()),
-                name: tc.function.name.clone(),
-                arguments_so_far: tc.function.arguments.clone(),
+                name: Some(tc.function.name.clone()),
+                arguments_delta: tc.function.arguments.clone(),
+                reset: true,
             });
         }
         sink.on_usage(comp.usage.clone());
@@ -339,6 +342,75 @@ fn ensure_completed_response(value: &Value) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    /// Serve one canned JSON response body over a local HTTP connection.
+    async fn serve_json(body: &'static str) -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = vec![0; 16 * 1024];
+            let _ = socket.read(&mut request).await.unwrap();
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            socket.write_all(response.as_bytes()).await.unwrap();
+        });
+        format!("http://{address}")
+    }
+
+    // The non-streaming Responses endpoint delivers each call whole: exactly
+    // one resetting delta per call, carrying id, name, and full arguments.
+    #[tokio::test]
+    async fn stream_emits_one_reset_delta_per_call() {
+        let base_url = serve_json(
+            r#"{"status":"completed","output":[
+                {"type":"message","content":[{"text":"reading now"}]},
+                {"type":"function_call","call_id":"call_9","name":"read","arguments":"{\"path\":\"a.txt\"}"}
+            ],"usage":{"input_tokens":3,"output_tokens":5}}"#,
+        )
+        .await;
+        let mut cfg = crate::ProviderConfig::openai_responses(&base_url, "test-key", "gpt-test");
+        cfg.proxy = Some("none".into());
+        let provider = OpenAiResponsesProvider::new(cfg);
+
+        #[derive(Default)]
+        struct Sink {
+            text: Vec<String>,
+            tool_deltas: Vec<crate::provider::ToolCallDelta>,
+        }
+        impl StreamSink for Sink {
+            fn on_text(&mut self, delta: &str) {
+                self.text.push(delta.into());
+            }
+            fn on_reasoning(&mut self, _: &str) {}
+            fn on_tool_call(&mut self, delta: &crate::provider::ToolCallDelta) {
+                self.tool_deltas.push(delta.clone());
+            }
+            fn on_usage(&mut self, _: Usage) {}
+        }
+        let mut sink = Sink::default();
+
+        let completion = provider
+            .stream(&[Message::user("read a file")], &[], &mut sink)
+            .await
+            .unwrap();
+
+        assert_eq!(completion.tool_calls.len(), 1);
+        assert_eq!(sink.text, ["reading now"]);
+        assert_eq!(
+            sink.tool_deltas,
+            vec![crate::provider::ToolCallDelta {
+                index: 0,
+                id: Some("call_9".into()),
+                name: Some("read".into()),
+                arguments_delta: "{\"path\":\"a.txt\"}".into(),
+                reset: true,
+            }]
+        );
+    }
 
     fn assistant_with_call(text: &str, call_id: &str, name: &str, args: &str) -> Message {
         let mut m = Message::assistant(text);

--- a/crates/wisp-runtime/src/tool.rs
+++ b/crates/wisp-runtime/src/tool.rs
@@ -142,6 +142,7 @@ async fn run_runtime(
                         success,
                         content: format_response(&response),
                         image: None,
+                        details: None,
                         control: wisp_tools::ToolControl::Continue,
                     };
                 }

--- a/crates/wisp-runtime/src/tool.rs
+++ b/crates/wisp-runtime/src/tool.rs
@@ -144,6 +144,7 @@ async fn run_runtime(
                         image: None,
                         details: None,
                         control: wisp_tools::ToolControl::Continue,
+                        blocked: false,
                     };
                 }
                 Some(RuntimeEvent::Finished(Err(error))) => {

--- a/crates/wisp-store/src/project_transfer.rs
+++ b/crates/wisp-store/src/project_transfer.rs
@@ -870,6 +870,27 @@ async fn sanitize_export_machine_state(
     .bind(project_id)
     .execute(&mut **tx)
     .await?;
+    // The same launch environment is also content-addressed into
+    // `env_snapshots` (linked via `run_environment_snapshots`) and copied
+    // verbatim above. Its `context.config`/`context.capabilities` embed the
+    // execution context's machine-private fields (SSH user/port/identity
+    // file, interpreter paths) and `process` holds the launching machine's
+    // locale variables. `runs.env_snapshot_json` is already nulled above, so
+    // strip the same machine state here. The hash columns intentionally keep
+    // their original values: the export is a portable snapshot, not a
+    // verifiable content-addressed store.
+    sqlx::query(
+        "UPDATE env_snapshots SET \
+         snapshot_json=json_remove(snapshot_json,'$.context.config','$.context.capabilities','$.process') \
+         WHERE json_valid(snapshot_json) AND hash IN (\
+           SELECT link.env_snapshot_hash FROM run_environment_snapshots link \
+           JOIN runs run ON run.id=link.run_id WHERE run.project_id=?\
+         )",
+    )
+    .bind(project_id)
+    .execute(&mut **tx)
+    .await?;
+    sanitize_export_ui_events(tx, project_id).await?;
     sqlx::query(
         "UPDATE capsule_builds SET output_path=NULL \
          WHERE revision_id IN (\
@@ -881,6 +902,78 @@ async fn sanitize_export_machine_state(
     .bind(project_id)
     .execute(&mut **tx)
     .await?;
+    Ok(())
+}
+
+/// Allowlist of keys a run tool's structured `details` payload may keep in
+/// an export. Mirrors the producer-side presentation in
+/// `src-tauri/src/run_context/tools.rs` (`RunPresentationDetails`): anything
+/// not listed here is machine- or credential-adjacent — remote/local
+/// workdirs, remote handles, environment snapshots, command lines,
+/// interpreter paths, process-control tokens — and must not leave the
+/// device. `run_id` covers the `run_in_context` submission payload shape.
+const RUN_TOOL_DETAILS_EXPORT_ALLOWLIST: &[&str] = &[
+    "id",
+    "run_id",
+    "status",
+    "title",
+    "exit_code",
+    "created_at",
+    "started_at",
+    "ended_at",
+    "stdout_tail",
+    "stderr_tail",
+    "wait_detached",
+];
+
+/// Rewrite one persisted UI event to its export-safe form. Returns `Some`
+/// only when the event is a run tool's `ToolResultDetails` patch whose
+/// `details` had keys outside the allowlist (legacy rows persisted the full
+/// `RunRecord`); any other event — including other tools' details — is left
+/// byte-for-byte untouched.
+fn sanitize_run_tool_ui_event(event_json: &str) -> Option<String> {
+    let mut event: serde_json::Value = serde_json::from_str(event_json).ok()?;
+    if event.get("kind")?.as_str()? != "ToolResultDetails" {
+        return None;
+    }
+    let name = event.get("name")?.as_str()?;
+    if !matches!(name, "run_in_context" | "monitor_run" | "wisp_monitor_run") {
+        return None;
+    }
+    let details = event.get_mut("details")?.as_object_mut()?;
+    let before = details.len();
+    details.retain(|key, _| RUN_TOOL_DETAILS_EXPORT_ALLOWLIST.contains(&key.as_str()));
+    if details.len() == before {
+        return None;
+    }
+    serde_json::to_string(&event).ok()
+}
+
+/// `session_ui_events` rows are copied verbatim, so run tool detail patches
+/// persisted before the sanitized presentation existed would re-introduce
+/// the machine-private `RunRecord` fields scrubbed from the `runs` table
+/// above. Reduce them to the same allowlist the producer now emits.
+async fn sanitize_export_ui_events(
+    tx: &mut Transaction<'_, Sqlite>,
+    project_id: &str,
+) -> Result<()> {
+    let events: Vec<(String, i64, String)> = sqlx::query_as(
+        "SELECT frame_id,seq,event_json FROM session_ui_events \
+         WHERE frame_id IN (SELECT id FROM frames WHERE project_id=?)",
+    )
+    .bind(project_id)
+    .fetch_all(&mut **tx)
+    .await?;
+    for (frame_id, seq, event_json) in events {
+        if let Some(scrubbed) = sanitize_run_tool_ui_event(&event_json) {
+            sqlx::query("UPDATE session_ui_events SET event_json=? WHERE frame_id=? AND seq=?")
+                .bind(scrubbed)
+                .bind(frame_id)
+                .bind(seq)
+                .execute(&mut **tx)
+                .await?;
+        }
+    }
     Ok(())
 }
 
@@ -2613,6 +2706,158 @@ mod tests {
         );
         source.pool.close().await;
         for path in [source_path, first_path, second_path, edited_path] {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+
+    #[tokio::test]
+    async fn export_scrubs_machine_secrets_from_runs_and_run_tool_ui_events() {
+        let token = uuid::Uuid::new_v4();
+        let source_path =
+            std::env::temp_dir().join(format!("wisp_export_scrub_source_{token}.sqlite"));
+        let archive_path =
+            std::env::temp_dir().join(format!("wisp_export_scrub_archive_{token}.sqlite"));
+        let source = Store::open(&source_path).await.unwrap();
+        source
+            .create_project("project", "Scrub project", "workspace")
+            .await
+            .unwrap();
+        source
+            .create_frame("frame", "project", "Run frame", "model")
+            .await
+            .unwrap();
+        let mut run = RunRecord::new("run", "project", "ssh:gpu", "Sensitive run", "ssh_direct");
+        run.frame_id = Some("frame".into());
+        run.remote_workdir = Some("ssh://sentinel-host/home/sentinel/work".into());
+        run.remote_handle_json = Some(
+            r#"{"identity_file":"/home/sentinel/.ssh/id_sentinel","token":"SENTINEL-TOKEN"}"#
+                .into(),
+        );
+        // Production shape from `run_environment_snapshot`: the execution
+        // context's config (SSH user/port/identity file, interpreter paths)
+        // rides `context.config` and is also content-addressed into
+        // `env_snapshots`.
+        run.env_snapshot_json = serde_json::json!({
+            "schema_version": 2,
+            "context": {
+                "id": "ssh:gpu",
+                "kind": "ssh",
+                "config": {
+                    "user": "sentinel",
+                    "host": "ssh://sentinel-host",
+                    "identity_file": "/home/sentinel/.ssh/id_sentinel"
+                },
+                "capabilities": {"python_executable": "/home/sentinel/bin/python"}
+            },
+            "process": {"API_KEY": "SENTINEL-TOKEN"},
+            "wisp_host": {"os": "linux", "arch": "x86_64"}
+        })
+        .to_string();
+        run.progress_json = r#"{"host":"ssh://sentinel-host"}"#.into();
+        run.status = RunStatus::Succeeded;
+        source.create_run(&run).await.unwrap();
+        // Legacy persisted patch: run tool details held the full RunRecord,
+        // including fields even the `runs` export keeps (command lines).
+        let mut legacy_details = serde_json::to_value(&run).unwrap();
+        legacy_details["command"] =
+            serde_json::json!("SENTINEL-COMMAND /home/sentinel/.ssh/id_sentinel");
+        source
+            .append_session_ui_event(
+                "frame",
+                0,
+                &serde_json::json!({
+                    "kind": "ToolResultDetails",
+                    "frame_id": "frame",
+                    "call_key": "0:0",
+                    "name": "monitor_run",
+                    "details": legacy_details,
+                })
+                .to_string(),
+            )
+            .await
+            .unwrap();
+        // An unrelated tool's details must survive verbatim.
+        let shell_event = serde_json::json!({
+            "kind": "ToolResultDetails",
+            "frame_id": "frame",
+            "call_key": "0:1",
+            "name": "shell",
+            "details": {"stdout": "keep me"},
+        })
+        .to_string();
+        source
+            .append_session_ui_event("frame", 1, &shell_event)
+            .await
+            .unwrap();
+
+        source
+            .export_project_database("project", &archive_path)
+            .await
+            .unwrap();
+        source.pool.close().await;
+
+        // Scan every table of the exported database: no sentinel may appear
+        // anywhere, including inside serialized UI event payloads.
+        let options =
+            SqliteConnectOptions::from_str(&format!("sqlite://{}", archive_path.display()))
+                .unwrap()
+                .read_only(true);
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(options)
+            .await
+            .unwrap();
+        let tables: Vec<String> =
+            sqlx::query_scalar("SELECT name FROM sqlite_master WHERE type='table'")
+                .fetch_all(&pool)
+                .await
+                .unwrap();
+        const SENTINELS: &[&str] = &[
+            "sentinel-host",
+            "id_sentinel",
+            "SENTINEL-TOKEN",
+            "/home/sentinel",
+            "SENTINEL-COMMAND",
+        ];
+        for table in &tables {
+            let rows = sqlx::query(&format!("SELECT * FROM \"{table}\""))
+                .fetch_all(&pool)
+                .await
+                .unwrap();
+            for row in rows {
+                for (index, column) in row.columns().iter().enumerate() {
+                    if let Ok(value) = row.try_get::<String, _>(index) {
+                        for sentinel in SENTINELS {
+                            assert!(
+                                !value.contains(sentinel),
+                                "{sentinel} leaked into exported {table}.{}",
+                                column.name()
+                            );
+                        }
+                    }
+                }
+            }
+        }
+        // The scrubbed run-tool event keeps exactly the safe allowlist…
+        let events: Vec<String> =
+            sqlx::query_scalar("SELECT event_json FROM session_ui_events ORDER BY seq")
+                .fetch_all(&pool)
+                .await
+                .unwrap();
+        assert_eq!(events.len(), 2);
+        let scrubbed: serde_json::Value = serde_json::from_str(&events[0]).unwrap();
+        let details = scrubbed["details"].as_object().unwrap();
+        for key in details.keys() {
+            assert!(
+                RUN_TOOL_DETAILS_EXPORT_ALLOWLIST.contains(&key.as_str()),
+                "unexpected key in exported run details: {key}"
+            );
+        }
+        assert_eq!(details["id"], serde_json::json!("run"));
+        // …while other tools' details survive byte-for-byte.
+        assert_eq!(events[1], shell_event);
+        pool.close().await;
+        for path in [source_path, archive_path] {
             let _ = std::fs::remove_file(path);
         }
     }

--- a/crates/wisp-tools/src/env.rs
+++ b/crates/wisp-tools/src/env.rs
@@ -235,6 +235,11 @@ pub struct ToolResult {
     /// boundaries out of prompt wording: stale sibling calls can be skipped,
     /// and tools such as `ask_user` can end the turn outright.
     pub control: ToolControl,
+    /// The call was refused by a policy or user decision (write lock, plan
+    /// mode, explicit `Deny`, confirm/resource denial), not by the tool
+    /// itself. The agent loop reports these as `ToolExecutionBlocked` instead
+    /// of `ToolExecutionFinished`. `content` carries the refusal reason.
+    pub blocked: bool,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -261,6 +266,7 @@ impl ToolResult {
             image: None,
             details: None,
             control: ToolControl::Continue,
+            blocked: false,
         }
     }
     pub fn fail(content: impl Into<String>) -> Self {
@@ -270,6 +276,19 @@ impl ToolResult {
             image: None,
             details: None,
             control: ToolControl::Continue,
+            blocked: false,
+        }
+    }
+    /// A policy or user-decision refusal, with the reason in `content`. The
+    /// agent loop surfaces it as `ToolExecutionBlocked` (never Finished).
+    pub fn blocked(reason: impl Into<String>) -> Self {
+        Self {
+            success: false,
+            content: reason.into(),
+            image: None,
+            details: None,
+            control: ToolControl::Continue,
+            blocked: true,
         }
     }
     pub fn image(img: ImageData) -> Self {
@@ -280,6 +299,7 @@ impl ToolResult {
             image: Some(img),
             details: None,
             control: ToolControl::Continue,
+            blocked: false,
         }
     }
     /// Attach structured host/UI details. Never reaches the model context.

--- a/crates/wisp-tools/src/env.rs
+++ b/crates/wisp-tools/src/env.rs
@@ -58,6 +58,13 @@ pub enum ToolEvent {
         kind: String,
         payload: serde_json::Value,
     },
+    /// Structured mid-execution progress for the host/UI (e.g. a live Run
+    /// snapshot while a monitor tool waits). Never enters the model context;
+    /// the agent loop forwards it only while the emitting invocation is
+    /// still active and drops anything emitted after the tool finished.
+    Progress {
+        details: serde_json::Value,
+    },
     Result {
         ok: bool,
     },
@@ -219,6 +226,11 @@ pub struct ToolResult {
     pub success: bool,
     pub content: String,
     pub image: Option<ImageData>,
+    /// Structured result data for the host/UI (e.g. a Run record). `content`
+    /// is the model-facing summary; `details` must NEVER enter the model
+    /// context — the agent loop forwards it on the tool-finished runtime
+    /// event instead of appending it to the conversation.
+    pub details: Option<serde_json::Value>,
     /// Code-level control flow for the agent loop. This keeps user-decision
     /// boundaries out of prompt wording: stale sibling calls can be skipped,
     /// and tools such as `ask_user` can end the turn outright.
@@ -247,6 +259,7 @@ impl ToolResult {
             success: true,
             content: content.into(),
             image: None,
+            details: None,
             control: ToolControl::Continue,
         }
     }
@@ -255,6 +268,7 @@ impl ToolResult {
             success: false,
             content: content.into(),
             image: None,
+            details: None,
             control: ToolControl::Continue,
         }
     }
@@ -264,8 +278,14 @@ impl ToolResult {
             success: true,
             content: label,
             image: Some(img),
+            details: None,
             control: ToolControl::Continue,
         }
+    }
+    /// Attach structured host/UI details. Never reaches the model context.
+    pub fn with_details(mut self, details: impl Into<serde_json::Value>) -> Self {
+        self.details = Some(details.into());
+        self
     }
     /// Skip tool calls that the model placed later in the same batch, then let
     /// the model react to this result in a fresh iteration.

--- a/crates/wisp-tools/src/lib.rs
+++ b/crates/wisp-tools/src/lib.rs
@@ -28,6 +28,7 @@ pub use tool::Tool;
 
 use serde_json::Value;
 use std::collections::HashSet;
+use std::sync::Arc;
 use wisp_llm::ToolSchema;
 
 /// Where a schema in the model request comes from. This is intentionally a
@@ -129,8 +130,14 @@ const MAX_MCP_SEARCH_LIMIT: usize = 10;
 const MAX_MCP_DESCRIPTION_CHARS: usize = 2_048;
 
 /// The built-in tool set plus any extras (repl, MCP) registered later.
+///
+/// Tools are held behind `Arc` so a host can cheaply clone the registry for
+/// read-only side uses (e.g. projecting live tool-call draft previews through
+/// `Tool::preview`) while the agent loop keeps running against the same tool
+/// instances. Cloning shares the tools; it never duplicates them.
+#[derive(Clone)]
 pub struct Registry {
-    tools: Vec<Box<dyn Tool>>,
+    tools: Vec<Arc<dyn Tool>>,
 }
 
 impl Registry {
@@ -149,11 +156,13 @@ impl Registry {
             Box::new(plan::UpdatePlanTool),
             Box::new(attempt_completion::AttemptCompletionTool),
         ];
-        Self { tools }
+        Self {
+            tools: tools.into_iter().map(Into::into).collect(),
+        }
     }
 
     pub fn add(&mut self, tool: Box<dyn Tool>) {
-        self.tools.push(tool);
+        self.tools.push(tool.into());
     }
 
     /// Keep only tools named by a host-resolved capability grant.
@@ -215,6 +224,14 @@ impl Registry {
             .iter()
             .find(|t| t.name() == name)
             .map(|t| t.as_ref())
+    }
+
+    /// One-line preview for a call to `name`, computed through the tool's own
+    /// `Tool::preview`. `None` when no tool with that name is registered.
+    /// This is the only sanctioned way to turn (possibly partial, possibly
+    /// sensitive) tool-call arguments into UI-facing text.
+    pub fn preview(&self, name: &str, args: &Value) -> Option<String> {
+        self.get(name).map(|tool| tool.preview(args))
     }
 
     /// Dispatch a tool call: enforce the approval policy, emit the call card,
@@ -1096,5 +1113,20 @@ mod approval_tests {
         assert_eq!(registry.names(), vec!["read", "grep"]);
         assert!(registry.get("write").is_none());
         assert!(registry.get("shell").is_none());
+    }
+
+    #[test]
+    fn cloned_registry_shares_tools_and_previews_through_the_tool() {
+        let registry = Registry::builtins();
+        let clone = registry.clone();
+        // The clone is a cheap shared view: same names, and previews come from
+        // the tool's own `Tool::preview`, never from the raw argument string.
+        assert_eq!(clone.names(), registry.names());
+        let args = serde_json::json!({ "path": "data/counts.tsv", "offset": 12 });
+        assert_eq!(
+            clone.preview("read", &args).as_deref(),
+            Some("data/counts.tsv")
+        );
+        assert!(clone.preview("no_such_tool", &args).is_none());
     }
 }

--- a/crates/wisp-tools/src/lib.rs
+++ b/crates/wisp-tools/src/lib.rs
@@ -285,7 +285,7 @@ impl Registry {
     async fn run_mcp_search(&self, args: &Value, env: &dyn ToolEnv) -> ToolResult {
         let approval = env.approval_mode(SEARCH_MCP_TOOLS).await;
         if approval == env::Approval::Deny {
-            return ToolResult::fail(format!(
+            return ToolResult::blocked(format!(
                 "tool '{SEARCH_MCP_TOOLS}' is blocked by the approval policy"
             ));
         }
@@ -305,8 +305,10 @@ impl Registry {
                 .await
         {
             env.emit(ToolEvent::Result { ok: false }).await;
-            return ToolResult::fail(format!("tool '{SEARCH_MCP_TOOLS}' was denied by the user"))
-                .stop_batch();
+            return ToolResult::blocked(format!(
+                "tool '{SEARCH_MCP_TOOLS}' was denied by the user"
+            ))
+            .stop_batch();
         }
         let result = self.search_mcp_tools(args);
         env.emit(ToolEvent::Result { ok: result.success }).await;
@@ -402,12 +404,12 @@ async fn run_registered_tool(tool: &dyn Tool, args: &Value, env: &dyn ToolEnv) -
     // ordinary conversations usable for research, but fail closed for every
     // tool that is not known to be retrieval-only.
     if env.project_write_locked() && plan_mode_blocks(name) && !tool.read_only() {
-        return ToolResult::fail(project_write_lock_refusal(name));
+        return ToolResult::blocked(project_write_lock_refusal(name));
     }
     // Plan-mode gate, ahead of approvals: a session that is only allowed to
     // plan never reaches the approval prompt for a tool that would execute.
     if env.plan_mode() && plan_mode_blocks(name) && !tool.read_only() {
-        return ToolResult::fail(plan_mode_refusal(name));
+        return ToolResult::blocked(plan_mode_refusal(name));
     }
     // Per-tool approval gate. `Deny` blocks before the call card even shows;
     // `Ask` shows the card then routes through `confirm`; `Allow` runs as before.
@@ -426,7 +428,7 @@ async fn run_registered_tool(tool: &dyn Tool, args: &Value, env: &dyn ToolEnv) -
         env::Approval::Allow
     };
     if approval == env::Approval::Deny {
-        return ToolResult::fail(format!("tool '{name}' is blocked by the approval policy"));
+        return ToolResult::blocked(format!("tool '{name}' is blocked by the approval policy"));
     }
     let preview = tool.preview(args);
     let event_name = if tool.defer_schema() {
@@ -441,13 +443,13 @@ async fn run_registered_tool(tool: &dyn Tool, args: &Value, env: &dyn ToolEnv) -
     .await;
     if approval == env::Approval::Ask && !env.confirm(&format!("Run tool '{name}'?")).await {
         env.emit(ToolEvent::Result { ok: false }).await;
-        return ToolResult::fail(format!("tool '{name}' was denied by the user")).stop_batch();
+        return ToolResult::blocked(format!("tool '{name}' was denied by the user")).stop_batch();
     }
     let _resource_lease = match env.acquire_tool_resources(name, args).await {
         Ok(lease) => lease,
         Err(error) => {
             env.emit(ToolEvent::Result { ok: false }).await;
-            return ToolResult::fail(error).stop_batch();
+            return ToolResult::blocked(error).stop_batch();
         }
     };
     tool.before(args, env).await;
@@ -806,20 +808,24 @@ mod approval_tests {
 
     #[tokio::test]
     async fn approval_gate() {
-        // Deny: never runs, fails.
+        // Deny: never runs, fails, and is marked as a policy/user refusal.
         let (ran, res) = run_with(Approval::Deny, true).await;
         assert!(!ran && !res.success, "deny must block the tool");
         assert_eq!(res.control, ToolControl::Continue);
+        assert!(res.blocked, "a policy refusal must be marked blocked");
         // Ask + confirm no: never runs, fails.
         let (ran, res) = run_with(Approval::Ask, false).await;
         assert!(!ran && !res.success, "ask+deny must block the tool");
         assert_eq!(res.control, ToolControl::StopBatch);
+        assert!(res.blocked, "a user denial must be marked blocked");
         // Ask + confirm yes: runs.
         let (ran, res) = run_with(Approval::Ask, true).await;
         assert!(ran && res.success, "ask+approve must run the tool");
+        assert!(!res.blocked);
         // Allow: runs without asking.
         let (ran, res) = run_with(Approval::Allow, false).await;
         assert!(ran && res.success, "allow must run the tool");
+        assert!(!res.blocked);
     }
 
     #[tokio::test]
@@ -885,6 +891,10 @@ mod approval_tests {
         };
         let blocked = reg.run("write", &write, &planning).await;
         assert!(!blocked.success);
+        assert!(
+            blocked.blocked,
+            "a plan-mode refusal must be marked blocked"
+        );
         assert!(blocked.content.contains("plan mode"), "{}", blocked.content);
         assert!(!dir.join("gated.txt").exists(), "the write must not happen");
         assert!(reg.run("read", &read, &planning).await.success);

--- a/src-tauri/src/device_hub.rs
+++ b/src-tauri/src/device_hub.rs
@@ -177,6 +177,8 @@ impl DeviceHub {
             ),
             AgentEvent::MessageBoundary { .. }
             | AgentEvent::Resources { .. }
+            | AgentEvent::ToolCallDraft { .. }
+            | AgentEvent::ToolCallDraftClear { .. }
             | AgentEvent::ToolPresentation { .. }
             | AgentEvent::Usage { .. }
             | AgentEvent::Compaction { .. }

--- a/src-tauri/src/device_hub.rs
+++ b/src-tauri/src/device_hub.rs
@@ -179,6 +179,9 @@ impl DeviceHub {
             | AgentEvent::Resources { .. }
             | AgentEvent::ToolCallDraft { .. }
             | AgentEvent::ToolCallDraftClear { .. }
+            | AgentEvent::ToolExecutionStarted { .. }
+            | AgentEvent::ToolProgress { .. }
+            | AgentEvent::ToolResultDetails { .. }
             | AgentEvent::ToolPresentation { .. }
             | AgentEvent::Usage { .. }
             | AgentEvent::Compaction { .. }

--- a/src-tauri/src/exploration_promotion.rs
+++ b/src-tauri/src/exploration_promotion.rs
@@ -811,8 +811,8 @@ pub(crate) async fn ensure_no_queued_turns<'a>(
     let sessions = state.sessions.lock().await;
     for frame_id in frame_ids {
         if let Some(runtime) = sessions.get(frame_id) {
-            if runtime.draining.load(std::sync::atomic::Ordering::SeqCst)
-                || !runtime.queued.lock().unwrap().is_empty()
+            if runtime.control.follow_ups().driver_active()
+                || !runtime.control.follow_ups().is_empty()
             {
                 return Err(coded(
                     ERR_EXPLORATION_BUSY,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -137,6 +137,23 @@ enum AgentEvent {
         name: String,
         preview: String,
     },
+    /// Live-only: the model is still streaming this call's arguments. `preview`
+    /// is computed through the tool's own `Tool::preview`; the raw argument
+    /// text never crosses to the UI, is never persisted, and is never logged.
+    /// `call_key` is `{round}:{index}` from the runtime `ToolInvocationKey`.
+    ToolCallDraft {
+        frame_id: String,
+        call_key: String,
+        name: String,
+        preview: String,
+    },
+    /// Live-only: drop draft rows so no ghosts remain. `Some(key)` clears the
+    /// one draft whose real call just started; `None` clears every draft of
+    /// the frame at a round/run boundary.
+    ToolCallDraftClear {
+        frame_id: String,
+        call_key: Option<String>,
+    },
     ToolResult {
         frame_id: String,
         name: String,
@@ -1641,6 +1658,24 @@ fn merge_pending_ui_event(
     pending: &mut Option<AgentEvent>,
     event: AgentEvent,
 ) -> Option<AgentEvent> {
+    // Argument drafts stream as full snapshots, not deltas: the same
+    // `call_key` collapses to the latest snapshot inside the flush window.
+    if let (
+        Some(AgentEvent::ToolCallDraft {
+            call_key, frame_id, ..
+        }),
+        AgentEvent::ToolCallDraft {
+            call_key: next_key,
+            frame_id: next_frame,
+            ..
+        },
+    ) = (pending.as_ref(), &event)
+    {
+        if call_key == next_key && frame_id == next_frame {
+            *pending = Some(event);
+            return None;
+        }
+    }
     let merged = match (pending.as_mut(), &event) {
         (Some(AgentEvent::Text { delta, .. }), AgentEvent::Text { delta: next, .. })
         | (Some(AgentEvent::Reasoning { delta, .. }), AgentEvent::Reasoning { delta: next, .. })
@@ -1718,7 +1753,10 @@ const LIVE_EVENT_FLUSH_INTERVAL: std::time::Duration = std::time::Duration::from
 fn is_streaming_delta_event(event: &AgentEvent) -> bool {
     matches!(
         event,
-        AgentEvent::Text { .. } | AgentEvent::Reasoning { .. } | AgentEvent::Stdout { .. }
+        AgentEvent::Text { .. }
+            | AgentEvent::Reasoning { .. }
+            | AgentEvent::Stdout { .. }
+            | AgentEvent::ToolCallDraft { .. }
     )
 }
 
@@ -2478,6 +2516,10 @@ struct TauriOutput {
     /// token/stdout flood cannot saturate the WebView IPC channel. `None`
     /// emits directly (tests).
     live_events: Option<tokio::sync::mpsc::UnboundedSender<AgentEvent>>,
+    /// Read-only clone of the turn's tool registry (shares the agent's tool
+    /// instances), used to project streaming argument drafts into safe
+    /// `Tool::preview` text. See `project_runtime_event`.
+    tools: wisp_tools::Registry,
     message_seq: std::sync::atomic::AtomicI64,
     /// Provenance sink: each tool-execution record the turn produces is sent here
     /// and persisted as an `execution_log` row by a background drain task.
@@ -2618,6 +2660,10 @@ fn emit_agent_event(app: &AppHandle, event: AgentEvent) {
 }
 
 fn should_persist_ui_event(event: &AgentEvent) -> bool {
+    // Live-only kinds are excluded by omission — notably ToolCallDraft /
+    // ToolCallDraftClear, which must never reach the replay store: a draft is
+    // superseded by the real ToolCall event and would otherwise replay as a
+    // ghost row after a restart.
     matches!(
         event,
         AgentEvent::User { .. }
@@ -2632,6 +2678,48 @@ fn should_persist_ui_event(event: &AgentEvent) -> bool {
             | AgentEvent::Usage { .. }
             | AgentEvent::Compaction { .. }
     )
+}
+
+/// Project one core runtime event onto the live-only UI draft protocol.
+/// Returns `None` for variants the desktop shell does not surface yet.
+///
+/// Safety: the draft's raw `arguments_so_far` is NEVER forwarded, persisted,
+/// or logged. The UI receives a preview only when the partial arguments parse
+/// as JSON AND the named tool is registered; the text comes exclusively from
+/// that tool's own `Tool::preview`. Anything else degrades to name-only.
+fn project_runtime_event(
+    tools: &wisp_tools::Registry,
+    frame_id: &str,
+    event: &wisp_core::AgentRuntimeEvent,
+) -> Option<AgentEvent> {
+    use wisp_core::AgentRuntimeEvent as Rt;
+    match event {
+        Rt::AssistantToolCallUpdated(draft) => {
+            let preview = serde_json::from_str::<serde_json::Value>(&draft.arguments_so_far)
+                .ok()
+                .and_then(|args| tools.preview(&draft.name, &args))
+                .unwrap_or_default();
+            Some(AgentEvent::ToolCallDraft {
+                frame_id: frame_id.into(),
+                call_key: format!("{}:{}", draft.key.round, draft.key.index),
+                name: draft.name.clone(),
+                preview: bounded_ui_tool_input(&preview),
+            })
+        }
+        // The real call supersedes its draft; the persisted ToolCall event
+        // follows through the normal `Output::tool_call` path.
+        Rt::ToolCallReady { key, .. } => Some(AgentEvent::ToolCallDraftClear {
+            frame_id: frame_id.into(),
+            call_key: Some(format!("{}:{}", key.round, key.index)),
+        }),
+        // A round or run that ends without the call ever becoming ready
+        // (provider error, cancel, blocked retry) must not leave ghost rows.
+        Rt::RoundFinished { .. } | Rt::RunFinished { .. } => Some(AgentEvent::ToolCallDraftClear {
+            frame_id: frame_id.into(),
+            call_key: None,
+        }),
+        _ => None,
+    }
 }
 
 fn provenance_ui_file_changes(rec: &wisp_core::ProvenanceRecord) -> &[String] {
@@ -2746,6 +2834,11 @@ impl Output for TauriOutput {
             frame_id: self.frame_id.clone(),
             chunk: chunk.into(),
         });
+    }
+    fn runtime_event(&self, event: &wisp_core::AgentRuntimeEvent) {
+        if let Some(event) = project_runtime_event(&self.tools, &self.frame_id, event) {
+            self.emit(event);
+        }
     }
     // Desktop approval must use the async hooks below. Fail closed if a future
     // caller accidentally reaches the legacy synchronous compatibility path.
@@ -5816,6 +5909,7 @@ async fn send_message_inner(
         persist: Some(persist_tx),
         ui_events: Some(ui_event_tx),
         live_events: Some(live_event_tx),
+        tools: agent.tools.clone(),
         message_seq: std::sync::atomic::AtomicI64::new(start_seq),
         prov: Some(prov_tx),
     };

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2590,6 +2590,10 @@ struct TauriOutput {
     /// instances), used to project streaming argument drafts into safe
     /// `Tool::preview` text. See `project_runtime_event`.
     tools: wisp_tools::Registry,
+    /// Per-call-key argument-draft accumulators. `Output::runtime_event` takes
+    /// `&self`, so the state lives behind a mutex; the raw accumulated text
+    /// never leaves this map (see `ToolCallDraftAcc`).
+    drafts: StdMutex<ToolCallDraftAccumulators>,
     message_seq: std::sync::atomic::AtomicI64,
     /// Provenance sink: each tool-execution record the turn produces is sent here
     /// and persisted as an `execution_log` row by a background drain task.
@@ -2753,38 +2757,121 @@ fn should_persist_ui_event(event: &AgentEvent) -> bool {
     )
 }
 
+/// Recompute budget for draft previews: parsing the accumulated JSON and
+/// running `Tool::preview` per argument fragment was the O(n²) hot path.
+/// Recompute at most this often per call key; between recomputes the delta is
+/// still accumulated but no event is emitted — the live-event merge window
+/// already collapses same-key drafts to the latest, so skipping loses nothing.
+const DRAFT_PREVIEW_RECOMPUTE_INTERVAL: std::time::Duration = LIVE_EVENT_FLUSH_INTERVAL;
+
+/// Host-side accumulator for one streaming tool call. The raw `arguments`
+/// text NEVER reaches the UI, persistence, or logs — only `Tool::preview`
+/// output computed from it crosses.
+#[derive(Default)]
+struct ToolCallDraftAcc {
+    name: String,
+    arguments: String,
+    last_preview_at: Option<std::time::Instant>,
+}
+
+/// Live-only draft accumulators, keyed by `call_key` (`{round}:{index}`).
+/// Deltas append; `reset` (first fragment, or a retried attempt reusing the
+/// index) drops prior state; ToolCallReady/RoundFinished/RunFinished evict.
+#[derive(Default)]
+struct ToolCallDraftAccumulators {
+    drafts: std::collections::HashMap<String, ToolCallDraftAcc>,
+}
+
+impl ToolCallDraftAccumulators {
+    /// Apply one argument fragment and, when the preview is due for a
+    /// recompute, project the accumulated state into a live-only draft event.
+    /// Returns `None` while throttled.
+    fn push_delta(
+        &mut self,
+        tools: &wisp_tools::Registry,
+        frame_id: &str,
+        call_key: &str,
+        name: Option<&str>,
+        arguments_delta: &str,
+        reset: bool,
+        now: std::time::Instant,
+    ) -> Option<AgentEvent> {
+        if reset {
+            self.drafts.remove(call_key);
+        }
+        let acc = self.drafts.entry(call_key.to_string()).or_default();
+        if let Some(name) = name {
+            acc.name = name.to_string();
+        }
+        acc.arguments.push_str(arguments_delta);
+        let due = acc.last_preview_at.map_or(true, |at| {
+            now.duration_since(at) >= DRAFT_PREVIEW_RECOMPUTE_INTERVAL
+        });
+        if !due {
+            return None;
+        }
+        let preview = serde_json::from_str::<serde_json::Value>(&acc.arguments)
+            .ok()
+            .and_then(|args| tools.preview(&acc.name, &args))
+            .unwrap_or_default();
+        acc.last_preview_at = Some(now);
+        Some(AgentEvent::ToolCallDraft {
+            frame_id: frame_id.into(),
+            call_key: call_key.to_string(),
+            name: acc.name.clone(),
+            preview: bounded_ui_tool_input(&preview),
+        })
+    }
+
+    fn evict(&mut self, call_key: &str) {
+        self.drafts.remove(call_key);
+    }
+
+    fn clear(&mut self) {
+        self.drafts.clear();
+    }
+}
+
 /// Project one core runtime event onto the live-only UI draft protocol.
 /// Returns `None` for variants the desktop shell does not surface yet.
 ///
-/// Safety: the draft's raw `arguments_so_far` is NEVER forwarded, persisted,
-/// or logged. The UI receives a preview only when the partial arguments parse
-/// as JSON AND the named tool is registered; the text comes exclusively from
-/// that tool's own `Tool::preview`. Anything else degrades to name-only.
+/// Safety: the accumulated raw arguments are NEVER forwarded, persisted, or
+/// logged. The UI receives a preview only when the accumulated arguments
+/// parse as JSON AND the named tool is registered; the text comes exclusively
+/// from that tool's own `Tool::preview`. Anything else degrades to name-only.
 fn project_runtime_event(
+    drafts: &mut ToolCallDraftAccumulators,
     tools: &wisp_tools::Registry,
     frame_id: &str,
     event: &wisp_core::AgentRuntimeEvent,
 ) -> Option<AgentEvent> {
     use wisp_core::AgentRuntimeEvent as Rt;
     match event {
-        Rt::AssistantToolCallUpdated(draft) => {
-            let preview = serde_json::from_str::<serde_json::Value>(&draft.arguments_so_far)
-                .ok()
-                .and_then(|args| tools.preview(&draft.name, &args))
-                .unwrap_or_default();
-            Some(AgentEvent::ToolCallDraft {
-                frame_id: frame_id.into(),
-                call_key: format!("{}:{}", draft.key.round, draft.key.index),
-                name: draft.name.clone(),
-                preview: bounded_ui_tool_input(&preview),
-            })
-        }
+        Rt::AssistantToolCallDelta {
+            key,
+            name,
+            arguments_delta,
+            reset,
+            ..
+        } => drafts.push_delta(
+            tools,
+            frame_id,
+            &format!("{}:{}", key.round, key.index),
+            name.as_deref(),
+            arguments_delta,
+            *reset,
+            std::time::Instant::now(),
+        ),
         // The real call supersedes its draft; the persisted ToolCall event
         // follows through the normal `Output::tool_call` path.
-        Rt::ToolCallReady { key, .. } => Some(AgentEvent::ToolCallDraftClear {
-            frame_id: frame_id.into(),
-            call_key: Some(format!("{}:{}", key.round, key.index)),
-        }),
+        Rt::ToolCallReady { key, .. } => {
+            let call_key = format!("{}:{}", key.round, key.index);
+            drafts.evict(&call_key);
+            Some(AgentEvent::ToolCallDraftClear {
+                frame_id: frame_id.into(),
+                call_key: Some(call_key),
+            })
+        }
         // Execution begins: the UI stamps this key onto the pending tool row
         // (live-only) so progress and final details can match by `call_key`.
         Rt::ToolExecutionStarted { key, name } => Some(AgentEvent::ToolExecutionStarted {
@@ -2813,10 +2900,13 @@ fn project_runtime_event(
         }),
         // A round or run that ends without the call ever becoming ready
         // (provider error, cancel, blocked retry) must not leave ghost rows.
-        Rt::RoundFinished { .. } | Rt::RunFinished { .. } => Some(AgentEvent::ToolCallDraftClear {
-            frame_id: frame_id.into(),
-            call_key: None,
-        }),
+        Rt::RoundFinished { .. } | Rt::RunFinished { .. } => {
+            drafts.clear();
+            Some(AgentEvent::ToolCallDraftClear {
+                frame_id: frame_id.into(),
+                call_key: None,
+            })
+        }
         _ => None,
     }
 }
@@ -2935,7 +3025,11 @@ impl Output for TauriOutput {
         });
     }
     fn runtime_event(&self, event: &wisp_core::AgentRuntimeEvent) {
-        if let Some(event) = project_runtime_event(&self.tools, &self.frame_id, event) {
+        let projected = {
+            let mut drafts = self.drafts.lock().unwrap();
+            project_runtime_event(&mut drafts, &self.tools, &self.frame_id, event)
+        };
+        if let Some(event) = projected {
             self.emit(event);
         }
     }
@@ -6015,6 +6109,7 @@ async fn send_message_inner(
         ui_events: Some(ui_event_tx),
         live_events: Some(live_event_tx),
         tools: agent.tools.clone(),
+        drafts: StdMutex::new(ToolCallDraftAccumulators::default()),
         message_seq: std::sync::atomic::AtomicI64::new(start_seq),
         prov: Some(prov_tx),
     };

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -154,6 +154,32 @@ enum AgentEvent {
         frame_id: String,
         call_key: Option<String>,
     },
+    /// Live-only: the tool started executing. Stamps the invocation key onto
+    /// the pending tool row so later progress/details patches can match by
+    /// `call_key` instead of by name.
+    ToolExecutionStarted {
+        frame_id: String,
+        call_key: String,
+        name: String,
+    },
+    /// Live-only structured mid-execution progress; never persisted and never
+    /// enters the model context. `call_key` matches the row stamped by
+    /// `ToolExecutionStarted`.
+    ToolProgress {
+        frame_id: String,
+        call_key: String,
+        details: serde_json::Value,
+    },
+    /// Persisted patch carrying a tool's final structured details, emitted
+    /// once per call that produced them. Replay applies it to the matching
+    /// tool row so a reload still shows the details, while no progress
+    /// fragment is ever persisted.
+    ToolResultDetails {
+        frame_id: String,
+        call_key: String,
+        name: String,
+        details: serde_json::Value,
+    },
     ToolResult {
         frame_id: String,
         name: String,
@@ -1033,6 +1059,10 @@ struct UiItem {
     locations: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     resources: Vec<resource_refs::UiMessageResource>,
+    /// The tool row's final structured details (from the persisted
+    /// `ToolResultDetails` patch). Never model-facing content.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    details: Option<serde_json::Value>,
 }
 
 /// Index in `msgs` where the `user_index`‑th user turn starts (0-based user count).
@@ -1089,6 +1119,7 @@ fn messages_to_items(msgs: &[wisp_llm::Message]) -> Vec<UiItem> {
                         status: None,
                         locations: None,
                         resources: Vec::new(),
+                        details: None,
                     });
                 } else if !t.trim().is_empty() {
                     out.push(UiItem {
@@ -1104,6 +1135,7 @@ fn messages_to_items(msgs: &[wisp_llm::Message]) -> Vec<UiItem> {
                         status: None,
                         locations: None,
                         resources: Vec::new(),
+                        details: None,
                     });
                 }
             }
@@ -1123,6 +1155,7 @@ fn messages_to_items(msgs: &[wisp_llm::Message]) -> Vec<UiItem> {
                             status: None,
                             locations: None,
                             resources: Vec::new(),
+                            details: None,
                         });
                     }
                 }
@@ -1141,6 +1174,7 @@ fn messages_to_items(msgs: &[wisp_llm::Message]) -> Vec<UiItem> {
                         status: None,
                         locations: None,
                         resources: Vec::new(),
+                        details: None,
                     });
                 }
             }
@@ -1161,6 +1195,7 @@ fn messages_to_items(msgs: &[wisp_llm::Message]) -> Vec<UiItem> {
                             status: None,
                             locations: None,
                             resources: Vec::new(),
+                            details: None,
                         });
                     }
                 } else if m.tool_name.as_deref() == Some(wisp_tools::ask_user::ASK_USER) {
@@ -1178,6 +1213,7 @@ fn messages_to_items(msgs: &[wisp_llm::Message]) -> Vec<UiItem> {
                         status: None,
                         locations: None,
                         resources: Vec::new(),
+                        details: None,
                     });
                 } else if matches!(
                     m.tool_name.as_deref(),
@@ -1199,6 +1235,7 @@ fn messages_to_items(msgs: &[wisp_llm::Message]) -> Vec<UiItem> {
                         status: None,
                         locations: None,
                         resources: Vec::new(),
+                        details: None,
                     });
                 } else if let Some(envelope) =
                     acp::AcpToolEnvelope::from_tool_message(m.tool_name.as_deref(), &text)
@@ -1216,6 +1253,7 @@ fn messages_to_items(msgs: &[wisp_llm::Message]) -> Vec<UiItem> {
                         status: Some(envelope.status),
                         locations: (!envelope.locations.is_empty()).then_some(envelope.locations),
                         resources: Vec::new(),
+                        details: None,
                     });
                 } else {
                     out.push(UiItem {
@@ -1235,6 +1273,7 @@ fn messages_to_items(msgs: &[wisp_llm::Message]) -> Vec<UiItem> {
                         status: None,
                         locations: None,
                         resources: Vec::new(),
+                        details: None,
                     });
                 }
             }
@@ -1366,6 +1405,7 @@ fn events_to_items(events: &[AgentEvent]) -> (Vec<UiItem>, HashMap<i64, usize>) 
                     status: None,
                     locations: None,
                     resources: Vec::new(),
+                    details: None,
                 });
             }
             AgentEvent::Usage {
@@ -1418,6 +1458,7 @@ fn events_to_items(events: &[AgentEvent]) -> (Vec<UiItem>, HashMap<i64, usize>) 
                 status: None,
                 locations: None,
                 resources: Vec::new(),
+                details: None,
             }),
             AgentEvent::Text { delta, .. } | AgentEvent::Reasoning { delta, .. } => {
                 let role = if matches!(event, AgentEvent::Text { .. }) {
@@ -1441,6 +1482,7 @@ fn events_to_items(events: &[AgentEvent]) -> (Vec<UiItem>, HashMap<i64, usize>) 
                         status: None,
                         locations: None,
                         resources: Vec::new(),
+                        details: None,
                     });
                 }
             }
@@ -1457,6 +1499,7 @@ fn events_to_items(events: &[AgentEvent]) -> (Vec<UiItem>, HashMap<i64, usize>) 
                 status: None,
                 locations: None,
                 resources: Vec::new(),
+                details: None,
             }),
             AgentEvent::ToolResult {
                 name,
@@ -1495,6 +1538,7 @@ fn events_to_items(events: &[AgentEvent]) -> (Vec<UiItem>, HashMap<i64, usize>) 
                         status: None,
                         locations: None,
                         resources: Vec::new(),
+                        details: None,
                     });
                     continue;
                 }
@@ -1528,8 +1572,22 @@ fn events_to_items(events: &[AgentEvent]) -> (Vec<UiItem>, HashMap<i64, usize>) 
                             status: None,
                             locations: None,
                             resources: Vec::new(),
+                            details: None,
                         });
                     }
+                }
+            }
+            AgentEvent::ToolResultDetails { name, details, .. } => {
+                // Persisted once, right after the call's ToolResult: patch the
+                // final structured details onto the matching tool row. Replay
+                // rows carry no `call_key`, so match the most recent row by
+                // name — the same fallback the live UI uses.
+                if let Some(item) = items
+                    .iter_mut()
+                    .rev()
+                    .find(|item| item.role == "tool" && item.tool_name.as_deref() == Some(name))
+                {
+                    item.details = Some(details.clone());
                 }
             }
             AgentEvent::FileChanged { path, .. } => items.push(UiItem {
@@ -1545,6 +1603,7 @@ fn events_to_items(events: &[AgentEvent]) -> (Vec<UiItem>, HashMap<i64, usize>) 
                 status: None,
                 locations: None,
                 resources: Vec::new(),
+                details: None,
             }),
             AgentEvent::MessageBoundary { seq, .. } => {
                 boundaries.insert(*seq, items.len());
@@ -1573,6 +1632,7 @@ fn events_to_items(events: &[AgentEvent]) -> (Vec<UiItem>, HashMap<i64, usize>) 
                         status: None,
                         locations: None,
                         resources: Vec::new(),
+                        details: None,
                     });
                 }
             }
@@ -1618,6 +1678,7 @@ fn usage_item(
         status: None,
         locations: None,
         resources: Vec::new(),
+        details: None,
     }
 }
 
@@ -1658,20 +1719,36 @@ fn merge_pending_ui_event(
     pending: &mut Option<AgentEvent>,
     event: AgentEvent,
 ) -> Option<AgentEvent> {
-    // Argument drafts stream as full snapshots, not deltas: the same
-    // `call_key` collapses to the latest snapshot inside the flush window.
-    if let (
-        Some(AgentEvent::ToolCallDraft {
-            call_key, frame_id, ..
-        }),
-        AgentEvent::ToolCallDraft {
-            call_key: next_key,
-            frame_id: next_frame,
-            ..
-        },
-    ) = (pending.as_ref(), &event)
-    {
-        if call_key == next_key && frame_id == next_frame {
+    // Argument drafts and structured progress stream as full snapshots, not
+    // deltas: the same `call_key` collapses to the latest snapshot inside the
+    // flush window (same kind only — a draft never swallows a progress patch).
+    let same_key = |pending: &AgentEvent, next: &AgentEvent| -> bool {
+        fn key_of(event: &AgentEvent) -> Option<(&str, &str)> {
+            match event {
+                AgentEvent::ToolCallDraft {
+                    call_key, frame_id, ..
+                }
+                | AgentEvent::ToolProgress {
+                    call_key, frame_id, ..
+                } => Some((call_key.as_str(), frame_id.as_str())),
+                _ => None,
+            }
+        }
+        matches!(
+            (pending, next),
+            (
+                AgentEvent::ToolCallDraft { .. },
+                AgentEvent::ToolCallDraft { .. }
+            ) | (
+                AgentEvent::ToolProgress { .. },
+                AgentEvent::ToolProgress { .. }
+            )
+        ) && key_of(pending)
+            .zip(key_of(next))
+            .is_some_and(|(a, b)| a == b)
+    };
+    if let Some(p) = pending.as_ref() {
+        if same_key(p, &event) {
             *pending = Some(event);
             return None;
         }
@@ -1757,6 +1834,7 @@ fn is_streaming_delta_event(event: &AgentEvent) -> bool {
             | AgentEvent::Reasoning { .. }
             | AgentEvent::Stdout { .. }
             | AgentEvent::ToolCallDraft { .. }
+            | AgentEvent::ToolProgress { .. }
     )
 }
 
@@ -2663,7 +2741,9 @@ fn should_persist_ui_event(event: &AgentEvent) -> bool {
     // Live-only kinds are excluded by omission — notably ToolCallDraft /
     // ToolCallDraftClear, which must never reach the replay store: a draft is
     // superseded by the real ToolCall event and would otherwise replay as a
-    // ghost row after a restart.
+    // ghost row after a restart. ToolExecutionStarted / ToolProgress are
+    // live-only for the same reason: the final structured state is persisted
+    // exactly once via ToolResultDetails.
     matches!(
         event,
         AgentEvent::User { .. }
@@ -2672,6 +2752,7 @@ fn should_persist_ui_event(event: &AgentEvent) -> bool {
             | AgentEvent::Reasoning { .. }
             | AgentEvent::ToolCall { .. }
             | AgentEvent::ToolResult { .. }
+            | AgentEvent::ToolResultDetails { .. }
             | AgentEvent::FileChanged { .. }
             | AgentEvent::ToolPresentation { .. }
             | AgentEvent::Stdout { .. }
@@ -2711,6 +2792,32 @@ fn project_runtime_event(
         Rt::ToolCallReady { key, .. } => Some(AgentEvent::ToolCallDraftClear {
             frame_id: frame_id.into(),
             call_key: Some(format!("{}:{}", key.round, key.index)),
+        }),
+        // Execution begins: the UI stamps this key onto the pending tool row
+        // (live-only) so progress and final details can match by `call_key`.
+        Rt::ToolExecutionStarted { key, name } => Some(AgentEvent::ToolExecutionStarted {
+            frame_id: frame_id.into(),
+            call_key: format!("{}:{}", key.round, key.index),
+            name: name.clone(),
+        }),
+        // Structured mid-execution progress: live-only, never persisted.
+        Rt::ToolExecutionUpdated { key, details } => Some(AgentEvent::ToolProgress {
+            frame_id: frame_id.into(),
+            call_key: format!("{}:{}", key.round, key.index),
+            details: details.clone(),
+        }),
+        // Final structured details persist exactly once, patched onto the tool
+        // row so a replayed transcript still shows them.
+        Rt::ToolExecutionFinished {
+            key,
+            name,
+            details: Some(details),
+            ..
+        } => Some(AgentEvent::ToolResultDetails {
+            frame_id: frame_id.into(),
+            call_key: format!("{}:{}", key.round, key.index),
+            name: name.clone(),
+            details: details.clone(),
         }),
         // A round or run that ends without the call ever becoming ready
         // (provider error, cancel, blocked retry) must not leave ghost rows.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2083,28 +2083,18 @@ struct SessionRuntime {
     /// Serializes an entire user workflow (primary turn + automatic review +
     /// correction), not merely one model turn.
     workflow: Arc<tokio::sync::Mutex<()>>,
-    cancel: Arc<AtomicBool>,
+    /// Cancel flag, mid-turn steering (Guide #410), and the parked follow-up
+    /// queue (Queue #433) — owned by wisp-core so the agent loop and the
+    /// commands below share one control plane.
+    control: wisp_core::AgentControl<QueuedItem>,
     deleted: AtomicBool,
     last_seq: StdMutex<i64>,
-    /// Guide (#410): mid-turn messages the running loop drains into user
-    /// messages at its next iteration; ids let queued senders detect that.
-    pending_guidance: wisp_core::GuidanceQueue,
-    guidance_seq: std::sync::atomic::AtomicU64,
     /// Where the last cancelled turn started, so an InterruptReplace send can
     /// roll the model context back to before the abandoned task.
     interrupted_turn_start: StdMutex<Option<usize>>,
     /// Latest state published by each live MCP App. Apps overwrite their own
     /// entry through the standard `ui/update-model-context` request.
     mcp_app_contexts: StdMutex<HashMap<String, McpAppContext>>,
-    /// Queue (#433): turns waiting for the running one to finish. Each item is
-    /// editable/cancellable while it waits; a single driver task drains them
-    /// FIFO into fresh turns. ponytail: in-memory only — lost on app restart,
-    /// same as the optimistic bubbles, which are never persisted either.
-    queued: StdMutex<Vec<QueuedItem>>,
-    /// True while a driver task owns draining `queued`. Flipped only under the
-    /// `queued` lock so an enqueue can never strand behind a driver that is
-    /// about to exit on an empty queue.
-    draining: AtomicBool,
 }
 
 /// One parked follow-up turn (#433). `id` is assigned by the frontend so the
@@ -2117,20 +2107,22 @@ struct QueuedItem {
     references: Vec<ComposerReferenceArg>,
 }
 
+impl wisp_core::FollowUpItem for QueuedItem {
+    fn id(&self) -> u64 {
+        self.id
+    }
+}
+
 impl SessionRuntime {
     fn new() -> Self {
         Self {
             agent: tokio::sync::Mutex::new(None),
             workflow: Arc::new(tokio::sync::Mutex::new(())),
-            cancel: Arc::new(AtomicBool::new(false)),
+            control: wisp_core::AgentControl::new(),
             deleted: AtomicBool::new(false),
             last_seq: StdMutex::new(0),
-            pending_guidance: wisp_core::GuidanceQueue::default(),
-            guidance_seq: std::sync::atomic::AtomicU64::new(0),
             interrupted_turn_start: StdMutex::new(None),
             mcp_app_contexts: StdMutex::new(HashMap::new()),
-            queued: StdMutex::new(Vec::new()),
-            draining: AtomicBool::new(false),
         }
     }
     fn last_seq(&self) -> i64 {
@@ -5190,7 +5182,7 @@ async fn send_message_inner(
             Some(guard) => guard,
             None => runtime.workflow.clone().lock_owned().await,
         };
-        runtime.cancel.store(false, Ordering::SeqCst);
+        runtime.control.reset_cancel();
         let refs = references.as_deref().unwrap_or_default();
         let skills = active_skill_index(&state.store, &ap).await;
         let mut injected_context =
@@ -5201,9 +5193,14 @@ async fn send_message_inner(
         if let Some(context) = runtime.mcp_app_context_injection() {
             injected_context.push(context);
         }
-        if let Some(injection) =
-            resolve_reader_references(&state.store, refs, &frame_id, &message, &runtime.cancel)
-                .await?
+        if let Some(injection) = resolve_reader_references(
+            &state.store,
+            refs,
+            &frame_id,
+            &message,
+            runtime.control.cancel_flag(),
+        )
+        .await?
         {
             injected_context.push(injection);
         }
@@ -5274,8 +5271,15 @@ async fn send_message_inner(
                         .await;
                 }
                 if !resume && load_auto_review_enabled(&state.store).await {
-                    automatic_review_acp(state, &app, &ap, &frame_id, &runtime.cancel, turn_start)
-                        .await;
+                    automatic_review_acp(
+                        state,
+                        &app,
+                        &ap,
+                        &frame_id,
+                        runtime.control.cancel_flag(),
+                        turn_start,
+                    )
+                    .await;
                 }
                 state.running_turns.lock().await.remove(&frame_id);
                 mark_seen_if_viewed(state, &frame_id).await;
@@ -5430,16 +5434,7 @@ async fn send_message_inner(
     // the lock is acquired and runs a normal turn with it.
     let guidance_id = if guide.unwrap_or(false) && !resume {
         let running = state.running_turns.lock().await.contains(&frame_id);
-        running.then(|| {
-            let id = rt
-                .guidance_seq
-                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            rt.pending_guidance
-                .lock()
-                .unwrap()
-                .push((id, message.clone()));
-            id
-        })
+        running.then(|| rt.control.push_steering(message.clone()))
     } else {
         None
     };
@@ -5447,12 +5442,9 @@ async fn send_message_inner(
         Some(guard) => guard,
         None => rt.workflow.clone().lock_owned().await,
     };
-    rt.cancel.store(false, Ordering::SeqCst);
+    rt.control.reset_cancel();
     if let Some(id) = guidance_id {
-        let mut pending = rt.pending_guidance.lock().unwrap();
-        let before = pending.len();
-        pending.retain(|(gid, _)| *gid != id);
-        if pending.len() == before {
+        if !rt.control.reclaim_steering(id) {
             // The loop already injected this message into the previous turn
             // (persisted + User event emitted there); nothing left to run.
             return Ok(frame_id);
@@ -5809,8 +5801,14 @@ async fn send_message_inner(
         {
             agent.ctx.inject_user(injection);
         }
-        if let Some(injection) =
-            resolve_reader_references(&state.store, &refs, &frame_id, &message, &rt.cancel).await?
+        if let Some(injection) = resolve_reader_references(
+            &state.store,
+            &refs,
+            &frame_id,
+            &message,
+            rt.control.cancel_flag(),
+        )
+        .await?
         {
             agent.ctx.inject_user(injection);
         }
@@ -5819,7 +5817,7 @@ async fn send_message_inner(
         // at the tail.
         agent.ctx.prefix_runtime_injections_to_user();
     }
-    if rt.cancel.load(Ordering::SeqCst) {
+    if rt.control.is_cancelled() {
         return Err("Turn was cancelled before it started.".into());
     }
 
@@ -6004,7 +6002,7 @@ async fn send_message_inner(
         project_root: ap.root.clone(),
         store: state.store.clone(),
         resource_leases: state.resource_leases.clone(),
-        cancel: rt.cancel.clone(),
+        cancel: rt.control.cancel_arc(),
         device_hub: state.device_hub.clone(),
         confirms: state.confirms.clone(),
         awaiting_confirm: state.awaiting_confirm.clone(),
@@ -6030,7 +6028,11 @@ async fn send_message_inner(
     state.running_turns.lock().await.insert(frame_id.clone());
     let mut result = if resume {
         agent
-            .run_resume(&output, Some(&rt.cancel), Some(&rt.pending_guidance))
+            .run_resume(
+                &output,
+                Some(rt.control.cancel_flag()),
+                Some(rt.control.steering_queue()),
+            )
             .await
     } else {
         agent
@@ -6039,15 +6041,15 @@ async fn send_message_inner(
                 &attached_images,
                 primary_supports_vision,
                 &output,
-                Some(&rt.cancel),
-                Some(&rt.pending_guidance),
+                Some(rt.control.cancel_flag()),
+                Some(rt.control.steering_queue()),
             )
             .await
     };
     // Remember where a cancelled turn began so an InterruptReplace follow-up
     // can roll the context back to it; any other outcome clears the marker.
     *rt.interrupted_turn_start.lock().unwrap() =
-        (result.is_err() && rt.cancel.load(Ordering::SeqCst)).then_some(turn_start);
+        (result.is_err() && rt.control.is_cancelled()).then_some(turn_start);
     if result.is_ok() {
         if !completion_delivery_ids.is_empty() {
             let _ = state
@@ -6066,7 +6068,7 @@ async fn send_message_inner(
                 &model_label,
                 agent,
                 &output,
-                &rt.cancel,
+                rt.control.cancel_flag(),
                 turn_start,
             )
             .await;
@@ -6131,7 +6133,7 @@ async fn send_message_inner(
             &ap.id,
             &frame_id,
             &ap.root,
-            Some(rt.cancel.clone()),
+            Some(rt.control.cancel_arc()),
         )
         .await
         {
@@ -6181,9 +6183,10 @@ fn client_turn_error(turn_started: bool, message: &str) -> String {
 
 /// Queue (#433): drain a session's parked follow-ups FIFO. Each acquires the
 /// workflow lock (fair → runs in enqueue order) and runs as a fresh turn with
-/// the item's *current* text, so edits made while it waited take effect. The
-/// `draining` flag is cleared under the `queued` lock so a concurrent enqueue
-/// can never leave an item stranded with no driver.
+/// the item's *current* text, so edits made while it waited take effect.
+/// `FollowUpQueue::driver_pop` releases the driver slot under the queue lock
+/// on an empty queue, so a concurrent enqueue can never leave an item stranded
+/// with no driver.
 fn spawn_queue_driver(
     app: AppHandle,
     rt: Arc<SessionRuntime>,
@@ -6193,15 +6196,8 @@ fn spawn_queue_driver(
     tauri::async_runtime::spawn(async move {
         loop {
             let guard = rt.workflow.clone().lock_owned().await;
-            let item = {
-                let mut q = rt.queued.lock().unwrap();
-                match q.is_empty() {
-                    true => {
-                        rt.draining.store(false, Ordering::SeqCst);
-                        break;
-                    }
-                    false => q.remove(0),
-                }
+            let Some(item) = rt.control.follow_ups().driver_pop() else {
+                break;
             };
             let state = app.state::<AppState>();
             if let Err(error) = send_message_inner(
@@ -6259,18 +6255,13 @@ async fn enqueue_turn(
             .or_insert_with(|| Arc::new(SessionRuntime::new()))
             .clone()
     };
-    let spawn = {
-        let mut q = rt.queued.lock().unwrap();
-        q.push(QueuedItem {
-            id,
-            message,
-            attachments: attachments.unwrap_or_default(),
-            references: references.unwrap_or_default(),
-        });
-        // Claim the driver slot atomically with the push: the driver only clears
-        // `draining` while holding this same lock on an empty queue.
-        !rt.draining.swap(true, Ordering::SeqCst)
-    };
+    // Claims the driver slot atomically with the push (see FollowUpQueue).
+    let spawn = rt.control.follow_ups().enqueue(QueuedItem {
+        id,
+        message,
+        attachments: attachments.unwrap_or_default(),
+        references: references.unwrap_or_default(),
+    });
     if spawn {
         spawn_queue_driver(app, rt, session_id, window.label().to_string());
     }
@@ -6283,31 +6274,15 @@ async fn enqueue_turn(
 /// - `cutin`  → pull it out and fold it into the *running* turn via the guide
 ///   path (#410); if nothing is running it stays queued and runs normally.
 fn begin_queued_cutin(rt: &SessionRuntime, id: u64) -> Option<(u64, QueuedItem)> {
-    let item = {
-        let mut queued = rt.queued.lock().unwrap();
-        queued
-            .iter()
-            .position(|item| item.id == id)
-            .map(|index| queued.remove(index))?
-    };
-    let guidance_id = rt
-        .guidance_seq
-        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    rt.pending_guidance
-        .lock()
-        .unwrap()
-        .push((guidance_id, item.message.clone()));
+    let item = rt.control.follow_ups().take(id)?;
+    let guidance_id = rt.control.push_steering(item.message.clone());
     Some((guidance_id, item))
 }
 
 fn reclaim_unconsumed_cutin(rt: &SessionRuntime, guidance_id: u64, item: QueuedItem) -> bool {
-    let mut pending = rt.pending_guidance.lock().unwrap();
-    let before = pending.len();
-    pending.retain(|(pending_id, _)| *pending_id != guidance_id);
-    let unconsumed = pending.len() != before;
-    drop(pending);
+    let unconsumed = rt.control.reclaim_steering(guidance_id);
     if unconsumed {
-        rt.queued.lock().unwrap().insert(0, item);
+        rt.control.follow_ups().insert_front(item);
     }
     unconsumed
 }
@@ -6332,14 +6307,11 @@ async fn queued_turn_action(
     match action.as_str() {
         "edit" => {
             if let Some(text) = message {
-                let mut q = rt.queued.lock().unwrap();
-                if let Some(item) = q.iter_mut().find(|it| it.id == id) {
-                    item.message = text;
-                }
+                rt.control.follow_ups().edit(id, |item| item.message = text);
             }
         }
         "cancel" => {
-            rt.queued.lock().unwrap().retain(|it| it.id != id);
+            rt.control.follow_ups().cancel(id);
         }
         "cutin" => {
             let running = state.running_turns.lock().await.contains(&session_id);
@@ -6353,33 +6325,20 @@ async fn queued_turn_action(
                     let guard = rt.workflow.clone().lock_owned().await;
                     let unconsumed = reclaim_unconsumed_cutin(&rt, guidance_id, item);
                     drop(guard);
-                    if unconsumed {
-                        if !rt.draining.swap(true, Ordering::SeqCst) {
-                            spawn_queue_driver(
-                                app,
-                                rt.clone(),
-                                session_id,
-                                window.label().to_string(),
-                            );
-                        }
+                    if unconsumed && rt.control.follow_ups().claim_driver() {
+                        spawn_queue_driver(app, rt.clone(), session_id, window.label().to_string());
                     }
                 }
             }
         }
         // Reorder within the queue (#433): swap with the neighbour, clamped at
-        // the ends. FIFO order is the Vec order, which the driver drains front-first.
-        "move_up" | "move_down" => {
-            let mut q = rt.queued.lock().unwrap();
-            if let Some(i) = q.iter().position(|it| it.id == id) {
-                let target = if action == "move_up" {
-                    i.checked_sub(1)
-                } else {
-                    (i + 1 < q.len()).then_some(i + 1)
-                };
-                if let Some(j) = target {
-                    q.swap(i, j);
-                }
-            }
+        // the ends. FIFO order is the queue order, which the driver drains
+        // front-first.
+        "move_up" => {
+            rt.control.follow_ups().move_up(id);
+        }
+        "move_down" => {
+            rt.control.follow_ups().move_down(id);
         }
         other => return Err(format!("unknown queued action: {other}")),
     }
@@ -6415,7 +6374,7 @@ async fn stop_agent(state: State<'_, AppState>, session_id: Option<String>) -> R
                 .collect(),
         };
     for (id, rt) in targets {
-        rt.cancel.store(true, Ordering::Relaxed);
+        rt.control.request_cancel();
         // Wake an agent suspended on the async approval receiver. The loop
         // observes the cancel flag after the denied tool result and exits
         // instead of leaving the Stop button waiting forever.

--- a/src-tauri/src/lib_tests.rs
+++ b/src-tauri/src/lib_tests.rs
@@ -10,7 +10,7 @@ use super::{
     copy_dir_recursive, enable_referenced_contexts, events_to_items, limit_persisted_ui_event,
     merge_pending_ui_event, message_uses_resource_bindings, messages_to_items,
     parse_disabled_skills, parse_enabled_skill_names, parse_follow_up_questions, parse_skill_tags,
-    persist_ui_events, provenance_ui_file_changes, receive_confirm_decision,
+    persist_ui_events, project_runtime_event, provenance_ui_file_changes, receive_confirm_decision,
     reclaim_unconsumed_cutin, resolve_acp_artifact_references, resolve_composer_references,
     resolve_reader_references, resolve_review_backend, resolve_workspace, session_runtime_status,
     should_hide_app_on_macos_close, should_persist_ui_event, user_message_start, AgentEvent,
@@ -797,6 +797,185 @@ fn pending_ui_event_merge_stays_bounded() {
         matches!(flushed, AgentEvent::Text { delta, .. } if delta.len() == MAX_PENDING_UI_EVENT_BYTES)
     );
     assert!(matches!(pending, Some(AgentEvent::Text { ref delta, .. }) if delta == "c"));
+}
+
+#[test]
+fn tool_call_draft_projects_preview_through_the_tool_only() {
+    let tools = wisp_tools::Registry::builtins();
+    let draft = wisp_core::AgentRuntimeEvent::AssistantToolCallUpdated(wisp_core::ToolCallDraft {
+        key: wisp_core::ToolInvocationKey::draft(1, 0),
+        id: None,
+        name: "read".into(),
+        arguments_so_far: r#"{"path": "data/counts.tsv", "offset": 12}"#.into(),
+    });
+    let Some(AgentEvent::ToolCallDraft {
+        frame_id,
+        call_key,
+        name,
+        preview,
+    }) = project_runtime_event(&tools, "f", &draft)
+    else {
+        panic!("draft must project to a ToolCallDraft");
+    };
+    assert_eq!(frame_id, "f");
+    assert_eq!(call_key, "1:0");
+    assert_eq!(name, "read");
+    assert_eq!(preview, "data/counts.tsv");
+}
+
+#[test]
+fn tool_call_draft_never_leaks_raw_arguments() {
+    let tools = wisp_tools::Registry::builtins();
+    // A secret-looking payload inside a field the tool's preview does not
+    // surface must not appear anywhere in the emitted event.
+    let raw = r#"{"path": "out.txt", "content": "sk-secret-marker-12345"}"#;
+    let draft = wisp_core::AgentRuntimeEvent::AssistantToolCallUpdated(wisp_core::ToolCallDraft {
+        key: wisp_core::ToolInvocationKey::draft(2, 1),
+        id: None,
+        name: "write".into(),
+        arguments_so_far: raw.into(),
+    });
+    let event = project_runtime_event(&tools, "f", &draft).unwrap();
+    let serialized = serde_json::to_string(&event).unwrap();
+    assert!(!serialized.contains("sk-secret-marker-12345"));
+    assert!(serialized.contains("out.txt"));
+    match event {
+        AgentEvent::ToolCallDraft { call_key, .. } => assert_eq!(call_key, "2:1"),
+        _ => panic!("expected ToolCallDraft"),
+    }
+}
+
+#[test]
+fn tool_call_draft_degrades_to_name_only_when_args_or_tool_unknown() {
+    let tools = wisp_tools::Registry::builtins();
+    // Partial JSON while the model is still streaming: no parse, no preview.
+    let partial =
+        wisp_core::AgentRuntimeEvent::AssistantToolCallUpdated(wisp_core::ToolCallDraft {
+            key: wisp_core::ToolInvocationKey::draft(1, 0),
+            id: None,
+            name: "read".into(),
+            arguments_so_far: r#"{"path": "data/cou"#.into(),
+        });
+    let Some(AgentEvent::ToolCallDraft { name, preview, .. }) =
+        project_runtime_event(&tools, "f", &partial)
+    else {
+        panic!("draft must project even with unparsable arguments");
+    };
+    assert_eq!(name, "read");
+    assert_eq!(preview, "");
+
+    // A tool the session never registered (or a virtual MCP gateway name):
+    // name-only, never the raw arguments.
+    let unknown =
+        wisp_core::AgentRuntimeEvent::AssistantToolCallUpdated(wisp_core::ToolCallDraft {
+            key: wisp_core::ToolInvocationKey::draft(1, 1),
+            id: None,
+            name: "use_mcp_tool".into(),
+            arguments_so_far: r#"{"tool_input": {"query": "raw-marker-678"}}"#.into(),
+        });
+    let Some(AgentEvent::ToolCallDraft { preview, .. }) =
+        project_runtime_event(&tools, "f", &unknown)
+    else {
+        panic!("draft must project even for unknown tools");
+    };
+    assert!(!preview.contains("raw-marker-678"));
+}
+
+#[test]
+fn same_name_draft_calls_are_keyed_separately() {
+    let tools = wisp_tools::Registry::builtins();
+    let draft = |index: usize, path: &str| {
+        wisp_core::AgentRuntimeEvent::AssistantToolCallUpdated(wisp_core::ToolCallDraft {
+            key: wisp_core::ToolInvocationKey::draft(1, index),
+            id: None,
+            name: "read".into(),
+            arguments_so_far: format!(r#"{{"path": "{path}"}}"#),
+        })
+    };
+    let first = project_runtime_event(&tools, "f", &draft(0, "a.tsv")).unwrap();
+    let second = project_runtime_event(&tools, "f", &draft(1, "b.tsv")).unwrap();
+    let key_of = |event: &AgentEvent| match event {
+        AgentEvent::ToolCallDraft {
+            call_key, preview, ..
+        } => (call_key.clone(), preview.clone()),
+        _ => panic!("expected ToolCallDraft"),
+    };
+    assert_eq!(key_of(&first), ("1:0".to_string(), "a.tsv".to_string()));
+    assert_eq!(key_of(&second), ("1:1".to_string(), "b.tsv".to_string()));
+}
+
+#[test]
+fn ready_and_run_boundaries_clear_drafts() {
+    let tools = wisp_tools::Registry::builtins();
+    let ready = wisp_core::AgentRuntimeEvent::ToolCallReady {
+        key: wisp_core::ToolInvocationKey::ready(1, 0, "call-1"),
+        name: "read".into(),
+    };
+    assert!(matches!(
+        project_runtime_event(&tools, "f", &ready),
+        Some(AgentEvent::ToolCallDraftClear { call_key: Some(key), .. }) if key == "1:0"
+    ));
+    for boundary in [
+        wisp_core::AgentRuntimeEvent::RoundFinished { round: 1 },
+        wisp_core::AgentRuntimeEvent::RunFinished {
+            outcome: wisp_core::RunOutcome::Cancelled,
+        },
+    ] {
+        assert!(matches!(
+            project_runtime_event(&tools, "f", &boundary),
+            Some(AgentEvent::ToolCallDraftClear { call_key: None, .. })
+        ));
+    }
+    // Other variants stay unprojected for now.
+    assert!(
+        project_runtime_event(&tools, "f", &wisp_core::AgentRuntimeEvent::RunStarted).is_none()
+    );
+}
+
+#[test]
+fn draft_events_are_live_only_and_never_persisted() {
+    assert!(!should_persist_ui_event(&AgentEvent::ToolCallDraft {
+        frame_id: "f".into(),
+        call_key: "1:0".into(),
+        name: "read".into(),
+        preview: "a.tsv".into(),
+    }));
+    assert!(!should_persist_ui_event(&AgentEvent::ToolCallDraftClear {
+        frame_id: "f".into(),
+        call_key: None,
+    }));
+}
+
+#[test]
+fn pending_drafts_of_the_same_call_key_collapse_to_latest() {
+    let draft = |key: &str, preview: &str| AgentEvent::ToolCallDraft {
+        frame_id: "f".into(),
+        call_key: key.into(),
+        name: "read".into(),
+        preview: preview.into(),
+    };
+    let mut pending = Some(draft("1:0", "a.t"));
+    // Same key: merged, latest snapshot wins, nothing flushed.
+    assert!(merge_pending_ui_event(&mut pending, draft("1:0", "a.tsv")).is_none());
+    assert!(
+        matches!(&pending, Some(AgentEvent::ToolCallDraft { preview, .. }) if preview == "a.tsv")
+    );
+    // Different key: the pending one flushes, the new one becomes pending.
+    let flushed = merge_pending_ui_event(&mut pending, draft("1:1", "b.tsv")).unwrap();
+    assert!(matches!(flushed, AgentEvent::ToolCallDraft { call_key, .. } if call_key == "1:0"));
+    assert!(
+        matches!(&pending, Some(AgentEvent::ToolCallDraft { call_key, .. }) if call_key == "1:1")
+    );
+    // A non-draft event flushes the pending draft unchanged.
+    let flushed = merge_pending_ui_event(
+        &mut pending,
+        AgentEvent::ToolCallDraftClear {
+            frame_id: "f".into(),
+            call_key: Some("1:1".into()),
+        },
+    )
+    .unwrap();
+    assert!(matches!(flushed, AgentEvent::ToolCallDraft { call_key, .. } if call_key == "1:1"));
 }
 
 #[tokio::test]

--- a/src-tauri/src/lib_tests.rs
+++ b/src-tauri/src/lib_tests.rs
@@ -947,6 +947,124 @@ fn draft_events_are_live_only_and_never_persisted() {
 }
 
 #[test]
+fn execution_start_and_progress_project_live_only() {
+    let tools = wisp_tools::Registry::builtins();
+    let key = wisp_core::ToolInvocationKey::ready(2, 1, "call-9");
+
+    let started = wisp_core::AgentRuntimeEvent::ToolExecutionStarted {
+        key: key.clone(),
+        name: "monitor_run".into(),
+    };
+    let Some(started) = project_runtime_event(&tools, "f", &started) else {
+        panic!("execution start must project");
+    };
+    assert!(
+        matches!(&started, AgentEvent::ToolExecutionStarted { call_key, name, .. } if call_key == "2:1" && name == "monitor_run")
+    );
+    assert!(
+        !should_persist_ui_event(&started),
+        "execution start is live-only"
+    );
+
+    let progress = wisp_core::AgentRuntimeEvent::ToolExecutionUpdated {
+        key,
+        details: serde_json::json!({"status": "running"}),
+    };
+    let Some(progress) = project_runtime_event(&tools, "f", &progress) else {
+        panic!("progress must project");
+    };
+    assert!(
+        matches!(&progress, AgentEvent::ToolProgress { call_key, details, .. } if call_key == "2:1" && details["status"] == "running")
+    );
+    assert!(
+        !should_persist_ui_event(&progress),
+        "a progress fragment must never be persisted"
+    );
+}
+
+#[test]
+fn final_details_project_to_a_persisted_patch_exactly_once() {
+    let tools = wisp_tools::Registry::builtins();
+    let finished =
+        |details: Option<serde_json::Value>| wisp_core::AgentRuntimeEvent::ToolExecutionFinished {
+            key: wisp_core::ToolInvocationKey::ready(1, 0, "call-1"),
+            name: "monitor_run".into(),
+            ok: true,
+            duration_ms: 5,
+            details,
+        };
+
+    // No details: nothing to patch, no extra persisted event.
+    assert!(project_runtime_event(&tools, "f", &finished(None)).is_none());
+
+    let projected = project_runtime_event(
+        &tools,
+        "f",
+        &finished(Some(serde_json::json!({"status": "succeeded"}))),
+    )
+    .expect("final details must project");
+    assert!(
+        matches!(&projected, AgentEvent::ToolResultDetails { call_key, name, details, .. } if call_key == "1:0" && name == "monitor_run" && details["status"] == "succeeded")
+    );
+    assert!(
+        should_persist_ui_event(&projected),
+        "the final details patch is the one persisted event"
+    );
+}
+
+#[test]
+fn replayed_tool_result_details_restore_the_tool_row() {
+    let frame_id = "f".to_string();
+    let details = serde_json::json!({"id": "run-1", "status": "succeeded", "exit_code": 0});
+    let events = vec![
+        AgentEvent::ToolCall {
+            frame_id: frame_id.clone(),
+            name: "monitor_run".into(),
+            preview: "run-1".into(),
+        },
+        AgentEvent::ToolResult {
+            frame_id: frame_id.clone(),
+            name: "monitor_run".into(),
+            ok: true,
+            content: "Run run-1 finished with status succeeded.".into(),
+            duration_ms: 7,
+        },
+        AgentEvent::ToolResultDetails {
+            frame_id,
+            call_key: "1:0".into(),
+            name: "monitor_run".into(),
+            details: details.clone(),
+        },
+    ];
+
+    let (items, _) = events_to_items(&events);
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].role, "tool");
+    assert_eq!(items[0].details, Some(details));
+}
+
+#[test]
+fn replay_ignores_progress_fragments() {
+    let frame_id = "f".to_string();
+    let events = vec![
+        AgentEvent::ToolCall {
+            frame_id: frame_id.clone(),
+            name: "monitor_run".into(),
+            preview: "run-1".into(),
+        },
+        AgentEvent::ToolProgress {
+            frame_id,
+            call_key: "1:0".into(),
+            details: serde_json::json!({"status": "running"}),
+        },
+    ];
+
+    let (items, _) = events_to_items(&events);
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].details, None);
+}
+
+#[test]
 fn pending_drafts_of_the_same_call_key_collapse_to_latest() {
     let draft = |key: &str, preview: &str| AgentEvent::ToolCallDraft {
         frame_id: "f".into(),

--- a/src-tauri/src/lib_tests.rs
+++ b/src-tauri/src/lib_tests.rs
@@ -2060,7 +2060,6 @@ fn foreign_project_notification_fallback_never_arms_focus_navigation() {
 // otherwise an item enqueued just as the driver exits would strand with no runner.
 #[test]
 fn queue_driver_claim_is_single_and_reclaimable() {
-    use std::sync::atomic::Ordering;
     let item = |id: u64| QueuedItem {
         id,
         message: format!("m{id}"),
@@ -2068,34 +2067,26 @@ fn queue_driver_claim_is_single_and_reclaimable() {
         references: vec![],
     };
     let rt = SessionRuntime::new();
+    let queue = rt.control.follow_ups();
 
     // First enqueue claims the driver slot; a concurrent second must not.
-    rt.queued.lock().unwrap().push(item(1));
+    assert!(queue.enqueue(item(1)), "first enqueue claims the driver");
     assert!(
-        !rt.draining.swap(true, Ordering::SeqCst),
-        "first enqueue claims the driver"
-    );
-    rt.queued.lock().unwrap().push(item(2));
-    assert!(
-        rt.draining.swap(true, Ordering::SeqCst),
+        !queue.enqueue(item(2)),
         "second enqueue sees a driver already running"
     );
 
     // The driver drains FIFO from the front.
-    assert_eq!(rt.queued.lock().unwrap().remove(0).id, 1);
-    assert_eq!(rt.queued.lock().unwrap().remove(0).id, 2);
+    assert_eq!(queue.driver_pop().map(|item| item.id), Some(1));
+    assert_eq!(queue.driver_pop().map(|item| item.id), Some(2));
 
-    // Empty → the driver clears the flag under the queued lock and exits.
-    {
-        let q = rt.queued.lock().unwrap();
-        assert!(q.is_empty());
-        rt.draining.store(false, Ordering::SeqCst);
-    }
+    // Empty → the driver releases the slot under the queue lock and exits.
+    assert!(queue.driver_pop().is_none());
+    assert!(!queue.driver_active());
 
     // A later enqueue re-claims the slot rather than stranding.
-    rt.queued.lock().unwrap().push(item(3));
     assert!(
-        !rt.draining.swap(true, Ordering::SeqCst),
+        queue.enqueue(item(3)),
         "post-drain enqueue re-claims the driver"
     );
 }
@@ -2103,7 +2094,7 @@ fn queue_driver_claim_is_single_and_reclaimable() {
 #[test]
 fn unconsumed_cutin_returns_to_the_front_of_the_queue() {
     let rt = SessionRuntime::new();
-    rt.queued.lock().unwrap().push(QueuedItem {
+    rt.control.follow_ups().enqueue(QueuedItem {
         id: 7,
         message: "close tabs".into(),
         attachments: vec![],
@@ -2111,16 +2102,16 @@ fn unconsumed_cutin_returns_to_the_front_of_the_queue() {
     });
 
     let (guidance_id, item) = begin_queued_cutin(&rt, 7).unwrap();
-    assert!(rt.queued.lock().unwrap().is_empty());
+    assert!(rt.control.follow_ups().is_empty());
     assert!(reclaim_unconsumed_cutin(&rt, guidance_id, item));
-    assert_eq!(rt.queued.lock().unwrap()[0].message, "close tabs");
-    assert!(rt.pending_guidance.lock().unwrap().is_empty());
+    assert_eq!(rt.control.follow_ups().snapshot()[0].message, "close tabs");
+    assert!(rt.control.steering_queue().lock().unwrap().is_empty());
 }
 
 #[test]
 fn consumed_cutin_is_not_queued_again() {
     let rt = SessionRuntime::new();
-    rt.queued.lock().unwrap().push(QueuedItem {
+    rt.control.follow_ups().enqueue(QueuedItem {
         id: 8,
         message: "use tab.close".into(),
         attachments: vec![],
@@ -2128,9 +2119,9 @@ fn consumed_cutin_is_not_queued_again() {
     });
 
     let (guidance_id, item) = begin_queued_cutin(&rt, 8).unwrap();
-    rt.pending_guidance.lock().unwrap().clear();
+    rt.control.steering_queue().lock().unwrap().clear();
     assert!(!reclaim_unconsumed_cutin(&rt, guidance_id, item));
-    assert!(rt.queued.lock().unwrap().is_empty());
+    assert!(rt.control.follow_ups().is_empty());
 }
 
 // Reorder (#433): move swaps with the neighbour and clamps at both ends, so the
@@ -2143,29 +2134,27 @@ fn queue_reorder_swaps_and_clamps() {
         attachments: vec![],
         references: vec![],
     };
-    let swap_toward = |q: &mut Vec<QueuedItem>, id: u64, up: bool| {
-        if let Some(i) = q.iter().position(|it| it.id == id) {
-            let target = if up {
-                i.checked_sub(1)
-            } else {
-                (i + 1 < q.len()).then_some(i + 1)
-            };
-            if let Some(j) = target {
-                q.swap(i, j);
-            }
-        }
+    let rt = SessionRuntime::new();
+    let queue = rt.control.follow_ups();
+    let ids = || {
+        queue
+            .snapshot()
+            .iter()
+            .map(|item| item.id)
+            .collect::<Vec<_>>()
     };
-    let ids = |q: &[QueuedItem]| q.iter().map(|it| it.id).collect::<Vec<_>>();
 
-    let mut q = vec![item(1), item(2), item(3)]; // A, B, C
-    swap_toward(&mut q, 3, true); // C up → A, C, B
-    assert_eq!(ids(&q), [1, 3, 2]);
-    swap_toward(&mut q, 1, false); // A down → C, A, B
-    assert_eq!(ids(&q), [3, 1, 2]);
-    swap_toward(&mut q, 3, true); // C already first → no-op
-    assert_eq!(ids(&q), [3, 1, 2]);
-    swap_toward(&mut q, 2, false); // B already last → no-op
-    assert_eq!(ids(&q), [3, 1, 2]);
+    queue.enqueue(item(1));
+    queue.enqueue(item(2));
+    queue.enqueue(item(3)); // A, B, C
+    queue.move_up(3); // C up → A, C, B
+    assert_eq!(ids(), [1, 3, 2]);
+    queue.move_down(1); // A down → C, A, B
+    assert_eq!(ids(), [3, 1, 2]);
+    assert!(!queue.move_up(3), "already first → no-op");
+    assert_eq!(ids(), [3, 1, 2]);
+    assert!(!queue.move_down(2), "already last → no-op");
+    assert_eq!(ids(), [3, 1, 2]);
 }
 
 #[test]

--- a/src-tauri/src/lib_tests.rs
+++ b/src-tauri/src/lib_tests.rs
@@ -15,8 +15,9 @@ use super::{
     resolve_reader_references, resolve_review_backend, resolve_workspace, session_runtime_status,
     should_hide_app_on_macos_close, should_persist_ui_event, user_message_start, AgentEvent,
     ComposerReferenceArg, McpConnection, McpHttpAuth, McpTransport, QueuedItem, SessionRuntime,
-    SkillInfo, StartupReport, StartupTimeline, MAX_PENDING_UI_EVENT_BYTES,
-    UI_STREAM_OUTPUT_MAX_BYTES, UI_TOOL_RESULT_MAX_CHARS,
+    SkillInfo, StartupReport, StartupTimeline, ToolCallDraftAccumulators,
+    DRAFT_PREVIEW_RECOMPUTE_INTERVAL, MAX_PENDING_UI_EVENT_BYTES, UI_STREAM_OUTPUT_MAX_BYTES,
+    UI_TOOL_RESULT_MAX_CHARS,
 };
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
@@ -802,20 +803,22 @@ fn pending_ui_event_merge_stays_bounded() {
 #[test]
 fn tool_call_draft_projects_preview_through_the_tool_only() {
     let tools = wisp_tools::Registry::builtins();
-    let draft = wisp_core::AgentRuntimeEvent::AssistantToolCallUpdated(wisp_core::ToolCallDraft {
+    let mut drafts = ToolCallDraftAccumulators::default();
+    let delta = wisp_core::AgentRuntimeEvent::AssistantToolCallDelta {
         key: wisp_core::ToolInvocationKey::draft(1, 0),
         id: None,
-        name: "read".into(),
-        arguments_so_far: r#"{"path": "data/counts.tsv", "offset": 12}"#.into(),
-    });
+        name: Some("read".into()),
+        arguments_delta: r#"{"path": "data/counts.tsv", "offset": 12}"#.into(),
+        reset: true,
+    };
     let Some(AgentEvent::ToolCallDraft {
         frame_id,
         call_key,
         name,
         preview,
-    }) = project_runtime_event(&tools, "f", &draft)
+    }) = project_runtime_event(&mut drafts, &tools, "f", &delta)
     else {
-        panic!("draft must project to a ToolCallDraft");
+        panic!("delta must project to a ToolCallDraft");
     };
     assert_eq!(frame_id, "f");
     assert_eq!(call_key, "1:0");
@@ -826,16 +829,18 @@ fn tool_call_draft_projects_preview_through_the_tool_only() {
 #[test]
 fn tool_call_draft_never_leaks_raw_arguments() {
     let tools = wisp_tools::Registry::builtins();
+    let mut drafts = ToolCallDraftAccumulators::default();
     // A secret-looking payload inside a field the tool's preview does not
     // surface must not appear anywhere in the emitted event.
     let raw = r#"{"path": "out.txt", "content": "sk-secret-marker-12345"}"#;
-    let draft = wisp_core::AgentRuntimeEvent::AssistantToolCallUpdated(wisp_core::ToolCallDraft {
+    let delta = wisp_core::AgentRuntimeEvent::AssistantToolCallDelta {
         key: wisp_core::ToolInvocationKey::draft(2, 1),
         id: None,
-        name: "write".into(),
-        arguments_so_far: raw.into(),
-    });
-    let event = project_runtime_event(&tools, "f", &draft).unwrap();
+        name: Some("write".into()),
+        arguments_delta: raw.into(),
+        reset: true,
+    };
+    let event = project_runtime_event(&mut drafts, &tools, "f", &delta).unwrap();
     let serialized = serde_json::to_string(&event).unwrap();
     assert!(!serialized.contains("sk-secret-marker-12345"));
     assert!(serialized.contains("out.txt"));
@@ -848,16 +853,17 @@ fn tool_call_draft_never_leaks_raw_arguments() {
 #[test]
 fn tool_call_draft_degrades_to_name_only_when_args_or_tool_unknown() {
     let tools = wisp_tools::Registry::builtins();
+    let mut drafts = ToolCallDraftAccumulators::default();
     // Partial JSON while the model is still streaming: no parse, no preview.
-    let partial =
-        wisp_core::AgentRuntimeEvent::AssistantToolCallUpdated(wisp_core::ToolCallDraft {
-            key: wisp_core::ToolInvocationKey::draft(1, 0),
-            id: None,
-            name: "read".into(),
-            arguments_so_far: r#"{"path": "data/cou"#.into(),
-        });
+    let partial = wisp_core::AgentRuntimeEvent::AssistantToolCallDelta {
+        key: wisp_core::ToolInvocationKey::draft(1, 0),
+        id: None,
+        name: Some("read".into()),
+        arguments_delta: r#"{"path": "data/cou"#.into(),
+        reset: true,
+    };
     let Some(AgentEvent::ToolCallDraft { name, preview, .. }) =
-        project_runtime_event(&tools, "f", &partial)
+        project_runtime_event(&mut drafts, &tools, "f", &partial)
     else {
         panic!("draft must project even with unparsable arguments");
     };
@@ -866,15 +872,15 @@ fn tool_call_draft_degrades_to_name_only_when_args_or_tool_unknown() {
 
     // A tool the session never registered (or a virtual MCP gateway name):
     // name-only, never the raw arguments.
-    let unknown =
-        wisp_core::AgentRuntimeEvent::AssistantToolCallUpdated(wisp_core::ToolCallDraft {
-            key: wisp_core::ToolInvocationKey::draft(1, 1),
-            id: None,
-            name: "use_mcp_tool".into(),
-            arguments_so_far: r#"{"tool_input": {"query": "raw-marker-678"}}"#.into(),
-        });
+    let unknown = wisp_core::AgentRuntimeEvent::AssistantToolCallDelta {
+        key: wisp_core::ToolInvocationKey::draft(1, 1),
+        id: None,
+        name: Some("use_mcp_tool".into()),
+        arguments_delta: r#"{"tool_input": {"query": "raw-marker-678"}}"#.into(),
+        reset: true,
+    };
     let Some(AgentEvent::ToolCallDraft { preview, .. }) =
-        project_runtime_event(&tools, "f", &unknown)
+        project_runtime_event(&mut drafts, &tools, "f", &unknown)
     else {
         panic!("draft must project even for unknown tools");
     };
@@ -884,16 +890,16 @@ fn tool_call_draft_degrades_to_name_only_when_args_or_tool_unknown() {
 #[test]
 fn same_name_draft_calls_are_keyed_separately() {
     let tools = wisp_tools::Registry::builtins();
-    let draft = |index: usize, path: &str| {
-        wisp_core::AgentRuntimeEvent::AssistantToolCallUpdated(wisp_core::ToolCallDraft {
-            key: wisp_core::ToolInvocationKey::draft(1, index),
-            id: None,
-            name: "read".into(),
-            arguments_so_far: format!(r#"{{"path": "{path}"}}"#),
-        })
+    let mut drafts = ToolCallDraftAccumulators::default();
+    let delta = |index: usize, path: &str| wisp_core::AgentRuntimeEvent::AssistantToolCallDelta {
+        key: wisp_core::ToolInvocationKey::draft(1, index),
+        id: None,
+        name: Some("read".into()),
+        arguments_delta: format!(r#"{{"path": "{path}"}}"#),
+        reset: true,
     };
-    let first = project_runtime_event(&tools, "f", &draft(0, "a.tsv")).unwrap();
-    let second = project_runtime_event(&tools, "f", &draft(1, "b.tsv")).unwrap();
+    let first = project_runtime_event(&mut drafts, &tools, "f", &delta(0, "a.tsv")).unwrap();
+    let second = project_runtime_event(&mut drafts, &tools, "f", &delta(1, "b.tsv")).unwrap();
     let key_of = |event: &AgentEvent| match event {
         AgentEvent::ToolCallDraft {
             call_key, preview, ..
@@ -905,14 +911,117 @@ fn same_name_draft_calls_are_keyed_separately() {
 }
 
 #[test]
-fn ready_and_run_boundaries_clear_drafts() {
+fn draft_accumulator_appends_fragments_and_evicts_on_ready() {
     let tools = wisp_tools::Registry::builtins();
+    let mut drafts = ToolCallDraftAccumulators::default();
+    let t0 = std::time::Instant::now();
+    let later = t0 + DRAFT_PREVIEW_RECOMPUTE_INTERVAL + std::time::Duration::from_millis(1);
+
+    // First fragment: reset with the name and a partial argument.
+    let first = drafts.push_delta(
+        &tools,
+        "f",
+        "1:0",
+        Some("read"),
+        r#"{"path": "da"#,
+        true,
+        t0,
+    );
+    let Some(AgentEvent::ToolCallDraft { preview, .. }) = first else {
+        panic!("first fragment must emit");
+    };
+    assert_eq!(preview, "", "partial JSON has no preview yet");
+
+    // Second fragment inside the recompute window: accumulated, not emitted.
+    assert!(
+        drafts
+            .push_delta(&tools, "f", "1:0", None, r#"ta/a.tsv"}"#, false, t0)
+            .is_none(),
+        "throttled fragment is accumulated silently"
+    );
+    // Once the window elapses, the preview reflects the WHOLE accumulation.
+    let third = drafts.push_delta(&tools, "f", "1:0", None, "", false, later);
+    let Some(AgentEvent::ToolCallDraft { preview, .. }) = third else {
+        panic!("recompute after the window must emit");
+    };
+    assert_eq!(preview, "data/a.tsv");
+
+    // ToolCallReady evicts the accumulator; the draft row is cleared.
     let ready = wisp_core::AgentRuntimeEvent::ToolCallReady {
         key: wisp_core::ToolInvocationKey::ready(1, 0, "call-1"),
         name: "read".into(),
     };
     assert!(matches!(
-        project_runtime_event(&tools, "f", &ready),
+        project_runtime_event(&mut drafts, &tools, "f", &ready),
+        Some(AgentEvent::ToolCallDraftClear { call_key: Some(key), .. }) if key == "1:0"
+    ));
+    assert!(drafts.drafts.is_empty(), "ready evicts the accumulator");
+}
+
+#[test]
+fn draft_accumulator_reset_replaces_a_retried_index_instead_of_appending() {
+    let tools = wisp_tools::Registry::builtins();
+    let mut drafts = ToolCallDraftAccumulators::default();
+    let t0 = std::time::Instant::now();
+    let later = t0 + DRAFT_PREVIEW_RECOMPUTE_INTERVAL + std::time::Duration::from_millis(1);
+
+    // First attempt streams a fragment, then a retry reuses the same index:
+    // its reset must drop the stale fragment, not concatenate onto it.
+    drafts.push_delta(
+        &tools,
+        "f",
+        "1:0",
+        Some("read"),
+        r#"{"path": "stale"#,
+        true,
+        t0,
+    );
+    drafts.push_delta(
+        &tools,
+        "f",
+        "1:0",
+        Some("read"),
+        r#"{"path": "a.tsv"}"#,
+        true,
+        later,
+    );
+    assert_eq!(
+        drafts.drafts["1:0"].arguments, r#"{"path": "a.tsv"}"#,
+        "reset drops the previous attempt's fragments"
+    );
+    let emitted = drafts.push_delta(
+        &tools,
+        "f",
+        "1:0",
+        None,
+        "",
+        false,
+        later + DRAFT_PREVIEW_RECOMPUTE_INTERVAL + std::time::Duration::from_millis(1),
+    );
+    let Some(AgentEvent::ToolCallDraft { preview, .. }) = emitted else {
+        panic!("post-reset accumulation must emit");
+    };
+    assert_eq!(preview, "a.tsv");
+
+    // A round boundary drops every live draft.
+    let boundary = wisp_core::AgentRuntimeEvent::RoundFinished { round: 1 };
+    assert!(matches!(
+        project_runtime_event(&mut drafts, &tools, "f", &boundary),
+        Some(AgentEvent::ToolCallDraftClear { call_key: None, .. })
+    ));
+    assert!(drafts.drafts.is_empty());
+}
+
+#[test]
+fn ready_and_run_boundaries_clear_drafts() {
+    let tools = wisp_tools::Registry::builtins();
+    let mut drafts = ToolCallDraftAccumulators::default();
+    let ready = wisp_core::AgentRuntimeEvent::ToolCallReady {
+        key: wisp_core::ToolInvocationKey::ready(1, 0, "call-1"),
+        name: "read".into(),
+    };
+    assert!(matches!(
+        project_runtime_event(&mut drafts, &tools, "f", &ready),
         Some(AgentEvent::ToolCallDraftClear { call_key: Some(key), .. }) if key == "1:0"
     ));
     for boundary in [
@@ -922,14 +1031,18 @@ fn ready_and_run_boundaries_clear_drafts() {
         },
     ] {
         assert!(matches!(
-            project_runtime_event(&tools, "f", &boundary),
+            project_runtime_event(&mut drafts, &tools, "f", &boundary),
             Some(AgentEvent::ToolCallDraftClear { call_key: None, .. })
         ));
     }
     // Other variants stay unprojected for now.
-    assert!(
-        project_runtime_event(&tools, "f", &wisp_core::AgentRuntimeEvent::RunStarted).is_none()
-    );
+    assert!(project_runtime_event(
+        &mut drafts,
+        &tools,
+        "f",
+        &wisp_core::AgentRuntimeEvent::RunStarted
+    )
+    .is_none());
 }
 
 #[test]
@@ -949,13 +1062,14 @@ fn draft_events_are_live_only_and_never_persisted() {
 #[test]
 fn execution_start_and_progress_project_live_only() {
     let tools = wisp_tools::Registry::builtins();
+    let mut drafts = ToolCallDraftAccumulators::default();
     let key = wisp_core::ToolInvocationKey::ready(2, 1, "call-9");
 
     let started = wisp_core::AgentRuntimeEvent::ToolExecutionStarted {
         key: key.clone(),
         name: "monitor_run".into(),
     };
-    let Some(started) = project_runtime_event(&tools, "f", &started) else {
+    let Some(started) = project_runtime_event(&mut drafts, &tools, "f", &started) else {
         panic!("execution start must project");
     };
     assert!(
@@ -970,7 +1084,7 @@ fn execution_start_and_progress_project_live_only() {
         key,
         details: serde_json::json!({"status": "running"}),
     };
-    let Some(progress) = project_runtime_event(&tools, "f", &progress) else {
+    let Some(progress) = project_runtime_event(&mut drafts, &tools, "f", &progress) else {
         panic!("progress must project");
     };
     assert!(
@@ -985,6 +1099,7 @@ fn execution_start_and_progress_project_live_only() {
 #[test]
 fn final_details_project_to_a_persisted_patch_exactly_once() {
     let tools = wisp_tools::Registry::builtins();
+    let mut drafts = ToolCallDraftAccumulators::default();
     let finished =
         |details: Option<serde_json::Value>| wisp_core::AgentRuntimeEvent::ToolExecutionFinished {
             key: wisp_core::ToolInvocationKey::ready(1, 0, "call-1"),
@@ -995,9 +1110,10 @@ fn final_details_project_to_a_persisted_patch_exactly_once() {
         };
 
     // No details: nothing to patch, no extra persisted event.
-    assert!(project_runtime_event(&tools, "f", &finished(None)).is_none());
+    assert!(project_runtime_event(&mut drafts, &tools, "f", &finished(None)).is_none());
 
     let projected = project_runtime_event(
+        &mut drafts,
         &tools,
         "f",
         &finished(Some(serde_json::json!({"status": "succeeded"}))),

--- a/src-tauri/src/project_commands.rs
+++ b/src-tauri/src/project_commands.rs
@@ -157,7 +157,7 @@ pub(super) async fn cancel_project_sessions(state: &AppState, project_id: &str) 
     };
     for (_, rt) in &runtimes {
         rt.deleted.store(true, Ordering::SeqCst);
-        rt.cancel.store(true, Ordering::SeqCst);
+        rt.control.request_cancel();
     }
     for fid in &frame_ids {
         acp::cancel_frame(state, fid).await;

--- a/src-tauri/src/run_context/tests.rs
+++ b/src-tauri/src/run_context/tests.rs
@@ -232,13 +232,13 @@ async fn run_in_context_can_suspend_until_terminal_without_get_run_calls() {
         .await;
 
     assert!(result.success, "{}", result.content);
-    // The model sees a human summary; the structured record rides `details`.
+    // The model sees a human summary; a sanitized structured view rides
+    // `details` — machine-private Run fields stay behind `get_run_detail`.
     assert!(result.content.contains("finished with status succeeded"));
     assert!(result.content.contains("stdout tail"));
-    let run: wisp_store::RunRecord =
-        serde_json::from_value(result.details.clone().expect("run details")).unwrap();
-    assert_eq!(run.status, wisp_store::RunStatus::Succeeded);
-    assert_eq!(run.stdout_tail.as_deref(), Some("finished"));
+    let details = result.details.clone().expect("run details");
+    assert_eq!(details["status"], serde_json::json!("succeeded"));
+    assert_eq!(details["stdout_tail"], serde_json::json!("finished"));
     let _ = std::fs::remove_dir_all(tmp);
 }
 
@@ -283,10 +283,9 @@ async fn run_in_context_wait_reports_a_failed_run_as_a_failed_tool_call() {
         !result.success,
         "failed Run must not render as a green tool call"
     );
-    let run: wisp_store::RunRecord =
-        serde_json::from_value(result.details.clone().expect("run details")).unwrap();
-    assert_eq!(run.status, wisp_store::RunStatus::Failed);
-    assert_eq!(run.exit_code, Some(127));
+    let details = result.details.clone().expect("run details");
+    assert_eq!(details["status"], serde_json::json!("failed"));
+    assert_eq!(details["exit_code"], serde_json::json!(127));
     let _ = std::fs::remove_dir_all(tmp);
 }
 
@@ -373,9 +372,12 @@ async fn run_in_context_preflight_is_structured_and_persisted_with_the_run() {
         .await;
 
     assert!(result.success, "{}", result.content);
-    let run: wisp_store::RunRecord =
-        serde_json::from_value(result.details.clone().expect("run details")).unwrap();
-    assert_eq!(run.status, wisp_store::RunStatus::Succeeded);
+    let details = result.details.clone().expect("run details");
+    assert_eq!(details["status"], serde_json::json!("succeeded"));
+    // The persisted details are sanitized; the preflight snapshot is verified
+    // on the stored record itself.
+    let run_id = details["id"].as_str().expect("run id").to_string();
+    let run = store.get_run(&run_id).await.unwrap().expect("run row");
     let snapshot: serde_json::Value = serde_json::from_str(&run.env_snapshot_json).unwrap();
     assert_eq!(snapshot["preflight"]["status"], "passed");
     assert_eq!(snapshot["preflight"]["language"], "python");
@@ -501,9 +503,9 @@ async fn monitor_run_waits_once_for_an_existing_run() {
         .await;
 
     assert!(result.success, "{}", result.content);
-    let run: wisp_store::RunRecord =
-        serde_json::from_value(result.details.clone().expect("run details")).unwrap();
-    assert_eq!(run.status, wisp_store::RunStatus::Succeeded);
+    let details = result.details.clone().expect("run details");
+    assert_eq!(details["id"], serde_json::json!("long-run"));
+    assert_eq!(details["status"], serde_json::json!("succeeded"));
     let _ = std::fs::remove_dir_all(tmp);
 }
 
@@ -566,6 +568,112 @@ async fn monitor_run_streams_progress_while_waiting() {
     // …and the terminal record lands once, on the result's details.
     let final_run = result.details.clone().expect("final run details");
     assert_eq!(final_run["status"], serde_json::json!("succeeded"));
+    let _ = std::fs::remove_dir_all(tmp);
+}
+
+#[tokio::test]
+async fn run_tool_details_and_progress_carry_only_the_sanitized_presentation() {
+    use wisp_tools::Tool;
+    let tmp = std::env::temp_dir().join(format!("wisp_run_sanitize_{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&tmp).unwrap();
+    let store = wisp_store::Store::open(&tmp.join("wisp.sqlite"))
+        .await
+        .unwrap();
+    store
+        .create_project("p", "project", &tmp.to_string_lossy())
+        .await
+        .unwrap();
+    // Machine-private fields a full RunRecord carries. None of these
+    // sentinels may reach the tool's details or its live progress snapshots:
+    // the host persists final details as session_ui_events rows and project
+    // export copies those rows.
+    let mut run =
+        wisp_store::RunRecord::new("sentinel-run", "p", "ssh:gpu", "Sentinel run", "ssh_direct");
+    run.command = Some("SENTINEL-COMMAND /home/sentinel/.ssh/id_sentinel".into());
+    run.script_path = Some("/home/sentinel/bin/python".into());
+    run.remote_workdir = Some("ssh://sentinel-host/home/sentinel/work".into());
+    run.remote_handle_json = Some(
+        r#"{"identity_file":"/home/sentinel/.ssh/id_sentinel","token":"SENTINEL-TOKEN"}"#.into(),
+    );
+    run.env_snapshot_json = r#"{"API_KEY":"SENTINEL-TOKEN","HOME":"/home/sentinel"}"#.into();
+    run.progress_json = r#"{"host":"ssh://sentinel-host"}"#.into();
+    run.last_poll_error = Some("ssh://sentinel-host unreachable".into());
+    store.create_run(&run).await.unwrap();
+    assert!(store
+        .activate_run_lifecycle(
+            "sentinel-run",
+            wisp_store::RunStatus::Submitted,
+            "monitor-owner",
+            60,
+        )
+        .await
+        .unwrap());
+    let finishing_store = store.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(25)).await;
+        assert!(finishing_store
+            .finish_active_run_owned(
+                "sentinel-run",
+                "monitor-owner",
+                wisp_store::RunStatus::Succeeded,
+                Some(0),
+            )
+            .await
+            .unwrap());
+    });
+
+    let env = RecordingRunToolEnv::new(tmp.clone());
+    let result = MonitorRunTool::new(store, "p".into())
+        .run(&serde_json::json!({ "run_id": "sentinel-run" }), &env)
+        .await;
+    assert!(result.success, "{}", result.content);
+
+    const SENTINELS: &[&str] = &[
+        "sentinel-host",
+        "id_sentinel",
+        "SENTINEL-TOKEN",
+        "/home/sentinel",
+        "SENTINEL-COMMAND",
+    ];
+    const SAFE_KEYS: &[&str] = &[
+        "id",
+        "status",
+        "title",
+        "exit_code",
+        "created_at",
+        "started_at",
+        "ended_at",
+        "stdout_tail",
+        "stderr_tail",
+        "wait_detached",
+    ];
+    let check_payload = |payload: &serde_json::Value| {
+        let object = payload.as_object().expect("run details object");
+        for key in object.keys() {
+            assert!(
+                SAFE_KEYS.contains(&key.as_str()),
+                "unexpected key in run presentation: {key}"
+            );
+        }
+        assert_eq!(payload["id"], serde_json::json!("sentinel-run"));
+        assert_eq!(payload["title"], serde_json::json!("Sentinel run"));
+        let serialized = payload.to_string();
+        for sentinel in SENTINELS {
+            assert!(
+                !serialized.contains(sentinel),
+                "run presentation leaks {sentinel}: {serialized}"
+            );
+        }
+    };
+    check_payload(&result.details.clone().expect("final run details"));
+    let progress = env.progress.lock().unwrap();
+    assert!(
+        !progress.is_empty(),
+        "the wait must stream at least one live snapshot"
+    );
+    for payload in progress.iter() {
+        check_payload(payload);
+    }
     let _ = std::fs::remove_dir_all(tmp);
 }
 

--- a/src-tauri/src/run_context/tests.rs
+++ b/src-tauri/src/run_context/tests.rs
@@ -140,6 +140,38 @@ impl wisp_tools::ToolEnv for DenyRunToolEnv {
     async fn emit(&self, _event: wisp_tools::ToolEvent) {}
 }
 
+/// Records structured progress payloads a tool emits while running.
+struct RecordingRunToolEnv {
+    root: PathBuf,
+    progress: std::sync::Mutex<Vec<serde_json::Value>>,
+}
+
+impl RecordingRunToolEnv {
+    fn new(root: PathBuf) -> Self {
+        Self {
+            root,
+            progress: std::sync::Mutex::new(Vec::new()),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl wisp_tools::ToolEnv for RecordingRunToolEnv {
+    fn project_root(&self) -> &std::path::Path {
+        &self.root
+    }
+
+    async fn confirm(&self, _message: &str) -> bool {
+        true
+    }
+
+    async fn emit(&self, event: wisp_tools::ToolEvent) {
+        if let wisp_tools::ToolEvent::Progress { details } = event {
+            self.progress.lock().unwrap().push(details);
+        }
+    }
+}
+
 #[tokio::test]
 async fn denied_dangerous_run_stops_the_model_batch() {
     use wisp_tools::{Tool, ToolControl};
@@ -200,7 +232,11 @@ async fn run_in_context_can_suspend_until_terminal_without_get_run_calls() {
         .await;
 
     assert!(result.success, "{}", result.content);
-    let run: wisp_store::RunRecord = serde_json::from_str(&result.content).unwrap();
+    // The model sees a human summary; the structured record rides `details`.
+    assert!(result.content.contains("finished with status succeeded"));
+    assert!(result.content.contains("stdout tail"));
+    let run: wisp_store::RunRecord =
+        serde_json::from_value(result.details.clone().expect("run details")).unwrap();
     assert_eq!(run.status, wisp_store::RunStatus::Succeeded);
     assert_eq!(run.stdout_tail.as_deref(), Some("finished"));
     let _ = std::fs::remove_dir_all(tmp);
@@ -247,7 +283,8 @@ async fn run_in_context_wait_reports_a_failed_run_as_a_failed_tool_call() {
         !result.success,
         "failed Run must not render as a green tool call"
     );
-    let run: wisp_store::RunRecord = serde_json::from_str(&result.content).unwrap();
+    let run: wisp_store::RunRecord =
+        serde_json::from_value(result.details.clone().expect("run details")).unwrap();
     assert_eq!(run.status, wisp_store::RunStatus::Failed);
     assert_eq!(run.exit_code, Some(127));
     let _ = std::fs::remove_dir_all(tmp);
@@ -336,7 +373,8 @@ async fn run_in_context_preflight_is_structured_and_persisted_with_the_run() {
         .await;
 
     assert!(result.success, "{}", result.content);
-    let run: wisp_store::RunRecord = serde_json::from_str(&result.content).unwrap();
+    let run: wisp_store::RunRecord =
+        serde_json::from_value(result.details.clone().expect("run details")).unwrap();
     assert_eq!(run.status, wisp_store::RunStatus::Succeeded);
     let snapshot: serde_json::Value = serde_json::from_str(&run.env_snapshot_json).unwrap();
     assert_eq!(snapshot["preflight"]["status"], "passed");
@@ -463,8 +501,71 @@ async fn monitor_run_waits_once_for_an_existing_run() {
         .await;
 
     assert!(result.success, "{}", result.content);
-    let run: wisp_store::RunRecord = serde_json::from_str(&result.content).unwrap();
+    let run: wisp_store::RunRecord =
+        serde_json::from_value(result.details.clone().expect("run details")).unwrap();
     assert_eq!(run.status, wisp_store::RunStatus::Succeeded);
+    let _ = std::fs::remove_dir_all(tmp);
+}
+
+#[tokio::test]
+async fn monitor_run_streams_progress_while_waiting() {
+    use wisp_tools::Tool;
+    let tmp = std::env::temp_dir().join(format!("wisp_monitor_progress_{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&tmp).unwrap();
+    let store = wisp_store::Store::open(&tmp.join("wisp.sqlite"))
+        .await
+        .unwrap();
+    store
+        .create_project("p", "project", &tmp.to_string_lossy())
+        .await
+        .unwrap();
+    let run = wisp_store::RunRecord::new("live-run", "p", "local", "Live run", "command");
+    store.create_run(&run).await.unwrap();
+    assert!(store
+        .activate_run_lifecycle(
+            "live-run",
+            wisp_store::RunStatus::Submitted,
+            "monitor-owner",
+            60,
+        )
+        .await
+        .unwrap());
+    let finishing_store = store.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(25)).await;
+        assert!(finishing_store
+            .finish_active_run_owned(
+                "live-run",
+                "monitor-owner",
+                wisp_store::RunStatus::Succeeded,
+                Some(0),
+            )
+            .await
+            .unwrap());
+    });
+
+    let env = RecordingRunToolEnv::new(tmp.clone());
+    let result = MonitorRunTool::new(store, "p".into())
+        .run(&serde_json::json!({ "run_id": "live-run" }), &env)
+        .await;
+
+    assert!(result.success, "{}", result.content);
+    // A non-terminal snapshot streamed as structured progress while waiting…
+    let progress: Vec<serde_json::Value> = env
+        .progress
+        .lock()
+        .unwrap()
+        .iter()
+        .filter(|details| details["id"] == "live-run")
+        .cloned()
+        .collect();
+    assert!(
+        !progress.is_empty(),
+        "the wait must stream at least one live Run snapshot"
+    );
+    // …and the terminal record lands once, on the result's details.
+    let final_run = result.details.clone().expect("final run details");
+    assert_eq!(final_run["status"], serde_json::json!("succeeded"));
     let _ = std::fs::remove_dir_all(tmp);
 }
 

--- a/src-tauri/src/run_context/tools.rs
+++ b/src-tauri/src/run_context/tools.rs
@@ -4,6 +4,50 @@ use super::{
 use wisp_llm::ToolSchema;
 use wisp_tools::{Tool, ToolEnv, ToolResult};
 
+/// Structured view of a Run attached to tool results and live progress for
+/// the host/UI. This is an explicit allowlist: the host persists the final
+/// details as a `session_ui_events` row, and project export copies those
+/// rows verbatim, so anything machine- or credential-adjacent — remote/local
+/// workdirs, remote handles, environment snapshots, command lines,
+/// interpreter paths, process-control tokens — must never appear here. Keep
+/// aligned with the export scrub in `crates/wisp-store/src/project_transfer.rs`
+/// (`RUN_TOOL_DETAILS_EXPORT_ALLOWLIST`), which reduces legacy full-record
+/// payloads to this same field set. Rich fields stay available live through
+/// the `get_run_detail` Tauri command.
+#[derive(Debug, Clone, serde::Serialize)]
+struct RunPresentationDetails {
+    /// Opaque run identifier; already known to the model and the UI.
+    id: String,
+    /// Lifecycle state string ("submitted", "succeeded", …).
+    status: String,
+    /// User/model-provided title; already model-facing.
+    title: String,
+    /// Process result; already reported to the model.
+    exit_code: Option<i64>,
+    /// Wall-clock timestamps carry no host or path information.
+    created_at: i64,
+    started_at: Option<i64>,
+    ended_at: Option<i64>,
+    /// Output tails are already part of the model-facing summary text.
+    stdout_tail: Option<String>,
+    stderr_tail: Option<String>,
+}
+
+fn run_presentation_details(run: &wisp_store::RunRecord) -> serde_json::Value {
+    serde_json::to_value(RunPresentationDetails {
+        id: run.id.clone(),
+        status: run.status.as_str().into(),
+        title: run.title.clone(),
+        exit_code: run.exit_code,
+        created_at: run.created_at,
+        started_at: run.started_at,
+        ended_at: run.ended_at,
+        stdout_tail: run.stdout_tail.clone(),
+        stderr_tail: run.stderr_tail.clone(),
+    })
+    .unwrap_or_default()
+}
+
 pub struct RunInContextTool {
     store: wisp_store::Store,
     manager: RunManager,
@@ -253,6 +297,12 @@ impl Tool for RunInContextTool {
                         RunPreflightStatus::Failed => "failed",
                     });
                 let mut value = serde_json::to_value(&res).unwrap_or_default();
+                // The remote workdir is machine-private (see
+                // RunPresentationDetails); the UI reads it live via
+                // `get_run_detail` instead of the persisted details.
+                if let Some(object) = value.as_object_mut() {
+                    object.remove("remote_workdir");
+                }
                 if let Some(report) = preflight_report {
                     value["preflight"] = serde_json::to_value(report).unwrap_or_default();
                 }
@@ -436,8 +486,9 @@ async fn wait_for_terminal(
         }
         // Live structured snapshot for the host/UI, emitted only when the
         // record actually changed so a quiet run doesn't spam progress.
-        // Never enters the model context.
-        let snapshot = serde_json::to_value(&run).unwrap_or_default();
+        // Never enters the model context. The sanitized presentation keeps
+        // machine-private Run fields out of every host channel.
+        let snapshot = run_presentation_details(&run);
         let fingerprint = snapshot.to_string();
         if fingerprint != last_progress {
             last_progress = fingerprint;
@@ -455,12 +506,13 @@ async fn wait_for_terminal(
 
 fn run_wait_result(run: wisp_store::RunRecord, detached: bool) -> ToolResult {
     let succeeded = run.status == wisp_store::RunStatus::Succeeded;
-    let mut details = serde_json::to_value(&run).unwrap_or_default();
+    let mut details = run_presentation_details(&run);
     if detached {
         details["wait_detached"] = serde_json::Value::Bool(true);
     }
-    // The model gets a short human-readable summary; the full Run record
-    // rides `details` for the host/UI and never enters the model context.
+    // The model gets a short human-readable summary; the sanitized
+    // presentation rides `details` for the host/UI and never enters the
+    // model context.
     let content = run_wait_summary(&run, detached);
     let result = if detached || succeeded {
         ToolResult::ok(content)

--- a/src-tauri/src/run_context/tools.rs
+++ b/src-tauri/src/run_context/tools.rs
@@ -246,11 +246,27 @@ impl Tool for RunInContextTool {
                 }
             }
             Ok(res) => {
-                let mut value = serde_json::to_value(res).unwrap_or_default();
+                let preflight_status =
+                    preflight_report.as_ref().map(|report| match report.status {
+                        RunPreflightStatus::Passed => "passed",
+                        RunPreflightStatus::Warning => "warning",
+                        RunPreflightStatus::Failed => "failed",
+                    });
+                let mut value = serde_json::to_value(&res).unwrap_or_default();
                 if let Some(report) = preflight_report {
                     value["preflight"] = serde_json::to_value(report).unwrap_or_default();
                 }
-                ToolResult::ok(value.to_string())
+                // The model gets a short actionable summary; the structured
+                // submission record rides `details` for the host/UI.
+                let mut content = format!(
+                    "Run submitted: {} (status: {}). Call monitor_run exactly once with this run_id to wait for it; never poll with get_run.",
+                    res.run_id,
+                    res.status.as_str()
+                );
+                if let Some(status) = preflight_status {
+                    content.push_str(&format!(" Preflight: {status}."));
+                }
+                ToolResult::ok(content).with_details(value)
             }
             Err(e) => ToolResult::fail(format!("run_in_context error: {e}")),
         }
@@ -405,6 +421,7 @@ async fn wait_for_terminal(
     run_id: &str,
     env: &dyn ToolEnv,
 ) -> Result<(wisp_store::RunRecord, bool), String> {
+    let mut last_progress = String::new();
     loop {
         let run = store
             .get_run(run_id)
@@ -417,6 +434,16 @@ async fn wait_for_terminal(
         if env.is_cancelled() {
             return Ok((run, true));
         }
+        // Live structured snapshot for the host/UI, emitted only when the
+        // record actually changed so a quiet run doesn't spam progress.
+        // Never enters the model context.
+        let snapshot = serde_json::to_value(&run).unwrap_or_default();
+        let fingerprint = snapshot.to_string();
+        if fingerprint != last_progress {
+            last_progress = fingerprint;
+            env.emit(wisp_tools::ToolEvent::Progress { details: snapshot })
+                .await;
+        }
         tokio::time::sleep(if cfg!(test) {
             std::time::Duration::from_millis(10)
         } else {
@@ -428,16 +455,59 @@ async fn wait_for_terminal(
 
 fn run_wait_result(run: wisp_store::RunRecord, detached: bool) -> ToolResult {
     let succeeded = run.status == wisp_store::RunStatus::Succeeded;
-    let mut value = serde_json::to_value(run).unwrap_or_default();
+    let mut details = serde_json::to_value(&run).unwrap_or_default();
     if detached {
-        value["wait_detached"] = serde_json::Value::Bool(true);
+        details["wait_detached"] = serde_json::Value::Bool(true);
     }
-    let content = value.to_string();
-    if detached || succeeded {
+    // The model gets a short human-readable summary; the full Run record
+    // rides `details` for the host/UI and never enters the model context.
+    let content = run_wait_summary(&run, detached);
+    let result = if detached || succeeded {
         ToolResult::ok(content)
     } else {
         ToolResult::fail(content)
+    };
+    result.with_details(details)
+}
+
+/// Model-facing summary of a finished (or detached) wait: outcome, exit code,
+/// and output tails — everything the model needs to react, nothing more.
+fn run_wait_summary(run: &wisp_store::RunRecord, detached: bool) -> String {
+    let mut text = if detached {
+        format!(
+            "Stopped monitoring Run {} (\"{}\"); it is still {} and keeps running in the background.",
+            run.id,
+            run.title,
+            run.status.as_str()
+        )
+    } else {
+        let mut line = format!(
+            "Run {} (\"{}\") finished with status {}",
+            run.id,
+            run.title,
+            run.status.as_str()
+        );
+        if let Some(exit_code) = run.exit_code {
+            line.push_str(&format!(" (exit code {exit_code})"));
+        }
+        line.push('.');
+        line
+    };
+    if let Some(stdout) = run
+        .stdout_tail
+        .as_deref()
+        .filter(|tail| !tail.trim().is_empty())
+    {
+        text.push_str(&format!("\nstdout tail:\n{stdout}"));
     }
+    if let Some(stderr) = run
+        .stderr_tail
+        .as_deref()
+        .filter(|tail| !tail.trim().is_empty())
+    {
+        text.push_str(&format!("\nstderr tail:\n{stderr}"));
+    }
+    text
 }
 
 pub struct CancelRunTool {

--- a/src-tauri/src/session_commands.rs
+++ b/src-tauri/src/session_commands.rs
@@ -434,7 +434,7 @@ pub(super) async fn converge_session_branches(
     for (id, runtime) in &runtimes {
         if id != &converged.main_session_id {
             runtime.deleted.store(true, Ordering::SeqCst);
-            runtime.cancel.store(true, Ordering::Relaxed);
+            runtime.control.request_cancel();
         }
     }
     {
@@ -701,7 +701,7 @@ pub(super) async fn transfer_session_to_project(
             .map_err(|error| error.to_string())?;
         if let Some(runtime) = runtime.as_ref() {
             runtime.deleted.store(true, Ordering::SeqCst);
-            runtime.cancel.store(true, Ordering::Relaxed);
+            runtime.control.request_cancel();
         }
         acp::close_frame(&state, &id).await;
         state.sessions.lock().await.remove(&id);
@@ -753,7 +753,7 @@ pub(super) async fn delete_session(
     let runtime = state.sessions.lock().await.get(&id).cloned();
     if let Some(rt) = runtime.as_ref() {
         rt.deleted.store(true, Ordering::SeqCst);
-        rt.cancel.store(true, Ordering::Relaxed);
+        rt.control.request_cancel();
     }
     acp::cancel_frame(&state, &id).await;
     // Match send/Plan lock order. The tombstone prevents work already queued

--- a/src-tauri/src/session_commands.rs
+++ b/src-tauri/src/session_commands.rs
@@ -980,6 +980,7 @@ async fn ask_user_items(state: &AppState, frame_id: &str) -> Vec<UiItem> {
                 status: None,
                 locations: None,
                 resources: Vec::new(),
+                details: None,
             }
         })
         .collect()
@@ -1076,6 +1077,7 @@ pub(super) fn transcript_page_items(
                 status: None,
                 locations: None,
                 resources: Vec::new(),
+                details: None,
             },
         );
         inserted += 1;

--- a/src-tauri/src/turn_undo.rs
+++ b/src-tauri/src/turn_undo.rs
@@ -422,7 +422,7 @@ pub(super) async fn undo_turn(
     };
     if runtime
         .as_ref()
-        .is_some_and(|runtime| !runtime.queued.lock().unwrap().is_empty())
+        .is_some_and(|runtime| !runtime.control.follow_ups().is_empty())
     {
         return Err("Remove queued messages before undoing the latest turn.".into());
     }

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -4547,6 +4547,20 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
               }, 30);
               return fid;
             }
+            // Draft-stream path: the turn starts and send_message stays pending
+            // (mirroring the native command lifecycle) until the test emits its
+            // own Done and resolves the run via `__draftRunResolvers`, so draft
+            // events are exercised deterministically while the turn is live.
+            if (String(msg).includes("DRAFTSTREAM")) {
+              setTimeout(() => {
+                emit("agent", { kind: "User", frame_id: fid, text: msg });
+                emit("agent", { kind: "Text", frame_id: fid, delta: "Working on it." });
+              }, 30);
+              return await new Promise<string>((resolve) => {
+                (window as any).__draftRunResolvers ??= {};
+                (window as any).__draftRunResolvers[fid] = resolve;
+              });
+            }
             setTimeout(() => {
               emit("agent", { kind: "User", frame_id: fid, text: msg });
               emit("agent", { kind: "ToolCall", frame_id: fid, name: "read", preview: "mock context" });

--- a/ui-tests/tests/tool-call-draft.spec.ts
+++ b/ui-tests/tests/tool-call-draft.spec.ts
@@ -1,0 +1,145 @@
+import { test, expect, type Page } from "@playwright/test";
+import { tauriMock } from "./mock-tauri";
+
+// Tool-call argument draft streaming: while the model is still streaming a
+// call's arguments, the host emits live-only ToolCallDraft events and the UI
+// shows an in-progress step row with the tool's safe preview. Drafts are keyed
+// by call_key (`{round}:{index}`), superseded by the real ToolCall, and dropped
+// at turn boundaries so no ghost rows remain.
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(tauriMock);
+});
+
+async function enterApp(page: Page) {
+  await page.goto("/");
+  await page.locator(".proj-card-main").first().click();
+  await expect(page.locator(".composer-inner").first()).toBeVisible();
+}
+
+async function emitAgent(page: Page, payload: unknown) {
+  await expect.poll(() => page.evaluate(() =>
+    Boolean((window as any).__tauriListenerReady?.("agent"))
+  )).toBe(true);
+  await page.evaluate((value) => {
+    (window as any).__tauriEmit("agent", value);
+  }, payload);
+}
+
+
+// End the open run the way the real backend does: Done event first, then the
+// pending send_message invoke resolves.
+async function finishRun(page: Page, frameId: string) {
+  await emitAgent(page, { kind: "Done", frame_id: frameId });
+  await page.evaluate((fid) => {
+    (window as any).__draftRunResolvers?.[fid]?.(fid);
+  }, frameId);
+}
+
+// DRAFTSTREAM starts the mocked turn but never emits Done, so the test drives
+// draft / clear / Done events deterministically while the run stays live.
+async function startOpenRun(page: Page, message: string) {
+  await page.locator("#composer-input").fill(message);
+  await page.getByRole("button", { name: "Send" }).click();
+  const sent = await page.evaluate(() => {
+    const calls = ((window as any).__skillInvokeLog ?? []).filter((c: any) => c.cmd === "send_message");
+    return calls.at(-1)?.args ?? null;
+  });
+  const frameId = String(sent?.sessionId ?? sent?.session_id ?? "");
+  expect(frameId).not.toBe("");
+  // The turn is underway once the user echo and the first assistant line render.
+  await expect(page.locator(".msg.assistant").first()).toBeVisible();
+  return frameId;
+}
+
+test("draft row with safe preview is visible before the run completes", async ({ page }) => {
+  await enterApp(page);
+  const frameId = await startOpenRun(page, "DRAFTSTREAM draft row");
+
+  await emitAgent(page, {
+    kind: "ToolCallDraft", frame_id: frameId, call_key: "1:0",
+    name: "read", preview: "data/counts.tsv",
+  });
+  const draftRow = page.locator(".step", { hasText: "data/counts.tsv" });
+  await expect(draftRow).toBeVisible();
+  // An in-progress row, not a finished one, and no Done has arrived.
+  await expect(draftRow.locator(".run-dot")).toBeVisible();
+
+  // A later snapshot for the same call_key updates the row in place.
+  await emitAgent(page, {
+    kind: "ToolCallDraft", frame_id: frameId, call_key: "1:0",
+    name: "read", preview: "data/counts-final.tsv",
+  });
+  await expect(page.locator(".step", { hasText: "data/counts-final.tsv" })).toBeVisible();
+  await expect(page.locator(".step", { hasText: "data/counts.tsv" })).toHaveCount(0);
+
+  await finishRun(page, frameId);
+});
+
+test("two drafts of the same tool render as two rows keyed separately", async ({ page }) => {
+  await enterApp(page);
+  const frameId = await startOpenRun(page, "DRAFTSTREAM two same-name drafts");
+
+  await emitAgent(page, {
+    kind: "ToolCallDraft", frame_id: frameId, call_key: "1:0",
+    name: "shell", preview: "make first",
+  });
+  await emitAgent(page, {
+    kind: "ToolCallDraft", frame_id: frameId, call_key: "1:1",
+    name: "shell", preview: "make second",
+  });
+  await expect(page.locator(".step", { hasText: "make first" })).toBeVisible();
+  await expect(page.locator(".step", { hasText: "make second" })).toBeVisible();
+
+  // Updating one key must not touch the other row.
+  await emitAgent(page, {
+    kind: "ToolCallDraft", frame_id: frameId, call_key: "1:0",
+    name: "shell", preview: "make first v2",
+  });
+  await expect(page.locator(".step", { hasText: "make first v2" })).toBeVisible();
+  await expect(page.locator(".step", { hasText: "make second" })).toBeVisible();
+
+  // The real call for 1:0 supersedes its draft; the sibling draft survives.
+  await emitAgent(page, { kind: "ToolCallDraftClear", frame_id: frameId, call_key: "1:0" });
+  await emitAgent(page, {
+    kind: "ToolCall", frame_id: frameId, name: "shell", preview: "make first v2",
+  });
+  await expect(page.locator(".step", { hasText: "make first v2" })).toHaveCount(1);
+  await expect(page.locator(".step", { hasText: "make second" })).toBeVisible();
+
+  await finishRun(page, frameId);
+});
+
+test("drafts disappear when the run ends without the tool executing", async ({ page }) => {
+  await enterApp(page);
+  const frameId = await startOpenRun(page, "DRAFTSTREAM ghost drafts");
+
+  // Mid-run round boundary (host sends call_key: null): both drafts go.
+  await emitAgent(page, {
+    kind: "ToolCallDraft", frame_id: frameId, call_key: "1:0",
+    name: "read", preview: "ghost/one.txt",
+  });
+  await emitAgent(page, {
+    kind: "ToolCallDraft", frame_id: frameId, call_key: "1:1",
+    name: "read", preview: "ghost/two.txt",
+  });
+  await expect(page.locator(".step", { hasText: "ghost/one.txt" })).toBeVisible();
+  await emitAgent(page, { kind: "ToolCallDraftClear", frame_id: frameId, call_key: null });
+  await expect(page.locator(".step", { hasText: "ghost/one.txt" })).toHaveCount(0);
+  await expect(page.locator(".step", { hasText: "ghost/two.txt" })).toHaveCount(0);
+
+  // A draft that never becomes a real call leaves no row once the run ends.
+  await emitAgent(page, {
+    kind: "ToolCallDraft", frame_id: frameId, call_key: "2:0",
+    name: "read", preview: "ghost/pending.txt",
+  });
+  await expect(page.locator(".step", { hasText: "ghost/pending.txt" })).toBeVisible();
+  await finishRun(page, frameId);
+  // The steps panel collapses into the activity summary once the turn settles;
+  // expand whatever remains and prove no ghost row survived.
+  const panel = page.locator(".steps.activity-summary").last();
+  if (await panel.count()) {
+    await panel.locator(".steps-head").click();
+  }
+  await expect(page.locator(".step", { hasText: "ghost/pending.txt" })).toHaveCount(0);
+});

--- a/ui-tests/tests/tool-result-details.spec.ts
+++ b/ui-tests/tests/tool-result-details.spec.ts
@@ -3,8 +3,10 @@ import { tauriMock } from "./mock-tauri";
 
 // Structured tool details: a tool's final `details` payload rides the
 // persisted ToolResultDetails patch and lands on the tool row. For
-// monitor_run the card prefers the structured RunRecord over scraping text,
-// so a run the poll list does not know still renders its real status.
+// monitor_run the card prefers the structured details over scraping text,
+// so a run the poll list does not know still renders its real status. The
+// persisted details are a sanitized subset of the RunRecord — command,
+// workdir, and environment fields only arrive live via `get_run_detail`.
 
 test.beforeEach(async ({ page }) => {
   await page.addInitScript(tauriMock);
@@ -53,26 +55,17 @@ test("monitor card renders structured status from final details", async ({ page 
 
   // A run the mocked `list_runs` poll does NOT know: only the details patch
   // can supply the record, so the card proves it consumed structured details.
+  // Shape matches the sanitized presentation the backend now emits.
   const record = {
     id: "run-details-777",
-    frame_id: frameId,
-    context_id: "local",
-    title: "Details-driven run",
-    kind: "local",
     status: "succeeded",
-    command: "echo done",
+    title: "Details-driven run",
+    exit_code: 0,
     created_at: 2000,
     started_at: 2000,
     ended_at: 2001,
-    exit_code: 0,
     stdout_tail: "done",
     stderr_tail: "",
-    remote_workdir: null,
-    timeout_secs: null,
-    last_polled_at: 2001,
-    last_poll_error: null,
-    progress_json: "{}",
-    env_snapshot_json: "{}",
   };
 
   await emitAgent(page, {

--- a/ui-tests/tests/tool-result-details.spec.ts
+++ b/ui-tests/tests/tool-result-details.spec.ts
@@ -1,0 +1,105 @@
+import { test, expect, type Page } from "@playwright/test";
+import { tauriMock } from "./mock-tauri";
+
+// Structured tool details: a tool's final `details` payload rides the
+// persisted ToolResultDetails patch and lands on the tool row. For
+// monitor_run the card prefers the structured RunRecord over scraping text,
+// so a run the poll list does not know still renders its real status.
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(tauriMock);
+});
+
+async function enterApp(page: Page) {
+  await page.goto("/");
+  await page.locator(".proj-card-main").first().click();
+  await expect(page.locator(".composer-inner").first()).toBeVisible();
+}
+
+async function emitAgent(page: Page, payload: unknown) {
+  await expect.poll(() => page.evaluate(() =>
+    Boolean((window as any).__tauriListenerReady?.("agent"))
+  )).toBe(true);
+  await page.evaluate((value) => {
+    (window as any).__tauriEmit("agent", value);
+  }, payload);
+}
+
+// End the open run the way the real backend does: Done event first, then the
+// pending send_message invoke resolves.
+async function finishRun(page: Page, frameId: string) {
+  await emitAgent(page, { kind: "Done", frame_id: frameId });
+  await page.evaluate((fid) => {
+    (window as any).__draftRunResolvers?.[fid]?.(fid);
+  }, frameId);
+}
+
+async function startOpenRun(page: Page, message: string) {
+  await page.locator("#composer-input").fill(message);
+  await page.getByRole("button", { name: "Send" }).click();
+  const sent = await page.evaluate(() => {
+    const calls = ((window as any).__skillInvokeLog ?? []).filter((c: any) => c.cmd === "send_message");
+    return calls.at(-1)?.args ?? null;
+  });
+  const frameId = String(sent?.sessionId ?? sent?.session_id ?? "");
+  expect(frameId).not.toBe("");
+  await expect(page.locator(".msg.assistant").first()).toBeVisible();
+  return frameId;
+}
+
+test("monitor card renders structured status from final details", async ({ page }) => {
+  await enterApp(page);
+  const frameId = await startOpenRun(page, "DETAILS monitor card");
+
+  // A run the mocked `list_runs` poll does NOT know: only the details patch
+  // can supply the record, so the card proves it consumed structured details.
+  const record = {
+    id: "run-details-777",
+    frame_id: frameId,
+    context_id: "local",
+    title: "Details-driven run",
+    kind: "local",
+    status: "succeeded",
+    command: "echo done",
+    created_at: 2000,
+    started_at: 2000,
+    ended_at: 2001,
+    exit_code: 0,
+    stdout_tail: "done",
+    stderr_tail: "",
+    remote_workdir: null,
+    timeout_secs: null,
+    last_polled_at: 2001,
+    last_poll_error: null,
+    progress_json: "{}",
+    env_snapshot_json: "{}",
+  };
+
+  await emitAgent(page, {
+    kind: "ToolExecutionStarted", frame_id: frameId, call_key: "1:0", name: "monitor_run",
+  });
+  await emitAgent(page, {
+    kind: "ToolCall", frame_id: frameId, name: "monitor_run", preview: "run-details-777",
+  });
+  // Live-only progress: updates the row but is never the persisted shape.
+  await emitAgent(page, {
+    kind: "ToolProgress", frame_id: frameId, call_key: "1:0",
+    details: { ...record, status: "running", ended_at: null, exit_code: null },
+  });
+  await emitAgent(page, {
+    kind: "ToolResult", frame_id: frameId, name: "monitor_run", ok: true,
+    content: "Run run-details-777 (\"Details-driven run\") finished with status succeeded (exit code 0).",
+    duration_ms: 5,
+  });
+  await emitAgent(page, {
+    kind: "ToolResultDetails", frame_id: frameId, call_key: "1:0", name: "monitor_run",
+    details: record,
+  });
+
+  const card = page.locator('[data-testid="run-monitor-card"][data-run-id="run-details-777"]');
+  await expect(card).toBeVisible();
+  await expect(card.locator(".run-status.succeeded").first()).toBeVisible();
+  await expect(card.locator(".run-monitor-title")).toContainText("Details-driven run");
+
+  await finishRun(page, frameId);
+});

--- a/ui/src/app_support/artifacts.rs
+++ b/ui/src/app_support/artifacts.rs
@@ -367,6 +367,7 @@ mod usage_row_tests {
             started_at_ms: None,
             duration_ms: None,
             call_key: None,
+            details: None,
         });
         upsert_turn_usage(
             &mut items,
@@ -484,6 +485,7 @@ mod promote_assistant_text_tests {
             started_at_ms: None,
             duration_ms: None,
             call_key: None,
+            details: None,
         }
     }
 
@@ -783,6 +785,7 @@ mod artifact_scan_tests {
             started_at_ms: None,
             duration_ms: Some(1),
             call_key: None,
+            details: None,
         });
         items.push(ChatItem::FileChanged("out/result.csv".into()));
         let a2 = collect_artifacts(&items, Locale::En, &mut cache);
@@ -825,6 +828,7 @@ mod artifact_scan_tests {
                 started_at_ms: None,
                 duration_ms: None,
                 call_key: None,
+                details: None,
             },
             ChatItem::FileChanged("result.csv".into()),
             ChatItem::Assistant {
@@ -849,6 +853,7 @@ mod artifact_scan_tests {
                 started_at_ms: None,
                 duration_ms: None,
                 call_key: None,
+                details: None,
             },
             ChatItem::FileChanged("evidence/one.png".into()),
             ChatItem::FileChanged("evidence/two.png".into()),
@@ -868,6 +873,7 @@ mod artifact_scan_tests {
                 started_at_ms: None,
                 duration_ms: None,
                 call_key: None,
+                details: None,
             },
             ChatItem::Assistant {
                 text: "The five comparison images are ready.".into(),
@@ -894,6 +900,7 @@ mod artifact_scan_tests {
                     started_at_ms: None,
                     duration_ms: None,
                     call_key: None,
+                    details: None,
                 },
                 ChatItem::Assistant {
                     text: "I inspected `old.csv`; no new file was created.".into(),

--- a/ui/src/app_support/artifacts.rs
+++ b/ui/src/app_support/artifacts.rs
@@ -366,6 +366,7 @@ mod usage_row_tests {
             output: String::new(),
             started_at_ms: None,
             duration_ms: None,
+            call_key: None,
         });
         upsert_turn_usage(
             &mut items,
@@ -482,6 +483,7 @@ mod promote_assistant_text_tests {
             output: String::new(),
             started_at_ms: None,
             duration_ms: None,
+            call_key: None,
         }
     }
 
@@ -780,6 +782,7 @@ mod artifact_scan_tests {
             output: "wrote out/result.csv".into(),
             started_at_ms: None,
             duration_ms: Some(1),
+            call_key: None,
         });
         items.push(ChatItem::FileChanged("out/result.csv".into()));
         let a2 = collect_artifacts(&items, Locale::En, &mut cache);
@@ -821,6 +824,7 @@ mod artifact_scan_tests {
                 output: "write completed".into(),
                 started_at_ms: None,
                 duration_ms: None,
+                call_key: None,
             },
             ChatItem::FileChanged("result.csv".into()),
             ChatItem::Assistant {
@@ -844,6 +848,7 @@ mod artifact_scan_tests {
                 output: "five images written".into(),
                 started_at_ms: None,
                 duration_ms: None,
+                call_key: None,
             },
             ChatItem::FileChanged("evidence/one.png".into()),
             ChatItem::FileChanged("evidence/two.png".into()),
@@ -862,6 +867,7 @@ mod artifact_scan_tests {
                 output: "image is legible".into(),
                 started_at_ms: None,
                 duration_ms: None,
+                call_key: None,
             },
             ChatItem::Assistant {
                 text: "The five comparison images are ready.".into(),
@@ -887,6 +893,7 @@ mod artifact_scan_tests {
                     output: "old.csv\nplots/old.png\nnotes/report.md".into(),
                     started_at_ms: None,
                     duration_ms: None,
+                    call_key: None,
                 },
                 ChatItem::Assistant {
                     text: "I inspected `old.csv`; no new file was created.".into(),

--- a/ui/src/app_support/chat_stream.rs
+++ b/ui/src/app_support/chat_stream.rs
@@ -507,6 +507,7 @@ mod start_user_turn_tests {
                 output: "1".into(),
                 started_at_ms: None,
                 duration_ms: Some(1),
+                call_key: None,
             },
         ];
 
@@ -530,6 +531,7 @@ mod start_user_turn_tests {
             output: String::new(),
             started_at_ms: None,
             duration_ms: None,
+            call_key: None,
         };
         let items = vec![
             ChatItem::User("question".into()),
@@ -555,6 +557,7 @@ mod start_user_turn_tests {
             output: String::new(),
             started_at_ms: None,
             duration_ms: None,
+            call_key: None,
         };
 
         assert!(is_image_generation_tool("generate_image"));
@@ -579,6 +582,7 @@ mod start_user_turn_tests {
                 output: String::new(),
                 started_at_ms: None,
                 duration_ms: Some(4),
+                call_key: None,
             },
             ChatItem::FileChanged("results/new.csv".into()),
             ChatItem::Tool {
@@ -588,6 +592,7 @@ mod start_user_turn_tests {
                 output: String::new(),
                 started_at_ms: None,
                 duration_ms: Some(2),
+                call_key: None,
             },
             assistant("final answer"),
         ];
@@ -730,6 +735,55 @@ pub(crate) fn process_item_insert_index(items: &[ChatItem]) -> usize {
     } else {
         queue_start
     }
+}
+
+/// Upsert a live tool-call draft row (arguments still streaming). Drafts are
+/// keyed by `call_key` (`{round}:{index}`), never by tool name, so two
+/// concurrent calls of the same tool keep separate rows. The row is a
+/// placeholder with no start time; the host clears it right before the real
+/// ToolCall event arrives, and `clear_tool_drafts` drops any leftovers.
+pub(crate) fn upsert_tool_draft(
+    items: &mut Vec<ChatItem>,
+    call_key: String,
+    name: String,
+    preview: String,
+) {
+    if let Some(row) = items.iter_mut().rev().find(|item| {
+        matches!(item, ChatItem::Tool { call_key: Some(key), ok: None, .. } if *key == call_key)
+    }) {
+        if let ChatItem::Tool {
+            name: row_name,
+            input,
+            ..
+        } = row
+        {
+            *row_name = name;
+            *input = preview;
+        }
+        return;
+    }
+    let idx = process_item_insert_index(items);
+    items.insert(
+        idx,
+        ChatItem::Tool {
+            name,
+            ok: None,
+            input: preview,
+            output: String::new(),
+            started_at_ms: None,
+            duration_ms: None,
+            call_key: Some(call_key),
+        },
+    );
+}
+
+/// Drop draft rows: just `Some(key)` when its real call starts, or every
+/// unfinished draft (`None`) at a turn boundary so no ghost rows remain.
+/// Finished rows are never drafts, so a late clear cannot remove real output.
+pub(crate) fn clear_tool_drafts(items: &mut Vec<ChatItem>, call_key: Option<&str>) {
+    items.retain(|item| {
+        !matches!(item, ChatItem::Tool { call_key: Some(key), ok: None, .. } if call_key.is_none_or(|target| key == target))
+    });
 }
 
 pub(crate) fn is_run_monitor_tool(name: &str) -> bool {
@@ -910,6 +964,7 @@ pub(crate) fn append_stdout_chunk(items: &mut Vec<ChatItem>, chunk: String) {
             output,
             started_at_ms: None,
             duration_ms: None,
+            call_key: None,
         },
     );
 }
@@ -1133,6 +1188,7 @@ mod terminal_chunk_tests {
             output: String::new(),
             started_at_ms: None,
             duration_ms: None,
+            call_key: None,
         }];
         append_stdout_chunk(&mut items, "building\n10%\r".into());
         append_stdout_chunk(&mut items, "90%\r100%\n".into());
@@ -1140,5 +1196,64 @@ mod terminal_chunk_tests {
             ChatItem::Tool { output, .. } => assert_eq!(output, "building\n100%\n"),
             _ => panic!("expected tool item"),
         }
+    }
+
+    #[test]
+    fn tool_drafts_upsert_by_call_key_not_by_name() {
+        let mut items = vec![ChatItem::User("go".into())];
+        upsert_tool_draft(&mut items, "1:0".into(), "read".into(), "a.t".into());
+        upsert_tool_draft(&mut items, "1:1".into(), "read".into(), "b.t".into());
+        // Same tool name, two concurrent calls: two rows, each with its own key.
+        assert_eq!(items.len(), 3);
+        // A later snapshot updates only its own row.
+        upsert_tool_draft(&mut items, "1:1".into(), "read".into(), "b.tsv".into());
+        assert_eq!(items.len(), 3);
+        let row = |key: &str| {
+            items
+                .iter()
+                .find_map(|item| match item {
+                    ChatItem::Tool {
+                        call_key: Some(k),
+                        input,
+                        ..
+                    } if k == key => Some(input.clone()),
+                    _ => None,
+                })
+                .unwrap()
+        };
+        assert_eq!(row("1:0"), "a.t");
+        assert_eq!(row("1:1"), "b.tsv");
+    }
+
+    #[test]
+    fn clearing_tool_drafts_never_removes_real_rows() {
+        let mut items = vec![
+            ChatItem::User("go".into()),
+            ChatItem::Tool {
+                name: "read".into(),
+                ok: Some(true),
+                input: "done.tsv".into(),
+                output: "contents".into(),
+                started_at_ms: None,
+                duration_ms: Some(3),
+                call_key: None,
+            },
+        ];
+        upsert_tool_draft(&mut items, "1:0".into(), "read".into(), "a.tsv".into());
+        upsert_tool_draft(&mut items, "1:1".into(), "shell".into(), "make".into());
+        // The real call for 1:0 starts: only that draft is dropped.
+        clear_tool_drafts(&mut items, Some("1:0"));
+        assert_eq!(items.len(), 3);
+        assert!(items.iter().any(|item| matches!(
+            item,
+            ChatItem::Tool { call_key: Some(k), .. } if k == "1:1"
+        )));
+        // Turn boundary: every remaining draft goes, real output rows stay.
+        clear_tool_drafts(&mut items, None);
+        assert_eq!(items.len(), 2);
+        assert!(items.iter().any(|item| matches!(
+            item,
+            ChatItem::Tool { ok: Some(true), output, .. } if output == "contents"
+        )));
     }
 }

--- a/ui/src/app_support/chat_stream.rs
+++ b/ui/src/app_support/chat_stream.rs
@@ -508,6 +508,7 @@ mod start_user_turn_tests {
                 started_at_ms: None,
                 duration_ms: Some(1),
                 call_key: None,
+                details: None,
             },
         ];
 
@@ -532,6 +533,7 @@ mod start_user_turn_tests {
             started_at_ms: None,
             duration_ms: None,
             call_key: None,
+            details: None,
         };
         let items = vec![
             ChatItem::User("question".into()),
@@ -558,6 +560,7 @@ mod start_user_turn_tests {
             started_at_ms: None,
             duration_ms: None,
             call_key: None,
+            details: None,
         };
 
         assert!(is_image_generation_tool("generate_image"));
@@ -583,6 +586,7 @@ mod start_user_turn_tests {
                 started_at_ms: None,
                 duration_ms: Some(4),
                 call_key: None,
+                details: None,
             },
             ChatItem::FileChanged("results/new.csv".into()),
             ChatItem::Tool {
@@ -593,6 +597,7 @@ mod start_user_turn_tests {
                 started_at_ms: None,
                 duration_ms: Some(2),
                 call_key: None,
+                details: None,
             },
             assistant("final answer"),
         ];
@@ -742,6 +747,8 @@ pub(crate) fn process_item_insert_index(items: &[ChatItem]) -> usize {
 /// concurrent calls of the same tool keep separate rows. The row is a
 /// placeholder with no start time; the host clears it right before the real
 /// ToolCall event arrives, and `clear_tool_drafts` drops any leftovers.
+/// `started_at_ms: None` keeps a real running row stamped with the same key
+/// from being mistaken for its own former draft.
 pub(crate) fn upsert_tool_draft(
     items: &mut Vec<ChatItem>,
     call_key: String,
@@ -749,7 +756,7 @@ pub(crate) fn upsert_tool_draft(
     preview: String,
 ) {
     if let Some(row) = items.iter_mut().rev().find(|item| {
-        matches!(item, ChatItem::Tool { call_key: Some(key), ok: None, .. } if *key == call_key)
+        matches!(item, ChatItem::Tool { call_key: Some(key), ok: None, started_at_ms: None, .. } if *key == call_key)
     }) {
         if let ChatItem::Tool {
             name: row_name,
@@ -773,17 +780,49 @@ pub(crate) fn upsert_tool_draft(
             started_at_ms: None,
             duration_ms: None,
             call_key: Some(call_key),
+            details: None,
         },
     );
 }
 
 /// Drop draft rows: just `Some(key)` when its real call starts, or every
 /// unfinished draft (`None`) at a turn boundary so no ghost rows remain.
-/// Finished rows are never drafts, so a late clear cannot remove real output.
+/// Finished rows are never drafts, so a late clear cannot remove real output;
+/// a real row still running (stamped with its key, `started_at_ms` set) is
+/// not a draft either and survives the boundary sweep.
 pub(crate) fn clear_tool_drafts(items: &mut Vec<ChatItem>, call_key: Option<&str>) {
     items.retain(|item| {
-        !matches!(item, ChatItem::Tool { call_key: Some(key), ok: None, .. } if call_key.is_none_or(|target| key == target))
+        !matches!(item, ChatItem::Tool { call_key: Some(key), ok: None, started_at_ms: None, .. } if call_key.is_none_or(|target| key == target))
     });
+}
+
+/// Patch a tool row's structured details (a live progress snapshot or the
+/// persisted final-details patch). Matches by `call_key` where a row carries
+/// one, falling back to the most recent row with the same tool name — the
+/// same rule the ToolResult handler uses. A patch whose row no longer exists
+/// is dropped.
+pub(crate) fn apply_tool_details(
+    items: &mut Vec<ChatItem>,
+    call_key: Option<&str>,
+    name: Option<&str>,
+    details: serde_json::Value,
+) {
+    let index = call_key
+        .and_then(|key| {
+            items.iter().rposition(
+                |item| matches!(item, ChatItem::Tool { call_key: Some(k), .. } if k == key),
+            )
+        })
+        .or_else(|| {
+            name.and_then(|name| {
+                items
+                    .iter()
+                    .rposition(|item| matches!(item, ChatItem::Tool { name: n, .. } if n == name))
+            })
+        });
+    if let Some(ChatItem::Tool { details: slot, .. }) = index.map(|i| &mut items[i]) {
+        *slot = Some(details);
+    }
 }
 
 pub(crate) fn is_run_monitor_tool(name: &str) -> bool {
@@ -965,6 +1004,7 @@ pub(crate) fn append_stdout_chunk(items: &mut Vec<ChatItem>, chunk: String) {
             started_at_ms: None,
             duration_ms: None,
             call_key: None,
+            details: None,
         },
     );
 }
@@ -1189,6 +1229,7 @@ mod terminal_chunk_tests {
             started_at_ms: None,
             duration_ms: None,
             call_key: None,
+            details: None,
         }];
         append_stdout_chunk(&mut items, "building\n10%\r".into());
         append_stdout_chunk(&mut items, "90%\r100%\n".into());
@@ -1214,6 +1255,7 @@ mod terminal_chunk_tests {
                 .find_map(|item| match item {
                     ChatItem::Tool {
                         call_key: Some(k),
+                        details: None,
                         input,
                         ..
                     } if k == key => Some(input.clone()),
@@ -1223,6 +1265,38 @@ mod terminal_chunk_tests {
         };
         assert_eq!(row("1:0"), "a.t");
         assert_eq!(row("1:1"), "b.tsv");
+    }
+
+    #[test]
+    fn running_rows_stamped_with_a_key_are_not_treated_as_drafts() {
+        // A real call in flight carries its invocation key and a start time:
+        // the boundary sweep must keep it, and a late draft snapshot for the
+        // same key must not rewrite it.
+        let mut items = vec![
+            ChatItem::User("go".into()),
+            ChatItem::Tool {
+                name: "monitor_run".into(),
+                ok: None,
+                input: "run-1".into(),
+                output: String::new(),
+                started_at_ms: Some(10),
+                duration_ms: None,
+                call_key: Some("1:0".into()),
+                details: None,
+            },
+        ];
+        clear_tool_drafts(&mut items, None);
+        assert_eq!(items.len(), 2, "a running stamped row is not a draft");
+        upsert_tool_draft(
+            &mut items,
+            "1:0".into(),
+            "monitor_run".into(),
+            "other".into(),
+        );
+        assert!(
+            matches!(&items[1], ChatItem::Tool { input, .. } if input == "run-1"),
+            "the running row keeps its own preview"
+        );
     }
 
     #[test]
@@ -1237,6 +1311,7 @@ mod terminal_chunk_tests {
                 started_at_ms: None,
                 duration_ms: Some(3),
                 call_key: None,
+                details: None,
             },
         ];
         upsert_tool_draft(&mut items, "1:0".into(), "read".into(), "a.tsv".into());
@@ -1255,5 +1330,77 @@ mod terminal_chunk_tests {
             item,
             ChatItem::Tool { ok: Some(true), output, .. } if output == "contents"
         )));
+    }
+
+    fn finished_tool_row(name: &str, call_key: Option<&str>) -> ChatItem {
+        ChatItem::Tool {
+            name: name.into(),
+            ok: Some(true),
+            input: String::new(),
+            output: "summary".into(),
+            started_at_ms: None,
+            duration_ms: Some(1),
+            call_key: call_key.map(str::to_string),
+            details: None,
+        }
+    }
+
+    #[test]
+    fn tool_details_match_by_call_key_before_name() {
+        // Two rows for the same tool: the keyed row wins even though it is not
+        // the most recent one with that name.
+        let mut items = vec![
+            ChatItem::User("go".into()),
+            finished_tool_row("monitor_run", Some("1:0")),
+            finished_tool_row("monitor_run", Some("1:1")),
+        ];
+        apply_tool_details(
+            &mut items,
+            Some("1:0"),
+            Some("monitor_run"),
+            serde_json::json!({"status": "succeeded"}),
+        );
+        assert!(
+            matches!(&items[1], ChatItem::Tool { details: Some(d), .. } if d["status"] == "succeeded")
+        );
+        assert!(matches!(&items[2], ChatItem::Tool { details: None, .. }));
+    }
+
+    #[test]
+    fn tool_details_fall_back_to_the_newest_row_with_the_name() {
+        // Replayed rows carry no call_key: match by name like ToolResult does.
+        let mut items = vec![
+            ChatItem::User("go".into()),
+            finished_tool_row("monitor_run", None),
+            finished_tool_row("monitor_run", None),
+        ];
+        apply_tool_details(
+            &mut items,
+            Some("1:0"),
+            Some("monitor_run"),
+            serde_json::json!({"status": "failed"}),
+        );
+        assert!(matches!(&items[1], ChatItem::Tool { details: None, .. }));
+        assert!(
+            matches!(&items[2], ChatItem::Tool { details: Some(d), .. } if d["status"] == "failed")
+        );
+    }
+
+    #[test]
+    fn tool_details_for_an_unknown_row_are_dropped() {
+        let mut items = vec![ChatItem::User("go".into())];
+        apply_tool_details(
+            &mut items,
+            Some("9:9"),
+            None,
+            serde_json::json!({"status": "running"}),
+        );
+        apply_tool_details(
+            &mut items,
+            None,
+            Some("monitor_run"),
+            serde_json::json!({"status": "running"}),
+        );
+        assert_eq!(items.len(), 1);
     }
 }

--- a/ui/src/chat_render.rs
+++ b/ui/src/chat_render.rs
@@ -424,6 +424,7 @@ pub(crate) fn render_steps_group(
                 } => *duration,
                 ChatItem::Tool {
                     duration_ms: None,
+                    call_key: None,
                     started_at_ms: Some(started),
                     ok: None,
                     ..
@@ -634,6 +635,7 @@ fn render_step_row(
             output,
             started_at_ms,
             duration_ms,
+            ..
         }) => {
             let step_id = format!("{group_id}:tool:{position}");
             let automatic = ok.is_none() && live;
@@ -835,6 +837,7 @@ mod steps_now_line_tests {
             output: String::new(),
             started_at_ms: None,
             duration_ms: None,
+            call_key: None,
         }
     }
 

--- a/ui/src/chat_render.rs
+++ b/ui/src/chat_render.rs
@@ -424,7 +424,6 @@ pub(crate) fn render_steps_group(
                 } => *duration,
                 ChatItem::Tool {
                     duration_ms: None,
-                    call_key: None,
                     started_at_ms: Some(started),
                     ok: None,
                     ..
@@ -838,6 +837,7 @@ mod steps_now_line_tests {
             started_at_ms: None,
             duration_ms: None,
             call_key: None,
+            details: None,
         }
     }
 
@@ -1018,10 +1018,15 @@ pub(crate) fn RunMonitorCard(
     clock: ReadSignal<i64>,
     tool_ok: Option<bool>,
     tool_output: String,
+    tool_details: Option<serde_json::Value>,
     dismissed_runs: RwSignal<HashSet<String>>,
 ) -> impl IntoView {
     let locale = use_locale();
-    let fallback = serde_json::from_str::<RunRecord>(&tool_output).ok();
+    // The structured details are the preferred source; older sessions only
+    // persisted the raw JSON tool output, which is the text fallback.
+    let fallback = tool_details
+        .and_then(|value| serde_json::from_value::<RunRecord>(value).ok())
+        .or_else(|| serde_json::from_str::<RunRecord>(&tool_output).ok());
     let detail = create_rw_signal(fallback.clone());
     let lookup_id = run_id.clone();
     let selected_id = run_id.clone();
@@ -1401,13 +1406,14 @@ pub(crate) fn render_item(
         }.into_view(),
         ChatItem::Tool { name, .. } if name == "attempt_completion" => view! {}.into_view(),
         ChatItem::FileChanged(_) => view! {}.into_view(),
-        ChatItem::Tool { name, ok, input, output, .. } if is_run_monitor_tool(name) => view! {
+        ChatItem::Tool { name, ok, input, output, details, .. } if is_run_monitor_tool(name) => view! {
             <RunMonitorCard
                 run_id=input.trim().to_string()
                 runs=runs
                 clock=run_clock
                 tool_ok=*ok
                 tool_output=output.clone()
+                tool_details=details.clone()
                 dismissed_runs=dismissed_runs
             />
         }.into_view(),

--- a/ui/src/chat_render.rs
+++ b/ui/src/chat_render.rs
@@ -1023,7 +1023,9 @@ pub(crate) fn RunMonitorCard(
 ) -> impl IntoView {
     let locale = use_locale();
     // The structured details are the preferred source; older sessions only
-    // persisted the raw JSON tool output, which is the text fallback.
+    // persisted the raw JSON tool output, which is the text fallback. The
+    // persisted details are a sanitized subset — the `get_run_detail` effect
+    // below fills in command, workdir, and environment at render time.
     let fallback = tool_details
         .and_then(|value| serde_json::from_value::<RunRecord>(value).ok())
         .or_else(|| serde_json::from_str::<RunRecord>(&tool_output).ok());

--- a/ui/src/dto.rs
+++ b/ui/src/dto.rs
@@ -233,6 +233,27 @@ pub(crate) enum AgentEvent {
         #[serde(default)]
         call_key: Option<String>,
     },
+    /// Live-only: the tool started executing; stamps the invocation key onto
+    /// the pending tool row so progress/details match by `call_key`.
+    ToolExecutionStarted {
+        frame_id: String,
+        call_key: String,
+        name: String,
+    },
+    /// Live-only structured mid-execution progress; never persisted host-side.
+    ToolProgress {
+        frame_id: String,
+        call_key: String,
+        details: serde_json::Value,
+    },
+    /// Persisted patch with a tool's final structured details; applied to the
+    /// matching tool row (by `call_key`, falling back to name).
+    ToolResultDetails {
+        frame_id: String,
+        call_key: String,
+        name: String,
+        details: serde_json::Value,
+    },
     ToolResult {
         frame_id: String,
         name: String,
@@ -387,10 +408,14 @@ pub(crate) enum ChatItem {
         started_at_ms: Option<u64>,
         /// Elapsed ms from tool call card to result.
         duration_ms: Option<u64>,
-        /// Live draft identity (`{round}:{index}`) while the model is still
-        /// streaming the call's arguments. `None` on real/persisted tool rows;
-        /// draft rows are never persisted and are cleared at turn boundaries.
+        /// Invocation identity (`{round}:{index}`). Draft rows (arguments
+        /// still streaming) always carry it; live rows are stamped with it
+        /// when execution starts so progress/details patches match by key.
+        /// `None` on replayed rows — persisted ToolCall events have no key.
         call_key: Option<String>,
+        /// Structured final details (or live progress snapshot) for the
+        /// host/UI — e.g. a Run record. Never model-facing content.
+        details: Option<serde_json::Value>,
     },
     /// Structured evidence that the active tool wrote a workspace file.
     /// Kept as a hidden transcript row so artifact attribution survives the
@@ -567,11 +592,16 @@ impl ChatItem {
                 input,
                 output,
                 duration_ms,
+                details,
                 ..
             } => {
                 (4u8, name, ok, duration_ms).hash(&mut h);
                 hash_text_sampled(&mut h, input);
                 hash_text_sampled(&mut h, output);
+                if let Some(details) = details {
+                    hash_text_sampled(&mut h, &details.to_string());
+                }
+                details.is_some().hash(&mut h);
             }
             Self::FileChanged(path) => {
                 14u8.hash(&mut h);
@@ -2180,6 +2210,8 @@ pub(crate) struct LoadedItem {
     pub(crate) locations: Option<String>,
     #[serde(default)]
     pub(crate) resources: Vec<MessageResource>,
+    #[serde(default)]
+    pub(crate) details: Option<serde_json::Value>,
 }
 
 #[derive(Deserialize)]
@@ -2263,6 +2295,7 @@ impl LoadedItem {
                 started_at_ms: None,
                 duration_ms: self.duration_ms,
                 call_key: None,
+                details: self.details,
             },
             "file_changed" => ChatItem::FileChanged(self.text),
             "usage" => {

--- a/ui/src/dto.rs
+++ b/ui/src/dto.rs
@@ -3634,12 +3634,20 @@ pub(crate) struct RuntimeSlot {
 /// the always-NULL `script_path`). No blanket `allow(dead_code)`: an unread
 /// field here means the UI is dropping data again, and the warning is the
 /// whole point.
+///
+/// Persisted run tool details are now a sanitized subset (id, status, title,
+/// exit code, timestamps, output tails) — command, workdir, and environment
+/// fields never leave the backend in a persisted payload. Fields that can be
+/// absent from that slim shape carry `#[serde(default)]`; the full record
+/// still arrives live through `get_run_detail`.
 #[derive(Deserialize, Clone, PartialEq)]
 pub(crate) struct RunRecord {
     pub(crate) id: String,
     pub(crate) frame_id: Option<String>,
+    #[serde(default)]
     pub(crate) context_id: String,
     pub(crate) title: String,
+    #[serde(default)]
     pub(crate) kind: String,
     pub(crate) status: String,
     pub(crate) command: Option<String>,
@@ -3657,6 +3665,7 @@ pub(crate) struct RunRecord {
     pub(crate) last_poll_error: Option<String>,
     #[serde(default)]
     pub(crate) progress_json: String,
+    #[serde(default)]
     pub(crate) env_snapshot_json: String,
 }
 

--- a/ui/src/dto.rs
+++ b/ui/src/dto.rs
@@ -217,6 +217,22 @@ pub(crate) enum AgentEvent {
         name: String,
         preview: String,
     },
+    /// Live-only draft of a tool call whose arguments are still streaming.
+    /// Keyed by `call_key` (`{round}:{index}`); superseded by the real
+    /// ToolCall or dropped by ToolCallDraftClear. Never persisted host-side.
+    ToolCallDraft {
+        frame_id: String,
+        call_key: String,
+        name: String,
+        preview: String,
+    },
+    /// Live-only: clear one draft (`Some(key)`) or all drafts of the frame
+    /// (`None`) so no ghost rows remain.
+    ToolCallDraftClear {
+        frame_id: String,
+        #[serde(default)]
+        call_key: Option<String>,
+    },
     ToolResult {
         frame_id: String,
         name: String,
@@ -371,6 +387,10 @@ pub(crate) enum ChatItem {
         started_at_ms: Option<u64>,
         /// Elapsed ms from tool call card to result.
         duration_ms: Option<u64>,
+        /// Live draft identity (`{round}:{index}`) while the model is still
+        /// streaming the call's arguments. `None` on real/persisted tool rows;
+        /// draft rows are never persisted and are cleared at turn boundaries.
+        call_key: Option<String>,
     },
     /// Structured evidence that the active tool wrote a workspace file.
     /// Kept as a hidden transcript row so artifact attribution survives the
@@ -2242,6 +2262,7 @@ impl LoadedItem {
                 output: self.text,
                 started_at_ms: None,
                 duration_ms: self.duration_ms,
+                call_key: None,
             },
             "file_changed" => ChatItem::FileChanged(self.text),
             "usage" => {

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -1911,8 +1911,28 @@ fn App() -> impl IntoView {
                             output: String::new(),
                             started_at_ms: Some(now_ms()),
                             duration_ms: None,
+                            call_key: None,
                         },
                     );
+                });
+                refresh_transcript_projections(&frame_id);
+            }
+            AgentEvent::ToolCallDraft {
+                frame_id,
+                call_key,
+                name,
+                preview,
+            } => {
+                flush_now();
+                route_items(active_cb, items_cb, transcripts_cb, &frame_id, |v| {
+                    upsert_tool_draft(v, call_key, name, preview);
+                });
+                refresh_transcript_projections(&frame_id);
+            }
+            AgentEvent::ToolCallDraftClear { frame_id, call_key } => {
+                flush_now();
+                route_items(active_cb, items_cb, transcripts_cb, &frame_id, |v| {
+                    clear_tool_drafts(v, call_key.as_deref());
                 });
                 refresh_transcript_projections(&frame_id);
             }
@@ -1976,6 +1996,7 @@ fn App() -> impl IntoView {
                                 output: content.clone(),
                                 started_at_ms: None,
                                 duration_ms: dur,
+                                call_key: None,
                             },
                         );
                     }
@@ -2098,6 +2119,9 @@ fn App() -> impl IntoView {
                 route_items(active_cb, items_cb, transcripts_cb, &frame_id, |items| {
                     strip_approval_pending(items);
                     settle_plan_cards(items);
+                    // The host clears drafts at round/run end; this is the
+                    // backstop so a missed clear can never leave a ghost row.
+                    clear_tool_drafts(items, None);
                     let Some((first_item, dropped_turns)) = transcript_tail_trim_point(
                         items,
                         TRANSCRIPT_LIVE_TRIM_TURNS,
@@ -2240,6 +2264,7 @@ fn App() -> impl IntoView {
                         Some(&frame_id),
                     );
                     route_items(active_cb, items_cb, transcripts_cb, &frame_id, |v| {
+                        clear_tool_drafts(v, None);
                         strip_approval_pending(v);
                         settle_plan_cards(v);
                         v.push(ChatItem::Assistant {
@@ -2295,6 +2320,7 @@ fn App() -> impl IntoView {
                             output: result,
                             started_at_ms: None,
                             duration_ms: None,
+                            call_key: None,
                         },
                     );
                 });

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -1732,6 +1732,13 @@ fn App() -> impl IntoView {
     // being applied per token; see the "Streaming delta batching" block above.
     let delta_buf: DeltaBuf = Rc::new(RefCell::new(HashMap::new()));
     let flush_scheduled = Rc::new(Cell::new(false));
+    // The runtime reports each tool execution's invocation key
+    // (`{round}:{index}`) just before the tool's own ToolCall event creates
+    // the row; remember it per frame so the row carries the key and later
+    // progress/details patches match by key instead of by name.
+    let pending_tool_keys: Rc<RefCell<HashMap<String, (String, String)>>> =
+        Rc::new(RefCell::new(HashMap::new()));
+    let cb_pending_tool_keys = pending_tool_keys.clone();
     let cb_buf = delta_buf.clone();
     let cb_scheduled = flush_scheduled.clone();
     let cb = Closure::wrap(Box::new(move |payload: JsValue| {
@@ -1895,6 +1902,12 @@ fn App() -> impl IntoView {
                 finish_compaction(&frame_id);
                 set_pet_activity(&frame_id, "review");
                 flush_now();
+                // Consume the invocation key the runtime announced for this
+                // call so the new row carries it (see ToolExecutionStarted).
+                let started_key = cb_pending_tool_keys
+                    .borrow_mut()
+                    .remove(&frame_id)
+                    .and_then(|(started_name, key)| (started_name == name).then_some(key));
                 route_items(active_cb, items_cb, transcripts_cb, &frame_id, |v| {
                     // The plan and question tools have no call card: their
                     // results carry the whole body, and that lands as a card.
@@ -1911,7 +1924,8 @@ fn App() -> impl IntoView {
                             output: String::new(),
                             started_at_ms: Some(now_ms()),
                             duration_ms: None,
-                            call_key: None,
+                            call_key: started_key,
+                            details: None,
                         },
                     );
                 });
@@ -1933,6 +1947,40 @@ fn App() -> impl IntoView {
                 flush_now();
                 route_items(active_cb, items_cb, transcripts_cb, &frame_id, |v| {
                     clear_tool_drafts(v, call_key.as_deref());
+                });
+                refresh_transcript_projections(&frame_id);
+            }
+            AgentEvent::ToolExecutionStarted {
+                frame_id,
+                call_key,
+                name,
+            } => {
+                // Announced just before the tool's own ToolCall event creates
+                // the row; stashed until that handler consumes it.
+                cb_pending_tool_keys
+                    .borrow_mut()
+                    .insert(frame_id, (name, call_key));
+            }
+            AgentEvent::ToolProgress {
+                frame_id,
+                call_key,
+                details,
+            } => {
+                // Live-only structured progress: update the row's details but
+                // never let a late fragment resurrect or move anything.
+                route_items(active_cb, items_cb, transcripts_cb, &frame_id, |v| {
+                    apply_tool_details(v, Some(&call_key), None, details);
+                });
+                refresh_transcript_projections(&frame_id);
+            }
+            AgentEvent::ToolResultDetails {
+                frame_id,
+                call_key,
+                name,
+                details,
+            } => {
+                route_items(active_cb, items_cb, transcripts_cb, &frame_id, |v| {
+                    apply_tool_details(v, Some(&call_key), Some(&name), details);
                 });
                 refresh_transcript_projections(&frame_id);
             }
@@ -1997,6 +2045,7 @@ fn App() -> impl IntoView {
                                 started_at_ms: None,
                                 duration_ms: dur,
                                 call_key: None,
+                                details: None,
                             },
                         );
                     }
@@ -2100,6 +2149,7 @@ fn App() -> impl IntoView {
             } => {
                 finish_compaction(&frame_id);
                 flush_now();
+                cb_pending_tool_keys.borrow_mut().remove(&frame_id);
                 conversation_outlines_cb.update(|outlines| {
                     if let Some(entry) = outlines
                         .get_mut(&frame_id)
@@ -2222,6 +2272,7 @@ fn App() -> impl IntoView {
             AgentEvent::Error { frame_id, message } => {
                 finish_compaction(&frame_id);
                 flush_now();
+                cb_pending_tool_keys.borrow_mut().remove(&frame_id);
                 conversation_outlines_cb.update(|outlines| {
                     if let Some(entry) = outlines
                         .get_mut(&frame_id)
@@ -2321,6 +2372,7 @@ fn App() -> impl IntoView {
                             started_at_ms: None,
                             duration_ms: None,
                             call_key: None,
+                            details: None,
                         },
                     );
                 });
@@ -9746,6 +9798,7 @@ fn App() -> impl IntoView {
                                             clock=run_clock.read_only()
                                             tool_ok=None
                                             tool_output=String::new()
+                                            tool_details=None
                                             dismissed_runs=dismissed_run_cards
                                         />
                                     </div>

--- a/ui/src/notebook.rs
+++ b/ui/src/notebook.rs
@@ -281,6 +281,7 @@ mod tests {
                 started_at_ms: None,
                 duration_ms: None,
                 call_key: None,
+                details: None,
             },
         ];
 
@@ -311,6 +312,7 @@ mod tests {
             started_at_ms: None,
             duration_ms: None,
             call_key: None,
+            details: None,
         }];
         let cells = collect_notebook_cells(&items, &mut NotebookCache::new());
         assert_eq!(cells.len(), 1);

--- a/ui/src/notebook.rs
+++ b/ui/src/notebook.rs
@@ -280,6 +280,7 @@ mod tests {
                 output: "1".into(),
                 started_at_ms: None,
                 duration_ms: None,
+                call_key: None,
             },
         ];
 
@@ -309,6 +310,7 @@ mod tests {
             output: "Length  Class".into(),
             started_at_ms: None,
             duration_ms: None,
+            call_key: None,
         }];
         let cells = collect_notebook_cells(&items, &mut NotebookCache::new());
         assert_eq!(cells.len(), 1);

--- a/ui/src/pet.rs
+++ b/ui/src/pet.rs
@@ -137,6 +137,8 @@ impl DesktopPetActivity {
             ),
             AgentEvent::MessageBoundary { .. }
             | AgentEvent::Usage { .. }
+            | AgentEvent::ToolCallDraft { .. }
+            | AgentEvent::ToolCallDraftClear { .. }
             | AgentEvent::ToolPresentation { .. }
             | AgentEvent::Compaction { .. }
             | AgentEvent::ContextWarning { .. }

--- a/ui/src/pet.rs
+++ b/ui/src/pet.rs
@@ -139,6 +139,9 @@ impl DesktopPetActivity {
             | AgentEvent::Usage { .. }
             | AgentEvent::ToolCallDraft { .. }
             | AgentEvent::ToolCallDraftClear { .. }
+            | AgentEvent::ToolExecutionStarted { .. }
+            | AgentEvent::ToolProgress { .. }
+            | AgentEvent::ToolResultDetails { .. }
             | AgentEvent::ToolPresentation { .. }
             | AgentEvent::Compaction { .. }
             | AgentEvent::ContextWarning { .. }


### PR DESCRIPTION
## 用户问题

模型流式输出工具调用期间，UI 在工具真正开始执行前没有任何可见状态；工具结果只有纯文本，UI 无法获得结构化数据（如 Run 状态）；steering/follow-up 队列的一致性逻辑散落在 Tauri 私有并发状态里，Core 无法测试。本 PR 为 agent 运行时引入统一的事件协议，并在此之上实现工具参数草稿流、结构化工具结果与进度、以及队列所有权收口。

## 变更摘要

**Core 事件协议（wisp-core）**
- 新增 `AgentRuntimeEvent`：Run/Round/Message 生命周期 + 工具状态机（`ToolCallReady` → `ToolExecutionStarted`/`Updated`/`Finished`/`ToolExecutionBlocked`），`ToolInvocationKey { round, index, call_id }` 标识每次调用。
- 契约：每次运行恰好一个 `RunFinished`（含成功/失败/取消，覆盖图片预处理失败路径）；Round 严格成对；策略或用户拒绝的调用是 `Blocked`（不再是 `Started→Finished(false)`）；`Started` 由准入检查通过后的 `ToolEvent::Call` 驱动，并携带与工具卡一致的 `mcp:` 规范名。
- `Output::runtime_event()` 默认空实现，旧回调全部保留（兼容期）。

**工具参数草稿流（wisp-llm / wisp-core / src-tauri / ui）**
- 三类 Provider 统一产生 `ToolCallDelta` 片段（每个 index/attempt 首片 `reset`）；Anthropic 维护 block_index→工具序号映射，草稿键与最终调用键一致。
- Core 不做累加直接转发；Tauri 侧单一累加器按 `call_key` 重建快照，`Tool::preview()` 安全预览每 33ms 窗口至多计算一次——原始参数永远不进入 UI、SQLite 或日志。UI 草稿行按 `call_key` upsert，同名并发调用分行；Ready/Round/RunFinished 清理，不留幽灵行。

**结构化 ToolResult 与进度（wisp-tools / wisp-core / src-tauri / ui）**
- `ToolResult.details`（宿主/UI 专用，绝不进入模型上下文）+ `ToolEvent::Progress`；循环经 `for_invocation` 注入调用身份，工具结束后迟到的 progress 被丢弃；details 限长 16KiB。
- `run_in_context`/`monitor_run` 首批迁移：模型得简短摘要，UI 得结构化 `RunPresentationDetails`（脱敏 allowlist；完整记录仍走 `get_run_detail`）。
- 最终 details 经持久化 `ToolResultDetails` patch 支持 session replay；项目导出对遗留事件与 `env_snapshots` 做二次清洗，杜绝 SSH 主机、私钥路径、控制 token 泄漏。

**队列收口（wisp-core / src-tauri）**
- `AgentControl`：可克隆的并发安全句柄（cancel + steering + `FollowUpQueue<T>`），`SessionRuntime` 五个私有并发字段收口为一。无丢唤醒不变量移入 Core 并有并发压测。Tauri 命令协议与产品语义不变（one-at-a-time、cut-in 仅文本）。

**未纳入**
- AgentMessage 消息分层（原阶段 5）按评审意见撤销并暂缓：待做真正的所有权迁移（ContextManager 持有 AgentMessage）时重新设计，避免当前形态的双重全历史克隆。

## 测试

- wisp-core：生命周期事件顺序、流式 delta 轮次标记、工具状态迁移、失败/取消/重试、Blocked 语义（策略拒绝无 Started、确认拒绝 Started→Blocked）、MCP 规范名、details 不进 Provider 请求、progress 顺序与迟到丢弃、FollowUpQueue 并发压测。
- wisp-llm：Anthropic 混合流（text/thinking + tool_use）草稿序号、OpenAI/Responses 片段序列。
- src-tauri：草稿投影/累加/节流/驱逐、replay 恢复最终 details、run 工具脱敏。
- wisp-store：导出库任意表不得出现敏感哨兵的端到端测试。
- Playwright：草稿行可见性/同名分离/幽灵行清理、run 监视行结构化 details。
- 全量：`cargo fmt --all -- --check`、`cargo test --workspace`、`cd ui && cargo check --target wasm32-unknown-unknown`、`npx playwright test`（345 passed, 1 skipped）。

## 手动冒烟

1. 让模型调用 `write`/`shell` 等工具：工具卡片在回答流式生成期间即出现并显示路径/命令预览。
2. 同一轮两个同名工具调用显示为两行，互不串卡。
3. 计划模式/审批拒绝一个工具：卡片显示为 Blocked 而非失败结果。
4. `run_in_context` 提交后 `monitor_run`：工具行实时刷新 Run 状态；重启会话后 replay 仍显示最终状态。
5. 排队多个 follow-up，重排/编辑/取消/cut-in 行为与之前一致。

## 已知限制与后续

- follow-up 队列仍为内存态，重启丢失（有意保留，代码已注明）。
- 自定义 `AgentMessage` 持久化与队列跨重启恢复需要单独的数据库设计，明确延期。
- 统一投影层（TauriOutput 全量投影 `AgentRuntimeEvent`、删除旧回调）保留在兼容期之后单独做。
