### PR TITLE
ci: Linux desktop release (x86_64 + aarch64) with webkit2gtk ARM64 workaround

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -1,0 +1,133 @@
+name: Linux Release
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Tag to build and publish (e.g. v0.1.0)
+        required: true
+        default: v0.1.0
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    strategy:
+      fail-fast: false
+      # Serial so the two jobs don't race to create the same release;
+      # first creates it, second appends its packages. Same pattern as macOS.
+      max-parallel: 1
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-24.04
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-24.04-arm
+    runs-on: ${{ matrix.os }}
+    env:
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libjavascriptcoregtk-4.1-dev \
+            libsoup-3.0-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            patchelf
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - uses: swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            . -> target
+            ui -> target
+          cache-on-failure: true
+
+      - name: Cache Trunk and Tauri CLI
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin
+          key: tauri-tools-${{ runner.os }}-${{ runner.arch }}-v1
+
+      # wasm-bindgen-cli must stay pinned at 0.2.96 with the repo's wrapper
+      # installed over it: webkit2gtk 2.52.3 on aarch64 cannot expose externref
+      # tables, so the wasm must be built without reference-types. See
+      # scripts/wasm-bindgen-wrapper.sh for the full explanation.
+      - name: Install Trunk, Tauri CLI and pinned wasm-bindgen
+        run: |
+          set -euo pipefail
+          command -v trunk >/dev/null 2>&1 || cargo install trunk --locked
+          command -v cargo-tauri >/dev/null 2>&1 || cargo install tauri-cli --version "^2" --locked
+          if ! command -v wasm-bindgen.real >/dev/null 2>&1 || ! wasm-bindgen.real --version | grep -q '0\.2\.96'; then
+            cargo install wasm-bindgen-cli --version 0.2.96 --locked
+            mv "$HOME/.cargo/bin/wasm-bindgen" "$HOME/.cargo/bin/wasm-bindgen.real"
+          fi
+          ln -sf "$GITHUB_WORKSPACE/scripts/wasm-bindgen-wrapper.sh" "$HOME/.cargo/bin/wasm-bindgen"
+          wasm-bindgen.real --version
+
+      - name: Read release notes
+        id: notes
+        run: |
+          TAG="$RELEASE_TAG"
+          FILE=".github/release-notes/$TAG.md"
+          if [ ! -f "$FILE" ]; then
+            echo "No release notes at $FILE, falling back to v0.1.0.md"
+            FILE=".github/release-notes/v0.1.0.md"
+          fi
+          if [ ! -f "$FILE" ]; then
+            echo "Release notes not found for $TAG" >&2
+            exit 1
+          fi
+          {
+            echo "body<<EOF"
+            cat "$FILE"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      # No updater artifacts on Linux yet: the macOS workflow owns latest.json,
+      # and concurrent updater-manifest uploads from two workflows could race.
+      - uses: tauri-apps/tauri-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          projectPath: src-tauri
+          tauriScript: cargo tauri
+          tagName: ${{ env.RELEASE_TAG }}
+          releaseName: wisp-science ${{ env.RELEASE_TAG }}
+          releaseBody: ${{ steps.notes.outputs.body }}
+          releaseDraft: false
+          prerelease: false
+          args: --target ${{ matrix.target }} --bundles deb,appimage
+
+  verify-assets:
+    needs: release
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+    steps:
+      - name: Verify both architectures published deb and AppImage
+        run: |
+          set -euo pipefail
+          gh release view "$RELEASE_TAG" --json assets --jq '.assets[].name' > assets.txt
+          cat assets.txt
+          debs=$(grep -c '\.deb$' assets.txt || true)
+          appimages=$(grep -c '\.AppImage$' assets.txt || true)
+          if [ "$debs" -lt 2 ] || [ "$appimages" -lt 2 ]; then
+            echo "::error::Expected >=2 .deb and >=2 .AppImage assets, got $debs deb / $appimages AppImage"
+            exit 1
+          fi

--- a/scripts/strip_reference_types.py
+++ b/scripts/strip_reference_types.py
@@ -1,0 +1,93 @@
+"""Strip `+reference-types` from a wasm's target_features custom section.
+
+This prevents wasm-bindgen-cli <0.2.100 from auto-enabling externref-xform,
+which produces an externref table that webkit2gtk 2.52.3 ARM64 cannot expose
+in instance.exports (a real engine bug, breaks wisp-tauri's webview).
+
+Usage: python3 strip_reference_types.py <wasm_path>
+Writes <wasm_path>.no_reftypes as the patched wasm.
+"""
+import sys, shutil
+
+def leb(v):
+    out = bytearray()
+    while True:
+        b = v & 0x7f
+        v >>= 7
+        if v:
+            out.append(b | 0x80)
+        else:
+            out.append(b)
+            return bytes(out)
+
+def read_uleb(data, off):
+    n = 0; sh = 0
+    while True:
+        b = data[off]; off += 1
+        n |= (b & 0x7f) << sh
+        if not (b & 0x80): return n, off
+        sh += 7
+
+def main(path):
+    with open(path, 'rb') as f:
+        data = bytearray(f.read())
+    assert data[:4] == b'\x00asm', "not a wasm"
+    i = 8  # skip magic+version
+    new_data = bytearray(data[:8])
+    while i < len(data):
+        sid = data[i]; i += 1
+        sz_start = i
+        size, i = read_uleb(data, i)
+        section_body_start = i
+        section_body_end = i + size
+        if sid == 0:  # custom
+            # parse name
+            name_len, off = read_uleb(data, section_body_start)
+            name = data[section_body_start + (off - section_body_start): section_body_start + (off - section_body_start) + name_len]
+            # simpler: just decode name properly
+            p = section_body_start
+            nl, p = read_uleb(data, p)
+            name = bytes(data[p:p+nl]); p += nl
+            if name == b'target_features':
+                # parse entries
+                cnt, p2 = read_uleb(data, p)
+                entries_start = p2
+                kept = []
+                pp = p2
+                for _ in range(cnt):
+                    prefix = chr(data[pp]); pp += 1
+                    fl, pp = read_uleb(data, pp)
+                    fname = bytes(data[pp:pp+fl]); pp += fl
+                    if prefix == '+' and fname == b'reference-types':
+                        print(f"  dropping +reference-types", file=sys.stderr)
+                        continue
+                    kept.append((prefix, fname))
+                # rebuild section body: name + leb(cnt) + entries
+                body = bytearray()
+                body += leb(nl) + name
+                body += leb(len(kept))
+                for prefix, fname in kept:
+                    body += bytes([ord(prefix)])
+                    body += leb(len(fname)) + fname
+                # rebuild section: sid + leb(len(body)) + body
+                new_data += bytes([sid]) + leb(len(body)) + bytes(body)
+                i = section_body_end
+                continue
+        # default: copy section as-is
+        # bytes from sid..section_body_end
+        section_bytes = bytes(data[sz_start - 1: section_body_end])
+        # but we already consumed sid and the size; reconstruct:
+        # actually simpler: copy from the original data[start_i-1 : section_body_end]
+        # where start_i-1 was the position of sid
+        # We've been appending into new_data; here just append the raw section bytes.
+        # The raw bytes start at (sz_start - 1) — that's where sid was.
+        new_data += data[sz_start - 1: section_body_end]
+        i = section_body_end
+    out = path + '.no_reftypes'
+    with open(out, 'wb') as f:
+        f.write(new_data)
+    print(f"wrote {out}", file=sys.stderr)
+    return out
+
+if __name__ == '__main__':
+    main(sys.argv[1])

--- a/scripts/wasm-bindgen-wrapper.sh
+++ b/scripts/wasm-bindgen-wrapper.sh
@@ -34,8 +34,11 @@
 
 set -e
 
+# Note: readlink -f resolves the ~/.cargo/bin/wasm-bindgen symlink back to the
+# repo, so SCRIPT_DIR is the repo's scripts/ dir. The real cli lives next to
+# the symlink in ~/.cargo/bin (per the install steps above), not in SCRIPT_DIR.
 SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
-REAL="${WASM_BINDGEN_REAL:-$SCRIPT_DIR/wasm-bindgen.real}"
+REAL="${WASM_BINDGEN_REAL:-$HOME/.cargo/bin/wasm-bindgen.real}"
 STRIP="${WASM_BINDGEN_STRIP:-$SCRIPT_DIR/strip_reference_types.py}"
 
 # Find the positional input wasm argument (last non-flag arg).

--- a/scripts/wasm-bindgen-wrapper.sh
+++ b/scripts/wasm-bindgen-wrapper.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# wasm-bindgen wrapper: strips `+reference-types` from the wasm's
+# target_features custom section before invoking the real wasm-bindgen-cli.
+#
+# Why this exists
+# ---------------
+# webkit2gtk 2.52.3 on aarch64 (Ubuntu 24.04 noble-security) does not expose
+# the externref table via `instance.exports` — a real engine bug. Any wasm
+# using reference-types therefore renders the webview blank on ARM64.
+#
+# Trigger chain:
+#   1. Rust 1.97's wasm32 target spec enables reference-types by default.
+#   2. wasm-bindgen-cli >= 0.2.96 detects `+reference-types` in the wasm's
+#      target_features custom section and auto-enables the externref-xform
+#      pass, producing an externref table + rewriting the JS glue.
+#   3. webkit2gtk ARM64 fails to expose that table → `table.grow(4)` runs on
+#      the wrong funcref table → RangeError → UI blank.
+#
+# This wrapper patches the wasm to remove `+reference-types` *before* the cli
+# sees it, causing wasm-bindgen-cli 0.2.96 to skip externref-xform entirely.
+#
+# Install (one-time, per machine)
+# -------------------------------
+#   cargo install wasm-bindgen-cli --version 0.2.96 --force
+#   mv ~/.cargo/bin/wasm-bindgen ~/.cargo/bin/wasm-bindgen.real
+#   ln -sf "$REPO/scripts/wasm-bindgen-wrapper.sh" ~/.cargo/bin/wasm-bindgen
+#
+# Override paths if needed:
+#   WASM_BINDGEN_REAL=/path/to/wasm-bindgen.real
+#   WASM_BINDGEN_STRIP=/path/to/strip_reference_types.py
+#
+# Trunk invokes us as:
+#   wasm-bindgen --target web --out-dir <dir> [--no-typescript] <input.wasm>
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+REAL="${WASM_BINDGEN_REAL:-$SCRIPT_DIR/wasm-bindgen.real}"
+STRIP="${WASM_BINDGEN_STRIP:-$SCRIPT_DIR/strip_reference_types.py}"
+
+# Find the positional input wasm argument (last non-flag arg).
+INPUT=""
+for arg in "$@"; do
+    case "$arg" in
+        --*) ;;
+        -*) ;;
+        *) INPUT="$arg" ;;
+    esac
+done
+
+if [ -n "$INPUT" ] && [ -f "$INPUT" ] && [[ "$INPUT" == *.wasm ]]; then
+    TMP="$(mktemp -p "$(dirname "$INPUT")" .wbg-XXXXXX.wasm)"
+    if python3 "$STRIP" "$INPUT" > /dev/null 2> /tmp/wbg-wrapper.log; then
+        mv "$INPUT.no_reftypes" "$TMP"
+        # Replace INPUT in argv with patched tmp file
+        new_args=()
+        for arg in "$@"; do
+            if [ "$arg" = "$INPUT" ]; then
+                new_args+=("$TMP")
+            else
+                new_args+=("$arg")
+            fi
+        done
+        "$REAL" "${new_args[@]}"
+        rc=$?
+        rm -f "$TMP"
+        exit $rc
+    else
+        cat /tmp/wbg-wrapper.log >&2
+        # Patch failed — fall through to real cli (let it error or run as-is)
+    fi
+fi
+
+exec "$REAL" "$@"

