### PR TITLE
feat(ui): queued 插队 → 立刻引导, 回溯 → 编辑回输入框

### DIFF
--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -9765,6 +9765,32 @@ test("queued follow-ups can be reordered up and down (#433)", async ({ page }) =
   )).toEqual(["move_up", "move_down"]);
 });
 
+test("editing a queued follow-up restores it to the composer", async ({ page }) => {
+  await page.addInitScript(parallelMock);
+  await page.goto("/");
+  await page.locator(".proj-card-main").first().click();
+  await expect(newSessionButton(page)).toBeVisible();
+
+  await composer(page).fill("alpha");
+  await page.getByRole("button", { name: "Send" }).click();
+  await expect(page.getByText("echo:alpha")).toBeVisible({ timeout: 10_000 });
+
+  await composer(page).fill("what is QC?");
+  await page.getByRole("button", { name: "Queue…" }).click();
+  const queued = page.locator(".msg.user.queued", { hasText: "what is QC?" });
+  await expect(queued).toBeVisible({ timeout: 500 });
+  await expect(queued.getByRole("button", { name: "Guide now" })).toBeVisible();
+
+  await queued.getByRole("button", { name: "Edit" }).click();
+  await expect(queued).toHaveCount(0);
+  await expect(composer(page)).toHaveValue("what is QC?");
+  await expect.poll(async () => page.evaluate(() =>
+    ((window as any).__sendInvokeLog ?? [])
+      .filter((c: any) => c.cmd === "queued_turn_action")
+      .map((c: any) => c.args?.action),
+  )).toEqual(["cancel"]);
+});
+
 test("project removal offers a files-preserving action in the in-app dialog (#96)", async ({ page }) => {
   // Native window.confirm() is a no-op in this webview (wry's WKUIDelegate has
   // no JS confirm panel), so the ✕ silently did nothing. Deletion now goes

--- a/ui/src/app_support/messages.rs
+++ b/ui/src/app_support/messages.rs
@@ -450,14 +450,14 @@ pub(crate) enum QueueOp {
     Cancel(u64),
     /// Fold it into the running turn now (native sessions only).
     CutIn(u64),
-    /// Replace its text (runs with the latest when it drains).
-    Save(u64, String),
+    /// Unqueue it and restore its text to the composer.
+    Edit(u64),
     /// Swap one place earlier / later in the FIFO order (clamped at the ends).
     MoveUp(u64),
     MoveDown(u64),
 }
 
-/// Queue (#433): a queued user turn bubble with inline edit + cancel + cut-in.
+/// Queue (#433): a queued user turn bubble with edit / cancel / cut-in.
 /// `id == 0` marks a transient cut-in bubble (no controls). `can_cut_in` is
 /// false for ACP sessions, which cannot fold a message into a running turn.
 #[component]
@@ -468,72 +468,39 @@ pub(crate) fn QueuedMessage(
     on_queue: Callback<QueueOp>,
 ) -> impl IntoView {
     let locale = use_locale();
-    let editing = create_rw_signal(false);
-    let draft = create_rw_signal(text.clone());
     let show_controls = id != 0;
-    let body = text.clone();
     view! {
         <div class="role">{move || t(locale.get(), "composer.queued")}</div>
         <div class="user-bubble queued-bubble">
-            {move || if editing.get() {
-                view! {
-                    <textarea class="queue-edit" prop:value=move || draft.get()
-                        on:input=move |ev| draft.set(event_target_value(&ev))></textarea>
-                    <div class="queue-actions">
+            <div class="body">{text}</div>
+            {show_controls.then(|| view! {
+                <div class="queue-actions">
+                    <button type="button" class="tool-btn queue-move"
+                        title=move || t(locale.get(), "queue.move_up")
+                        on:click=move |_| on_queue.call(QueueOp::MoveUp(id))>
+                        {compose_icon("up")}
+                    </button>
+                    <button type="button" class="tool-btn queue-move"
+                        title=move || t(locale.get(), "queue.move_down")
+                        on:click=move |_| on_queue.call(QueueOp::MoveDown(id))>
+                        {compose_icon("chevron-down")}
+                    </button>
+                    {can_cut_in.then(|| view! {
                         <button type="button" class="tool-btn"
-                            on:click=move |_| editing.set(false)>
-                            {move || t(locale.get(), "settings.cancel")}
+                            on:click=move |_| on_queue.call(QueueOp::CutIn(id))>
+                            {move || t(locale.get(), "queue.cut_in")}
                         </button>
-                        <button type="button" class="tool-btn"
-                            on:click=move |_| {
-                                let v = draft.get();
-                                if !v.trim().is_empty() {
-                                    editing.set(false);
-                                    on_queue.call(QueueOp::Save(id, v));
-                                }
-                            }>
-                            {move || t(locale.get(), "settings.save")}
-                        </button>
-                    </div>
-                }.into_view()
-            } else {
-                let body = body.clone();
-                let edit_from = body.clone();
-                view! {
-                    <div class="body">{body}</div>
-                    {show_controls.then(|| view! {
-                        <div class="queue-actions">
-                            <button type="button" class="tool-btn queue-move"
-                                title=move || t(locale.get(), "queue.move_up")
-                                on:click=move |_| on_queue.call(QueueOp::MoveUp(id))>
-                                {compose_icon("up")}
-                            </button>
-                            <button type="button" class="tool-btn queue-move"
-                                title=move || t(locale.get(), "queue.move_down")
-                                on:click=move |_| on_queue.call(QueueOp::MoveDown(id))>
-                                {compose_icon("chevron-down")}
-                            </button>
-                            {can_cut_in.then(|| view! {
-                                <button type="button" class="tool-btn"
-                                    on:click=move |_| on_queue.call(QueueOp::CutIn(id))>
-                                    {move || t(locale.get(), "queue.cut_in")}
-                                </button>
-                            })}
-                            <button type="button" class="tool-btn"
-                                on:click={
-                                    let edit_from = edit_from.clone();
-                                    move |_| { draft.set(edit_from.clone()); editing.set(true); }
-                                }>
-                                {move || t(locale.get(), "msg.edit")}
-                            </button>
-                            <button type="button" class="tool-btn"
-                                on:click=move |_| on_queue.call(QueueOp::Cancel(id))>
-                                {move || t(locale.get(), "settings.cancel")}
-                            </button>
-                        </div>
                     })}
-                }.into_view()
-            }}
+                    <button type="button" class="tool-btn"
+                        on:click=move |_| on_queue.call(QueueOp::Edit(id))>
+                        {move || t(locale.get(), "queue.edit")}
+                    </button>
+                    <button type="button" class="tool-btn"
+                        on:click=move |_| on_queue.call(QueueOp::Cancel(id))>
+                        {move || t(locale.get(), "settings.cancel")}
+                    </button>
+                </div>
+            })}
         </div>
     }
 }

--- a/ui/src/dto.rs
+++ b/ui/src/dto.rs
@@ -345,7 +345,7 @@ fn default_evidence_coverage() -> u8 {
 pub(crate) enum ChatItem {
     User(String),
     /// A user turn queued (#433) while the same session is still running. It
-    /// waits, editable/cancellable, until the backend drains it into a fresh
+    /// waits, cancellable, until the backend drains it into a fresh
     /// turn (or a cut-in folds it into the running one) and emits the matching
     /// User event. `id` is the frontend-assigned key the queue commands target.
     QueuedUser {

--- a/ui/src/i18n.rs
+++ b/ui/src/i18n.rs
@@ -290,7 +290,8 @@ fn lookup(locale: Locale, key: &str) -> Option<&'static str> {
         (Locale::En, "composer.queue_button") => Some("Queue…"),
         (Locale::En, "composer.cut_in_now") => Some("Cut in (this turn)"),
         (Locale::En, "composer.interrupt_replace") => Some("Interrupt & replace"),
-        (Locale::En, "queue.cut_in") => Some("Cut in"),
+        (Locale::En, "queue.cut_in") => Some("Guide now"),
+        (Locale::En, "queue.edit") => Some("Edit"),
         (Locale::En, "queue.move_up") => Some("Move up"),
         (Locale::En, "queue.move_down") => Some("Move down"),
         (Locale::En, "composer.send_options") => Some("Message options"),
@@ -2444,7 +2445,8 @@ Do not leave generated files in the project root.",
         (Locale::Zh, "composer.queue_button") => Some("排队…"),
         (Locale::Zh, "composer.cut_in_now") => Some("插队(本回合)"),
         (Locale::Zh, "composer.interrupt_replace") => Some("中断并替换"),
-        (Locale::Zh, "queue.cut_in") => Some("插队"),
+        (Locale::Zh, "queue.cut_in") => Some("立刻引导"),
+        (Locale::Zh, "queue.edit") => Some("编辑"),
         (Locale::Zh, "queue.move_up") => Some("上移"),
         (Locale::Zh, "queue.move_down") => Some("下移"),
         (Locale::Zh, "composer.send_options") => Some("消息选项"),
@@ -4821,6 +4823,22 @@ mod api_error_hint_tests {
         let out = localize_backend(Locale::Zh, msg);
         assert!(out.starts_with(msg), "raw error must stay visible");
         assert!(out.contains(&t(Locale::Zh, "err.hint.balance")));
+    }
+}
+
+#[cfg(test)]
+mod queue_label_tests {
+    use super::*;
+
+    #[test]
+    fn queued_bubble_actions_use_guide_and_edit() {
+        assert_eq!(t(Locale::Zh, "queue.cut_in"), "立刻引导");
+        assert_eq!(t(Locale::En, "queue.cut_in"), "Guide now");
+        assert_eq!(t(Locale::Zh, "queue.edit"), "编辑");
+        assert_eq!(t(Locale::En, "queue.edit"), "Edit");
+        // Sent-message rewind keeps its own label.
+        assert_eq!(t(Locale::Zh, "msg.edit"), "回溯");
+        assert_eq!(t(Locale::En, "msg.edit"), "Rewind");
     }
 }
 

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -3236,8 +3236,9 @@ fn App() -> impl IntoView {
             dismiss_follow_up_questions(follow_up_questions, follow_up_generation, id);
         }
         // Queue (#433): a plain send into a busy session parks behind the
-        // running turn — editable/cancellable until the driver runs it — instead
-        // of a dialog. Cut-in / interrupt-replace are explicit dropdown choices.
+        // running turn — cancellable / restorable to the composer until the
+        // driver runs it — instead of a dialog. Cut-in / interrupt-replace are
+        // explicit dropdown choices.
         if queued && action == ComposerSendAction::Normal {
             let Some(session) = active.clone() else {
                 return;
@@ -3873,29 +3874,31 @@ fn App() -> impl IntoView {
         if sid.is_empty() {
             return;
         }
+        let restore = matches!(op, QueueOp::Edit(_));
         let (id, action, message): (u64, &'static str, Option<String>) = match op {
-            QueueOp::Cancel(id) => {
+            QueueOp::Cancel(id) | QueueOp::Edit(id) => {
+                let mut draft = String::new();
                 route_items(active_session, items, transcripts, &sid, |rows| {
+                    if restore {
+                        if let Some(ChatItem::QueuedUser { text, .. }) = rows.iter().find(
+                            |it| matches!(it, ChatItem::QueuedUser { id: qid, .. } if *qid == id),
+                        ) {
+                            draft = composer_text_from_user_message(text);
+                        }
+                    }
                     rows.retain(
                         |it| !matches!(it, ChatItem::QueuedUser { id: qid, .. } if *qid == id),
                     );
                 });
+                if restore {
+                    input.set(draft);
+                    focus_composer();
+                }
                 (id, "cancel", None)
             }
             // The bubble stays; it promotes to a User row when the running turn
             // folds it in and emits the matching User event.
             QueueOp::CutIn(id) => (id, "cutin", None),
-            QueueOp::Save(id, text) => {
-                route_items(active_session, items, transcripts, &sid, |rows| {
-                    if let Some(ChatItem::QueuedUser { text: slot, .. }) = rows
-                        .iter_mut()
-                        .find(|it| matches!(it, ChatItem::QueuedUser { id: qid, .. } if *qid == id))
-                    {
-                        *slot = text.clone();
-                    }
-                });
-                (id, "edit", Some(text))
-            }
             // Reorder (#433): swap with the neighbouring queued row locally, then
             // mirror it server-side. Queued rows sit contiguously at the tail, so
             // a neighbour that is not a QueuedUser means we are at an end → no-op.

--- a/ui/src/styles/chat.css
+++ b/ui/src/styles/chat.css
@@ -612,10 +612,9 @@ button.msg-icon-btn svg { width: 14px; height: 14px; }
 button.tool-btn { background: var(--bg-app); color: var(--text-muted); border: 1px solid var(--border); border-radius: var(--radius-xs); padding: 4px 10px; font: inherit; font-size: 11.5px; cursor: pointer; }
 button.tool-btn:hover { color: var(--text); border-color: var(--border-strong); }
 button.tool-btn.card-copy { margin-left: auto; flex: 0 0 auto; padding: 2px 8px; font-size: 11px; }
-/* Queue (#433): inline edit + actions on a parked follow-up bubble. */
+/* Queue (#433): actions on a parked follow-up bubble. */
 .queued-bubble .queue-actions { display: flex; gap: 6px; margin-top: 6px; flex-wrap: wrap; align-items: center; }
 .queued-bubble .queue-move { padding: 4px 6px; display: inline-flex; align-items: center; }
-.queued-bubble .queue-edit { width: 100%; box-sizing: border-box; min-height: 48px; resize: vertical; font: inherit; font-size: 13px; padding: 6px 8px; border: 1px solid var(--border); border-radius: var(--radius-xs); background: var(--bg-app); color: var(--text); }
 .tool-input, .tool-output { color: var(--text-muted); white-space: pre-wrap; max-height: 260px; overflow: auto; font-family: var(--font-mono); font-size: 12px; line-height: 1.5; margin: 0 0 8px; padding: 8px 10px; background: var(--bg-app); border: 1px solid var(--border); border-radius: var(--radius-xs); }
 .tool-output { margin-bottom: 0; }
 .tool .content { color: var(--text-muted); margin-top: 8px; white-space: pre-wrap; max-height: 260px; overflow: auto; font-family: var(--font-mono); font-size: 12px; line-height: 1.5; }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Queued follow-up bubbles reused the sent-message **Rewind** label and edited text inline in the bubble. That made the parked-turn actions read as destructive rewind instead of “guide now / edit this draft.”

## Changes

- Rename queued **Cut in** / **插队** to **Guide now** / **立刻引导**.
- Replace queued **Rewind** / **回溯** with **Edit** / **编辑**.
- Clicking **Edit** removes the item from the queue and restores its text to the composer (same restore path as rewind: strip attachment suffixes, focus the input). Sent-message rewind is unchanged.
- Drop the unused inline queue textarea.

## Tests

- `ui/src/i18n.rs`: label assertions for both locales.
- Playwright: queue a follow-up while a turn is running, click **Edit**, assert the bubble is gone and the composer has the original text; backend `queued_turn_action` is `cancel`.

## Manual smoke

1. Send a message so the session is busy, then queue a second message.
2. Confirm the bubble shows **立刻引导** (or **Guide now**) and **编辑** (or **Edit**), not 插队 / 回溯.
3. Click **编辑**: the bubble disappears and the text is in the composer, ready to edit and re-queue/send.
4. **立刻引导** still folds the parked message into the running turn.

## Follow-up

The send-menu item **插队(本回合)** / **Cut in (this turn)** is unchanged. Say if that should match **立刻引导** too.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-820c450b-e5c1-4ef0-a4e1-3a2a4f1ea043?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-820c450b-e5c1-4ef0-a4e1-3a2a4f1ea043&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

