### PR TITLE
Add headless memory-v1 eval dataset: compaction modes, retrieval, stage loading

### DIFF
--- a/crates/wisp-cli/eval-suites/memory-v1.yaml
+++ b/crates/wisp-cli/eval-suites/memory-v1.yaml
@@ -1,0 +1,315 @@
+schema: wisp.agent-eval-suite.v1
+id: wisp-memory-v1
+description: >-
+  Deterministic headless dataset for the memory mechanism: context compaction
+  under every trigger mode (auto, manual, overflow) with explicit
+  anti-forgetting assertions, project-memory retrieval through search_memory,
+  and memory loading at each lifecycle stage (session-start rules, per-turn
+  ephemeral injection, durable notes across restart).
+defaults:
+  max_context_tokens: 128000
+  max_rounds: 12
+  timeout_ms: 15000
+  max_tool_errors: 0
+
+cases:
+  # --- 1. Compaction modes: compression must not forget early facts -------
+  #
+  # Shared shape: two early facts buried under bulk filler, then two clean
+  # recent turns. After compaction the final provider request must still carry
+  # both facts (via the summary checkpoint), the archive pointer, and the
+  # recent tail, while the bulk assistant filler must be gone. The filler
+  # marker lives only in assistant messages because folded user messages are
+  # excerpted verbatim into the checkpoint by design.
+
+  - id: compact-auto-preserves-early-facts
+    description: Auto compaction at the model boundary keeps early facts reachable.
+    tags: [memory, compaction, auto]
+    prompt: Recall the two early facts after compression.
+    allowed_tools: [attempt_completion]
+    auto_compact: true
+    limits: {max_context_tokens: 10000}
+    context_seed:
+      - {role: user, repeat: 40, content: "EARLY_FACT_ALPHA: the QC threshold is 0.05. xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}
+      - {role: assistant, repeat: 40, content: "Noted. FORGOTTEN_FILLER_ZZZ yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"}
+      - {role: user, repeat: 40, content: "EARLY_FACT_BETA: the cohort id is HCC-2024. xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}
+      - {role: assistant, repeat: 40, content: "Noted. FORGOTTEN_FILLER_ZZZ yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"}
+      - {role: user, content: "RECENT_NOTE_ONE: keep both early facts available."}
+      - {role: assistant, content: "RECENT_ACK_ONE: both facts stay available."}
+      - {role: user, content: "RECENT_NOTE_TWO: the next answer must cite both facts."}
+      - {role: assistant, content: "RECENT_ACK_TWO: understood."}
+    script:
+      - content: "Compaction checkpoint summary: EARLY_FACT_ALPHA is the QC threshold 0.05. EARLY_FACT_BETA is the cohort id HCC-2024. The user requires both facts to stay available after compression."
+        finish_reason: stop
+      - tool_calls:
+          - {id: done-1, name: attempt_completion, arguments: {result: "EARLY_FACT_ALPHA=0.05; EARLY_FACT_BETA=HCC-2024"}}
+    expect:
+      compactions: 1
+      compaction_strategies: [auto]
+      max_compaction_ratio_percent: 60
+      completion_contains: ["EARLY_FACT_ALPHA=0.05", "EARLY_FACT_BETA=HCC-2024"]
+      final_request_contains:
+        - "[context summary checkpoint]"
+        - "wisp-history:"
+        - EARLY_FACT_ALPHA
+        - EARLY_FACT_BETA
+        - RECENT_NOTE_TWO
+      final_request_not_contains: [FORGOTTEN_FILLER_ZZZ]
+
+  - id: compact-manual-preserves-early-facts
+    description: Manual /compact keeps early facts reachable in the next request.
+    tags: [memory, compaction, manual]
+    allowed_tools: [attempt_completion]
+    auto_compact: false
+    limits: {max_context_tokens: 10000}
+    context_seed:
+      - {role: user, repeat: 40, content: "EARLY_FACT_ALPHA: the QC threshold is 0.05. xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}
+      - {role: assistant, repeat: 40, content: "Noted. FORGOTTEN_FILLER_ZZZ yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"}
+      - {role: user, repeat: 40, content: "EARLY_FACT_BETA: the cohort id is HCC-2024. xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}
+      - {role: assistant, repeat: 40, content: "Noted. FORGOTTEN_FILLER_ZZZ yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"}
+      - {role: user, content: "RECENT_NOTE_ONE: keep both early facts available."}
+      - {role: assistant, content: "RECENT_ACK_ONE: both facts stay available."}
+      - {role: user, content: "RECENT_NOTE_TWO: the next answer must cite both facts."}
+      - {role: assistant, content: "RECENT_ACK_TWO: understood."}
+    script:
+      - content: "Compaction checkpoint summary: EARLY_FACT_ALPHA is the QC threshold 0.05. EARLY_FACT_BETA is the cohort id HCC-2024. The user requires both facts to stay available after compression."
+        finish_reason: stop
+      - tool_calls:
+          - {id: done-1, name: attempt_completion, arguments: {result: "EARLY_FACT_ALPHA=0.05; EARLY_FACT_BETA=HCC-2024"}}
+    actions:
+      - {kind: compact}
+      - {kind: send, prompt: "Recall the two early facts after compression."}
+    expect:
+      compactions: 1
+      compaction_strategies: [manual]
+      max_compaction_ratio_percent: 60
+      completion_contains: ["EARLY_FACT_ALPHA=0.05", "EARLY_FACT_BETA=HCC-2024"]
+      final_request_contains:
+        - "[context summary checkpoint]"
+        - "wisp-history:"
+        - EARLY_FACT_ALPHA
+        - EARLY_FACT_BETA
+        - RECENT_NOTE_TWO
+      final_request_not_contains: [FORGOTTEN_FILLER_ZZZ]
+
+  - id: compact-overflow-recovery-preserves-early-facts
+    description: A provider context-overflow error forces one compaction and a successful retry.
+    tags: [memory, compaction, overflow]
+    prompt: Recall the two early facts after compression.
+    allowed_tools: [attempt_completion]
+    auto_compact: false
+    limits: {max_context_tokens: 10000}
+    context_seed:
+      - {role: user, repeat: 40, content: "EARLY_FACT_ALPHA: the QC threshold is 0.05. xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}
+      - {role: assistant, repeat: 40, content: "Noted. FORGOTTEN_FILLER_ZZZ yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"}
+      - {role: user, repeat: 40, content: "EARLY_FACT_BETA: the cohort id is HCC-2024. xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}
+      - {role: assistant, repeat: 40, content: "Noted. FORGOTTEN_FILLER_ZZZ yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"}
+      - {role: user, content: "RECENT_NOTE_ONE: keep both early facts available."}
+      - {role: assistant, content: "RECENT_ACK_ONE: both facts stay available."}
+      - {role: user, content: "RECENT_NOTE_TWO: the next answer must cite both facts."}
+      - {role: assistant, content: "RECENT_ACK_TWO: understood."}
+    script:
+      - api_error: {status: 400, body: "maximum context length exceeded"}
+      - content: "Compaction checkpoint summary: EARLY_FACT_ALPHA is the QC threshold 0.05. EARLY_FACT_BETA is the cohort id HCC-2024. The user requires both facts to stay available after compression."
+        finish_reason: stop
+      - tool_calls:
+          - {id: done-1, name: attempt_completion, arguments: {result: "EARLY_FACT_ALPHA=0.05; EARLY_FACT_BETA=HCC-2024"}}
+    expect:
+      compactions: 1
+      compaction_strategies: [overflow]
+      max_compaction_ratio_percent: 60
+      completion_contains: ["EARLY_FACT_ALPHA=0.05", "EARLY_FACT_BETA=HCC-2024"]
+      final_request_contains:
+        - "[context summary checkpoint]"
+        - "wisp-history:"
+        - EARLY_FACT_ALPHA
+        - EARLY_FACT_BETA
+      final_request_not_contains: [FORGOTTEN_FILLER_ZZZ]
+
+  # --- 2. Retrieval: search_memory over seeded .wisp/memory notes ---------
+
+  - id: memory-retrieval-multi-query
+    description: Complementary exact+concept queries retrieve the right chunk and only that chunk.
+    tags: [memory, retrieval]
+    prompt: What QC threshold did we settle on for study TS-999?
+    memory_enabled: true
+    allowed_tools: [search_memory, attempt_completion]
+    files:
+      .wisp/memory/2025-06-01.md: |
+        [TURN-MEMORY · session demo1 · turn 2]
+        MEMORY_FACT_TS999: the QC threshold for study TS-999 is min_genes=200.
+
+        DISTRACTOR_NOTE_PLOTS: prefer seaborn styling for figures.
+
+        MEMORY_FACT_BACKED: Scanpy h5ad OOM was fixed with backed mode loading.
+    script:
+      - tool_calls:
+          - id: search-1
+            name: search_memory
+            arguments:
+              queries:
+                - {text: "TS-999 QC threshold", kind: exact}
+                - {text: "minimum genes quality control", kind: concept}
+              max_results: 1
+      - tool_calls:
+          - {id: done-1, name: attempt_completion, arguments: {result: "TS-999 uses min_genes=200"}}
+    expect:
+      completion_contains: ["min_genes=200"]
+      required_tools: [search_memory, attempt_completion]
+      tool_order: [search_memory, attempt_completion]
+      tool_args:
+        - {name: search_memory, pointer: /queries/0/kind, equals: exact}
+        - {name: search_memory, pointer: /queries/1/kind, equals: concept}
+      request_contains: [MEMORY_FACT_TS999, match_reasons]
+      final_request_not_contains: [DISTRACTOR_NOTE_PLOTS]
+
+  - id: memory-retrieval-cjk
+    description: CJK queries match stored notes without whitespace tokenization.
+    tags: [memory, retrieval, cjk]
+    prompt: 单细胞分析爆内存时我们之前是怎么解决的？
+    memory_enabled: true
+    allowed_tools: [search_memory, attempt_completion]
+    files:
+      .wisp/memory/2025-05-20.md: |
+        [TURN-MEMORY · session demo2 · turn 5]
+        MEMORY_FACT_CJK：单细胞分析内存不足时使用 backed 模式分批读取。
+    script:
+      - tool_calls:
+          - id: search-1
+            name: search_memory
+            arguments:
+              queries:
+                - {text: "单细胞爆内存", kind: concept}
+      - tool_calls:
+          - {id: done-1, name: attempt_completion, arguments: {result: "之前用 backed 模式分批读取解决"}}
+    expect:
+      completion_contains: [backed]
+      required_tools: [search_memory, attempt_completion]
+      request_contains: [MEMORY_FACT_CJK]
+
+  - id: memory-retrieval-miss-is-explicit
+    description: A query with no stored evidence returns empty results and an honest answer.
+    tags: [memory, retrieval]
+    prompt: What retention policy did we pick for PROJECT-KRAKEN?
+    memory_enabled: true
+    allowed_tools: [search_memory, attempt_completion]
+    files:
+      .wisp/memory/2025-06-01.md: |
+        [TURN-MEMORY · session demo1 · turn 2]
+        MEMORY_FACT_TS999: the QC threshold for study TS-999 is min_genes=200.
+    script:
+      - tool_calls:
+          - id: search-1
+            name: search_memory
+            arguments:
+              queries:
+                - {text: "PROJECT-KRAKEN retention", kind: exact}
+      - tool_calls:
+          - {id: done-1, name: attempt_completion, arguments: {result: "that memory was not found"}}
+    expect:
+      completion_contains: [not found]
+      required_tools: [search_memory, attempt_completion]
+      request_contains: ["\"results\": []"]
+
+  - id: memory-tool-gated-by-setting
+    description: search_memory is not registered while the memory setting is off.
+    tags: [memory, retrieval, gating]
+    prompt: Try to search memory, then report that memory tools are unavailable.
+    script:
+      - tool_calls:
+          - id: search-1
+            name: search_memory
+            arguments:
+              queries:
+                - {text: "anything", kind: exact}
+      - tool_calls:
+          - {id: done-1, name: attempt_completion, arguments: {result: "memory tools are unavailable"}}
+    limits: {max_tool_errors: 1}
+    expect:
+      completion_contains: [unavailable]
+      required_tools: [attempt_completion]
+      request_contains: ["unknown tool 'search_memory'"]
+
+  # --- 3. Loading stages: session start, per-turn injection, durable notes -
+
+  - id: stage-session-start-rules-loaded
+    description: AGENTS.md and .wisp/WISP.md are loaded into the seeded system prompt.
+    tags: [memory, stage, session-start]
+    prompt: Confirm which project rules are loaded.
+    allowed_tools: [attempt_completion]
+    files:
+      AGENTS.md: "PROJECT_RULE_MARKER_71: always report units in the final answer.\n"
+      .wisp/WISP.md: "USER_RULE_MARKER_72: prefer concise summaries.\n"
+    script:
+      - tool_calls:
+          - {id: done-1, name: attempt_completion, arguments: {result: "loaded PROJECT_RULE_MARKER_71 and USER_RULE_MARKER_72"}}
+    expect:
+      completion_contains: [PROJECT_RULE_MARKER_71, USER_RULE_MARKER_72]
+      request_contains:
+        - "Project Instructions (AGENTS.md)"
+        - PROJECT_RULE_MARKER_71
+        - USER_RULE_MARKER_72
+
+  - id: stage-turn-injection-visible
+    description: Host-injected global memory reaches the provider request for the turn.
+    tags: [memory, stage, injection]
+    prompt: Which output format do I prefer?
+    allowed_tools: [attempt_completion]
+    runtime_injections:
+      - "<global_memory>\n- GLOBAL_MEMORY_MARKER_88: outputs must be written as parquet.\n</global_memory>"
+    script:
+      - tool_calls:
+          - {id: done-1, name: attempt_completion, arguments: {result: "parquet, per GLOBAL_MEMORY_MARKER_88"}}
+    expect:
+      completion_contains: [parquet]
+      request_contains: [GLOBAL_MEMORY_MARKER_88, "<global_memory>"]
+
+  - id: stage-injection-ephemeral-after-restart
+    description: Per-turn injections never become durable history across a restart.
+    tags: [memory, stage, injection, restart]
+    allowed_tools: [attempt_completion]
+    runtime_injections:
+      - "<global_memory>\n- GLOBAL_EPHEMERAL_MARKER_93: temporary host context.\n</global_memory>"
+    script:
+      - tool_calls:
+          - {id: done-1, name: attempt_completion, arguments: {result: "context acknowledged"}}
+      - tool_calls:
+          - {id: done-2, name: attempt_completion, arguments: {result: "the injected context is no longer present"}}
+    actions:
+      - {kind: send, prompt: "Acknowledge the injected context without repeating it."}
+      - {kind: restart}
+      - {kind: send, prompt: "Is the injected context still present?"}
+    expect:
+      completion_contains: [no longer present]
+      request_contains: [GLOBAL_EPHEMERAL_MARKER_93]
+      final_request_not_contains: [GLOBAL_EPHEMERAL_MARKER_93]
+
+  - id: stage-durable-memory-after-restart
+    description: Durable project notes stay retrievable after a full restart.
+    tags: [memory, stage, retrieval, restart]
+    memory_enabled: true
+    allowed_tools: [search_memory, attempt_completion]
+    files:
+      .wisp/memory/2025-04-10.md: |
+        [TURN-MEMORY · session demo3 · turn 7]
+        MEMORY_FACT_DURABLE_55: the atlas normalization uses CPM with log1p.
+    script:
+      - tool_calls:
+          - {id: done-1, name: attempt_completion, arguments: {result: "ready"}}
+      - tool_calls:
+          - id: search-1
+            name: search_memory
+            arguments:
+              queries:
+                - {text: "atlas normalization", kind: exact}
+      - tool_calls:
+          - {id: done-2, name: attempt_completion, arguments: {result: "CPM with log1p"}}
+    actions:
+      - {kind: send, prompt: "Say ready."}
+      - {kind: restart}
+      - {kind: send, prompt: "How is the atlas normalized?"}
+    expect:
+      completion_contains: [log1p]
+      required_tools: [search_memory, attempt_completion]
+      tool_order: [attempt_completion, search_memory, attempt_completion]
+      request_contains: [MEMORY_FACT_DURABLE_55]

--- a/crates/wisp-cli/src/eval.rs
+++ b/crates/wisp-cli/src/eval.rs
@@ -22,6 +22,8 @@ const TRAJECTORY_SCHEMA: &str = "wisp.agent-trajectory.v1";
 const BUILTIN_SUITE: &str = include_str!("../eval-suites/offline-v1.yaml");
 #[cfg(test)]
 const LIVE_COMPACTION_SUITE: &str = include_str!("../eval-suites/live-compaction-v1.yaml");
+#[cfg(test)]
+const MEMORY_SUITE: &str = include_str!("../eval-suites/memory-v1.yaml");
 const DEFAULT_MAX_CONTEXT: usize = 128_000;
 const DEFAULT_MAX_ROUNDS: usize = 12;
 const DEFAULT_TIMEOUT_MS: u64 = 60_000;
@@ -190,6 +192,15 @@ struct EvalCase {
     fixture_runtimes: bool,
     #[serde(default)]
     fixture_mcp: BTreeMap<String, String>,
+    /// Register the project-memory `search_memory` tool, mirroring the host's
+    /// memory setting. Seed notes with `files` under `.wisp/memory/*.md`.
+    #[serde(default)]
+    memory_enabled: bool,
+    /// Ephemeral host context injected before the first send, mirroring the
+    /// desktop host's per-turn global-memory injection. Injections are not
+    /// durable history: a `restart` action drops them.
+    #[serde(default)]
+    runtime_injections: Vec<String>,
     #[serde(default)]
     context_seed: Vec<SeedMessage>,
     #[serde(default)]
@@ -270,12 +281,25 @@ struct EvalExpectation {
     tool_args: Vec<ToolArgumentExpectation>,
     #[serde(default)]
     request_contains: Vec<String>,
+    /// Fragments the last provider request must contain. Sharper than
+    /// `request_contains` after compaction or restart: it proves retention in
+    /// the final working context rather than anywhere in the run.
+    #[serde(default)]
+    final_request_contains: Vec<String>,
+    /// Fragments the last provider request must not contain, e.g. folded
+    /// filler after compaction or an ephemeral injection after restart.
+    #[serde(default)]
+    final_request_not_contains: Vec<String>,
     #[serde(default)]
     approvals: Option<usize>,
     #[serde(default)]
     remaining_script: Option<usize>,
     #[serde(default)]
     compactions: Option<usize>,
+    /// Exact ordered list of observed compaction strategies
+    /// (`auto`, `overflow`, `manual`).
+    #[serde(default)]
+    compaction_strategies: Vec<String>,
     #[serde(default)]
     max_compaction_ratio_percent: Option<u64>,
 }
@@ -299,9 +323,12 @@ impl Default for EvalExpectation {
             tool_order: Vec::new(),
             tool_args: Vec::new(),
             request_contains: Vec::new(),
+            final_request_contains: Vec::new(),
+            final_request_not_contains: Vec::new(),
             approvals: None,
             remaining_script: None,
             compactions: None,
+            compaction_strategies: Vec::new(),
             max_compaction_ratio_percent: None,
         }
     }
@@ -1159,6 +1186,12 @@ async fn run_case(
         agent.set_auto_compact(enabled);
     }
     seed_context(&mut agent.ctx, &case.context_seed)?;
+    // Mirror the host's per-turn global-memory injection: ephemeral user
+    // context placed before the next durable user request.
+    for injection in &case.runtime_injections {
+        agent.ctx.inject_user(injection);
+    }
+    agent.ctx.prefix_runtime_injections_to_user();
 
     let cancel = Arc::new(AtomicBool::new(false));
     if let Some(delay) = case.cancel_after_ms {
@@ -1353,7 +1386,7 @@ fn build_agent(
     let skill_paths = vec![root.join(".wisp").join("skills")];
     let skills = Arc::new(SkillIndex::load(&skill_paths));
     let memory = Arc::new(MemoryManager::new(root));
-    let mut registry = wisp_core::build_registry(skills.clone(), memory, false);
+    let mut registry = wisp_core::build_registry(skills.clone(), memory, case.memory_enabled);
     registry.add(Box::new(wisp_tools::ask_user::AskUserTool));
     for (name, result) in &case.fixture_mcp {
         registry.add(Box::new(FixtureMcpTool {
@@ -1610,6 +1643,24 @@ fn verify_case(
             ));
         }
     }
+    if !case.expect.compaction_strategies.is_empty() {
+        let observed = captured
+            .compactions
+            .iter()
+            .map(|compaction| compaction.strategy.as_str())
+            .collect::<Vec<_>>();
+        let expected = case
+            .expect
+            .compaction_strategies
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>();
+        if observed != expected {
+            failures.push(format!(
+                "expected compaction strategies {expected:?}, observed {observed:?}"
+            ));
+        }
+    }
     if let Some(max_percent) = case.expect.max_compaction_ratio_percent {
         for compaction in &captured.compactions {
             let ratio = if compaction.before_tokens == 0 {
@@ -1626,19 +1677,47 @@ fn verify_case(
         }
     }
     if let Some(provider) = provider {
+        fn request_has_fragment(request: &wisp_llm::ScriptedRequest, fragment: &str) -> bool {
+            request.messages.iter().any(|message| {
+                contains_folded(&message.content.as_text(), fragment)
+                    || message
+                        .reasoning
+                        .as_deref()
+                        .is_some_and(|value| contains_folded(value, fragment))
+            })
+        }
         for fragment in &case.expect.request_contains {
-            let found = provider.requests.iter().any(|request| {
-                request.messages.iter().any(|message| {
-                    contains_folded(&message.content.as_text(), fragment)
-                        || message
-                            .reasoning
-                            .as_deref()
-                            .is_some_and(|value| contains_folded(value, fragment))
-                })
-            });
-            if !found {
+            if !provider
+                .requests
+                .iter()
+                .any(|request| request_has_fragment(request, fragment))
+            {
                 failures.push(format!("no provider request contained '{fragment}'"));
             }
+        }
+        let final_expectations = !case.expect.final_request_contains.is_empty()
+            || !case.expect.final_request_not_contains.is_empty();
+        match provider.requests.last() {
+            Some(request) => {
+                for fragment in &case.expect.final_request_contains {
+                    if !request_has_fragment(request, fragment) {
+                        failures.push(format!(
+                            "the final provider request did not contain '{fragment}'"
+                        ));
+                    }
+                }
+                for fragment in &case.expect.final_request_not_contains {
+                    if request_has_fragment(request, fragment) {
+                        failures.push(format!(
+                            "the final provider request unexpectedly contained '{fragment}'"
+                        ));
+                    }
+                }
+            }
+            None if final_expectations => {
+                failures.push("no provider request was recorded for final-request checks".into())
+            }
+            None => {}
         }
         let expected_remaining = case.expect.remaining_script.unwrap_or(0);
         if provider.remaining_completions != expected_remaining {
@@ -2213,6 +2292,81 @@ mod tests {
     }
 
     #[test]
+    fn memory_suite_is_valid_and_covers_every_memory_axis() {
+        let suite: EvalSuite = serde_yaml::from_str(MEMORY_SUITE).unwrap();
+        validate_suite(&suite, EvalMode::Offline).unwrap();
+        let tags: BTreeSet<_> = suite
+            .cases
+            .iter()
+            .flat_map(|case| case.tags.iter().map(String::as_str))
+            .collect();
+        for required in [
+            "compaction",
+            "auto",
+            "manual",
+            "overflow",
+            "retrieval",
+            "cjk",
+            "gating",
+            "stage",
+            "injection",
+            "restart",
+        ] {
+            assert!(
+                tags.contains(required),
+                "missing memory coverage tag {required}"
+            );
+        }
+        // Every compaction trigger mode asserts its strategy, real shrinkage,
+        // and that folded filler no longer reaches the final request.
+        for strategy in ["auto", "manual", "overflow"] {
+            let case = suite
+                .cases
+                .iter()
+                .find(|case| case.expect.compaction_strategies == vec![strategy.to_string()])
+                .unwrap_or_else(|| panic!("no case pins the '{strategy}' compaction strategy"));
+            assert_eq!(case.expect.compactions, Some(1), "{strategy}");
+            assert!(
+                case.expect.max_compaction_ratio_percent.is_some(),
+                "{strategy}"
+            );
+            assert!(
+                !case.expect.final_request_not_contains.is_empty(),
+                "{strategy}"
+            );
+        }
+        assert!(
+            suite.cases.iter().any(|case| case.memory_enabled),
+            "retrieval cases must exercise the enabled memory registry"
+        );
+        assert!(
+            suite
+                .cases
+                .iter()
+                .any(|case| !case.runtime_injections.is_empty()),
+            "stage cases must exercise per-turn injection"
+        );
+    }
+
+    #[tokio::test]
+    async fn memory_suite_cases_pass_offline() {
+        let suite: EvalSuite = serde_yaml::from_str(MEMORY_SUITE).unwrap();
+        for case in suite.cases {
+            let id = case.id.clone();
+            let result = run_case(
+                case,
+                1,
+                suite.defaults.clone(),
+                None,
+                EvalOptions::default(),
+            )
+            .await
+            .unwrap();
+            assert!(result.passed, "{id}: {:?}", result.failures);
+        }
+    }
+
+    #[test]
     fn model_matrix_is_live_only_and_unique() {
         let offline = EvalOptions {
             models: vec!["model-a".into()],
@@ -2277,6 +2431,8 @@ mod tests {
             explore_script: vec![],
             fixture_runtimes: false,
             fixture_mcp: BTreeMap::new(),
+            memory_enabled: false,
+            runtime_injections: vec![],
             context_seed: vec![],
             approval: EvalApproval::default(),
             plan_mode: false,

--- a/crates/wisp-llm/src/lib.rs
+++ b/crates/wisp-llm/src/lib.rs
@@ -26,6 +26,6 @@ pub use provider::{
 pub use provider::{LlmError, Result};
 pub use routed::RoutedProvider;
 pub use scripted::{
-    ScriptedCompletion, ScriptedProvider, ScriptedProviderSnapshot, ScriptedRequest,
-    ScriptedToolCall,
+    ScriptedApiError, ScriptedCompletion, ScriptedProvider, ScriptedProviderSnapshot,
+    ScriptedRequest, ScriptedToolCall,
 };

--- a/crates/wisp-llm/src/scripted.rs
+++ b/crates/wisp-llm/src/scripted.rs
@@ -29,6 +29,15 @@ fn empty_object() -> serde_json::Value {
     serde_json::json!({})
 }
 
+/// A deterministic provider-side API failure. Suites use this to script error
+/// paths such as context-overflow recovery without a real endpoint.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ScriptedApiError {
+    pub status: u16,
+    #[serde(default)]
+    pub body: String,
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ScriptedCompletion {
     #[serde(default)]
@@ -54,6 +63,10 @@ pub struct ScriptedCompletion {
     /// Unicode scalar values. Zero emits one chunk.
     #[serde(default)]
     pub chunk_chars: usize,
+    /// Fail this scripted step with an API error instead of a completion. The
+    /// request is still recorded and the script advances past this step.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub api_error: Option<ScriptedApiError>,
 }
 
 impl ScriptedCompletion {
@@ -229,6 +242,12 @@ impl Provider for ScriptedProvider {
         if scripted.delay_ms > 0 {
             tokio::time::sleep(Duration::from_millis(scripted.delay_ms)).await;
         }
+        if let Some(error) = &scripted.api_error {
+            return Err(LlmError::Api {
+                status: error.status,
+                body: error.body.clone(),
+            });
+        }
         Ok(scripted.materialize(sequence))
     }
 
@@ -240,6 +259,12 @@ impl Provider for ScriptedProvider {
     ) -> Result<Completion> {
         let (sequence, scripted) = self.next(messages, tools)?;
         deterministic_delay(scripted.delay_ms, sink).await?;
+        if let Some(error) = &scripted.api_error {
+            return Err(LlmError::Api {
+                status: error.status,
+                body: error.body.clone(),
+            });
+        }
         for chunk in chunks(
             scripted.reasoning.as_deref().unwrap_or_default(),
             scripted.chunk_chars,
@@ -297,6 +322,40 @@ mod tests {
         assert_eq!(snapshot.requests.len(), 1);
         assert_eq!(snapshot.requests[0].messages[0].role, Role::User);
         assert_eq!(snapshot.requests[0].tool_names, vec!["read"]);
+        assert_eq!(snapshot.remaining_completions, 0);
+    }
+
+    #[tokio::test]
+    async fn scripted_api_error_fails_one_step_and_advances_the_script() {
+        let provider = ScriptedProvider::new(
+            "fixture",
+            vec![
+                ScriptedCompletion {
+                    api_error: Some(ScriptedApiError {
+                        status: 400,
+                        body: "maximum context length exceeded".into(),
+                    }),
+                    ..ScriptedCompletion::default()
+                },
+                ScriptedCompletion {
+                    content: "recovered".into(),
+                    ..ScriptedCompletion::default()
+                },
+            ],
+        );
+        let mut sink = NullSink;
+        let error = provider
+            .stream(&[Message::user("first")], &[], &mut sink)
+            .await
+            .unwrap_err();
+        assert!(error.is_context_overflow(), "{error}");
+        let completion = provider
+            .complete(&[Message::user("second")], &[])
+            .await
+            .unwrap();
+        assert_eq!(completion.content, "recovered");
+        let snapshot = provider.snapshot();
+        assert_eq!(snapshot.requests.len(), 2);
         assert_eq!(snapshot.remaining_completions, 0);
     }
 }

--- a/docs/headless-agent-testing.md
+++ b/docs/headless-agent-testing.md
@@ -76,6 +76,44 @@ provider. Live mode requires the normal `WISP_API_KEY`, `WISP_PROVIDER`, and
 `WISP_MODEL` environment variables. Scripted steps are ignored in live mode;
 live suites should use tolerant semantic assertions rather than exact prose.
 
+### Memory and compaction dataset
+
+`crates/wisp-cli/eval-suites/memory-v1.yaml` is a deterministic offline
+dataset for the memory mechanism. It verifies three axes:
+
+1. **Compression without forgetting.** One scenario per compaction trigger
+   mode — `auto` (80% boundary before a model call), `manual` (`/compact`
+   action), and `overflow` (a scripted provider context-overflow error forces
+   one recovery compaction and a retry). Each seeds early facts buried under
+   bulk filler, requires exactly that strategy, requires real shrinkage via
+   `max_compaction_ratio_percent`, and asserts through `final_request_contains`
+   / `final_request_not_contains` that the post-compaction request still
+   carries the early facts, the `[context summary checkpoint]`, the
+   `wisp-history:` archive pointer, and the recent tail, while the folded
+   filler is gone.
+2. **Retrieval correctness.** `search_memory` scenarios over seeded
+   `.wisp/memory/*.md` notes: multi-query fan-out that must return the right
+   chunk and exclude distractors, CJK matching, an explicit empty-result miss,
+   and the setting gate (the tool is not registered while memory is disabled).
+3. **Stage loading.** Session-start rules (`AGENTS.md` + `.wisp/WISP.md` in
+   the system prompt), per-turn ephemeral host injection reaching the provider
+   request, injections *not* surviving a restart as durable history, and
+   durable project notes remaining retrievable after a restart.
+
+```bash
+cargo run -p wisp-cli -- eval --suite crates/wisp-cli/eval-suites/memory-v1.yaml
+```
+
+The suite also runs inside `cargo test -p wisp-cli` so regressions surface in
+the normal workspace test run. Case knobs added for this dataset:
+`memory_enabled` registers the production `search_memory` tool, and
+`runtime_injections` mirrors the host's per-turn global-memory injection.
+Expectation knobs: `compaction_strategies` pins the exact ordered trigger
+modes, and `final_request_contains` / `final_request_not_contains` assert on
+the last provider request only — sharper than `request_contains` after a
+compaction or restart. Scripted steps may fail deterministically with
+`api_error: {status, body}` to exercise provider error paths.
+
 ### Cross-model compaction benchmark
 
 The repository includes `crates/wisp-cli/eval-suites/live-compaction-v1.yaml`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Headless memory test dataset (memory-v1)

## Problem

The memory mechanism had unit tests but no end-to-end headless dataset. There was no deterministic way to verify, through the production agent loop, that (1) compaction under each trigger mode avoids context forgetting, (2) `search_memory` retrieval returns the right chunks, and (3) memory loaded at each lifecycle stage actually reaches the model. The offline eval harness also could not express these scenarios: the memory tool was hard-disabled, per-turn host injections were not representable, and the `overflow` compaction trigger could not be scripted.

## What this adds

**New dataset — `crates/wisp-cli/eval-suites/memory-v1.yaml` (11 cases, all offline, no API key/network):**

1. **Compression without forgetting** — one case per trigger mode: `auto` (80% boundary), `manual` (`/compact` action), `overflow` (scripted 400 "maximum context length exceeded" forces one recovery compaction + retry). Each seeds early facts buried under bulk filler and asserts: exact strategy (`compaction_strategies`), real shrinkage (`max_compaction_ratio_percent: 60`), and that the **final** provider request still carries both early facts, the `[context summary checkpoint]`, the `wisp-history:` archive pointer, and the recent tail — while the folded filler is gone (`final_request_not_contains`). The filler marker lives only in assistant messages because folded user messages are excerpted verbatim into checkpoints by design.
2. **Retrieval correctness** — `search_memory` over seeded `.wisp/memory/*.md`: multi-query fan-out returning the right chunk and excluding distractors, CJK query matching, explicit empty-result miss, and the setting gate (tool not registered while memory is off).
3. **Stage loading** — session-start rules (`AGENTS.md` + `.wisp/WISP.md` in the system prompt), per-turn ephemeral injection reaching the request, injections *not* surviving `restart` as durable history, and durable notes remaining retrievable after `restart`.

**Harness extensions — `crates/wisp-cli/src/eval.rs`:**
- Case knobs: `memory_enabled` (registers the production `search_memory` tool) and `runtime_injections` (mirrors the desktop host's per-turn global-memory injection via `inject_user` + `prefix_runtime_injections_to_user`).
- Expectations: `compaction_strategies` (exact ordered trigger modes) and `final_request_contains` / `final_request_not_contains` (assert on the last provider request only — sharper than `request_contains` after compaction/restart).

**Provider — `crates/wisp-llm/src/scripted.rs`:**
- `ScriptedCompletion.api_error: {status, body}` fails one scripted step deterministically (request still recorded, script advances), enabling the overflow-recovery scenario headlessly.

## Tests

- `scripted_api_error_fails_one_step_and_advances_the_script` (wisp-llm).
- `memory_suite_is_valid_and_covers_every_memory_axis` — validates the suite and pins coverage of all three axes and all three compaction strategies.
- `memory_suite_cases_pass_offline` — executes all 11 dataset cases through the production agent loop inside `cargo test`.
- `cargo fmt --all -- --check` clean; `cargo test --workspace` fully green (all crates, 0 failures).

## Manual smoke

```bash
cargo run -p wisp-cli -- eval --suite crates/wisp-cli/eval-suites/memory-v1.yaml
```

Result: 11/11 pass, 3 compactions (one per strategy), `pass_rate_percent: 100`.

## Docs

`docs/headless-agent-testing.md` gains a "Memory and compaction dataset" section describing the axes, the run command, and the new knobs.

## Known limitations / follow-ups

- Global-memory injection is modeled at the harness boundary (`runtime_injections`); the SQLite `global_memories` cap/ordering remains covered by `src-tauri` unit tests.
- Recency-weighted retrieval (`time_hint: recent`) is not in the YAML dataset because fixture files share one mtime; scoring stays covered by `wisp-core/src/memory.rs` unit tests.
- Prune-only compaction (old tool results → tombstones) is not expressible via `context_seed` (user/assistant/system roles only); it remains covered by `context.rs` unit tests. A `tool` seed role would be a natural follow-up.
- Incremental checkpoint update across two compactions is unit-tested in `context.rs` but not yet a YAML case.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-02486b4a-f650-4f2d-9513-5daff2ae182b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02486b4a-f650-4f2d-9513-5daff2ae182b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

