### PR TITLE
fix(mcp): harden cancelled shutdown

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,9 @@ jobs:
           cache-on-failure: true
           shared-key: headless-agent-${{ matrix.os }}
 
+      - name: Run MCP process-tree shutdown regression
+        run: cargo test -p wisp-mcp --test process_tree_shutdown
+
       - name: Run deterministic headless agent suite
         run: cargo run -p wisp-cli -- eval --artifacts target/headless-agent-eval --save target/headless-agent-eval/report.json
 

--- a/crates/wisp-mcp/src/client.rs
+++ b/crates/wisp-mcp/src/client.rs
@@ -19,6 +19,8 @@ use tokio::sync::Mutex;
 
 /// Hard cap on a single stdio JSON-RPC exchange, matching the HTTP transport's
 /// request timeout. Without it a hung server blocks the agent turn forever.
+/// Exceeding this cap closes the stdio transport and terminates its process
+/// tree because a late JSON-RPC response cannot be safely reused.
 const STDIO_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
 const STDIO_SHUTDOWN_EOF_GRACE: std::time::Duration = std::time::Duration::from_millis(100);
 const STDIO_SHUTDOWN_TERM_GRACE: std::time::Duration = std::time::Duration::from_millis(500);
@@ -178,25 +180,25 @@ pub struct McpClient {
     transport: Transport,
 }
 
-struct RequestCancellation<'a> {
+struct CancellationCleanup<'a> {
     process_tree: &'a ProcessTree,
     child: &'a Mutex<Option<tokio::process::Child>>,
     closing: &'a AtomicBool,
     armed: bool,
 }
 
-impl RequestCancellation<'_> {
+impl CancellationCleanup<'_> {
     fn disarm(&mut self) {
         self.armed = false;
     }
 }
 
-impl Drop for RequestCancellation<'_> {
+impl Drop for CancellationCleanup<'_> {
     fn drop(&mut self) {
         if self.armed {
             self.closing.store(true, Ordering::SeqCst);
             if let Err(error) = self.process_tree.terminate_forcefully() {
-                tracing::warn!(%error, "failed to terminate cancelled MCP process tree");
+                tracing::warn!(%error, "failed to terminate MCP process tree after cancellation");
             }
             // No await is legal in Drop. Taking the Child invokes the existing
             // kill_on_drop guard and hands Unix reaping to Tokio's orphan
@@ -416,7 +418,7 @@ impl McpClient {
                         }
                     }
                 };
