### PR TITLE
ui: edit reasoning effort per model row in the model picker

### DIFF
--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -33,13 +33,13 @@ The composer model picker binds the selected HTTP model to the current
 conversation. Switching one populated conversation asks for confirmation and
 does not change any other conversation. Empty conversations switch immediately
 without a warning. The active profile in Settings remains the default for new
-conversations. The reasoning-effort selector in the same menu is also scoped to
-the current conversation: changing it overrides that conversation's model
-profile without editing the profile or affecting other conversations. A new
-conversation inherits the reasoning effort configured on its model profile.
-The selector lists the effort levels the bound model family is documented to
-support (same curated list as the model form in Settings), and choosing
-"default" clears the conversation override so it follows the profile again.
+conversations. Each model row in the picker shows the reasoning effort
+configured on that profile; the row's **Edit** button opens a flyout listing
+the effort levels the model family is documented to support (same curated
+list as the model form in Settings). Choosing a level saves it as the
+profile's default — it applies to every conversation using that model and is
+not scoped to the current conversation. Choosing "default" clears the value
+so the provider decides.
 
 Model profiles describe model access and capabilities for the **built-in Wisp
 agent**. External coding agents (Codex / Claude via ACP) are configured under

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -947,59 +947,57 @@ test("model selection stays bound to its conversation", async ({ page }) => {
   await expect(page.locator(".model-picker-label")).toHaveText("opus-4.8");
 });
 
