### PR TITLE
Restore per-conversation scroll positions

### DIFF
--- a/docs/ui-design-principles.md
+++ b/docs/ui-design-principles.md
@@ -34,7 +34,7 @@
 - Files, images, skills, artifacts, conversations, execution environments, and runtime references must remain visually distinguishable before and after send.
 - Image attachments use a real thumbnail when the project file is readable. Other files use a document card with a filename and type label.
 - Persisted transcript markers such as `Uploaded files:` and `Selected skills:` are transport metadata. The chat UI renders them as cards instead of exposing the raw marker text.
-- Saved conversations open at their latest message. After the user scrolls up, deferred content growth preserves the visible reading position instead of pulling the viewport toward the middle.
+- Saved conversations open at their latest message. After the user scrolls up, deferred content growth and switching between conversations preserve each conversation's visible reading position instead of pulling the viewport toward the middle or resetting to the latest message.
 - Long attachment names truncate inside the card; the full value remains available through the control's title.
 - Remove controls live inside the related card and retain an accessible label.
 

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -8642,6 +8642,28 @@ test("opening a long conversation lands at the latest message and stays stable o
     .toBeGreaterThan(readingPosition + 400);
 });
 
+test("switching conversations restores each reading position (#849)", async ({ page }) => {
+  await page.goto("/?mockLongPages=8");
+  await page.locator(".proj-card-main").first().click();
+
+  const scroller = page.locator("#chat-scroller");
+  await expect(page.getByText(/Window page 0 row 19/)).toBeVisible();
+  await scroller.evaluate((element) => {
+    element.scrollTop = Math.max(120, element.scrollHeight / 3);
+    element.dispatchEvent(new WheelEvent("wheel", { deltaY: -80, bubbles: true }));
+  });
+  const readingTop = await scroller.evaluate((element) => element.scrollTop);
+
+  await newSessionButton(page).click();
+  await expect(page.locator(".empty")).toBeVisible();
+  await page.locator(".side-item.ses", { hasText: "Long transcript" }).click();
+  await expect(page.getByText(/Window page 0 row 19/)).toBeVisible();
+  await expect.poll(() => scroller.evaluate((element) => element.scrollTop))
+    .toBeGreaterThan(readingTop - 40);
+  await expect.poll(() => scroller.evaluate((element) => element.scrollTop))
+    .toBeLessThan(readingTop + 40);
+});
+
 test("conversation outline loads and jumps to an older user question", async ({ page }) => {
   await page.goto("/?mockLongSession=1");
   await page.locator(".proj-card-main").first().click();

--- a/ui/src/bindings.rs
+++ b/ui/src/bindings.rs
@@ -90,6 +90,7 @@ extern "C" {
     fn attach_chat_scroll(scroller_id: &str, content_id: &str);
     fn notify_chat_scroll(scroller_id: &str);
     fn force_chat_scroll_bottom(scroller_id: &str);
+    fn switch_chat_scroll(scroller_id: &str, session_id: &str);
     fn preserve_chat_scroll_on_prepend(scroller_id: &str, content_id: &str);
     fn jump_chat_scroll(scroller_id: &str, selector: &str);
     fn jump_chat_scroll_last_user(scroller_id: &str);
@@ -129,6 +130,11 @@ pub(crate) fn schedule_chat_follow() {
 /// Force the chat view to jump to the bottom (e.g. after switching sessions).
 pub(crate) fn force_chat_bottom() {
     force_chat_scroll_bottom(CHAT_SCROLLER_ID);
+}
+
+/// Save the previous conversation's position and restore this conversation.
+pub(crate) fn restore_chat_session_scroll(session_id: &str) {
+    switch_chat_scroll(CHAT_SCROLLER_ID, session_id);
 }
 
 /// Re-pin every run output panel to the bottom after a run-list refresh

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -36,8 +36,8 @@ use bindings::{
     force_chat_bottom, invoke, invoke_checked, invoke_timeout, is_mac, is_windows,
     jump_chat_to_item, jump_chat_to_last_user, jump_chat_to_user, listen, listen_current_window,
     listen_native_file_drop, native_drop_in_composer, open_external_url, pasted_image_count,
-    preserve_chat_prepend_position, preview_selection, schedule_chat_follow, set_saved_marks,
-    CHAT_SCROLLER_ID, CHAT_THREAD_ID,
+    preserve_chat_prepend_position, preview_selection, restore_chat_session_scroll,
+    schedule_chat_follow, set_saved_marks, CHAT_SCROLLER_ID, CHAT_THREAD_ID,
 };
 use context_menu::{ContextMenuPortal, CtxMenu};
 use dto::*;
@@ -5049,6 +5049,7 @@ fn App() -> impl IntoView {
                 status.set(t(locale.get(), "status.send_failed").into());
                 return;
             };
+            restore_chat_session_scroll(&id);
             replace_visible_transcript(
                 active_session.get_untracked(),
                 None,
@@ -5308,6 +5309,7 @@ fn App() -> impl IntoView {
         attachments.set(vec![]);
         sel_artifact.set(0);
         right_tab.set(RightTab::Artifacts);
+        restore_chat_session_scroll(&id);
         // Swap the visible transcript before changing the active id. Agent
         // events are app-wide and route by `active_session`; publishing the new
         // id while `items` still belongs to the old frame creates a transition
@@ -5337,7 +5339,7 @@ fn App() -> impl IntoView {
             transcript_pages.update(|pages| {
                 pages.entry(id.clone()).or_default().window_user_start = usize::MAX;
             });
-            force_chat_bottom();
+            restore_chat_session_scroll(&id);
             // Still retarget the backend's viewed-session marker so uploads
             // attach here (#194). Not `load_session`: that would overwrite the
             // running turn's persisted seq with the DB snapshot.
@@ -5401,7 +5403,7 @@ fn App() -> impl IntoView {
                             ));
                         }
                     }
-                    force_chat_bottom();
+                    restore_chat_session_scroll(&id);
                 } else {
                     transcripts.update(|m| {
                         m.insert(id.clone(), chats);

--- a/ui/src/scroll.js
+++ b/ui/src/scroll.js
@@ -1,6 +1,7 @@
 // Chat scroll follow (mirrors web-dist ConversationView pinned-at-bottom behavior).
 
 const hooks = new Map();
+const chatPositions = new Map();
 
 // ponytail: single chat scroller, so the jump pill id is a constant.
 const JUMP_PILL_ID = "chat-jump-pill";
@@ -32,6 +33,8 @@ export function attach_chat_scroll(scrollerId, contentId) {
   let follow = true;
   let lastHeight = content.scrollHeight;
   let readingTop = scroller.scrollTop;
+  let activeSession = null;
+  let restoreGeneration = 0;
   let hidden = false;
   const setFollow = (value) => {
     follow = value;
@@ -162,10 +165,48 @@ export function attach_chat_scroll(scrollerId, contentId) {
         });
       });
     },
+    switchSession: (sessionId) => {
+      if (activeSession !== sessionId) {
+        if (activeSession) {
+          chatPositions.set(activeSession, {
+            top: scroller.scrollTop,
+            follow,
+          });
+        }
+        activeSession = sessionId;
+      }
+
+      const generation = ++restoreGeneration;
+      const saved = chatPositions.get(sessionId);
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          if (generation !== restoreGeneration || activeSession !== sessionId) return;
+          if (!saved || saved.follow) {
+            setFollow(true);
+            snapBottom(scroller);
+          } else {
+            setFollow(false);
+            const max = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
+            readingTop = Math.min(saved.top, max);
+            scroller.scrollTop = readingTop;
+          }
+          lastHeight = content.scrollHeight;
+          syncPill();
+        });
+      });
+    },
   });
 
   setFollow(true);
   snapBottom(scroller);
