### PR TITLE
docs: name workflow engines (snakemake/nextflow/oxo-flow) in local-env-setup skill

### DIFF
--- a/skills/local-env-setup/SKILL.md
+++ b/skills/local-env-setup/SKILL.md
@@ -13,7 +13,7 @@ wisp-science needs three **independent** local toolchains:
 |---|---|---|
 | **Core** | `uv` + managed Python venv | App bootstrap, `python` tool, bundled MCP servers |
 | **Literature** | Node >= 20, `npm`, `sci` (scimaster-cli) | Bundled `bear-*` skills (real paper search) |
-| **Bioinformatics** | `pixi` | Per-project conda/pip multi-env analysis (scanpy, nextflow-adjacent stacks, etc.) |
+| **Bioinformatics** | `pixi` | Per-project conda/pip multi-env analysis (scanpy, workflow engines like snakemake/nextflow/oxo-flow) |
 
 Core is **required** for the app. Literature and bioinformatics layers are optional until the user runs those skills — but Capabilities shows all of them; install what's missing for the user's goal.
 
@@ -215,6 +215,16 @@ Settings -> Credentials -> SCIMaster. Wisp will sync that key into
 ## Layer 3 — Bioinformatics: pixi
 
 **pixi** manages isolated per-project environments (conda + pip) — use for scanpy/single-cell, variant calling stacks, etc. The wisp **`python` tool** uses the core uv venv; run bioinfo code via **`shell`**: `pixi run python …` or `pixi run …` in the project directory.
+
+### Workflow engines
+
+For **multi-step analysis pipelines** (many rules, parallel execution, resume after failure), pair pixi with a dedicated workflow engine — pixi manages the environments, the engine schedules the steps. Run engines from **`shell`** in the project directory.
+
+| Engine | What it is | When to choose |
+|---|---|---|
+| [snakemake](https://snakemake.github.io) | Python-defined rules, mature conda/mamba integration | Established rules; Python-centric teams |
+| [nextflow](https://www.nextflow.io) | Groovy DSL, container-first | nf-core ecosystem; HPC/cloud portability |
+| [oxo-flow](https://github.com/Traitome/oxo-flow) | Rust-native, TOML-defined DAG engine; CLI + web UI | Lightweight single-binary install; rule-level conda/mamba/pixi/docker/singularity backends; checkpoint/resume |
 
 ### Install pixi
 


### PR DESCRIPTION
## Problem

The Bioinformatics layer of `local-env-setup` recommends pixi but never names a workflow engine — the table row mentioned "nextflow-adjacent stacks" without telling users what to choose for multi-step pipelines (many rules, parallel execution, resume after failure). Users asking how to run a real analysis pipeline inside wisp get no guidance.

## Changes

- `skills/local-env-setup/SKILL.md`:
  - Table row now names the engines: "scanpy, workflow engines like snakemake/nextflow/oxo-flow".
  - New "Workflow engines" subsection under Layer 3 with a 3-engine comparison table (what it is / when to choose) and how engines relate to pixi (pixi manages environments, the engine schedules steps).

## Tests

- `cargo test -p wisp-skills` — 19 passed, 0 failed (incl. `every_bundled_skill_parses_and_matches_its_directory`).

## Smoke steps

1. `cargo test -p wisp-skills` passes.
2. Frontmatter untouched; skill still parses; catalog entry unchanged.

## Known limitations

- Doc-only change; no code paths touched.
- Disclosure: I maintain [oxo-flow](https://github.com/Traitome/oxo-flow) (Apache-2.0). The table wording is a suggestion — happy to rephrase if you prefer engine-agnostic language or a different placement (e.g. a dedicated docs page).

---

**中文摘要**：`local-env-setup` 技能目前只推荐 pixi 管理环境，从未点名任何工作流引擎。本 PR 在表格行与 Layer 3 下新增引擎选择指引（snakemake / nextflow / oxo-flow），说明 pixi 管环境、引擎调度步骤的分工与各自适用场景。纯文档改动，`cargo test -p wisp-skills` 19 项测试全部通过。
