### PR TITLE
fix(models): unify session reasoning-effort override with model profiles

### DIFF
--- a/crates/wisp-llm/src/anthropic.rs
+++ b/crates/wisp-llm/src/anthropic.rs
@@ -125,6 +125,12 @@ impl AnthropicProvider {
         if !system.is_empty() {
             body["system"] = json!(system);
         }
+        // Anthropic's effort knob lives under output_config (GA since the
+        // effort beta graduated); unsupported models 400, which the UI's
+        // curated effort list steers away from.
+        if let Some(effort) = &self.cfg.reasoning_effort {
+            body["output_config"] = json!({ "effort": effort });
+        }
         let tools_json: Vec<Value> = tools
             .iter()
             .map(|t| json!({ "name": t.function.name, "description": t.function.description, "input_schema": t.function.parameters }))
@@ -553,6 +559,20 @@ mod tests {
         ));
         let (_, out, _) = provider.build_body(messages, &[], false);
         out
+    }
+
+    #[test]
+    fn reasoning_effort_maps_to_output_config_effort() {
+        let mut cfg =
+            crate::ProviderConfig::anthropic("https://example.test", "", "claude-sonnet-5");
+        let provider = AnthropicProvider::new(cfg.clone());
+        let (_, _, body) = provider.build_body(&[Message::user("hi")], &[], false);
+        assert!(body.get("output_config").is_none());
+
+        cfg.reasoning_effort = Some("max".into());
+        let provider = AnthropicProvider::new(cfg);
+        let (_, _, body) = provider.build_body(&[Message::user("hi")], &[], false);
+        assert_eq!(body["output_config"]["effort"], "max");
     }
 
     #[test]

