### PR TITLE
Animate conversation outline open and close

### DIFF
--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -7764,13 +7764,14 @@ test("conversation outline loads and jumps to an older user question", async ({ 
 
   const toggle = page.getByRole("button", { name: "Show conversation outline" });
   await expect(toggle).toBeVisible();
+  await expect(page.getByTestId("conversation-outline")).toHaveCount(0);
   await toggle.click();
   const outline = page.getByTestId("conversation-outline");
   await expect(outline).toBeVisible();
   await expect(outline).toHaveClass(/is-open/);
   await page.keyboard.press("Escape");
   await expect(outline).toBeHidden();
-  await expect(outline).not.toHaveClass(/is-open/);
+  await expect(page.getByTestId("conversation-outline")).toHaveCount(0);
   await expect(toggle).toBeVisible();
 
   await toggle.click();
@@ -7808,6 +7809,7 @@ test("conversation outline loads and jumps to an older user question", async ({ 
   await page.getByRole("button", { name: "Hide conversation outline" }).click();
   await expect(outline).toBeHidden();
   await expect(toggle).toBeVisible();
+  await expect(page.getByTestId("conversation-outline")).toHaveCount(0);
 });
 
 test("long transcript rendering keeps a bounded turn window", async ({ page }) => {

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -7767,8 +7767,10 @@ test("conversation outline loads and jumps to an older user question", async ({ 
   await toggle.click();
   const outline = page.getByTestId("conversation-outline");
   await expect(outline).toBeVisible();
+  await expect(outline).toHaveClass(/is-open/);
   await page.keyboard.press("Escape");
-  await expect(outline).toHaveCount(0);
+  await expect(outline).toBeHidden();
+  await expect(outline).not.toHaveClass(/is-open/);
   await expect(toggle).toBeVisible();
 
   await toggle.click();
@@ -7804,7 +7806,7 @@ test("conversation outline loads and jumps to an older user question", async ({ 
   })).toBe(true);
 
   await page.getByRole("button", { name: "Hide conversation outline" }).click();
-  await expect(outline).toHaveCount(0);
+  await expect(outline).toBeHidden();
   await expect(toggle).toBeVisible();
 });
 

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -304,7 +304,26 @@ fn App() -> impl IntoView {
     let conversation_outlines =
         create_rw_signal::<HashMap<String, Vec<SessionOutlineItem>>>(HashMap::new());
     let conversation_outline_open = create_rw_signal(false);
+    let conversation_outline_mounted = create_rw_signal(false);
     let conversation_outline_selected = create_rw_signal::<Option<usize>>(None);
+    create_effect(move |_| {
+        if conversation_outline_open.get() {
+            conversation_outline_mounted.set(true);
+            return;
+        }
+        if !conversation_outline_mounted.get_untracked() {
+            return;
+        }
+        set_timeout(
+            move || {
+                if !conversation_outline_open.get_untracked() {
+                    conversation_outline_mounted.set(false);
+                }
+            },
+            // Keep mounted through `--motion-duration-medium` so the close animation can play.
+            std::time::Duration::from_millis(280),
+        );
+    });
     let busy = create_rw_signal(false);
     let turn_undo_dialog = create_rw_signal::<Option<TurnUndoDialog>>(None);
     let turn_undo_busy = create_rw_signal(false);
@@ -10429,41 +10448,43 @@ fn App() -> impl IntoView {
                         <button
                             type="button"
                             class="conversation-outline-toggle"
-                            class:is-hidden=move || conversation_outline_open.get()
+                            class:is-hidden=move || conversation_outline_mounted.get()
                             data-testid="conversation-outline-toggle"
                             title=move || t(locale.get(), "outline.show")
                             aria-label=move || t(locale.get(), "outline.show")
                             aria-expanded=move || conversation_outline_open.get().to_string()
-                            aria-hidden=move || conversation_outline_open.get().to_string()
+                            aria-hidden=move || conversation_outline_mounted.get().to_string()
                             on:click=move |_| conversation_outline_open.set(true)
                         >
                             <span class="conversation-outline-marks" aria-hidden="true">{marks}</span>
                         </button>
-                        <nav
-                            class="conversation-outline-panel"
-                            class:is-open=move || conversation_outline_open.get()
-                            data-testid="conversation-outline"
-                            aria-label=move || t(locale.get(), "outline.title")
-                            aria-hidden=move || (!conversation_outline_open.get()).to_string()
-                            prop:inert=move || !conversation_outline_open.get()
-                        >
-                            <header>
-                                <div>
-                                    <strong>{move || t(locale.get(), "outline.title")}</strong>
-                                    <span>{move || tf(locale.get(), "outline.questions_n", &[("n", &count)])}</span>
-                                </div>
-                                <button
-                                    type="button"
-                                    class="icon-btn"
-                                    title=move || t(locale.get(), "outline.hide")
-                                    aria-label=move || t(locale.get(), "outline.hide")
-                                    on:click=move |_| conversation_outline_open.set(false)
-                                >
-                                    {compose_icon("close")}
-                                </button>
-                            </header>
-                            <div class="conversation-outline-list">{entries}</div>
-                        </nav>
+                        {conversation_outline_mounted.get().then(|| view! {
+                            <nav
+                                class="conversation-outline-panel"
+                                class:is-open=move || conversation_outline_open.get()
+                                data-testid="conversation-outline"
+                                aria-label=move || t(locale.get(), "outline.title")
+                                aria-hidden=move || (!conversation_outline_open.get()).to_string()
+                                prop:inert=move || !conversation_outline_open.get()
+                            >
+                                <header>
+                                    <div>
+                                        <strong>{move || t(locale.get(), "outline.title")}</strong>
+                                        <span>{move || tf(locale.get(), "outline.questions_n", &[("n", &count)])}</span>
+                                    </div>
+                                    <button
+                                        type="button"
+                                        class="icon-btn"
+                                        title=move || t(locale.get(), "outline.hide")
+                                        aria-label=move || t(locale.get(), "outline.hide")
+                                        on:click=move |_| conversation_outline_open.set(false)
+                                    >
+                                        {compose_icon("close")}
+                                    </button>
+                                </header>
+                                <div class="conversation-outline-list">{entries}</div>
+                            </nav>
+                        })}
                     }
                 })
             }}

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -10347,125 +10347,123 @@ fn App() -> impl IntoView {
             {move || {
                 let rows = conversation_outline.get();
                 (!rows.is_empty()).then(|| {
-                    if conversation_outline_open.get() {
-                        let count = rows.len().to_string();
-                        let entries = rows
-                            .iter()
-                            .enumerate()
-                            .map(|(position, entry)| {
-                                let target = entry.user_index;
-                                let before_seq =
-                                    rows.get(position + 1).and_then(|next| next.seq);
-                                let clean = user_message_presentation(&entry.text).body;
-                                let label = if clean.is_empty() {
-                                    t(locale.get(), "outline.attachment")
-                                } else {
-                                    clean
-                                };
-                                let aria_label = label.clone();
-                                let title = label.clone();
-                                let sent_at = entry.sent_at.filter(|timestamp| *timestamp > 0);
-                                view! {
-                                    <button
-                                        type="button"
-                                        class="conversation-outline-item"
-                                        class:active=move || conversation_outline_selected.get() == Some(target)
-                                        aria-label=aria_label
-                                        title=title
-                                        prop:disabled=move || {
-                                            if !busy.get() {
-                                                return false;
+                    let count = rows.len().to_string();
+                    let entries = rows
+                        .iter()
+                        .enumerate()
+                        .map(|(position, entry)| {
+                            let target = entry.user_index;
+                            let before_seq =
+                                rows.get(position + 1).and_then(|next| next.seq);
+                            let clean = user_message_presentation(&entry.text).body;
+                            let label = if clean.is_empty() {
+                                t(locale.get(), "outline.attachment")
+                            } else {
+                                clean
+                            };
+                            let aria_label = label.clone();
+                            let title = label.clone();
+                            let sent_at = entry.sent_at.filter(|timestamp| *timestamp > 0);
+                            view! {
+                                <button
+                                    type="button"
+                                    class="conversation-outline-item"
+                                    class:active=move || conversation_outline_selected.get() == Some(target)
+                                    aria-label=aria_label
+                                    title=title
+                                    prop:disabled=move || {
+                                        if !busy.get() {
+                                            return false;
+                                        }
+                                        !loaded_conversation_user_range
+                                            .get()
+                                            .contains(&target)
+                                    }
+                                    on:click=move |_| {
+                                        jump_to_conversation_outline.call((target, before_seq));
+                                    }
+                                >
+                                    <span class="conversation-outline-number" aria-hidden="true">
+                                        {target + 1}
+                                    </span>
+                                    <span class="conversation-outline-copy">
+                                        <span class="conversation-outline-text">{label}</span>
+                                        {sent_at.map(|timestamp| {
+                                            let compact = format_message_time(timestamp);
+                                            view! {
+                                                <time
+                                                    class="conversation-outline-time"
+                                                    data-timestamp=timestamp.to_string()
+                                                    title=move || tf(
+                                                        locale.get(),
+                                                        "msg.sent_at",
+                                                        &[("time", &format_message_datetime(timestamp, locale.get()))],
+                                                    )
+                                                >
+                                                    {compact}
+                                                </time>
                                             }
-                                            !loaded_conversation_user_range
-                                                .get()
-                                                .contains(&target)
-                                        }
-                                        on:click=move |_| {
-                                            jump_to_conversation_outline.call((target, before_seq));
-                                        }
-                                    >
-                                        <span class="conversation-outline-number" aria-hidden="true">
-                                            {target + 1}
-                                        </span>
-                                        <span class="conversation-outline-copy">
-                                            <span class="conversation-outline-text">{label}</span>
-                                            {sent_at.map(|timestamp| {
-                                                let compact = format_message_time(timestamp);
-                                                view! {
-                                                    <time
-                                                        class="conversation-outline-time"
-                                                        data-timestamp=timestamp.to_string()
-                                                        title=move || tf(
-                                                            locale.get(),
-                                                            "msg.sent_at",
-                                                            &[("time", &format_message_datetime(timestamp, locale.get()))],
-                                                        )
-                                                    >
-                                                        {compact}
-                                                    </time>
-                                                }
-                                            })}
-                                        </span>
-                                    </button>
-                                }
-                            })
-                            .collect_view();
-                        view! {
-                            <nav
-                                class="conversation-outline-panel"
-                                data-testid="conversation-outline"
-                                aria-label=move || t(locale.get(), "outline.title")
-                            >
-                                <header>
-                                    <div>
-                                        <strong>{move || t(locale.get(), "outline.title")}</strong>
-                                        <span>{move || tf(locale.get(), "outline.questions_n", &[("n", &count)])}</span>
-                                    </div>
-                                    <button
-                                        type="button"
-                                        class="icon-btn"
-                                        title=move || t(locale.get(), "outline.hide")
-                                        aria-label=move || t(locale.get(), "outline.hide")
-                                        on:click=move |_| conversation_outline_open.set(false)
-                                    >
-                                        {compose_icon("close")}
-                                    </button>
-                                </header>
-                                <div class="conversation-outline-list">{entries}</div>
-                            </nav>
-                        }
-                        .into_view()
-                    } else {
-                        let stride = (rows.len() + 27) / 28;
-                        let marks = rows
-                            .iter()
-                            .step_by(stride.max(1))
-                            .map(|entry| {
-                                let width = 45 + entry.text.chars().count().min(40);
-                                let target = entry.user_index;
-                                view! {
-                                    <span
-                                        class="conversation-outline-mark"
-                                        class:active=move || conversation_outline_selected.get() == Some(target)
-                                        style=format!("width:{width}%")
-                                    ></span>
-                                }
-                            })
-                            .collect_view();
-                        view! {
-                            <button
-                                type="button"
-                                class="conversation-outline-toggle"
-                                data-testid="conversation-outline-toggle"
-                                title=move || t(locale.get(), "outline.show")
-                                aria-label=move || t(locale.get(), "outline.show")
-                                aria-expanded="false"
-                                on:click=move |_| conversation_outline_open.set(true)
-                            >
-                                <span class="conversation-outline-marks" aria-hidden="true">{marks}</span>
-                            </button>
-                        }
-                        .into_view()
+                                        })}
+                                    </span>
+                                </button>
+                            }
+                        })
+                        .collect_view();
+                    let stride = (rows.len() + 27) / 28;
+                    let marks = rows
+                        .iter()
+                        .step_by(stride.max(1))
+                        .map(|entry| {
+                            let width = 45 + entry.text.chars().count().min(40);
+                            let target = entry.user_index;
+                            view! {
+                                <span
+                                    class="conversation-outline-mark"
+                                    class:active=move || conversation_outline_selected.get() == Some(target)
+                                    style=format!("width:{width}%")
+                                ></span>
+                            }
+                        })
+                        .collect_view();
+                    view! {
+                        <button
+                            type="button"
+                            class="conversation-outline-toggle"
+                            class:is-hidden=move || conversation_outline_open.get()
+                            data-testid="conversation-outline-toggle"
+                            title=move || t(locale.get(), "outline.show")
+                            aria-label=move || t(locale.get(), "outline.show")
+                            aria-expanded=move || conversation_outline_open.get().to_string()
+                            aria-hidden=move || conversation_outline_open.get().to_string()
+                            on:click=move |_| conversation_outline_open.set(true)
+                        >
+                            <span class="conversation-outline-marks" aria-hidden="true">{marks}</span>
+                        </button>
+                        <nav
+                            class="conversation-outline-panel"
+                            class:is-open=move || conversation_outline_open.get()
+                            data-testid="conversation-outline"
+                            aria-label=move || t(locale.get(), "outline.title")
+                            aria-hidden=move || (!conversation_outline_open.get()).to_string()
+                            prop:inert=move || !conversation_outline_open.get()
+                        >
+                            <header>
+                                <div>
+                                    <strong>{move || t(locale.get(), "outline.title")}</strong>
+                                    <span>{move || tf(locale.get(), "outline.questions_n", &[("n", &count)])}</span>
+                                </div>
+                                <button
+                                    type="button"
+                                    class="icon-btn"
+                                    title=move || t(locale.get(), "outline.hide")
+                                    aria-label=move || t(locale.get(), "outline.hide")
+                                    on:click=move |_| conversation_outline_open.set(false)
+                                >
+                                    {compose_icon("close")}
+                                </button>
+                            </header>
+                            <div class="conversation-outline-list">{entries}</div>
+                        </nav>
                     }
                 })
             }}

--- a/ui/src/styles/chat.css
+++ b/ui/src/styles/chat.css
@@ -393,12 +393,14 @@
 .conversation-outline-panel.is-open {
   opacity: 1; visibility: visible; pointer-events: auto; transform: none;
   transition-delay: 0s;
+  animation: motion-drawer-in var(--motion-duration-medium) var(--motion-ease-decelerate) both;
 }
 @media (prefers-reduced-motion: reduce) {
   .conversation-outline-toggle,
   .conversation-outline-toggle.is-hidden,
   .conversation-outline-panel,
   .conversation-outline-panel.is-open {
+    animation: none;
     transition: none;
   }
 }

--- a/ui/src/styles/chat.css
+++ b/ui/src/styles/chat.css
@@ -361,6 +361,15 @@
   overflow: hidden; border: 1px solid var(--border); border-radius: var(--radius-sm);
   background: color-mix(in srgb, var(--bg-elev) 92%, transparent); color: var(--text-faint);
   box-shadow: var(--shadow-sm); backdrop-filter: blur(8px); cursor: pointer;
+  transition:
+    opacity var(--motion-duration-fast) var(--motion-ease-standard),
+    transform var(--motion-duration-fast) var(--motion-ease-standard),
+    visibility 0s;
+}
+.conversation-outline-toggle.is-hidden {
+  opacity: 0; visibility: hidden; pointer-events: none;
+  transform: translateY(-50%) translateX(6px);
+  transition-delay: 0s, 0s, var(--motion-duration-fast);
 }
 .conversation-outline-toggle:hover, .conversation-outline-toggle:focus-visible {
   border-color: var(--border-strong); color: var(--text-muted); background: var(--bg-elev);
@@ -374,6 +383,24 @@
   overflow: hidden; border: 1px solid var(--border-strong); border-radius: var(--radius-sm);
   background: color-mix(in srgb, var(--bg-elev) 96%, transparent);
   box-shadow: 0 14px 42px rgba(0,0,0,.16); backdrop-filter: blur(12px);
+  opacity: 0; visibility: hidden; pointer-events: none;
+  transform: translate3d(var(--motion-distance-md), 0, 0);
+  transition:
+    opacity var(--motion-duration-medium) var(--motion-ease-decelerate),
+    transform var(--motion-duration-medium) var(--motion-ease-decelerate),
+    visibility 0s var(--motion-duration-medium);
+}
+.conversation-outline-panel.is-open {
+  opacity: 1; visibility: visible; pointer-events: auto; transform: none;
+  transition-delay: 0s;
+}
+@media (prefers-reduced-motion: reduce) {
+  .conversation-outline-toggle,
+  .conversation-outline-toggle.is-hidden,
+  .conversation-outline-panel,
+  .conversation-outline-panel.is-open {
+    transition: none;
+  }
 }
 .conversation-outline-panel > header {
   display: flex; min-height: 52px; flex: 0 0 auto; align-items: center; gap: 10px;


### PR DESCRIPTION
## Summary
- The conversation outline used to mount and unmount instantly, so open/close felt abrupt.
- Keep the toggle and panel mounted and transition them with the existing motion tokens (slide + fade). Escape still closes the topmost layer.

## Test plan
- [x] Playwright: `conversation outline loads and jumps to an older user question`
- [ ] Open the outline from the right-edge marks, then close with Escape and the header button; both should animate
- [ ] Confirm `prefers-reduced-motion` skips the transition
