### PR TITLE
docs: add a no-auth remote MCP connection example

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,13 @@ into every model request.
 or **Save** — either opens Notion's authorization page in your browser. OAuth
 tokens stay in the OS keyring; deleting the connection removes its credential.
 
+### Remote MCP (Parallel Search example)
+
+For live web search and URL fetching, add another **Remote URL** connection,
+enter `https://search.parallel.ai/mcp`, set **Authentication** to **None**, and
+**Test** or **Save**. Parallel Search MCP is free and requires no account or
+API key.
+
 ## Bundled demos
 
 `seed/` ships five pre-baked ESR1 / GSE153250 examples in research order: find

--- a/README_zh.md
+++ b/README_zh.md
@@ -224,6 +224,12 @@ Agent 先用 `search_mcp_tools` 发现匹配的工具，再通过 `use_mcp_tool`
 **保存**——两者都会在浏览器中打开 Notion 授权页。OAuth 令牌保存在系统密钥
 环中，不会写入项目数据库；删除连接即清除对应凭据。
 
+### 远程 MCP（Parallel Search 示例）
+
+如需实时网页搜索和 URL 内容提取，请再添加一个**远程 URL**连接，填写
+`https://search.parallel.ai/mcp`，将**认证方式**设为**无**，然后点击**测试**或
+**保存**。Parallel Search MCP 免费且无需账号或 API Key。
+
 ## 内置演示
 
 `seed/` 提供五个按研究叙事排序的 ESR1 / GSE153250 示例：查找数据 → 查看样本/


### PR DESCRIPTION
Wisp already supports remote MCP connections, but the README currently demonstrates only an OAuth service. This documents the existing no-auth path for users who want live web search and URL fetching.

## What changed

- Added a Parallel Search MCP connection example to the English README.
- Added the matching setup instructions to the Chinese README.
- Kept the existing Notion example and all runtime behavior unchanged.

## Validation

- `git diff --check`
- Verified both READMEs retain the Notion endpoint and use the current `None` / `无` authentication labels for the new endpoint.
- Tests and manual runtime smoke were not run because this is a documentation-only change.

## Known limitations and follow-up

- This does not add a built-in connector or change runtime behavior.
- No follow-up is required for the documentation-only scope.

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.