### PR TITLE
Make chat text follow the UI font size setting

### DIFF
--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -6271,13 +6271,41 @@ test("UI font size setting scales chat message body text", async ({ page }) => {
   await expect(page.getByText("FX细胞")).toBeVisible({ timeout: 10_000 });
   const bodyFontSize = () => page.locator(".msg.assistant .body.md").first()
     .evaluate((el) => getComputedStyle(el).fontSize);
+  const composerFontSize = () => composer(page)
+    .evaluate((el) => getComputedStyle(el).fontSize);
   expect(await bodyFontSize()).toBe("15px");
+  expect(await composerFontSize()).toBe("14px");
 
   await openSettingsSection(page, "Appearance");
   await page.getByRole("slider", { name: "UI font size" }).fill("18");
   await page.getByRole("button", { name: "Back to app" }).click();
 
   await expect.poll(bodyFontSize).toBe("19px");
+  await expect.poll(composerFontSize).toBe("18px");
+});
+
+test("UI font size setting scales Chinese chat markdown and composer", async ({ page }) => {
+  await page.goto("/?mockLocale=zh");
+  await page.locator(".proj-card-main").first().click();
+  await expect(page.locator(".sidebar").getByRole("button", { name: "新建会话" })).toBeVisible();
+  await expect(page.locator("html")).toHaveAttribute("lang", "zh");
+  await composer(page).fill("MDLIST");
+  await page.getByRole("button", { name: "发送" }).click();
+  await expect(page.getByText("FX细胞")).toBeVisible({ timeout: 10_000 });
+  const bodyFontSize = () => page.locator(".msg.assistant .body.md").first()
+    .evaluate((el) => getComputedStyle(el).fontSize);
+  const composerFontSize = () => composer(page)
+    .evaluate((el) => getComputedStyle(el).fontSize);
+  expect(await bodyFontSize()).toBe("15.5px");
+  expect(await composerFontSize()).toBe("14px");
+
+  await page.getByRole("button", { name: "设置", exact: true }).click();
+  await page.getByRole("button", { name: "外观", exact: true }).click();
+  await page.getByRole("slider", { name: "UI 字号" }).fill("18");
+  await page.getByRole("button", { name: "返回应用" }).click();
+
+  await expect.poll(bodyFontSize).toBe("19.5px");
+  await expect.poll(composerFontSize).toBe("18px");
 });
 
 test("vision assignment keeps model fields and stored key placeholder untouched", async ({ page }) => {

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -257,7 +257,7 @@
 :lang(zh) .md,
 :lang(zh) .msg.assistant .body.md {
   line-height: 1.78;
-  font-size: 15.5px;
+  font-size: calc(var(--ui-font-size, 14px) + 1.5px);
   font-weight: 400;
   text-spacing-trim: space-all;
 }

--- a/ui/src/styles/chat.css
+++ b/ui/src/styles/chat.css
@@ -1113,7 +1113,7 @@ details.tool:not([open]) > summary.head .run-dot { animation: tool-pulse 1.1s ea
   resize: none; min-height: 26px; overflow-x: hidden; overflow-y: auto;
   overflow-wrap: anywhere; word-break: break-word;
   background: transparent; color: var(--text); border: none; outline: none;
-  font: inherit; font-family: var(--font-ui); font-size: 14.5px; line-height: 1.5; padding: 4px 0;
+  font: inherit; font-family: var(--font-ui); font-size: var(--ui-font-size, 14px); line-height: 1.5; padding: 4px 0;
 }
 .composer textarea::placeholder { color: var(--text-faint); }
 .composer textarea:disabled { color: var(--text-muted); cursor: not-allowed; }
@@ -1413,10 +1413,10 @@ button.stop:disabled { opacity: .6; cursor: default; }
 .sidechat-empty { margin: auto; max-width: 260px; color: var(--text-faint); font-size: 13px; line-height: 1.5; text-align: center; }
 .sidechat-row { display: flex; flex-direction: column; gap: 4px; }
 .sidechat-row.user { align-items: flex-end; }
-.sidechat-bubble { max-width: 86%; min-width: 0; padding: 9px 12px; border-radius: var(--radius-sm); background: var(--bg-sunken); color: var(--text); font-size: 13.5px; line-height: 1.45; white-space: pre-wrap; overflow-wrap: anywhere; word-break: break-word; box-sizing: border-box; }
+.sidechat-bubble { max-width: 86%; min-width: 0; padding: 9px 12px; border-radius: var(--radius-sm); background: var(--bg-sunken); color: var(--text); font-size: calc(var(--ui-font-size, 14px) - 0.5px); line-height: 1.45; white-space: pre-wrap; overflow-wrap: anywhere; word-break: break-word; box-sizing: border-box; }
 .sidechat-row.user .sidechat-bubble { background: var(--clay-soft); }
 .sidechat-model-label { font-family: var(--font-mono); font-size: 11px; color: var(--text-faint); }
-.sidechat-answer { font-size: 13.5px; line-height: 1.55; color: var(--text); }
+.sidechat-answer { font-size: calc(var(--ui-font-size, 14px) - 0.5px); line-height: 1.55; color: var(--text); }
 .sidechat-answer.error { color: var(--err); }
 .sidechat-evidence { margin-top: 5px; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--bg-sunken); overflow: hidden; }
 .sidechat-evidence > summary { padding: 8px 10px; color: var(--text-muted); font-size: 11.5px; cursor: pointer; user-select: none; }
@@ -1430,7 +1430,7 @@ button.stop:disabled { opacity: .6; cursor: default; }
 .sidechat-composer { flex: 0 0 auto; padding: 12px 14px 14px; border-top: 1px solid var(--border); background: var(--bg-app); }
 .sidechat-quotes { flex-direction: column; align-items: stretch; flex-wrap: nowrap; max-height: 132px; margin: 0 0 8px; padding: 2px 4px 2px 0; overflow-y: auto; }
 .sidechat-quotes .composer-attachment-row { width: 100%; min-height: 44px; box-sizing: border-box; }
-.sidechat-composer textarea { width: 100%; min-height: 78px; max-height: 180px; resize: vertical; box-sizing: border-box; border: 1px solid var(--border-strong); border-radius: var(--radius-sm); background: var(--bg-input); color: var(--text); font: inherit; font-size: 13.5px; line-height: 1.45; padding: 10px 11px; outline: none; }
+.sidechat-composer textarea { width: 100%; min-height: 78px; max-height: 180px; resize: vertical; box-sizing: border-box; border: 1px solid var(--border-strong); border-radius: var(--radius-sm); background: var(--bg-input); color: var(--text); font: inherit; font-size: var(--ui-font-size, 14px); line-height: 1.45; padding: 10px 11px; outline: none; }
 .sidechat-composer textarea:focus { border-color: color-mix(in srgb, var(--clay) 45%, var(--border-strong)); box-shadow: 0 0 0 3px var(--focus-ring); }
 .sidechat-actions { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-top: 8px; }
 .sidechat-model { position: relative; min-width: 0; }


### PR DESCRIPTION
## Summary
- Chinese chat markdown was locked at `15.5px`, so Appearance / command-palette UI font size changes never affected conversation text.
- Composer and side-chat copy now use `--ui-font-size` as well.

## Test plan
- [ ] Switch the app to Chinese, open Appearance, set UI font size to 18, and confirm chat replies plus the composer grow.
- [ ] Repeat in English and confirm the same.
- [ ] `npx playwright test tests/ui.spec.ts -g "UI font size setting scales"` in `ui-tests`.

Made with [Cursor](https://cursor.com)