+}
+
+/** Save the previous conversation and restore this conversation after render.
+ * Calling this again for the same session reapplies its saved position after an
+ * asynchronous transcript load without overwriting the saved state.
+ * @param {string} scrollerId @param {string} sessionId */
+export function switch_chat_scroll(scrollerId, sessionId) {
+  hooks.get(scrollerId)?.switchSession(sessionId);
 }
 
 /** @param {string} scrollerId */


### PR DESCRIPTION
Closes #849

## What changed

- remember the chat viewport position and bottom-follow state for each conversation during the current app run
- restore cached and asynchronously loaded conversations after their transcript renders
- guard delayed restores so rapid conversation switches cannot apply stale positions
- preserve the existing jump-to-bottom behavior for new messages and first-time conversation opens
- document the conversation-switch behavior and add a Playwright regression test

## Why

The chat scroller previously kept only one global `readingTop`/follow state, while `load_session` forced every reopened conversation to the bottom. Switching away from a long conversation therefore lost the user's reading position.

## Validation

- `cargo check --target wasm32-unknown-unknown`
- `WISP_CATALOG_OFFLINE=1 CARGO_TARGET_DIR=/tmp/wisp-849-target cargo test --workspace`
- six focused scroll Playwright tests, including the new #849 regression
- full Playwright run reached 110 passing tests before being stopped after unrelated failures; the transient tool-only timeout passed when rerun, while two existing shortcut assertions expect Ctrl labels even though the macOS UI correctly renders Command labels

## Manual smoke steps

1. Open a long conversation and scroll to an older message.
2. Switch to another or a new conversation.
3. Switch back and confirm the prior viewport is restored.
4. Open a conversation for the first time and confirm it starts at the latest message.

## Known limitation

Positions are retained only for the lifetime of the current app UI; they are not persisted across app restarts.