### PR TITLE
Scheduled automations v0: interval triggers that fire prompts into sessions

### DIFF
--- a/crates/wisp-store/src/lib.rs
+++ b/crates/wisp-store/src/lib.rs
@@ -30,6 +30,7 @@ mod remote_staging;
 mod research;
 mod resources;
 mod runs;
+mod schedules;
 pub mod secrets;
 mod session_imports;
 mod sessions;
@@ -71,6 +72,7 @@ pub use project_transfer::ProjectTransferStats;
 pub use projects::{is_scratch_project_id, SCRATCH_PROJECT_PREFIX};
 pub use provenance::{canonical_json, canonical_json_sha256};
 pub use remote_staging::RemoteStagingEntry;
+pub use schedules::{next_slot_after, ScheduleRecord, ScheduleRunRecord};
 pub use sessions::{
     ModelTokenUsage, ProjectTokenUsage, SessionBranchDeltaMessage, SessionBranchLink,
     SessionBranchMerge, SessionBranchMergeCard, SessionBranchMergePreview, SessionTokenUsage,
@@ -160,6 +162,7 @@ const CONTEXT_STORAGE_PREFS_MIGRATION: &str = "0044_context_storage_prefs";
 const RUN_CLEANUP_STATE_MIGRATION: &str = "0045_run_cleanup_state";
 const REMOTE_STAGING_MIGRATION: &str = "0046_remote_staging";
 const RUN_RETENTION_MIGRATION: &str = "0047_run_retention";
+const SCHEDULES_MIGRATION: &str = "0048_schedules";
 
 #[derive(Clone)]
 pub struct Store {
@@ -627,6 +630,45 @@ impl Store {
             )
             .await?;
             Self::record_migration(pool, RUN_RETENTION_MIGRATION).await?;
+        }
+        if !Self::migration_applied(pool, SCHEDULES_MIGRATION).await? {
+            // frame_id stays a plain column on purpose: a schedule must
+            // survive its target session being deleted so it can keep firing
+            // into fresh sessions or be re-pointed by the user.
+            sqlx::query(
+                "CREATE TABLE IF NOT EXISTS schedules(\
+                 id TEXT PRIMARY KEY, \
+                 project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE, \
+                 frame_id TEXT, \
+                 name TEXT NOT NULL, prompt TEXT NOT NULL, skill TEXT, \
+                 interval_secs INTEGER NOT NULL, enabled INTEGER NOT NULL DEFAULT 1, \
+                 next_run_at INTEGER NOT NULL, last_run_at INTEGER, \
+                 created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)",
+            )
+            .execute(pool)
+            .await?;
+            sqlx::query(
+                "CREATE INDEX IF NOT EXISTS ix_schedules_due \
+                 ON schedules(enabled, next_run_at)",
+            )
+            .execute(pool)
+            .await?;
+            sqlx::query(
+                "CREATE TABLE IF NOT EXISTS schedule_runs(\
+                 id TEXT PRIMARY KEY, \
+                 schedule_id TEXT NOT NULL REFERENCES schedules(id) ON DELETE CASCADE, \
+                 frame_id TEXT, status TEXT NOT NULL, error TEXT, \
+                 fired_at INTEGER NOT NULL)",
+            )
+            .execute(pool)
+            .await?;
+            sqlx::query(
+                "CREATE INDEX IF NOT EXISTS ix_schedule_runs_schedule \
+                 ON schedule_runs(schedule_id, fired_at DESC)",
+            )
+            .execute(pool)
+            .await?;
+            Self::record_migration(pool, SCHEDULES_MIGRATION).await?;
         }
         Ok(())
     }