-test("reasoning effort stays scoped to the current conversation", async ({ page }) => {
+test("model effort is shown per row and saved to the model profile", async ({ page }) => {
   await enterApp(page, "/?mockSessionModels=1");
-  await page.locator('[data-session-id="s-model-a"]').click();
-
   await page.locator(".model-picker-btn").click();
-  await page.getByRole("button", { name: /opus-4\.8/ }).click();
-  await page.getByTestId("model-switch-confirm")
-    .getByRole("button", { name: "Yes, switch" }).click();
-  await expect(page.locator(".model-picker-label")).toHaveText("opus-4.8");
 
-  await page.locator(".model-picker-btn").click();
-  const effortTrigger = page.locator(".model-menu-effort-trigger");
-  const effortValue = page.locator(".model-menu-effort-value");
-  await expect(effortValue).toHaveText("max");
-  await effortTrigger.click();
-  await page.locator(".model-menu-effort-option[data-effort='high']").click();
-  await expect.poll(() => lastInvokeArgs(page, "set_session_reasoning_effort")).toMatchObject({
-    sessionId: "s-model-a",
-    effort: "high",
+  // Each chat model row shows its own configured effort.
+  const opusRow = page.locator(".model-menu-row", { hasText: "opus-4.8" });
+  const deepseekRow = page.locator(".model-menu-row", { hasText: "deepseek-v4-pro" });
+  await expect(opusRow.locator(".model-menu-effort-tag")).toHaveText("max");
+  await expect(deepseekRow.locator(".model-menu-effort-tag")).toHaveText("low");
+
+  await opusRow.locator(".model-menu-effort-edit").click();
+  const flyout = page.locator(".model-menu-effort-flyout[data-effort-for='opus']");
+  await expect(flyout).toBeVisible();
+  // The stored value carries the check mark.
+  await expect(
+    flyout.locator(".model-menu-effort-option[data-effort='max'] .model-menu-effort-check"),
+  ).toBeVisible();
+  await flyout.locator(".model-menu-effort-option[data-effort='high']").click();
+
+  // The effort is written onto the model profile, not the conversation.
+  await expect.poll(() => lastInvokeArgs(page, "save_model")).toMatchObject({
+    profile: { id: "opus", reasoning_effort: "high" },
   });
-  await expect.poll(() => lastInvokeArgs(page, "save_model")).toBeNull();
-  await page.locator(".model-menu-backdrop").click();
+  await expect.poll(() => lastInvokeArgs(page, "set_session_reasoning_effort")).toBeNull();
 
-  await page.locator('[data-session-id="s-model-b"]').click();
-  await page.locator(".model-picker-btn").click();
-  await expect(page.locator(".model-menu-effort-value")).toHaveText("low");
-  await page.locator(".model-menu-backdrop").click();
+  // The flyout closes, the menu stays open, and the row shows the new value.
+  await expect(page.locator(".model-menu-effort-flyout")).toHaveCount(0);
+  await expect(page.locator(".model-menu")).toBeVisible();
+  await expect(opusRow.locator(".model-menu-effort-tag")).toHaveText("high");
 
-  await page.locator('[data-session-id="s-model-a"]').click();
-  await page.locator(".model-picker-btn").click();
-  await expect(page.locator(".model-menu-effort-value")).toHaveText("high");
-
-  // "default" clears the override: the session follows the bound profile
-  // (opus-4.8 defaults to max) instead of pinning "provider default".
-  await effortTrigger.click();
-  await page.locator(".model-menu-effort-option[data-effort='default']").click();
-  await expect.poll(() => lastInvokeArgs(page, "set_session_reasoning_effort")).toMatchObject({
-    sessionId: "s-model-a",
-    effort: "",
+  // "default" clears the profile value again.
+  await opusRow.locator(".model-menu-effort-edit").click();
+  await flyout.locator(".model-menu-effort-option[data-effort='default']").click();
+  await expect.poll(() => lastInvokeArgs(page, "save_model")).toMatchObject({
+    profile: { id: "opus", reasoning_effort: "" },
   });
-  await expect(page.locator(".model-menu-effort-value")).toHaveText("max");
+  await expect(opusRow.locator(".model-menu-effort-tag")).toHaveCount(0);
 });
 
-test("effort options close on Escape before the model menu", async ({ page }) => {
+test("effort flyout closes on Escape before the model menu", async ({ page }) => {
   await enterApp(page, "/?mockSessionModels=1");
-  await page.locator('[data-session-id="s-model-a"]').click();
   await page.locator(".model-picker-btn").click();
-  await page.locator(".model-menu-effort-trigger").click();
-  await expect(page.locator(".model-menu-effort-options")).toBeVisible();
+  await page
+    .locator(".model-menu-row", { hasText: "opus-4.8" })
+    .locator(".model-menu-effort-edit")
+    .click();
+  await expect(page.locator(".model-menu-effort-flyout")).toBeVisible();
 
-  // One Escape closes only the effort options; the model menu stays open.
+  // One Escape closes only the flyout; the model menu stays open.
   await page.keyboard.press("Escape");
-  await expect(page.locator(".model-menu-effort-options")).toHaveCount(0);
+  await expect(page.locator(".model-menu-effort-flyout")).toHaveCount(0);
   await expect(page.locator(".model-menu")).toBeVisible();
 
   await page.keyboard.press("Escape");

--- a/ui/src/dto.rs
+++ b/ui/src/dto.rs
@@ -1077,8 +1077,7 @@ pub(crate) fn session_model_label(
 }
 
 /// The profile a session resolves to right now: bound profile → active →
-/// first chat model. Shared by the effort/window getters and the composer
-/// effort dropdown.
+/// first chat model. Shared by the session-scoped getters.
 pub(crate) fn session_profile<'a>(
     models: &'a [ModelProfile],
     session_models: &HashMap<String, String>,
@@ -1094,25 +1093,6 @@ pub(crate) fn session_profile<'a>(
                 .find(|model| model.active && model.is_chat_model())
         })
         .or_else(|| models.iter().find(|model| model.is_chat_model()))
-}
-
-/// Effective effort for the active conversation. A value loaded from the
-/// frame wins; before that IPC read completes, fall back to the bound profile.
-/// An empty stored value means "no override" (inherit the profile again).
-pub(crate) fn session_reasoning_effort(
-    models: &[ModelProfile],
-    session_models: &HashMap<String, String>,
-    session_efforts: &HashMap<String, String>,
-    session_id: Option<&str>,
-) -> String {
-    if let Some(effort) = session_id.and_then(|id| session_efforts.get(id)) {
-        if !effort.is_empty() {
-            return effort.clone();
-        }
-    }
-    session_profile(models, session_models, session_id)
-        .map(|model| model.reasoning_effort.clone())
-        .unwrap_or_default()
 }
 
 /// Mirrors `models::effective_context_window` in src-tauri: a configured
@@ -1161,7 +1141,7 @@ mod model_label_tests {
 
 #[cfg(test)]
 mod session_context_window_tests {
-    use super::{session_context_window, session_reasoning_effort, ModelProfile};
+    use super::{session_context_window, ModelProfile};
     use std::collections::HashMap;
 
     fn profile(id: &str, active: bool, context_window: u64) -> ModelProfile {
@@ -1189,39 +1169,6 @@ mod session_context_window_tests {
         assert_eq!(
             session_context_window(&models, &bindings, Some("s1")),
             Some(1_000_000)
-        );
-    }
-
-    #[test]
-    fn session_effort_override_wins_without_changing_profile() {
-        let mut active = profile("a", true, 128_000);
-        active.reasoning_effort = "max".into();
-        let mut bound = profile("b", false, 128_000);
-        bound.reasoning_effort = "max".into();
-        let models = vec![active, bound];
-        let bindings = HashMap::from([("s1".to_string(), "b".to_string())]);
-        let efforts = HashMap::from([("s1".to_string(), "high".to_string())]);
-
-        assert_eq!(
-            session_reasoning_effort(&models, &bindings, &efforts, Some("s1")),
-            "high"
-        );
-        assert_eq!(models[0].reasoning_effort, "max");
-        assert_eq!(models[1].reasoning_effort, "max");
-    }
-
-    #[test]
-    fn empty_effort_override_inherits_profile_again() {
-        let mut bound = profile("b", true, 128_000);
-        bound.reasoning_effort = "max".into();
-        let models = vec![bound];
-        let bindings = HashMap::from([("s1".to_string(), "b".to_string())]);
-        // Legacy rows and a just-cleared override both surface as "".
-        let efforts = HashMap::from([("s1".to_string(), String::new())]);
-
-        assert_eq!(
-            session_reasoning_effort(&models, &bindings, &efforts, Some("s1")),
-            "max"
         );
     }
 

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -518,7 +518,6 @@ fn App() -> impl IntoView {
         conversation_outline_selected.set(None);
     });
     let session_model_ids = create_rw_signal::<HashMap<String, String>>(HashMap::new());
-    let session_reasoning_efforts = create_rw_signal::<HashMap<String, String>>(HashMap::new());
     let acp_agents = create_rw_signal::<Vec<AcpAgentProfile>>(vec![]);
     let active_acp_agent_id = create_rw_signal::<Option<String>>(None);
     let acp_context_usage =
@@ -593,12 +592,54 @@ fn App() -> impl IntoView {
     let project_transition_target = Rc::new(RefCell::new(None::<String>));
     let project_open_gate = Rc::new(RefCell::new(ProjectOpenGate::default()));
     let model_menu_open = create_rw_signal(false);
-    let effort_menu_open = create_rw_signal(false);
-    // The effort picker lives inside the model menu; collapse it with the menu.
+    // Per-model effort flyout inside the model menu: (model id, left, top) in
+    // viewport coordinates. Rendered `position: fixed` so the menu's scroll
+    // box doesn't clip it.
+    let effort_menu_for = create_rw_signal(None::<(String, f64, f64)>);
+    // The effort flyout lives inside the model menu; collapse it with the menu.
     create_effect(move |_| {
         if !model_menu_open.get() {
-            effort_menu_open.set(false);
+            effort_menu_for.set(None);
         }
+    });
+    // Persist a reasoning-effort default onto the model profile itself
+    // (Cursor-style per-model effort). Sessions without an explicit override
+    // inherit the new default on their next turn.
+    let apply_model_effort = Callback::new(move |(id, effort): (String, String)| {
+        effort_menu_for.set(None);
+        let Some(profile) = models.get_untracked().into_iter().find(|m| m.id == id) else {
+            return;
+        };
+        spawn_local(async move {
+            let arg = to_value(&serde_json::json!({
+                "profile": {
+                    "id": profile.id,
+                    "label": profile.label,
+                    "provider": profile.provider,
+                    "api_url": profile.api_url,
+                    "model": profile.model,
+                    "max_tokens": profile.max_tokens,
+                    "context_window": profile.context_window,
+                    "reasoning_effort": effort,
+                    "supports_vision": profile.supports_vision,
+                    "use_for_vision": profile.use_for_vision,
+                    "use_for_image_generation": profile.use_for_image_generation,
+                },
+                // No key field: the backend keeps the stored key.
+                "key": Option::<String>::None,
+                "useForVision": profile.use_for_vision,
+                "useForImageGeneration": profile.use_for_image_generation,
+            }))
+            .unwrap();
+            match invoke_checked("save_model", arg).await {
+                Ok(v) => {
+                    if let Ok(list) = serde_wasm_bindgen::from_value::<Vec<ModelProfile>>(v) {
+                        models.set(list);
+                    }
+                }
+                Err(err) => show_warning_toast(&js_error_text(err)),
+            }
+        });
     });
     let model_switch_confirm = create_rw_signal::<Option<(String, String, bool)>>(None);
     let status = create_rw_signal(String::new());
@@ -777,16 +818,6 @@ fn App() -> impl IntoView {
                     if active_session.get_untracked().as_deref() == Some(session_id.as_str()) {
                         session_model_ids.update(|models| {
                             models.insert(session_id.clone(), model_id);
-                        });
-                    }
-                }
-            }
-            let args = to_value(&serde_json::json!({ "sessionId": session_id.clone() })).unwrap();
-            if let Ok(value) = invoke_checked("get_session_reasoning_effort", args).await {
-                if let Some(effort) = value.as_string() {
-                    if active_session.get_untracked().as_deref() == Some(session_id.as_str()) {
-                        session_reasoning_efforts.update(|efforts| {
-                            efforts.insert(session_id, effort);
                         });
                     }
                 }
@@ -7552,9 +7583,9 @@ fn App() -> impl IntoView {
             specialist_menu_open.set(false);
             return;
         }
-        if effort_menu_open.get() {
+        if effort_menu_for.get().is_some() {
             ev.prevent_default();
-            effort_menu_open.set(false);
+            effort_menu_for.set(None);
             return;
         }
         if model_menu_open.get() {
@@ -11501,7 +11532,9 @@ fn App() -> impl IntoView {
                                     </button>
                                     {move || model_menu_open.get().then(|| view! {
                                         <div class="model-menu-backdrop" on:click=move |_| model_menu_open.set(false)></div>
-                                        <div class="model-menu" on:click=move |_| effort_menu_open.set(false)>
+                                        <div class="model-menu"
+                                            on:click=move |_| effort_menu_for.set(None)
+                                            on:scroll=move |_| effort_menu_for.set(None)>
                                             {move || {
                                                 let list = models.get();
                                                 let selected = active_session.get().and_then(|session_id| {
@@ -11516,6 +11549,10 @@ fn App() -> impl IntoView {
                                                     let is_active = !acp_selected
                                                         && selected.as_deref().map_or(m.active, |id| id == m.id);
                                                     let show_sub = !m.model.is_empty() && m.model != m.label;
+                                                    let effort = m.reasoning_effort.clone();
+                                                    let effort_id = m.id.clone();
+                                                    let effort_id_open = m.id.clone();
+                                                    let effort_id_expanded = m.id.clone();
                                                     view! {
                                                         <div class="model-menu-row" class:active=is_active>
                                                             <button type="button" class="model-menu-pick"
@@ -11544,12 +11581,89 @@ fn App() -> impl IntoView {
                                                                     <span class="model-menu-label">{m.label.clone()}</span>
                                                                     {show_sub.then(|| view! { <span class="model-menu-sub">{m.model.clone()}</span> })}
                                                                 </span>
+                                                                {(!effort.is_empty()).then(|| view! {
+                                                                    <span class="model-menu-effort-tag">{effort}</span>
+                                                                })}
                                                                 {is_active.then(|| view! { <span class="model-menu-check">"✓"</span> })}
+                                                            </button>
+                                                            <button type="button" class="model-menu-effort-edit"
+                                                                class:open=move || effort_menu_for.get().as_ref().is_some_and(|(open_id, _, _)| open_id == &effort_id_open)
+                                                                title=move || t(locale.get(), "settings.reasoning_effort")
+                                                                attr:aria-expanded=move || if effort_menu_for.get().as_ref().is_some_and(|(open_id, _, _)| open_id == &effort_id_expanded) { "true" } else { "false" }
+                                                                on:click=move |ev| {
+                                                                    ev.stop_propagation();
+                                                                    if effort_menu_for.get_untracked().as_ref().is_some_and(|(open_id, _, _)| open_id == &effort_id) {
+                                                                        effort_menu_for.set(None);
+                                                                        return;
+                                                                    }
+                                                                    let Some(el) = ev.target().and_then(|target| target.dyn_into::<web_sys::HtmlElement>().ok()) else { return; };
+                                                                    let rect = el.get_bounding_client_rect();
+                                                                    let menu_left = el
+                                                                        .closest(".model-menu")
+                                                                        .ok()
+                                                                        .flatten()
+                                                                        .map(|menu| menu.get_bounding_client_rect().left())
+                                                                        .unwrap_or(rect.left());
+                                                                    // Keep in sync with the flyout width in chat.css.
+                                                                    const FLYOUT_WIDTH: f64 = 200.0;
+                                                                    // Generous height allowance (default + every known level + label)
+                                                                    // so the flyout never runs past the viewport bottom.
+                                                                    const FLYOUT_MAX_HEIGHT: f64 = 340.0;
+                                                                    let left = (menu_left - FLYOUT_WIDTH - 6.0).max(8.0);
+                                                                    let viewport_h = web_sys::window()
+                                                                        .and_then(|w| w.inner_height().ok())
+                                                                        .and_then(|h| h.as_f64())
+                                                                        .unwrap_or(800.0);
+                                                                    let top = (rect.top() - 4.0).clamp(8.0, (viewport_h - FLYOUT_MAX_HEIGHT - 8.0).max(8.0));
+                                                                    effort_menu_for.set(Some((effort_id.clone(), left, top)));
+                                                                }>
+                                                                <span class="model-menu-effort-edit-label">{move || t(locale.get(), "menu.edit")}</span>
+                                                                {compose_icon("chevron-down")}
                                                             </button>
                                                         </div>
                                                     }
                                                 }).collect_view()
                                             }}
+                                            {move || effort_menu_for.get().and_then(|(id, left, top)| {
+                                                let profile = models.get().into_iter().find(|m| m.id == id)?;
+                                                let current = profile.reasoning_effort.clone();
+                                                let mut values: Vec<String> = known_effort_values(&profile.provider, &profile.model)
+                                                    .unwrap_or(ALL_EFFORT_VALUES)
+                                                    .iter()
+                                                    .map(|v| v.to_string())
+                                                    .collect();
+                                                // Keep a stored value visible even when the curated list
+                                                // for this model doesn't include it.
+                                                if !current.is_empty() && !values.iter().any(|v| v == &current) {
+                                                    values.push(current.clone());
+                                                }
+                                                let default_selected = current.is_empty();
+                                                let style = format!("left:{left:.0}px;top:{top:.0}px");
+                                                let default_id = id.clone();
+                                                Some(view! {
+                                                    <div class="model-menu-effort-flyout" style=style data-effort-for=id.clone()
+                                                        on:click=|ev| ev.stop_propagation()>
+                                                        <div class="model-menu-effort-flyout-label">{move || t(locale.get(), "settings.reasoning_effort")}</div>
+                                                        <button type="button" class="model-menu-effort-option" data-effort="default"
+                                                            on:click=move |_| apply_model_effort.call((default_id.clone(), String::new()))>
+                                                            <span class="model-menu-effort-option-label">{move || t(locale.get(), "settings.reasoning_effort.default")}</span>
+                                                            {default_selected.then(|| view! { <span class="model-menu-effort-check">{compose_icon("check")}</span> })}
+                                                        </button>
+                                                        {values.into_iter().map(|lvl| {
+                                                            let selected = !default_selected && lvl == current;
+                                                            let pick = lvl.clone();
+                                                            let option_id = id.clone();
+                                                            view! {
+                                                                <button type="button" class="model-menu-effort-option" data-effort=lvl.clone()
+                                                                    on:click=move |_| apply_model_effort.call((option_id.clone(), pick.clone()))>
+                                                                    <span class="model-menu-effort-option-label">{lvl}</span>
+                                                                    {selected.then(|| view! { <span class="model-menu-effort-check">{compose_icon("check")}</span> })}
+                                                                </button>
+                                                            }
+                                                        }).collect_view()}
+                                                    </div>
+                                                })
+                                            })}
                                             {move || (!acp_agents.get().is_empty()).then(|| view! {
                                                 <div class="compose-group-label">"ACP Agents"</div>
                                                 {acp_agents.get().into_iter().map(|agent| {
@@ -11785,112 +11899,6 @@ fn App() -> impl IntoView {
                                                         }).collect_view()}
                                                     </div>
                                                 })
-                                            })}
-                                            {move || active_acp_agent_id.get().is_none().then(|| {
-                                                let apply_effort = Rc::new(move |v: String| {
-                                                    effort_menu_open.set(false);
-                                                    let Some(session_id) = active_session.get_untracked() else { return; };
-                                                    let effort = if v == "default" { String::new() } else { v };
-                                                    spawn_local(async move {
-                                                        let arg = to_value(&serde_json::json!({
-                                                            "sessionId": session_id.clone(),
-                                                            "effort": effort.clone(),
-                                                        })).unwrap();
-                                                        if invoke_checked("set_session_reasoning_effort", arg).await.is_ok() {
-                                                            session_reasoning_efforts.update(|efforts| {
-                                                                if effort.is_empty() {
-                                                                    // Cleared override: inherit the
-                                                                    // bound profile again.
-                                                                    efforts.remove(&session_id);
-                                                                } else {
-                                                                    efforts.insert(session_id, effort);
-                                                                }
-                                                            });
-                                                        }
-                                                    });
-                                                });
-                                                let current_effort = move || {
-                                                    let models = models.get();
-                                                    let session_models = session_model_ids.get();
-                                                    let efforts = session_reasoning_efforts.get();
-                                                    let session_id = active_session.get();
-                                                    session_reasoning_effort(
-                                                        &models,
-                                                        &session_models,
-                                                        &efforts,
-                                                        session_id.as_deref(),
-                                                    )
-                                                };
-                                                view! {
-                                                <div class="model-menu-effort" on:click=|ev| ev.stop_propagation()>
-                                                    <button type="button" class="model-menu-effort-trigger"
-                                                        class:open=move || effort_menu_open.get()
-                                                        attr:aria-expanded=move || if effort_menu_open.get() { "true" } else { "false" }
-                                                        on:click=move |_| effort_menu_open.update(|o| *o = !*o)>
-                                                        <span class="model-menu-effort-label">{move || t(locale.get(), "settings.reasoning_effort")}</span>
-                                                        <span class="model-menu-effort-value">{move || {
-                                                            let current = current_effort();
-                                                            // The trigger shows the effective effort:
-                                                            // an inherited profile value is displayed
-                                                            // as-is; the default label appears only
-                                                            // when nothing is configured anywhere.
-                                                            if current.is_empty() {
-                                                                t(locale.get(), "settings.reasoning_effort.default").to_string()
-                                                            } else {
-                                                                current
-                                                            }
-                                                        }}</span>
-                                                        <span class="model-menu-effort-chev">{compose_icon("chevron-down")}</span>
-                                                    </button>
-                                                    {move || effort_menu_open.get().then(|| {
-                                                        let current = current_effort();
-                                                        let models = models.get();
-                                                        let session_models = session_model_ids.get();
-                                                        let session_id = active_session.get();
-                                                        let mut values: Vec<String> = session_profile(
-                                                            &models,
-                                                            &session_models,
-                                                            session_id.as_deref(),
-                                                        )
-                                                        .map(|profile| {
-                                                            known_effort_values(&profile.provider, &profile.model)
-                                                                .unwrap_or(ALL_EFFORT_VALUES)
-                                                        })
-                                                        .unwrap_or(ALL_EFFORT_VALUES)
-                                                        .iter()
-                                                        .map(|v| v.to_string())
-                                                        .collect();
-                                                        // Keep a stored override visible even when the
-                                                        // curated list for this model doesn't include it.
-                                                        if !current.is_empty() && !values.iter().any(|v| v == &current) {
-                                                            values.push(current.clone());
-                                                        }
-                                                        let default_selected = current.is_empty();
-                                                        let apply_default = apply_effort.clone();
-                                                        view! {
-                                                            <div class="model-menu-effort-options">
-                                                                <button type="button" class="model-menu-effort-option" data-effort="default"
-                                                                    on:click=move |_| apply_default("default".to_string())>
-                                                                    <span class="model-menu-effort-option-label">{move || t(locale.get(), "settings.reasoning_effort.default")}</span>
-                                                                    {default_selected.then(|| view! { <span class="model-menu-effort-check">{compose_icon("check")}</span> })}
-                                                                </button>
-                                                                {values.into_iter().map(|lvl| {
-                                                                    let selected = !default_selected && lvl == current;
-                                                                    let apply = apply_effort.clone();
-                                                                    let pick = lvl.clone();
-                                                                    view! {
-                                                                        <button type="button" class="model-menu-effort-option" data-effort=lvl.clone()
-                                                                            on:click=move |_| apply(pick.clone())>
-                                                                            <span class="model-menu-effort-option-label">{lvl}</span>
-                                                                            {selected.then(|| view! { <span class="model-menu-effort-check">{compose_icon("check")}</span> })}
-                                                                        </button>
-                                                                    }
-                                                                }).collect_view()}
-                                                            </div>
-                                                        }
-                                                    })}
-                                                </div>
-                                                }
                                             })}
                                             <button type="button" class="model-menu-add" on:click=move |_| {
                                                 model_menu_open.set(false);

--- a/ui/src/styles/chat.css
+++ b/ui/src/styles/chat.css
@@ -1137,15 +1137,15 @@ details.tool:not([open]) > summary.head .run-dot { animation: tool-pulse 1.1s ea
 .model-menu-check { flex: 0 0 auto; color: var(--clay-strong); font-weight: 700; }
 .model-menu-del { flex: 0 0 auto; background: transparent; border: none; color: var(--text-faint); font-size: 15px; line-height: 1; padding: 4px 8px; cursor: pointer; border-radius: var(--radius-xs); }
 .model-menu-del:hover { color: var(--err); }
-.model-menu-effort { border-top: 1px solid var(--border); margin-top: 4px; padding-top: 4px; }
-.model-menu-effort-trigger { display: flex; align-items: center; gap: 8px; width: 100%; padding: 7px 10px; border: none; border-radius: var(--radius-xs); background: transparent; color: var(--text); font: inherit; cursor: pointer; }
-.model-menu-effort-trigger:hover, .model-menu-effort-trigger.open { background: var(--bg-sunken); }
-.model-menu-effort-label { flex: 1 1 auto; min-width: 0; text-align: left; font-size: 12px; color: var(--text-muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.model-menu-effort-value { flex: 0 1 auto; max-width: 48%; font-family: var(--font-mono); font-size: 11.5px; color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.model-menu-effort-chev { flex: 0 0 auto; display: inline-flex; color: var(--text-faint); transition: transform .12s ease; }
-.model-menu-effort-chev svg { width: 13px; height: 13px; }
-.model-menu-effort-trigger.open .model-menu-effort-chev { transform: rotate(180deg); }
-.model-menu-effort-options { display: flex; flex-direction: column; gap: 1px; padding: 2px 0 4px; }
+.model-menu-effort-tag { flex: 0 0 auto; font-family: var(--font-mono); font-size: 11px; color: var(--text-faint); white-space: nowrap; }
+.model-menu-effort-edit { flex: 0 0 auto; display: inline-flex; align-items: center; gap: 2px; margin-right: 4px; padding: 4px 6px; background: transparent; border: none; border-radius: var(--radius-xs); color: var(--text-faint); font: inherit; font-size: 12px; cursor: pointer; opacity: 0; transition: opacity .12s ease; }
+.model-menu-row:hover .model-menu-effort-edit,
+.model-menu-effort-edit:focus-visible,
+.model-menu-effort-edit.open { opacity: 1; }
+.model-menu-effort-edit:hover, .model-menu-effort-edit.open { background: var(--bg-sunken); color: var(--text); }
+.model-menu-effort-edit svg { width: 12px; height: 12px; }
+.model-menu-effort-flyout { position: fixed; z-index: 42; width: 200px; display: flex; flex-direction: column; gap: 1px; padding: 6px; background: var(--bg-elev); border: 1px solid var(--border-strong); border-radius: var(--radius-sm); box-shadow: 0 8px 28px rgba(0,0,0,.14); }
+.model-menu-effort-flyout-label { padding: 4px 10px 6px; font-size: 11px; font-weight: 600; letter-spacing: .04em; text-transform: uppercase; color: var(--text-faint); }
 .model-menu-effort-option { display: flex; align-items: center; gap: 8px; width: 100%; padding: 6px 10px; border: none; border-radius: var(--radius-xs); background: transparent; color: var(--text); font: inherit; font-size: 12.5px; cursor: pointer; text-align: left; }
 .model-menu-effort-option:hover { background: var(--bg-sunken); }
 .model-menu-effort-option-label { flex: 1 1 auto; min-width: 0; font-family: var(--font-mono); font-size: 12px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }


### PR DESCRIPTION
## Problem

The reasoning-effort control lived at the bottom of the composer model menu as a single session-scoped selector: it was visually detached from the models it affects, and its conversation-override semantics were easy to miss.

## What changed

- Each chat-model row in the model picker now shows that profile's configured effort as a small tag (Cursor-style).
- A row's **Edit** button (revealed on hover, like Cursor) opens a flyout listing the effort levels that model family is documented to support — the same curated list as the Settings model form — with the current value checked.
- Choosing a level persists it as the **model profile default** via `save_model` (key untouched); every conversation using that model inherits it. Choosing "default" clears the value so the provider decides.
- The session-scoped effort control at the bottom of the menu is removed, together with the now-unused `session_reasoning_efforts` signal, its `get_session_reasoning_effort` fetch, and the `dto::session_reasoning_effort` helper + tests.

## Files

- `ui/src/main.rs` — `effort_menu_for` signal (model id + viewport coords), `apply_model_effort` callback, row Edit button + fixed-position flyout, Escape-stack entry, removal of the bottom control.
- `ui/src/styles/chat.css` — effort tag / Edit button / flyout styles; old trigger styles removed.
- `ui/src/dto.rs` — dropped the unused `session_reasoning_effort` helper and its two tests.
- `ui-tests/tests/ui.spec.ts` — rewrote the two effort tests for per-row editing and the Escape order.
- `docs/model-configuration.md` — describes the new per-model behavior.

## Tests

- `cargo fmt --all -- --check` clean; `cargo test --workspace` green; `cd ui && cargo check --target wasm32-unknown-unknown` clean.
- Full Playwright suite: 354 passed, 1 skipped — including the two rewritten tests (per-row effort saved via `save_model`, flyout closes on Escape before the menu).

## Manual smoke

1. Open the composer model picker → each model row shows its configured effort.
2. Hover a row → **Edit ⌄** appears; click it → flyout opens to the left of the menu with the current level checked.
3. Pick a level → flyout closes, menu stays open, row tag updates; reopen Settings → Models to confirm the profile persisted.
4. Escape once closes only the flyout; Escape again closes the menu.

## Known limitations / follow-ups

- Sessions that still hold a legacy per-conversation effort override (set by older builds) keep winning over the profile default; there is no UI to clear that override anymore. The backend commands remain intact, so a small "clear override when editing the bound model's default" pass could be a follow-up if this surfaces.
- The flyout is `position: fixed` to escape the menu's scroll clipping; it closes on menu scroll rather than tracking the row.