--- a/crates/wisp-llm/src/provider.rs
+++ b/crates/wisp-llm/src/provider.rs
@@ -147,7 +147,8 @@ pub struct ProviderConfig {
     pub anthropic_version: String,
     /// Cap on output tokens per turn.
     pub max_tokens: u64,
-    /// OpenAI reasoning effort (`reasoning.effort` / `reasoning_effort`). None = provider default.
+    /// Reasoning effort: `reasoning.effort` / `reasoning_effort` for OpenAI,
+    /// `output_config.effort` for Anthropic. None = provider default.
     pub reasoning_effort: Option<String>,
     /// HTTP proxy override. `None`/empty = follow system/env proxy settings;
     /// `"none"` = force a direct connection; otherwise a proxy URL

--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -37,6 +37,9 @@ conversations. The reasoning-effort selector in the same menu is also scoped to
 the current conversation: changing it overrides that conversation's model
 profile without editing the profile or affecting other conversations. A new
 conversation inherits the reasoning effort configured on its model profile.
+The selector lists the effort levels the bound model family is documented to
+support (same curated list as the model form in Settings), and choosing
+"default" clears the conversation override so it follows the profile again.
 
 Model profiles describe model access and capabilities for the **built-in Wisp
 agent**. External coding agents (Codex / Claude via ACP) are configured under

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1799,7 +1799,7 @@ struct Settings {
     /// Max output tokens per LLM turn. 0 = provider default.
     #[serde(default)]
     max_tokens: u64,
-    /// OpenAI reasoning effort (none/minimal/low/medium/high/xhigh). Empty = provider default.
+    /// Reasoning effort (none/minimal/low/medium/high/xhigh/max/ultra, model-dependent). Empty = provider default.
     #[serde(default)]
     reasoning_effort: String,
     /// LLM HTTP proxy. Empty = follow system/env proxy; `none` = force direct;

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -545,13 +545,17 @@ pub async fn session_label(store: &wisp_store::Store, frame_id: &str) -> String 
 
 /// Effective reasoning effort for a conversation: an explicit frame override
 /// wins, otherwise the bound model profile supplies its configured default.
+/// An empty stored override (written by older builds for "provider default")
+/// counts as no override, so the profile default applies again.
 pub async fn session_reasoning_effort(
     store: &wisp_store::Store,
     frame_id: &str,
     profile_default: &str,
 ) -> String {
     if let Ok(Some(effort)) = store.frame_reasoning_effort(frame_id).await {
-        return effort;
+        if !effort.is_empty() {
+            return effort;
+        }
     }
     profile_default.to_string()
 }
@@ -1153,9 +1157,16 @@ pub async fn set_session_reasoning_effort(
         Some(&session_id),
     )
     .await?;
+    // Empty effort clears the override: the session inherits the bound model
+    // profile again instead of pinning "provider default" forever.
+    let override_value = if effort.is_empty() {
+        None
+    } else {
+        Some(effort)
+    };
     state
         .store
-        .set_frame_reasoning_effort(&session_id, &project.id, Some(effort))
+        .set_frame_reasoning_effort(&session_id, &project.id, override_value)
         .await
         .map_err(|error| error.to_string())?;
     crate::clear_session_agent(&state, &session_id).await;
@@ -1289,6 +1300,40 @@ mod tests {
         assert_eq!(session_reasoning_effort(&store, "a", "max").await, "high");
         assert_eq!(session_reasoning_effort(&store, "b", "max").await, "max");
         assert_eq!(profile_llm(&store, "m1").await.unwrap().5, "max");
+        drop(store);
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    #[tokio::test]
+    async fn cleared_or_empty_session_override_inherits_profile() {
+        let tmp = std::env::temp_dir().join(format!(
+            "wisp_session_reasoning_clear_{}.sqlite",
+            uuid::Uuid::new_v4()
+        ));
+        let store = wisp_store::Store::open(&tmp).await.unwrap();
+        store.create_project("p", "project", "").await.unwrap();
+        store.create_frame("a", "p", "OPERON", "m1").await.unwrap();
+        store.create_frame("b", "p", "OPERON", "m1").await.unwrap();
+
+        store
+            .set_frame_reasoning_effort("a", "p", Some("high"))
+            .await
+            .unwrap();
+        assert_eq!(session_reasoning_effort(&store, "a", "max").await, "high");
+        // Clearing the override (selecting "default" in the composer) makes
+        // the session follow the profile default again.
+        store
+            .set_frame_reasoning_effort("a", "p", None)
+            .await
+            .unwrap();
+        assert_eq!(session_reasoning_effort(&store, "a", "max").await, "max");
+        // Legacy rows hold Some("") for "provider default"; they must not pin
+        // the session away from the profile either.
+        store
+            .set_frame_reasoning_effort("b", "p", Some(""))
+            .await
+            .unwrap();
+        assert_eq!(session_reasoning_effort(&store, "b", "max").await, "max");
         drop(store);
         let _ = std::fs::remove_file(&tmp);
     }

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -3052,7 +3052,14 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
           }
           case "set_session_reasoning_effort": {
             const sessionId = String(arg("sessionId") ?? "");
-            sessionReasoningEfforts[sessionId] = String(arg("effort") ?? "");
+            const effort = String(arg("effort") ?? "");
+            // Empty effort clears the override; the session inherits the
+            // bound profile again (mirrors src-tauri models.rs).
+            if (effort === "") {
+              delete sessionReasoningEfforts[sessionId];
+            } else {
+              sessionReasoningEfforts[sessionId] = effort;
+            }
             return null;
           }
           case "get_project_info":

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -922,6 +922,15 @@ test("reasoning effort stays scoped to the current conversation", async ({ page 
   await page.locator('[data-session-id="s-model-a"]').click();
   await page.locator(".model-picker-btn").click();
   await expect(page.locator(".model-menu-effort-select")).toHaveValue("high");
+
+  // "default" clears the override: the session follows the bound profile
+  // (opus-4.8 defaults to max) instead of pinning "provider default".
+  await effort.selectOption("default");
+  await expect.poll(() => lastInvokeArgs(page, "set_session_reasoning_effort")).toMatchObject({
+    sessionId: "s-model-a",
+    effort: "",
+  });
+  await expect(page.locator(".model-menu-effort-select")).toHaveValue("max");
 });
 
 test("Settings Models page can open ACP Agents dialog", async ({ page }) => {

--- a/ui/src/dto.rs
+++ b/ui/src/dto.rs
@@ -1080,17 +1080,14 @@ pub(crate) fn session_model_label(
     )
 }
 
-/// Effective effort for the active conversation. A value loaded from the
-/// frame wins; before that IPC read completes, fall back to the bound profile.
-pub(crate) fn session_reasoning_effort(
-    models: &[ModelProfile],
+/// The profile a session resolves to right now: bound profile → active →
+/// first chat model. Shared by the effort/window getters and the composer
+/// effort dropdown.
+pub(crate) fn session_profile<'a>(
+    models: &'a [ModelProfile],
     session_models: &HashMap<String, String>,
-    session_efforts: &HashMap<String, String>,
     session_id: Option<&str>,
-) -> String {
-    if let Some(effort) = session_id.and_then(|id| session_efforts.get(id)) {
-        return effort.clone();
-    }
+) -> Option<&'a ModelProfile> {
     let bound = session_id.and_then(|id| session_models.get(id));
     models
         .iter()
@@ -1101,6 +1098,23 @@ pub(crate) fn session_reasoning_effort(
                 .find(|model| model.active && model.is_chat_model())
         })
         .or_else(|| models.iter().find(|model| model.is_chat_model()))
+}
+
+/// Effective effort for the active conversation. A value loaded from the
+/// frame wins; before that IPC read completes, fall back to the bound profile.
+/// An empty stored value means "no override" (inherit the profile again).
+pub(crate) fn session_reasoning_effort(
+    models: &[ModelProfile],
+    session_models: &HashMap<String, String>,
+    session_efforts: &HashMap<String, String>,
+    session_id: Option<&str>,
+) -> String {
+    if let Some(effort) = session_id.and_then(|id| session_efforts.get(id)) {
+        if !effort.is_empty() {
+            return effort.clone();
+        }
+    }
+    session_profile(models, session_models, session_id)
         .map(|model| model.reasoning_effort.clone())
         .unwrap_or_default()
 }
@@ -1130,15 +1144,7 @@ pub(crate) fn session_context_window(
     if bound.is_some_and(|id| id.starts_with("acp:")) {
         return None;
     }
-    models
-        .iter()
-        .find(|model| model.is_chat_model() && bound == Some(&model.id))
-        .or_else(|| {
-            models
-                .iter()
-                .find(|model| model.active && model.is_chat_model())
-        })
-        .or_else(|| models.iter().find(|model| model.is_chat_model()))
+    session_profile(models, session_models, session_id)
         .map(|model| effective_context_window(model.context_window))
 }
 
@@ -1206,6 +1212,21 @@ mod session_context_window_tests {
         );
         assert_eq!(models[0].reasoning_effort, "max");
         assert_eq!(models[1].reasoning_effort, "max");
+    }
+
+    #[test]
+    fn empty_effort_override_inherits_profile_again() {
+        let mut bound = profile("b", true, 128_000);
+        bound.reasoning_effort = "max".into();
+        let models = vec![bound];
+        let bindings = HashMap::from([("s1".to_string(), "b".to_string())]);
+        // Legacy rows and a just-cleared override both surface as "".
+        let efforts = HashMap::from([("s1".to_string(), String::new())]);
+
+        assert_eq!(
+            session_reasoning_effort(&models, &bindings, &efforts, Some("s1")),
+            "max"
+        );
     }
 
     #[test]

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -64,6 +64,7 @@ use session_modals::{
     SessionTransferOverlayState, TurnUndoOverlay, TurnUndoOverlayState,
 };
 use settings_view::{DeleteConfirm, SettingsView, SettingsViewState};
+use settings_view::{known_effort_values, ALL_EFFORT_VALUES};
 use sidebar::{Sidebar, SidebarState};
 use std::cell::{Cell, RefCell};
 use std::collections::{HashMap, HashSet};
@@ -11598,8 +11599,8 @@ fn App() -> impl IntoView {
                                                     <select class="model-menu-effort-select"
                                                         on:change=move |ev| {
                                                             let v = dom_value(&ev);
-                                                            let effort = if v == "default" { String::new() } else { v };
                                                             let Some(session_id) = active_session.get_untracked() else { return; };
+                                                            let effort = if v == "default" { String::new() } else { v };
                                                             spawn_local(async move {
                                                                 let arg = to_value(&serde_json::json!({
                                                                     "sessionId": session_id.clone(),
@@ -11607,31 +11608,67 @@ fn App() -> impl IntoView {
                                                                 })).unwrap();
                                                                 if invoke_checked("set_session_reasoning_effort", arg).await.is_ok() {
                                                                     session_reasoning_efforts.update(|efforts| {
-                                                                        efforts.insert(session_id, effort);
+                                                                        if effort.is_empty() {
+                                                                            // Cleared override: inherit the
+                                                                            // bound profile again.
+                                                                            efforts.remove(&session_id);
+                                                                        } else {
+                                                                            efforts.insert(session_id, effort);
+                                                                        }
                                                                     });
                                                                 }
                                                             });
                                                         }>
-                                                        <option value="default"
-                                                            prop:selected=move || session_reasoning_effort(
-                                                                &models.get(),
-                                                                &session_model_ids.get(),
-                                                                &session_reasoning_efforts.get(),
-                                                                active_session.get().as_deref(),
-                                                            ).is_empty()>
-                                                            {move || t(locale.get(), "settings.reasoning_effort.default")}
-                                                        </option>
-                                                        {["none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"].into_iter().map(|lvl| view! {
-                                                            <option value=lvl
-                                                                prop:selected=move || session_reasoning_effort(
-                                                                    &models.get(),
-                                                                    &session_model_ids.get(),
-                                                                    &session_reasoning_efforts.get(),
-                                                                    active_session.get().as_deref(),
-                                                                ) == lvl>
-                                                                {lvl}
-                                                            </option>
-                                                        }).collect_view()}
+                                                        {move || {
+                                                            let models = models.get();
+                                                            let session_models = session_model_ids.get();
+                                                            let efforts = session_reasoning_efforts.get();
+                                                            let session_id = active_session.get();
+                                                            let current = session_reasoning_effort(
+                                                                &models,
+                                                                &session_models,
+                                                                &efforts,
+                                                                session_id.as_deref(),
+                                                            );
+                                                            let mut values: Vec<String> = session_profile(
+                                                                &models,
+                                                                &session_models,
+                                                                session_id.as_deref(),
+                                                            )
+                                                            .map(|profile| {
+                                                                known_effort_values(&profile.provider, &profile.model)
+                                                                    .unwrap_or(ALL_EFFORT_VALUES)
+                                                            })
+                                                            .unwrap_or(ALL_EFFORT_VALUES)
+                                                            .iter()
+                                                            .map(|v| v.to_string())
+                                                            .collect();
+                                                            // Keep a stored override visible even when the
+                                                            // curated list for this model doesn't include it.
+                                                            if !current.is_empty() && !values.iter().any(|v| v == &current) {
+                                                                values.push(current.clone());
+                                                            }
+                                                            // The select shows the effective effort:
+                                                            // an inherited profile value is displayed
+                                                            // as-is; "default" is selected only when
+                                                            // nothing is configured anywhere.
+                                                            let default_selected = current.is_empty();
+                                                            view! {
+                                                                <option value="default"
+                                                                    prop:selected=default_selected>
+                                                                    {move || t(locale.get(), "settings.reasoning_effort.default")}
+                                                                </option>
+                                                                {values.into_iter().map(|lvl| {
+                                                                    let selected = !default_selected && lvl == current;
+                                                                    view! {
+                                                                        <option value=lvl.clone()
+                                                                            prop:selected=selected>
+                                                                            {lvl}
+                                                                        </option>
+                                                                    }
+                                                                }).collect_view()}
+                                                            }
+                                                        }}
                                                     </select>
                                                 </div>
                                             })}

