### PR TITLE
fix(acp): preserve delegated agent message chunks

### DIFF
--- a/src-tauri/src/delegation_runtime.rs
+++ b/src-tauri/src/delegation_runtime.rs
@@ -4463,7 +4463,6 @@ fn acp_text(payload: &Value) -> Option<&str> {
     payload
         .get("content")
         .and_then(|content| content.get("text"))
-        .and_then(|content| content.get("text"))
         .and_then(Value::as_str)
         .or_else(|| payload.get("text").and_then(Value::as_str))
 }
@@ -4493,6 +4492,23 @@ mod tests {
     fn bounded_values_snap_to_utf8_boundaries() {
         assert_eq!(bounded_text("a中b", 2), "a…");
         assert_eq!(bounded_json(&json!({"text": "中"}), 11), "{\"text\":\"…");
+    }
+
+    #[test]
+    fn acp_text_reads_standard_agent_message_chunk_payload() {
+        let payload = json!({
+            "sessionUpdate": "agent_message_chunk",
+            "content": {
+                "type": "text",
+                "text": "reviewed result"
+            }
+        });
+
+        assert_eq!(acp_text(&payload), Some("reviewed result"));
+        assert_eq!(
+            acp_text(&json!({"text": "legacy result"})),
+            Some("legacy result")
+        );
     }
 
     async fn dynamic_fixture() -> (Store, std::path::PathBuf) {


### PR DESCRIPTION
## Problem

ACP v1 `agent_message_chunk` text is shaped as:

```json
{"content":{"type":"text","text":"reviewed result"}}
```

`delegation_runtime::acp_text` read `content.text.text`, so delegated ACP message chunks were discarded and a provider could appear to return an empty final message. The regular ACP path in `src-tauri/src/acp.rs` already reads the standard single-level shape.

## Change

- Remove only the extra nested `.get("text")`.
- Add one regression test for the standard ACP payload.
- Keep the existing top-level `{"text":"legacy result"}` fallback covered.

No timeout, scheduler, session, provider, permission, output-schema, UI, manifest, lockfile, or dependency changes are included.

## Validation

- RED before the parser change: exact regression test failed with `left: None` and `right: Some("reviewed result")`.
- GREEN after the parser change: exact regression test passed (`1 passed`).
- `delegation_runtime::tests`: `39 passed, 0 failed`.
- `cargo test --workspace`: `1034 passed, 0 failed, 1 ignored`, plus the ACP process tests.
- Target file `rustfmt --check` and `git diff --check`: passed.
- UI WASM and Playwright: not run / not applicable because this changes neither UI behavior nor a Tauri command contract.
- Full `cargo fmt --all -- --check` is currently blocked by pre-existing formatting drift on `main` in `crates/wisp-store/src/artifacts.rs`; this PR does not touch that file.

## Local supplemental evidence

A real, read-only Claude Research PI → Kimi Reviewer workflow that previously lost the delegated body completed after this parser fix, and the reviewer dependency payload matched the Claude result. This is supplemental local evidence only, not a CI requirement. The reviewer made one logical read-only skill read, so this run is not claimed as a zero-tool execution; it made no project writes and did not change canonical scientific state.

## Limitations

This patch covers delegated ACP text chunks and the retained legacy fallback only. It does not change other ACP session/runtime behavior or add a live-provider test requirement.