### PR TITLE
Hide follow-up suggestions as soon as the user sends

### DIFF
--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -4610,7 +4610,7 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
               emit("agent", { kind: "Text", frame_id: fid, delta: "Hello " });
               emit("agent", { kind: "Text", frame_id: fid, delta: "from mock wisp-science." });
               emit("agent", { kind: "Done", frame_id: fid });
-            }, 50);
+            }, 50 + Number((window as any).__userEventDelayMs ?? 0));
             return fid;
           }
           case "open_external_url":

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -326,6 +326,23 @@ test("send streams a mocked assistant reply", async ({ page, context }) => {
   await expect(page.locator(".copy-toast")).toHaveText("Copied");
 });
 
+test("sending a follow-up hides suggestions before the User event arrives", async ({ page }) => {
+  await enterApp(page);
+  await composer(page).fill("hello there");
+  await page.getByRole("button", { name: "Send" }).click();
+  await expect(page.getByText("Hello from mock wisp-science.")).toBeVisible({ timeout: 10_000 });
+  const followUps = page.getByTestId("follow-up-questions");
+  await expect(followUps.getByRole("button")).toHaveCount(4);
+
+  await page.evaluate(() => {
+    (window as any).__userEventDelayMs = 800;
+  });
+  await composer(page).fill("how to read this figure");
+  await page.getByRole("button", { name: "Send" }).click();
+  await expect(page.getByText("how to read this figure")).toBeVisible();
+  await expect(followUps).toHaveCount(0, { timeout: 300 });
+});
+
 test("completed turns propose editable memory and require confirmation", async ({ page }) => {
   await enterApp(page);
   await composer(page).fill("summarize this project convention");

--- a/ui/src/app_support/chat_stream.rs
+++ b/ui/src/app_support/chat_stream.rs
@@ -1,5 +1,20 @@
 use super::*;
 
+/// Drop suggested follow-ups for `frame_id` and invalidate any in-flight
+/// generation so a late `generate_follow_up_questions` cannot put them back.
+pub(crate) fn dismiss_follow_up_questions(
+    questions: RwSignal<HashMap<String, Vec<String>>>,
+    generations: RwSignal<HashMap<String, u64>>,
+    frame_id: &str,
+) {
+    questions.update(|all| {
+        all.remove(frame_id);
+    });
+    generations.update(|all| {
+        *all.entry(frame_id.to_string()).or_default() += 1;
+    });
+}
+
 pub(crate) fn begin_pending_turn(
     pending: RwSignal<HashMap<String, usize>>,
     running: RwSignal<HashSet<String>>,
@@ -224,13 +239,29 @@ pub(crate) fn start_user_turn(items: &mut Vec<ChatItem>, text: String, model: Op
 mod start_user_turn_tests {
     use super::{
         append_assistant_delta, append_reasoning_delta, completed_activity_end,
-        composer_text_from_user_message, is_commentary_at, is_image_generation_tool,
-        is_tool_activity, message_with_attachments, message_with_composer_context,
-        message_with_quotes, message_with_read_only_quotes, process_item_insert_index,
-        runtime_object_quote, selection_targets_center_file, start_user_turn, trailing_queue_start,
-        ComposerQuote, ComposerReferenceChip,
+        composer_text_from_user_message, dismiss_follow_up_questions, is_commentary_at,
+        is_image_generation_tool, is_tool_activity, message_with_attachments,
+        message_with_composer_context, message_with_quotes, message_with_read_only_quotes,
+        process_item_insert_index, runtime_object_quote, selection_targets_center_file,
+        start_user_turn, trailing_queue_start, ComposerQuote, ComposerReferenceChip,
     };
     use crate::dto::{ChatItem, ContextUsage};
+    use leptos::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn dismiss_follow_up_questions_removes_and_invalidates_generation() {
+        let runtime = create_runtime();
+        let questions = create_rw_signal(HashMap::from([(
+            "s1".to_string(),
+            vec!["one?".into(), "two?".into(), "three?".into()],
+        )]));
+        let generations = create_rw_signal(HashMap::from([("s1".to_string(), 3u64)]));
+        dismiss_follow_up_questions(questions, generations, "s1");
+        assert!(questions.get_untracked().is_empty());
+        assert_eq!(generations.get_untracked().get("s1").copied(), Some(4));
+        runtime.dispose();
+    }
 
     #[test]
     fn message_with_attachments_appends_suffix() {

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -1858,12 +1858,7 @@ fn App() -> impl IntoView {
                 }
             }
             AgentEvent::User { frame_id, text } => {
-                follow_up_questions.update(|questions| {
-                    questions.remove(&frame_id);
-                });
-                follow_up_generation.update(|generations| {
-                    *generations.entry(frame_id.clone()).or_default() += 1;
-                });
+                dismiss_follow_up_questions(follow_up_questions, follow_up_generation, &frame_id);
                 set_pet_activity(&frame_id, "running");
                 flush_now();
                 let outline_text = text.clone();
@@ -2922,6 +2917,12 @@ fn App() -> impl IntoView {
         }
         let branch = action == ComposerSendAction::BranchNew;
         let queued = !branch && active.as_ref().is_some_and(|id| running.get().contains(id));
+        // Do not wait for AgentEvent::User: send_message can sit on the
+        // session lock / prompt build for a long time while the optimistic
+        // user bubble is already on screen.
+        if let Some(id) = active.as_ref() {
+            dismiss_follow_up_questions(follow_up_questions, follow_up_generation, id);
+        }
         // Queue (#433): a plain send into a busy session parks behind the
         // running turn — editable/cancellable until the driver runs it — instead
         // of a dialog. Cut-in / interrupt-replace are explicit dropdown choices.
@@ -10280,7 +10281,7 @@ fn App() -> impl IntoView {
                             }
                         }
                     />
-                    {move || active_session.get().and_then(|frame_id| {
+                    {move || (!busy.get()).then(|| active_session.get()).flatten().and_then(|frame_id| {
                         follow_up_questions.with(|all| all.get(&frame_id).cloned()).map(|questions| {
                             let close_frame_id = frame_id.clone();
                             view! {


### PR DESCRIPTION
## Summary
- Follow-up questions stayed on screen after send because they waited for the backend `User` event, which can lag while `send_message` builds a large prompt.
- Dismiss suggestions immediately on send, hide them while the turn is busy, and invalidate in-flight generation so a late response cannot put them back.

## Test plan
- [x] `cargo test dismiss_follow_up_questions_removes_and_invalidates_generation` in `ui/`
- [x] Playwright: `sending a follow-up hides suggestions before the User event arrives`
- [x] Playwright: existing follow-up suggestion tests still pass
- [ ] Send a new message after suggestions appear and confirm they vanish immediately
