### PR TITLE
chore: apply 10 mechanical clippy fixes

### DIFF
--- a/crates/wisp-store/src/agent_workflows.rs
+++ b/crates/wisp-store/src/agent_workflows.rs
@@ -91,21 +91,16 @@ impl BudgetReservation {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentWorkflowStatus {
+    #[default]
     Draft,
     Approved,
     Running,
     Succeeded,
     Failed,
     Cancelled,
-}
-
-impl Default for AgentWorkflowStatus {
-    fn default() -> Self {
-        Self::Draft
-    }
 }
 
 fn manual_mode() -> String {

--- a/src-tauri/src/codex_import.rs
+++ b/src-tauri/src/codex_import.rs
@@ -604,7 +604,7 @@ fn candidates_from_stamps(
     cached: &[ExternalSessionCacheRecord],
 ) -> Vec<SessionCandidate> {
     let cached = cached
-        .into_iter()
+        .iter()
         .map(|record| (record.source_path.as_str(), record))
         .collect::<HashMap<_, _>>();
     stamps
@@ -619,7 +619,7 @@ fn candidates_from_stamps(
             let metadata = read_metadata_preview(provider, Path::new(&stamp.path))
                 .ok()
                 .and_then(|jsonl| metadata_from_jsonl(provider, &jsonl, &stamp))
-                .or_else(|| previous.map(|record| metadata_from_cache(record)))?;
+                .or_else(|| previous.map(metadata_from_cache))?;
             Some(SessionCandidate {
                 path: stamp.path,
                 file_size: stamp.size,
@@ -909,7 +909,7 @@ fn parse_context_listing(
         if size > CONTEXT_ROLLOUT_MAX_BYTES as i64 {
             continue;
         }
-        validate_context_path(provider, &path)?;
+        validate_context_path(provider, path)?;
         files.push(FileStamp {
             path: path.to_string(),
             size,

--- a/src-tauri/src/delegation_runtime.rs
+++ b/src-tauri/src/delegation_runtime.rs
@@ -1730,7 +1730,6 @@ async fn persisted_successful_steps(
     let mut completed = Vec::new();
     for attempt in latest
         .into_values()
-        .into_iter()
         .filter(|attempt| attempt.status == AgentWorkflowAttemptStatus::Succeeded)
     {
         let Some(raw) = attempt.response_json else {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5861,7 +5861,7 @@ async fn send_message_inner(
             .is_some_and(|specialist| specialist.id == "reviewer");
         if !resume && !is_reviewer && load_auto_review_enabled(&state.store).await {
             automatic_review(
-                &state,
+                state,
                 &app,
                 &frame_id,
                 &model_label,
@@ -5923,7 +5923,7 @@ async fn send_message_inner(
     let turn_started = resume || agent.ctx.messages.len() > turn_start;
     drop(guard);
     // After the persist flush so the seen snapshot covers the final messages.
-    mark_seen_if_viewed(&state, &frame_id).await;
+    mark_seen_if_viewed(state, &frame_id).await;
 
     if result.is_ok() {
         if let Err(error) = project_state_revisions::record_completed_mainline_turn(

--- a/src-tauri/src/project_sync.rs
+++ b/src-tauri/src/project_sync.rs
@@ -167,11 +167,7 @@ fn valid_windows_component(component: &str) -> bool {
 }
 
 fn valid_portable_path(path: &str) -> bool {
-    !path.is_empty()
-        && !path.contains('\\')
-        && path
-            .split('/')
-            .all(|component| valid_windows_component(component))
+    !path.is_empty() && !path.contains('\\') && path.split('/').all(valid_windows_component)
 }
 
 fn valid_relay_component(value: &str) -> bool {

--- a/src-tauri/src/runtime_launcher.rs
+++ b/src-tauri/src/runtime_launcher.rs
@@ -244,8 +244,8 @@ impl RuntimeLauncher for TauriRuntimeLauncher {
             }
         }
         let ssh_auth_envs = if context.kind == wisp_store::ExecutionContextKind::Ssh {
-            let connection = SshConnection::from_execution_context(&context)
-                .map_err(|e| anyhow::Error::msg(e))?;
+            let connection =
+                SshConnection::from_execution_context(&context).map_err(anyhow::Error::msg)?;
             crate::ssh_hosts::auth_envs_for_connection(&connection).map_err(anyhow::Error::msg)?
         } else {
             Vec::new()

--- a/src-tauri/src/session_commands.rs
+++ b/src-tauri/src/session_commands.rs
@@ -1061,7 +1061,7 @@ pub(super) fn transcript_page_items(
     }
     let mut inserted = 0usize;
     for (message_seq, report_json) in &page.reviews {
-        let report: review::ReviewReport = serde_json::from_str(&report_json)
+        let report: review::ReviewReport = serde_json::from_str(report_json)
             .map_err(|e| format!("invalid persisted review: {e}"))?;
         let at = boundaries.get(message_seq).copied().unwrap_or_else(|| {
             let message_count = page


### PR DESCRIPTION
### Summary

Pure code-quality cleanup. **No user-facing behavior change** — every fix is a compiler-proven-equivalent refactoring suggested by `cargo clippy`. Resolves 10 warnings (workspace clippy count 67 → 57).

### Changes

| lint | count | files |
|---|---|---|
| `needless_borrow` | 4 | `codex_import`, `session_commands`, `lib` |
| `redundant_closure` | 3 | `codex_import`, `runtime_launcher`, `project_sync` |
| `useless_conversion` | 1 | `delegation_runtime` |
| `into_iter_on_ref` | 1 | `codex_import` |
| `derivable_impls` | 1 | `wisp-store` (manual `impl Default` → `#[derive(Default)]`) |

No new abstractions, no API or control-flow changes.

### Verification

- `cargo clippy --workspace`: **67 → 57** warnings (these 10 gone, no new warnings)
- `cargo fmt --all --check`: clean
- `cargo test -p wisp-store agent_workflow`: **9/9 pass** (covers the `AgentWorkflowStatus` Default change)

### Remaining clippy warnings (57)

57 warnings still remain on this branch. I left them out of this PR on purpose:

- **Design-level (~29)** — likely intentional, needs a maintainer call: `too_many_arguments`, `type_complexity`, `large_enum_variant`, `result_large_err`.
- **Per-site review (~28)** — small, but each needs a semantic check: `manual_clamp`, `manual_checked_ops`, `while_let_loop`, `unnecessary_sort_by`, `obfuscated_if_else`, etc.

Full list with locations (current line numbers):

<details>
<summary>Show all 57 remaining warnings (grouped by lint)</summary>

**`clippy::too_many_arguments`** (21)
- `crates/wisp-core/src/agent.rs:109` — this function has too many arguments (9/7)
- `crates/wisp-core/src/agent.rs:224` — this function has too many arguments (9/7)
- `crates/wisp-core/src/agent.rs:249` — this function has too many arguments (9/7)
- `crates/wisp-core/src/output.rs:22` — this function has too many arguments (9/7)
- `crates/wisp-core/src/lib.rs:87` — this function has too many arguments (8/7)
- `src-tauri/src/delegation_runtime.rs:271` — this function has too many arguments (8/7)
- `src-tauri/src/delegation_runtime.rs:3231` — this function has too many arguments (10/7)
- `src-tauri/src/harvest.rs:131` — this function has too many arguments (10/7)
- `src-tauri/src/harvest.rs:209` — this function has too many arguments (8/7)
- `src-tauri/src/method_search.rs:422` — this function has too many arguments (9/7)
- `src-tauri/src/method_search_coordinator.rs:1297` — this function has too many arguments (9/7)
- `src-tauri/src/native_delegation.rs:119` — this function has too many arguments (11/7)
- `src-tauri/src/project_sync.rs:789` — this function has too many arguments (8/7)
- `src-tauri/src/project_sync.rs:982` — this function has too many arguments (8/7)
- `src-tauri/src/project_transfer.rs:310` — this function has too many arguments (9/7)
- `src-tauri/src/run_context.rs:205` — this function has too many arguments (8/7)
- `src-tauri/src/run_context.rs:1370` — this function has too many arguments (9/7)
- `src-tauri/src/run_context.rs:1968` — this function has too many arguments (9/7)
- `src-tauri/src/lib.rs:4850` — this function has too many arguments (12/7)
- `src-tauri/src/lib.rs:6034` — this function has too many arguments (8/7)
- `src-tauri/src/lib.rs:6421` — this function has too many arguments (8/7)

**`clippy::type_complexity`** (7)
- `crates/wisp-store/src/library.rs:345` — very complex type used. Consider factoring parts into `type` definitions
- `crates/wisp-store/src/library.rs:413` — very complex type used. Consider factoring parts into `type` definitions
- `crates/wisp-store/src/plugins.rs:228` — very complex type used. Consider factoring parts into `type` definitions
- `src-tauri/src/pet_commands.rs:169` — very complex type used. Consider factoring parts into `type` definitions
- `src-tauri/src/project_sync.rs:236` — very complex type used. Consider factoring parts into `type` definitions
- `src-tauri/src/run_context/remote.rs:102` — very complex type used. Consider factoring parts into `type` definitions
- `src-tauri/src/terminal_sessions.rs:260` — very complex type used. Consider factoring parts into `type` definitions

**`clippy::obfuscated_if_else`** (4)
- `src-tauri/src/delegation_runtime.rs:4138` — this method chain can be written more clearly with `if .. else ..`
- `src-tauri/src/image_generation_tool.rs:138` — this method chain can be written more clearly with `if .. else ..`
- `src-tauri/src/run_context/transfer.rs:945` — this method chain can be written more clearly with `if .. else ..`
- `src-tauri/src/ssh_hosts.rs:709` — this method chain can be written more clearly with `if .. else ..`

**`clippy::unnecessary_sort_by`** (4)
- `crates/wisp-tools/src/search.rs:77` — consider using `sort_by_key`
- `crates/wisp-core/src/memory.rs:116` — consider using `sort_by_key`
- `src-tauri/src/codex_import.rs:1157` — consider using `sort_by_key`
- `src-tauri/src/lib.rs:7196` — consider using `sort_by_key`

**`clippy::manual_checked_ops`** (3)
- `crates/wisp-cli/src/main.rs:231` — manual checked division
- `crates/wisp-cli/src/main.rs:278` — manual checked division
- `src-tauri/src/review.rs:174` — manual checked division

**`clippy::empty_line_after_doc_comments`** (2)
- `crates/wisp-store/src/artifacts.rs:641` — empty line after doc comment
- `crates/wisp-store/src/sessions.rs:2006` — empty line after doc comment

**`clippy::manual_clamp`** (2)
- `src-tauri/src/method_search.rs:661` — clamp-like pattern without using clamp function
- `src-tauri/src/settings_commands.rs:44` — clamp-like pattern without using clamp function

**`clippy::while_let_loop`** (2)
- `crates/wisp-runtime/src/kernel.rs:276` — this loop could be written as a `while let` loop
- `crates/wisp-core/src/execution.rs:353` — this loop could be written as a `while let` loop

**`clippy::byte_char_slices`** (1)
- `crates/wisp-acp/src/lib.rs:862` — can be more succinctly written as a byte str

**`clippy::cmp_owned`** (1)
- `src-tauri/src/acp.rs:507` — this creates an owned instance just for comparison

**`clippy::collapsible_if`** (1)
- `src-tauri/src/lib.rs:6157` — this `if` statement can be collapsed

**`clippy::doc_lazy_continuation`** (1)
- `src-tauri/src/ssh_master.rs:40` — doc list item without indentation

**`clippy::explicit_counter_loop`** (1)
- `src-tauri/src/session_commands.rs:1063` — the variable `inserted` is used as a loop counter

**`clippy::identity_op`** (1)
- `src-tauri/src/channels/pbbp2.rs:139` — this operation has no effect

**`clippy::large_enum_variant`** (1)
- `crates/wisp-store/src/agent_workflow_attempts.rs:7` — large size difference between variants

**`clippy::manual_is_multiple_of`** (1)
- `crates/wisp-core/src/method_search.rs:540` — manual implementation of `.is_multiple_of()`

**`clippy::needless_borrows_for_generic_args`** (1)
- `src-tauri/src/lib.rs:7013` — the borrowed expression implements the required traits

**`clippy::needless_range_loop`** (1)
- `crates/wisp-core/src/agent.rs:646` — the loop variable `attempt` is used to index `RETRY_DELAYS`

**`clippy::print_literal`** (1)
- `crates/wisp-cli/src/main.rs:184` — literal with an empty format string

**`clippy::result_large_err`** (1)
- `src-tauri/src/browser_bridge.rs:185` — the `Err`-variant returned from this closure is very large


</details>

### Notes / follow-ups

I scoped this PR to a small, clearly-correct set: borrow removals, eta-redundant closures, one redundant `.into_iter()`, and one derive. I intentionally avoided the design-level lints the codebase currently allows, and the per-site ones that need careful review. Happy to send follow-up PRs for the remaining mechanical warnings (`unnecessary_sort_by`, `obfuscated_if_else`, `manual_is_multiple_of`, …) if this kind of cleanup is welcome.
