### PR TITLE
fix: show workspace path as artifact location

### DIFF
--- a/crates/wisp-store/src/artifacts.rs
+++ b/crates/wisp-store/src/artifacts.rs
@@ -704,4 +704,15 @@ impl Store {
         })
         .transpose()
     }
+
+    /// The logical workspace identity an artifact was registered under, when
+    /// one exists. This is the user-facing location; `storage_path` is an
+    /// internal snapshot path under `.wisp/` and must not be shown as the
+    /// document's real location.
+    pub async fn artifact_location(&self, id: &str) -> Result<Option<String>> {
+        Ok(sqlx::query_scalar("SELECT logical_key FROM artifacts WHERE id=?")
+            .bind(id)
+            .fetch_optional(&self.pool)
+            .await?)
+    }
 }

--- a/src-tauri/src/artifact_commands.rs
+++ b/src-tauri/src/artifact_commands.rs
@@ -75,6 +75,21 @@ fn existing_artifact_path(
     Ok(real)
 }
 
+/// Convert an artifact's stored logical key into the path users should see in
+/// the file browser. `path:` and `source:` keys are workspace paths; anything
+/// else (internal run keys, remote URIs, legacy rows) keeps the storage path
+/// as a fallback rather than inventing a user-facing location.
+fn user_artifact_location(logical_key: Option<&str>, storage_path: &str) -> String {
+    logical_key
+        .and_then(|key| {
+            key.strip_prefix("path:")
+                .or_else(|| key.strip_prefix("source:"))
+        })
+        .filter(|path| !path.is_empty())
+        .unwrap_or(storage_path)
+        .to_string()
+}
+
 async fn register_artifact_at(
     state: &AppState,
     label: &str,
@@ -149,6 +164,7 @@ async fn register_artifact_at(
         name: filename,
         kind: mime,
         path: captured.storage_path,
+        location: Some(source_path),
         ts,
         project_id: Some(ap.id.clone()),
         project_name: None,
@@ -241,6 +257,24 @@ mod tests {
 
         let _ = std::fs::remove_dir_all(root);
     }
+
+    #[test]
+    fn user_artifact_location_uses_workspace_keys_and_falls_back_to_storage() {
+        let storage = ".wisp/artifacts/sha256/aa/report.md";
+        assert_eq!(
+            user_artifact_location(Some("path:results/report.md"), storage),
+            "results/report.md"
+        );
+        assert_eq!(
+            user_artifact_location(Some("source:notes/claim.md"), storage),
+            "notes/claim.md"
+        );
+        assert_eq!(
+            user_artifact_location(Some("method-search-run:run:spec"), storage),
+            storage
+        );
+        assert_eq!(user_artifact_location(None, storage), storage);
+    }
 }
 #[tauri::command]
 pub(super) async fn list_artifacts(
@@ -260,13 +294,19 @@ pub(super) async fn list_artifacts(
         .list_artifacts(&fid)
         .await
         .map_err(|e| format!("{e}"))?;
-    Ok(rows
-        .into_iter()
-        .map(|(id, name, ct, path, ts)| ArtifactInfo {
+    let mut out = Vec::with_capacity(rows.len());
+    for (id, name, ct, path, ts) in rows {
+        let logical_key = state
+            .store
+            .artifact_location(&id)
+            .await
+            .map_err(|e| format!("{e}"))?;
+        out.push(ArtifactInfo {
             id,
             name: name.clone(),
             kind: ct,
-            path,
+            path: path.clone(),
+            location: Some(user_artifact_location(logical_key.as_deref(), &path)),
             ts,
             project_id: None,
             project_name: None,
@@ -274,8 +314,9 @@ pub(super) async fn list_artifacts(
             session_title: None,
             size_bytes: None,
             origin: None,
-        })
-        .collect())
+        });
+    }
+    Ok(out)
 }
 
 #[tauri::command]
@@ -328,13 +369,20 @@ pub(super) async fn search_artifacts(
                 .map_err(|e| format!("{e}"))?
         }
     };
-    Ok(rows
-        .into_iter()
-        .map(|a| ArtifactInfo {
+    let mut out = Vec::with_capacity(rows.len());
+    for a in rows {
+        let path = a.path.clone();
+        let logical_key = state
+            .store
+            .artifact_location(&a.id)
+            .await
+            .map_err(|e| format!("{e}"))?;
+        out.push(ArtifactInfo {
             id: a.id,
             name: a.name,
             kind: a.kind,
-            path: a.path,
+            path: path.clone(),
+            location: Some(user_artifact_location(logical_key.as_deref(), &path)),
             ts: a.ts,
             project_id: Some(a.project_id),
             project_name: Some(a.project_name),
@@ -342,8 +390,9 @@ pub(super) async fn search_artifacts(
             session_title: Some(a.session_title),
             size_bytes: a.size_bytes,
             origin: Some(a.origin),
-        })
-        .collect())
+        });
+    }
+    Ok(out)
 }
 
 /// Given candidate artifact file paths (as they appear in chat), return the

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -480,6 +480,8 @@ struct ArtifactInfo {
     name: String,
     kind: String,
     path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    location: Option<String>,
     ts: i64,
     #[serde(skip_serializing_if = "Option::is_none")]
     project_id: Option<String>,

--- a/ui/src/app_support/artifacts.rs
+++ b/ui/src/app_support/artifacts.rs
@@ -175,6 +175,7 @@ pub(crate) fn assemble_artifacts(
                         name: tf(locale, "artifact.table", &[("n", &scan.tbl_n.to_string())]),
                         kind: "table",
                         data: PreviewData::Table(t.clone()),
+                        location: None,
                         source_item,
                         superseded: false,
                     });
@@ -187,6 +188,7 @@ pub(crate) fn assemble_artifacts(
                         name: format!("data-{}.csv", scan.csv_n),
                         kind: "csv",
                         data: PreviewData::Table(t.clone()),
+                        location: None,
                         source_item,
                         superseded: false,
                     });
@@ -198,6 +200,7 @@ pub(crate) fn assemble_artifacts(
                         name: format!("alignment-{}.fasta", scan.csv_n),
                         kind: "fasta",
                         data: PreviewData::Fasta(body.clone()),
+                        location: None,
                         source_item,
                         superseded: false,
                     });
