### PR TITLE
Fix repeated auto-compaction and replace the fixed 60% target

### DIFF
--- a/crates/wisp-core/src/agent.rs
+++ b/crates/wisp-core/src/agent.rs
@@ -299,6 +299,7 @@ async fn agent_loop_inner(
         iteration += 1;
         let (schemas, schema_origins) = tools.schemas_with_origins();
         let fixed_request_tokens = ContextManager::estimated_tool_tokens(&schemas);
+        ctx.note_request_boundary(fixed_request_tokens);
         // Match the long-context behaviour used by mangopi-cli: check the
         // budget at every model boundary, not only when the user first sends a
         // turn. Wisp's archive-first compactor preserves the full transcript
@@ -318,6 +319,9 @@ async fn agent_loop_inner(
             {
                 Ok((before, after)) => output.compaction(before, after, "auto"),
                 Err(error) => {
+                    // Identical input fails identically: suppress automatic
+                    // retries until the context has grown past this level.
+                    ctx.note_auto_compact_failure(fixed_request_tokens);
                     tracing::warn!(
                         archive = %archive.display(),
                         "automatic context compaction failed: {error}"
@@ -561,6 +565,7 @@ async fn agent_loop_inner(
                 output,
                 max_iter,
                 iteration + 1,
+                fixed_request_tokens,
                 cancel,
             )
             .await?;
@@ -619,24 +624,31 @@ async fn summarize_at_iteration_limit(
     output: &dyn Output,
     max_iter: usize,
     usage_round: usize,
+    // The summary request itself exposes no tools, but a compaction here
+    // persists into the next turn, where schemas return — so it is triggered
+    // and budgeted with the same fixed reserve as the main loop.
+    fixed_tokens: usize,
     cancel: Option<&AtomicBool>,
 ) -> Result<()> {
     let original_injection_count = ctx.runtime_injections.len();
     ctx.inject_user(iteration_limit_summary_prompt(max_iter));
 
     let result = async {
-        if ctx.needs_auto_compact_with_reserve(0) {
+        if ctx.needs_auto_compact_with_reserve(fixed_tokens) {
             let (archive, archive_reference) = context_archive(root);
             output.compaction_started("auto");
             match ctx
-                .compact_with_reserve_reference(provider, &archive, 0, &archive_reference)
+                .compact_with_reserve_reference(provider, &archive, fixed_tokens, &archive_reference)
                 .await
             {
                 Ok((before, after)) => output.compaction(before, after, "auto"),
-                Err(error) => tracing::warn!(
-                    archive = %archive.display(),
-                    "automatic context compaction before iteration-limit summary failed: {error}"
-                ),
+                Err(error) => {
+                    ctx.note_auto_compact_failure(fixed_tokens);
+                    tracing::warn!(
+                        archive = %archive.display(),
+                        "automatic context compaction before iteration-limit summary failed: {error}"
+                    );
+                }
             }
         }
 
@@ -655,7 +667,12 @@ async fn summarize_at_iteration_limit(
                     let (archive, archive_reference) = context_archive(root);
                     output.compaction_started("overflow");
                     match ctx
-                        .compact_with_reserve_reference(provider, &archive, 0, &archive_reference)
+                        .compact_with_reserve_reference(
+                            provider,
+                            &archive,
+                            fixed_tokens,
+                            &archive_reference,
+                        )
                         .await
                     {
                         Ok((before, after)) => output.compaction(before, after, "overflow"),
@@ -1178,6 +1195,50 @@ mod tests {
         }
     }
 
+    /// complete() (the compaction summary step) always fails; stream() plays
+    /// the queued completions. Used to prove a failed automatic compaction is
+    /// suppressed instead of retried at every model boundary.
+    struct FlakySummaryProvider {
+        complete_calls: AtomicUsize,
+        stream_calls: AtomicUsize,
+        completions: Mutex<VecDeque<Completion>>,
+    }
+
+    #[async_trait]
+    impl Provider for FlakySummaryProvider {
+        fn name(&self) -> &str {
+            "flaky-summary"
+        }
+
+        fn model(&self) -> &str {
+            "flaky-summary"
+        }
+
+        async fn complete(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSchema],
+        ) -> wisp_llm::Result<Completion> {
+            self.complete_calls.fetch_add(1, Ordering::SeqCst);
+            Err(LlmError::Config("forced summary failure".into()))
+        }
+
+        async fn stream(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSchema],
+            _sink: &mut dyn wisp_llm::StreamSink,
+        ) -> wisp_llm::Result<Completion> {
+            self.stream_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(self
+                .completions
+                .lock()
+                .unwrap()
+                .pop_front()
+                .unwrap_or_default())
+        }
+    }
+
     impl SequenceProvider {
         fn new(completions: impl IntoIterator<Item = Completion>) -> Self {
             Self {
@@ -1417,6 +1478,77 @@ mod tests {
             .as_text()
             .contains("Return only the updated checkpoint")));
         assert_eq!(provider.complete_requests.lock().unwrap().len(), 1);
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    // Regression for the repeated-compaction bug: a compaction that rolls back
+    // must not be re-attempted (archive write + doomed LLM summary) at every
+    // following model boundary of the same turn.
+    #[tokio::test]
+    async fn failed_auto_compaction_is_not_retried_at_the_next_boundary() {
+        let root = std::env::temp_dir().join(format!(
+            "wisp_auto_compact_suppressed_{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let provider = FlakySummaryProvider {
+            complete_calls: AtomicUsize::new(0),
+            stream_calls: AtomicUsize::new(0),
+            completions: Mutex::new(VecDeque::from([
+                Completion {
+                    tool_calls: vec![ToolCall {
+                        id: "call_1".into(),
+                        kind: "function".into(),
+                        function: FunctionCall {
+                            name: "ok_tool".into(),
+                            arguments: "{}".into(),
+                        },
+                    }],
+                    finish_reason: Some("tool_calls".into()),
+                    ..Completion::default()
+                },
+                Completion {
+                    content: "done".into(),
+                    finish_reason: Some("stop".into()),
+                    ..Completion::default()
+                },
+            ])),
+        };
+        let mut tools = Registry::builtins();
+        tools.add(Box::new(OkTool));
+        let mut ctx = ContextManager::new(10_000);
+        // Over the 80% trigger with content the compactor cannot reduce: no
+        // tool rounds to prune, no tool results to fold, and the summary step
+        // fails — so the attempt rolls back.
+        ctx.append_user(format!("oversized {}", "x".repeat(50_000)));
+
+        agent_loop(
+            &mut ctx,
+            &provider,
+            None,
+            &tools,
+            &root,
+            &NullOutput,
+            "continue",
+            0,
+            None,
+        )
+        .await
+        .unwrap();
+
+        // Two model boundaries streamed, but the doomed summary ran once.
+        assert_eq!(provider.stream_calls.load(Ordering::SeqCst), 2);
+        assert_eq!(
+            provider.complete_calls.load(Ordering::SeqCst),
+            1,
+            "a failed compaction must be suppressed until the context grows"
+        );
+        // The failed compaction rolled back: the oversized message survives.
+        assert!(ctx
+            .messages
+            .iter()
+            .any(|m| m.content.as_text().contains("oversized")));
 
         let _ = std::fs::remove_dir_all(root);
     }

--- a/crates/wisp-core/src/context.rs
+++ b/crates/wisp-core/src/context.rs
@@ -19,11 +19,27 @@ use std::path::Path;
 use wisp_llm::{Content, Message, Part, Provider, Role, ToolCall, ToolSchema};
 use wisp_tools::ToolSchemaOrigin;
 
-/// Recent turns protected from the safe tool/media pruning pass.
-const PRUNE_PROTECT_TURNS: usize = 10;
-/// Automatic compaction triggers at 80%, but targets 60% so one ordinary tool
-/// result cannot immediately cross the trigger again.
-const COMPACTION_TARGET_PERCENT: usize = 60;
+/// Recent activity protected from the safe tool/media pruning pass, counted
+/// in agent rounds: one user message or one assistant tool-call batch. A
+/// single user instruction can precede hundreds of tool calls, so protecting
+/// "the last N user turns" would protect the entire history of an autonomous
+/// session and leave nothing for the free pruning stage to remove.
+const PRUNE_PROTECT_ROUNDS: usize = 10;
+/// Automatic compaction triggers at 80% of the window. The target sits below
+/// the trigger by an adaptive headroom derived from measured per-iteration
+/// growth, so a slow conversation keeps most of its context while a fast,
+/// tool-heavy loop still lands well clear of the next trigger. The headroom
+/// never exceeds this share of the window (the historical fixed 60% target)
+/// and never drops the target below half the trigger.
+const COMPACTION_MAX_HEADROOM_PERCENT: usize = 20;
+/// Lower bound on the compaction headroom, roughly four maximum-size tool
+/// results, so the first compaction in a session still buys real room.
+const COMPACTION_MIN_HEADROOM_TOKENS: usize = 16_000;
+/// After a failed automatic compaction, suppress retries until the request
+/// estimate grows by at least this share of the window: identical input fails
+/// identically, and retrying every model boundary pays for an archive write
+/// plus a doomed LLM summary each time.
+const AUTO_COMPACT_RETRY_GROWTH_PERCENT: usize = 10;
 /// Head + tail bytes retained when a recent tool result is the part preventing
 /// compaction. The full result remains in the archive named by the marker.
 const RECENT_TOOL_EXCERPT_BYTES: usize = 4 * 1024;
@@ -238,6 +254,16 @@ pub struct ContextManager {
     /// comparing them to provider-reported input usage.
     token_estimate_factor: f64,
     last_request_estimated_tokens: usize,
+    /// EMA of per-model-boundary growth in the request estimate, in the same
+    /// scaled token space as `request_tokens`. Drives the adaptive compaction
+    /// headroom; 0 until two boundaries have been observed.
+    request_growth_ema: f64,
+    last_boundary_tokens: Option<usize>,
+    /// Automatic compaction is suppressed while the request estimate stays
+    /// below this level. Set after a failed attempt so a turn does not pay for
+    /// a doomed retry at every model boundary; cleared by any successful
+    /// compaction.
+    auto_compact_retry_floor: Option<usize>,
 }
 
 impl ContextManager {
@@ -258,6 +284,9 @@ impl ContextManager {
             last_request_tool_schema_count: None,
             token_estimate_factor: 1.0,
             last_request_estimated_tokens: 0,
+            request_growth_ema: 0.0,
+            last_boundary_tokens: None,
+            auto_compact_retry_floor: None,
         }
     }
 
@@ -288,9 +317,47 @@ impl ContextManager {
     }
 
     /// Same threshold check, including fixed request payload such as tool
-    /// schemas that are not represented as conversation messages.
+    /// schemas that are not represented as conversation messages. Stays false
+    /// while a previous failure's retry floor suppresses automatic compaction.
     pub fn needs_auto_compact_with_reserve(&self, fixed_tokens: usize) -> bool {
-        self.auto_compact && self.request_tokens_with_reserve(fixed_tokens) >= self.warn_threshold
+        let tokens = self.request_tokens_with_reserve(fixed_tokens);
+        if let Some(floor) = self.auto_compact_retry_floor {
+            if tokens < floor {
+                return false;
+            }
+        }
+        self.auto_compact && tokens >= self.warn_threshold
+    }
+
+    /// Record a failed automatic compaction: suppress further attempts until
+    /// the request estimate has grown meaningfully past the level that already
+    /// failed once. A compaction that cannot reach the target fails
+    /// identically on identical input, and each retry costs an archive write
+    /// plus (worst case) a full LLM summary.
+    pub fn note_auto_compact_failure(&mut self, fixed_tokens: usize) {
+        let tokens = self.request_tokens_with_reserve(fixed_tokens);
+        let margin = self
+            .max_context
+            .saturating_mul(AUTO_COMPACT_RETRY_GROWTH_PERCENT)
+            / 100;
+        self.auto_compact_retry_floor = Some(tokens.saturating_add(margin));
+    }
+
+    /// Feed the request estimate at a model boundary into the growth EMA that
+    /// sizes the compaction headroom. Only positive deltas count: a drop means
+    /// a compaction landed between the two observations, not negative growth.
+    pub fn note_request_boundary(&mut self, fixed_tokens: usize) {
+        let now = self.request_tokens_with_reserve(fixed_tokens);
+        if let Some(prev) = self.last_boundary_tokens.replace(now) {
+            if now > prev {
+                let delta = (now - prev) as f64;
+                self.request_growth_ema = if self.request_growth_ema <= 0.0 {
+                    delta
+                } else {
+                    self.request_growth_ema * 0.7 + delta * 0.3
+                };
+            }
+        }
     }
 
     pub fn compaction_revision(&self) -> u64 {
@@ -702,8 +769,25 @@ impl ContextManager {
         tools.iter().map(Self::estimated_tool_schema_tokens).sum()
     }
 
+    /// Post-compaction target: the 80% trigger minus an adaptive headroom.
+    /// The headroom is twice the measured per-boundary growth EMA, floored at
+    /// [`COMPACTION_MIN_HEADROOM_TOKENS`] so the first compaction buys real
+    /// room, capped at [`COMPACTION_MAX_HEADROOM_PERCENT`] of the window (the
+    /// historical fixed 60% target), and never pushes the target below half
+    /// the trigger on tiny windows.
     fn compaction_target(&self) -> usize {
-        self.max_context.saturating_mul(COMPACTION_TARGET_PERCENT) / 100
+        let max_headroom = self
+            .max_context
+            .saturating_mul(COMPACTION_MAX_HEADROOM_PERCENT)
+            / 100;
+        let growth_headroom = (self.request_growth_ema * 2.0).ceil() as usize;
+        let headroom = growth_headroom
+            .clamp(
+                COMPACTION_MIN_HEADROOM_TOKENS.min(max_headroom),
+                max_headroom.max(COMPACTION_MIN_HEADROOM_TOKENS),
+            )
+            .min(self.warn_threshold / 2);
+        self.warn_threshold.saturating_sub(headroom)
     }
 
     /// Rough token estimate (~JSON length / 4) from field lengths directly.
@@ -753,52 +837,65 @@ impl ContextManager {
         }
     }
 
-    /// Safely prune turns older than the protected tail. Tool outputs and
+    /// Index before which messages are old enough to prune, counting activity
+    /// rounds from the end: one round = one user message or one assistant
+    /// tool-call batch. A user-turn boundary alone is the wrong granularity —
+    /// one instruction can precede hundreds of tool calls in an autonomous
+    /// session, so turn-based protection would cover the entire history and
+    /// leave this stage nothing to remove.
+    fn prune_cut_index(messages: &[Message], protect_rounds: usize) -> usize {
+        let mut rounds = 0usize;
+        for (index, message) in messages.iter().enumerate().rev() {
+            let starts_round = match message.role {
+                Role::User => true,
+                Role::Assistant => !message.tool_calls.is_empty(),
+                _ => false,
+            };
+            if starts_round {
+                rounds += 1;
+                if rounds > protect_rounds {
+                    return index + 1;
+                }
+            }
+        }
+        0
+    }
+
+    /// Safely prune rounds older than the protected tail. Tool outputs and
     /// images become archive-backed tombstones and hidden reasoning is
     /// bounded, but user and visible assistant text are never shortened here.
     /// If this pass is insufficient, the untouched original history is what
     /// the semantic summary pass sees.
-    fn prune_old_noise(&mut self, protect_turns: usize, tombstone: &str) -> bool {
-        let systems: Vec<Message> = self
-            .messages
-            .iter()
-            .filter(|m| m.role == Role::System)
-            .cloned()
-            .collect();
-        let turns = self.split_turns();
-        if turns.len() <= protect_turns {
+    fn prune_old_noise(&mut self, protect_rounds: usize, tombstone: &str) -> bool {
+        let cut = Self::prune_cut_index(&self.messages, protect_rounds);
+        if cut == 0 {
             return false;
         }
-        let old = &turns[..turns.len() - protect_turns];
-        let recent = &turns[turns.len() - protect_turns..];
-        let mut compacted: Vec<Message> = vec![];
-        for turn in old {
-            for mut m in turn.clone() {
-                Self::age_images(&mut m, tombstone);
-                if m.role == Role::Tool {
-                    let content = m.content.as_text();
-                    if !content.is_empty() && !content.starts_with(TOMBSTONE_PREFIX) {
-                        m.content = wisp_llm::Content::text(tombstone);
-                    }
-                } else if m.role == Role::Assistant {
-                    if let Some(r) = m.reasoning.clone() {
-                        if (r.len() / 4 + 4) > OLD_REASONING_MAX_TOKENS {
-                            m.reasoning = Some(Self::compact_text(
-                                &r,
-                                OLD_REASONING_KEEP.0,
-                                OLD_REASONING_KEEP.1,
-                            ));
-                        }
+        let mut changed = false;
+        for m in &mut self.messages[..cut] {
+            let had_image = matches!(&m.content, Content::Parts(parts) if parts.iter().any(|part| matches!(part, Part::Image { .. })));
+            Self::age_images(m, tombstone);
+            changed |= had_image;
+            if m.role == Role::Tool {
+                let content = m.content.as_text();
+                if !content.is_empty() && !content.starts_with(TOMBSTONE_PREFIX) {
+                    m.content = wisp_llm::Content::text(tombstone);
+                    changed = true;
+                }
+            } else if m.role == Role::Assistant {
+                if let Some(r) = m.reasoning.clone() {
+                    if (r.len() / 4 + 4) > OLD_REASONING_MAX_TOKENS {
+                        m.reasoning = Some(Self::compact_text(
+                            &r,
+                            OLD_REASONING_KEEP.0,
+                            OLD_REASONING_KEEP.1,
+                        ));
+                        changed = true;
                     }
                 }
-                compacted.push(m);
             }
         }
-        for turn in recent {
-            compacted.extend(turn.clone());
-        }
-        self.messages = systems.into_iter().chain(compacted).collect();
-        true
+        changed
     }
 
     /// Bound the largest still-live tool results first. A single `read`,
@@ -1448,7 +1545,7 @@ impl ContextManager {
         let raw_target = ((target as f64) / self.token_estimate_factor).floor() as usize;
         let durable_target =
             raw_target.saturating_sub(injection_tokens.saturating_add(fixed_tokens));
-        self.prune_old_noise(PRUNE_PROTECT_TURNS, &tombstone);
+        self.prune_old_noise(PRUNE_PROTECT_ROUNDS, &tombstone);
         if self.request_tokens_with_reserve(fixed_tokens) > target {
             self.fold_oversized_tool_results(target, fixed_tokens, &tombstone);
         }
@@ -1488,6 +1585,7 @@ impl ContextManager {
             ));
         }
         self.warned = false;
+        self.auto_compact_retry_floor = None;
         self.compaction_revision = self.compaction_revision.wrapping_add(1);
         Ok((before, after))
     }
@@ -1848,8 +1946,13 @@ mod tests {
         let provider = StubProvider {
             allow_summary: false,
         };
+        ctx.note_auto_compact_failure(0);
         let (before, after) = ctx.compact(&provider, &archive).await.unwrap();
         assert!(before > after, "folding must shrink the estimate");
+        assert!(
+            ctx.auto_compact_retry_floor.is_none(),
+            "a successful compaction clears any failure suppression"
+        );
 
         let archived = std::fs::read_to_string(&archive).unwrap();
         assert!(
@@ -1964,7 +2067,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn compact_targets_sixty_percent_instead_of_barely_crossing_eighty() {
+    async fn compact_targets_below_the_trigger_with_headroom() {
         let mut ctx = ContextManager::new(10_000);
         for turn in 0..12 {
             ctx.append_user(format!("question {turn} {}", "u".repeat(1_500)));
@@ -1984,6 +2087,103 @@ mod tests {
             .messages
             .iter()
             .any(ContextManager::is_summary_checkpoint));
+    }
+
+    // The repeated-compaction regression: one user instruction can precede
+    // hundreds of tool calls in an autonomous session. Protecting "the last N
+    // user turns" covered the entire history of such a session, so the free
+    // pruning stage removed nothing and every compaction had to pay for the
+    // LLM summary. Protection is counted in agent rounds instead.
+    #[tokio::test]
+    async fn compact_prunes_old_tool_rounds_within_one_user_turn() {
+        let mut ctx = ContextManager::new(1_000_000);
+        ctx.append_user("autonomous task".to_string());
+        for round in 0..30 {
+            let call = ToolCall {
+                id: format!("call{round}"),
+                kind: "function".into(),
+                function: wisp_llm::FunctionCall {
+                    name: "read".into(),
+                    arguments: "{}".into(),
+                },
+            };
+            ctx.append_assistant(format!("reading batch {round}"), vec![call], None);
+            ctx.append_tool(
+                format!("call{round}"),
+                "read",
+                Content::text(format!("result-{round}")),
+            );
+        }
+        let archive = archive_path("tool-rounds.json");
+        let provider = StubProvider {
+            allow_summary: false,
+        };
+
+        ctx.compact(&provider, &archive).await.unwrap();
+
+        let tool_text = |round: usize| {
+            let id = format!("call{round}");
+            ctx.messages
+                .iter()
+                .find(|m| m.role == Role::Tool && m.tool_call_id.as_deref() == Some(id.as_str()))
+                .unwrap_or_else(|| panic!("tool result for {id}"))
+                .content
+                .as_text()
+        };
+        assert!(
+            tool_text(0).starts_with(TOMBSTONE_PREFIX),
+            "old round pruned"
+        );
+        assert!(
+            tool_text(18).starts_with(TOMBSTONE_PREFIX),
+            "round 18 is old"
+        );
+        assert_eq!(tool_text(19), "result-19", "protected round verbatim");
+        assert_eq!(tool_text(29), "result-29", "newest round verbatim");
+    }
+
+    #[test]
+    fn compaction_target_tracks_measured_growth_between_boundaries() {
+        let mut ctx = ContextManager::new(1_000_000);
+        // No growth observed yet: the floor headroom applies (not the old
+        // fixed 60% target).
+        assert_eq!(ctx.compaction_target(), 800_000 - 16_000);
+
+        // Slow growth (~4K tokens per boundary) stays at the floor.
+        ctx.append_user("u".repeat(16_000));
+        ctx.note_request_boundary(0);
+        ctx.append_assistant("a".repeat(16_000), vec![], None);
+        ctx.note_request_boundary(0);
+        assert_eq!(ctx.compaction_target(), 800_000 - 16_000);
+
+        // Fast growth (~200K per boundary, twice) saturates the headroom cap,
+        // which reproduces the historical fixed 60% target.
+        ctx.append_user("u".repeat(800_000));
+        ctx.note_request_boundary(0);
+        ctx.append_assistant("a".repeat(800_000), vec![], None);
+        ctx.note_request_boundary(0);
+        assert_eq!(ctx.compaction_target(), 600_000);
+    }
+
+    #[test]
+    fn failed_auto_compaction_is_suppressed_until_the_context_grows() {
+        let mut ctx = ContextManager::new(100_000);
+        ctx.append_user("u".repeat(340_000)); // ≈85K tokens, past the 80% trigger
+        assert!(ctx.needs_auto_compact());
+
+        ctx.note_auto_compact_failure(0);
+        assert!(
+            !ctx.needs_auto_compact(),
+            "identical input must not retry a failed compaction"
+        );
+
+        // Growth below the 10%-of-window retry margin stays suppressed.
+        ctx.append_assistant("a".repeat(20_000), vec![], None); // ≈5K tokens
+        assert!(!ctx.needs_auto_compact());
+
+        // Growth past the floor re-arms the automatic path.
+        ctx.append_user("u".repeat(60_000)); // ≈15K tokens
+        assert!(ctx.needs_auto_compact());
     }
 
     #[tokio::test]

--- a/docs/development.md
+++ b/docs/development.md
@@ -131,9 +131,12 @@ wisp-science/
   streaming tokens to an `Output` sink. Stops on `attempt_completion` or when
   the model returns no tool calls.
 - **Context compaction** (`wisp-core::context`): an archive-first pipeline fires
-  before each model call at 80% of the context budget — prune tool/media noise,
-  then summarize sanitized history, keeping one incremental checkpoint plus an
-  8K-token recent tail. Old turns are never silently dropped.
+  before each model call at 80% of the context budget — prune tool/media noise
+  older than the protected recent agent rounds, then summarize sanitized
+  history, keeping one incremental checkpoint plus an 8K-token recent tail. The
+  post-compact target adapts to measured per-iteration growth instead of a
+  fixed percentage, and a failed attempt suppresses automatic retries until the
+  estimate grows further. Old turns are never silently dropped.
 - **Providers** (`wisp-llm`): one trait, two wire formats (OpenAI
   `/chat/completions` and Anthropic `/v1/messages`), both with SSE streaming.
   `RoutedProvider` picks a low/medium/high tier per turn.

--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -138,17 +138,24 @@ questions are not generated for that interrupted turn.
 default. Following mangopi-cli's model-boundary approach, Wisp checks the
 estimated context before every native-agent model call, including later calls
 after large tool results and ephemeral host/reviewer injections. At 80% it
-archives the complete pre-compact history and targets 60%, leaving headroom so
-the next ordinary result does not immediately trigger another rewrite. Older
-tool output, reasoning, and images are safely pruned first without shortening
-user messages or visible assistant answers; oversized recent tool payloads
-become bounded excerpts that point to the archive. If semantic turns must be
-removed, Wisp summarizes a sanitized projection of the original history before
-deleting them, then retains one incrementally updated summary checkpoint plus
-at most two recent turns in an 8K-token tail. Raw images and large tool results
-are not replayed to the summary model. The internal summary instruction is
-never added to the conversation, and a failed compaction rolls back the rewrite
-and stops before Wisp can send the known-oversized main request. Tool
+archives the complete pre-compact history and targets the trigger minus an
+adaptive headroom (twice the measured per-iteration growth, at least ~16K
+tokens, at most 20% of the window), so slow conversations keep more context
+while fast tool loops still land well clear of the next trigger. Older tool
+output, reasoning, and images are safely pruned first without shortening user
+messages or visible assistant answers — protection is counted in agent rounds
+(user messages and tool-call batches), so a single instruction followed by
+hundreds of tool calls still leaves old rounds prunable; oversized recent tool
+payloads become bounded excerpts that point to the archive. If semantic turns
+must be removed, Wisp summarizes a sanitized projection of the original
+history before deleting them, then retains one incrementally updated summary
+checkpoint plus at most two recent turns in an 8K-token tail. Raw images and
+large tool results are not replayed to the summary model. The internal summary
+instruction is never added to the conversation, and a failed compaction rolls
+back the rewrite and stops before Wisp can send the known-oversized main
+request; after such a failure, automatic retries are suppressed until the
+estimate grows by another tenth of the window, so a doomed compaction is not
+repaid at every model boundary. Tool
 results are also capped to a 16 KiB head/tail excerpt when they enter model
 context (the full result is still shown in the tool event), preventing one
 read, grep, browser, or MCP response from consuming the whole window. Each

--- a/src-tauri/src/debug_request.rs
+++ b/src-tauri/src/debug_request.rs
@@ -72,6 +72,14 @@ struct DebugRequestSnapshot {
     /// restart when no resident runtime can prove the historical value.
     effective_max_iter: Option<usize>,
     termination_reason: Option<String>,
+    /// Context window the compactor works against. Known for live agents;
+    /// for the stored-message fallback it is re-resolved from the active
+    /// model profile, which may have changed since the captured turn.
+    max_context: Option<usize>,
+    /// Session token-estimate calibration factor and compaction count. Only a
+    /// live agent can report them; `null` in the stored-message fallback.
+    token_estimate_factor: Option<f64>,
+    compaction_revision: Option<u64>,
     terminal_event_count: usize,
     /// Persisted Done/Error boundaries. Older sessions may legitimately have
     /// none because builds before this field did not store terminal events.
@@ -104,6 +112,10 @@ fn build_snapshot(
     configured_max_iter: usize,
     effective_max_iter: Option<usize>,
     termination_reason: Option<String>,
+    // (max_context, token_estimate_factor, compaction_revision) as the live
+    // compactor reports them; the stored fallback can only recover the
+    // context window, and only from the currently active profile.
+    compactor: (Option<usize>, Option<f64>, Option<u64>),
 ) -> DebugRequestSnapshot {
     let mut sections = Vec::with_capacity(messages.len());
     let mut total = 0usize;
@@ -168,6 +180,9 @@ fn build_snapshot(
         configured_max_iter,
         effective_max_iter,
         termination_reason,
+        max_context: compactor.0,
+        token_estimate_factor: compactor.1,
+        compaction_revision: compactor.2,
         terminal_event_count: terminal_events.len(),
         terminal_events,
         tools: tool_schemas,
@@ -283,6 +298,11 @@ pub(super) async fn export_debug_request(
                     configured_max_iter,
                     effective_max_iter,
                     termination_reason.clone(),
+                    (
+                        Some(agent.ctx.max_context),
+                        Some(agent.ctx.token_estimate_factor()),
+                        Some(agent.ctx.compaction_revision()),
+                    ),
                 )
             })
         })
@@ -296,6 +316,11 @@ pub(super) async fn export_debug_request(
                 .load_messages(&session_id)
                 .await
                 .map_err(|e| format!("{e}"))?;
+            // The compactor state is gone with the agent, but the context
+            // window can still be recovered from the active model profile so
+            // exports remain interpretable against the 80% trigger.
+            let max_context =
+                usize::try_from(crate::models::active_context_window(&state.store).await).ok();
             build_snapshot(
                 &session_id,
                 captured_at,
@@ -308,6 +333,7 @@ pub(super) async fn export_debug_request(
                 configured_max_iter,
                 effective_max_iter,
                 termination_reason,
+                (max_context, None, None),
             )
         }
     };
@@ -385,6 +411,7 @@ mod tests {
             100,
             Some(100),
             None,
+            (None, None, None),
         );
 
         assert_eq!(snap.message_count, 3);
@@ -409,6 +436,9 @@ mod tests {
         assert_eq!(json["effective_max_iter"], 100);
         assert!(json["termination_reason"].is_null());
         assert!(json.get("tool_count").is_none());
+        assert!(json["max_context"].is_null());
+        assert!(json["token_estimate_factor"].is_null());
+        assert!(json["compaction_revision"].is_null());
     }
 
     #[test]
@@ -431,6 +461,7 @@ mod tests {
             100,
             None,
             None,
+            (None, None, None),
         );
         assert!(snap.messages[1].text.contains("data.xls"));
         assert!(snap.messages[1].text.contains("col_a,col_b"));
@@ -456,11 +487,15 @@ mod tests {
             100,
             Some(100),
             None,
+            (Some(128_000), Some(1.2), Some(3)),
         );
         assert_eq!(snap.tool_schema_count, 1);
         assert!(snap.tools[0].est_tokens > 0);
         let msg_sum: usize = snap.messages.iter().map(|m| m.est_tokens).sum();
         assert_eq!(snap.total_est_tokens, msg_sum + snap.tools[0].est_tokens);
+        assert_eq!(snap.max_context, Some(128_000));
+        assert_eq!(snap.token_estimate_factor, Some(1.2));
+        assert_eq!(snap.compaction_revision, Some(3));
     }
 
     #[test]
@@ -482,6 +517,7 @@ mod tests {
             100,
             Some(20),
             Some("error".into()),
+            (None, None, None),
         );
         assert_eq!(snap.terminal_event_count, 1);
         assert_eq!(snap.terminal_events, vec![terminal]);
@@ -518,6 +554,7 @@ mod tests {
             100,
             Some(20),
             Some("max_iterations".into()),
+            (None, None, None),
         );
 
         assert_eq!(snap.tool_schema_count, 0);


### PR DESCRIPTION
## Problem

A debug-request export from a long autonomous session (94K estimated tokens, 102 messages, only 4 user messages, 74 live tool outputs) exposed three compactor defects:

1. **Free pruning never fired in agentic sessions.** `prune_old_noise` protected "the last 10 user turns", but turns are delimited by user messages — one instruction can precede hundreds of tool calls, so the entire history was protected and every threshold crossing fell through to the expensive LLM summary.
2. **The fixed 60% target was disconnected from retrigger conditions.** On large windows it discarded far more context than needed (and forced the summary step); on small ones the 20% headroom held only a few maximum-size tool results, so compaction re-fired almost immediately.
3. **A rolled-back compaction was retried at every model boundary**, paying an archive write plus a doomed LLM summary each time, since the agent loop only logged the failure.

## What changed

- **Round-granularity pruning** (`wisp-core::context`): protection is counted in agent rounds (user messages and assistant tool-call batches), so old tool outputs within one long turn are tombstoned by the free stage again.
- **Adaptive target**: the 80% trigger stays; the target is now the trigger minus twice the measured per-boundary growth EMA, floored at 16K tokens and capped at 20% of the window (exactly the historical 60% target), never below half the trigger. Growth is sampled by the agent loop via `note_request_boundary`. Slow conversations keep more context and skip the LLM summary more often; fast tool loops keep the old strength.
- **Failure suppression**: a rolled-back compaction sets a retry floor (failed-at estimate + 10% of the window); `needs_auto_compact` stays false below it and any successful compaction clears it.
- **Consistent reserve**: the pre-summary compaction at the iteration limit now budgets with the same fixed schema reserve as the main loop, so the compacted state still fits once tool schemas return next turn.
- **Debug export**: adds `max_context` (re-resolved from the active profile in the stored-messages fallback), `token_estimate_factor`, and `compaction_revision`.

## Tests

- New: round-granularity pruning within one user turn, adaptive target vs. measured growth, suppression until the context grows, no retry at the next loop boundary after a failed compaction; debug snapshot serializes the new fields.
- Renamed `compact_targets_sixty_percent_...` to `compact_targets_below_the_trigger_with_headroom` (numeric expectations unchanged on small windows, where the cap reproduces 60%).

Passed: `cargo fmt --all -- --check`, `cargo test --workspace` (all green), `cd ui && cargo check --target wasm32-unknown-unknown`.

## Known limitations / follow-ups

- The growth EMA lives in `ContextManager` and resets on session resume; the floor/ceiling keep the first compaction of a resumed session sane.
- No background pre-pass or disk-segment pointers (grok-build-style two-pass/segments) — deliberately out of scope.