-                let mut cancellation = RequestCancellation {
+                let mut cancellation = CancellationCleanup {
                     process_tree,
                     child,
                     closing,
@@ -432,7 +434,6 @@ impl McpClient {
                         Err(error)
                     }
                     Err(_) => {
-                        cancellation.disarm();
                         let cleanup = shutdown_stdio(
                             stdin,
                             child,
@@ -442,6 +443,7 @@ impl McpClient {
                             shutdown_lock,
                         )
                         .await;
+                        cancellation.disarm();
                         let message = format!(
                             "MCP stdio request '{method}' timed out after {}s",
                             STDIO_REQUEST_TIMEOUT.as_secs()
@@ -676,46 +678,60 @@ async fn shutdown_stdio(
         return Ok(());
     }
 
-    // A cancelled request may still be unwinding while holding this mutex, and
-    // a blocked write must never make App exit unbounded. Close stdin only when
-    // immediately available; otherwise continue to the bounded tree signals.
-    if let Ok(mut stdin) = stdin.try_lock() {
-        stdin.take();
-    }
-    let mut child = child.lock().await;
-
-    #[cfg(unix)]
-    {
-        signal_unix_tree_before_reap(process_tree).await?;
-    }
-
-    #[cfg(not(unix))]
-    {
-        if wait_for_process_tree(&mut child, process_tree, STDIO_SHUTDOWN_EOF_GRACE).await? {
-            process_tree.disarm();
-            terminated.store(true, Ordering::SeqCst);
-            return Ok(());
+    let mut cancellation = CancellationCleanup {
+        process_tree,
+        child,
+        closing,
+        armed: true,
+    };
+    let result = async {
+        // A cancelled request may still be unwinding while holding this mutex,
+        // and a blocked write must never make App exit unbounded. Close stdin
+        // only when immediately available; otherwise continue to the bounded
+        // tree signals.
+        if let Ok(mut stdin) = stdin.try_lock() {
+            stdin.take();
         }
-        process_tree.terminate_gracefully()?;
-        if wait_for_process_tree(&mut child, process_tree, STDIO_SHUTDOWN_TERM_GRACE).await? {
-            process_tree.disarm();
-            terminated.store(true, Ordering::SeqCst);
-            return Ok(());
-        }
-        process_tree.terminate_forcefully()?;
-    }
+        let mut child = child.lock().await;
 
-    if !wait_for_process_tree(&mut child, process_tree, STDIO_SHUTDOWN_KILL_WAIT).await? {
-        // Keep the FORCE_SENT state: it prohibits any later numeric PGID
-        // signal while still allowing a repeated shutdown to poll/reap the
-        // actual tree instead of reporting a false success.
-        return Err(anyhow!(
-            "MCP server process tree did not exit after forceful shutdown"
-        ));
+        #[cfg(unix)]
+        {
+            signal_unix_tree_before_reap(process_tree).await?;
+        }
+
+        #[cfg(not(unix))]
+        {
+            if wait_for_process_tree(&mut child, process_tree, STDIO_SHUTDOWN_EOF_GRACE).await? {
+                process_tree.disarm();
+                terminated.store(true, Ordering::SeqCst);
+                return Ok(());
+            }
+            process_tree.terminate_gracefully()?;
+            if wait_for_process_tree(&mut child, process_tree, STDIO_SHUTDOWN_TERM_GRACE).await? {
+                process_tree.disarm();
+                terminated.store(true, Ordering::SeqCst);
+                return Ok(());
+            }
+            process_tree.terminate_forcefully()?;
+        }
+
+        if !wait_for_process_tree(&mut child, process_tree, STDIO_SHUTDOWN_KILL_WAIT).await? {
+            // Keep the FORCE_SENT state: it prohibits any later numeric PGID
+            // signal while still allowing a repeated shutdown to poll/reap the
+            // actual tree instead of reporting a false success.
+            return Err(anyhow!(
+                "MCP server process tree did not exit after forceful shutdown"
+            ));
+        }
+        process_tree.disarm();
+        terminated.store(true, Ordering::SeqCst);
+        Ok(())
     }
-    process_tree.disarm();
-    terminated.store(true, Ordering::SeqCst);
-    Ok(())
+    .await;
+    if result.is_ok() {
+        cancellation.disarm();
+    }
+    result
 }
 
 #[cfg(unix)]

--- a/crates/wisp-mcp/src/process_tree.rs
+++ b/crates/wisp-mcp/src/process_tree.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::{AtomicU8, Ordering};
 use tokio::process::{Child, Command};
 
 const TREE_ACTIVE: u8 = 0;
+#[cfg(unix)]
 const GRACEFUL_SENT: u8 = 1;
 const FORCE_SENT: u8 = 2;
 const TREE_DISARMED: u8 = 3;
@@ -266,11 +267,10 @@ impl Drop for ProcessTree {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
 
-    #[cfg(unix)]
     #[test]
     fn force_sent_still_polls_until_the_tree_is_confirmed_empty() {
         let tree = ProcessTree {

--- a/crates/wisp-mcp/tests/process_tree_shutdown.rs
+++ b/crates/wisp-mcp/tests/process_tree_shutdown.rs
@@ -37,6 +37,7 @@ async fn run_regressions() -> Result<(), String> {
     initialize_failure_terminates_wrapper_and_grandchild().await?;
     drop_client_terminates_wrapper_and_grandchild().await?;
     explicit_shutdown_is_idempotent_and_terminates_process_tree().await?;
+    cancelled_shutdown_terminates_process_tree().await?;
     cancelled_request_terminates_process_tree().await
 }
 
@@ -75,6 +76,18 @@ fn fake_wrapper(root: Option<PathBuf>, fail_initialize: bool) -> ExitCode {
         };
         let method = request.get("method").and_then(Value::as_str);
         if fail_initialize && method == Some("initialize") {
+            // Return a protocol-level failure instead of relying on stdout EOF.
+            // On Windows a long-lived grandchild can inherit the wrapper's pipe
+            // handle, which would make this fixture wait for the unrelated 120s
+            // request timeout instead of exercising initialization cleanup.
+            let response = json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "error": { "code": -32000, "message": "forced initialize failure" }
+            });
+            if writeln!(stdout, "{response}").is_err() || stdout.flush().is_err() {
+                return ExitCode::FAILURE;
+            }
             return ExitCode::FAILURE;
         }
         let result = match method {
@@ -163,6 +176,34 @@ async fn explicit_shutdown_is_idempotent_and_terminates_process_tree() -> Result
         .await
         .map_err(|error| format!("second explicit shutdown failed: {error}"))?;
     drop(fixture.client);
+    assert_fixture_stopped(fixture.root, fixture.wrapper, fixture.grandchild).await
+}
+
+async fn cancelled_shutdown_terminates_process_tree() -> Result<(), String> {
+    let fixture = launch_fixture().await?;
+    let shutdown = fixture.client.shutdown();
+    if let Ok(result) = tokio::time::timeout(Duration::from_millis(50), shutdown).await {
+        cleanup_fixture(&fixture.root, fixture.wrapper, fixture.grandchild);
+        return Err(format!(
+            "MCP shutdown unexpectedly completed before cancellation: {result:?}"
+        ));
+    }
+
+    // Cancelling orderly shutdown during its EOF grace period must fall back
+    // to synchronous tree termination while the client owner remains alive.
+    let wrapper_stopped = wait_until_stopped(fixture.wrapper, Duration::from_secs(3)).await;
+    let grandchild_stopped = wait_until_stopped(fixture.grandchild, Duration::from_secs(3)).await;
+    if !wrapper_stopped || !grandchild_stopped {
+        cleanup_fixture(&fixture.root, fixture.wrapper, fixture.grandchild);
+        return Err(format!(
+            "cancelled MCP shutdown left processes alive: wrapper_alive={}, grandchild_alive={}",
+            !wrapper_stopped, !grandchild_stopped
+        ));
+    }
+
+    let cleanup_result = fixture.client.shutdown().await;
+    drop(fixture.client);
+    cleanup_result.map_err(|error| format!("retry after cancelled shutdown failed: {error}"))?;
     assert_fixture_stopped(fixture.root, fixture.wrapper, fixture.grandchild).await
 }
 
@@ -268,10 +309,9 @@ async fn wait_for_pid(path: &Path) -> Result<u32, String> {
     let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
     loop {
         if let Ok(value) = std::fs::read_to_string(path) {
-            return value
-                .trim()
-                .parse::<u32>()
-                .map_err(|error| error.to_string());
+            if let Ok(pid) = value.trim().parse::<u32>() {
+                return Ok(pid);
+            }
         }
         if tokio::time::Instant::now() >= deadline {
             return Err(format!("timed out waiting for {}", path.display()));


### PR DESCRIPTION
## Problem

PR #825 added OS-owned process-tree shutdown for stdio MCP servers, but cancellation could still land during the asynchronous shutdown grace period after the request-level guard had been disarmed. On Windows, the initialization-failure regression also waited for the full 120-second request timeout because a long-lived grandchild could keep the wrapper pipe open.

## Changes

- keep cancellation cleanup armed until timeout-triggered shutdown returns
- protect orderly `shutdown()` itself with the same forceful cancellation fallback
- add a regression that cancels shutdown during its EOF grace period and verifies the wrapper and grandchild stop while the client remains alive
- make the initialization-failure fixture return an immediate JSON-RPC error instead of measuring the unrelated request timeout
- tolerate PID-file creation races in the integration harness
- gate Unix-only test state on Unix to keep Windows builds warning-free
- run the MCP process-tree regression in the existing Ubuntu, macOS, and Windows CI matrix
- document that a stdio request timeout permanently tears down that transport and process tree

## Validation

- Windows process-tree regression: 10/10 consecutive passes in 16.227 seconds total
- `cargo test -p wisp-mcp --no-fail-fast`: passed
- `cargo run -p wisp-mcp --example smoke`: passed
- the broader workspace run was stopped at user direction after unrelated `method_search`, `resource_leases`, and publication test failures appeared; MCP tests had passed

## Impact

Cancelled MCP shutdown can no longer strand a closing client with a live process tree, and the platform regression is fast enough to run on every supported CI OS.