@@ -217,6 +220,7 @@ pub(crate) fn assemble_artifacts(
                             tex: tex.clone(),
                             display: true,
                         },
+                        location: None,
                         source_item,
                         superseded: false,
                     });
@@ -243,6 +247,7 @@ pub(crate) fn assemble_artifacts(
                             path: path.clone(),
                             kind: kind.to_string(),
                         },
+                        location: None,
                         source_item,
                         superseded: false,
                     });
@@ -672,10 +677,14 @@ pub(crate) fn current_artifacts(
     }
     current.reverse();
     for info in registered {
-        if !seen_files.insert(artifact_file_identity(&info.path, project_root)) {
+        let location = info
+            .location
+            .clone()
+            .unwrap_or_else(|| info.path.clone());
+        if !seen_files.insert(artifact_file_identity(&location, project_root)) {
             continue;
         }
-        let kind = file_kind(&info.path)
+        let kind = file_kind(&location)
             .or_else(|| file_kind(&info.name))
             .unwrap_or("file");
         current.push(Artifact {
@@ -686,6 +695,7 @@ pub(crate) fn current_artifacts(
                 path: info.path.clone(),
                 kind: kind.to_string(),
             },
+            location: Some(location),
             // No transcript message produced these, so they never render as an
             // inline card under one (`artifacts_for_item` matches on this).
             source_item: usize::MAX,
@@ -952,6 +962,7 @@ mod artifact_scan_tests {
             name: name.into(),
             kind: "table".into(),
             path: path.into(),
+            location: None,
             ts: 0,
             project_id: None,
             project_name: None,

--- a/ui/src/app_support/composer.rs
+++ b/ui/src/app_support/composer.rs
@@ -308,7 +308,7 @@ fn merge_finished_uploads(items: &mut Vec<ComposerAttachment>, results: Vec<Uplo
             .unwrap_or_else(|| "file".into());
         if result.ok {
             if let Some(info) = result.info {
-                let path = info.path;
+                let path = info.location.unwrap_or(info.path);
                 if !ready_paths.insert(path.clone()) {
                     continue;
                 }
@@ -728,6 +728,7 @@ mod upload_attachment_tests {
                 name: name.clone(),
                 kind: "file".into(),
                 path: path.into(),
+                location: None,
                 ts: 0,
                 project_id: None,
                 project_name: None,

--- a/ui/src/app_support/markdown.rs
+++ b/ui/src/app_support/markdown.rs
@@ -189,6 +189,12 @@ pub(crate) fn artifact_file_paths(a: &Artifact) -> Vec<String> {
     match &a.data {
         PreviewData::File { path, .. } => {
             let mut out = vec![normalize_path(path)];
+            if let Some(location) = a.location.as_deref() {
+                let location = normalize_path(location);
+                if !out.contains(&location) {
+                    out.push(location);
+                }
+            }
             if let Some(name) = path.rsplit(['/', '\\']).next() {
                 let name = normalize_path(name);
                 if !out.contains(&name) {
@@ -633,6 +639,7 @@ mod art_ref_marker_tests {
                     path: "a/denovo_design_worklist.csv".into(),
                     kind: "csv".into(),
                 },
+                location: None,
                 source_item: 0,
                 superseded: false,
             },
@@ -644,6 +651,7 @@ mod art_ref_marker_tests {
                     path: "b/denovo_design_worklist.csv".into(),
                     kind: "csv".into(),
                 },
+                location: None,
                 source_item: 0,
                 superseded: false,
             },

--- a/ui/src/app_support/previews.rs
+++ b/ui/src/app_support/previews.rs
@@ -71,6 +71,7 @@ pub(crate) fn artifact_meta(a: &Artifact, locale: Locale) -> String {
             ],
         ),
         PreviewData::File { path, kind } => {
+            let path = a.location.as_deref().unwrap_or(path);
             if kind == "fasta" {
                 t(locale, "artifact.kind.fasta").into()
             } else if kind == "msa" {

--- a/ui/src/app_support/projects.rs
+++ b/ui/src/app_support/projects.rs
@@ -178,7 +178,7 @@ pub(crate) fn ProjectsScreen(
         {
             if pos == idx {
                 search_open.set(false);
-                let path = stored_artifact_path(&a.path);
+                let path = stored_artifact_path(a.location.as_deref().unwrap_or(&a.path));
                 let kind = file_kind(&a.name)
                     .or_else(|| file_kind(&path))
                     .unwrap_or_else(|| {
@@ -585,7 +585,7 @@ pub(crate) fn ProjectsScreen(
                                                 <span class="project-search-main">
                                                     <span class="project-search-title">{a.name.clone()}</span>
                                                     <span class="project-search-sub">
-                                                        {a.path.clone()}{(!when.is_empty()).then(|| format!(" · {when}")).unwrap_or_default()}
+                                                        {a.location.as_deref().unwrap_or(&a.path).to_string()}{(!when.is_empty()).then(|| format!(" · {when}")).unwrap_or_default()}
                                                     </span>
                                                 </span>
                                                 <span class="project-search-badge">{badge}</span>

--- a/ui/src/context_menu.rs
+++ b/ui/src/context_menu.rs
@@ -537,6 +537,10 @@ pub fn build(
     if let Some(tile) = closest(&target, ".rp-tile") {
         let name = tile.get_attribute("data-artifact-name").unwrap_or_default();
         let path = tile.get_attribute("data-artifact-path").unwrap_or_default();
+        let location = tile
+            .get_attribute("data-artifact-location")
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| path.clone());
         if !name.is_empty() {
             let mut items = vec![item("copyName", i18n::t(locale, "ctx.copy_name"), name)];
             if !path.is_empty() {
@@ -553,7 +557,7 @@ pub fn build(
                     item(
                         "attachWorkspaceFile",
                         i18n::t(locale, "ctx.attach_file"),
-                        path.clone(),
+                        location.clone(),
                     ),
                 );
                 items.push(item(
@@ -564,7 +568,7 @@ pub fn build(
                 items.push(item(
                     "revealInFileManager",
                     i18n::t(locale, "ctx.reveal_in_manager"),
-                    path,
+                    location,
                 ));
             }
             return Some(CtxMenu { x, y, items });

--- a/ui/src/dto.rs
+++ b/ui/src/dto.rs
@@ -1257,6 +1257,8 @@ pub(crate) struct ArtifactInfo {
     pub(crate) name: String,
     pub(crate) kind: String,
     pub(crate) path: String,
+    #[serde(default)]
+    pub(crate) location: Option<String>,
     pub(crate) ts: i64,
     #[serde(default)]
     pub(crate) project_id: Option<String>,
@@ -2351,6 +2353,8 @@ pub(crate) struct Artifact {
     pub(crate) name: String,
     pub(crate) kind: &'static str,
     pub(crate) data: PreviewData,
+    /// Workspace-visible location when `data` points at an internal snapshot.
+    pub(crate) location: Option<String>,
     /// Transcript item that most recently produced or mentioned this artifact.
     pub(crate) source_item: usize,
     pub(crate) superseded: bool,

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -11929,6 +11929,10 @@ fn App() -> impl IntoView {
                                         };
                                         let file_click = file.clone();
                                         let context_path = file.as_ref().map(|(path, _)| path.clone()).unwrap_or_default();
+                                        let context_location = a
+                                            .location
+                                            .clone()
+                                            .unwrap_or_else(|| context_path.clone());
                                         let name_click = name.clone();
                                         let publication_source = db_artifacts.get().iter()
                                             .find(|artifact| artifact.id == a.id)
@@ -11939,6 +11943,8 @@ fn App() -> impl IntoView {
                                             });
                                         let tools = file.map(|(path, fkind)| {
                                         let (dl, vn) = (path.clone(), name.clone());
+                                        let workspace_location =
+                                            a.location.clone().unwrap_or_else(|| path.clone());
                                         let publication_source = publication_source.clone();
                                         view! {
                                             <div class="rp-tile-tools">
@@ -11957,9 +11963,10 @@ fn App() -> impl IntoView {
                                                 let (mi, cx, cy) = artifact_menu.get()?;
                                                 (mi == i).then(|| {
                                                 let (p, n, k) = (path.clone(), vn.clone(), fkind.clone());
-                                                let (mv, sp, dw) = (p.clone(), p.clone(), p.clone());
-                                                let rv = p.clone();
-                                                let at = p.clone();
+                                                let (mv, dw) = (p.clone(), p.clone());
+                                                let sp = workspace_location.clone();
+                                                let at = workspace_location.clone();
+                                                let rv = workspace_location.clone();
                                                 let oc = CenterFileTab::new(p.clone(), n.clone(), k.clone());
                                                 let (mvn, mvk) = (n.clone(), k.clone());
                                                 view! {
@@ -12029,7 +12036,8 @@ fn App() -> impl IntoView {
                                     view! {
                                         <div class="rp-tile" class:active=move || sel_artifact.get() == i
                                             data-artifact-name=name.clone()
-                                            data-artifact-path=context_path>
+                                            data-artifact-path=context_path
+                                            data-artifact-location=context_location>
                                             <button type="button" class="rp-tile-main"
                                                 on:click=move |_| {
                                                     artifact_menu.set(None);

--- a/ui/src/text.rs
+++ b/ui/src/text.rs
@@ -683,8 +683,9 @@ pub(crate) fn artifact_group_key(a: &crate::dto::Artifact, project_root: &str) -
     use crate::dto::PreviewData;
     match &a.data {
         PreviewData::File { path, .. } => {
-            let relative = artifact_workspace_path(path, project_root);
-            let outside_workspace_absolute = relative == path.trim().replace('\\', "/")
+            let display_path = a.location.as_deref().unwrap_or(path);
+            let relative = artifact_workspace_path(display_path, project_root);
+            let outside_workspace_absolute = relative == display_path.trim().replace('\\', "/")
                 && (relative.starts_with('/')
                     || relative.as_bytes().get(1) == Some(&b':')
                     || relative.contains("://"));
@@ -739,6 +740,7 @@ mod artifact_group_tests {
                 path: path.into(),
                 kind: "image".into(),
             },
+            location: None,
             source_item: 0,
             superseded: false,
         }
@@ -765,6 +767,26 @@ mod artifact_group_tests {
         assert_eq!(artifact_group_key(&outside, r"D:\project"), "results/");
         let remote = file("ssh://gpu/work/results/plot.png");
         assert_eq!(artifact_group_key(&remote, r"D:\project"), "results/");
+    }
+
+    #[test]
+    fn registered_artifact_groups_by_workspace_location_not_snapshot_path() {
+        let snapshot = Artifact {
+            id: "artifact-1".into(),
+            name: "report.md".into(),
+            kind: "markdown",
+            data: PreviewData::File {
+                path: ".wisp/artifacts/sha256/aa/report.md".into(),
+                kind: "markdown".into(),
+            },
+            location: Some("results/report.md".into()),
+            source_item: 0,
+            superseded: false,
+        };
+        assert_eq!(
+            artifact_group_key(&snapshot, r"D:\project"),
+            "results/"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #789.

## Root cause
Artifacts exposed the internal `.wisp/artifacts/...` snapshot storage path as their user-facing document location. Preview worked because it read through the snapshot path, but "Reveal in Files" / "Show in file manager" tried to locate that internal path and failed with `os error 2`.

## Changes
- Backend now returns a `location` field derived from the artifact logical key (`path:` / `source:`) alongside the storage path.
- UI keeps using the snapshot path for previews, but uses the workspace location for artifact grouping, meta, attach-to-chat, reveal in Files, and reveal in file manager.
- Right-click artifact actions use the same workspace location.
- Added regression coverage for grouping by workspace location instead of snapshot path.

## Verification
- `cargo check -p wisp-store` passed
- `cargo check -p wisp-tauri` passed
- `cargo check --manifest-path ui/Cargo.toml` passed
- `cargo test --manifest-path ui/Cargo.toml` passed (224 tests)