--- a/ui/src/settings_view.rs
+++ b/ui/src/settings_view.rs
@@ -445,31 +445,77 @@ fn settings_provider_defaults(provider: &str) -> (&'static str, &'static str) {
 
 /// Every effort value any supported provider understands; shown when the
 /// model is not in the curated table below.
-const ALL_EFFORT_VALUES: &[&str] = &[
+pub(crate) const ALL_EFFORT_VALUES: &[&str] = &[
     "none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra",
 ];
 
-/// Curated reasoning-effort support per model family. `None` = unknown model
-/// (full list + "can't verify" hint); `Some(&[])` = the parameter is never
-/// sent for this provider, so only "default" makes sense.
+/// Curated reasoning-effort support per model family, per vendor docs as of
+/// 2026-08 (OpenAI reasoning guide, Anthropic effort docs, xAI reasoning
+/// docs, DeepSeek/Moonshot/Alibaba API references). `None` = unknown model
+/// (full list + "can't verify" hint); `Some(&[])` = the provider rejects the
+/// parameter for this model, so only "default" makes sense.
 /// ponytail: name-pattern table — no provider exposes a capability-discovery
-/// API for this; extend as new families matter.
-pub(crate) fn known_effort_values(provider: &str, model: &str) -> Option<&'static [&'static str]> {
-    if settings_provider_value(provider) == "anthropic" {
-        // anthropic.rs never forwards reasoning_effort.
-        return Some(&[]);
-    }
-    let m = model.to_ascii_lowercase();
-    if m.contains("codex-max") {
-        Some(&["low", "medium", "high", "xhigh"])
-    } else if m.contains("gpt-5.1") {
+/// API for this; extend as new families matter. Keep longer patterns above
+/// their shorter siblings ("claude-opus-4-5" before "claude-opus").
+pub(crate) fn known_effort_values(
+    _provider: &str,
+    model: &str,
+) -> Option<&'static [&'static str]> {
+    // Users write model names loosely ("opus-4.8", "claude-opus-4-8"), so
+    // match on a normalized form and don't require the vendor prefix.
+    let m = model.to_ascii_lowercase().replace(['.', '_'], "-");
+    if m.contains("gpt-5-pro") {
+        Some(&["high"])
+    } else if m.contains("codex-max") {
+        Some(&["none", "low", "medium", "high", "xhigh"])
+    } else if m.contains("gpt-5-1") {
         Some(&["none", "low", "medium", "high"])
+    } else if m.contains("gpt-5-6") {
+        Some(&["none", "low", "medium", "high", "xhigh", "max"])
+    } else if m.contains("gpt-5-2")
+        || m.contains("gpt-5-3")
+        || m.contains("gpt-5-4")
+        || m.contains("gpt-5-5")
+    {
+        Some(&["none", "low", "medium", "high", "xhigh"])
     } else if m.contains("gpt-5") {
         Some(&["minimal", "low", "medium", "high"])
+    } else if m.starts_with("o1-mini") || m.starts_with("o1-preview") {
+        Some(&[])
     } else if m.starts_with("o1") || m.starts_with("o3") || m.starts_with("o4") {
+        Some(&["low", "medium", "high"])
+    } else if m.contains("opus-4-5") {
+        Some(&["low", "medium", "high"])
+    } else if m.contains("sonnet-4-5") || m.contains("haiku") {
+        // These reject the effort parameter with a 400.
+        Some(&[])
+    } else if m.contains("opus-4-6")
+        || m.contains("sonnet-4-6")
+        || m.contains("mythos-preview")
+    {
+        Some(&["low", "medium", "high", "max"])
+    } else if m.contains("opus")
+        || m.contains("sonnet")
+        || m.contains("fable")
+        || m.contains("mythos")
+    {
+        Some(&["low", "medium", "high", "xhigh", "max"])
+    } else if m.contains("grok-4-6") || m.contains("grok-4-20") {
+        Some(&["low", "medium", "high", "xhigh"])
+    } else if m.contains("grok-4") {
         Some(&["low", "medium", "high"])
     } else if m.contains("grok") {
         Some(&["low", "high"])
+    } else if m.contains("deepseek-v4") {
+        // medium/xhigh are silently down-mapped to high; don't offer them.
+        Some(&["low", "high", "max"])
+    } else if m.contains("kimi-k3") {
+        Some(&["low", "high", "max"])
+    } else if m.contains("kimi-k2") {
+        // k2.x only toggles thinking on/off; no effort parameter.
+        Some(&[])
+    } else if m.contains("qwen3-8-max") {
+        Some(&["low", "medium", "xhigh"])
     } else {
         None
     }
@@ -483,21 +529,72 @@ mod effort_values_tests {
     fn maps_families_and_leaves_unknown_open() {
         assert_eq!(
             known_effort_values("anthropic", "claude-sonnet-5"),
+            Some(&["low", "medium", "high", "xhigh", "max"][..])
+        );
+        assert_eq!(
+            known_effort_values("anthropic", "claude-opus-4-5"),
+            Some(&["low", "medium", "high"][..])
+        );
+        assert_eq!(
+            known_effort_values("anthropic", "claude-sonnet-4-6"),
+            Some(&["low", "medium", "high", "max"][..])
+        );
+        assert_eq!(
+            known_effort_values("anthropic", "claude-haiku-4-5"),
+            Some(&[][..])
+        );
+        assert_eq!(
+            known_effort_values("anthropic", "claude-sonnet-4-5"),
             Some(&[][..])
         );
         assert_eq!(
             known_effort_values("openai", "gpt-5.1-codex-max"),
-            Some(&["low", "medium", "high", "xhigh"][..])
+            Some(&["none", "low", "medium", "high", "xhigh"][..])
         );
         assert_eq!(
             known_effort_values("openai_responses", "gpt-5.1"),
             Some(&["none", "low", "medium", "high"][..])
         );
         assert_eq!(
+            known_effort_values("openai_responses", "gpt-5.6"),
+            Some(&["none", "low", "medium", "high", "xhigh", "max"][..])
+        );
+        assert_eq!(
+            known_effort_values("openai", "gpt-5-pro"),
+            Some(&["high"][..])
+        );
+        assert_eq!(
             known_effort_values("openai", "o3-mini"),
             Some(&["low", "medium", "high"][..])
         );
-        assert_eq!(known_effort_values("openai", "deepseek-v4-pro"), None);
+        assert_eq!(known_effort_values("openai", "o1-mini"), Some(&[][..]));
+        // Loose user spelling (no vendor prefix, dots) matches the same family.
+        assert_eq!(
+            known_effort_values("anthropic", "opus-4.8"),
+            Some(&["low", "medium", "high", "xhigh", "max"][..])
+        );
+        assert_eq!(
+            known_effort_values("openai", "grok-4.6"),
+            Some(&["low", "medium", "high", "xhigh"][..])
+        );
+        assert_eq!(
+            known_effort_values("openai", "grok-4"),
+            Some(&["low", "medium", "high"][..])
+        );
+        assert_eq!(
+            known_effort_values("openai", "deepseek-v4-pro"),
+            Some(&["low", "high", "max"][..])
+        );
+        assert_eq!(
+            known_effort_values("openai", "kimi-k3"),
+            Some(&["low", "high", "max"][..])
+        );
+        assert_eq!(known_effort_values("openai", "kimi-k2.5"), Some(&[][..]));
+        assert_eq!(
+            known_effort_values("openai", "qwen3.8-max-preview"),
+            Some(&["low", "medium", "xhigh"][..])
+        );
+        assert_eq!(known_effort_values("openai", "some-future-model"), None);
     }
 }
 


### PR DESCRIPTION
## Problem

Issue analysis (#794) surfaced two real defects in the per-conversation reasoning-effort override introduced by #782:

1. **Level lists disagreed.** The composer dropdown always offered all 8 levels (`none`…`ultra`), while Settings → Models curates levels per model family. A session could be pinned to a level the bound model doesn't even accept.
2. **No way back to "inherit".** Choosing "default" in the composer stored `Some("")` ("provider default") instead of clearing the override (`None`). Once touched, the session ignored the model profile's effort forever.

Note: the current "override wins, profile untouched" semantics from #782 are **kept** — this PR does not reverse-sync session changes into the profile (the reporter's expectation), it only fixes the two defects above.

## Changes

- **Composer dropdown** (`ui/src/main.rs`): lists the same curated levels as the model form via `known_effort_values(provider, model)` for the session's bound profile (full 8-level list + "can't verify" semantics unchanged for unknown models); a stored value outside the curated list stays visible.
- **Inherit fix** (`src-tauri/src/models.rs`, `ui/src/dto.rs`): empty effort now clears the frame override (`NULL`), so the session inherits the bound profile again; legacy `""` rows count as "no override" on read. Shared `session_profile()` helper removes the duplicated bound→active→first fallback chain.
- **Broader model table** (`ui/src/settings_view.rs`): researched vendor docs (2026-08) — Claude opus/sonnet/haiku/fable/mythos (Anthropic `output_config.effort` is GA; opus-4-5 = low/medium/high, 4-6 families add `max`, 5-series add `xhigh`, sonnet-4-5/haiku reject the param), full gpt-5.x line (incl. gpt-5.6 `max`, gpt-5-pro high-only), o-series (o1-mini unsupported), grok-4.x, deepseek-v4 (low/high/max), kimi-k2 (toggle-only) / k3, qwen3.8-max. Matching normalizes loose spellings (`opus-4.8` ≡ `claude-opus-4-8`).
- **Anthropic forwarding** (`crates/wisp-llm`): a configured effort is now sent as `output_config.effort` instead of being silently dropped.

## Tests

- `cargo test --workspace`: all green (628 wisp-tauri, incl. new `cleared_or_empty_session_override_inherits_profile`; wisp-llm 43, incl. new `output_config.effort` body test; ui 225, incl. new `empty_effort_override_inherits_profile_again` and expanded family-table tests).
- Playwright: **344 passed, 1 skipped** — existing effort-scoping test extended to assert "default" clears the override (`effort: ""`) and the select falls back to the profile value; mock bridge updated to match backend semantics.
- `cargo fmt --all -- --check` clean; `cargo check --target wasm32-unknown-unknown` clean.

## Manual smoke

1. Bind a conversation to an Anthropic profile (e.g. claude-sonnet-5, default `max`) → composer dropdown shows only `low/medium/high/xhigh/max`.
2. Pick `high` → only this conversation changes; Settings still shows `max`.
3. Pick `default` → dropdown shows `max` again (inherits profile); editing the profile default applies to the session once more.

## Known limitations / follow-ups

- The family table is name-pattern based (no provider capability API exists); new families need manual entries.
- `ultra` remains unused by every known provider; kept only in the unknown-model fallback list.
- Reverse-sync (session → profile) intentionally not implemented pending a product-semantics decision on #794.