--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "build": {
+    "beforeDevCommand": {
+      "script": "node sync-vendor.mjs && trunk serve --address 127.0.0.1 --port 1421 --dist dist-dev",
+      "cwd": "../ui"
+    },
+    "beforeBuildCommand": {
+      "script": "node sync-vendor.mjs && trunk build --release --dist dist",
+      "cwd": "../ui"
+    }
+  }
+}

--- a/ui/.cargo/config.toml
+++ b/ui/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.wasm32-unknown-unknown]
+# Disable reference-types so wasm-bindgen-cli 0.2.96 skips externref-xform.
+# webkit2gtk 2.52.3 ARM64 cannot expose externref tables in instance.exports,
+# so the externref optimization makes wisp-ui unrenderable on that engine.
+rustflags = ["-C", "target-feature=-reference-types"]

--- a/ui/Cargo.lock
+++ b/ui/Cargo.lock
@@ -581,12 +581,10 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "fb15147158e79fd8b8afd0252522769c4f48725460b37338544d8379d94fc8f9"
 dependencies = [
- "cfg-if",
- "futures-util",
  "wasm-bindgen",
 ]
 
@@ -778,6 +776,12 @@ checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
  "scopeguard",
 ]
+
+[[package]]
+name = "log"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "manyhow"
@@ -1563,44 +1567,24 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "21d3b25c3ea1126a2ad5f4f9068483c2af1e64168f847abe863a526b8dbfe00b"
 dependencies = [
  "cfg-if",
  "once_cell",
- "rustversion",
  "wasm-bindgen-macro",
- "wasm-bindgen-shared",
 ]
 
 [[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.76"
+name = "wasm-bindgen-backend"
+version = "0.2.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.126"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.126"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "52857d4c32e496dc6537646b5b117081e71fd2ff06de792e3577a150627db283"
 dependencies = [
  "bumpalo",
+ "log",
+ "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -1608,13 +1592,45 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.126"
+name = "wasm-bindgen-futures"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
 dependencies = [
- "unicode-ident",
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.96"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "920b0ffe069571ebbfc9ddc0b36ba305ef65577c94b06262ed793716a1afd981"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.96"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf59002391099644be3524e23b781fa43d2be0c5aa0719a18c0731b9d195cab6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.96"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5047c5392700766601942795a436d7d2599af60dcc3cc1248c9120bfb0827b0"
 
 [[package]]
 name = "wasm-streams"
@@ -1631,9 +1647,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.103"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+checksum = "476364ff87d0ae6bfb661053a9104ab312542658c3d8f963b7ace80b6f9b26b9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",


### PR DESCRIPTION
## Problem

wisp-science ships macOS and Windows releases but no Linux desktop build. On Linux ARM64 (Ubuntu 24.04, webkit2gtk 4.1 / 2.52.3) the webview also rendered blank due to a webkit2gtk engine bug with externref tables.

## Changes

- Merges #803 (thanks @ChrisLou-bioinfo): pins the wasm-bindgen stack to 0.2.96, disables `reference-types` for the wasm build, and adds `scripts/strip_reference_types.py` + `scripts/wasm-bindgen-wrapper.sh` so wasm-bindgen-cli skips externref-xform. Also adds `src-tauri/tauri.linux.conf.json` (trunk-based dev/build commands, same pattern as `tauri.macos.conf.json`).
- **`.github/workflows/release-linux.yml`** (new): tag-triggered (`v*`) matrix release building **deb + AppImage** on `ubuntu-24.04` (x86_64) and `ubuntu-24.04-arm` (aarch64), with the pinned wasm-bindgen + wrapper wired into CI, and a post-release job verifying both architectures published their packages.
- **`scripts/wasm-bindgen-wrapper.sh`**: fixes the default `REAL` path — `readlink -f` resolves the `~/.cargo/bin/wasm-bindgen` symlink back to the repo, so the old default (`$SCRIPT_DIR/wasm-bindgen.real`) never matched the documented install steps; it now defaults to `$HOME/.cargo/bin/wasm-bindgen.real`.

## Tests

- No Rust/UI behavior changed; existing CI (rust, headless eval, ui-e2e) covers regressions.
- New workflow validated as YAML; wrapper passes `bash -n`; strip script compiles. The release path itself can only be fully exercised by pushing a tag after merge.

## Known limitations / follow-ups

- Linux builds publish **no updater artifacts** yet — the macOS workflow owns `latest.json` and concurrent updater-manifest uploads could race. Enabling the updater for Linux AppImage is a follow-up.
- The wasm-bindgen 0.2.96 pin is a workaround for a webkit2gtk ARM64 engine bug; it should be reverted once fixed upstream (no upstream bug link recorded yet).
- Local Linux dev still requires the one-time wrapper install documented in `scripts/wasm-bindgen-wrapper.sh`.