### PR TITLE
fix(reader): keep `#` session references from aborting the send (#784)

### DIFF
--- a/crates/wisp-llm/src/provider.rs
+++ b/crates/wisp-llm/src/provider.rs
@@ -61,11 +61,22 @@ pub enum LlmError {
     Config(String),
     #[error("stream ended without completion")]
     Incomplete,
+    /// A Responses-API turn that ended in a terminal status other than
+    /// `completed` (HTTP 200, but `incomplete`/`failed`/`cancelled`). Carries
+    /// the wire detail (`incomplete_details.reason` or `error.message`) so
+    /// callers can tell an exhausted output budget from a genuine failure.
+    #[error("response ended with status '{status}' ({reason})")]
+    NotCompleted { status: String, reason: String },
 }
 
 pub type Result<T> = std::result::Result<T, LlmError>;
 
 impl LlmError {
+    /// The model stopped because it exhausted the output token budget
+    /// (`max_output_tokens`), so a retry with a larger budget can succeed.
+    pub fn output_limit_hit(&self) -> bool {
+        matches!(self, LlmError::NotCompleted { reason, .. } if reason == "max_output_tokens")
+    }
     /// Provider rejected the request because the assembled prompt exceeds the
     /// model context window.
     pub fn is_context_overflow(&self) -> bool {

--- a/crates/wisp-llm/src/responses.rs
+++ b/crates/wisp-llm/src/responses.rs
@@ -327,7 +327,15 @@ impl Provider for OpenAiResponsesProvider {
 fn ensure_completed_response(value: &Value) -> Result<()> {
     match value.get("status").and_then(Value::as_str) {
         None | Some("completed") => Ok(()),
-        Some(_) => Err(LlmError::Incomplete),
+        Some(status) => Err(LlmError::NotCompleted {
+            status: status.to_string(),
+            reason: value
+                .pointer("/incomplete_details/reason")
+                .and_then(Value::as_str)
+                .or_else(|| value.pointer("/error/message").and_then(Value::as_str))
+                .unwrap_or("no detail provided")
+                .to_string(),
+        }),
     }
 }
 
@@ -521,13 +529,54 @@ mod tests {
                 "output_text": "partial report",
                 "incomplete_details": {"reason": "upstream_error"}
             });
-            assert!(matches!(
-                ensure_completed_response(&value),
-                Err(LlmError::Incomplete)
-            ));
+            match ensure_completed_response(&value) {
+                Err(LlmError::NotCompleted { status: s, reason }) => {
+                    assert_eq!(s, status);
+                    assert_eq!(reason, "upstream_error");
+                }
+                other => panic!("expected NotCompleted, got {other:?}"),
+            }
         }
         assert!(ensure_completed_response(&json!({"status": "completed"})).is_ok());
         assert!(ensure_completed_response(&json!({"output_text": "relay response"})).is_ok());
+    }
+
+    #[test]
+    fn output_token_limit_is_distinguished_from_other_failures() {
+        let limited = ensure_completed_response(&json!({
+            "status": "incomplete",
+            "incomplete_details": {"reason": "max_output_tokens"}
+        }))
+        .unwrap_err();
+        assert!(limited.output_limit_hit());
+        assert_eq!(
+            limited.to_string(),
+            "response ended with status 'incomplete' (max_output_tokens)"
+        );
+
+        let filtered = ensure_completed_response(&json!({
+            "status": "incomplete",
+            "incomplete_details": {"reason": "content_filter"}
+        }))
+        .unwrap_err();
+        assert!(!filtered.output_limit_hit());
+
+        let failed = ensure_completed_response(&json!({
+            "status": "failed",
+            "error": {"message": "upstream exploded"}
+        }))
+        .unwrap_err();
+        assert!(!failed.output_limit_hit());
+        assert_eq!(
+            failed.to_string(),
+            "response ended with status 'failed' (upstream exploded)"
+        );
+
+        let undetailed = ensure_completed_response(&json!({"status": "cancelled"})).unwrap_err();
+        assert_eq!(
+            undetailed.to_string(),
+            "response ended with status 'cancelled' (no detail provided)"
+        );
     }
 
     #[test]

--- a/src-tauri/src/project_reader.rs
+++ b/src-tauri/src/project_reader.rs
@@ -226,7 +226,7 @@ pub async fn read_references(
         inputs.push(SessionInput { info, messages });
     }
 
-    let (provider, api_url, model, api_key, _, reasoning_effort) =
+    let (provider, api_url, model, api_key, profile_max_tokens, reasoning_effort) =
         crate::specialists::specialist_llm(store, &reader).await;
     let cfg = crate::build_provider_config(
         &provider,
@@ -238,6 +238,23 @@ pub async fn read_references(
     )
     .map_err(|error| format!("Reader model is unavailable: {error}"))?;
     let llm: Arc<dyn Provider> = Arc::from(wisp_llm::build(cfg));
+    // A reasoning model can burn the compact Reader budget on hidden reasoning
+    // before writing any JSON (`max_output_tokens`, #784). Keep the profile's
+    // full budget on hand so a chunk that hits the limit can retry once.
+    let retry_llm: Option<Arc<dyn Provider>> = if profile_max_tokens > READER_OUTPUT_TOKENS {
+        crate::build_provider_config(
+            &provider,
+            &api_url,
+            &api_key,
+            &model,
+            profile_max_tokens,
+            &reasoning_effort,
+        )
+        .ok()
+        .map(|cfg| Arc::from(wisp_llm::build(cfg)))
+    } else {
+        None
+    };
 
     let mut tasks = Vec::new();
     for (session_index, session) in inputs.iter().enumerate() {
@@ -254,7 +271,7 @@ pub async fn read_references(
         }
     }
     let task_count = tasks.len();
-    let results = run_tasks(llm, &question, tasks, cancel).await;
+    let results = run_tasks(llm, retry_llm, &question, tasks, cancel).await;
 
     if cancel.load(Ordering::SeqCst) {
         return Err("Project reading was cancelled.".into());
@@ -264,12 +281,10 @@ pub async fn read_references(
         .filter(|result| result.result.is_ok())
         .count();
     if successful_tasks == 0 {
-        let detail = results
-            .iter()
-            .find_map(|result| result.result.as_ref().err())
-            .cloned()
-            .unwrap_or_else(|| "Reader returned no result.".into());
-        return Err(format!("Reader could not inspect any session: {detail}"));
+        // A failed Reader augmentation must not abort the whole send (#784):
+        // degrade to a visible note so the turn proceeds and the model tells
+        // the user the reference could not be retrieved.
+        return Ok(Some(failure_injection(&results)));
     }
 
     let mut by_session: Vec<Vec<(usize, ChunkResult)>> = vec![Vec::new(); inputs.len()];
@@ -282,17 +297,32 @@ pub async fn read_references(
     Ok(Some(render_injection(&inputs, by_session, failed_tasks)))
 }
 
+fn failure_injection(results: &[TaskResult]) -> String {
+    let detail = results
+        .iter()
+        .find_map(|result| result.result.as_ref().err())
+        .cloned()
+        .unwrap_or_else(|| "Reader returned no result.".into());
+    format!(
+        "## Reader project search\nThe Reader could not inspect the referenced session(s): {detail}. \
+         Tell the user the `#` reference could not be retrieved, then answer as best you can without it."
+    )
+}
+
 async fn run_tasks(
     llm: Arc<dyn Provider>,
+    retry_llm: Option<Arc<dyn Provider>>,
     question: &str,
     tasks: Vec<Task>,
     cancel: &AtomicBool,
 ) -> Vec<TaskResult> {
     stream::iter(tasks.into_iter().map(|task| {
         let llm = llm.clone();
+        let retry_llm = retry_llm.clone();
         let question = question.to_string();
         async move {
-            let result = run_task(llm, &question, &task, cancel).await;
+            let result =
+                run_task(llm.as_ref(), retry_llm.as_deref(), &question, &task, cancel).await;
             TaskResult {
                 session_index: task.session_index,
                 chunk_index: task.chunk_index,
@@ -305,8 +335,17 @@ async fn run_tasks(
     .await
 }
 
+/// A chunk call that failed. `OutputLimit` is the one failure worth a retry:
+/// the model exhausted `max_output_tokens` before producing JSON, so a larger
+/// budget may still succeed.
+enum ChunkFailure {
+    OutputLimit(String),
+    Other(String),
+}
+
 async fn run_task(
-    llm: Arc<dyn Provider>,
+    llm: &dyn Provider,
+    retry_llm: Option<&dyn Provider>,
     question: &str,
     task: &Task,
     cancel: &AtomicBool,
@@ -324,17 +363,50 @@ async fn run_task(
         task.chunk.transcript
     );
     let messages = [Message::system(READER_RUBRIC), Message::user(prompt)];
-    let request = llm.complete(&messages, &[]);
+    let completion = match complete_chunk(llm, &messages, cancel).await {
+        Ok(completion) => completion,
+        Err(ChunkFailure::Other(error)) => return Err(error),
+        Err(ChunkFailure::OutputLimit(first)) => match retry_llm {
+            Some(retry) if !cancel.load(Ordering::SeqCst) => {
+                match complete_chunk(retry, &messages, cancel).await {
+                    Ok(completion) => completion,
+                    Err(ChunkFailure::OutputLimit(second)) | Err(ChunkFailure::Other(second)) => {
+                        return Err(format!(
+                            "{first}; retry with the profile's full output budget also failed: {second}"
+                        ));
+                    }
+                }
+            }
+            _ => return Err(first),
+        },
+    };
+    parse_result(&completion.content, &task.chunk)
+}
+
+async fn complete_chunk(
+    llm: &dyn Provider,
+    messages: &[Message],
+    cancel: &AtomicBool,
+) -> Result<wisp_llm::Completion, ChunkFailure> {
+    let request = llm.complete(messages, &[]);
     tokio::pin!(request);
     let completion = tokio::select! {
-        result = &mut request => result.map_err(|error| error.to_string())?,
-        _ = wait_for_cancel(cancel) => return Err("cancelled".into()),
-        _ = tokio::time::sleep(READER_TIMEOUT) => return Err("Reader model timed out.".into()),
+        result = &mut request => result.map_err(|error| {
+            if error.output_limit_hit() {
+                ChunkFailure::OutputLimit(error.to_string())
+            } else {
+                ChunkFailure::Other(error.to_string())
+            }
+        })?,
+        _ = wait_for_cancel(cancel) => return Err(ChunkFailure::Other("cancelled".into())),
+        _ = tokio::time::sleep(READER_TIMEOUT) => {
+            return Err(ChunkFailure::Other("Reader model timed out.".into()));
+        }
     };
     if cancel.load(Ordering::SeqCst) {
-        return Err("cancelled".into());
+        return Err(ChunkFailure::Other("cancelled".into()));
     }
-    parse_result(&completion.content, &task.chunk)
+    Ok(completion)
 }
 
 async fn wait_for_cancel(cancel: &AtomicBool) {
@@ -872,11 +944,162 @@ mod tests {
             })
             .collect();
         let cancel = AtomicBool::new(false);
-        let results = run_tasks(provider.clone(), "find it", tasks, &cancel).await;
+        let results = run_tasks(provider.clone(), None, "find it", tasks, &cancel).await;
         assert_eq!(results.len(), 8);
         assert!(results.iter().all(|result| result.result.is_ok()));
         let max_active = provider.max_active.load(Ordering::SeqCst);
         assert!(max_active > 1, "tasks ran serially");
         assert!(max_active <= READER_PARALLELISM, "unbounded fan-out");
+    }
+
+    /// Always fails with the given error; records how often it was called.
+    struct FailingProvider {
+        error: String,
+        output_limit: bool,
+        calls: AtomicUsize,
+    }
+
+    #[async_trait::async_trait]
+    impl Provider for FailingProvider {
+        fn name(&self) -> &str {
+            "fake"
+        }
+
+        fn model(&self) -> &str {
+            "fake-reader"
+        }
+
+        async fn complete(
+            &self,
+            _messages: &[Message],
+            _tools: &[wisp_llm::ToolSchema],
+        ) -> wisp_llm::Result<wisp_llm::Completion> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            if self.output_limit {
+                return Err(wisp_llm::LlmError::NotCompleted {
+                    status: "incomplete".into(),
+                    reason: "max_output_tokens".into(),
+                });
+            }
+            Err(wisp_llm::LlmError::Api {
+                status: 500,
+                body: self.error.clone(),
+            })
+        }
+
+        async fn stream(
+            &self,
+            messages: &[Message],
+            tools: &[wisp_llm::ToolSchema],
+            _sink: &mut dyn wisp_llm::StreamSink,
+        ) -> wisp_llm::Result<wisp_llm::Completion> {
+            self.complete(messages, tools).await
+        }
+    }
+
+    fn one_chunk_task() -> Task {
+        Task {
+            session_index: 0,
+            chunk_index: 0,
+            chunk_count: 1,
+            session: SessionSearchResult {
+                id: "s0".into(),
+                project_id: "p".into(),
+                project_name: "Project".into(),
+                title: "Session 0".into(),
+                created_at: 0,
+                activity_at: 0,
+                last_role: None,
+                unseen: false,
+            },
+            chunk: SessionChunk {
+                transcript: "[message seq=1 USER]\nevidence".into(),
+                sources: HashMap::from([(1, "evidence".into())]),
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn output_limit_retries_once_with_larger_budget() {
+        let primary = FailingProvider {
+            error: String::new(),
+            output_limit: true,
+            calls: AtomicUsize::new(0),
+        };
+        let retry = SlowProvider {
+            active: AtomicUsize::new(0),
+            max_active: AtomicUsize::new(0),
+        };
+        let cancel = AtomicBool::new(false);
+        let result = run_task(
+            &primary,
+            Some(&retry),
+            "find it",
+            &one_chunk_task(),
+            &cancel,
+        )
+        .await;
+        assert!(
+            result.is_ok(),
+            "output-limit retry should succeed: {result:?}"
+        );
+        assert_eq!(primary.calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn output_limit_without_retry_budget_surfaces_the_reason() {
+        let primary = FailingProvider {
+            error: String::new(),
+            output_limit: true,
+            calls: AtomicUsize::new(0),
+        };
+        let cancel = AtomicBool::new(false);
+        let error = run_task(&primary, None, "find it", &one_chunk_task(), &cancel)
+            .await
+            .unwrap_err();
+        assert!(
+            error.contains("max_output_tokens"),
+            "error should name the wire reason: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn non_output_limit_failures_do_not_retry() {
+        let primary = FailingProvider {
+            error: "boom".into(),
+            output_limit: false,
+            calls: AtomicUsize::new(0),
+        };
+        let retry = FailingProvider {
+            error: "boom".into(),
+            output_limit: false,
+            calls: AtomicUsize::new(0),
+        };
+        let cancel = AtomicBool::new(false);
+        let error = run_task(
+            &primary,
+            Some(&retry),
+            "find it",
+            &one_chunk_task(),
+            &cancel,
+        )
+        .await
+        .unwrap_err();
+        assert!(error.contains("boom"), "{error}");
+        assert_eq!(retry.calls.load(Ordering::SeqCst), 0, "must not retry");
+    }
+
+    #[test]
+    fn failure_injection_degrades_to_a_user_visible_note() {
+        let results = vec![TaskResult {
+            session_index: 0,
+            chunk_index: 0,
+            result: Err("response ended with status 'incomplete' (max_output_tokens)".into()),
+        }];
+        let note = failure_injection(&results);
+        assert!(note.contains("## Reader project search"));
+        assert!(note.contains("max_output_tokens"));
+        assert!(note.contains("could not be retrieved"));
+        assert!(failure_injection(&[]).contains("Reader returned no result."));
     }
 }


### PR DESCRIPTION
Closes #784

## 用户问题

在输入框用 `#` 引用对话后点发送，整个发送失败：`发送失败：Reader could not inspect any session: stream ended without completion`。

根因：Reader specialist 未绑定模型时回落到当前激活模型（本例 deepseek-v4-flash，`openai_responses`，reasoning effort = max），但 Reader 的输出预算硬编码为 2048 token。Responses API 下隐藏推理会先耗尽这 2048 token，线上返回 HTTP 200 + `status: "incomplete"`（`incomplete_details.reason: "max_output_tokens"`），被统一报成误导性的 "stream ended without completion"，且所有 chunk 失败后直接 `Err` 中断了整个发送。

## 改动

- `crates/wisp-llm/src/provider.rs`：新增 `LlmError::NotCompleted { status, reason }`（Display 形如 `response ended with status 'incomplete' (max_output_tokens)`）与 `output_limit_hit()` helper。非流式 Responses 调用不再复用流式场景的 `Incomplete` 文案。
- `crates/wisp-llm/src/responses.rs`：`ensure_completed_response` 提取 `incomplete_details.reason`（或 `error.message`）填入 `NotCompleted`。
- `src-tauri/src/project_reader.rs`：
  - chunk 因 `max_output_tokens` 失败时，用 profile 的完整输出预算（`specialist_llm` 返回的 max_tokens，此前被丢弃）自动重试一次；
  - 所有 chunk 仍失败时不再中断发送，降级为一条可见注入（`## Reader project search … could not be retrieved …`），让回合继续并由模型告知用户引用取数失败。

## 测试

- `wisp-llm`：`rejects_partial_terminal_responses` 更新为断言 status/reason 保留；新增 `output_token_limit_is_distinguished_from_other_failures`。
- `project_reader` 新增 4 个测试：输出上限触发重试并成功、无重试预算时错误携带 `max_output_tokens`、非输出上限错误不重试、失败降级注入文案。
- `cargo fmt --all -- --check` 通过；`cargo test --workspace`：本改动相关测试全部通过。

## 已知问题 / 后续

- `cargo test --workspace` 中 `wisp-tauri --lib` 有 10 个**既有**失败（`method_search*`、`resource_leases`、`publication_commands`），已在不带本改动的 origin/main 基线上复跑确认同样失败，与本 PR 无关。
- 运行时 LLM 错误仍不写入 `wisp.log`，排障只能靠界面文案；日志增强留作后续。
- 降级而非硬失败是有意的行为变化：`#` 引用是增强上下文，取数失败不应阻断用户消息发送；失败原因会出现在注入文本中并由模型转述。

## 手动冒烟

1. 激活模型配为 Responses-API 推理模型且 reasoning effort 为 high/max；
2. 输入框 `#` 引用一个历史会话并发送；
3. 修复前：发送直接失败；修复后：消息正常发出，Reader 成功注入证据，或在仍失败时模型明确告知引用取数失败原因并继续回答。