--- a/crates/wisp-store/src/schedules.rs
+++ b/crates/wisp-store/src/schedules.rs
@@ -1,0 +1,370 @@
+//! Scheduled automations: interval-based triggers that fire a prompt (with an
+//! optional skill) into a chat session while the app is running.
+//!
+//! Schedules only fire in-process; there is no system-level daemon. Missed
+//! slots collapse into one catch-up fire on the next launch, and slot math is
+//! anchored at `next_run_at` so a daily schedule keeps a stable wall-clock
+//! time instead of drifting by the poll interval.
+
+use super::Store;
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use sqlx::Row;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ScheduleRecord {
+    pub id: String,
+    pub project_id: String,
+    /// Target session. `None` creates a fresh session for every fire.
+    pub frame_id: Option<String>,
+    pub name: String,
+    pub prompt: String,
+    pub skill: Option<String>,
+    pub interval_secs: i64,
+    pub enabled: bool,
+    pub next_run_at: i64,
+    pub last_run_at: Option<i64>,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ScheduleRunRecord {
+    pub id: String,
+    pub schedule_id: String,
+    pub frame_id: Option<String>,
+    /// `fired` or `failed`.
+    pub status: String,
+    pub error: Option<String>,
+    pub fired_at: i64,
+}
+
+/// Smallest `anchor + k*interval` strictly greater than `now`. Advancing from
+/// the previous slot (not `now`) keeps the schedule on its original cadence.
+pub fn next_slot_after(anchor: i64, interval_secs: i64, now: i64) -> i64 {
+    let interval = interval_secs.max(1);
+    if anchor > now {
+        return anchor;
+    }
+    anchor + ((now - anchor) / interval + 1) * interval
+}
+
+fn schedule_from_row(row: sqlx::sqlite::SqliteRow) -> Result<ScheduleRecord> {
+    Ok(ScheduleRecord {
+        id: row.try_get("id")?,
+        project_id: row.try_get("project_id")?,
+        frame_id: row.try_get("frame_id")?,
+        name: row.try_get("name")?,
+        prompt: row.try_get("prompt")?,
+        skill: row.try_get("skill")?,
+        interval_secs: row.try_get("interval_secs")?,
+        enabled: row.try_get::<i64, _>("enabled")? != 0,
+        next_run_at: row.try_get("next_run_at")?,
+        last_run_at: row.try_get("last_run_at")?,
+        created_at: row.try_get("created_at")?,
+        updated_at: row.try_get("updated_at")?,
+    })
+}
+
+const SCHEDULE_COLUMNS: &str =
+    "id,project_id,frame_id,name,prompt,skill,interval_secs,enabled,next_run_at,last_run_at,created_at,updated_at";
+
+impl Store {
+    pub async fn create_schedule(&self, schedule: &ScheduleRecord) -> Result<()> {
+        sqlx::query(
+            "INSERT INTO schedules(\
+             id,project_id,frame_id,name,prompt,skill,interval_secs,enabled,next_run_at,last_run_at,created_at,updated_at) \
+             VALUES(?,?,?,?,?,?,?,?,?,?,?,?)",
+        )
+        .bind(&schedule.id)
+        .bind(&schedule.project_id)
+        .bind(schedule.frame_id.as_deref())
+        .bind(&schedule.name)
+        .bind(&schedule.prompt)
+        .bind(schedule.skill.as_deref())
+        .bind(schedule.interval_secs)
+        .bind(schedule.enabled as i64)
+        .bind(schedule.next_run_at)
+        .bind(schedule.last_run_at)
+        .bind(schedule.created_at)
+        .bind(schedule.updated_at)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn get_schedule(&self, id: &str) -> Result<Option<ScheduleRecord>> {
+        let row = sqlx::query(&format!(
+            "SELECT {SCHEDULE_COLUMNS} FROM schedules WHERE id=?"
+        ))
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await?;
+        row.map(schedule_from_row).transpose()
+    }
+
+    pub async fn list_schedules(&self, project_id: &str) -> Result<Vec<ScheduleRecord>> {
+        let rows = sqlx::query(&format!(
+            "SELECT {SCHEDULE_COLUMNS} FROM schedules WHERE project_id=? ORDER BY created_at,id"
+        ))
+        .bind(project_id)
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter().map(schedule_from_row).collect()
+    }
+
+    pub async fn set_schedule_enabled(&self, id: &str, enabled: bool, now: i64) -> Result<bool> {
+        let result = sqlx::query("UPDATE schedules SET enabled=?, updated_at=? WHERE id=?")
+            .bind(enabled as i64)
+            .bind(now)
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+        Ok(result.rows_affected() == 1)
+    }
+
+    pub async fn delete_schedule(&self, id: &str) -> Result<()> {
+        sqlx::query("DELETE FROM schedule_runs WHERE schedule_id=?")
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+        sqlx::query("DELETE FROM schedules WHERE id=?")
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Enabled schedules whose slot has passed. The poller claims each row
+    /// before firing so a slow turn can never double-fire a schedule.
+    pub async fn due_schedules(&self, now: i64) -> Result<Vec<ScheduleRecord>> {
+        let rows = sqlx::query(&format!(
+            "SELECT {SCHEDULE_COLUMNS} FROM schedules \
+             WHERE enabled=1 AND next_run_at<=? ORDER BY next_run_at,id"
+        ))
+        .bind(now)
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter().map(schedule_from_row).collect()
+    }
+
+    /// Atomically advance `next_run_at` past `now` and stamp `last_run_at`.
+    /// Returns false when another tick already claimed this slot or the
+    /// schedule was disabled in between, so exactly one fire happens per slot.
+    pub async fn claim_schedule_fire(
+        &self,
+        id: &str,
+        expected_next_run_at: i64,
+        new_next_run_at: i64,
+        fired_at: i64,
+    ) -> Result<bool> {
+        let result = sqlx::query(
+            "UPDATE schedules SET next_run_at=?, last_run_at=?, updated_at=? \
+             WHERE id=? AND next_run_at=? AND enabled=1",
+        )
+        .bind(new_next_run_at)
+        .bind(fired_at)
+        .bind(fired_at)
+        .bind(id)
+        .bind(expected_next_run_at)
+        .execute(&self.pool)
+        .await?;
+        Ok(result.rows_affected() == 1)
+    }
+
+    pub async fn record_schedule_run(&self, run: &ScheduleRunRecord) -> Result<()> {
+        sqlx::query(
+            "INSERT INTO schedule_runs(id,schedule_id,frame_id,status,error,fired_at) \
+             VALUES(?,?,?,?,?,?)",
+        )
+        .bind(&run.id)
+        .bind(&run.schedule_id)
+        .bind(run.frame_id.as_deref())
+        .bind(&run.status)
+        .bind(run.error.as_deref())
+        .bind(run.fired_at)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn list_schedule_runs(
+        &self,
+        schedule_id: &str,
+        limit: usize,
+    ) -> Result<Vec<ScheduleRunRecord>> {
+        let rows = sqlx::query(
+            "SELECT id,schedule_id,frame_id,status,error,fired_at FROM schedule_runs \
+             WHERE schedule_id=? ORDER BY fired_at DESC,id DESC LIMIT ?",
+        )
+        .bind(schedule_id)
+        .bind(limit.clamp(1, 200) as i64)
+        .fetch_all(&self.pool)
+        .await?;
+        rows.into_iter()
+            .map(|row| {
+                Ok(ScheduleRunRecord {
+                    id: row.try_get("id")?,
+                    schedule_id: row.try_get("schedule_id")?,
+                    frame_id: row.try_get("frame_id")?,
+                    status: row.try_get("status")?,
+                    error: row.try_get("error")?,
+                    fired_at: row.try_get("fired_at")?,
+                })
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::Uuid;
+
+    #[test]
+    fn next_slot_stays_anchored_and_moves_past_now() {
+        // Daily slot anchored at t=100; polled at t=150 lands on the next day.
+        assert_eq!(next_slot_after(100, 86_400, 150), 86_500);
+        // Three missed days still land on the single next slot, not now+delta.
+        assert_eq!(
+            next_slot_after(100, 86_400, 100 + 86_400 * 3 + 1),
+            100 + 86_400 * 4
+        );
+        // A future anchor is its own first slot.
+        assert_eq!(next_slot_after(1_000, 60, 150), 1_000);
+        // Exact boundary counts as due, so the next slot is one interval out.
+        assert_eq!(next_slot_after(100, 60, 100), 160);
+        // Degenerate intervals never divide by zero or stall.
+        assert_eq!(next_slot_after(100, 0, 250), 251);
+    }
+
+    fn test_schedule(id: &str, project_id: &str, next_run_at: i64) -> ScheduleRecord {
+        ScheduleRecord {
+            id: id.into(),
+            project_id: project_id.into(),
+            frame_id: None,
+            name: "Daily summary".into(),
+            prompt: "Summarize today's progress.".into(),
+            skill: Some("literature-review".into()),
+            interval_secs: 86_400,
+            enabled: true,
+            next_run_at,
+            last_run_at: None,
+            created_at: 1,
+            updated_at: 1,
+        }
+    }
+
+    async fn test_store() -> (Store, std::path::PathBuf) {
+        let root = std::env::temp_dir().join(format!("wisp-schedules-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&root).unwrap();
+        let store = Store::open(&root.join("store.sqlite")).await.unwrap();
+        store.create_project("p1", "proj", "").await.unwrap();
+        (store, root)
+    }
+
+    #[tokio::test]
+    async fn schedule_crud_and_enable_roundtrip() {
+        let (store, root) = test_store().await;
+        let schedule = test_schedule("s1", "p1", 500);
+        store.create_schedule(&schedule).await.unwrap();
+        assert_eq!(
+            store.get_schedule("s1").await.unwrap(),
+            Some(schedule.clone())
+        );
+        assert_eq!(
+            store.list_schedules("p1").await.unwrap(),
+            vec![schedule.clone()]
+        );
+        assert!(store.list_schedules("p2").await.unwrap().is_empty());
+
+        assert!(store.set_schedule_enabled("s1", false, 10).await.unwrap());
+        let disabled = store.get_schedule("s1").await.unwrap().unwrap();
+        assert!(!disabled.enabled);
+        assert!(store.due_schedules(1_000).await.unwrap().is_empty());
+        assert!(!store
+            .set_schedule_enabled("missing", true, 10)
+            .await
+            .unwrap());
+
+        store.delete_schedule("s1").await.unwrap();
+        assert_eq!(store.get_schedule("s1").await.unwrap(), None);
+
+        drop(store);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn due_claim_is_atomic_and_advances_the_slot() {
+        let (store, root) = test_store().await;
+        let mut future = test_schedule("future", "p1", 10_000);
+        store.create_schedule(&future).await.unwrap();
+        let due = test_schedule("due", "p1", 100);
+        store.create_schedule(&due).await.unwrap();
+
+        let due_rows = store.due_schedules(500).await.unwrap();
+        assert_eq!(due_rows, vec![due.clone()]);
+
+        let new_next = next_slot_after(due.next_run_at, due.interval_secs, 500);
+        assert!(store
+            .claim_schedule_fire("due", due.next_run_at, new_next, 500)
+            .await
+            .unwrap());
+        // A second claim for the same slot loses the race.
+        assert!(!store
+            .claim_schedule_fire("due", due.next_run_at, new_next, 500)
+            .await
+            .unwrap());
+        let claimed = store.get_schedule("due").await.unwrap().unwrap();
+        assert_eq!(claimed.next_run_at, new_next);
+        assert_eq!(claimed.last_run_at, Some(500));
+        // The claimed slot is gone; nothing else is due before `future`.
+        assert!(store.due_schedules(9_999).await.unwrap().is_empty());
+        assert_eq!(
+            store.due_schedules(new_next).await.unwrap(),
+            vec![
+                // `future` (10_000) comes first: ordering is by next_run_at.
+                store.get_schedule("future").await.unwrap().unwrap(),
+                claimed.clone()
+            ]
+        );
+
+        future.enabled = false;
+        drop(store);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn schedule_runs_record_and_delete_with_schedule() {
+        let (store, root) = test_store().await;
+        store
+            .create_schedule(&test_schedule("s1", "p1", 100))
+            .await
+            .unwrap();
+        for (id, status, fired_at) in [("r1", "fired", 100), ("r2", "failed", 200)] {
+            store
+                .record_schedule_run(&ScheduleRunRecord {
+                    id: id.into(),
+                    schedule_id: "s1".into(),
+                    frame_id: Some("f1".into()),
+                    status: status.into(),
+                    error: (status == "failed").then(|| "boom".into()),
+                    fired_at,
+                })
+                .await
+                .unwrap();
+        }
+        let runs = store.list_schedule_runs("s1", 10).await.unwrap();
+        assert_eq!(runs.len(), 2);
+        assert_eq!(runs[0].id, "r2", "newest first");
+        assert_eq!(runs[0].error.as_deref(), Some("boom"));
+        assert_eq!(runs[1].id, "r1");
+        assert_eq!(store.list_schedule_runs("s1", 1).await.unwrap().len(), 1);
+
+        store.delete_schedule("s1").await.unwrap();
+        assert!(store.list_schedule_runs("s1", 10).await.unwrap().is_empty());
+
+        drop(store);
+        let _ = std::fs::remove_dir_all(root);
+    }
+}

--- a/crates/wisp-store/src/store_tests.rs
+++ b/crates/wisp-store/src/store_tests.rs
@@ -3275,6 +3275,7 @@ async fn store_open_records_migrations_and_seeds_local_context() {
             RUN_CLEANUP_STATE_MIGRATION.to_string(),
             REMOTE_STAGING_MIGRATION.to_string(),
             RUN_RETENTION_MIGRATION.to_string(),
+            SCHEDULES_MIGRATION.to_string(),
         ]
     );
 

--- a/docs/superpowers/specs/2026-08-15-scheduled-automations-design.md
+++ b/docs/superpowers/specs/2026-08-15-scheduled-automations-design.md
@@ -1,0 +1,59 @@
+# Scheduled Automations Design (v0)
+
+Date: 2026-08-15
+Status: Implemented (v0)
+
+## Problem
+
+Users want recurring agent work — e.g. a daily literature or progress summary —
+without manually opening a session and typing the same prompt. The app needs a
+durable trigger that runs a prompt (optionally bound to a skill) on a schedule.
+
+## Scope decision
+
+v0 fires **only while the app is running**; there is no system-level daemon
+(launchd / Task Scheduler / systemd). Slots missed while the app was closed
+collapse into **one catch-up fire** on next launch. This keeps v0 free of
+platform-specific registration code and cross-platform test burden.
+
+## Data model (wisp-store, migration `0048_schedules`)
+
+- `schedules`: `id`, `project_id` (FK, cascade), `frame_id` (nullable — `NULL`
+  means a fresh session per fire; deliberately not an FK so a schedule survives
+  its target session being deleted), `name`, `prompt`, `skill` (nullable skill
+  name), `interval_secs`, `enabled`, `next_run_at`, `last_run_at`,
+  `created_at`, `updated_at`. Index `(enabled, next_run_at)` for the due scan.
+- `schedule_runs`: one row per fire — `id`, `schedule_id` (FK, cascade),
+  `frame_id`, `status` (`fired` | `failed`), `error`, `fired_at`.
+
+## Semantics
+
+- Slot math is anchored: `next_slot_after(anchor, interval, now)` returns the
+  smallest `anchor + k*interval` strictly greater than `now`, so an 08:00 daily
+  schedule stays at 08:00 regardless of poll timing or catch-ups.
+- Firing is claimed atomically (`UPDATE ... WHERE id=? AND next_run_at=? AND
+  enabled=1`) so a slow turn or concurrent tick can never double-fire a slot.
+- Each fire is a normal agent turn via `send_message_inner` (same path as
+  channel messages and delegation auto-resume): it persists to the transcript,
+  streams through existing turn events, and queues behind a running turn via
+  the per-session workflow lock. The prompt is prefixed with
+  `[Scheduled task: <name>]` for provenance.
+- An optional skill is attached as a `ComposerReferenceArg::Skill`, rendered
+  inline exactly like a user-attached skill; a missing/disabled skill fails the
+  run and is recorded in `schedule_runs`.
+- Minimum interval is 60s; creation with a past `start_at` makes the schedule
+  immediately due (catch-up on the first tick, ~5s after app setup).
+
+## Tauri commands
+
+`create_schedule`, `list_schedules`, `list_schedule_runs`,
+`set_schedule_enabled`, `delete_schedule`, `run_schedule_now` (manual,
+out-of-cadence fire that leaves `next_run_at` untouched).
+
+## Deliberate exclusions (follow-ups)
+
+- No UI surface yet; commands are ready for a schedules panel.
+- No cron expressions / calendar times — interval + anchor only.
+- No system-level (app-closed) firing.
+- No workflow targets — prompt/skill only; workflow binding can reuse the same
+  tables later.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -78,6 +78,7 @@ mod run_context;
 mod runtime_commands;
 mod runtime_config_tool;
 mod runtime_launcher;
+mod scheduler;
 mod scratch_commands;
 mod seed;
 mod session_commands;
@@ -7783,6 +7784,7 @@ pub fn run() {
             app.manage(terminal_sessions::TerminalManager::new());
             app.manage(channels::ChannelManager::new());
             delegation_completion::start_dispatcher(app.handle());
+            scheduler::start_scheduler(app.handle());
             {
                 let handle = app.handle().clone();
                 tauri::async_runtime::spawn(async move {
@@ -7874,6 +7876,12 @@ pub fn run() {
             plan_mode::set_session_plan_mode,
             delegation_completion::get_session_agent_completion,
             delegation_completion::set_session_agent_completion,
+            scheduler::create_schedule,
+            scheduler::list_schedules,
+            scheduler::list_schedule_runs,
+            scheduler::set_schedule_enabled,
+            scheduler::delete_schedule,
+            scheduler::run_schedule_now,
             delegation_runtime::get_dynamic_agent_options,
             delegation_runtime::get_agent_workflow_result,
             delegation_runtime::approve_agent_workflow,

--- a/src-tauri/src/scheduler.rs
+++ b/src-tauri/src/scheduler.rs
@@ -1,0 +1,360 @@
+//! Scheduled automations: fire a prompt (optionally bound to a skill) into a
+//! chat session on an interval while the app is running.
+//!
+//! There is no system-level daemon: schedules only fire in-process, and slots
+//! missed while the app was closed collapse into a single catch-up fire on
+//! the next launch. Each fire is a normal agent turn routed through
+//! `send_message_inner` (like channel and delegation-resume turns), so it
+//! persists to the session transcript and streams to the UI through the
+//! existing turn events.
+
+use crate::{create_session_frame, send_message_inner, AppState, ComposerReferenceArg};
+use std::time::Duration;
+use tauri::{AppHandle, Manager, State};
+use uuid::Uuid;
+use wisp_store::{next_slot_after, ScheduleRecord, ScheduleRunRecord};
+
+/// Due schedules are picked up within one poll interval of their slot.
+const POLL_INTERVAL: Duration = Duration::from_secs(30);
+/// Let windows/projects restore before the first catch-up scan.
+const START_DELAY: Duration = Duration::from_secs(5);
+/// Sub-minute intervals would turn a missed-slot catch-up into a busy loop.
+const MIN_INTERVAL_SECS: i64 = 60;
+const MAX_NAME_CHARS: usize = 80;
+
+pub(crate) fn start_scheduler(app: &AppHandle) {
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        tokio::time::sleep(START_DELAY).await;
+        let mut tick = tokio::time::interval(POLL_INTERVAL);
+        loop {
+            tick.tick().await;
+            fire_due_schedules(&app).await;
+        }
+    });
+}
+
+async fn fire_due_schedules(app: &AppHandle) {
+    let state = app.state::<AppState>();
+    let now = chrono::Utc::now().timestamp();
+    let due = match state.store.due_schedules(now).await {
+        Ok(due) => due,
+        Err(error) => {
+            tracing::warn!(target: "wisp", %error, "failed to poll due schedules");
+            return;
+        }
+    };
+    for schedule in due {
+        // A fired turn can run for minutes; never let one schedule delay the
+        // others (or the next poll) behind it.
+        let app = app.clone();
+        tauri::async_runtime::spawn(async move {
+            fire_schedule(app, schedule, now, true).await;
+        });
+    }
+}
+
+/// Fire one schedule. With `advance`, the slot is first claimed atomically so
+/// a schedule can never double-fire; manual runs skip the claim and leave the
+/// cadence untouched.
+async fn fire_schedule(app: AppHandle, schedule: ScheduleRecord, now: i64, advance: bool) {
+    let state = app.state::<AppState>();
+    if advance {
+        let new_next = next_slot_after(schedule.next_run_at, schedule.interval_secs, now);
+        match state
+            .store
+            .claim_schedule_fire(&schedule.id, schedule.next_run_at, new_next, now)
+            .await
+        {
+            Ok(true) => {}
+            Ok(false) => return,
+            Err(error) => {
+                tracing::warn!(target: "wisp", %error, schedule_id = %schedule.id, "failed to claim schedule");
+                return;
+            }
+        }
+    }
+    let result = run_scheduled_turn(&app, &state, &schedule).await;
+    let (status, error) = match &result {
+        Ok(_) => ("fired", None),
+        Err(error) => ("failed", Some(error.clone())),
+    };
+    let run = ScheduleRunRecord {
+        id: Uuid::new_v4().to_string(),
+        schedule_id: schedule.id.clone(),
+        frame_id: result.ok().flatten().or_else(|| schedule.frame_id.clone()),
+        status: status.into(),
+        error,
+        fired_at: now,
+    };
+    if let Err(error) = state.store.record_schedule_run(&run).await {
+        tracing::warn!(target: "wisp", %error, schedule_id = %schedule.id, "failed to record schedule run");
+    }
+}
+
+/// Returns the frame the turn ran in. A schedule bound to a session fires
+/// into it; an unbound schedule gets a fresh session per fire.
+async fn run_scheduled_turn(
+    app: &AppHandle,
+    state: &State<'_, AppState>,
+    schedule: &ScheduleRecord,
+) -> Result<Option<String>, String> {
+    let frame_id = match schedule.frame_id.as_deref().map(str::trim) {
+        Some(id) if !id.is_empty() => id.to_string(),
+        _ => create_session_frame(&state.store, &schedule.project_id).await?,
+    };
+    let references = schedule
+        .skill
+        .as_deref()
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .map(|name| {
+            vec![ComposerReferenceArg::Skill {
+                name: name.to_string(),
+            }]
+        });
+    // Provenance for both the user and the model: this turn was not typed.
+    let message = format!("[Scheduled task: {}]\n\n{}", schedule.name, schedule.prompt);
+    send_message_inner(
+        state.inner(),
+        app.clone(),
+        "main",
+        Some(frame_id.clone()),
+        message,
+        None,
+        references,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    .await
+    .map(Some)
+}
+
+struct ScheduleArgs {
+    name: String,
+    prompt: String,
+    skill: Option<String>,
+    frame_id: Option<String>,
+    interval_secs: i64,
+    next_run_at: i64,
+}
+
+fn normalize_schedule_args(
+    name: &str,
+    prompt: &str,
+    interval_secs: i64,
+    skill: Option<String>,
+    session_id: Option<String>,
+    start_at: Option<i64>,
+    now: i64,
+) -> Result<ScheduleArgs, String> {
+    let prompt = prompt.trim();
+    if prompt.is_empty() {
+        return Err("Schedule prompt cannot be empty.".into());
+    }
+    let name = {
+        let name = name.trim();
+        if name.is_empty() {
+            prompt
+                .lines()
+                .next()
+                .unwrap_or_default()
+                .chars()
+                .take(MAX_NAME_CHARS)
+                .collect()
+        } else {
+            name.chars().take(MAX_NAME_CHARS).collect()
+        }
+    };
+    let skill = skill
+        .map(|skill| skill.trim().to_string())
+        .filter(|skill| !skill.is_empty());
+    let frame_id = session_id
+        .map(|id| id.trim().to_string())
+        .filter(|id| !id.is_empty());
+    // A past start date means "catch up now"; an absent one means the first
+    // fire happens one interval from creation.
+    let next_run_at = start_at.unwrap_or(now + interval_secs.max(MIN_INTERVAL_SECS));
+    Ok(ScheduleArgs {
+        name,
+        prompt: prompt.to_string(),
+        skill,
+        frame_id,
+        interval_secs: interval_secs.max(MIN_INTERVAL_SECS),
+        next_run_at,
+    })
+}
+
+async fn load_schedule(state: &AppState, id: &str) -> Result<ScheduleRecord, String> {
+    state
+        .store
+        .get_schedule(id.trim())
+        .await
+        .map_err(|error| error.to_string())?
+        .ok_or_else(|| "The schedule no longer exists.".to_string())
+}
+
+#[tauri::command]
+pub(crate) async fn create_schedule(
+    state: State<'_, AppState>,
+    window: tauri::WebviewWindow,
+    name: String,
+    prompt: String,
+    interval_secs: i64,
+    session_id: Option<String>,
+    skill: Option<String>,
+    start_at: Option<i64>,
+) -> Result<ScheduleRecord, String> {
+    let now = chrono::Utc::now().timestamp();
+    let args = normalize_schedule_args(
+        &name,
+        &prompt,
+        interval_secs,
+        skill,
+        session_id,
+        start_at,
+        now,
+    )?;
+    let project_id = state.active(window.label()).id;
+    if let Some(frame_id) = args.frame_id.as_deref() {
+        let owner = state
+            .store
+            .frame_project_id(frame_id)
+            .await
+            .map_err(|error| error.to_string())?
+            .ok_or_else(|| "The target session no longer exists.".to_string())?;
+        if owner != project_id {
+            return Err("The target session belongs to a different project.".into());
+        }
+    }
+    let schedule = ScheduleRecord {
+        id: Uuid::new_v4().to_string(),
+        project_id,
+        frame_id: args.frame_id,
+        name: args.name,
+        prompt: args.prompt,
+        skill: args.skill,
+        interval_secs: args.interval_secs,
+        enabled: true,
+        next_run_at: args.next_run_at,
+        last_run_at: None,
+        created_at: now,
+        updated_at: now,
+    };
+    state
+        .store
+        .create_schedule(&schedule)
+        .await
+        .map_err(|error| error.to_string())?;
+    Ok(schedule)
+}
+
+#[tauri::command]
+pub(crate) async fn list_schedules(
+    state: State<'_, AppState>,
+    window: tauri::WebviewWindow,
+) -> Result<Vec<ScheduleRecord>, String> {
+    let project_id = state.active(window.label()).id;
+    state
+        .store
+        .list_schedules(&project_id)
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+pub(crate) async fn list_schedule_runs(
+    state: State<'_, AppState>,
+    id: String,
+    limit: Option<usize>,
+) -> Result<Vec<ScheduleRunRecord>, String> {
+    state
+        .store
+        .list_schedule_runs(id.trim(), limit.unwrap_or(50))
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+pub(crate) async fn set_schedule_enabled(
+    state: State<'_, AppState>,
+    id: String,
+    enabled: bool,
+) -> Result<(), String> {
+    let now = chrono::Utc::now().timestamp();
+    if state
+        .store
+        .set_schedule_enabled(id.trim(), enabled, now)
+        .await
+        .map_err(|error| error.to_string())?
+    {
+        Ok(())
+    } else {
+        Err("The schedule no longer exists.".into())
+    }
+}
+
+#[tauri::command]
+pub(crate) async fn delete_schedule(state: State<'_, AppState>, id: String) -> Result<(), String> {
+    state
+        .store
+        .delete_schedule(id.trim())
+        .await
+        .map_err(|error| error.to_string())
+}
+
+/// Fire immediately, out of cadence: the slot schedule is left untouched.
+#[tauri::command]
+pub(crate) async fn run_schedule_now(
+    state: State<'_, AppState>,
+    app: AppHandle,
+    id: String,
+) -> Result<(), String> {
+    let schedule = load_schedule(&state, &id).await?;
+    let now = chrono::Utc::now().timestamp();
+    tauri::async_runtime::spawn(async move {
+        fire_schedule(app, schedule, now, false).await;
+    });
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn schedule_args_validate_and_default() {
+        assert!(normalize_schedule_args("x", "  ", 3600, None, None, None, 1_000).is_err());
+
+        let args = normalize_schedule_args(
+            "",
+            "Summarize new papers.\nDetails follow.",
+            86_400,
+            Some(" literature-review ".into()),
+            Some(" frame-1 ".into()),
+            None,
+            1_000,
+        )
+        .unwrap();
+        assert_eq!(args.name, "Summarize new papers.");
+        assert_eq!(args.skill.as_deref(), Some("literature-review"));
+        assert_eq!(args.frame_id.as_deref(), Some("frame-1"));
+        // No explicit start: first fire is one interval out.
+        assert_eq!(args.next_run_at, 1_000 + 86_400);
+    }
+
+    #[test]
+    fn schedule_args_clamp_interval_and_keep_past_start_for_catch_up() {
+        let args = normalize_schedule_args("daily", "go", 5, None, None, Some(500), 1_000).unwrap();
+        assert_eq!(args.interval_secs, MIN_INTERVAL_SECS);
+        assert_eq!(args.next_run_at, 500, "past start stays due for catch-up");
+
+        let future =
+            normalize_schedule_args("daily", "go", 86_400, None, None, Some(9_999), 1_000).unwrap();
+        assert_eq!(future.next_run_at, 9_999);
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Users want recurring agent work — e.g. a daily literature/progress summary ("每日总结") — without manually opening a session and typing the same prompt every time. The app needs a durable trigger that runs a prompt (optionally bound to a user-developed skill) on a schedule.

## Scope decision

Per discussion: v0 fires **only while the app is running** (no system-level daemon), and slots missed while the app was closed collapse into **one catch-up fire** on the next launch.

## Changes

- **`crates/wisp-store/src/schedules.rs`** (new): `ScheduleRecord` / `ScheduleRunRecord`, CRUD, `due_schedules` scan, atomic `claim_schedule_fire` (a slow turn or concurrent tick can never double-fire a slot), and pure `next_slot_after` slot math. Slot advancement is anchored at the previous slot, so an 08:00 daily schedule stays at 08:00 regardless of poll timing.
- **`crates/wisp-store/src/lib.rs`**: idempotent migration `0048_schedules` (`schedules` + `schedule_runs` tables, due-scan index). `frame_id` is deliberately not an FK so a schedule survives its target session being deleted.
- **`src-tauri/src/scheduler.rs`** (new): poll loop (30s interval, 5s startup delay) spawned at app setup. Each fire routes through `send_message_inner` — the same path as channel messages and delegation auto-resume — so scheduled turns persist to the transcript, stream through existing turn events, and queue behind a running turn via the per-session workflow lock. A schedule bound to a session fires into it; an unbound schedule gets a fresh session per fire. The prompt is prefixed `[Scheduled task: <name>]` for provenance. Every fire is recorded in `schedule_runs` (`fired`/`failed` + error).
- **Tauri commands**: `create_schedule`, `list_schedules`, `list_schedule_runs`, `set_schedule_enabled`, `delete_schedule`, `run_schedule_now` (manual, out-of-cadence).
- **`docs/superpowers/specs/2026-08-15-scheduled-automations-design.md`**: design note.

## Tests

- wisp-store: CRUD/enable roundtrip, due-scan filtering, atomic claim (second claim for the same slot loses), slot advancement, schedule-runs ordering/limits, cascade delete; pure `next_slot_after` boundary tests.
- src-tauri: argument validation/defaulting, interval clamping, past-start catch-up semantics.
- Migration-list test updated for `0048_schedules`.
- `cargo fmt --all -- --check` clean; `cargo test --workspace` green (25 suites).

## Manual smoke steps

1. Create a schedule via `create_schedule` (e.g. interval 60s, a prompt like "say hello", no session) and wait for the poll tick — a new session appears with the fired turn.
2. Create one with `session_id` set — the turn lands in that conversation.
3. Close the app past a due slot, relaunch — one catch-up fire runs within ~35s.
4. `list_schedule_runs` shows `fired` entries; disabling stops further fires; `run_schedule_now` fires immediately without disturbing the cadence.

## Known limitations / follow-ups

- No UI surface yet; commands are ready for a schedules panel (roadmap step 5).
- No cron expressions — interval + anchor only (a daily-at-time UI computes `start_at` client-side).
- No firing while the app is closed (would need launchd / Task Scheduler / systemd registration).
- No workflow targets — prompt/skill only; workflow binding can reuse the same tables.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b307db5f-3cf1-4f49-bd54-49b9355bfd7a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b307db5f-3cf1-4f49-bd54-49b9355bfd7a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

