### PR TITLE
fix(mcp): terminate stdio process trees

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7214,11 +7214,13 @@ version = "1.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "libc",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tokio",
  "tracing",
+ "windows-sys 0.61.2",
  "wisp-llm",
  "wisp-paths",
  "wisp-tools",

--- a/crates/wisp-mcp/Cargo.toml
+++ b/crates/wisp-mcp/Cargo.toml
@@ -16,3 +16,20 @@ wisp-llm = { workspace = true }
 wisp-tools = { workspace = true }
 wisp-paths = { workspace = true }
 reqwest = { workspace = true }
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_System_Diagnostics_ToolHelp",
+    "Win32_System_JobObjects",
+    "Win32_System_Threading",
+] }
+
+[[test]]
+name = "process_tree_shutdown"
+path = "tests/process_tree_shutdown.rs"
+harness = false

--- a/crates/wisp-mcp/src/client.rs
+++ b/crates/wisp-mcp/src/client.rs
@@ -6,11 +6,12 @@
 //! `tools/call`. Each remote tool is exposed to the agent as a
 //! [`wisp_tools::Tool`] via [`McpTool`].
 
+use crate::process_tree::ProcessTree;
 use anyhow::{anyhow, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{ChildStdin, ChildStdout};
@@ -19,6 +20,10 @@ use tokio::sync::Mutex;
 /// Hard cap on a single stdio JSON-RPC exchange, matching the HTTP transport's
 /// request timeout. Without it a hung server blocks the agent turn forever.
 const STDIO_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+const STDIO_SHUTDOWN_EOF_GRACE: std::time::Duration = std::time::Duration::from_millis(100);
+const STDIO_SHUTDOWN_TERM_GRACE: std::time::Duration = std::time::Duration::from_millis(500);
+const STDIO_SHUTDOWN_KILL_WAIT: std::time::Duration = std::time::Duration::from_secs(2);
+const STDIO_SHUTDOWN_LOCK_WAIT: std::time::Duration = std::time::Duration::from_secs(3);
 
 /// Path to the vendored bio-tools MCP servers bundled with the app.
 pub fn bundled_bio_tools_dir() -> Option<PathBuf> {
@@ -121,9 +126,13 @@ struct JsonRpcError {
 
 enum Transport {
     Stdio {
-        stdin: Arc<Mutex<ChildStdin>>,
+        stdin: Arc<Mutex<Option<ChildStdin>>>,
         stdout: Arc<Mutex<BufReader<ChildStdout>>>,
-        child: Mutex<tokio::process::Child>,
+        child: Mutex<Option<tokio::process::Child>>,
+        process_tree: ProcessTree,
+        closing: AtomicBool,
+        terminated: AtomicBool,
+        shutdown_lock: Mutex<()>,
         next_id: AtomicU64,
     },
     Http(HttpTransport),
@@ -169,6 +178,37 @@ pub struct McpClient {
     transport: Transport,
 }
 
+struct RequestCancellation<'a> {
+    process_tree: &'a ProcessTree,
+    child: &'a Mutex<Option<tokio::process::Child>>,
+    closing: &'a AtomicBool,
+    armed: bool,
+}
+
+impl RequestCancellation<'_> {
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for RequestCancellation<'_> {
+    fn drop(&mut self) {
+        if self.armed {
+            self.closing.store(true, Ordering::SeqCst);
+            if let Err(error) = self.process_tree.terminate_forcefully() {
+                tracing::warn!(%error, "failed to terminate cancelled MCP process tree");
+            }
+            // No await is legal in Drop. Taking the Child invokes the existing
+            // kill_on_drop guard and hands Unix reaping to Tokio's orphan
+            // queue. If explicit shutdown already owns this lock, that path is
+            // responsible for the bounded wait/reap instead.
+            if let Ok(mut child) = self.child.try_lock() {
+                child.take();
+            }
+        }
+    }
+}
+
 fn bio_tools_command(
     python: &std::path::Path,
     run_server: &std::path::Path,
@@ -199,7 +239,12 @@ impl McpClient {
             .stderr(std::process::Stdio::piped())
             .kill_on_drop(true);
         wisp_tools::process::hide_console_async(&mut cmd);
+        ProcessTree::configure(&mut cmd);
         let mut child = cmd.spawn().map_err(|e| anyhow!("spawn MCP server: {e}"))?;
+        let process_tree = ProcessTree::attach(&child).map_err(|error| {
+            let _ = child.start_kill();
+            anyhow!("attach MCP server process tree: {error}")
+        })?;
         let stdin = child.stdin.take().ok_or_else(|| anyhow!("no stdin"))?;
         let stdout = child.stdout.take().ok_or_else(|| anyhow!("no stdout"))?;
         let stderr = child.stderr.take();
@@ -232,9 +277,13 @@ impl McpClient {
 
         let client = Self {
             transport: Transport::Stdio {
-                stdin: Arc::new(Mutex::new(stdin)),
+                stdin: Arc::new(Mutex::new(Some(stdin))),
                 stdout: Arc::new(Mutex::new(BufReader::new(stdout))),
-                child: Mutex::new(child),
+                child: Mutex::new(Some(child)),
+                process_tree,
+                closing: AtomicBool::new(false),
+                terminated: AtomicBool::new(false),
+                shutdown_lock: Mutex::new(()),
                 next_id: AtomicU64::new(1),
             },
         };
@@ -256,9 +305,7 @@ impl McpClient {
             tokio::time::sleep(std::time::Duration::from_millis(100)).await;
             let tail = stderr_tail.lock().await.clone();
             let tail = tail.trim();
-            if let Transport::Stdio { child, .. } = &client.transport {
-                let _ = child.lock().await.kill().await;
-            }
+            let _ = client.shutdown().await;
             if tail.is_empty() {
                 return Err(e);
             }
@@ -318,9 +365,16 @@ impl McpClient {
             Transport::Stdio {
                 stdin,
                 stdout,
+                child,
+                process_tree,
+                closing,
+                terminated,
+                shutdown_lock,
                 next_id,
-                ..
             } => {
+                if closing.load(Ordering::SeqCst) {
+                    return Err(anyhow!("MCP stdio connection is shutting down"));
+                }
                 let id = next_id.fetch_add(1, Ordering::SeqCst);
                 let req = JsonRpcReq {
                     jsonrpc: "2.0",
@@ -333,6 +387,9 @@ impl McpClient {
                     // send
                     {
                         let mut w = stdin.lock().await;
+                        let w = w
+                            .as_mut()
+                            .ok_or_else(|| anyhow!("MCP server stdin is closed"))?;
                         w.write_all(val.to_string().as_bytes()).await?;
                         w.write_all(b"\n").await?;
                         w.flush().await?;
@@ -359,12 +416,41 @@ impl McpClient {
                         }
                     }
                 };
+                let mut cancellation = RequestCancellation {
+                    process_tree,
+                    child,
+                    closing,
+                    armed: true,
+                };
                 match tokio::time::timeout(STDIO_REQUEST_TIMEOUT, exchange).await {
-                    Ok(res) => res,
-                    Err(_) => Err(anyhow!(
-                        "MCP stdio request '{method}' timed out after {}s",
-                        STDIO_REQUEST_TIMEOUT.as_secs()
-                    )),
+                    Ok(Ok(result)) => {
+                        cancellation.disarm();
+                        Ok(result)
+                    }
+                    Ok(Err(error)) => {
+                        cancellation.disarm();
+                        Err(error)
+                    }
+                    Err(_) => {
+                        cancellation.disarm();
+                        let cleanup = shutdown_stdio(
+                            stdin,
+                            child,
+                            process_tree,
+                            closing,
+                            terminated,
+                            shutdown_lock,
+                        )
+                        .await;
+                        let message = format!(
+                            "MCP stdio request '{method}' timed out after {}s",
+                            STDIO_REQUEST_TIMEOUT.as_secs()
+                        );
+                        match cleanup {
+                            Ok(()) => Err(anyhow!(message)),
+                            Err(error) => Err(anyhow!("{message}; shutdown failed: {error}")),
+                        }
+                    }
                 }
             }
             Transport::Http(h) => {
@@ -433,6 +519,9 @@ impl McpClient {
             Transport::Stdio { stdin, .. } => {
                 let val = json!({ "jsonrpc": "2.0", "method": method, "params": params });
                 let mut w = stdin.lock().await;
+                let w = w
+                    .as_mut()
+                    .ok_or_else(|| anyhow!("MCP server stdin is closed"))?;
                 w.write_all(val.to_string().as_bytes()).await?;
                 w.write_all(b"\n").await?;
                 w.flush().await?;
@@ -518,6 +607,149 @@ impl McpClient {
         let run_server = dir.join("run_server.py");
         let cmd = bio_tools_command(python, &run_server, pkg, envs);
         Self::launch_with_command(cmd).await
+    }
+
+    /// Stop this MCP connection and, for stdio transports, its complete child
+    /// process tree. Safe to call repeatedly. Drop remains a forceful safety
+    /// net for owners that cannot await this method.
+    pub async fn shutdown(&self) -> Result<()> {
+        match &self.transport {
+            Transport::Stdio {
+                stdin,
+                child,
+                process_tree,
+                closing,
+                terminated,
+                shutdown_lock,
+                ..
+            } => {
+                shutdown_stdio(
+                    stdin,
+                    child,
+                    process_tree,
+                    closing,
+                    terminated,
+                    shutdown_lock,
+                )
+                .await
+            }
+            Transport::Http(_) => Ok(()),
+        }
+    }
+}
+
+impl Drop for McpClient {
+    fn drop(&mut self) {
+        if let Transport::Stdio {
+            process_tree,
+            closing,
+            ..
+        } = &self.transport
+        {
+            closing.store(true, Ordering::SeqCst);
+            let _ = process_tree.terminate_forcefully();
+        }
+    }
+}
+
+async fn shutdown_stdio(
+    stdin: &Arc<Mutex<Option<ChildStdin>>>,
+    child: &Mutex<Option<tokio::process::Child>>,
+    process_tree: &ProcessTree,
+    closing: &AtomicBool,
+    terminated: &AtomicBool,
+    shutdown_lock: &Mutex<()>,
+) -> Result<()> {
+    closing.store(true, Ordering::SeqCst);
+    let _shutdown = match tokio::time::timeout(STDIO_SHUTDOWN_LOCK_WAIT, shutdown_lock.lock()).await
+    {
+        Ok(guard) => guard,
+        Err(_) => {
+            // A prior shutdown normally completes within 2.6s. Never let a
+            // stalled caller make App exit unbounded; the tree-wide kill is
+            // synchronous even though this path cannot own/reap `child`.
+            process_tree.terminate_forcefully()?;
+            return Err(anyhow!("timed out waiting for concurrent MCP shutdown"));
+        }
+    };
+    if terminated.load(Ordering::SeqCst) {
+        return Ok(());
+    }
+
+    // A cancelled request may still be unwinding while holding this mutex, and
+    // a blocked write must never make App exit unbounded. Close stdin only when
+    // immediately available; otherwise continue to the bounded tree signals.
+    if let Ok(mut stdin) = stdin.try_lock() {
+        stdin.take();
+    }
+    let mut child = child.lock().await;
+
+    #[cfg(unix)]
+    {
+        signal_unix_tree_before_reap(process_tree).await?;
+    }
+
+    #[cfg(not(unix))]
+    {
+        if wait_for_process_tree(&mut child, process_tree, STDIO_SHUTDOWN_EOF_GRACE).await? {
+            process_tree.disarm();
+            terminated.store(true, Ordering::SeqCst);
+            return Ok(());
+        }
+        process_tree.terminate_gracefully()?;
+        if wait_for_process_tree(&mut child, process_tree, STDIO_SHUTDOWN_TERM_GRACE).await? {
+            process_tree.disarm();
+            terminated.store(true, Ordering::SeqCst);
+            return Ok(());
+        }
+        process_tree.terminate_forcefully()?;
+    }
+
+    if !wait_for_process_tree(&mut child, process_tree, STDIO_SHUTDOWN_KILL_WAIT).await? {
+        // Keep the FORCE_SENT state: it prohibits any later numeric PGID
+        // signal while still allowing a repeated shutdown to poll/reap the
+        // actual tree instead of reporting a false success.
+        return Err(anyhow!(
+            "MCP server process tree did not exit after forceful shutdown"
+        ));
+    }
+    process_tree.disarm();
+    terminated.store(true, Ordering::SeqCst);
+    Ok(())
+}
+
+#[cfg(unix)]
+async fn signal_unix_tree_before_reap(process_tree: &ProcessTree) -> Result<()> {
+    // This helper deliberately cannot access Child. Keeping the process-group
+    // leader's PID occupied as a zombie, if it exits during either grace
+    // period, makes numeric PGID reuse impossible before SIGKILL. Once the
+    // force state is recorded, ProcessTree will never signal that PGID again
+    // and the caller may safely reap/poll.
+    tokio::time::sleep(STDIO_SHUTDOWN_EOF_GRACE).await;
+    process_tree.terminate_gracefully()?;
+    tokio::time::sleep(STDIO_SHUTDOWN_TERM_GRACE).await;
+    process_tree.terminate_forcefully()?;
+    Ok(())
+}
+
+async fn wait_for_process_tree(
+    child: &mut Option<tokio::process::Child>,
+    process_tree: &ProcessTree,
+    timeout: std::time::Duration,
+) -> Result<bool> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if let Some(child) = child.as_mut() {
+            let _ = child.try_wait()?;
+        }
+        if !process_tree.is_running()? {
+            child.take();
+            return Ok(true);
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Ok(false);
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
     }
 }
 

--- a/crates/wisp-mcp/src/lib.rs
+++ b/crates/wisp-mcp/src/lib.rs
@@ -15,6 +15,7 @@
 //! ```
 
 pub mod client;
+mod process_tree;
 pub mod tool;
 
 pub use client::{bundled_bio_tools_dir, McpCallResult, McpClient, RemoteTool};

--- a/crates/wisp-mcp/src/process_tree.rs
+++ b/crates/wisp-mcp/src/process_tree.rs
@@ -1,0 +1,329 @@
+use std::io;
+use std::sync::atomic::{AtomicU8, Ordering};
+use tokio::process::{Child, Command};
+
+const TREE_ACTIVE: u8 = 0;
+const GRACEFUL_SENT: u8 = 1;
+const FORCE_SENT: u8 = 2;
+const TREE_DISARMED: u8 = 3;
+
+/// One OS-owned termination boundary for an MCP stdio wrapper and every child
+/// it starts. The wrapper PID is never looked up by name.
+pub(crate) struct ProcessTree {
+    state: AtomicU8,
+    signal_lock: std::sync::Mutex<()>,
+    #[cfg(unix)]
+    process_group: libc::pid_t,
+    #[cfg(windows)]
+    job: std::os::windows::io::OwnedHandle,
+}
+
+impl ProcessTree {
+    /// Configure the child before spawn so descendants cannot escape through a
+    /// race between wrapper startup and attaching the termination boundary.
+    pub(crate) fn configure(command: &mut Command) {
+        #[cfg(unix)]
+        command.process_group(0);
+
+        #[cfg(windows)]
+        command.creation_flags(
+            windows_sys::Win32::System::Threading::CREATE_NO_WINDOW
+                | windows_sys::Win32::System::Threading::CREATE_SUSPENDED,
+        );
+    }
+
+    pub(crate) fn attach(child: &Child) -> io::Result<Self> {
+        #[cfg(unix)]
+        {
+            let process_group = child
+                .id()
+                .and_then(|pid| libc::pid_t::try_from(pid).ok())
+                .ok_or_else(|| io::Error::other("MCP child has no process id"))?;
+            Ok(Self {
+                state: AtomicU8::new(TREE_ACTIVE),
+                signal_lock: std::sync::Mutex::new(()),
+                process_group,
+            })
+        }
+
+        #[cfg(windows)]
+        {
+            Self::attach_windows(child)
+        }
+
+        #[cfg(not(any(unix, windows)))]
+        {
+            let _ = child;
+            Err(io::Error::other(
+                "MCP process-tree shutdown is unsupported on this platform",
+            ))
+        }
+    }
+
+    #[cfg(unix)]
+    pub(crate) fn terminate_gracefully(&self) -> io::Result<()> {
+        let _signal = self
+            .signal_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if self.state.load(Ordering::SeqCst) != TREE_ACTIVE {
+            return Ok(());
+        }
+        if self.signal_group(libc::SIGTERM)? {
+            self.state.store(GRACEFUL_SENT, Ordering::SeqCst);
+        } else {
+            self.state.store(TREE_DISARMED, Ordering::SeqCst);
+        }
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    pub(crate) fn terminate_gracefully(&self) -> io::Result<()> {
+        self.terminate_forcefully()
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    pub(crate) fn terminate_gracefully(&self) -> io::Result<()> {
+        Ok(())
+    }
+
+    pub(crate) fn terminate_forcefully(&self) -> io::Result<()> {
+        let _signal = self
+            .signal_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if self.state.load(Ordering::SeqCst) >= FORCE_SENT {
+            return Ok(());
+        }
+        #[cfg(unix)]
+        {
+            if self.signal_group(libc::SIGKILL)? {
+                self.state.store(FORCE_SENT, Ordering::SeqCst);
+            } else {
+                self.state.store(TREE_DISARMED, Ordering::SeqCst);
+            }
+            return Ok(());
+        }
+
+        #[cfg(windows)]
+        {
+            use std::os::windows::io::AsRawHandle;
+            use windows_sys::Win32::System::JobObjects::TerminateJobObject;
+            let result = unsafe { TerminateJobObject(self.job.as_raw_handle() as _, 1) };
+            if result == 0 {
+                let error = io::Error::last_os_error();
+                if self.is_running_unlocked().unwrap_or(true) {
+                    return Err(error);
+                }
+            }
+            self.state.store(FORCE_SENT, Ordering::SeqCst);
+            return Ok(());
+        }
+
+        #[cfg(not(any(unix, windows)))]
+        Ok(())
+    }
+
+    pub(crate) fn is_running(&self) -> io::Result<bool> {
+        let _signal = self
+            .signal_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let running = self.is_running_unlocked()?;
+        if !running {
+            // Keep the emptiness observation and the transition that prevents
+            // later numeric PGID signals inside the same critical section.
+            self.state.store(TREE_DISARMED, Ordering::SeqCst);
+        }
+        Ok(running)
+    }
+
+    fn is_running_unlocked(&self) -> io::Result<bool> {
+        if self.state.load(Ordering::SeqCst) == TREE_DISARMED {
+            return Ok(false);
+        }
+        #[cfg(unix)]
+        {
+            let result = unsafe { libc::kill(-self.process_group, 0) };
+            if result == 0 {
+                return Ok(true);
+            }
+            let error = io::Error::last_os_error();
+            return match error.raw_os_error() {
+                Some(libc::ESRCH) => Ok(false),
+                Some(libc::EPERM) => Ok(true),
+                _ => Err(error),
+            };
+        }
+
+        #[cfg(windows)]
+        {
+            use std::mem::size_of;
+            use std::os::windows::io::AsRawHandle;
+            use std::ptr;
+            use windows_sys::Win32::System::JobObjects::{
+                JobObjectBasicAccountingInformation, QueryInformationJobObject,
+                JOBOBJECT_BASIC_ACCOUNTING_INFORMATION,
+            };
+
+            let mut accounting = JOBOBJECT_BASIC_ACCOUNTING_INFORMATION::default();
+            let result = unsafe {
+                QueryInformationJobObject(
+                    self.job.as_raw_handle() as _,
+                    JobObjectBasicAccountingInformation,
+                    &mut accounting as *mut _ as _,
+                    size_of::<JOBOBJECT_BASIC_ACCOUNTING_INFORMATION>() as u32,
+                    ptr::null_mut(),
+                )
+            };
+            if result == 0 {
+                return Err(io::Error::last_os_error());
+            }
+            return Ok(accounting.ActiveProcesses > 0);
+        }
+
+        #[cfg(not(any(unix, windows)))]
+        Ok(false)
+    }
+
+    /// Stop issuing numeric process-group signals after the tree is known to be
+    /// empty. This prevents a later Drop from targeting a reused Unix PGID.
+    pub(crate) fn disarm(&self) {
+        let _signal = self
+            .signal_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        self.state.store(TREE_DISARMED, Ordering::SeqCst);
+    }
+
+    #[cfg(unix)]
+    /// Returns whether the target process group existed when the signal was
+    /// issued. ESRCH permanently disarms this numeric PGID.
+    fn signal_group(&self, signal: libc::c_int) -> io::Result<bool> {
+        let result = unsafe { libc::kill(-self.process_group, signal) };
+        if result == 0 {
+            return Ok(true);
+        }
+        let error = io::Error::last_os_error();
+        if error.raw_os_error() == Some(libc::ESRCH) {
+            Ok(false)
+        } else {
+            Err(error)
+        }
+    }
+
+    #[cfg(windows)]
+    fn attach_windows(child: &Child) -> io::Result<Self> {
+        use std::mem::size_of;
+        use std::os::windows::io::{FromRawHandle, OwnedHandle};
+        use std::ptr;
+        use windows_sys::Win32::System::JobObjects::{
+            AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation,
+            SetInformationJobObject, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+            JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+        };
+
+        let raw_job = unsafe { CreateJobObjectW(ptr::null(), ptr::null()) };
+        if raw_job.is_null() {
+            return Err(io::Error::last_os_error());
+        }
+        let job = unsafe { OwnedHandle::from_raw_handle(raw_job as _) };
+        let mut limits = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+        limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        let configured = unsafe {
+            SetInformationJobObject(
+                raw_job,
+                JobObjectExtendedLimitInformation,
+                &limits as *const _ as _,
+                size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+            )
+        };
+        if configured == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        let process = child
+            .raw_handle()
+            .ok_or_else(|| io::Error::other("MCP child has no process handle"))?;
+        if unsafe { AssignProcessToJobObject(raw_job, process as _) } == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        resume_suspended_process(
+            child
+                .id()
+                .ok_or_else(|| io::Error::other("MCP child has no process id"))?,
+        )?;
+        Ok(Self {
+            state: AtomicU8::new(TREE_ACTIVE),
+            signal_lock: std::sync::Mutex::new(()),
+            job,
+        })
+    }
+}
+
+impl Drop for ProcessTree {
+    fn drop(&mut self) {
+        let _ = self.terminate_forcefully();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn force_sent_still_polls_until_the_tree_is_confirmed_empty() {
+        let tree = ProcessTree {
+            state: AtomicU8::new(FORCE_SENT),
+            signal_lock: std::sync::Mutex::new(()),
+            process_group: i32::MAX,
+        };
+
+        assert!(!tree.is_running().unwrap());
+        assert_eq!(tree.state.load(Ordering::SeqCst), TREE_DISARMED);
+    }
+}
+
+#[cfg(windows)]
+fn resume_suspended_process(process_id: u32) -> io::Result<()> {
+    use std::mem::size_of;
+    use std::os::windows::io::{FromRawHandle, OwnedHandle};
+    use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE};
+    use windows_sys::Win32::System::Diagnostics::ToolHelp::{
+        CreateToolhelp32Snapshot, Thread32First, Thread32Next, TH32CS_SNAPTHREAD, THREADENTRY32,
+    };
+    use windows_sys::Win32::System::Threading::{OpenThread, ResumeThread, THREAD_SUSPEND_RESUME};
+
+    let raw_snapshot = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0) };
+    if raw_snapshot == INVALID_HANDLE_VALUE {
+        return Err(io::Error::last_os_error());
+    }
+    let snapshot = unsafe { OwnedHandle::from_raw_handle(raw_snapshot as _) };
+    let mut entry = THREADENTRY32 {
+        dwSize: size_of::<THREADENTRY32>() as u32,
+        ..Default::default()
+    };
+    let mut has_entry = unsafe { Thread32First(raw_snapshot, &mut entry) } != 0;
+    while has_entry {
+        if entry.th32OwnerProcessID == process_id {
+            let thread = unsafe { OpenThread(THREAD_SUSPEND_RESUME, 0, entry.th32ThreadID) };
+            if thread.is_null() {
+                return Err(io::Error::last_os_error());
+            }
+            let resumed = unsafe { ResumeThread(thread) };
+            unsafe {
+                CloseHandle(thread);
+            }
+            if resumed == u32::MAX {
+                return Err(io::Error::last_os_error());
+            }
+            drop(snapshot);
+            return Ok(());
+        }
+        has_entry = unsafe { Thread32Next(raw_snapshot, &mut entry) } != 0;
+    }
+    Err(io::Error::new(
+        io::ErrorKind::NotFound,
+        "could not find the suspended MCP process thread",
+    ))
+}

--- a/crates/wisp-mcp/tests/process_tree_shutdown.rs
+++ b/crates/wisp-mcp/tests/process_tree_shutdown.rs
@@ -1,0 +1,341 @@
+use serde_json::{json, Value};
+use std::io::{BufRead, Write};
+use std::path::{Path, PathBuf};
+use std::process::{ExitCode, Stdio};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use wisp_mcp::McpClient;
+
+const WRAPPER_ARG: &str = "--fake-mcp-wrapper";
+const GRANDCHILD_ARG: &str = "--fake-mcp-grandchild";
+const FAIL_INITIALIZE_ARG: &str = "--fail-initialize";
+
+fn main() -> ExitCode {
+    let args = std::env::args().collect::<Vec<_>>();
+    match args.get(1).map(String::as_str) {
+        Some(WRAPPER_ARG) => fake_wrapper(
+            args.get(2).map(PathBuf::from),
+            args.get(3).is_some_and(|arg| arg == FAIL_INITIALIZE_ARG),
+        ),
+        Some(GRANDCHILD_ARG) => fake_grandchild(args.get(2).map(PathBuf::from)),
+        _ => {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("test runtime");
+            match runtime.block_on(run_regressions()) {
+                Ok(()) => ExitCode::SUCCESS,
+                Err(error) => {
+                    eprintln!("process-tree shutdown regression failed: {error}");
+                    ExitCode::FAILURE
+                }
+            }
+        }
+    }
+}
+
+async fn run_regressions() -> Result<(), String> {
+    initialize_failure_terminates_wrapper_and_grandchild().await?;
+    drop_client_terminates_wrapper_and_grandchild().await?;
+    explicit_shutdown_is_idempotent_and_terminates_process_tree().await?;
+    cancelled_request_terminates_process_tree().await
+}
+
+fn fake_wrapper(root: Option<PathBuf>, fail_initialize: bool) -> ExitCode {
+    let Some(root) = root else {
+        return ExitCode::FAILURE;
+    };
+    if write_pid(&root.join("wrapper.pid")).is_err() {
+        return ExitCode::FAILURE;
+    }
+    let Ok(executable) = std::env::current_exe() else {
+        return ExitCode::FAILURE;
+    };
+    let Ok(_grandchild) = std::process::Command::new(executable)
+        .arg(GRANDCHILD_ARG)
+        .arg(&root)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+    else {
+        return ExitCode::FAILURE;
+    };
+
+    let stdin = std::io::stdin();
+    let mut stdout = std::io::stdout().lock();
+    for line in stdin.lock().lines() {
+        let Ok(line) = line else {
+            return ExitCode::FAILURE;
+        };
+        let Ok(request) = serde_json::from_str::<Value>(&line) else {
+            return ExitCode::FAILURE;
+        };
+        let Some(id) = request.get("id").and_then(Value::as_u64) else {
+            continue;
+        };
+        let method = request.get("method").and_then(Value::as_str);
+        if fail_initialize && method == Some("initialize") {
+            return ExitCode::FAILURE;
+        }
+        let result = match method {
+            Some("initialize") => json!({
+                "protocolVersion": "2024-11-05",
+                "capabilities": { "tools": {} },
+                "serverInfo": { "name": "fake-wrapper", "version": "1" }
+            }),
+            Some("tools/list") => json!({
+                "tools": [{
+                    "name": "hang",
+                    "description": "Never answer the request",
+                    "inputSchema": { "type": "object" }
+                }]
+            }),
+            Some("tools/call") => loop {
+                std::thread::sleep(Duration::from_secs(60));
+            },
+            _ => return ExitCode::FAILURE,
+        };
+        let response = json!({ "jsonrpc": "2.0", "id": id, "result": result });
+        if writeln!(stdout, "{response}").is_err() || stdout.flush().is_err() {
+            return ExitCode::FAILURE;
+        }
+    }
+    ExitCode::SUCCESS
+}
+
+fn fake_grandchild(root: Option<PathBuf>) -> ExitCode {
+    let Some(root) = root else {
+        return ExitCode::FAILURE;
+    };
+    #[cfg(unix)]
+    unsafe {
+        // Force the explicit shutdown test through its SIGKILL path after the
+        // wrapper/group leader has exited on stdin EOF. This exercises the
+        // invariant that the leader is not reaped before the final group signal.
+        libc::signal(libc::SIGTERM, libc::SIG_IGN);
+    }
+    if write_pid(&root.join("grandchild.pid")).is_err() {
+        return ExitCode::FAILURE;
+    }
+    loop {
+        std::thread::sleep(Duration::from_secs(60));
+    }
+}
+
+fn write_pid(path: &Path) -> std::io::Result<()> {
+    std::fs::write(path, std::process::id().to_string())
+}
+
+async fn drop_client_terminates_wrapper_and_grandchild() -> Result<(), String> {
+    let fixture = launch_fixture().await?;
+
+    drop(fixture.client);
+    assert_fixture_stopped(fixture.root, fixture.wrapper, fixture.grandchild).await
+}
+
+async fn initialize_failure_terminates_wrapper_and_grandchild() -> Result<(), String> {
+    let root = unique_temp_dir()?;
+    let executable = std::env::current_exe().map_err(|error| error.to_string())?;
+    let args = vec![
+        WRAPPER_ARG.to_string(),
+        root.to_string_lossy().into_owned(),
+        FAIL_INITIALIZE_ARG.to_string(),
+    ];
+    if McpClient::launch(&executable.to_string_lossy(), &args)
+        .await
+        .is_ok()
+    {
+        return Err("fake MCP initialize failure unexpectedly succeeded".into());
+    }
+    let wrapper = wait_for_pid(&root.join("wrapper.pid")).await?;
+    let grandchild = wait_for_pid(&root.join("grandchild.pid")).await?;
+    assert_fixture_stopped(root, wrapper, grandchild).await
+}
+
+async fn explicit_shutdown_is_idempotent_and_terminates_process_tree() -> Result<(), String> {
+    let fixture = launch_fixture().await?;
+    let (first, concurrent) = tokio::join!(fixture.client.shutdown(), fixture.client.shutdown());
+    first.map_err(|error| format!("first explicit shutdown failed: {error}"))?;
+    concurrent.map_err(|error| format!("concurrent explicit shutdown failed: {error}"))?;
+    fixture
+        .client
+        .shutdown()
+        .await
+        .map_err(|error| format!("second explicit shutdown failed: {error}"))?;
+    drop(fixture.client);
+    assert_fixture_stopped(fixture.root, fixture.wrapper, fixture.grandchild).await
+}
+
+async fn cancelled_request_terminates_process_tree() -> Result<(), String> {
+    let fixture = launch_fixture().await?;
+    let arguments = json!({});
+    let request = fixture.client.tool_call("hang", &arguments);
+    if let Ok(result) = tokio::time::timeout(Duration::from_millis(150), request).await {
+        cleanup_fixture(&fixture.root, fixture.wrapper, fixture.grandchild);
+        return Err(format!(
+            "fake hanging request unexpectedly completed: {result:?}"
+        ));
+    }
+
+    // The outer timeout cancels the in-flight request future. Its cancellation
+    // guard must synchronously terminate the whole tree and schedule direct-
+    // child reaping; this must complete while the client owner remains alive,
+    // before any explicit shutdown supplies a second cleanup path.
+    let wrapper_stopped = wait_until_stopped(fixture.wrapper, Duration::from_secs(3)).await;
+    let grandchild_stopped = wait_until_stopped(fixture.grandchild, Duration::from_secs(3)).await;
+    if !wrapper_stopped || !grandchild_stopped {
+        cleanup_fixture(&fixture.root, fixture.wrapper, fixture.grandchild);
+        return Err(format!(
+            "cancelled MCP request left processes alive before shutdown: wrapper_alive={}, grandchild_alive={}",
+            !wrapper_stopped, !grandchild_stopped
+        ));
+    }
+
+    // Explicit shutdown remains safe and idempotent after the cancellation
+    // path has already killed and reaped the direct child.
+    let cleanup_result = fixture.client.shutdown().await;
+    drop(fixture.client);
+    cleanup_result
+        .map_err(|error| format!("shutdown after request cancellation failed: {error}"))?;
+    assert_fixture_stopped(fixture.root, fixture.wrapper, fixture.grandchild).await
+}
+
+struct Fixture {
+    root: PathBuf,
+    client: McpClient,
+    wrapper: u32,
+    grandchild: u32,
+}
+
+async fn launch_fixture() -> Result<Fixture, String> {
+    let root = unique_temp_dir()?;
+    let executable = std::env::current_exe().map_err(|error| error.to_string())?;
+    let args = vec![WRAPPER_ARG.to_string(), root.to_string_lossy().into_owned()];
+    let client = McpClient::launch(&executable.to_string_lossy(), &args)
+        .await
+        .map_err(|error| error.to_string())?;
+    let wrapper = wait_for_pid(&root.join("wrapper.pid")).await?;
+    let grandchild = wait_for_pid(&root.join("grandchild.pid")).await?;
+    Ok(Fixture {
+        root,
+        client,
+        wrapper,
+        grandchild,
+    })
+}
+
+async fn assert_fixture_stopped(
+    root: PathBuf,
+    wrapper: u32,
+    grandchild: u32,
+) -> Result<(), String> {
+    let wrapper_stopped = wait_until_stopped(wrapper, Duration::from_secs(3)).await;
+    let grandchild_stopped = wait_until_stopped(grandchild, Duration::from_secs(3)).await;
+    if !wrapper_stopped {
+        terminate_exact(wrapper);
+    }
+    if !grandchild_stopped {
+        terminate_exact(grandchild);
+    }
+    let _ = std::fs::remove_dir_all(&root);
+
+    if !wrapper_stopped || !grandchild_stopped {
+        return Err(format!(
+            "McpClient cleanup left processes alive: wrapper_alive={}, grandchild_alive={}",
+            !wrapper_stopped, !grandchild_stopped
+        ));
+    }
+    Ok(())
+}
+
+fn cleanup_fixture(root: &Path, wrapper: u32, grandchild: u32) {
+    terminate_exact(wrapper);
+    terminate_exact(grandchild);
+    let _ = std::fs::remove_dir_all(root);
+}
+
+fn unique_temp_dir() -> Result<PathBuf, String> {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|error| error.to_string())?
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!("wisp-mcp-process-tree-{nonce}"));
+    std::fs::create_dir_all(&root).map_err(|error| error.to_string())?;
+    Ok(root)
+}
+
+async fn wait_for_pid(path: &Path) -> Result<u32, String> {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if let Ok(value) = std::fs::read_to_string(path) {
+            return value
+                .trim()
+                .parse::<u32>()
+                .map_err(|error| error.to_string());
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err(format!("timed out waiting for {}", path.display()));
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+async fn wait_until_stopped(pid: u32, timeout: Duration) -> bool {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if !process_exists(pid) {
+            return true;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return false;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+#[cfg(unix)]
+fn process_exists(pid: u32) -> bool {
+    let result = unsafe { libc::kill(pid as libc::pid_t, 0) };
+    result == 0 || std::io::Error::last_os_error().raw_os_error() != Some(libc::ESRCH)
+}
+
+#[cfg(unix)]
+fn terminate_exact(pid: u32) {
+    unsafe {
+        libc::kill(pid as libc::pid_t, libc::SIGKILL);
+    }
+}
+
+#[cfg(windows)]
+fn process_exists(pid: u32) -> bool {
+    use windows_sys::Win32::Foundation::{CloseHandle, WAIT_TIMEOUT};
+    use windows_sys::Win32::System::Threading::{
+        OpenProcess, WaitForSingleObject, PROCESS_QUERY_LIMITED_INFORMATION, PROCESS_SYNCHRONIZE,
+    };
+    unsafe {
+        let process = OpenProcess(
+            PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_SYNCHRONIZE,
+            0,
+            pid,
+        );
+        if process.is_null() {
+            return false;
+        }
+        let status = WaitForSingleObject(process, 0);
+        CloseHandle(process);
+        status == WAIT_TIMEOUT
+    }
+}
+
+#[cfg(windows)]
+fn terminate_exact(pid: u32) {
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::System::Threading::{OpenProcess, TerminateProcess, PROCESS_TERMINATE};
+    unsafe {
+        let process = OpenProcess(PROCESS_TERMINATE, 0, pid);
+        if !process.is_null() {
+            TerminateProcess(process, 1);
+            CloseHandle(process);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This change gives each stdio MCP server an OS-owned process-tree boundary and makes explicit shutdown drain that boundary before the direct child is reaped.

- On Unix, the wrapper starts in a dedicated process group. Explicit shutdown closes stdin, allows a 100 ms EOF grace period, sends `SIGTERM`, waits up to 500 ms, and forcefully terminates the group before reaping the group leader when needed. The boundary is disarmed after the group is confirmed empty to avoid signaling a reused numeric PGID.
- On Windows, the wrapper starts suspended, is attached to a kill-on-close Job Object, and is then resumed. Shutdown checks the Job Object and terminates it when the EOF grace path does not empty the tree.
- Initialization failure, request cancellation, explicit shutdown, and `Drop` all retain bounded cleanup paths. `Drop` is a forceful safety net; it is not the preferred orderly shutdown path.
- MCP request timeout behavior is unchanged.

## Behavioral baseline

On the unchanged pre-patch implementation, the regression showed that dropping an MCP client could leave its grandchild alive after the wrapper exited. This is a behavioral baseline for stdio MCP process-tree cleanup only. It does not establish the root cause of the Personal Lab GUI timeout.

## Validation

- Fresh process-tree regression: PASS
- Process-tree regression repeated 10 consecutive times: 10/10 PASS
- `cargo test -p wisp-mcp --no-fail-fast`: 7 unit tests passed; process-tree integration harness passed; 1 doc-test ignored
- `cargo fmt --all -- --check`: PASS
- `cargo run -p wisp-mcp --example smoke`: PASS
- Windows `x86_64-pc-windows-msvc` static compilation of the actual process-tree module and Windows test helpers: PASS

## Limitations and follow-up

- Windows runtime behavior is **UNVERIFIED**; only static compilation was performed.
- Session-owner retirement and draining of owned clients remain out of scope for this PR and are planned as a separate PR2.
- This PR should not be presented as a confirmed fix or root-cause proof for the Personal Lab GUI timeout.
