### PR TITLE
fix(desktop): center new project windows and match titlebar menus to the active page

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7497,7 +7497,8 @@ fn spawn_deferred_startup(
         // ones. A project that was since deleted simply fails to spawn.
         for id in project_commands::persisted_windows(&store).await {
             let state = app.state::<AppState>();
-            let _ = project_commands::spawn_project_window(&app, state.inner(), &id, None).await;
+            let _ =
+                project_commands::spawn_project_window(&app, state.inner(), &id, None, None).await;
         }
         let ms = started.elapsed().as_millis();
         update_startup_report(|report| report.deferred_ms = Some(ms));

--- a/src-tauri/src/lib_tests.rs
+++ b/src-tauri/src/lib_tests.rs
@@ -1739,6 +1739,24 @@ fn project_window_url_carries_the_target_session() {
     );
 }
 
+#[test]
+fn centered_window_position_centers_over_the_anchor() {
+    assert_eq!(
+        super::project_commands::centered_window_position((100, 50), (1600, 1000), (1100, 760)),
+        (350, 170)
+    );
+    // A window larger than its anchor overflows symmetrically.
+    assert_eq!(
+        super::project_commands::centered_window_position((100, 50), (800, 600), (1100, 760)),
+        (-50, -30)
+    );
+    // Anchors on monitors left of/above the primary keep negative origins.
+    assert_eq!(
+        super::project_commands::centered_window_position((-1600, -50), (1600, 1000), (1100, 760)),
+        (-1350, 70)
+    );
+}
+
 #[tokio::test]
 async fn project_workspace_data_deletion_removes_only_the_resolved_project_directory() {
     let root = std::env::temp_dir().join(format!("wisp_project_delete_{}", uuid::Uuid::new_v4()));

--- a/src-tauri/src/project_commands.rs
+++ b/src-tauri/src/project_commands.rs
@@ -287,15 +287,32 @@ pub(super) fn project_window_url(id: &str, session: Option<&str>) -> String {
     }
 }
 
+/// Top-left position (physical px) that centers a window of `window_size`
+/// over an anchor window at `anchor_pos`/`anchor_size`. Pure so placement
+/// stays testable; the caller converts to logical coordinates.
+pub(super) fn centered_window_position(
+    anchor_pos: (i32, i32),
+    anchor_size: (u32, u32),
+    window_size: (u32, u32),
+) -> (i32, i32) {
+    (
+        anchor_pos.0 + (anchor_size.0 as i32 - window_size.0 as i32) / 2,
+        anchor_pos.1 + (anchor_size.1 as i32 - window_size.1 as i32) / 2,
+    )
+}
+
 /// Open a project in its own window (or focus the existing one), wiring up
 /// cleanup on close. Shared by the `open_project_window` command and the
 /// startup restore (#52). With `session`, the window opens straight into that
 /// session — an existing window is told via the `open-session` event (#423).
