### PR TITLE
feat: add headless agent evaluation and RPC

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,34 @@ on:
     branches: [main]
 
 jobs:
+  headless-agent-eval:
+    name: Headless agent eval (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          shared-key: headless-agent-${{ matrix.os }}
+
+      - name: Run deterministic headless agent suite
+        run: cargo run -p wisp-cli -- eval --artifacts target/headless-agent-eval --save target/headless-agent-eval/report.json
+
+      - name: Upload headless eval artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: headless-agent-eval-${{ matrix.os }}
+          path: target/headless-agent-eval
+          if-no-files-found: error
+
   rust:
     runs-on: ubuntu-latest
     strategy:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7151,18 +7151,22 @@ name = "wisp-cli"
 version = "1.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "chrono",
  "dirs 5.0.1",
  "serde",
  "serde_json",
+ "serde_yaml",
  "sha2",
  "tokio",
  "tracing-subscriber",
+ "uuid",
  "wisp-core",
  "wisp-llm",
  "wisp-mcp",
  "wisp-runtime",
  "wisp-skills",
+ "wisp-tools",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -188,13 +188,19 @@ cargo run -p wisp-cli -- run "Summarize the files in this project"
 cargo run -p wisp-cli -- run --output jsonl "Summarize the files in this project"
 ```
 
-The CLI also ships a repeatable agent regression suite (six fixed file tasks,
-JSON report, pass/fail plus latency/token deltas against a baseline):
+The CLI also ships a deterministic, API-key-free agent conformance suite with
+versioned trajectories, lifecycle/capability cases, budgets, filtering,
+parallel repeats, and baseline regression thresholds:
 
 ```bash
 cargo run -p wisp-cli -- eval --save baseline.json
 cargo run -p wisp-cli -- eval --compare baseline.json --save current.json
 ```
+
+For a long-lived controller, `wisp-science rpc` provides a versioned JSONL
+stdin/stdout protocol with correlated approvals and cancellation. See
+[Headless agent testing](docs/headless-agent-testing.md) for suite authoring,
+artifact schemas, limits, and the RPC contract.
 
 ### ACP agents (optional)
 

--- a/crates/wisp-cli/Cargo.toml
+++ b/crates/wisp-cli/Cargo.toml
@@ -17,9 +17,13 @@ dirs = "5"
 chrono = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 sha2 = { workspace = true }
+uuid = { workspace = true }
+async-trait = "0.1"
 wisp-runtime = { workspace = true }
 wisp-mcp = { workspace = true }
 wisp-llm = { workspace = true }
 wisp-core = { workspace = true }
 wisp-skills = { workspace = true }
+wisp-tools = { workspace = true }

--- a/crates/wisp-cli/eval-suites/offline-v1.yaml
+++ b/crates/wisp-cli/eval-suites/offline-v1.yaml
@@ -1,0 +1,346 @@
+schema: wisp.agent-eval-suite.v1
+id: wisp-offline-core-v1
+description: Deterministic headless coverage for the native agent loop and host boundaries.
+defaults:
+  max_context_tokens: 128000
+  max_rounds: 12
+  timeout_ms: 15000
+  max_tool_errors: 0
+
+cases:
+  - id: read-facts
+    description: Read grounded facts without modifying the workspace.
+    tags: [filesystem, read]
+    prompt: Inspect notes.txt and report the number of non-empty lines and first word.
+    files:
+      notes.txt: "alpha beta\n\ngamma delta\n"
+    allowed_tools: [read, attempt_completion]
+    script:
+      - tool_calls:
+          - {id: read-1, name: read, arguments: {path: notes.txt}}
+        input_tokens: 20
+        output_tokens: 4
+      - tool_calls:
+          - {id: done-1, name: attempt_completion, arguments: {result: "lines=2; first=alpha"}}
+        input_tokens: 30
+        output_tokens: 4
+    limits: {max_tool_calls: 2}
+    expect:
+      completion_contains: ["lines=2", "first=alpha"]
+      required_tools: [read, attempt_completion]
+      forbidden_tools: [write, edit, shell]
+      tool_order: [read, attempt_completion]
+      tool_args:
+        - {name: read, pointer: /path, equals: notes.txt}
+
+  - id: targeted-edit
+    description: Apply one exact edit and preserve every other workspace byte.
+    tags: [filesystem, write]
+    prompt: Change iterations from 10 to 25 in config.toml and preserve everything else.
+    files:
+      config.toml: "iterations = 10\nmode = \"fast\"\n"
+    allowed_tools: [read, edit, attempt_completion]
+    script:
+      - tool_calls:
+          - {id: read-1, name: read, arguments: {path: config.toml}}
+      - tool_calls:
+          - id: edit-1
+            name: edit
+            arguments: {path: config.toml, old: "iterations = 10", new: "iterations = 25"}
+      - tool_calls:
+          - {id: done-1, name: attempt_completion, arguments: {result: updated config}}
+    expect:
+      expected_files:
+        config.toml: "iterations = 25\nmode = \"fast\"\n"
+      required_tools: [read, edit, attempt_completion]
+      tool_order: [read, edit, attempt_completion]
+      tool_args:
+        - {name: edit, pointer: /new, equals: "iterations = 25"}
+
+  - id: shell-execution
+    description: Run a bounded portable shell command and capture its result.
+    tags: [shell, execution]
+    prompt: Use the shell to print the portable marker HEADLESS_OK.
+    allowed_tools: [shell, attempt_completion]
+    script:
+      - tool_calls:
+          - {id: shell-1, name: shell, arguments: {cmd: "echo HEADLESS_OK"}}
+      - tool_calls:
+          - {id: done-1, name: attempt_completion, arguments: {result: HEADLESS_OK}}
+    expect:
+      completion_contains: [HEADLESS_OK]
+      required_tools: [shell, attempt_completion]
+      tool_order: [shell, attempt_completion]
+
+  - id: python-runtime-persistence
+    description: Keep Python state across cells through the production runtime tool boundary.
+    tags: [runtime, python]
+    prompt: Store the marker 41 in Python, read it in a second cell, and report it.
+    fixture_runtimes: true
+    allowed_tools: [python, attempt_completion]
+    script:
+      - tool_calls:
+          - {id: python-set-1, name: python, arguments: {code: "set:41"}}
+      - tool_calls:
+          - {id: python-get-1, name: python, arguments: {code: get}}
+      - tool_calls:
+          - {id: done-1, name: attempt_completion, arguments: {result: "python persisted 41"}}
+    expect:
+      completion_contains: [persisted, "41"]
+      required_tools: [python, attempt_completion]
+      tool_order: [python, python, attempt_completion]
+      tool_args:
+        - {name: python, pointer: /code, equals: "set:41"}
+
+  - id: r-runtime-persistence
+    description: Keep R state across cells through the production runtime tool boundary.
+    tags: [runtime, r]
+    prompt: Store the marker 73 in R, read it in a second cell, and report it.
+    fixture_runtimes: true
+    allowed_tools: [r, attempt_completion]
+    script:
+      - tool_calls:
+          - {id: r-set-1, name: r, arguments: {code: "set:73"}}
+      - tool_calls:
+          - {id: r-get-1, name: r, arguments: {code: get}}
+      - tool_calls:
+          - {id: done-1, name: attempt_completion, arguments: {result: "R persisted 73"}}
+    expect:
+      completion_contains: [persisted, "73"]
+      required_tools: [r, attempt_completion]
+      tool_order: [r, r, attempt_completion]
+      tool_args:
+        - {name: r, pointer: /code, equals: "set:73"}
+
+  - id: approval-denial
+    description: Denied mutations are reported and the workspace stays unchanged.
+    tags: [approval, safety, filesystem]
+    prompt: Try to write blocked.txt, then report that the host denied it.
+    allowed_tools: [write, attempt_completion]
+    approval:
+      modes: {write: ask}
+      decisions: [false]
+    script:
+      - tool_calls:
+          - {id: write-1, name: write, arguments: {path: blocked.txt, content: "no\n"}}
+      - tool_calls:
+          - {id: done-1, name: attempt_completion, arguments: {result: "write denied"}}
+    limits: {max_tool_errors: 1}
+    expect:
+      completion_contains: [denied]
+      required_tools: [write, attempt_completion]
+      approvals: 1
+
+  - id: skill-loading
+    description: Discover and load a project-local Skill through production tools.
+    tags: [skills]
+    prompt: Find the demo-analysis Skill, load it, and report its marker.
+    files:
+      .wisp/skills/demo-analysis/SKILL.md: |
+        ---
+        name: demo-analysis
+        description: Offline demo analysis workflow.
+        tags: [offline, demo]
+        ---
+        # Demo
+        SKILL_MARKER_42
+    allowed_tools: [search_skills, use_skill, attempt_completion]
+    script:
+      - tool_calls:
+          - {id: search-1, name: search_skills, arguments: {query: demo analysis}}
+      - tool_calls:
+          - {id: skill-1, name: use_skill, arguments: {name: demo-analysis}}
+      - tool_calls:
+          - {id: done-1, name: attempt_completion, arguments: {result: SKILL_MARKER_42}}
+    expect:
+      completion_contains: [SKILL_MARKER_42]
+      required_tools: [search_skills, use_skill, attempt_completion]
+      tool_order: [search_skills, use_skill, attempt_completion]
+      request_contains: [SKILL_MARKER_42]
+
+  - id: deferred-mcp
+    description: Discover and call a deferred MCP fixture through the gateway.
+    tags: [mcp]
+    prompt: Search the MCP catalog for a gene lookup tool and call it for TP53.
+    allowed_tools: [fixture_gene_lookup, attempt_completion]
+    fixture_mcp:
+      fixture_gene_lookup: "TP53 chromosome=17"
+    script:
+      - tool_calls:
+          - {id: search-1, name: search_mcp_tools, arguments: {query: gene lookup}}
+      - tool_calls:
+          - id: mcp-1
+            name: use_mcp_tool
+            arguments: {tool_name: fixture_gene_lookup, tool_input: {query: TP53}}
+      - tool_calls:
+          - {id: done-1, name: attempt_completion, arguments: {result: "TP53 chromosome=17"}}
+    expect:
+      completion_contains: [TP53, chromosome=17]
+      required_tools: [search_mcp_tools, use_mcp_tool, attempt_completion]
+      tool_order: [search_mcp_tools, use_mcp_tool, attempt_completion]
+
+  - id: explore-delegation
+    description: Delegate read-only discovery to the production explore subagent boundary.
+    tags: [delegation, subagent, filesystem]
+    prompt: Delegate inspection of notes.txt and return only the subagent's grounded marker.
+    files:
+      notes.txt: "DELEGATED_FACT_88\n"
+    allowed_tools: [explore, attempt_completion]
+    explore_script:
+      - tool_calls:
+          - {id: nested-read-1, name: read, arguments: {path: notes.txt}}
+      - content: "findings:\n- claim: DELEGATED_FACT_88 | path: notes.txt | lines: 1\nsummary: grounded"
+        finish_reason: stop
+    script:
+      - tool_calls:
+          - {id: explore-1, name: explore, arguments: {question: "What marker is in notes.txt?"}}
+      - tool_calls:
+          - {id: done-1, name: attempt_completion, arguments: {result: DELEGATED_FACT_88}}
+    expect:
+      completion_contains: [DELEGATED_FACT_88]
+      request_contains: [DELEGATED_FACT_88]
+      required_tools: [explore, attempt_completion]
+      tool_order: [explore, attempt_completion]
+
+  - id: resume-without-tool-replay
+    description: Resume a failed turn without replaying a completed mutation.
+    tags: [resume, session]
+    prompt: Write result.txt, tolerate the interrupted reply, then resume and finish.
+    allowed_tools: [write, attempt_completion]
+    script:
+      - tool_calls:
+          - {id: write-1, name: write, arguments: {path: result.txt, content: "done\n"}}
+      - content: ""
+        finish_reason: stop
+      - tool_calls:
+          - {id: done-1, name: attempt_completion, arguments: {result: resumed}}
+    actions:
+      - {kind: send, prompt: "Write result.txt and finish.", allow_error: true}
+      - {kind: resume}
+    expect:
+      expected_files: {result.txt: "done\n"}
+      completion_contains: [resumed]
+      required_tools: [write, attempt_completion]
+      tool_order: [write, attempt_completion]
+
+  - id: session-restart
+    description: Persist and restore the native context across a headless restart.
+    tags: [session, restart]
+    prompt: Remember a fact, restart, then prove that the next request still sees it.
+    allowed_tools: [attempt_completion]
+    script:
+      - tool_calls:
+          - {id: done-1, name: attempt_completion, arguments: {result: remembered}}
+      - tool_calls:
+          - {id: done-2, name: attempt_completion, arguments: {result: SESSION_FACT_77}}
+    actions:
+      - {kind: send, prompt: "Remember SESSION_FACT_77."}
+      - {kind: restart}
+      - {kind: send, prompt: "What fact did I ask you to remember?"}
+    expect:
+      completion_contains: [SESSION_FACT_77]
+      request_contains: [SESSION_FACT_77]
+      required_tools: [attempt_completion]
+
+  - id: queued-guidance
+    description: Consume a queued steering message at the next model boundary.
+    tags: [guidance, queue]
+    prompt: Follow the queued instruction.
+    allowed_tools: [attempt_completion]
+    script:
+      - tool_calls:
+          - {id: done-1, name: attempt_completion, arguments: {result: GUIDANCE_MARKER_9}}
+    actions:
+      - kind: send
+        prompt: Follow the queued instruction.
+        guidance: ["Use GUIDANCE_MARKER_9 in the result."]
+    expect:
+      completion_contains: [GUIDANCE_MARKER_9]
+      request_contains: [GUIDANCE_MARKER_9]
+
+  - id: cancellation
+    description: Cancel an in-flight deterministic provider response.
+    tags: [cancel, lifecycle]
+    prompt: This response should be cancelled before it completes.
+    allowed_tools: [attempt_completion]
+    cancel_after_ms: 10
+    script:
+      - delay_ms: 200
+        tool_calls:
+          - {id: done-1, name: attempt_completion, arguments: {result: too-late}}
+    expect:
+      outcome: error
+      error_contains: [stopped by user]
+
+  - id: vision-fallback
+    description: Analyze an image tool result through a separate vision provider.
+    tags: [vision, image]
+    prompt: Inspect pixel.png and report the vision marker.
+    base64_files:
+      pixel.png: iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=
+    allowed_tools: [view_image, attempt_completion]
+    vision_script:
+      - content: VISION_MARKER_BLUE_PIXEL
+        finish_reason: stop
+    script:
+      - tool_calls:
+          - {id: image-1, name: view_image, arguments: {path: pixel.png, question: "What is visible?"}}
+      - tool_calls:
+          - {id: done-1, name: attempt_completion, arguments: {result: VISION_MARKER_BLUE_PIXEL}}
+    expect:
+      completion_contains: [VISION_MARKER_BLUE_PIXEL]
+      required_tools: [view_image, attempt_completion]
+
+  - id: manual-compaction
+    description: Archive and compact a seeded long context without network access.
+    tags: [compaction, context]
+    prompt: Compact the seeded history, then finish.
+    allowed_tools: [attempt_completion]
+    limits: {max_context_tokens: 10000}
+    context_seed:
+      - {role: user, repeat: 30, content: "COMPACTION_FACT_A xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}
+      - {role: assistant, repeat: 30, content: "answer A yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"}
+      - {role: user, repeat: 30, content: "COMPACTION_FACT_B xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}
+      - {role: assistant, repeat: 30, content: "answer B yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"}
+    script:
+      - content: "summary keeps COMPACTION_FACT_A and COMPACTION_FACT_B"
+        finish_reason: stop
+      - tool_calls:
+          - {id: done-1, name: attempt_completion, arguments: {result: compacted}}
+    actions:
+      - {kind: compact}
+      - {kind: send, prompt: "Finish after compaction."}
+    expect:
+      completion_contains: [compacted]
+      request_contains: [COMPACTION_FACT]
+
+  - id: plan-mode-gate
+    description: Plan mode blocks execution even when the model asks for shell.
+    tags: [plan, safety]
+    prompt: Attempt a shell command while plan mode is active, then report the refusal.
+    plan_mode: true
+    allowed_tools: [shell, attempt_completion]
+    script:
+      - tool_calls:
+          - {id: shell-1, name: shell, arguments: {cmd: "echo SHOULD_NOT_RUN"}}
+      - tool_calls:
+          - {id: done-1, name: attempt_completion, arguments: {result: "shell unavailable in plan mode"}}
+    limits: {max_tool_errors: 1}
+    expect:
+      completion_contains: [plan mode]
+      required_tools: [shell, attempt_completion]
+
+  - id: path-sandbox
+    description: Scoped reads reject traversal outside the temporary project.
+    tags: [filesystem, safety, windows, macos]
+    prompt: Try to read outside the project and report the sandbox refusal.
+    allowed_tools: [read, attempt_completion]
+    script:
+      - tool_calls:
+          - {id: read-1, name: read, arguments: {path: ../secret.txt}}
+      - tool_calls:
+          - {id: done-1, name: attempt_completion, arguments: {result: "sandbox rejected traversal"}}
+    limits: {max_tool_errors: 1}
+    expect:
+      completion_contains: [sandbox]
+      required_tools: [read, attempt_completion]

--- a/crates/wisp-cli/src/eval.rs
+++ b/crates/wisp-cli/src/eval.rs
@@ -1,151 +1,602 @@
 use anyhow::{bail, Context, Result};
+use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
-use std::collections::{BTreeMap, BTreeSet};
-use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::path::{Component, Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::{Instant, SystemTime, UNIX_EPOCH};
-use wisp_core::{Agent, MemoryManager, Output};
-use wisp_llm::ProviderConfig;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use wisp_core::{Agent, ContextManager, ExploreTool, GuidanceQueue, MemoryManager, Output};
+use wisp_llm::{
+    Message, Provider, ProviderConfig, Role, ScriptedCompletion, ScriptedProvider,
+    ScriptedProviderSnapshot, ToolSchema,
+};
 use wisp_skills::SkillIndex;
+use wisp_tools::{Approval, Tool, ToolEnv, ToolResult};
 
-const SUITE_VERSION: &str = "agent-eval-v0";
-const MAX_CONTEXT_TOKENS: usize = 128_000;
-const MAX_ROUNDS: usize = 12;
-const EVAL_TOOLS: [&str; 6] = [
-    "read",
-    "write",
-    "edit",
-    "search",
-    "grep",
-    "attempt_completion",
-];
+const SUITE_SCHEMA: &str = "wisp.agent-eval-suite.v1";
+const REPORT_SCHEMA: &str = "wisp.agent-eval-report.v1";
+const TRAJECTORY_SCHEMA: &str = "wisp.agent-trajectory.v1";
+const BUILTIN_SUITE: &str = include_str!("../eval-suites/offline-v1.yaml");
+const DEFAULT_MAX_CONTEXT: usize = 128_000;
+const DEFAULT_MAX_ROUNDS: usize = 12;
+const DEFAULT_TIMEOUT_MS: u64 = 60_000;
 
-#[derive(Clone, Copy)]
-struct Scenario {
-    id: &'static str,
-    description: &'static str,
-    prompt: &'static str,
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EvalMode {
+    Offline,
+    Live,
 }
 
-fn scenarios() -> [Scenario; 6] {
-    [
-        Scenario {
-            id: "read_facts",
-            description: "Read a file and report grounded facts without changing it.",
-            prompt: "Use read to inspect notes.txt. Do not create or modify files. Report the number \
-                     of non-empty lines and the first word as `lines=<integer>; first=<word>`, then \
-                     finish with attempt_completion.",
-        },
-        Scenario {
-            id: "search_files",
-            description: "Find matching files and report stable relative paths.",
-            prompt: "Use search to find every Python file in the workspace. Do not create or modify \
-                     files. Report the relative paths in ascending order, then finish with \
-                     attempt_completion.",
-        },
-        Scenario {
-            id: "grep_marker",
-            description: "Locate a content marker without changing the workspace.",
-            prompt: "Use grep to find every line containing the literal marker CALIBRATE. Do not \
-                     create or modify files. Report each matching relative path and line, then \
-                     finish with attempt_completion.",
-        },
-        Scenario {
-            id: "targeted_edit",
-            description: "Make one exact configuration edit and preserve surrounding content.",
-            prompt: "Use edit to change only `iterations = 10` to `iterations = 25` in config.toml. \
-                     Preserve every other byte and finish with attempt_completion.",
-        },
-        Scenario {
-            id: "derive_file",
-            description: "Read tabular input, calculate a value, and write one derived file.",
-            prompt: "Read measurements.csv. Create results/summary.txt with exactly two lines: \
-                     `count=<number of data rows>` and `mean=<one decimal mean of value>`, including \
-                     a final newline. Use write for the new file and finish with \
-                     attempt_completion.",
-        },
-        Scenario {
-            id: "avoid_noop_edit",
-            description: "Recognize an already-satisfied state and avoid an unnecessary edit.",
-            prompt: "Read settings.json and check whether enabled is already true. If it is, do not \
-                     modify any file. Report `enabled=<value>; limit=<value>` and finish with \
-                     attempt_completion.",
-        },
-    ]
+impl EvalMode {
+    pub fn parse(value: &str) -> Result<Self> {
+        match value {
+            "offline" => Ok(Self::Offline),
+            "live" => Ok(Self::Live),
+            _ => bail!("unknown eval mode '{value}'; expected offline or live"),
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Offline => "offline",
+            Self::Live => "live",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EvalOptions {
+    pub mode: EvalMode,
+    pub suite: Option<PathBuf>,
+    pub save: Option<PathBuf>,
+    pub compare: Option<PathBuf>,
+    pub artifacts: Option<PathBuf>,
+    pub cases: Vec<String>,
+    pub tags: Vec<String>,
+    pub repeat: usize,
+    pub timeout_ms: Option<u64>,
+    pub parallel: usize,
+    pub keep_failed_workspace: bool,
+    pub max_tool_calls: Option<u64>,
+    pub max_input_tokens: Option<u64>,
+    pub max_duration_ms: Option<u64>,
+    pub max_cost_microusd: Option<u64>,
+    pub input_cost_microusd_per_million: u64,
+    pub output_cost_microusd_per_million: u64,
+    pub reasoning_cost_microusd_per_million: u64,
+    pub max_token_regression_percent: Option<u64>,
+    pub max_round_regression: Option<u64>,
+    pub min_pass_rate_percent: u64,
+    pub allow_regressions: bool,
+}
+
+impl Default for EvalOptions {
+    fn default() -> Self {
+        Self {
+            mode: EvalMode::Offline,
+            suite: None,
+            save: None,
+            compare: None,
+            artifacts: None,
+            cases: Vec::new(),
+            tags: Vec::new(),
+            repeat: 1,
+            timeout_ms: None,
+            parallel: 1,
+            keep_failed_workspace: false,
+            max_tool_calls: None,
+            max_input_tokens: None,
+            max_duration_ms: None,
+            max_cost_microusd: None,
+            input_cost_microusd_per_million: 0,
+            output_cost_microusd_per_million: 0,
+            reasoning_cost_microusd_per_million: 0,
+            max_token_regression_percent: None,
+            max_round_regression: None,
+            min_pass_rate_percent: 100,
+            allow_regressions: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct EvalSuite {
+    schema: String,
+    id: String,
+    #[serde(default)]
+    description: String,
+    #[serde(default)]
+    defaults: EvalLimits,
+    cases: Vec<EvalCase>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct EvalLimits {
+    #[serde(default)]
+    max_context_tokens: Option<usize>,
+    #[serde(default)]
+    max_rounds: Option<usize>,
+    #[serde(default)]
+    timeout_ms: Option<u64>,
+    #[serde(default)]
+    max_tool_calls: Option<u64>,
+    #[serde(default)]
+    max_tool_errors: Option<u64>,
+    #[serde(default)]
+    max_input_tokens: Option<u64>,
+    #[serde(default)]
+    max_duration_ms: Option<u64>,
+    #[serde(default)]
+    max_cost_microusd: Option<u64>,
+}
+
+impl EvalLimits {
+    fn merged(&self, case: &Self, options: &EvalOptions) -> Self {
+        Self {
+            max_context_tokens: case.max_context_tokens.or(self.max_context_tokens),
+            max_rounds: case.max_rounds.or(self.max_rounds),
+            timeout_ms: options.timeout_ms.or(case.timeout_ms).or(self.timeout_ms),
+            max_tool_calls: options
+                .max_tool_calls
+                .or(case.max_tool_calls)
+                .or(self.max_tool_calls),
+            max_tool_errors: case.max_tool_errors.or(self.max_tool_errors),
+            max_input_tokens: options
+                .max_input_tokens
+                .or(case.max_input_tokens)
+                .or(self.max_input_tokens),
+            max_duration_ms: options
+                .max_duration_ms
+                .or(case.max_duration_ms)
+                .or(self.max_duration_ms),
+            max_cost_microusd: options
+                .max_cost_microusd
+                .or(case.max_cost_microusd)
+                .or(self.max_cost_microusd),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct EvalCase {
+    id: String,
+    description: String,
+    #[serde(default)]
+    tags: Vec<String>,
+    #[serde(default)]
+    prompt: String,
+    #[serde(default)]
+    actions: Vec<EvalAction>,
+    #[serde(default)]
+    files: BTreeMap<String, String>,
+    #[serde(default)]
+    base64_files: BTreeMap<String, String>,
+    #[serde(default)]
+    allowed_tools: Vec<String>,
+    #[serde(default)]
+    script: Vec<ScriptedCompletion>,
+    #[serde(default)]
+    vision_script: Vec<ScriptedCompletion>,
+    #[serde(default)]
+    explore_script: Vec<ScriptedCompletion>,
+    #[serde(default)]
+    fixture_runtimes: bool,
+    #[serde(default)]
+    fixture_mcp: BTreeMap<String, String>,
+    #[serde(default)]
+    context_seed: Vec<SeedMessage>,
+    #[serde(default)]
+    approval: EvalApproval,
+    #[serde(default)]
+    plan_mode: bool,
+    #[serde(default)]
+    cancel_after_ms: Option<u64>,
+    #[serde(default)]
+    auto_compact: Option<bool>,
+    #[serde(default)]
+    limits: EvalLimits,
+    #[serde(default)]
+    expect: EvalExpectation,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SeedMessage {
+    role: String,
+    content: String,
+    #[serde(default = "default_seed_repeat")]
+    repeat: usize,
+}
+
+fn default_seed_repeat() -> usize {
+    1
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum EvalAction {
+    Send {
+        prompt: String,
+        #[serde(default)]
+        guidance: Vec<String>,
+        #[serde(default)]
+        allow_error: bool,
+    },
+    Resume {
+        #[serde(default)]
+        allow_error: bool,
+    },
+    Compact,
+    Restart,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct EvalApproval {
+    #[serde(default)]
+    modes: BTreeMap<String, String>,
+    #[serde(default)]
+    decisions: Vec<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct EvalExpectation {
+    #[serde(default = "default_outcome")]
+    outcome: String,
+    #[serde(default)]
+    error_contains: Vec<String>,
+    #[serde(default)]
+    completion_contains: Vec<String>,
+    #[serde(default)]
+    expected_files: BTreeMap<String, String>,
+    #[serde(default)]
+    deleted_files: Vec<String>,
+    #[serde(default)]
+    required_tools: Vec<String>,
+    #[serde(default)]
+    forbidden_tools: Vec<String>,
+    #[serde(default)]
+    tool_order: Vec<String>,
+    #[serde(default)]
+    tool_args: Vec<ToolArgumentExpectation>,
+    #[serde(default)]
+    request_contains: Vec<String>,
+    #[serde(default)]
+    approvals: Option<usize>,
+    #[serde(default)]
+    remaining_script: Option<usize>,
+}
+
+fn default_outcome() -> String {
+    "success".into()
+}
+
+impl Default for EvalExpectation {
+    fn default() -> Self {
+        Self {
+            outcome: default_outcome(),
+            error_contains: Vec::new(),
+            completion_contains: Vec::new(),
+            expected_files: BTreeMap::new(),
+            deleted_files: Vec::new(),
+            required_tools: Vec::new(),
+            forbidden_tools: Vec::new(),
+            tool_order: Vec::new(),
+            tool_args: Vec::new(),
+            request_contains: Vec::new(),
+            approvals: None,
+            remaining_script: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ToolArgumentExpectation {
+    name: String,
+    #[serde(default)]
+    pointer: String,
+    equals: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ToolCallRecord {
+    call_id: String,
+    name: String,
+    arguments: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct TrajectoryEvent {
+    schema: String,
+    sequence: u64,
+    kind: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    call_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    ok: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    payload: Option<Value>,
 }
 
 #[derive(Debug, Clone, Default)]
 struct Captured {
     rounds: usize,
-    tool_calls: Vec<String>,
+    tool_calls: Vec<ToolCallRecord>,
     tool_errors: u64,
     input_tokens: u64,
     output_tokens: u64,
     reasoning_tokens: u64,
     cached_tokens: u64,
     completion: Option<String>,
+    approvals: Vec<bool>,
+    events: Vec<TrajectoryEvent>,
 }
 
-#[derive(Default)]
 struct EvalOutput {
     captured: Mutex<Captured>,
+    next_sequence: AtomicU64,
+    approval_modes: BTreeMap<String, Approval>,
+    decisions: Mutex<std::collections::VecDeque<bool>>,
+    plan_mode: bool,
 }
 
 impl EvalOutput {
+    fn new(approval: &EvalApproval, plan_mode: bool) -> Result<Self> {
+        let approval_modes = approval
+            .modes
+            .iter()
+            .map(|(tool, mode)| {
+                let mode = match mode.as_str() {
+                    "allow" => Approval::Allow,
+                    "ask" => Approval::Ask,
+                    "deny" => Approval::Deny,
+                    other => bail!(
+                        "approval mode for '{tool}' is '{other}'; expected allow, ask, or deny"
+                    ),
+                };
+                Ok((tool.clone(), mode))
+            })
+            .collect::<Result<BTreeMap<_, _>>>()?;
+        Ok(Self {
+            captured: Mutex::new(Captured::default()),
+            next_sequence: AtomicU64::new(1),
+            approval_modes,
+            decisions: Mutex::new(approval.decisions.iter().copied().collect()),
+            plan_mode,
+        })
+    }
+
+    fn push(
+        &self,
+        kind: &str,
+        call_id: Option<String>,
+        name: Option<String>,
+        ok: Option<bool>,
+        payload: Option<Value>,
+    ) {
+        let sequence = self.next_sequence.fetch_add(1, Ordering::Relaxed);
+        self.captured
+            .lock()
+            .expect("eval capture mutex poisoned")
+            .events
+            .push(TrajectoryEvent {
+                schema: TRAJECTORY_SCHEMA.into(),
+                sequence,
+                kind: kind.into(),
+                call_id,
+                name,
+                ok,
+                payload,
+            });
+    }
+
     fn snapshot(&self) -> Captured {
         self.captured
             .lock()
-            .expect("eval output mutex poisoned")
+            .expect("eval capture mutex poisoned")
             .clone()
     }
 }
 
 impl Output for EvalOutput {
-    fn tool_call(&self, name: &str, _preview: &str) {
-        self.captured
-            .lock()
-            .expect("eval output mutex poisoned")
-            .tool_calls
-            .push(name.to_string());
+    fn assistant_text(&self, delta: &str) {
+        self.push(
+            "assistant_delta",
+            None,
+            None,
+            None,
+            Some(json!({"delta": delta})),
+        );
     }
 
-    fn tool_result(&self, name: &str, ok: bool, content: &str, _duration_ms: u64) {
-        let mut captured = self.captured.lock().expect("eval output mutex poisoned");
+    fn reasoning(&self, delta: &str) {
+        self.push(
+            "reasoning_delta",
+            None,
+            None,
+            None,
+            Some(json!({"delta": delta})),
+        );
+    }
+
+    fn tool_call(&self, name: &str, preview: &str) {
+        self.push(
+            "tool_preview",
+            None,
+            Some(name.into()),
+            None,
+            Some(json!({"preview": preview})),
+        );
+    }
+
+    fn tool_result(&self, name: &str, ok: bool, content: &str, duration_ms: u64) {
+        let mut captured = self.captured.lock().expect("eval capture mutex poisoned");
         if !ok {
             captured.tool_errors += 1;
         }
         if name == "attempt_completion" && ok {
             captured.completion = Some(content.to_string());
         }
+        drop(captured);
+        self.push(
+            "tool_execution",
+            None,
+            Some(name.into()),
+            Some(ok),
+            Some(json!({"content": content, "duration_ms": duration_ms})),
+        );
     }
 
     fn usage(
         &self,
-        _round: usize,
+        round: usize,
         input: u64,
         output: u64,
         reasoning: u64,
         cached: u64,
-        _ctx_tokens: usize,
-        _max_context: usize,
-        _context_usage: wisp_core::ContextUsage,
+        ctx_tokens: usize,
+        max_context: usize,
+        context_usage: wisp_core::ContextUsage,
     ) {
-        let mut captured = self.captured.lock().expect("eval output mutex poisoned");
+        let mut captured = self.captured.lock().expect("eval capture mutex poisoned");
         captured.rounds += 1;
         captured.input_tokens += input;
         captured.output_tokens += output;
         captured.reasoning_tokens += reasoning;
         captured.cached_tokens += cached;
+        drop(captured);
+        self.push(
+            "usage",
+            None,
+            None,
+            None,
+            Some(json!({
+                "round": round,
+                "input_tokens": input,
+                "output_tokens": output,
+                "reasoning_tokens": reasoning,
+                "cached_tokens": cached,
+                "context_tokens": ctx_tokens,
+                "max_context_tokens": max_context,
+                "context_usage": context_usage,
+            })),
+        );
     }
 
-    fn confirm(&self, _message: &str) -> bool {
-        false
+    fn compaction_started(&self, strategy: &str) {
+        self.push(
+            "compaction_started",
+            None,
+            None,
+            None,
+            Some(json!({"strategy": strategy})),
+        );
+    }
+
+    fn compaction(&self, before: usize, after: usize, strategy: &str) {
+        self.push(
+            "compaction",
+            None,
+            None,
+            None,
+            Some(json!({"before_tokens": before, "after_tokens": after, "strategy": strategy})),
+        );
+    }
+
+    fn confirm(&self, message: &str) -> bool {
+        let approved = self
+            .decisions
+            .lock()
+            .expect("eval approval mutex poisoned")
+            .pop_front()
+            .unwrap_or(false);
+        self.captured
+            .lock()
+            .expect("eval capture mutex poisoned")
+            .approvals
+            .push(approved);
+        self.push(
+            "approval",
+            None,
+            None,
+            Some(approved),
+            Some(json!({"message": message})),
+        );
+        approved
+    }
+
+    fn approval_mode(&self, tool: &str) -> Approval {
+        self.approval_modes
+            .get(tool)
+            .copied()
+            .unwrap_or(Approval::Allow)
     }
 
     fn restrict_read_paths_to_project(&self) -> bool {
         true
+    }
+
+    fn plan_mode(&self) -> bool {
+        self.plan_mode
+    }
+
+    fn on_message(&self, message: &Message) {
+        match message.role {
+            Role::Assistant => {
+                for call in &message.tool_calls {
+                    let arguments = call.args_value();
+                    self.captured
+                        .lock()
+                        .expect("eval capture mutex poisoned")
+                        .tool_calls
+                        .push(ToolCallRecord {
+                            call_id: call.id.clone(),
+                            name: call.function.name.clone(),
+                            arguments: arguments.clone(),
+                        });
+                    self.push(
+                        "tool_call",
+                        Some(call.id.clone()),
+                        Some(call.function.name.clone()),
+                        None,
+                        Some(json!({"arguments": arguments})),
+                    );
+                }
+                if !message.content.as_text().is_empty() {
+                    self.push(
+                        "assistant_message",
+                        None,
+                        None,
+                        None,
+                        Some(json!({"content": message.content, "reasoning": message.reasoning})),
+                    );
+                }
+            }
+            Role::Tool => self.push(
+                "tool_result",
+                message.tool_call_id.clone(),
+                message.tool_name.clone(),
+                None,
+                Some(json!({"content": message.content})),
+            ),
+            Role::User => self.push(
+                "user_message",
+                None,
+                None,
+                None,
+                Some(json!({"content": message.content})),
+            ),
+            Role::System => self.push(
+                "system_message",
+                None,
+                None,
+                None,
+                Some(json!({"content": message.content})),
+            ),
+        }
     }
 }
 
@@ -153,23 +604,34 @@ impl Output for EvalOutput {
 struct ScenarioResult {
     id: String,
     description: String,
+    tags: Vec<String>,
+    repetition: usize,
     passed: bool,
-    failure: Option<String>,
+    failures: Vec<String>,
     duration_ms: u64,
     rounds: usize,
-    tool_calls: Vec<String>,
+    tool_calls: Vec<ToolCallRecord>,
     tool_errors: u64,
     input_tokens: u64,
     output_tokens: u64,
     reasoning_tokens: u64,
     cached_tokens: u64,
+    cost_microusd: u64,
     completion: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    agent_error: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    trajectory_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    failed_workspace: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 struct ReportSummary {
-    total: usize,
+    cases: usize,
+    attempts: usize,
     passed: usize,
+    pass_rate_percent: u64,
     duration_ms: u64,
     rounds: usize,
     tool_calls: u64,
@@ -178,325 +640,1138 @@ struct ReportSummary {
     output_tokens: u64,
     reasoning_tokens: u64,
     cached_tokens: u64,
+    cost_microusd: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct BaselineComparison {
     baseline: String,
     warnings: Vec<String>,
-    passed_delta: i64,
-    duration_ms_delta: i64,
-    rounds_delta: i64,
-    tool_calls_delta: i64,
-    tool_errors_delta: i64,
-    input_tokens_delta: i64,
-    output_tokens_delta: i64,
-    reasoning_tokens_delta: i64,
-    cached_tokens_delta: i64,
     regressions: Vec<String>,
     improvements: Vec<String>,
+    threshold_failures: Vec<String>,
+    passed_delta: i64,
+    input_tokens_delta: i64,
+    rounds_delta: i64,
+    duration_ms_delta: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct EvalReport {
-    suite_version: String,
+    schema: String,
+    suite_schema: String,
+    suite_id: String,
+    suite_hash: String,
     wisp_version: String,
     generated_at: String,
+    mode: String,
     provider: String,
     model: String,
-    max_context_tokens: usize,
-    max_rounds: usize,
-    tools: Vec<String>,
-    scenario_prompt_hash: String,
-    tool_schema_hash: String,
+    repeat: usize,
     summary: ReportSummary,
     scenarios: Vec<ScenarioResult>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     comparison: Option<BaselineComparison>,
 }
 
-pub async fn run(cfg: ProviderConfig, save: Option<&Path>, compare: Option<&Path>) -> Result<()> {
-    let baseline = compare
-        .map(|path| {
-            let bytes = std::fs::read(path)
-                .with_context(|| format!("could not read baseline {}", path.display()))?;
-            serde_json::from_slice::<EvalReport>(&bytes)
-                .with_context(|| format!("invalid eval baseline {}", path.display()))
-        })
-        .transpose()?;
+#[derive(Clone)]
+enum ProviderSource {
+    Offline(ScriptedProvider),
+    Live(ProviderConfig),
+}
 
-    let mut report = evaluate(cfg).await?;
-    if let (Some(path), Some(baseline)) = (compare, baseline.as_ref()) {
-        report.comparison = Some(compare_reports(&report, baseline, path));
+impl ProviderSource {
+    fn build(&self) -> Box<dyn Provider> {
+        match self {
+            Self::Offline(provider) => Box::new(provider.clone()),
+            Self::Live(config) => wisp_llm::build(config.clone()),
+        }
+    }
+
+    fn offline_snapshot(&self) -> Option<ScriptedProviderSnapshot> {
+        match self {
+            Self::Offline(provider) => Some(provider.snapshot()),
+            Self::Live(_) => None,
+        }
+    }
+}
+
+struct FixtureMcpTool {
+    name: String,
+    result: String,
+}
+
+#[derive(Default)]
+struct EvalRuntimeLauncher;
+
+#[async_trait]
+impl wisp_runtime::RuntimeLauncher for EvalRuntimeLauncher {
+    async fn launch(
+        &self,
+        _key: &wisp_runtime::RuntimeKey,
+        _cwd: &Path,
+    ) -> Result<wisp_runtime::LaunchedRuntime> {
+        Ok(wisp_runtime::LaunchedRuntime::new(
+            Box::new(EvalRuntimeKernel::default()),
+            wisp_runtime::RuntimeMetadata {
+                interpreter: Some("headless-fixture".into()),
+                version: Some("v1".into()),
+                process_id: None,
+            },
+        ))
+    }
+}
+
+#[derive(Default)]
+struct EvalRuntimeKernel {
+    value: String,
+}
+
+#[async_trait]
+impl wisp_runtime::RuntimeKernel for EvalRuntimeKernel {
+    async fn execute(
+        &mut self,
+        _id: &str,
+        code: &str,
+        _output: &wisp_runtime::RuntimeOutput,
+    ) -> Result<wisp_runtime::KernelResp> {
+        let stdout = if let Some(value) = code.strip_prefix("set:") {
+            self.value = value.to_string();
+            String::new()
+        } else if code == "get" {
+            self.value.clone()
+        } else {
+            return Ok(wisp_runtime::KernelResp {
+                error: Some(format!("unsupported fixture code '{code}'")),
+                ..wisp_runtime::KernelResp::default()
+            });
+        };
+        Ok(wisp_runtime::KernelResp {
+            stdout,
+            ..wisp_runtime::KernelResp::default()
+        })
+    }
+
+    async fn inspect(&mut self, _id: &str) -> Result<wisp_runtime::RuntimeObjectList> {
+        Ok(wisp_runtime::RuntimeObjectList {
+            objects: vec![wisp_runtime::RuntimeObject {
+                name: "value".into(),
+                type_name: "string".into(),
+                summary: self.value.clone(),
+                size_bytes: Some(self.value.len() as u64),
+            }],
+            total_count: 1,
+        })
+    }
+
+    async fn shutdown(&mut self) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Tool for FixtureMcpTool {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn schema(&self) -> ToolSchema {
+        ToolSchema::new(
+            &self.name,
+            "Deterministic offline MCP retrieval fixture for agent evaluation.",
+            json!({
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+                "additionalProperties": true
+            }),
+        )
+    }
+
+    fn defer_schema(&self) -> bool {
+        true
+    }
+
+    fn read_only(&self) -> bool {
+        true
+    }
+
+    async fn run(&self, _args: &Value, _env: &dyn ToolEnv) -> ToolResult {
+        ToolResult::ok(&self.result)
+    }
+}
+
+pub async fn run(live_config: Option<ProviderConfig>, options: &EvalOptions) -> Result<()> {
+    validate_options(options)?;
+    let suite = load_suite(options.suite.as_deref())?;
+    validate_suite(&suite, options.mode)?;
+    let selected = select_cases(&suite, options)?;
+    if selected.is_empty() {
+        bail!("no eval cases matched the requested filters");
+    }
+    if options.mode == EvalMode::Live && live_config.is_none() {
+        bail!("live eval requires a configured provider");
+    }
+    if let Some(dir) = &options.artifacts {
+        std::fs::create_dir_all(dir)
+            .with_context(|| format!("could not create eval artifacts dir {}", dir.display()))?;
+    }
+
+    let suite_hash = sha256_hex(serde_yaml::to_string(&suite)?.as_bytes());
+    let semaphore = Arc::new(tokio::sync::Semaphore::new(options.parallel));
+    let mut tasks = tokio::task::JoinSet::new();
+    for (case_index, case) in selected.into_iter().cloned().enumerate() {
+        for repetition in 1..=options.repeat {
+            let permit = semaphore.clone().acquire_owned().await?;
+            let case = case.clone();
+            let defaults = suite.defaults.clone();
+            let options = options.clone();
+            let live_config = live_config.clone();
+            tasks.spawn(async move {
+                let _permit = permit;
+                let order = case_index * options.repeat + repetition;
+                let result = run_case(case, repetition, defaults, live_config, options).await;
+                (order, result)
+            });
+        }
+    }
+
+    let mut ordered = Vec::new();
+    while let Some(joined) = tasks.join_next().await {
+        let (order, result) = joined.context("eval worker panicked")?;
+        ordered.push((order, result?));
+    }
+    ordered.sort_by_key(|(order, _)| *order);
+    let scenarios: Vec<_> = ordered.into_iter().map(|(_, result)| result).collect();
+
+    let model = live_config
+        .as_ref()
+        .map(|config| config.model.clone())
+        .unwrap_or_else(|| "scripted-v1".into());
+    let provider = live_config
+        .as_ref()
+        .map(|config| format!("{:?}", config.kind))
+        .unwrap_or_else(|| "Scripted".into());
+    let mut report = EvalReport {
+        schema: REPORT_SCHEMA.into(),
+        suite_schema: suite.schema.clone(),
+        suite_id: suite.id.clone(),
+        suite_hash,
+        wisp_version: env!("CARGO_PKG_VERSION").into(),
+        generated_at: chrono::Utc::now().to_rfc3339(),
+        mode: options.mode.as_str().into(),
+        provider,
+        model,
+        repeat: options.repeat,
+        summary: summarize(&scenarios),
+        scenarios,
+        comparison: None,
+    };
+
+    if let Some(path) = &options.compare {
+        let bytes = std::fs::read(path)
+            .with_context(|| format!("could not read baseline {}", path.display()))?;
+        let baseline: EvalReport = serde_json::from_slice(&bytes)
+            .with_context(|| format!("invalid eval v1 baseline {}", path.display()))?;
+        report.comparison = Some(compare_reports(&report, &baseline, path, options));
     }
 
     let mut rendered = serde_json::to_string_pretty(&report)?;
     rendered.push('\n');
-    if let Some(path) = save {
+    if let Some(path) = &options.save {
+        if let Some(parent) = path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+        {
+            std::fs::create_dir_all(parent)?;
+        }
         std::fs::write(path, &rendered)
             .with_context(|| format!("could not save eval report {}", path.display()))?;
     }
     print!("{rendered}");
 
-    if report.summary.passed != report.summary.total {
+    let comparison_failed = report.comparison.as_ref().is_some_and(|comparison| {
+        !options.allow_regressions
+            && (!comparison.regressions.is_empty() || !comparison.threshold_failures.is_empty())
+    });
+    if report.summary.pass_rate_percent < options.min_pass_rate_percent || comparison_failed {
         bail!(
-            "agent eval failed: {}/{} scenarios passed",
+            "agent eval failed: {}/{} attempts passed ({}%; required {}%)",
             report.summary.passed,
-            report.summary.total
+            report.summary.attempts,
+            report.summary.pass_rate_percent,
+            options.min_pass_rate_percent
         );
     }
     Ok(())
 }
 
-async fn evaluate(cfg: ProviderConfig) -> Result<EvalReport> {
-    let catalog = scenarios();
-    let model = cfg.model.clone();
-    let provider = format!("{:?}", cfg.kind);
-    let mut results = Vec::with_capacity(catalog.len());
-    let mut tool_schema_hash = None;
-
-    for (index, scenario) in catalog.iter().copied().enumerate() {
-        eprintln!(
-            "[{}/{}] {} — {}",
-            index + 1,
-            catalog.len(),
-            scenario.id,
-            scenario.description
-        );
-        let (result, current_schema_hash) = run_scenario(cfg.clone(), scenario).await?;
-        if let Some(expected) = tool_schema_hash.as_ref() {
-            if expected != &current_schema_hash {
-                bail!("eval tool schemas changed between isolated scenarios");
-            }
-        } else {
-            tool_schema_hash = Some(current_schema_hash);
-        }
-        eprintln!(
-            "  {} ({} ms, {} rounds, {} tool calls)",
-            if result.passed { "pass" } else { "FAIL" },
-            result.duration_ms,
-            result.rounds,
-            result.tool_calls.len()
-        );
-        results.push(result);
+fn validate_options(options: &EvalOptions) -> Result<()> {
+    if options.repeat == 0 {
+        bail!("--repeat must be positive");
     }
-
-    Ok(EvalReport {
-        suite_version: SUITE_VERSION.into(),
-        wisp_version: env!("CARGO_PKG_VERSION").into(),
-        generated_at: chrono::Utc::now().to_rfc3339(),
-        provider,
-        model,
-        max_context_tokens: MAX_CONTEXT_TOKENS,
-        max_rounds: MAX_ROUNDS,
-        tools: EVAL_TOOLS.iter().map(|tool| (*tool).to_string()).collect(),
-        scenario_prompt_hash: scenario_prompt_hash(&catalog),
-        tool_schema_hash: tool_schema_hash.unwrap_or_default(),
-        summary: summarize(&results),
-        scenarios: results,
-        comparison: None,
-    })
+    if options.parallel == 0 {
+        bail!("--parallel must be positive");
+    }
+    if options.min_pass_rate_percent > 100 {
+        bail!("--min-pass-rate must be between 0 and 100");
+    }
+    if options.keep_failed_workspace && options.artifacts.is_none() {
+        bail!("--keep-failed-workspace requires --artifacts <dir>");
+    }
+    Ok(())
 }
 
-async fn run_scenario(cfg: ProviderConfig, scenario: Scenario) -> Result<(ScenarioResult, String)> {
-    let workspace = TempWorkspace::new(scenario.id)?;
-    setup_fixture(scenario.id, workspace.path())?;
-    let before = snapshot_workspace(workspace.path())?;
-    let (mut agent, tool_schema_hash) = build_agent(cfg, workspace.path());
-    let output = EvalOutput::default();
+fn load_suite(path: Option<&Path>) -> Result<EvalSuite> {
+    let (label, contents) = match path {
+        Some(path) => (
+            path.display().to_string(),
+            std::fs::read_to_string(path)
+                .with_context(|| format!("could not read eval suite {}", path.display()))?,
+        ),
+        None => ("built-in offline-v1".into(), BUILTIN_SUITE.into()),
+    };
+    if path.is_some_and(|path| path.extension().and_then(|value| value.to_str()) == Some("json")) {
+        serde_json::from_str(&contents).with_context(|| format!("invalid JSON eval suite {label}"))
+    } else {
+        serde_yaml::from_str(&contents).with_context(|| format!("invalid YAML eval suite {label}"))
+    }
+}
 
+fn validate_suite(suite: &EvalSuite, mode: EvalMode) -> Result<()> {
+    if suite.schema != SUITE_SCHEMA {
+        bail!(
+            "unsupported eval suite schema '{}'; expected {SUITE_SCHEMA}",
+            suite.schema
+        );
+    }
+    if suite.id.trim().is_empty() || suite.cases.is_empty() {
+        bail!("eval suite requires a non-empty id and at least one case");
+    }
+    let mut ids = BTreeSet::new();
+    for case in &suite.cases {
+        if case.id.trim().is_empty() || !ids.insert(case.id.as_str()) {
+            bail!("eval case ids must be non-empty and unique: '{}'", case.id);
+        }
+        if case.prompt.trim().is_empty() && case.actions.is_empty() {
+            bail!("eval case '{}' requires prompt or actions", case.id);
+        }
+        if mode == EvalMode::Offline && case.script.is_empty() {
+            bail!("offline eval case '{}' requires a script", case.id);
+        }
+        for path in case
+            .files
+            .keys()
+            .chain(case.base64_files.keys())
+            .chain(case.expect.expected_files.keys())
+            .chain(case.expect.deleted_files.iter())
+        {
+            validate_relative_path(path)
+                .with_context(|| format!("invalid path in eval case '{}'", case.id))?;
+        }
+        if !matches!(case.expect.outcome.as_str(), "success" | "error") {
+            bail!("eval case '{}' outcome must be success or error", case.id);
+        }
+    }
+    Ok(())
+}
+
+fn validate_relative_path(path: &str) -> Result<()> {
+    let path = Path::new(path);
+    if path.as_os_str().is_empty() || path.is_absolute() {
+        bail!("path must be a non-empty relative path");
+    }
+    if path.components().any(|component| {
+        matches!(
+            component,
+            Component::ParentDir | Component::RootDir | Component::Prefix(_)
+        )
+    }) {
+        bail!("path may not escape the eval workspace");
+    }
+    Ok(())
+}
+
+fn select_cases<'a>(suite: &'a EvalSuite, options: &EvalOptions) -> Result<Vec<&'a EvalCase>> {
+    let known: BTreeSet<_> = suite.cases.iter().map(|case| case.id.as_str()).collect();
+    for requested in &options.cases {
+        if !known.contains(requested.as_str()) {
+            bail!("unknown eval case '{requested}'");
+        }
+    }
+    Ok(suite
+        .cases
+        .iter()
+        .filter(|case| {
+            (options.cases.is_empty() || options.cases.iter().any(|id| id == &case.id))
+                && (options.tags.is_empty()
+                    || options
+                        .tags
+                        .iter()
+                        .all(|tag| case.tags.iter().any(|candidate| candidate == tag)))
+        })
+        .collect())
+}
+
+async fn run_case(
+    case: EvalCase,
+    repetition: usize,
+    defaults: EvalLimits,
+    live_config: Option<ProviderConfig>,
+    options: EvalOptions,
+) -> Result<ScenarioResult> {
+    eprintln!(
+        "[{} #{}] {} — {}",
+        options.mode.as_str(),
+        repetition,
+        case.id,
+        case.description
+    );
+    let limits = defaults.merged(&case.limits, &options);
+    let mut workspace = TempWorkspace::new(&case.id, repetition)?;
+    setup_workspace(&case, workspace.path())?;
+    let before = snapshot_workspace(workspace.path())?;
+    let output = Arc::new(EvalOutput::new(&case.approval, case.plan_mode)?);
+    let provider_source = match options.mode {
+        EvalMode::Offline => ProviderSource::Offline(ScriptedProvider::new(
+            format!("scripted:{}", case.id),
+            case.script.clone(),
+        )),
+        EvalMode::Live => ProviderSource::Live(
+            live_config
+                .clone()
+                .context("live eval provider was not configured")?,
+        ),
+    };
+    let vision_source = match options.mode {
+        EvalMode::Offline if !case.vision_script.is_empty() => {
+            Some(ProviderSource::Offline(ScriptedProvider::new(
+                format!("scripted-vision:{}", case.id),
+                case.vision_script.clone(),
+            )))
+        }
+        _ => None,
+    };
+    let max_context = limits.max_context_tokens.unwrap_or(DEFAULT_MAX_CONTEXT);
+    let max_rounds = limits.max_rounds.unwrap_or(DEFAULT_MAX_ROUNDS);
+    let mut agent = build_agent(
+        &case,
+        workspace.path(),
+        &provider_source,
+        vision_source.as_ref(),
+        max_context,
+        max_rounds,
+    )?;
+    if let Some(enabled) = case.auto_compact {
+        agent.set_auto_compact(enabled);
+    }
+    seed_context(&mut agent.ctx, &case.context_seed)?;
+
+    let cancel = Arc::new(AtomicBool::new(false));
+    if let Some(delay) = case.cancel_after_ms {
+        let cancel = cancel.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(delay)).await;
+            cancel.store(true, Ordering::Relaxed);
+        });
+    }
+    let actions = if case.actions.is_empty() {
+        vec![EvalAction::Send {
+            prompt: case.prompt.clone(),
+            guidance: Vec::new(),
+            allow_error: false,
+        }]
+    } else {
+        case.actions.clone()
+    };
     let started = Instant::now();
-    let agent_result = agent.run(scenario.prompt, &output, None).await;
+    let timeout = Duration::from_millis(limits.timeout_ms.unwrap_or(DEFAULT_TIMEOUT_MS));
+    let execution = tokio::time::timeout(
+        timeout,
+        run_actions(
+            &case,
+            &actions,
+            &mut agent,
+            &provider_source,
+            vision_source.as_ref(),
+            max_context,
+            max_rounds,
+            output.as_ref(),
+            cancel.as_ref(),
+        ),
+    )
+    .await;
+    let agent_error = match execution {
+        Ok(Ok(())) => None,
+        Ok(Err(error)) => Some(error.to_string()),
+        Err(_) => {
+            cancel.store(true, Ordering::Relaxed);
+            Some(format!(
+                "scenario timed out after {} ms",
+                timeout.as_millis()
+            ))
+        }
+    };
     let duration_ms = started.elapsed().as_millis().min(u64::MAX as u128) as u64;
     let captured = output.snapshot();
     let after = snapshot_workspace(workspace.path())?;
-    let verification = match agent_result {
-        Ok(()) => verify_scenario(scenario.id, &before, &after, &captured),
-        Err(error) => Err(anyhow::anyhow!("agent error: {error}")),
-    };
-    let failure = verification.err().map(|error| error.to_string());
-
-    Ok((
-        ScenarioResult {
-            id: scenario.id.into(),
-            description: scenario.description.into(),
-            passed: failure.is_none(),
-            failure,
-            duration_ms,
-            rounds: captured.rounds,
-            tool_calls: captured.tool_calls,
-            tool_errors: captured.tool_errors,
-            input_tokens: captured.input_tokens,
-            output_tokens: captured.output_tokens,
-            reasoning_tokens: captured.reasoning_tokens,
-            cached_tokens: captured.cached_tokens,
-            completion: captured.completion,
-        },
-        tool_schema_hash,
-    ))
-}
-
-fn build_agent(cfg: ProviderConfig, root: &Path) -> (Agent, String) {
-    let skills = Arc::new(SkillIndex::default());
-    let memory = Arc::new(MemoryManager::new(root));
-    let mut agent = Agent::new(
-        cfg,
-        skills.clone(),
-        memory.clone(),
-        root.to_path_buf(),
-        MAX_CONTEXT_TOKENS,
-        MAX_ROUNDS,
-        false,
-        None,
+    let cost_microusd = calculate_cost(&captured, &options);
+    let mut failures = verify_case(
+        &case,
+        &before,
+        &after,
+        &captured,
+        agent_error.as_deref(),
+        provider_source.offline_snapshot().as_ref(),
     );
-    let allowed: Vec<String> = EVAL_TOOLS.iter().map(|tool| (*tool).to_string()).collect();
-    agent.tools = wisp_core::build_registry(skills.clone(), memory, false).filtered(&allowed);
-    agent.seed_system_prompt(&skills, None);
-    let schemas = serde_json::to_vec(&agent.tools.schemas()).expect("tool schemas serialize");
-    (agent, sha256_hex(&schemas))
+    apply_limits(
+        &limits,
+        &captured,
+        duration_ms,
+        cost_microusd,
+        &mut failures,
+    );
+
+    let trajectory_path = if let Some(artifacts) = &options.artifacts {
+        Some(write_trajectory(
+            artifacts,
+            &case,
+            repetition,
+            &captured,
+            provider_source.offline_snapshot().as_ref(),
+            vision_source
+                .as_ref()
+                .and_then(ProviderSource::offline_snapshot)
+                .as_ref(),
+        )?)
+    } else {
+        None
+    };
+    let failed_workspace = if !failures.is_empty() && options.keep_failed_workspace {
+        let artifacts = options
+            .artifacts
+            .as_ref()
+            .expect("validated artifacts requirement");
+        let target = artifacts.join("failed-workspaces").join(format!(
+            "{}-{}-{}",
+            safe_name(&case.id),
+            repetition,
+            uuid::Uuid::new_v4().simple()
+        ));
+        Some(workspace.preserve(&target)?.to_string_lossy().into_owned())
+    } else {
+        None
+    };
+
+    let passed = failures.is_empty();
+    eprintln!(
+        "  {} ({} ms, {} rounds, {} tool calls)",
+        if passed { "pass" } else { "FAIL" },
+        duration_ms,
+        captured.rounds,
+        captured.tool_calls.len()
+    );
+    Ok(ScenarioResult {
+        id: case.id,
+        description: case.description,
+        tags: case.tags,
+        repetition,
+        passed,
+        failures,
+        duration_ms,
+        rounds: captured.rounds,
+        tool_calls: captured.tool_calls,
+        tool_errors: captured.tool_errors,
+        input_tokens: captured.input_tokens,
+        output_tokens: captured.output_tokens,
+        reasoning_tokens: captured.reasoning_tokens,
+        cached_tokens: captured.cached_tokens,
+        cost_microusd,
+        completion: captured.completion,
+        agent_error,
+        trajectory_path: trajectory_path.map(|path| path.to_string_lossy().into_owned()),
+        failed_workspace,
+    })
 }
 
-fn setup_fixture(id: &str, root: &Path) -> Result<()> {
-    match id {
-        "read_facts" => write_fixture(root, "notes.txt", "alpha beta\n\ngamma delta\n"),
-        "search_files" => {
-            write_fixture(root, "src/analyze.py", "print('analysis')\n")?;
-            write_fixture(root, "tools/export.py", "print('export')\n")?;
-            write_fixture(root, "src/lib.rs", "pub fn analyze() {}\n")
+fn setup_workspace(case: &EvalCase, root: &Path) -> Result<()> {
+    for (path, contents) in &case.files {
+        write_fixture(root, path, contents.as_bytes())?;
+    }
+    for (path, encoded) in &case.base64_files {
+        let bytes = decode_base64(encoded)
+            .with_context(|| format!("invalid base64 fixture '{path}' in case '{}'", case.id))?;
+        write_fixture(root, path, &bytes)?;
+    }
+    Ok(())
+}
+
+fn decode_base64(value: &str) -> Result<Vec<u8>> {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut inverse = [u8::MAX; 256];
+    for (index, byte) in ALPHABET.iter().enumerate() {
+        inverse[*byte as usize] = index as u8;
+    }
+    let clean: Vec<_> = value
+        .bytes()
+        .filter(|byte| !byte.is_ascii_whitespace())
+        .collect();
+    if clean.len() % 4 != 0 {
+        bail!("base64 length is not divisible by four");
+    }
+    let mut out = Vec::new();
+    for chunk in clean.chunks(4) {
+        let mut numbers = [0u8; 4];
+        let mut padding = 0;
+        for (index, byte) in chunk.iter().enumerate() {
+            if *byte == b'=' {
+                padding += 1;
+                numbers[index] = 0;
+            } else {
+                let decoded = inverse[*byte as usize];
+                if decoded == u8::MAX {
+                    bail!("invalid base64 character");
+                }
+                numbers[index] = decoded;
+            }
         }
-        "grep_marker" => {
-            write_fixture(
-                root,
-                "src/analysis.py",
-                "# TODO(CALIBRATE): validate offset\nvalue = 3\n",
-            )?;
-            write_fixture(root, "docs/notes.md", "Calibration notes are pending.\n")
+        out.push((numbers[0] << 2) | (numbers[1] >> 4));
+        if padding < 2 {
+            out.push((numbers[1] << 4) | (numbers[2] >> 2));
         }
-        "targeted_edit" => write_fixture(root, "config.toml", "iterations = 10\nmode = \"fast\"\n"),
-        "derive_file" => {
-            write_fixture(root, "measurements.csv", "sample,value\na,1\nb,2\nc,3\n")?;
-            std::fs::create_dir_all(root.join("results"))?;
-            Ok(())
+        if padding == 0 {
+            out.push((numbers[2] << 6) | numbers[3]);
         }
-        "avoid_noop_edit" => {
-            write_fixture(root, "settings.json", "{\"enabled\":true,\"limit\":5}\n")
+    }
+    Ok(out)
+}
+
+fn build_agent(
+    case: &EvalCase,
+    root: &Path,
+    provider: &ProviderSource,
+    vision: Option<&ProviderSource>,
+    max_context: usize,
+    max_rounds: usize,
+) -> Result<Agent> {
+    let skill_paths = vec![root.join(".wisp").join("skills")];
+    let skills = Arc::new(SkillIndex::load(&skill_paths));
+    let memory = Arc::new(MemoryManager::new(root));
+    let mut registry = wisp_core::build_registry(skills.clone(), memory, false);
+    registry.add(Box::new(wisp_tools::ask_user::AskUserTool));
+    for (name, result) in &case.fixture_mcp {
+        registry.add(Box::new(FixtureMcpTool {
+            name: name.clone(),
+            result: result.clone(),
+        }));
+    }
+    if !case.explore_script.is_empty() {
+        let provider = Arc::new(ScriptedProvider::new(
+            "scripted-explore-v1",
+            case.explore_script.clone(),
+        ));
+        registry.add(Box::new(ExploreTool::new(provider, max_context)));
+    }
+    if case.fixture_runtimes {
+        let manager = wisp_runtime::RuntimeManager::new(Arc::new(EvalRuntimeLauncher));
+        let project_id = root.to_string_lossy().into_owned();
+        registry.add(Box::new(wisp_runtime::ReplTool::new(
+            manager.clone(),
+            &project_id,
+        )));
+        registry.add(Box::new(wisp_runtime::RTool::new(manager, project_id)));
+    }
+    if !case.allowed_tools.is_empty() {
+        registry = registry.filtered(&case.allowed_tools);
+    }
+    let mut agent = Agent::with_provider(
+        provider.build(),
+        vision.map(ProviderSource::build),
+        registry,
+        root.to_path_buf(),
+        max_context,
+        max_rounds,
+    );
+    agent.seed_system_prompt(&skills, None);
+    Ok(agent)
+}
+
+fn seed_context(ctx: &mut ContextManager, seeds: &[SeedMessage]) -> Result<()> {
+    for seed in seeds {
+        if seed.repeat == 0 {
+            bail!("context seed repeat must be at least 1");
         }
-        _ => bail!("unknown eval scenario '{id}'"),
+        let content = seed.content.repeat(seed.repeat);
+        match seed.role.as_str() {
+            "user" => ctx.append_user(&content),
+            "assistant" => ctx.append_assistant(content, vec![], None),
+            "system" => ctx.append_system(&content),
+            other => bail!("unsupported context seed role '{other}'"),
+        }
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_actions(
+    case: &EvalCase,
+    actions: &[EvalAction],
+    agent: &mut Agent,
+    provider: &ProviderSource,
+    vision: Option<&ProviderSource>,
+    max_context: usize,
+    max_rounds: usize,
+    output: &EvalOutput,
+    cancel: &AtomicBool,
+) -> Result<()> {
+    for action in actions {
+        match action {
+            EvalAction::Send {
+                prompt,
+                guidance,
+                allow_error,
+            } => {
+                let queue: GuidanceQueue = Mutex::new(
+                    guidance
+                        .iter()
+                        .enumerate()
+                        .map(|(index, value)| (index as u64 + 1, value.clone()))
+                        .collect(),
+                );
+                let result = agent
+                    .run_with_images(
+                        prompt,
+                        &[],
+                        false,
+                        output,
+                        Some(cancel),
+                        (!guidance.is_empty()).then_some(&queue),
+                    )
+                    .await;
+                if let Err(error) = result {
+                    output.push(
+                        "action_error",
+                        None,
+                        None,
+                        Some(false),
+                        Some(json!({"action": "send", "error": error.to_string()})),
+                    );
+                    if !allow_error {
+                        return Err(error);
+                    }
+                    cancel.store(false, Ordering::Relaxed);
+                }
+                agent.save();
+            }
+            EvalAction::Resume { allow_error } => {
+                let result = agent.run_resume(output, Some(cancel), None).await;
+                if let Err(error) = result {
+                    output.push(
+                        "action_error",
+                        None,
+                        None,
+                        Some(false),
+                        Some(json!({"action": "resume", "error": error.to_string()})),
+                    );
+                    if !allow_error {
+                        return Err(error);
+                    }
+                    cancel.store(false, Ordering::Relaxed);
+                }
+                agent.save();
+            }
+            EvalAction::Compact => {
+                output.compaction_started("manual");
+                let (before, after, _) = agent.compact().await.map_err(anyhow::Error::msg)?;
+                output.compaction(before, after, "manual");
+                agent.save();
+            }
+            EvalAction::Restart => {
+                agent.save();
+                *agent = build_agent(case, &agent.root, provider, vision, max_context, max_rounds)?;
+                if let Some(enabled) = case.auto_compact {
+                    agent.set_auto_compact(enabled);
+                }
+                output.push("restart", None, None, Some(true), None);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn verify_case(
+    case: &EvalCase,
+    before: &BTreeMap<String, Vec<u8>>,
+    after: &BTreeMap<String, Vec<u8>>,
+    captured: &Captured,
+    agent_error: Option<&str>,
+    provider: Option<&ScriptedProviderSnapshot>,
+) -> Vec<String> {
+    let mut failures = Vec::new();
+    match case.expect.outcome.as_str() {
+        "success" if agent_error.is_some() => failures.push(format!(
+            "agent returned an unexpected error: {}",
+            agent_error.unwrap_or_default()
+        )),
+        "error" if agent_error.is_none() => {
+            failures.push("agent succeeded but an error was expected".into())
+        }
+        _ => {}
+    }
+    if let Some(error) = agent_error {
+        for fragment in &case.expect.error_contains {
+            if !contains_folded(error, fragment) {
+                failures.push(format!("agent error did not contain '{fragment}'"));
+            }
+        }
+    }
+    for fragment in &case.expect.completion_contains {
+        if !captured
+            .completion
+            .as_deref()
+            .is_some_and(|completion| contains_folded(completion, fragment))
+        {
+            failures.push(format!("completion did not contain '{fragment}'"));
+        }
+    }
+    for tool in &case.expect.required_tools {
+        if !captured.tool_calls.iter().any(|call| &call.name == tool) {
+            failures.push(format!("required tool '{tool}' was not called"));
+        }
+    }
+    for tool in &case.expect.forbidden_tools {
+        if captured.tool_calls.iter().any(|call| &call.name == tool) {
+            failures.push(format!("forbidden tool '{tool}' was called"));
+        }
+    }
+    if !case.expect.tool_order.is_empty() {
+        let mut cursor = 0;
+        for call in &captured.tool_calls {
+            if case.expect.tool_order.get(cursor) == Some(&call.name) {
+                cursor += 1;
+            }
+        }
+        if cursor != case.expect.tool_order.len() {
+            failures.push(format!(
+                "required tool order {:?} was not observed in {:?}",
+                case.expect.tool_order,
+                captured
+                    .tool_calls
+                    .iter()
+                    .map(|call| call.name.as_str())
+                    .collect::<Vec<_>>()
+            ));
+        }
+    }
+    for expectation in &case.expect.tool_args {
+        let matched = captured
+            .tool_calls
+            .iter()
+            .filter(|call| call.name == expectation.name)
+            .any(|call| {
+                let actual = if expectation.pointer.is_empty() {
+                    Some(&call.arguments)
+                } else {
+                    call.arguments.pointer(&expectation.pointer)
+                };
+                actual == Some(&expectation.equals)
+            });
+        if !matched {
+            failures.push(format!(
+                "tool '{}' never had {} = {}",
+                expectation.name,
+                if expectation.pointer.is_empty() {
+                    "arguments"
+                } else {
+                    &expectation.pointer
+                },
+                expectation.equals
+            ));
+        }
+    }
+    if let Some(expected) = case.expect.approvals {
+        if captured.approvals.len() != expected {
+            failures.push(format!(
+                "expected {expected} approval request(s), observed {}",
+                captured.approvals.len()
+            ));
+        }
+    }
+    if let Some(provider) = provider {
+        for fragment in &case.expect.request_contains {
+            let found = provider.requests.iter().any(|request| {
+                request.messages.iter().any(|message| {
+                    contains_folded(&message.content.as_text(), fragment)
+                        || message
+                            .reasoning
+                            .as_deref()
+                            .is_some_and(|value| contains_folded(value, fragment))
+                })
+            });
+            if !found {
+                failures.push(format!("no provider request contained '{fragment}'"));
+            }
+        }
+        let expected_remaining = case.expect.remaining_script.unwrap_or(0);
+        if provider.remaining_completions != expected_remaining {
+            failures.push(format!(
+                "script has {} completion(s) remaining; expected {expected_remaining}",
+                provider.remaining_completions
+            ));
+        }
+    }
+    let mut expected = before.clone();
+    for path in &case.expect.deleted_files {
+        expected.remove(path);
+    }
+    for (path, contents) in &case.expect.expected_files {
+        expected.insert(path.clone(), contents.as_bytes().to_vec());
+    }
+    if &expected != after {
+        let paths: BTreeSet<_> = expected
+            .keys()
+            .chain(after.keys())
+            .filter(|path| expected.get(*path) != after.get(*path))
+            .cloned()
+            .collect();
+        failures.push(format!(
+            "workspace differed at: {}",
+            paths.into_iter().collect::<Vec<_>>().join(", ")
+        ));
+    }
+    failures
+}
+
+fn contains_folded(haystack: &str, needle: &str) -> bool {
+    haystack
+        .to_ascii_lowercase()
+        .replace('\\', "/")
+        .contains(&needle.to_ascii_lowercase().replace('\\', "/"))
+}
+
+fn apply_limits(
+    limits: &EvalLimits,
+    captured: &Captured,
+    duration_ms: u64,
+    cost_microusd: u64,
+    failures: &mut Vec<String>,
+) {
+    for (label, actual, maximum) in [
+        (
+            "rounds",
+            captured.rounds as u64,
+            limits.max_rounds.map(|value| value as u64),
+        ),
+        (
+            "tool calls",
+            captured.tool_calls.len() as u64,
+            limits.max_tool_calls,
+        ),
+        ("tool errors", captured.tool_errors, limits.max_tool_errors),
+        (
+            "input tokens",
+            captured.input_tokens,
+            limits.max_input_tokens,
+        ),
+        ("duration ms", duration_ms, limits.max_duration_ms),
+        ("cost microusd", cost_microusd, limits.max_cost_microusd),
+    ] {
+        if maximum.is_some_and(|maximum| actual > maximum) {
+            failures.push(format!(
+                "{label} exceeded limit: {actual} > {}",
+                maximum.unwrap_or_default()
+            ));
+        }
     }
 }
 
-fn write_fixture(root: &Path, relative: &str, content: &str) -> Result<()> {
+fn calculate_cost(captured: &Captured, options: &EvalOptions) -> u64 {
+    fn component(tokens: u64, rate: u64) -> u128 {
+        u128::from(tokens)
+            .saturating_mul(u128::from(rate))
+            .div_ceil(1_000_000)
+    }
+    component(
+        captured.input_tokens.saturating_sub(captured.cached_tokens),
+        options.input_cost_microusd_per_million,
+    )
+    .saturating_add(component(
+        captured.output_tokens,
+        options.output_cost_microusd_per_million,
+    ))
+    .saturating_add(component(
+        captured.reasoning_tokens,
+        options.reasoning_cost_microusd_per_million,
+    ))
+    .min(u128::from(u64::MAX)) as u64
+}
+
+fn write_trajectory(
+    artifacts: &Path,
+    case: &EvalCase,
+    repetition: usize,
+    captured: &Captured,
+    provider: Option<&ScriptedProviderSnapshot>,
+    vision_provider: Option<&ScriptedProviderSnapshot>,
+) -> Result<PathBuf> {
+    let dir = artifacts.join("trajectories");
+    std::fs::create_dir_all(&dir)?;
+    let path = dir.join(format!("{}-{repetition}.jsonl", safe_name(&case.id)));
+    let mut lines = String::new();
+    lines.push_str(&serde_json::to_string(&json!({
+        "schema": TRAJECTORY_SCHEMA,
+        "sequence": 0,
+        "kind": "metadata",
+        "case_id": case.id,
+        "repetition": repetition,
+        "provider_requests": provider,
+        "vision_provider_requests": vision_provider,
+    }))?);
+    lines.push('\n');
+    for event in &captured.events {
+        lines.push_str(&serde_json::to_string(event)?);
+        lines.push('\n');
+    }
+    std::fs::write(&path, lines)?;
+    Ok(path)
+}
+
+fn summarize(results: &[ScenarioResult]) -> ReportSummary {
+    let passed = results.iter().filter(|result| result.passed).count();
+    ReportSummary {
+        cases: results
+            .iter()
+            .map(|result| result.id.as_str())
+            .collect::<BTreeSet<_>>()
+            .len(),
+        attempts: results.len(),
+        passed,
+        pass_rate_percent: if results.is_empty() {
+            0
+        } else {
+            (passed as u64 * 100) / results.len() as u64
+        },
+        duration_ms: results.iter().map(|result| result.duration_ms).sum(),
+        rounds: results.iter().map(|result| result.rounds).sum(),
+        tool_calls: results
+            .iter()
+            .map(|result| result.tool_calls.len() as u64)
+            .sum(),
+        tool_errors: results.iter().map(|result| result.tool_errors).sum(),
+        input_tokens: results.iter().map(|result| result.input_tokens).sum(),
+        output_tokens: results.iter().map(|result| result.output_tokens).sum(),
+        reasoning_tokens: results.iter().map(|result| result.reasoning_tokens).sum(),
+        cached_tokens: results.iter().map(|result| result.cached_tokens).sum(),
+        cost_microusd: results.iter().map(|result| result.cost_microusd).sum(),
+    }
+}
+
+fn compare_reports(
+    current: &EvalReport,
+    baseline: &EvalReport,
+    path: &Path,
+    options: &EvalOptions,
+) -> BaselineComparison {
+    let mut warnings = Vec::new();
+    for (label, current_value, baseline_value) in [
+        (
+            "report schema",
+            current.schema.as_str(),
+            baseline.schema.as_str(),
+        ),
+        (
+            "suite",
+            current.suite_id.as_str(),
+            baseline.suite_id.as_str(),
+        ),
+        (
+            "suite hash",
+            current.suite_hash.as_str(),
+            baseline.suite_hash.as_str(),
+        ),
+        ("mode", current.mode.as_str(), baseline.mode.as_str()),
+        (
+            "provider",
+            current.provider.as_str(),
+            baseline.provider.as_str(),
+        ),
+        ("model", current.model.as_str(), baseline.model.as_str()),
+    ] {
+        if current_value != baseline_value {
+            warnings.push(format!("{label} differs"));
+        }
+    }
+    let baseline_passes: HashMap<_, _> = baseline
+        .scenarios
+        .iter()
+        .map(|result| ((result.id.clone(), result.repetition), result.passed))
+        .collect();
+    let current_passes: HashMap<_, _> = current
+        .scenarios
+        .iter()
+        .map(|result| ((result.id.clone(), result.repetition), result.passed))
+        .collect();
+    let regressions = baseline_passes
+        .iter()
+        .filter(|(key, passed)| **passed && current_passes.get(*key) == Some(&false))
+        .map(|((id, repetition), _)| format!("{id}#{repetition}"))
+        .collect();
+    let improvements = baseline_passes
+        .iter()
+        .filter(|(key, passed)| !**passed && current_passes.get(*key) == Some(&true))
+        .map(|((id, repetition), _)| format!("{id}#{repetition}"))
+        .collect();
+    let mut threshold_failures = Vec::new();
+    if let Some(percent) = options.max_token_regression_percent {
+        let allowed = baseline.summary.input_tokens.saturating_mul(100 + percent) / 100;
+        if current.summary.input_tokens > allowed {
+            threshold_failures.push(format!(
+                "input tokens regressed by more than {percent}%: {} > {allowed}",
+                current.summary.input_tokens
+            ));
+        }
+    }
+    if let Some(delta) = options.max_round_regression {
+        let allowed = baseline.summary.rounds.saturating_add(delta as usize);
+        if current.summary.rounds > allowed {
+            threshold_failures.push(format!(
+                "rounds regressed by more than {delta}: {} > {allowed}",
+                current.summary.rounds
+            ));
+        }
+    }
+    BaselineComparison {
+        baseline: path.to_string_lossy().into_owned(),
+        warnings,
+        regressions,
+        improvements,
+        threshold_failures,
+        passed_delta: delta(
+            current.summary.passed as u64,
+            baseline.summary.passed as u64,
+        ),
+        input_tokens_delta: delta(current.summary.input_tokens, baseline.summary.input_tokens),
+        rounds_delta: delta(
+            current.summary.rounds as u64,
+            baseline.summary.rounds as u64,
+        ),
+        duration_ms_delta: delta(current.summary.duration_ms, baseline.summary.duration_ms),
+    }
+}
+
+fn delta(current: u64, baseline: u64) -> i64 {
+    i128::from(current)
+        .saturating_sub(i128::from(baseline))
+        .clamp(i128::from(i64::MIN), i128::from(i64::MAX)) as i64
+}
+
+fn write_fixture(root: &Path, relative: &str, contents: &[u8]) -> Result<()> {
+    validate_relative_path(relative)?;
     let path = root.join(relative);
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    std::fs::write(path, content)?;
+    std::fs::write(path, contents)?;
     Ok(())
-}
-
-fn verify_scenario(
-    id: &str,
-    before: &BTreeMap<String, Vec<u8>>,
-    after: &BTreeMap<String, Vec<u8>>,
-    captured: &Captured,
-) -> Result<()> {
-    require_tool(captured, "attempt_completion")?;
-    let mut expected = before.clone();
-    match id {
-        "read_facts" => {
-            require_tool(captured, "read")?;
-            require_no_mutation_tools(captured)?;
-            require_completion(captured, &["lines=2", "first=alpha"])?;
-        }
-        "search_files" => {
-            require_tool(captured, "search")?;
-            require_no_mutation_tools(captured)?;
-            let completion = require_completion(captured, &["src/analyze.py", "tools/export.py"])?;
-            let completion = completion.to_ascii_lowercase().replace('\\', "/");
-            if completion.find("src/analyze.py") > completion.find("tools/export.py") {
-                bail!("Python paths were not reported in ascending order");
-            }
-        }
-        "grep_marker" => {
-            require_tool(captured, "grep")?;
-            require_no_mutation_tools(captured)?;
-            require_completion(captured, &["src/analysis.py", "calibrate"])?;
-        }
-        "targeted_edit" => {
-            require_tool(captured, "edit")?;
-            expected.insert(
-                "config.toml".into(),
-                b"iterations = 25\nmode = \"fast\"\n".to_vec(),
-            );
-        }
-        "derive_file" => {
-            require_tool(captured, "read")?;
-            require_tool(captured, "write")?;
-            expected.insert(
-                "results/summary.txt".into(),
-                b"count=3\nmean=2.0\n".to_vec(),
-            );
-        }
-        "avoid_noop_edit" => {
-            require_tool(captured, "read")?;
-            require_no_mutation_tools(captured)?;
-            require_completion(captured, &["enabled=true", "limit=5"])?;
-        }
-        _ => bail!("unknown eval scenario '{id}'"),
-    }
-    require_workspace(&expected, after)
-}
-
-fn require_tool(captured: &Captured, name: &str) -> Result<()> {
-    if captured.tool_calls.iter().any(|tool| tool == name) {
-        Ok(())
-    } else {
-        bail!("required tool '{name}' was not called")
-    }
-}
-
-fn require_no_mutation_tools(captured: &Captured) -> Result<()> {
-    if let Some(tool) = captured
-        .tool_calls
-        .iter()
-        .find(|tool| matches!(tool.as_str(), "write" | "edit"))
-    {
-        bail!("unexpected mutation tool '{tool}' was called");
-    }
-    Ok(())
-}
-
-fn require_completion<'a>(captured: &'a Captured, fragments: &[&str]) -> Result<&'a str> {
-    let completion = captured
-        .completion
-        .as_deref()
-        .context("attempt_completion returned no result")?;
-    let lowercase = completion.to_ascii_lowercase().replace('\\', "/");
-    for fragment in fragments {
-        if !lowercase.contains(&fragment.to_ascii_lowercase()) {
-            bail!("completion did not contain '{fragment}'");
-        }
-    }
-    Ok(completion)
-}
-
-fn require_workspace(
-    expected: &BTreeMap<String, Vec<u8>>,
-    actual: &BTreeMap<String, Vec<u8>>,
-) -> Result<()> {
-    if expected == actual {
-        return Ok(());
-    }
-    let paths: BTreeSet<_> = expected
-        .keys()
-        .chain(actual.keys())
-        .filter(|path| expected.get(*path) != actual.get(*path))
-        .cloned()
-        .collect();
-    bail!(
-        "workspace differed at: {}",
-        paths.into_iter().collect::<Vec<_>>().join(", ")
-    )
 }
 
 fn snapshot_workspace(root: &Path) -> Result<BTreeMap<String, Vec<u8>>> {
@@ -526,132 +1801,22 @@ fn snapshot_workspace(root: &Path) -> Result<BTreeMap<String, Vec<u8>>> {
         }
         Ok(())
     }
-
     let mut files = BTreeMap::new();
     visit(root, root, &mut files)?;
     Ok(files)
 }
 
-fn summarize(results: &[ScenarioResult]) -> ReportSummary {
-    ReportSummary {
-        total: results.len(),
-        passed: results.iter().filter(|result| result.passed).count(),
-        duration_ms: results.iter().map(|result| result.duration_ms).sum(),
-        rounds: results.iter().map(|result| result.rounds).sum(),
-        tool_calls: results
-            .iter()
-            .map(|result| result.tool_calls.len() as u64)
-            .sum(),
-        tool_errors: results.iter().map(|result| result.tool_errors).sum(),
-        input_tokens: results.iter().map(|result| result.input_tokens).sum(),
-        output_tokens: results.iter().map(|result| result.output_tokens).sum(),
-        reasoning_tokens: results.iter().map(|result| result.reasoning_tokens).sum(),
-        cached_tokens: results.iter().map(|result| result.cached_tokens).sum(),
-    }
-}
-
-fn compare_reports(current: &EvalReport, baseline: &EvalReport, path: &Path) -> BaselineComparison {
-    let mut warnings = Vec::new();
-    for (label, current_value, baseline_value) in [
-        (
-            "suite version",
-            current.suite_version.as_str(),
-            baseline.suite_version.as_str(),
-        ),
-        (
-            "scenario prompts",
-            current.scenario_prompt_hash.as_str(),
-            baseline.scenario_prompt_hash.as_str(),
-        ),
-        (
-            "tool schemas",
-            current.tool_schema_hash.as_str(),
-            baseline.tool_schema_hash.as_str(),
-        ),
-        (
-            "provider",
-            current.provider.as_str(),
-            baseline.provider.as_str(),
-        ),
-        ("model", current.model.as_str(), baseline.model.as_str()),
-    ] {
-        if current_value != baseline_value {
-            warnings.push(format!("{label} differ"));
-        }
-    }
-
-    let baseline_passes: BTreeMap<_, _> = baseline
-        .scenarios
-        .iter()
-        .map(|result| (result.id.as_str(), result.passed))
-        .collect();
-    let current_passes: BTreeMap<_, _> = current
-        .scenarios
-        .iter()
-        .map(|result| (result.id.as_str(), result.passed))
-        .collect();
-    if baseline_passes.keys().collect::<Vec<_>>() != current_passes.keys().collect::<Vec<_>>() {
-        warnings.push("scenario IDs differ".into());
-    }
-    let regressions = baseline_passes
-        .iter()
-        .filter(|(id, passed)| **passed && current_passes.get(*id) == Some(&false))
-        .map(|(id, _)| (*id).to_string())
-        .collect();
-    let improvements = baseline_passes
-        .iter()
-        .filter(|(id, passed)| !**passed && current_passes.get(*id) == Some(&true))
-        .map(|(id, _)| (*id).to_string())
-        .collect();
-
-    BaselineComparison {
-        baseline: path.to_string_lossy().into_owned(),
-        warnings,
-        passed_delta: delta(
-            current.summary.passed as u64,
-            baseline.summary.passed as u64,
-        ),
-        duration_ms_delta: delta(current.summary.duration_ms, baseline.summary.duration_ms),
-        rounds_delta: delta(
-            current.summary.rounds as u64,
-            baseline.summary.rounds as u64,
-        ),
-        tool_calls_delta: delta(current.summary.tool_calls, baseline.summary.tool_calls),
-        tool_errors_delta: delta(current.summary.tool_errors, baseline.summary.tool_errors),
-        input_tokens_delta: delta(current.summary.input_tokens, baseline.summary.input_tokens),
-        output_tokens_delta: delta(
-            current.summary.output_tokens,
-            baseline.summary.output_tokens,
-        ),
-        reasoning_tokens_delta: delta(
-            current.summary.reasoning_tokens,
-            baseline.summary.reasoning_tokens,
-        ),
-        cached_tokens_delta: delta(
-            current.summary.cached_tokens,
-            baseline.summary.cached_tokens,
-        ),
-        regressions,
-        improvements,
-    }
-}
-
-fn delta(current: u64, baseline: u64) -> i64 {
-    i128::from(current)
-        .saturating_sub(i128::from(baseline))
-        .clamp(i128::from(i64::MIN), i128::from(i64::MAX)) as i64
-}
-
-fn scenario_prompt_hash(catalog: &[Scenario]) -> String {
-    let mut bytes = Vec::new();
-    bytes.extend_from_slice(SUITE_VERSION.as_bytes());
-    for scenario in catalog {
-        bytes.extend_from_slice(scenario.id.as_bytes());
-        bytes.push(0);
-        bytes.extend_from_slice(scenario.prompt.as_bytes());
-        bytes.push(0xff);
-    }
-    sha256_hex(&bytes)
+fn safe_name(value: &str) -> String {
+    value
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || matches!(character, '-' | '_') {
+                character
+            } else {
+                '-'
+            }
+        })
+        .collect()
 }
 
 fn sha256_hex(bytes: &[u8]) -> String {
@@ -666,10 +1831,11 @@ static WORKSPACE_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 struct TempWorkspace {
     path: PathBuf,
     base: PathBuf,
+    preserved: bool,
 }
 
 impl TempWorkspace {
-    fn new(id: &str) -> Result<Self> {
+    fn new(id: &str, repetition: usize) -> Result<Self> {
         let base = std::env::temp_dir();
         let nonce = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -677,21 +1843,50 @@ impl TempWorkspace {
             .as_nanos();
         let sequence = WORKSPACE_SEQUENCE.fetch_add(1, Ordering::Relaxed);
         let path = base.join(format!(
-            "wisp-agent-eval-{}-{nonce}-{sequence}-{id}",
-            std::process::id()
+            "wisp-agent-eval-{}-{nonce}-{sequence}-{}-{repetition}",
+            std::process::id(),
+            safe_name(id)
         ));
         std::fs::create_dir(&path)
             .with_context(|| format!("could not create eval workspace {}", path.display()))?;
-        Ok(Self { path, base })
+        Ok(Self {
+            path,
+            base,
+            preserved: false,
+        })
     }
 
     fn path(&self) -> &Path {
         &self.path
     }
+
+    fn preserve(&mut self, target: &Path) -> Result<PathBuf> {
+        if target.exists() {
+            bail!(
+                "refusing to overwrite preserved eval workspace {}",
+                target.display()
+            );
+        }
+        if let Some(parent) = target.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::rename(&self.path, target).with_context(|| {
+            format!(
+                "could not preserve failed workspace {} as {}",
+                self.path.display(),
+                target.display()
+            )
+        })?;
+        self.preserved = true;
+        Ok(target.to_path_buf())
+    }
 }
 
 impl Drop for TempWorkspace {
     fn drop(&mut self) {
+        if self.preserved {
+            return;
+        }
         let is_eval_dir = self.path.parent() == Some(self.base.as_path())
             && self
                 .path
@@ -709,140 +1904,116 @@ mod tests {
     use super::*;
 
     #[test]
-    fn all_scenario_fixtures_accept_the_expected_outcome() {
-        for scenario in scenarios() {
-            let workspace = TempWorkspace::new(scenario.id).unwrap();
-            setup_fixture(scenario.id, workspace.path()).unwrap();
-            let before = snapshot_workspace(workspace.path()).unwrap();
-            let (tool_calls, completion) = expected_capture(scenario.id);
-            materialize_expected(scenario.id, workspace.path()).unwrap();
-            let after = snapshot_workspace(workspace.path()).unwrap();
-            let captured = Captured {
-                tool_calls,
-                completion: Some(completion.into()),
-                ..Captured::default()
-            };
-            verify_scenario(scenario.id, &before, &after, &captured).unwrap();
+    fn built_in_suite_is_valid_and_covers_p0_p1_domains() {
+        let suite: EvalSuite = serde_yaml::from_str(BUILTIN_SUITE).unwrap();
+        validate_suite(&suite, EvalMode::Offline).unwrap();
+        let tags: BTreeSet<_> = suite
+            .cases
+            .iter()
+            .flat_map(|case| case.tags.iter().map(String::as_str))
+            .collect();
+        for required in [
+            "filesystem",
+            "shell",
+            "skills",
+            "mcp",
+            "approval",
+            "resume",
+            "session",
+            "guidance",
+            "cancel",
+            "vision",
+            "compaction",
+            "delegation",
+            "python",
+            "r",
+        ] {
+            assert!(
+                tags.contains(required),
+                "missing built-in coverage tag {required}"
+            );
         }
     }
 
     #[test]
-    fn verifier_rejects_an_unexpected_workspace_change() {
-        let workspace = TempWorkspace::new("read_facts").unwrap();
-        setup_fixture("read_facts", workspace.path()).unwrap();
-        let before = snapshot_workspace(workspace.path()).unwrap();
-        write_fixture(workspace.path(), "extra.txt", "unexpected\n").unwrap();
-        let after = snapshot_workspace(workspace.path()).unwrap();
+    fn unsafe_fixture_paths_are_rejected() {
+        for path in ["", "../escape", "/absolute", "a/../../escape"] {
+            assert!(validate_relative_path(path).is_err(), "{path} should fail");
+        }
+        assert!(validate_relative_path("results/summary.txt").is_ok());
+    }
+
+    #[test]
+    fn cost_uses_uncached_input_and_declared_rates() {
         let captured = Captured {
-            tool_calls: vec!["read".into(), "attempt_completion".into()],
-            completion: Some("lines=2; first=alpha".into()),
+            input_tokens: 2_000_000,
+            cached_tokens: 1_000_000,
+            output_tokens: 500_000,
+            reasoning_tokens: 250_000,
             ..Captured::default()
         };
-        let error = verify_scenario("read_facts", &before, &after, &captured).unwrap_err();
-        assert!(error.to_string().contains("extra.txt"));
+        let options = EvalOptions {
+            input_cost_microusd_per_million: 10,
+            output_cost_microusd_per_million: 20,
+            reasoning_cost_microusd_per_million: 40,
+            ..EvalOptions::default()
+        };
+        assert_eq!(calculate_cost(&captured, &options), 30);
     }
 
     #[test]
-    fn baseline_comparison_reports_regressions_and_metric_deltas() {
-        let baseline = report(vec![
-            result("read_facts", true, 100, 10),
-            result("search_files", false, 200, 20),
-        ]);
-        let current = report(vec![
-            result("read_facts", false, 150, 15),
-            result("search_files", true, 250, 25),
-        ]);
-        let comparison = compare_reports(&current, &baseline, Path::new("baseline.json"));
-
-        assert_eq!(comparison.regressions, vec!["read_facts"]);
-        assert_eq!(comparison.improvements, vec!["search_files"]);
-        assert_eq!(comparison.duration_ms_delta, 100);
-        assert_eq!(comparison.input_tokens_delta, 10);
-    }
-
-    #[test]
-    fn prompt_hash_is_stable_and_sensitive_to_prompt_text() {
-        let catalog = scenarios();
-        let hash = scenario_prompt_hash(&catalog);
-        assert_eq!(hash, scenario_prompt_hash(&catalog));
-        let mut changed = catalog;
-        changed[0].prompt = "changed";
-        assert_ne!(hash, scenario_prompt_hash(&changed));
-    }
-
-    fn expected_capture(id: &str) -> (Vec<String>, &'static str) {
-        match id {
-            "read_facts" => (
-                vec!["read".into(), "attempt_completion".into()],
-                "lines=2; first=alpha",
-            ),
-            "search_files" => (
-                vec!["search".into(), "attempt_completion".into()],
-                "src/analyze.py\ntools/export.py",
-            ),
-            "grep_marker" => (
-                vec!["grep".into(), "attempt_completion".into()],
-                "src/analysis.py:1: CALIBRATE",
-            ),
-            "targeted_edit" => (
-                vec!["edit".into(), "attempt_completion".into()],
-                "updated config",
-            ),
-            "derive_file" => (
-                vec!["read".into(), "write".into(), "attempt_completion".into()],
-                "wrote summary",
-            ),
-            "avoid_noop_edit" => (
-                vec!["read".into(), "attempt_completion".into()],
-                "enabled=true; limit=5",
-            ),
-            _ => panic!("unknown scenario"),
-        }
-    }
-
-    fn materialize_expected(id: &str, root: &Path) -> Result<()> {
-        match id {
-            "targeted_edit" => {
-                write_fixture(root, "config.toml", "iterations = 25\nmode = \"fast\"\n")
-            }
-            "derive_file" => write_fixture(root, "results/summary.txt", "count=3\nmean=2.0\n"),
-            _ => Ok(()),
-        }
-    }
-
-    fn result(id: &str, passed: bool, duration_ms: u64, input_tokens: u64) -> ScenarioResult {
-        ScenarioResult {
-            id: id.into(),
-            description: String::new(),
-            passed,
-            failure: None,
-            duration_ms,
-            rounds: 1,
-            tool_calls: vec!["attempt_completion".into()],
-            tool_errors: 0,
-            input_tokens,
-            output_tokens: 1,
-            reasoning_tokens: 0,
-            cached_tokens: 0,
-            completion: None,
-        }
-    }
-
-    fn report(scenarios: Vec<ScenarioResult>) -> EvalReport {
-        EvalReport {
-            suite_version: SUITE_VERSION.into(),
-            wisp_version: "test".into(),
-            generated_at: String::new(),
-            provider: "test".into(),
-            model: "test".into(),
-            max_context_tokens: MAX_CONTEXT_TOKENS,
-            max_rounds: MAX_ROUNDS,
-            tools: Vec::new(),
-            scenario_prompt_hash: "prompts".into(),
-            tool_schema_hash: "tools".into(),
-            summary: summarize(&scenarios),
-            scenarios,
-            comparison: None,
-        }
+    fn verifier_checks_tool_argument_json_pointer() {
+        let case = EvalCase {
+            id: "args".into(),
+            description: "args".into(),
+            tags: vec![],
+            prompt: "args".into(),
+            actions: vec![],
+            files: BTreeMap::new(),
+            base64_files: BTreeMap::new(),
+            allowed_tools: vec![],
+            script: vec![ScriptedCompletion::default()],
+            vision_script: vec![],
+            explore_script: vec![],
+            fixture_runtimes: false,
+            fixture_mcp: BTreeMap::new(),
+            context_seed: vec![],
+            approval: EvalApproval::default(),
+            plan_mode: false,
+            cancel_after_ms: None,
+            auto_compact: None,
+            limits: EvalLimits::default(),
+            expect: EvalExpectation {
+                tool_args: vec![ToolArgumentExpectation {
+                    name: "read".into(),
+                    pointer: "/path".into(),
+                    equals: json!("notes.txt"),
+                }],
+                remaining_script: Some(0),
+                ..EvalExpectation::default()
+            },
+        };
+        let captured = Captured {
+            tool_calls: vec![ToolCallRecord {
+                call_id: "c1".into(),
+                name: "read".into(),
+                arguments: json!({"path": "notes.txt"}),
+            }],
+            ..Captured::default()
+        };
+        let provider = ScriptedProviderSnapshot {
+            model: "fixture".into(),
+            requests: vec![],
+            remaining_completions: 0,
+        };
+        assert!(verify_case(
+            &case,
+            &BTreeMap::new(),
+            &BTreeMap::new(),
+            &captured,
+            None,
+            Some(&provider)
+        )
+        .is_empty());
     }
 }

--- a/crates/wisp-cli/src/main.rs
+++ b/crates/wisp-cli/src/main.rs
@@ -1,19 +1,37 @@
 mod eval;
+mod rpc;
 
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
+use std::collections::VecDeque;
 use std::io::{IsTerminal, Write};
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use wisp_core::{Agent, MemoryManager, Output};
-use wisp_llm::ProviderConfig;
+use wisp_llm::{Message, ProviderConfig, ToolCall};
 use wisp_skills::SkillIndex;
 
 const HELP: &str = "Built-in commands:\n  /q, /quit       Quit\n  /n, /new        Start a new session (old session is backed up)\n  /c, /compact    Compact the context (full history is archived to .wisp/history/ first)\n  /h, /help       Show this help";
+const EVENT_SCHEMA: &str = "wisp.agent-event.v1";
 const USAGE: &str = "Usage:
   wisp-science
   wisp-science run [--output console|jsonl] <prompt>
-  wisp-science eval [--save report.json] [--compare baseline.json]
+  wisp-science rpc
+  wisp-science eval [--mode offline|live] [--suite suite.yaml] [options]
   wisp-science dev
+
+Eval defaults to the built-in deterministic offline suite and requires no API key.
+Use --mode live for a real configured model. Common options:
+  --case ID                 Run one case (repeatable)
+  --tag TAG                 Require a case tag (repeatable)
+  --repeat N                Repeat every selected case
+  --parallel N              Maximum concurrent cases
+  --timeout-ms N            Per-case wall-time timeout
+  --artifacts DIR           Write trajectory JSONL files
+  --keep-failed-workspace   Preserve failed workspaces under --artifacts
+  --save REPORT             Save the JSON report
+  --compare BASELINE        Compare against an eval v1 report
+  --min-pass-rate PERCENT   Required attempt pass rate (default 100)
 
 With no command, wisp-science starts the interactive terminal.";
 
@@ -24,10 +42,8 @@ enum CliCommand {
         prompt: String,
         output: OutputFormat,
     },
-    Eval {
-        save: Option<PathBuf>,
-        compare: Option<PathBuf>,
-    },
+    Eval(eval::EvalOptions),
+    Rpc,
     Dev,
     Help,
 }
@@ -48,7 +64,7 @@ fn parse_output(value: &str) -> Result<OutputFormat> {
 }
 
 fn parse_command(args: impl IntoIterator<Item = String>) -> Result<CliCommand> {
-    let mut args = args.into_iter();
+    let mut args = args.into_iter().collect::<Vec<_>>().into_iter();
     let Some(command) = args.next() else {
         return Ok(CliCommand::Interactive);
     };
@@ -59,6 +75,12 @@ fn parse_command(args: impl IntoIterator<Item = String>) -> Result<CliCommand> {
                 bail!("dev does not accept arguments");
             }
             Ok(CliCommand::Dev)
+        }
+        "rpc" => {
+            if args.next().is_some() {
+                bail!("rpc does not accept arguments");
+            }
+            Ok(CliCommand::Rpc)
         }
         "-h" | "--help" | "help" => Ok(CliCommand::Help),
         "run" => {
@@ -94,25 +116,91 @@ fn parse_command(args: impl IntoIterator<Item = String>) -> Result<CliCommand> {
             })
         }
         "eval" => {
-            let mut save = None;
-            let mut compare = None;
+            let mut options = eval::EvalOptions::default();
             while let Some(arg) = args.next() {
-                let target = match arg.as_str() {
-                    "--save" => &mut save,
-                    "--compare" => &mut compare,
-                    _ => bail!("unknown eval option '{arg}'"),
+                let value = |args: &mut std::vec::IntoIter<String>| -> Result<String> {
+                    args.next()
+                        .ok_or_else(|| anyhow::anyhow!("{arg} requires a value"))
                 };
-                let value = args
-                    .next()
-                    .ok_or_else(|| anyhow::anyhow!("{arg} requires a path"))?;
-                if target.replace(PathBuf::from(value)).is_some() {
-                    bail!("{arg} may only be specified once");
+                match arg.as_str() {
+                    "--mode" => options.mode = eval::EvalMode::parse(&value(&mut args)?)?,
+                    "--suite" => replace_path(&mut options.suite, &arg, value(&mut args)?)?,
+                    "--save" => replace_path(&mut options.save, &arg, value(&mut args)?)?,
+                    "--compare" => replace_path(&mut options.compare, &arg, value(&mut args)?)?,
+                    "--artifacts" => replace_path(&mut options.artifacts, &arg, value(&mut args)?)?,
+                    "--case" => options.cases.push(value(&mut args)?),
+                    "--tag" => options.tags.push(value(&mut args)?),
+                    "--repeat" => options.repeat = parse_usize(&arg, &value(&mut args)?)?,
+                    "--parallel" => options.parallel = parse_usize(&arg, &value(&mut args)?)?,
+                    "--timeout-ms" => {
+                        options.timeout_ms = Some(parse_u64(&arg, &value(&mut args)?)?)
+                    }
+                    "--max-tool-calls" => {
+                        options.max_tool_calls = Some(parse_u64(&arg, &value(&mut args)?)?)
+                    }
+                    "--max-input-tokens" => {
+                        options.max_input_tokens = Some(parse_u64(&arg, &value(&mut args)?)?)
+                    }
+                    "--max-duration-ms" => {
+                        options.max_duration_ms = Some(parse_u64(&arg, &value(&mut args)?)?)
+                    }
+                    "--max-cost-microusd" => {
+                        options.max_cost_microusd = Some(parse_u64(&arg, &value(&mut args)?)?)
+                    }
+                    "--input-cost-microusd-per-million" => {
+                        options.input_cost_microusd_per_million =
+                            parse_u64(&arg, &value(&mut args)?)?
+                    }
+                    "--output-cost-microusd-per-million" => {
+                        options.output_cost_microusd_per_million =
+                            parse_u64(&arg, &value(&mut args)?)?
+                    }
+                    "--reasoning-cost-microusd-per-million" => {
+                        options.reasoning_cost_microusd_per_million =
+                            parse_u64(&arg, &value(&mut args)?)?
+                    }
+                    "--max-token-regression-percent" => {
+                        options.max_token_regression_percent =
+                            Some(parse_percent(&arg, &value(&mut args)?)?)
+                    }
+                    "--max-round-regression" => {
+                        options.max_round_regression = Some(parse_u64(&arg, &value(&mut args)?)?)
+                    }
+                    "--min-pass-rate" => {
+                        options.min_pass_rate_percent = parse_percent(&arg, &value(&mut args)?)?
+                    }
+                    "--keep-failed-workspace" => options.keep_failed_workspace = true,
+                    "--allow-regressions" => options.allow_regressions = true,
+                    _ => bail!("unknown eval option '{arg}'"),
                 }
             }
-            Ok(CliCommand::Eval { save, compare })
+            Ok(CliCommand::Eval(options))
         }
         _ => bail!("unknown command '{command}'\n\n{USAGE}"),
     }
+}
+
+fn replace_path(target: &mut Option<PathBuf>, option: &str, value: String) -> Result<()> {
+    if target.replace(PathBuf::from(value)).is_some() {
+        bail!("{option} may only be specified once");
+    }
+    Ok(())
+}
+
+fn parse_u64(option: &str, value: &str) -> Result<u64> {
+    value
+        .parse()
+        .with_context(|| format!("{option} requires a non-negative integer"))
+}
+
+fn parse_usize(option: &str, value: &str) -> Result<usize> {
+    value
+        .parse()
+        .with_context(|| format!("{option} requires a non-negative integer"))
+}
+
+fn parse_percent(option: &str, value: &str) -> Result<u64> {
+    parse_u64(option, value.trim_end_matches('%'))
 }
 
 struct CliOutput;
@@ -263,6 +351,14 @@ impl Output for CliOutput {
             self.reset()
         );
     }
+
+    fn compaction_started(&self, strategy: &str) {
+        println!(
+            "{}[compact {strategy}] preparing checkpoint...{}",
+            self.yellow(),
+            self.reset()
+        );
+    }
     fn compaction(&self, before: usize, after: usize, strategy: &str) {
         println!(
             "{}[compact {}] {} → {} (-{}){}",
@@ -305,16 +401,33 @@ impl Output for CliOutput {
 
 struct JsonlOutput<W> {
     writer: Mutex<W>,
+    sequence: AtomicU64,
+    session_id: String,
+    turn_id: String,
+    pending_calls: Mutex<VecDeque<ToolCall>>,
+    active_call_ids: Mutex<VecDeque<String>>,
 }
 
 impl<W: Write + Send> JsonlOutput<W> {
     fn new(writer: W) -> Self {
         Self {
             writer: Mutex::new(writer),
+            sequence: AtomicU64::new(0),
+            session_id: uuid::Uuid::new_v4().to_string(),
+            turn_id: uuid::Uuid::new_v4().to_string(),
+            pending_calls: Mutex::new(VecDeque::new()),
+            active_call_ids: Mutex::new(VecDeque::new()),
         }
     }
 
-    fn emit(&self, event: serde_json::Value) {
+    fn emit(&self, mut event: serde_json::Value) {
+        let sequence = self.sequence.fetch_add(1, Ordering::Relaxed);
+        if let Some(object) = event.as_object_mut() {
+            object.insert("schema".into(), EVENT_SCHEMA.into());
+            object.insert("sequence".into(), sequence.into());
+            object.insert("session_id".into(), self.session_id.clone().into());
+            object.insert("turn_id".into(), self.turn_id.clone().into());
+        }
         let Ok(mut writer) = self.writer.lock() else {
             return;
         };
@@ -362,16 +475,41 @@ impl<W: Write + Send> Output for JsonlOutput<W> {
     }
 
     fn tool_call(&self, name: &str, preview: &str) {
+        let call = self.pending_calls.lock().ok().and_then(|mut calls| {
+            calls
+                .iter()
+                .position(|call| call.function.name == name)
+                .and_then(|index| calls.remove(index))
+        });
+        let (call_id, arguments) = call
+            .map(|call| {
+                let arguments = call.args_value();
+                (Some(call.id), Some(arguments))
+            })
+            .unwrap_or_default();
+        if let Some(call_id) = &call_id {
+            if let Ok(mut active) = self.active_call_ids.lock() {
+                active.push_back(call_id.clone());
+            }
+        }
         self.emit(serde_json::json!({
             "type": "tool_call",
+            "call_id": call_id,
             "name": name,
+            "arguments": arguments,
             "preview": preview,
         }));
     }
 
     fn tool_result(&self, name: &str, ok: bool, content: &str, duration_ms: u64) {
+        let call_id = self
+            .active_call_ids
+            .lock()
+            .ok()
+            .and_then(|mut ids| ids.pop_front());
         self.emit(serde_json::json!({
             "type": "tool_result",
+            "call_id": call_id,
             "name": name,
             "ok": ok,
             "content": content,
@@ -399,6 +537,13 @@ impl<W: Write + Send> Output for JsonlOutput<W> {
             "cached_tokens": cached,
             "context_tokens": ctx_tokens,
             "max_context_tokens": max_context,
+        }));
+    }
+
+    fn compaction_started(&self, strategy: &str) {
+        self.emit(serde_json::json!({
+            "type": "compaction_started",
+            "strategy": strategy,
         }));
     }
 
@@ -451,6 +596,23 @@ impl<W: Write + Send> Output for JsonlOutput<W> {
             "approved": false,
         }));
         false
+    }
+
+    fn on_message(&self, message: &Message) {
+        if !message.tool_calls.is_empty() {
+            if let Ok(mut calls) = self.pending_calls.lock() {
+                calls.extend(message.tool_calls.iter().cloned());
+            }
+        }
+        self.emit(serde_json::json!({
+            "type": "message",
+            "role": message.role,
+            "content": message.content,
+            "reasoning": message.reasoning,
+            "tool_call_id": message.tool_call_id,
+            "tool_name": message.tool_name,
+            "tool_calls": message.tool_calls,
+        }));
     }
 }
 
@@ -581,10 +743,11 @@ async fn main() -> Result<()> {
     }
     let jsonl = matches!(
         &command,
-        CliCommand::Run {
-            output: OutputFormat::Jsonl,
-            ..
-        }
+        CliCommand::Rpc
+            | CliCommand::Run {
+                output: OutputFormat::Jsonl,
+                ..
+            }
     );
 
     tracing_subscriber::fmt()
@@ -593,23 +756,32 @@ async fn main() -> Result<()> {
         )
         .init();
 
+    if let CliCommand::Eval(options) = &command {
+        let live_config = if options.mode == eval::EvalMode::Live {
+            Some(provider_config()?)
+        } else {
+            None
+        };
+        return eval::run(live_config, options).await;
+    }
     let cfg = match provider_config() {
         Ok(cfg) => cfg,
         Err(error) => {
-            if jsonl {
+            if command == CliCommand::Rpc {
+                rpc::startup_error(&error);
+            } else if jsonl {
                 JsonlOutput::new(std::io::stdout()).error(&error);
             }
             return Err(error);
         }
     };
-    if let CliCommand::Eval { save, compare } = &command {
-        return eval::run(cfg, save.as_deref(), compare.as_deref()).await;
-    }
     let root = match std::env::current_dir() {
         Ok(root) => root,
         Err(error) => {
             let error = anyhow::Error::from(error);
-            if jsonl {
+            if command == CliCommand::Rpc {
+                rpc::startup_error(&error);
+            } else if jsonl {
                 JsonlOutput::new(std::io::stdout()).error(&error);
             }
             return Err(error);
@@ -731,6 +903,11 @@ async fn main() -> Result<()> {
     }
 
     let out = CliOutput;
+    if command == CliCommand::Rpc {
+        let result = rpc::serve(agent).await;
+        runtime_manager.shutdown_all().await;
+        return result;
+    }
     if let CliCommand::Run { prompt, output } = command {
         let result = match output {
             OutputFormat::Console => {
@@ -835,6 +1012,7 @@ mod tests {
     fn parses_interactive_and_dev_commands() {
         assert_eq!(command(&[]).unwrap(), CliCommand::Interactive);
         assert_eq!(command(&["dev"]).unwrap(), CliCommand::Dev);
+        assert_eq!(command(&["rpc"]).unwrap(), CliCommand::Rpc);
         assert_eq!(command(&["--help"]).unwrap(), CliCommand::Help);
     }
 
@@ -885,6 +1063,9 @@ mod tests {
 
     #[test]
     fn parses_eval_paths_and_rejects_duplicate_options() {
+        let mut expected = eval::EvalOptions::default();
+        expected.save = Some(PathBuf::from("current.json"));
+        expected.compare = Some(PathBuf::from("baseline.json"));
         assert_eq!(
             command(&[
                 "eval",
@@ -894,15 +1075,12 @@ mod tests {
                 "baseline.json"
             ])
             .unwrap(),
-            CliCommand::Eval {
-                save: Some(PathBuf::from("current.json")),
-                compare: Some(PathBuf::from("baseline.json")),
-            }
+            CliCommand::Eval(expected)
         );
         assert!(command(&["eval", "--save"])
             .unwrap_err()
             .to_string()
-            .contains("requires a path"));
+            .contains("requires a value"));
         assert!(command(&["eval", "--save", "one", "--save", "two"])
             .unwrap_err()
             .to_string()
@@ -933,6 +1111,39 @@ mod tests {
         assert_eq!(events[3]["duration_ms"], 12);
         assert_eq!(events[4]["input_tokens"], 10);
         assert_eq!(events[5]["approved"], false);
-        assert_eq!(events[6], serde_json::json!({"type": "done", "ok": true}));
+        assert_eq!(events[6]["type"], "done");
+        assert_eq!(events[6]["ok"], true);
+        for (sequence, event) in events.iter().enumerate() {
+            assert_eq!(event["schema"], EVENT_SCHEMA);
+            assert_eq!(event["sequence"], sequence);
+            assert!(event["session_id"].is_string());
+            assert!(event["turn_id"].is_string());
+        }
+    }
+
+    #[test]
+    fn jsonl_output_correlates_full_tool_calls_and_results() {
+        let output = JsonlOutput::new(Vec::new());
+        let mut message = Message::assistant("");
+        message.tool_calls.push(ToolCall {
+            id: "call-42".into(),
+            kind: "function".into(),
+            function: wisp_llm::FunctionCall {
+                name: "read".into(),
+                arguments: serde_json::json!({"path": "notes.txt"}).to_string(),
+            },
+        });
+        output.on_message(&message);
+        output.tool_call("read", "notes.txt");
+        output.tool_result("read", true, "contents", 3);
+
+        let events: Vec<serde_json::Value> = String::from_utf8(output.into_inner())
+            .unwrap()
+            .lines()
+            .map(|line| serde_json::from_str(line).unwrap())
+            .collect();
+        assert_eq!(events[1]["call_id"], "call-42");
+        assert_eq!(events[1]["arguments"]["path"], "notes.txt");
+        assert_eq!(events[2]["call_id"], "call-42");
     }
 }

--- a/crates/wisp-cli/src/rpc.rs
+++ b/crates/wisp-cli/src/rpc.rs
@@ -1,0 +1,533 @@
+use anyhow::{Context, Result};
+use serde::Deserialize;
+use serde_json::{json, Value};
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::io::{BufRead, Write};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use wisp_core::{Agent, Output, OutputFuture};
+use wisp_llm::{Message, ToolCall};
+use wisp_tools::{Approval, ConfirmDecision};
+
+pub const RPC_SCHEMA: &str = "wisp.agent-rpc.v1";
+
+#[derive(Debug, Deserialize)]
+struct CommandEnvelope {
+    schema: String,
+    id: String,
+    #[serde(flatten)]
+    command: RpcCommand,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum RpcCommand {
+    Prompt {
+        prompt: String,
+    },
+    Cancel,
+    ApprovalResponse {
+        approval_id: String,
+        approved: bool,
+        #[serde(default)]
+        feedback: Option<String>,
+    },
+    Ping,
+    Shutdown,
+}
+
+struct RpcOutput<W> {
+    writer: Mutex<W>,
+    sequence: AtomicU64,
+    session_id: String,
+    command_id: Mutex<Option<String>>,
+    pending_calls: Mutex<VecDeque<ToolCall>>,
+    active_call_ids: Mutex<VecDeque<String>>,
+    approvals: Mutex<HashMap<String, tokio::sync::oneshot::Sender<ConfirmDecision>>>,
+}
+
+impl<W: Write + Send> RpcOutput<W> {
+    fn new(writer: W) -> Self {
+        Self {
+            writer: Mutex::new(writer),
+            sequence: AtomicU64::new(0),
+            session_id: uuid::Uuid::new_v4().to_string(),
+            command_id: Mutex::new(None),
+            pending_calls: Mutex::new(VecDeque::new()),
+            active_call_ids: Mutex::new(VecDeque::new()),
+            approvals: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn set_command(&self, command_id: Option<String>) {
+        if let Ok(mut current) = self.command_id.lock() {
+            *current = command_id;
+        }
+    }
+
+    fn emit(&self, mut event: Value) {
+        let sequence = self.sequence.fetch_add(1, Ordering::Relaxed);
+        if let Some(object) = event.as_object_mut() {
+            object.insert("schema".into(), RPC_SCHEMA.into());
+            object.insert("sequence".into(), sequence.into());
+            object.insert("session_id".into(), self.session_id.clone().into());
+            if let Some(id) = self.command_id.lock().ok().and_then(|id| id.clone()) {
+                object.insert("command_id".into(), id.into());
+            }
+        }
+        let Ok(mut writer) = self.writer.lock() else {
+            return;
+        };
+        if serde_json::to_writer(&mut *writer, &event).is_ok() {
+            let _ = writer.write_all(b"\n");
+            let _ = writer.flush();
+        }
+    }
+
+    fn emit_for(&self, command_id: &str, event: Value) {
+        let previous = self.command_id.lock().ok().and_then(|id| id.clone());
+        self.set_command(Some(command_id.to_string()));
+        self.emit(event);
+        self.set_command(previous);
+    }
+
+    fn resolve_approval(
+        &self,
+        approval_id: &str,
+        approved: bool,
+        feedback: Option<String>,
+    ) -> bool {
+        let sender = self
+            .approvals
+            .lock()
+            .ok()
+            .and_then(|mut pending| pending.remove(approval_id));
+        let decision = if approved {
+            ConfirmDecision::Approved
+        } else {
+            ConfirmDecision::Denied { feedback }
+        };
+        sender.is_some_and(|sender| sender.send(decision).is_ok())
+    }
+
+    fn reject_pending_approvals(&self) {
+        let pending = self
+            .approvals
+            .lock()
+            .map(|mut approvals| {
+                approvals
+                    .drain()
+                    .map(|(_, sender)| sender)
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        for sender in pending {
+            let _ = sender.send(ConfirmDecision::Denied {
+                feedback: Some("turn cancelled".into()),
+            });
+        }
+    }
+}
+
+impl<W: Write + Send> Output for RpcOutput<W> {
+    fn assistant_text(&self, delta: &str) {
+        self.emit(json!({"type": "text", "delta": delta}));
+    }
+
+    fn reasoning(&self, delta: &str) {
+        self.emit(json!({"type": "reasoning", "delta": delta}));
+    }
+
+    fn tool_call(&self, name: &str, preview: &str) {
+        let call = self.pending_calls.lock().ok().and_then(|mut calls| {
+            calls
+                .iter()
+                .position(|call| call.function.name == name)
+                .and_then(|index| calls.remove(index))
+        });
+        let (call_id, arguments) = call
+            .map(|call| {
+                let arguments = call.args_value();
+                (Some(call.id), Some(arguments))
+            })
+            .unwrap_or_default();
+        if let Some(call_id) = &call_id {
+            if let Ok(mut active) = self.active_call_ids.lock() {
+                active.push_back(call_id.clone());
+            }
+        }
+        self.emit(json!({
+            "type": "tool_call",
+            "call_id": call_id,
+            "name": name,
+            "arguments": arguments,
+            "preview": preview,
+        }));
+    }
+
+    fn tool_result(&self, name: &str, ok: bool, content: &str, duration_ms: u64) {
+        let call_id = self
+            .active_call_ids
+            .lock()
+            .ok()
+            .and_then(|mut ids| ids.pop_front());
+        self.emit(json!({
+            "type": "tool_result",
+            "call_id": call_id,
+            "name": name,
+            "ok": ok,
+            "content": content,
+            "duration_ms": duration_ms,
+        }));
+    }
+
+    fn usage(
+        &self,
+        round: usize,
+        input: u64,
+        output: u64,
+        reasoning: u64,
+        cached: u64,
+        ctx_tokens: usize,
+        max_context: usize,
+        context_usage: wisp_core::ContextUsage,
+    ) {
+        self.emit(json!({
+            "type": "usage",
+            "round": round,
+            "input_tokens": input,
+            "output_tokens": output,
+            "reasoning_tokens": reasoning,
+            "cached_tokens": cached,
+            "context_tokens": ctx_tokens,
+            "max_context_tokens": max_context,
+            "context_usage": context_usage,
+        }));
+    }
+
+    fn compaction_started(&self, strategy: &str) {
+        self.emit(json!({"type": "compaction_started", "strategy": strategy}));
+    }
+
+    fn compaction(&self, before: usize, after: usize, strategy: &str) {
+        self.emit(json!({
+            "type": "compaction",
+            "before_tokens": before,
+            "after_tokens": after,
+            "strategy": strategy,
+        }));
+    }
+
+    fn context_warning(&self, ctx_tokens: usize, max_context: usize) {
+        self.emit(json!({
+            "type": "context_warning",
+            "context_tokens": ctx_tokens,
+            "max_context_tokens": max_context,
+        }));
+    }
+
+    fn diff(&self, path: &str, old: &str, new: &str) {
+        self.emit(json!({"type": "diff", "path": path, "old": old, "new": new}));
+    }
+
+    fn file_changed(&self, path: &str) {
+        self.emit(json!({"type": "file_changed", "path": path}));
+    }
+
+    fn stdout_chunk(&self, chunk: &str) {
+        self.emit(json!({"type": "stdout", "chunk": chunk}));
+    }
+
+    fn tool_presentation(&self, kind: &str, payload: &Value) {
+        self.emit(json!({"type": "tool_presentation", "kind": kind, "payload": payload}));
+    }
+
+    fn approval_mode(&self, _tool: &str) -> Approval {
+        Approval::Allow
+    }
+
+    fn confirm_decision_async<'a>(&'a self, message: &'a str) -> OutputFuture<'a, ConfirmDecision> {
+        Box::pin(async move {
+            let approval_id = uuid::Uuid::new_v4().to_string();
+            let (sender, receiver) = tokio::sync::oneshot::channel();
+            if let Ok(mut approvals) = self.approvals.lock() {
+                approvals.insert(approval_id.clone(), sender);
+            } else {
+                return ConfirmDecision::Denied {
+                    feedback: Some("approval state unavailable".into()),
+                };
+            }
+            self.emit(json!({
+                "type": "approval_required",
+                "approval_id": approval_id,
+                "message": message,
+            }));
+            receiver.await.unwrap_or(ConfirmDecision::Denied {
+                feedback: Some("approval channel closed".into()),
+            })
+        })
+    }
+
+    fn confirm_async<'a>(&'a self, message: &'a str) -> OutputFuture<'a, bool> {
+        Box::pin(async move {
+            matches!(
+                self.confirm_decision_async(message).await,
+                ConfirmDecision::Approved
+            )
+        })
+    }
+
+    fn on_message(&self, message: &Message) {
+        if !message.tool_calls.is_empty() {
+            if let Ok(mut calls) = self.pending_calls.lock() {
+                calls.extend(message.tool_calls.iter().cloned());
+            }
+        }
+        self.emit(json!({
+            "type": "message",
+            "role": message.role,
+            "content": message.content,
+            "reasoning": message.reasoning,
+            "tool_call_id": message.tool_call_id,
+            "tool_name": message.tool_name,
+            "tool_calls": message.tool_calls,
+        }));
+    }
+}
+
+pub async fn serve(mut agent: Agent) -> Result<()> {
+    let output = Arc::new(RpcOutput::new(std::io::stdout()));
+    output.emit(json!({
+        "type": "ready",
+        "protocol": RPC_SCHEMA,
+        "model": agent.provider.model(),
+        "root": agent.root,
+        "capabilities": ["prompt", "cancel", "approval_response", "ping", "shutdown"],
+    }));
+
+    let (input_tx, mut input_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+    std::thread::spawn(move || {
+        let stdin = std::io::stdin();
+        for line in stdin.lock().lines() {
+            match line {
+                Ok(line) => {
+                    if input_tx.send(line).is_err() {
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    let mut command_ids = HashSet::new();
+    while let Some(line) = input_rx.recv().await {
+        let command = match parse_command(&line) {
+            Ok(command) => command,
+            Err(error) => {
+                output.emit(json!({"type": "protocol_error", "message": error.to_string()}));
+                continue;
+            }
+        };
+        if !command_ids.insert(command.id.clone()) {
+            output.emit_for(
+                &command.id,
+                json!({"type": "command_error", "message": "duplicate command id"}),
+            );
+            continue;
+        }
+        match command.command {
+            RpcCommand::Ping => output.emit_for(&command.id, json!({"type": "pong"})),
+            RpcCommand::Shutdown => {
+                output.emit_for(&command.id, json!({"type": "shutdown_complete"}));
+                break;
+            }
+            RpcCommand::Cancel | RpcCommand::ApprovalResponse { .. } => output.emit_for(
+                &command.id,
+                json!({"type": "command_error", "message": "no turn is active"}),
+            ),
+            RpcCommand::Prompt { prompt } => {
+                if prompt.trim().is_empty() {
+                    output.emit_for(
+                        &command.id,
+                        json!({"type": "command_error", "message": "prompt cannot be empty"}),
+                    );
+                    continue;
+                }
+                let turn_id = command.id;
+                let cancel = Arc::new(AtomicBool::new(false));
+                output.set_command(Some(turn_id.clone()));
+                output.emit(json!({"type": "turn_started"}));
+                let stamped = format!(
+                    "{}, Current date: {}",
+                    prompt,
+                    chrono::Local::now().format("%Y-%m-%d %H:%M:%S")
+                );
+                let mut run = Box::pin(agent.run(&stamped, output.as_ref(), Some(&cancel)));
+                let mut shutdown = false;
+                let mut shutdown_command_id = None;
+                let mut input_open = true;
+                let result = loop {
+                    tokio::select! {
+                        result = &mut run => break result,
+                        next = input_rx.recv(), if input_open => {
+                            let Some(line) = next else {
+                                cancel.store(true, Ordering::Relaxed);
+                                output.reject_pending_approvals();
+                                shutdown = true;
+                                input_open = false;
+                                continue;
+                            };
+                            let incoming = match parse_command(&line) {
+                                Ok(command) => command,
+                                Err(error) => {
+                                    output.emit(json!({"type": "protocol_error", "message": error.to_string()}));
+                                    continue;
+                                }
+                            };
+                            if !command_ids.insert(incoming.id.clone()) {
+                                output.emit_for(
+                                    &incoming.id,
+                                    json!({"type": "command_error", "message": "duplicate command id"}),
+                                );
+                                continue;
+                            }
+                            match incoming.command {
+                                RpcCommand::Cancel => {
+                                    cancel.store(true, Ordering::Relaxed);
+                                    output.reject_pending_approvals();
+                                    output.emit_for(&incoming.id, json!({"type": "cancel_accepted", "turn_id": turn_id}));
+                                }
+                                RpcCommand::ApprovalResponse { approval_id, approved, feedback } => {
+                                    let accepted = output.resolve_approval(&approval_id, approved, feedback);
+                                    output.emit_for(&incoming.id, json!({
+                                        "type": "approval_response_accepted",
+                                        "approval_id": approval_id,
+                                        "accepted": accepted,
+                                    }));
+                                }
+                                RpcCommand::Ping => output.emit_for(&incoming.id, json!({"type": "pong"})),
+                                RpcCommand::Shutdown => {
+                                    cancel.store(true, Ordering::Relaxed);
+                                    output.reject_pending_approvals();
+                                    output.emit_for(&incoming.id, json!({"type": "shutdown_accepted"}));
+                                    shutdown = true;
+                                    shutdown_command_id = Some(incoming.id);
+                                }
+                                RpcCommand::Prompt { .. } => output.emit_for(
+                                    &incoming.id,
+                                    json!({"type": "command_error", "message": "a turn is already active"}),
+                                ),
+                            }
+                        }
+                    }
+                };
+                drop(run);
+                agent.ctx.clear_runtime_injections();
+                agent.save();
+                match result {
+                    Ok(()) => output.emit(json!({"type": "turn_completed", "ok": true})),
+                    Err(error) => output.emit(json!({
+                        "type": "turn_completed",
+                        "ok": false,
+                        "error": error.to_string(),
+                    })),
+                }
+                output.set_command(None);
+                if shutdown {
+                    if let Some(command_id) = shutdown_command_id {
+                        output.emit_for(&command_id, json!({"type": "shutdown_complete"}));
+                    } else {
+                        output.emit(json!({
+                            "type": "shutdown_complete",
+                            "reason": "stdin_closed",
+                        }));
+                    }
+                    break;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+pub fn startup_error(error: &anyhow::Error) {
+    RpcOutput::new(std::io::stdout()).emit(json!({
+        "type": "startup_error",
+        "message": error.to_string(),
+    }));
+}
+
+fn parse_command(line: &str) -> Result<CommandEnvelope> {
+    let command: CommandEnvelope =
+        serde_json::from_str(line).context("invalid RPC command JSON")?;
+    if command.schema != RPC_SCHEMA {
+        anyhow::bail!(
+            "unsupported RPC schema '{}'; expected {RPC_SCHEMA}",
+            command.schema
+        );
+    }
+    if command.id.trim().is_empty() {
+        anyhow::bail!("RPC command id cannot be empty");
+    }
+    Ok(command)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_versioned_commands_and_rejects_unknown_schemas() {
+        let command = parse_command(
+            r#"{"schema":"wisp.agent-rpc.v1","id":"turn-1","type":"prompt","prompt":"inspect"}"#,
+        )
+        .unwrap();
+        assert_eq!(command.id, "turn-1");
+        assert!(matches!(command.command, RpcCommand::Prompt { .. }));
+
+        assert!(
+            parse_command(r#"{"schema":"wisp.agent-rpc.v0","id":"turn-1","type":"cancel"}"#)
+                .unwrap_err()
+                .to_string()
+                .contains("unsupported RPC schema")
+        );
+    }
+
+    #[tokio::test]
+    async fn approval_responses_are_correlated() {
+        let output = Arc::new(RpcOutput::new(Vec::new()));
+        let waiting = {
+            let output = output.clone();
+            tokio::spawn(async move { output.confirm_decision_async("write file?").await })
+        };
+        tokio::task::yield_now().await;
+        let approval_id = output
+            .approvals
+            .lock()
+            .unwrap()
+            .keys()
+            .next()
+            .cloned()
+            .unwrap();
+        assert!(output.resolve_approval(&approval_id, false, Some("not now".into())));
+        assert_eq!(
+            waiting.await.unwrap(),
+            ConfirmDecision::Denied {
+                feedback: Some("not now".into())
+            }
+        );
+        let bytes = output.writer.lock().unwrap().clone();
+        let event: Value = serde_json::from_slice(
+            bytes
+                .split(|byte| *byte == b'\n')
+                .find(|line| !line.is_empty())
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(event["schema"], RPC_SCHEMA);
+        assert_eq!(event["sequence"], 0);
+        assert_eq!(event["type"], "approval_required");
+        assert_eq!(event["approval_id"], approval_id);
+    }
+}

--- a/crates/wisp-core/src/lib.rs
+++ b/crates/wisp-core/src/lib.rs
@@ -120,6 +120,56 @@ impl Agent {
         }
     }
 
+    /// Construct an Agent from host-supplied runtime parts.
+    ///
+    /// Headless tests and embedding hosts use this boundary to inject a
+    /// deterministic provider and an exact tool registry while exercising the
+    /// production agent loop. The caller owns any extra tools (such as
+    /// `explore`), context seeding, and session persistence policy.
+    pub fn from_parts(
+        provider: Box<dyn Provider>,
+        vision_provider: Option<Box<dyn Provider>>,
+        tools: Registry,
+        ctx: ContextManager,
+        root: PathBuf,
+        max_iter: usize,
+        session_path: PathBuf,
+    ) -> Self {
+        Self {
+            provider,
+            vision_provider,
+            tools,
+            ctx,
+            root,
+            max_iter,
+            session_path,
+        }
+    }
+
+    /// Convenience form of [`Self::from_parts`] that loads the conventional
+    /// `.wisp/session.json` path and starts a context with `max_context`.
+    pub fn with_provider(
+        provider: Box<dyn Provider>,
+        vision_provider: Option<Box<dyn Provider>>,
+        tools: Registry,
+        root: PathBuf,
+        max_context: usize,
+        max_iter: usize,
+    ) -> Self {
+        let session_path = root.join(".wisp").join("session.json");
+        let mut ctx = ContextManager::new(max_context);
+        ctx.load(&session_path);
+        Self::from_parts(
+            provider,
+            vision_provider,
+            tools,
+            ctx,
+            root,
+            max_iter,
+            session_path,
+        )
+    }
+
     /// Seed a fresh system prompt or refresh its catalog-free skills section.
     pub fn seed_system_prompt(&mut self, skills: &SkillIndex, compute_hosts: Option<String>) {
         let system_prompt = SystemPrompt::new(&self.root, skills, compute_hosts);

--- a/crates/wisp-llm/Cargo.toml
+++ b/crates/wisp-llm/Cargo.toml
@@ -10,6 +10,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { workspace = true }
 futures-util = { workspace = true }
+tokio = { workspace = true }
 async-trait = "0.1"
 thiserror = { workspace = true }
 url = { workspace = true }

--- a/crates/wisp-llm/src/lib.rs
+++ b/crates/wisp-llm/src/lib.rs
@@ -15,6 +15,7 @@ pub mod openai;
 pub mod provider;
 pub mod responses;
 pub mod routed;
+pub mod scripted;
 
 pub use message::{
     Completion, Content, FunctionCall, ImageUrl, Message, Part, Role, ToolCall, ToolSchema, Usage,
@@ -24,3 +25,7 @@ pub use provider::{
 };
 pub use provider::{LlmError, Result};
 pub use routed::RoutedProvider;
+pub use scripted::{
+    ScriptedCompletion, ScriptedProvider, ScriptedProviderSnapshot, ScriptedRequest,
+    ScriptedToolCall,
+};

--- a/crates/wisp-llm/src/scripted.rs
+++ b/crates/wisp-llm/src/scripted.rs
@@ -1,0 +1,302 @@
+//! Deterministic provider for offline agent tests and host conformance suites.
+//!
+//! Unlike the small one-off fake providers used by unit tests, this provider
+//! is public, serializable at its script boundary, records every request, and
+//! drives the same streaming path as network providers. It deliberately lives
+//! in `wisp-llm` so headless hosts can test the real agent loop without an API
+//! key or network access.
+
+use crate::{
+    Completion, FunctionCall, LlmError, Message, Provider, Result, StreamSink, ToolCall,
+    ToolSchema, Usage,
+};
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ScriptedToolCall {
+    #[serde(default)]
+    pub id: String,
+    pub name: String,
+    #[serde(default = "empty_object")]
+    pub arguments: serde_json::Value,
+}
+
+fn empty_object() -> serde_json::Value {
+    serde_json::json!({})
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ScriptedCompletion {
+    #[serde(default)]
+    pub content: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning: Option<String>,
+    #[serde(default)]
+    pub tool_calls: Vec<ScriptedToolCall>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub finish_reason: Option<String>,
+    #[serde(default)]
+    pub input_tokens: u64,
+    #[serde(default)]
+    pub output_tokens: u64,
+    #[serde(default)]
+    pub reasoning_tokens: u64,
+    #[serde(default)]
+    pub cached_input_tokens: u64,
+    /// Optional deterministic latency used by timeout and cancellation tests.
+    #[serde(default)]
+    pub delay_ms: u64,
+    /// Split streamed text/reasoning into chunks no larger than this many
+    /// Unicode scalar values. Zero emits one chunk.
+    #[serde(default)]
+    pub chunk_chars: usize,
+}
+
+impl ScriptedCompletion {
+    fn materialize(&self, sequence: usize) -> Completion {
+        let calls = self
+            .tool_calls
+            .iter()
+            .enumerate()
+            .map(|(index, call)| ToolCall {
+                id: if call.id.trim().is_empty() {
+                    format!("script-{sequence}-{index}")
+                } else {
+                    call.id.clone()
+                },
+                kind: "function".into(),
+                function: FunctionCall {
+                    name: call.name.clone(),
+                    arguments: serde_json::to_string(&call.arguments)
+                        .unwrap_or_else(|_| "{}".into()),
+                },
+            })
+            .collect::<Vec<_>>();
+        Completion {
+            content: self.content.clone(),
+            reasoning: self.reasoning.clone(),
+            finish_reason: self.finish_reason.clone().or_else(|| {
+                Some(if calls.is_empty() {
+                    "stop".into()
+                } else {
+                    "tool_calls".into()
+                })
+            }),
+            tool_calls: calls,
+            usage: Usage {
+                input_tokens: self.input_tokens,
+                output_tokens: self.output_tokens,
+                reasoning_tokens: self.reasoning_tokens,
+                cached_input_tokens: self.cached_input_tokens,
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScriptedRequest {
+    pub sequence: usize,
+    pub messages: Vec<Message>,
+    pub tool_names: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScriptedProviderSnapshot {
+    pub model: String,
+    pub requests: Vec<ScriptedRequest>,
+    pub remaining_completions: usize,
+}
+
+#[derive(Debug)]
+struct State {
+    completions: VecDeque<ScriptedCompletion>,
+    requests: Vec<ScriptedRequest>,
+}
+
+/// A cloneable provider whose clones consume one shared FIFO script.
+#[derive(Clone, Debug)]
+pub struct ScriptedProvider {
+    model: String,
+    state: Arc<Mutex<State>>,
+}
+
+impl ScriptedProvider {
+    pub fn new(model: impl Into<String>, completions: Vec<ScriptedCompletion>) -> Self {
+        Self {
+            model: model.into(),
+            state: Arc::new(Mutex::new(State {
+                completions: completions.into(),
+                requests: Vec::new(),
+            })),
+        }
+    }
+
+    pub fn snapshot(&self) -> ScriptedProviderSnapshot {
+        let state = self.state.lock().expect("scripted provider mutex poisoned");
+        ScriptedProviderSnapshot {
+            model: self.model.clone(),
+            requests: state.requests.clone(),
+            remaining_completions: state.completions.len(),
+        }
+    }
+
+    pub fn remaining(&self) -> usize {
+        self.state
+            .lock()
+            .expect("scripted provider mutex poisoned")
+            .completions
+            .len()
+    }
+
+    fn next(
+        &self,
+        messages: &[Message],
+        tools: &[ToolSchema],
+    ) -> Result<(usize, ScriptedCompletion)> {
+        let mut state = self.state.lock().expect("scripted provider mutex poisoned");
+        let sequence = state.requests.len() + 1;
+        state.requests.push(ScriptedRequest {
+            sequence,
+            messages: messages.to_vec(),
+            tool_names: tools
+                .iter()
+                .map(|schema| schema.function.name.clone())
+                .collect(),
+        });
+        let completion = state.completions.pop_front().ok_or_else(|| {
+            LlmError::Config(format!(
+                "scripted provider exhausted after {} request(s)",
+                sequence - 1
+            ))
+        })?;
+        Ok((sequence, completion))
+    }
+}
+
+fn chunks(text: &str, limit: usize) -> Vec<String> {
+    if text.is_empty() {
+        return Vec::new();
+    }
+    if limit == 0 {
+        return vec![text.to_string()];
+    }
+    let mut out = Vec::new();
+    let mut chunk = String::new();
+    for character in text.chars() {
+        chunk.push(character);
+        if chunk.chars().count() >= limit {
+            out.push(std::mem::take(&mut chunk));
+        }
+    }
+    if !chunk.is_empty() {
+        out.push(chunk);
+    }
+    out
+}
+
+async fn deterministic_delay(delay_ms: u64, sink: &mut dyn StreamSink) -> Result<()> {
+    let mut remaining = delay_ms;
+    while remaining > 0 {
+        if sink.is_cancelled() {
+            return Err(LlmError::Incomplete);
+        }
+        let slice = remaining.min(10);
+        tokio::time::sleep(Duration::from_millis(slice)).await;
+        remaining -= slice;
+    }
+    if sink.is_cancelled() {
+        return Err(LlmError::Incomplete);
+    }
+    Ok(())
+}
+
+#[async_trait]
+impl Provider for ScriptedProvider {
+    fn name(&self) -> &str {
+        "scripted"
+    }
+
+    fn model(&self) -> &str {
+        &self.model
+    }
+
+    async fn complete(&self, messages: &[Message], tools: &[ToolSchema]) -> Result<Completion> {
+        let (sequence, scripted) = self.next(messages, tools)?;
+        if scripted.delay_ms > 0 {
+            tokio::time::sleep(Duration::from_millis(scripted.delay_ms)).await;
+        }
+        Ok(scripted.materialize(sequence))
+    }
+
+    async fn stream(
+        &self,
+        messages: &[Message],
+        tools: &[ToolSchema],
+        sink: &mut dyn StreamSink,
+    ) -> Result<Completion> {
+        let (sequence, scripted) = self.next(messages, tools)?;
+        deterministic_delay(scripted.delay_ms, sink).await?;
+        for chunk in chunks(
+            scripted.reasoning.as_deref().unwrap_or_default(),
+            scripted.chunk_chars,
+        ) {
+            if sink.is_cancelled() {
+                return Err(LlmError::Incomplete);
+            }
+            sink.on_reasoning(&chunk);
+        }
+        for chunk in chunks(&scripted.content, scripted.chunk_chars) {
+            if sink.is_cancelled() {
+                return Err(LlmError::Incomplete);
+            }
+            sink.on_text(&chunk);
+        }
+        let completion = scripted.materialize(sequence);
+        for (index, call) in completion.tool_calls.iter().enumerate() {
+            sink.on_tool_call(index, &call.function.name, &call.function.arguments);
+        }
+        sink.on_usage(completion.usage.clone());
+        Ok(completion)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{NullSink, Role};
+
+    #[tokio::test]
+    async fn consumes_fifo_and_records_exact_requests() {
+        let provider = ScriptedProvider::new(
+            "fixture",
+            vec![ScriptedCompletion {
+                tool_calls: vec![ScriptedToolCall {
+                    name: "read".into(),
+                    arguments: serde_json::json!({"path": "notes.txt"}),
+                    ..ScriptedToolCall::default()
+                }],
+                ..ScriptedCompletion::default()
+            }],
+        );
+        let mut sink = NullSink;
+        let completion = provider
+            .stream(
+                &[Message::user("inspect")],
+                &[ToolSchema::new("read", "read", serde_json::json!({}))],
+                &mut sink,
+            )
+            .await
+            .unwrap();
+        assert_eq!(completion.tool_calls[0].function.name, "read");
+        assert_eq!(completion.finish_reason.as_deref(), Some("tool_calls"));
+        let snapshot = provider.snapshot();
+        assert_eq!(snapshot.requests.len(), 1);
+        assert_eq!(snapshot.requests[0].messages[0].role, Role::User);
+        assert_eq!(snapshot.requests[0].tool_names, vec!["read"]);
+        assert_eq!(snapshot.remaining_completions, 0);
+    }
+}

--- a/docs/headless-agent-testing.md
+++ b/docs/headless-agent-testing.md
@@ -1,0 +1,177 @@
+# Headless agent testing
+
+Wisp has two complementary headless interfaces:
+
+- `wisp-science eval` runs repeatable agent conformance and regression suites.
+- `wisp-science rpc` runs a long-lived agent over a versioned JSONL stdin/stdout protocol.
+
+Both exercise the production `Agent` loop and tool registry. The default eval
+suite uses a deterministic scripted provider, temporary workspaces, and fixture
+MCP/subagent boundaries, so it requires no API key, network, SSH host, GPU,
+scheduler, Python, or R installation.
+
+## Offline evaluation
+
+Run the built-in suite:
+
+```bash
+cargo run -p wisp-cli -- eval \
+  --artifacts target/headless-agent-eval \
+  --save target/headless-agent-eval/report.json
+```
+
+The suite covers reads and exact edits, shell execution, persistent Python and
+R runtime cells, approval denial, skills, deferred MCP discovery, read-only
+subagent delegation, resume without tool replay, session restart, queued
+guidance, cancellation, vision fallback, manual compaction, plan-mode gating,
+and project path containment.
+
+Useful selection and stress controls:
+
+```bash
+# Select by stable case id or require a tag.
+cargo run -p wisp-cli -- eval --case targeted-edit --tag filesystem
+
+# Detect nondeterminism and exercise concurrent workspace isolation.
+cargo run -p wisp-cli -- eval --repeat 20 --parallel 4
+
+# Preserve only failed temporary projects for investigation.
+cargo run -p wisp-cli -- eval \
+  --keep-failed-workspace --artifacts target/headless-agent-eval
+```
+
+Every trajectory is JSONL with schema `wisp.agent-trajectory.v1`. It includes
+the full provider requests, messages, tool call IDs, parsed tool arguments,
+tool results, approvals, compaction events, and usage. The JSON summary uses
+`wisp.agent-eval-report.v1`.
+
+### Budgets and baselines
+
+The runner fails when a selected case fails, a budget is exceeded, the pass
+rate is below the requested threshold, or a baseline regression crosses a
+configured threshold:
+
+```bash
+cargo run -p wisp-cli -- eval \
+  --max-tool-calls 8 \
+  --max-input-tokens 200000 \
+  --max-duration-ms 15000 \
+  --max-cost-microusd 50000 \
+  --input-cost-microusd-per-million 3000000 \
+  --output-cost-microusd-per-million 15000000
+
+cargo run -p wisp-cli -- eval --save baseline.json
+cargo run -p wisp-cli -- eval \
+  --compare baseline.json \
+  --max-token-regression-percent 10 \
+  --max-round-regression 2 \
+  --save current.json
+```
+
+Cost rates are explicit integer micro-USD per million tokens; offline defaults
+are zero. Cached input is excluded from the billable input estimate.
+
+Use `--mode live` to run the same declarative suite against the configured
+provider. Live mode requires the normal `WISP_API_KEY`, `WISP_PROVIDER`, and
+`WISP_MODEL` environment variables. Scripted steps are ignored in live mode;
+live suites should use tolerant semantic assertions rather than exact prose.
+
+### Custom suites
+
+Pass a YAML or JSON file with `--suite`. The top-level schema is
+`wisp.agent-eval-suite.v1`:
+
+```yaml
+schema: wisp.agent-eval-suite.v1
+id: project-smoke-v1
+defaults:
+  timeout_ms: 15000
+  max_rounds: 8
+cases:
+  - id: inspect-config
+    description: Read the fixture and report its mode.
+    tags: [filesystem, smoke]
+    prompt: Read config.toml and report mode.
+    files:
+      config.toml: "mode = \"safe\"\n"
+    allowed_tools: [read, attempt_completion]
+    script:
+      - tool_calls:
+          - id: read-1
+            name: read
+            arguments: {path: config.toml}
+      - tool_calls:
+          - id: done-1
+            name: attempt_completion
+            arguments: {result: "mode=safe"}
+    expect:
+      outcome: success
+      completion_contains: [mode=safe]
+      required_tools: [read, attempt_completion]
+      forbidden_tools: [write, edit, shell]
+      tool_order: [read, attempt_completion]
+      tool_args:
+        - {name: read, pointer: /path, equals: config.toml}
+```
+
+Fixture paths must be relative and remain under the temporary project.
+`allowed_tools` is an exact capability allowlist. Binary fixtures use
+`base64_files`. Multi-turn lifecycle scenarios use `actions` (`send`, `resume`,
+`compact`, and `restart`).
+
+## One-shot JSONL
+
+`run --output jsonl` emits `wisp.agent-event.v1`. Every line contains a
+monotonic `sequence`, `session_id`, `turn_id`, and event `type`. Tool events
+include the provider call ID and full parsed arguments when available. Setup
+diagnostics go to stderr, leaving stdout machine-readable.
+
+```bash
+cargo run -p wisp-cli -- run --output jsonl "Inspect this project"
+```
+
+This mode is intentionally non-interactive: an approval request is emitted and
+denied. Use RPC when the controller must answer approvals or cancel a turn.
+
+## Bidirectional RPC
+
+Start a persistent process with the normal provider configuration:
+
+```bash
+cargo run -p wisp-cli -- rpc
+```
+
+Commands are one JSON object per stdin line. All commands must use
+`wisp.agent-rpc.v1` and a caller-defined unique `id`:
+
+```json
+{"schema":"wisp.agent-rpc.v1","id":"turn-1","type":"prompt","prompt":"Inspect README.md"}
+{"schema":"wisp.agent-rpc.v1","id":"ping-1","type":"ping"}
+{"schema":"wisp.agent-rpc.v1","id":"cancel-1","type":"cancel"}
+{"schema":"wisp.agent-rpc.v1","id":"approval-1","type":"approval_response","approval_id":"<event approval_id>","approved":false,"feedback":"Do not mutate files"}
+{"schema":"wisp.agent-rpc.v1","id":"shutdown-1","type":"shutdown"}
+```
+
+The process first emits `ready`. A prompt produces `turn_started`, streaming
+message/text/reasoning/tool/usage events, then exactly one `turn_completed`.
+While a turn is active the controller may send `ping`, `cancel`,
+`approval_response`, or `shutdown`; a second prompt is rejected. Every event
+has the schema, sequence, process `session_id`, and relevant `command_id`.
+
+When a tool needs confirmation, Wisp emits:
+
+```json
+{"schema":"wisp.agent-rpc.v1","type":"approval_required","approval_id":"...","message":"Run tool 'write'?", "command_id":"turn-1"}
+```
+
+The agent remains suspended without blocking the command reader until a
+matching `approval_response`, cancellation, shutdown, or stdin closure. Unknown
+schemas and malformed input produce `protocol_error` events without terminating
+the process.
+
+## CI contract
+
+The offline suite runs on Linux, macOS, and Windows. Tests must never add a
+dependency on a real remote host, scheduler, API key, or language runtime.
+Platform integrations should use fake command runners and parsing tests; live
+provider suites belong in separately credentialed, non-blocking jobs.


### PR DESCRIPTION
## What changed

- adds an injectable `Agent` construction boundary and reusable deterministic `ScriptedProvider`
- replaces the fixed smoke eval with the versioned `wisp.agent-eval-suite.v1` declarative runner
- adds 17 offline scenarios covering files, shell, Python/R runtime persistence, approvals, skills, MCP, subagent delegation, session lifecycle, cancellation, vision, compaction, plan mode, and path safety
- adds versioned trajectory/report artifacts, filters, repeats, parallel isolation, timeouts, budgets, cost accounting, and baseline regression checks
- upgrades one-shot JSONL to `wisp.agent-event.v1`
- adds bidirectional `wisp.agent-rpc.v1` over stdin/stdout with correlated approvals and cancellation
- runs the deterministic suite on Linux, macOS, and Windows CI and documents suite/RPC usage

## Why

The existing headless CLI could run prompts, but it did not provide a deterministic provider seam, stable machine protocol, declarative capability tests, complete trajectory capture, or regression budgets. That made agent-loop changes difficult to validate without a live provider and left host integrations without a reliable bidirectional protocol.

## Impact

Developers can now test the production agent loop without an API key or external infrastructure, compare reports against baselines, preserve failed workspaces, and embed a persistent headless Wisp process with interactive approvals and cancellation. Live provider evaluation remains opt-in.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace --quiet` — 1038 passed, 0 failed
- `cargo run -p wisp-cli -- eval --parallel 4` — 17/17 passed
- repeated deterministic stress run — 45/45 passed
- baseline comparison — no regressions

## Known limitations

Real provider, SSH, GPU, and scheduler coverage remains in opt-in live/integration suites; deterministic CI intentionally uses no external services or hosts.