### PR TITLE
Fix silent task failures and blank completions with DeepSeek/GLM (#798)

### DIFF
--- a/crates/wisp-llm/src/openai.rs
+++ b/crates/wisp-llm/src/openai.rs
@@ -373,6 +373,44 @@ fn ensure_named_tool_calls(calls: &[ToolCall]) -> Result<()> {
     Ok(())
 }
 
+/// Detect an in-band error payload on an otherwise-healthy SSE stream and
+/// carry the upstream detail out as `LlmError::Api`, so the user sees the
+/// provider's actual reason instead of a generic "stream cut" message (#798).
+/// Shapes seen from compatible relays: `{"error":{"message":..,"code":..}}`,
+/// `{"error":"plain text"}`, and `{"type":"error","message":..}`. A `"error":
+/// null` field on a normal chunk is not an error. When the payload carries a
+/// numeric HTTP-like code, use it as the status so retry (429/5xx) and
+/// context-overflow (400) handling keep working; otherwise report the 200 the
+/// relay actually sent.
+fn in_band_stream_error(val: &Value) -> Option<LlmError> {
+    let err = val.get("error").filter(|e| !e.is_null());
+    if err.is_none() && val.get("type").and_then(Value::as_str) != Some("error") {
+        return None;
+    }
+    let detail = err.unwrap_or(val);
+    let message = detail
+        .as_str()
+        .or_else(|| detail.get("message").and_then(Value::as_str))
+        .or_else(|| val.get("message").and_then(Value::as_str))
+        .map(str::to_string)
+        .unwrap_or_else(|| detail.to_string());
+    let status = detail
+        .get("code")
+        .or_else(|| detail.get("status"))
+        .and_then(|code| match code {
+            Value::Number(n) => n.as_u64(),
+            Value::String(s) => s.parse().ok(),
+            _ => None,
+        })
+        .and_then(|code| u16::try_from(code).ok())
+        .filter(|code| (100..=599).contains(code))
+        .unwrap_or(200);
+    Some(LlmError::Api {
+        status,
+        body: message,
+    })
+}
+
 fn append_stream_content_delta(
     delta: &Value,
     content: &mut String,
@@ -490,10 +528,8 @@ impl Provider for OpenAiProvider {
                     // encode the failure as a normal `data:` payload and may
                     // still append `[DONE]`. Treating `[DONE]` alone as success
                     // in that case commits a partial answer and ends the turn.
-                    if val.get("error").is_some()
-                        || val.get("type").and_then(Value::as_str) == Some("error")
-                    {
-                        return Err(LlmError::Incomplete);
+                    if let Some(error) = in_band_stream_error(&val) {
+                        return Err(error);
                     }
                     // The final usage chunk carries an empty `choices` array, so
                     // parse usage before the choice guard would `continue` past it.
@@ -739,6 +775,8 @@ mod tests {
         );
     }
 
+    // #798: the upstream failure reason must survive to the user instead of
+    // collapsing into a generic "stream cut" message.
     #[tokio::test]
     async fn stream_rejects_in_band_error_even_when_relay_appends_done() {
         let (base_url, requests) = serve_responses(vec![(
@@ -755,9 +793,51 @@ mod tests {
             .await
             .unwrap_err();
 
-        assert!(matches!(error, LlmError::Incomplete));
+        assert!(
+            matches!(&error, LlmError::Api { status: 200, body } if body == "upstream connection reset"),
+            "in-band error must carry the upstream message, got: {error}"
+        );
         assert_eq!(sink.text, ["partial"]);
         assert_eq!(requests.await.unwrap(), ["/chat/completions"]);
+    }
+
+    // #798: detail extraction across the payload shapes compatible relays use,
+    // without misreading `"error": null` on healthy chunks as a failure.
+    #[test]
+    fn in_band_stream_error_extracts_detail_and_spares_null_error_fields() {
+        let cases = [
+            (
+                json!({"error": {"message": "insufficient balance", "code": "1113"}}),
+                (200u16, "insufficient balance"),
+            ),
+            (
+                json!({"error": {"message": "rate limit reached", "code": 429}}),
+                (429, "rate limit reached"),
+            ),
+            (
+                json!({"error": "plain relay failure"}),
+                (200, "plain relay failure"),
+            ),
+            (
+                json!({"type": "error", "message": "upstream timeout"}),
+                (200, "upstream timeout"),
+            ),
+        ];
+        for (val, (want_status, want_body)) in cases {
+            match in_band_stream_error(&val) {
+                Some(LlmError::Api { status, body }) => {
+                    assert_eq!((status, body.as_str()), (want_status, want_body), "{val}");
+                }
+                other => panic!("{val} should be an Api error, got {other:?}"),
+            }
+        }
+        // A `"error": null` field beside normal deltas (some relays emit it on
+        // every chunk) must not fail the whole stream.
+        assert!(in_band_stream_error(
+            &json!({"error": null, "choices": [{"delta": {"content": "hi"}}]})
+        )
+        .is_none());
+        assert!(in_band_stream_error(&json!({"choices": []})).is_none());
     }
 
     #[tokio::test]

--- a/crates/wisp-tools/src/attempt_completion.rs
+++ b/crates/wisp-tools/src/attempt_completion.rs
@@ -31,6 +31,70 @@ impl Tool for AttemptCompletionTool {
             Ok(r) => r,
             Err(e) => return ToolResult::fail(e),
         };
+        // An empty result would end the turn with no visible answer — the UI
+        // hides this tool row and only promotes non-empty result text, so the
+        // user sees a bare "Processed" block (#798). Refuse it so the model
+        // retries with the actual final answer.
+        if result.trim().is_empty() {
+            return ToolResult::fail(
+                "attempt_completion error: 'result' must contain the final answer text for the \
+                 user — it is the only text shown as your response. Call attempt_completion \
+                 again with the complete result.",
+            );
+        }
         ToolResult::ok(result).stop_turn()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AttemptCompletionTool;
+    use crate::env::{ToolControl, ToolEnv, ToolEvent};
+    use crate::tool::Tool;
+    use serde_json::json;
+    use std::path::Path;
+
+    struct NoEnv;
+
+    #[async_trait::async_trait]
+    impl ToolEnv for NoEnv {
+        fn project_root(&self) -> &Path {
+            Path::new(".")
+        }
+        async fn confirm(&self, _message: &str) -> bool {
+            false
+        }
+        async fn emit(&self, _event: ToolEvent) {}
+    }
+
+    #[tokio::test]
+    async fn non_empty_result_stops_the_turn() {
+        let result = AttemptCompletionTool
+            .run(&json!({ "result": "All 12 samples aligned." }), &NoEnv)
+            .await;
+        assert!(result.success);
+        assert_eq!(result.control, ToolControl::StopTurn);
+        assert_eq!(result.content, "All 12 samples aligned.");
+    }
+
+    // #798: an empty result used to end the turn "successfully" while the UI
+    // had nothing to show — the user saw a blank "Processed" row. It must be
+    // a tool failure that keeps the loop running so the model supplies the
+    // real answer.
+    #[tokio::test]
+    async fn empty_result_is_rejected_instead_of_ending_the_turn() {
+        for args in [
+            json!({}),
+            json!({ "result": "" }),
+            json!({ "result": "  \n" }),
+        ] {
+            let result = AttemptCompletionTool.run(&args, &NoEnv).await;
+            assert!(!result.success, "{args} must not be accepted");
+            assert_eq!(
+                result.control,
+                ToolControl::Continue,
+                "a rejected completion must not stop the turn"
+            );
+        }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Fixes #798: with DeepSeek/GLM (and similar OpenAI-compatible relays), users frequently saw:

1. **Tasks failing with no reason.** Compatible relays keep the HTTP response at 200 and encode upstream failures (insufficient balance, rate limits, connection resets) as in-band `data: {"error": ...}` SSE payloads. The stream parser collapsed all of these into `LlmError::Incomplete`, so the user only ever saw the generic "stream cut mid-response" message — the actual reason was discarded.
2. **Turns "completing" with no visible output**, requiring the user to type "继续" repeatedly. When the model called `attempt_completion` with an empty `result`, the tool stopped the turn successfully, but the UI hides that tool row and only promotes non-empty result text — leaving a bare "已处理/Processed" block with no answer.

## Changes

- `crates/wisp-llm/src/openai.rs`
  - New `in_band_stream_error()` extracts the upstream error message (object, plain-string, and `{"type":"error"}` shapes) and returns it as `LlmError::Api`, so the real reason reaches the user's error card. Numeric codes (e.g. 429/5xx/400) are carried as the status, so existing retry and context-overflow-recovery handling still applies.
  - `"error": null` fields on healthy chunks (which some relays emit on every delta) no longer fail the whole stream.
- `crates/wisp-tools/src/attempt_completion.rs`
  - An empty/whitespace `result` is now rejected as a tool failure (loop continues, model retries with the real answer) instead of stopping the turn with nothing to show.

## Tests

- `stream_rejects_in_band_error_even_when_relay_appends_done` updated to assert the upstream message survives.
- New `in_band_stream_error_extracts_detail_and_spares_null_error_fields` covering all payload shapes plus the `"error": null` case.
- New `attempt_completion` tests: non-empty result stops the turn; empty/missing result is rejected and does not stop the turn.
- `cargo fmt --all -- --check` and `cargo test --workspace` pass.

## Manual smoke steps

1. Point Wisp at a relay that fails mid-stream in-band (e.g. exhausted DeepSeek balance): the error card now shows the provider's message (e.g. `api: 200 insufficient balance`) instead of the generic stream-cut text.
2. Give a task where the model finishes via `attempt_completion`: an empty result no longer produces a blank "已处理" turn; the model is pushed to supply the final answer text.

## Known limitations / follow-ups

- `AgentEvent::Error` is still not persisted, so an error card disappears after reload/session switch — worth a separate PR.
- The desktop notification title is still the fixed "任务失败"; the detail is only in the body.
- The Anthropic and Responses providers were not touched; the issue reports are specific to OpenAI-compatible models.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7e09372b-f857-4c48-bb4f-fb99105deab7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7e09372b-f857-4c48-bb4f-fb99105deab7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