+/// `anchor_label` is the window the new one centers over; `None` (startup
+/// restore) falls back to the main window.
 pub(super) async fn spawn_project_window(
     app: &AppHandle,
     state: &AppState,
     id: &str,
     session: Option<&str>,
+    anchor_label: Option<&str>,
 ) -> Result<String, String> {
     let label = project_window_label(id);
     if let Some(w) = app.get_webview_window(&label) {
@@ -313,10 +330,26 @@ pub(super) async fn spawn_project_window(
     // even before the window's frontend calls open_project.
     set_active_project(state, &label, id).await?;
     let url = tauri::WebviewUrl::App(project_window_url(id, session).into());
-    let builder = tauri::WebviewWindowBuilder::new(app, &label, url)
+    let mut builder = tauri::WebviewWindowBuilder::new(app, &label, url)
         .title("wisp science")
         .inner_size(1100.0, 760.0)
         .resizable(true);
+    // Center over the requesting window (or the main window on startup
+    // restore); otherwise the OS cascades each new window to an arbitrary
+    // spot. Sizes/positions are physical, so convert through the anchor's
+    // scale factor for the builder's logical `position`.
+    let anchor = anchor_label
+        .and_then(|label| app.get_webview_window(label))
+        .or_else(|| app.get_webview_window("main"));
+    if let Some(anchor) = anchor {
+        if let (Ok(pos), Ok(size)) = (anchor.outer_position(), anchor.outer_size()) {
+            let scale = anchor.scale_factor().unwrap_or(1.0);
+            let physical = ((1100.0 * scale) as u32, (760.0 * scale) as u32);
+            let (x, y) =
+                centered_window_position((pos.x, pos.y), (size.width, size.height), physical);
+            builder = builder.position(x as f64 / scale, y as f64 / scale);
+        }
+    }
     #[cfg(target_os = "windows")]
     let builder = builder.decorations(false).shadow(true);
     let win = builder.build().map_err(|e| e.to_string())?;
@@ -350,10 +383,18 @@ pub(super) async fn spawn_project_window(
 pub(super) async fn open_project_window(
     app: AppHandle,
     state: State<'_, AppState>,
+    window: tauri::WebviewWindow,
     id: String,
     session: Option<String>,
 ) -> Result<String, String> {
-    spawn_project_window(&app, state.inner(), &id, session.as_deref()).await
+    spawn_project_window(
+        &app,
+        state.inner(),
+        &id,
+        session.as_deref(),
+        Some(window.label()),
+    )
+    .await
 }
 
 #[tauri::command]

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -8986,15 +8986,46 @@ test("Windows uses the integrated title bar without covering the project landing
   )).toBe(38);
   await page.getByRole("button", { name: "Back to app" }).click();
 
+  // Home menus only list actions that work without an open project.
   await page.getByRole("button", { name: "File", exact: true }).click();
-  await expect(page.getByRole("menuitem", { name: "Open projects" })).toBeVisible();
-  await expect(page.getByRole("menuitem", { name: "Export current project" })).toBeDisabled();
-  await page.getByRole("menuitem", { name: "Open projects" }).click();
-  await expect(page.locator(".projects-screen")).toBeVisible();
+  await expect(page.getByRole("menuitem", { name: "New project" })).toBeVisible();
+  await expect(page.getByRole("menuitem", { name: "Import project" })).toBeVisible();
+  await expect(page.getByRole("menuitem", { name: "Scratch chat" })).toBeVisible();
+  await expect(page.getByRole("menuitem", { name: "Open settings" })).toBeVisible();
+  await expect(page.getByRole("menuitem", { name: "New session" })).toHaveCount(0);
+  await expect(page.getByRole("menuitem", { name: "Open projects" })).toHaveCount(0);
+  await expect(page.getByRole("menuitem", { name: "Export current project" })).toHaveCount(0);
+  await page.getByRole("menuitem", { name: "New project" }).click();
+  await expect(page.locator(".overlay .proj-settings-modal")).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(page.locator(".proj-settings-modal")).toHaveCount(0);
+
+  // Ctrl+N on the landing means a new project too, but Chromium never
+  // delivers Ctrl+N to web content, so that path is only exercisable in the
+  // real webview — the menu item above covers the same "new-project" action.
+
+  await page.getByRole("button", { name: "File", exact: true }).click();
+  await page.getByRole("menuitem", { name: "Import project" }).click();
+  await expect(page.getByTestId("project-import-options")).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("project-import-options")).toHaveCount(0);
+
+  await page.getByRole("button", { name: "Edit", exact: true }).click();
+  await expect(page.getByRole("menuitem", { name: "All commands" })).toBeVisible();
+  await expect(page.getByRole("menuitem", { name: "Import Codex conversations" })).toHaveCount(0);
+  await page.keyboard.press("Escape");
+
+  await page.getByRole("button", { name: "View", exact: true }).click();
+  await expect(page.getByRole("menuitem", { name: "Light theme" })).toBeVisible();
+  await expect(page.getByRole("menuitem", { name: "Toggle sidebar" })).toHaveCount(0);
+  await page.keyboard.press("Escape");
 
   await page.locator(".proj-card-main").first().click();
   await expect(newSessionButton(page)).toBeVisible();
   await page.getByRole("button", { name: "File", exact: true }).click();
+  // Inside a workspace the menus flip back to the session-scoped set.
+  await expect(page.getByRole("menuitem", { name: "New session" })).toBeVisible();
+  await expect(page.getByRole("menuitem", { name: "New project" })).toHaveCount(0);
   const exportCurrentProject = page.getByRole("menuitem", { name: "Export current project" });
   await expect(exportCurrentProject).toBeEnabled();
   await exportCurrentProject.click();

--- a/ui/src/app_support/projects.rs
+++ b/ui/src/app_support/projects.rs
@@ -19,6 +19,10 @@ pub(crate) fn ProjectsScreen(
     project_transfer: RwSignal<Option<ProjectTransferProgress>>,
     privacy_mode_active: RwSignal<bool>,
     privacy_hidden_project_ids: RwSignal<HashSet<String>>,
+    // One-shot requests from the Windows titlebar File menu, which lives
+    // outside this screen; the dialogs themselves are owned here.
+    menu_new_project: RwSignal<bool>,
+    menu_import_project: RwSignal<bool>,
 ) -> impl IntoView {
     let projects = create_rw_signal(Vec::<ProjectSummary>::new());
     let recent = create_rw_signal(Vec::<RecentSession>::new());
@@ -255,6 +259,21 @@ pub(crate) fn ProjectsScreen(
         if creating.get() {
             let block = t(locale.get(), "projects.layout_context");
             new_ctx.update(|c| *c = apply_layout_block(c, &block, new_layout.get()));
+        }
+    });
+
+    // Titlebar File menu requests (one-shot flags; reset before opening so a
+    // repeated request retriggers the effect).
+    create_effect(move |_| {
+        if menu_new_project.get() {
+            menu_new_project.set(false);
+            creating.set(true);
+        }
+    });
+    create_effect(move |_| {
+        if menu_import_project.get() {
+            menu_import_project.set(false);
+            import_options_open.set(true);
         }
     });
 

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -8923,6 +8923,10 @@ fn App() -> impl IntoView {
         status: String,
         message_count: usize,
     }
+    // One-shot requests from the Windows titlebar File menu into the projects
+    // landing screen, which owns the create/import dialogs.
+    let menu_new_project = create_rw_signal(false);
+    let menu_import_project = create_rw_signal(false);
     let palette_action = {
         let new_session = palette_new_session.clone();
         let open_scratch = open_scratch.clone();
@@ -8931,7 +8935,25 @@ fn App() -> impl IntoView {
         let run_update_check = run_update_check.clone();
         let export_current_project = export_current_project.clone();
         Callback::new(move |action: &'static str| match action {
-            "new" => new_session.call(()),
+            // On the projects landing, "new" can only mean a new project —
+            // there is no workspace to hold a session yet.
+            "new" => {
+                if show_projects.get_untracked() {
+                    menu_new_project.set(true);
+                } else {
+                    new_session.call(())
+                }
+            }
+            "new-project" => {
+                if show_projects.get_untracked() {
+                    menu_new_project.set(true);
+                }
+            }
+            "import-project" => {
+                if show_projects.get_untracked() {
+                    menu_import_project.set(true);
+                }
+            }
             "scratch" => open_scratch.call(()),
             "search" => command_palette_open.set(true),
             "commands" => action_palette_open.set(true),
@@ -9109,6 +9131,7 @@ fn App() -> impl IntoView {
         scratch_open.get()
             || (project_info.get().is_some() && !show_projects.get() && !demo_mode.get())
     });
+    let home_page = Signal::derive(move || show_projects.get());
     let shortcut_action = palette_action.clone();
     window_event_listener(ev::keydown, move |ev| {
         let Some(ev) = ev.dyn_ref::<web_sys::KeyboardEvent>() else {
@@ -9267,7 +9290,7 @@ fn App() -> impl IntoView {
     view! {
         {is_windows().then(|| view! {
             <WindowTitlebar locale=locale has_current_project=has_current_project
-                on_action=palette_action.clone() />
+                home=home_page on_action=palette_action.clone() />
         })}
         <ActionPalette open=action_palette_open has_current_project=has_current_project
             on_action=palette_action />
@@ -9322,6 +9345,7 @@ fn App() -> impl IntoView {
                 demos, modal_artifact, locale, running, approval_pending,
                 sync_actions_available, command_palette_open, project_transfer,
                 privacy_mode_active, privacy_hidden_project_ids,
+                menu_new_project, menu_import_project,
             }
             open_project=switch_project
             open_project_session=palette_open_session

--- a/ui/src/project_landing.rs
+++ b/ui/src/project_landing.rs
@@ -23,6 +23,10 @@ pub(super) struct ProjectLandingState {
     pub(super) project_transfer: RwSignal<Option<ProjectTransferProgress>>,
     pub(super) privacy_mode_active: RwSignal<bool>,
     pub(super) privacy_hidden_project_ids: RwSignal<HashSet<String>>,
+    /// One-shot requests from the titlebar File menu; ProjectsScreen owns the
+    /// actual dialogs and resets these flags.
+    pub(super) menu_new_project: RwSignal<bool>,
+    pub(super) menu_import_project: RwSignal<bool>,
 }
 #[component]
 pub(super) fn ProjectLanding(
@@ -50,6 +54,8 @@ pub(super) fn ProjectLanding(
         project_transfer,
         privacy_mode_active,
         privacy_hidden_project_ids,
+        menu_new_project,
+        menu_import_project,
     } = state;
 
     move || {
@@ -91,6 +97,8 @@ pub(super) fn ProjectLanding(
                     project_transfer=project_transfer
                     privacy_mode_active=privacy_mode_active
                     privacy_hidden_project_ids=privacy_hidden_project_ids
+                    menu_new_project=menu_new_project
+                    menu_import_project=menu_import_project
                 />
             }
         })

--- a/ui/src/window_titlebar.rs
+++ b/ui/src/window_titlebar.rs
@@ -46,6 +46,29 @@ const VIEW_ITEMS: &[MenuItem] = &[
     ("theme-system", "command.theme_system", ""),
 ];
 
+// Projects landing (home) variants: only actions that work without an open
+// project. Anything session-scoped would sit there looking clickable but
+// doing nothing, which reads as a bug.
+const HOME_FILE_ITEMS: &[MenuItem] = &[
+    ("new-project", "projects.new", "Ctrl+N"),
+    ("import-project", "projects.import", ""),
+    ("scratch", "command.scratch", "Ctrl+Shift+N"),
+    ("settings", "command.settings", "Ctrl+,"),
+    ("", "", ""), // separator
+    ("quit", "menu.quit", ""),
+];
+
+const HOME_EDIT_ITEMS: &[MenuItem] = &[
+    ("search", "command.search", "Ctrl+K"),
+    ("commands", "menu.commands", "Ctrl+P"),
+];
+
+const HOME_VIEW_ITEMS: &[MenuItem] = &[
+    ("theme-light", "command.theme_light", ""),
+    ("theme-dark", "command.theme_dark", ""),
+    ("theme-system", "command.theme_system", ""),
+];
+
 const HELP_ITEMS: &[MenuItem] = &[
     ("check-updates", "settings.check_updates", ""),
     ("", "", ""),
@@ -58,6 +81,7 @@ const HELP_ITEMS: &[MenuItem] = &[
 pub(super) fn WindowTitlebar(
     locale: RwSignal<Locale>,
     has_current_project: Signal<bool>,
+    home: Signal<bool>,
     on_action: Callback<&'static str>,
 ) -> impl IntoView {
     let open = create_rw_signal(None::<&'static str>);
@@ -80,11 +104,12 @@ pub(super) fn WindowTitlebar(
         })
     };
 
-    let menus: &[(&'static str, &'static str, &[MenuItem])] = &[
-        ("file", "menu.file", FILE_ITEMS),
-        ("edit", "menu.edit", EDIT_ITEMS),
-        ("view", "menu.view", VIEW_ITEMS),
-        ("help", "menu.help", HELP_ITEMS),
+    // (id, label key, session-page items, home-page items)
+    let menus: &[(&'static str, &'static str, &[MenuItem], &[MenuItem])] = &[
+        ("file", "menu.file", FILE_ITEMS, HOME_FILE_ITEMS),
+        ("edit", "menu.edit", EDIT_ITEMS, HOME_EDIT_ITEMS),
+        ("view", "menu.view", VIEW_ITEMS, HOME_VIEW_ITEMS),
+        ("help", "menu.help", HELP_ITEMS, HELP_ITEMS),
     ];
 
     window_event_listener(ev::keydown, move |ev| {
@@ -108,10 +133,11 @@ pub(super) fn WindowTitlebar(
                 <span class="window-brand-version">{concat!("v", env!("CARGO_PKG_VERSION"))}</span>
             </div>
             <nav class="window-menu" aria-label="Application menu">
-                {menus.iter().map(|(id, label_key, items)| {
+                {menus.iter().map(|(id, label_key, items, home_items)| {
                     let id = *id;
                     let label_key = *label_key;
                     let items = *items;
+                    let home_items = *home_items;
                     let run = run.clone();
                     view! {
                         <div class="window-menu-group">
@@ -127,6 +153,7 @@ pub(super) fn WindowTitlebar(
                             </button>
                             {move || (open.get() == Some(id)).then(|| {
                                 let run = run.clone();
+                                let items = if home.get() { home_items } else { items };
                                 view! {
                                     <div class="window-menu-drop" role="menu" on:click=|ev| ev.stop_propagation()>
                                         {items.iter().map(|(action, key, shortcut)| {


### PR DESCRIPTION
## Problem

1. Every new project window opened at an arbitrary OS-cascaded position — never the same place twice.
2. On the projects landing (home), the Windows titlebar File/Edit/View menus listed session-scoped actions (New session, Export current project, sidebar panels, imports) that silently did nothing without an open project, which read as broken UI.

## Changes

- `src-tauri/src/project_commands.rs`: `spawn_project_window` now centers the new window over the requesting window (falling back to the main window on startup restore). A pure `centered_window_position` helper computes the physical-pixel placement; the builder receives logical coordinates converted through the anchor's scale factor, so HiDPI setups land correctly. `open_project_window` injects the invoking `WebviewWindow` as the anchor.
- `ui/src/window_titlebar.rs`: new `home` prop; while the landing is shown, menus swap to home-specific sets — File: New project (Ctrl+N) / Import project / Scratch chat (Ctrl+Shift+N) / Settings / Exit; Edit: Search / All commands; View: theme only; Help unchanged (already global).
- `ui/src/main.rs`: `palette_action` gains `new-project` / `import-project`; `"new"` on the landing opens the create-project dialog so Ctrl+N matches the menu label.
- `ui/src/project_landing.rs`, `ui/src/app_support/projects.rs`: one-shot request signals bridge the titlebar into the ProjectsScreen-owned create/import dialogs.

## Tests

- New Rust unit tests for `centered_window_position` (centered, overflowing, negative multi-monitor origins); `cargo test -p wisp-tauri --lib`: 675 passed.
- Updated Playwright Windows titlebar test: home menu contents, create/import dialogs open from the menu, and the session menu set returning after entering a project. Full suite: 336 passed, 1 skipped.
- `cargo fmt --all -- --check` clean; `cargo check --target wasm32-unknown-unknown` clean.
- Note: Ctrl+N on the landing is not covered by Playwright — Chromium never delivers Ctrl+N to web content; it works in the real WebView2.

## Manual smoke

1. On Windows, open a project in a new window twice — the window appears centered over the window you clicked from each time.
2. On the projects landing, open File/Edit/View: only home-applicable items appear; File → New project opens the create dialog; File → Import project opens the import options.
3. Enter a project: menus show the full session set again (Export current project enabled, Edit → imports, View → panels).

## Known limitations / follow-ups

- The macOS native app menu is still installed once with the full item set (page-aware rebuild needs focus-window tracking on the app-global menu bar); on the landing its session-scoped items remain harmless no-ops, and Cmd+N already opens create-project there. Tracked as a follow-up.