### PR TITLE
ui: replace native reasoning-effort select with in-menu option list

### DIFF
--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -904,9 +904,11 @@ test("reasoning effort stays scoped to the current conversation", async ({ page 
   await expect(page.locator(".model-picker-label")).toHaveText("opus-4.8");
 
   await page.locator(".model-picker-btn").click();
-  const effort = page.locator(".model-menu-effort-select");
-  await expect(effort).toHaveValue("max");
-  await effort.selectOption("high");
+  const effortTrigger = page.locator(".model-menu-effort-trigger");
+  const effortValue = page.locator(".model-menu-effort-value");
+  await expect(effortValue).toHaveText("max");
+  await effortTrigger.click();
+  await page.locator(".model-menu-effort-option[data-effort='high']").click();
   await expect.poll(() => lastInvokeArgs(page, "set_session_reasoning_effort")).toMatchObject({
     sessionId: "s-model-a",
     effort: "high",
@@ -916,21 +918,38 @@ test("reasoning effort stays scoped to the current conversation", async ({ page 
 
   await page.locator('[data-session-id="s-model-b"]').click();
   await page.locator(".model-picker-btn").click();
-  await expect(page.locator(".model-menu-effort-select")).toHaveValue("low");
+  await expect(page.locator(".model-menu-effort-value")).toHaveText("low");
   await page.locator(".model-menu-backdrop").click();
 
   await page.locator('[data-session-id="s-model-a"]').click();
   await page.locator(".model-picker-btn").click();
-  await expect(page.locator(".model-menu-effort-select")).toHaveValue("high");
+  await expect(page.locator(".model-menu-effort-value")).toHaveText("high");
 
   // "default" clears the override: the session follows the bound profile
   // (opus-4.8 defaults to max) instead of pinning "provider default".
-  await effort.selectOption("default");
+  await effortTrigger.click();
+  await page.locator(".model-menu-effort-option[data-effort='default']").click();
   await expect.poll(() => lastInvokeArgs(page, "set_session_reasoning_effort")).toMatchObject({
     sessionId: "s-model-a",
     effort: "",
   });
-  await expect(page.locator(".model-menu-effort-select")).toHaveValue("max");
+  await expect(page.locator(".model-menu-effort-value")).toHaveText("max");
+});
+
+test("effort options close on Escape before the model menu", async ({ page }) => {
+  await enterApp(page, "/?mockSessionModels=1");
+  await page.locator('[data-session-id="s-model-a"]').click();
+  await page.locator(".model-picker-btn").click();
+  await page.locator(".model-menu-effort-trigger").click();
+  await expect(page.locator(".model-menu-effort-options")).toBeVisible();
+
+  // One Escape closes only the effort options; the model menu stays open.
+  await page.keyboard.press("Escape");
+  await expect(page.locator(".model-menu-effort-options")).toHaveCount(0);
+  await expect(page.locator(".model-menu")).toBeVisible();
+
+  await page.keyboard.press("Escape");
+  await expect(page.locator(".model-menu")).toHaveCount(0);
 });
 
 test("Settings Models page can open ACP Agents dialog", async ({ page }) => {

--- a/ui/src/app_support/sessions.rs
+++ b/ui/src/app_support/sessions.rs
@@ -181,6 +181,7 @@ mod branch_nesting_tests {
             branched_from: branched_from.map(Into::into),
             pinned: false,
             branch_state: branched_from.map(|_| "active".into()),
+            stale_prompt: false,
         }
     }
 

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -593,6 +593,13 @@ fn App() -> impl IntoView {
     let project_transition_target = Rc::new(RefCell::new(None::<String>));
     let project_open_gate = Rc::new(RefCell::new(ProjectOpenGate::default()));
     let model_menu_open = create_rw_signal(false);
+    let effort_menu_open = create_rw_signal(false);
+    // The effort picker lives inside the model menu; collapse it with the menu.
+    create_effect(move |_| {
+        if !model_menu_open.get() {
+            effort_menu_open.set(false);
+        }
+    });
     let model_switch_confirm = create_rw_signal::<Option<(String, String, bool)>>(None);
     let status = create_rw_signal(String::new());
     let compaction_active = create_rw_signal(false);
@@ -7505,6 +7512,11 @@ fn App() -> impl IntoView {
             specialist_menu_open.set(false);
             return;
         }
+        if effort_menu_open.get() {
+            ev.prevent_default();
+            effort_menu_open.set(false);
+            return;
+        }
         if model_menu_open.get() {
             ev.prevent_default();
             model_menu_open.set(false);
@@ -11407,7 +11419,7 @@ fn App() -> impl IntoView {
                                     </button>
                                     {move || model_menu_open.get().then(|| view! {
                                         <div class="model-menu-backdrop" on:click=move |_| model_menu_open.set(false)></div>
-                                        <div class="model-menu">
+                                        <div class="model-menu" on:click=move |_| effort_menu_open.set(false)>
                                             {move || {
                                                 let list = models.get();
                                                 let selected = active_session.get().and_then(|session_id| {
@@ -11692,84 +11704,111 @@ fn App() -> impl IntoView {
                                                     </div>
                                                 })
                                             })}
-                                            {move || active_acp_agent_id.get().is_none().then(|| view! {
-                                                <div class="model-menu-effort" on:click=|ev| ev.stop_propagation()>
-                                                    <span class="model-menu-effort-label">{move || t(locale.get(), "settings.reasoning_effort")}</span>
-                                                    <select class="model-menu-effort-select"
-                                                        on:change=move |ev| {
-                                                            let v = dom_value(&ev);
-                                                            let Some(session_id) = active_session.get_untracked() else { return; };
-                                                            let effort = if v == "default" { String::new() } else { v };
-                                                            spawn_local(async move {
-                                                                let arg = to_value(&serde_json::json!({
-                                                                    "sessionId": session_id.clone(),
-                                                                    "effort": effort.clone(),
-                                                                })).unwrap();
-                                                                if invoke_checked("set_session_reasoning_effort", arg).await.is_ok() {
-                                                                    session_reasoning_efforts.update(|efforts| {
-                                                                        if effort.is_empty() {
-                                                                            // Cleared override: inherit the
-                                                                            // bound profile again.
-                                                                            efforts.remove(&session_id);
-                                                                        } else {
-                                                                            efforts.insert(session_id, effort);
-                                                                        }
-                                                                    });
+                                            {move || active_acp_agent_id.get().is_none().then(|| {
+                                                let apply_effort = Rc::new(move |v: String| {
+                                                    effort_menu_open.set(false);
+                                                    let Some(session_id) = active_session.get_untracked() else { return; };
+                                                    let effort = if v == "default" { String::new() } else { v };
+                                                    spawn_local(async move {
+                                                        let arg = to_value(&serde_json::json!({
+                                                            "sessionId": session_id.clone(),
+                                                            "effort": effort.clone(),
+                                                        })).unwrap();
+                                                        if invoke_checked("set_session_reasoning_effort", arg).await.is_ok() {
+                                                            session_reasoning_efforts.update(|efforts| {
+                                                                if effort.is_empty() {
+                                                                    // Cleared override: inherit the
+                                                                    // bound profile again.
+                                                                    efforts.remove(&session_id);
+                                                                } else {
+                                                                    efforts.insert(session_id, effort);
                                                                 }
                                                             });
-                                                        }>
-                                                        {move || {
-                                                            let models = models.get();
-                                                            let session_models = session_model_ids.get();
-                                                            let efforts = session_reasoning_efforts.get();
-                                                            let session_id = active_session.get();
-                                                            let current = session_reasoning_effort(
-                                                                &models,
-                                                                &session_models,
-                                                                &efforts,
-                                                                session_id.as_deref(),
-                                                            );
-                                                            let mut values: Vec<String> = session_profile(
-                                                                &models,
-                                                                &session_models,
-                                                                session_id.as_deref(),
-                                                            )
-                                                            .map(|profile| {
-                                                                known_effort_values(&profile.provider, &profile.model)
-                                                                    .unwrap_or(ALL_EFFORT_VALUES)
-                                                            })
-                                                            .unwrap_or(ALL_EFFORT_VALUES)
-                                                            .iter()
-                                                            .map(|v| v.to_string())
-                                                            .collect();
-                                                            // Keep a stored override visible even when the
-                                                            // curated list for this model doesn't include it.
-                                                            if !current.is_empty() && !values.iter().any(|v| v == &current) {
-                                                                values.push(current.clone());
-                                                            }
-                                                            // The select shows the effective effort:
+                                                        }
+                                                    });
+                                                });
+                                                let current_effort = move || {
+                                                    let models = models.get();
+                                                    let session_models = session_model_ids.get();
+                                                    let efforts = session_reasoning_efforts.get();
+                                                    let session_id = active_session.get();
+                                                    session_reasoning_effort(
+                                                        &models,
+                                                        &session_models,
+                                                        &efforts,
+                                                        session_id.as_deref(),
+                                                    )
+                                                };
+                                                view! {
+                                                <div class="model-menu-effort" on:click=|ev| ev.stop_propagation()>
+                                                    <button type="button" class="model-menu-effort-trigger"
+                                                        class:open=move || effort_menu_open.get()
+                                                        attr:aria-expanded=move || if effort_menu_open.get() { "true" } else { "false" }
+                                                        on:click=move |_| effort_menu_open.update(|o| *o = !*o)>
+                                                        <span class="model-menu-effort-label">{move || t(locale.get(), "settings.reasoning_effort")}</span>
+                                                        <span class="model-menu-effort-value">{move || {
+                                                            let current = current_effort();
+                                                            // The trigger shows the effective effort:
                                                             // an inherited profile value is displayed
-                                                            // as-is; "default" is selected only when
-                                                            // nothing is configured anywhere.
-                                                            let default_selected = current.is_empty();
-                                                            view! {
-                                                                <option value="default"
-                                                                    prop:selected=default_selected>
-                                                                    {move || t(locale.get(), "settings.reasoning_effort.default")}
-                                                                </option>
+                                                            // as-is; the default label appears only
+                                                            // when nothing is configured anywhere.
+                                                            if current.is_empty() {
+                                                                t(locale.get(), "settings.reasoning_effort.default").to_string()
+                                                            } else {
+                                                                current
+                                                            }
+                                                        }}</span>
+                                                        <span class="model-menu-effort-chev">{compose_icon("chevron-down")}</span>
+                                                    </button>
+                                                    {move || effort_menu_open.get().then(|| {
+                                                        let current = current_effort();
+                                                        let models = models.get();
+                                                        let session_models = session_model_ids.get();
+                                                        let session_id = active_session.get();
+                                                        let mut values: Vec<String> = session_profile(
+                                                            &models,
+                                                            &session_models,
+                                                            session_id.as_deref(),
+                                                        )
+                                                        .map(|profile| {
+                                                            known_effort_values(&profile.provider, &profile.model)
+                                                                .unwrap_or(ALL_EFFORT_VALUES)
+                                                        })
+                                                        .unwrap_or(ALL_EFFORT_VALUES)
+                                                        .iter()
+                                                        .map(|v| v.to_string())
+                                                        .collect();
+                                                        // Keep a stored override visible even when the
+                                                        // curated list for this model doesn't include it.
+                                                        if !current.is_empty() && !values.iter().any(|v| v == &current) {
+                                                            values.push(current.clone());
+                                                        }
+                                                        let default_selected = current.is_empty();
+                                                        let apply_default = apply_effort.clone();
+                                                        view! {
+                                                            <div class="model-menu-effort-options">
+                                                                <button type="button" class="model-menu-effort-option" data-effort="default"
+                                                                    on:click=move |_| apply_default("default".to_string())>
+                                                                    <span class="model-menu-effort-option-label">{move || t(locale.get(), "settings.reasoning_effort.default")}</span>
+                                                                    {default_selected.then(|| view! { <span class="model-menu-effort-check">{compose_icon("check")}</span> })}
+                                                                </button>
                                                                 {values.into_iter().map(|lvl| {
                                                                     let selected = !default_selected && lvl == current;
+                                                                    let apply = apply_effort.clone();
+                                                                    let pick = lvl.clone();
                                                                     view! {
-                                                                        <option value=lvl.clone()
-                                                                            prop:selected=selected>
-                                                                            {lvl}
-                                                                        </option>
+                                                                        <button type="button" class="model-menu-effort-option" data-effort=lvl.clone()
+                                                                            on:click=move |_| apply(pick.clone())>
+                                                                            <span class="model-menu-effort-option-label">{lvl}</span>
+                                                                            {selected.then(|| view! { <span class="model-menu-effort-check">{compose_icon("check")}</span> })}
+                                                                        </button>
                                                                     }
                                                                 }).collect_view()}
-                                                            }
-                                                        }}
-                                                    </select>
+                                                            </div>
+                                                        }
+                                                    })}
                                                 </div>
+                                                }
                                             })}
                                             <button type="button" class="model-menu-add" on:click=move |_| {
                                                 model_menu_open.set(false);

--- a/ui/src/styles/chat.css
+++ b/ui/src/styles/chat.css
@@ -1137,9 +1137,20 @@ details.tool:not([open]) > summary.head .run-dot { animation: tool-pulse 1.1s ea
 .model-menu-check { flex: 0 0 auto; color: var(--clay-strong); font-weight: 700; }
 .model-menu-del { flex: 0 0 auto; background: transparent; border: none; color: var(--text-faint); font-size: 15px; line-height: 1; padding: 4px 8px; cursor: pointer; border-radius: var(--radius-xs); }
 .model-menu-del:hover { color: var(--err); }
-.model-menu-effort { display: flex; align-items: center; justify-content: space-between; gap: 8px; border-top: 1px solid var(--border); margin-top: 4px; padding: 8px 10px 4px; }
-.model-menu-effort-label { font-size: 12px; color: var(--text-muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.model-menu-effort-select { font: inherit; font-size: 12.5px; max-width: 150px; padding: 4px 6px; border: 1px solid var(--border-strong); border-radius: var(--radius-sm); background: var(--bg-input); color: var(--text); }
+.model-menu-effort { border-top: 1px solid var(--border); margin-top: 4px; padding-top: 4px; }
+.model-menu-effort-trigger { display: flex; align-items: center; gap: 8px; width: 100%; padding: 7px 10px; border: none; border-radius: var(--radius-xs); background: transparent; color: var(--text); font: inherit; cursor: pointer; }
+.model-menu-effort-trigger:hover, .model-menu-effort-trigger.open { background: var(--bg-sunken); }
+.model-menu-effort-label { flex: 1 1 auto; min-width: 0; text-align: left; font-size: 12px; color: var(--text-muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.model-menu-effort-value { flex: 0 1 auto; max-width: 48%; font-family: var(--font-mono); font-size: 11.5px; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.model-menu-effort-chev { flex: 0 0 auto; display: inline-flex; color: var(--text-faint); transition: transform .12s ease; }
+.model-menu-effort-chev svg { width: 13px; height: 13px; }
+.model-menu-effort-trigger.open .model-menu-effort-chev { transform: rotate(180deg); }
+.model-menu-effort-options { display: flex; flex-direction: column; gap: 1px; padding: 2px 0 4px; }
+.model-menu-effort-option { display: flex; align-items: center; gap: 8px; width: 100%; padding: 6px 10px; border: none; border-radius: var(--radius-xs); background: transparent; color: var(--text); font: inherit; font-size: 12.5px; cursor: pointer; text-align: left; }
+.model-menu-effort-option:hover { background: var(--bg-sunken); }
+.model-menu-effort-option-label { flex: 1 1 auto; min-width: 0; font-family: var(--font-mono); font-size: 12px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.model-menu-effort-check { flex: 0 0 auto; display: inline-flex; color: var(--clay-strong); }
+.model-menu-effort-check svg { width: 14px; height: 14px; }
 .model-menu-add { width: 100%; text-align: left; background: transparent; border: none; border-top: 1px solid var(--border); margin-top: 4px; padding: 9px 10px; font: inherit; font-size: 12.5px; font-weight: 600; color: var(--clay-strong); cursor: pointer; }
 .model-menu-add:hover { background: var(--clay-soft); }
 .model-menu-configs { border-top: 1px solid var(--border); margin-top: 4px; padding-top: 4px; }


### PR DESCRIPTION
## Problem

The composer model menu's reasoning-effort picker used a native OS `<select>`. On Windows it rendered with platform styling and opened a native dropdown that spilled over the send button — visually inconsistent with the rest of the model menu.

## Changes

- `ui/src/main.rs`: replaced the `<select>` with a trigger row (label + current effective value + chevron from the shared `compose_icon` set) that expands an inline option list inside the model menu; the effective value gets a check icon. Behavior is unchanged: picking a value calls `set_session_reasoning_effort`, "default" clears the session override, and an override absent from the curated list is still shown.
- `ui/src/styles/chat.css`: styles for the trigger/options/check, reusing existing design tokens; removed the old `.model-menu-effort-select` rule.
- Escape stack: the options layer sits above the model menu — one Escape closes only the options, the next closes the menu; the options also collapse whenever the model menu closes.
- `ui/src/app_support/sessions.rs`: fixed a stale `SessionInfo` test initializer (missing `stale_prompt`) that broke `cargo test` for wisp-ui on main.

## Tests

- Updated `reasoning effort stays scoped to the current conversation` for the new interaction model.
- Added `effort options close on Escape before the model menu` covering the Escape layering.
- `cargo fmt --all -- --check`, `cargo check --target wasm32-unknown-unknown`, `cargo test --workspace`, `cargo test` for wisp-ui (229), and the full Playwright suite (350 passed, 1 skipped; one unrelated navigation-timeout flake under parallel load passes in isolation) all green.
- Verified rendering with a screenshot of the open menu.

## Manual smoke

1. Open the model picker in the composer → click the "Reasoning effort" row → options expand inline with the current value checked.
2. Pick a value → list collapses, trigger shows the new value; press Escape → only the options close, menu stays open.

## Known limitations

- The ACP session config rows in the same menu still use native `<select>`s (out of scope here).