### PR TITLE
Refine queued follow-ups into a composer card

### DIFF
--- a/docs/ui-design-principles.md
+++ b/docs/ui-design-principles.md
@@ -26,6 +26,12 @@
 - Chat empty and research-graph empty reuse the logo treatment (`.empty-logo` / `.rp-empty-icon.brand`) instead of dashed placeholders.
 - Research graph headings use Source Serif at `--text-lg`; list/canvas stay utilitarian.
 
+## Queued follow-ups
+
+- Follow-ups typed while a turn is running sit in a compact card above the composer, not as dashed transcript bubbles.
+- The card shows a count, the parked text, and icon actions. Reorder controls appear only when two or more items are waiting. Cut-in stays a labeled clay pill because it is the distinctive action.
+- Icon-only queue controls keep both `title` and `aria-label`.
+
 ## Composer attachments and references
 
 - The composer keeps its top-edge resize affordance invisible at rest while preserving the full-width drag target and persisted custom height.

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -10347,12 +10347,16 @@ test("a running conversation accepts another message for queueing", async ({ pag
 
   await composer(page).fill("queued");
   // Queue (#433): sending into a busy session queues directly — no dialog. The
-  // busy send button reads "Queue…" and the message parks as an editable bubble.
+  // busy send button reads "Queue…" and the message parks in the composer queue.
   const send = page.getByRole("button", { name: "Queue…" });
   await expect(send).toBeEnabled({ timeout: 500 });
   await send.click();
   const queued = page.locator(".msg.user.queued .body", { hasText: /^queued$/ });
   await expect(queued).toBeVisible({ timeout: 500 });
+  await expect(page.getByTestId("composer-queue")).toBeVisible();
+  await expect(page.locator(".thread .msg.user.queued")).toHaveCount(0);
+  await expect(page.getByTestId("composer-queue")).toContainText("1 queued");
+  await expect(page.locator(".msg.user.queued").getByTitle("Move up")).toHaveCount(0);
 
   // The parked turn goes through enqueue_turn, not send_message.
   await expect.poll(async () => page.evaluate(() =>
@@ -10401,6 +10405,7 @@ test("queued follow-ups can be reordered up and down (#433)", async ({ page }) =
 
   const queuedTexts = () => page.locator(".msg.user.queued .body").allInnerTexts();
   expect(await queuedTexts()).toEqual(["bravo", "charlie"]);
+  await expect(page.getByTestId("composer-queue")).toContainText("2 queued");
 
   // Move charlie up → [charlie, bravo]; then back down → [bravo, charlie].
   const charlieRow = page.locator(".msg.user.queued", { hasText: "charlie" });

--- a/ui/src/app_support/messages.rs
+++ b/ui/src/app_support/messages.rs
@@ -226,6 +226,7 @@ pub(crate) fn compose_icon(kind: &str) -> impl IntoView {
         "split" => view! { <rect x="3" y="4" width="18" height="16" rx="2"/><path d="M14 4v16"/> }.into_view(),
         "runtime-panel" => view! { <rect x="3" y="3" width="18" height="18" rx="2"/><path d="M14 3v18"/><path d="M3 15h11"/><circle cx="17.5" cy="7" r="1" fill="currentColor" stroke="none"/><circle cx="17.5" cy="11" r="1" fill="currentColor" stroke="none"/> }.into_view(),
         "play" => view! { <path d="M6 4.5v15l13-7.5Z"/> }.into_view(),
+        "bolt" => view! { <path d="M13 2 3 14h8l-1 8 10-12h-8l1-8z"/> }.into_view(),
         "up" => view! { <path d="m18 15-6-6-6 6"/> }.into_view(),
         "copy" => view! { <rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/> }.into_view(),
         "star" => view! { <path d="m12 2.7 2.85 5.77 6.37.93-4.61 4.49 1.09 6.34L12 17.23l-5.7 3 1.09-6.34L2.78 9.4l6.37-.93Z"/> }.into_view(),
@@ -461,51 +462,109 @@ pub(crate) enum QueueOp {
     MoveDown(u64),
 }
 
-/// Queue (#433): a queued user turn bubble with edit / cancel / cut-in.
-/// `id == 0` marks a transient cut-in bubble (no controls). `can_cut_in` is
-/// false for ACP sessions, which cannot fold a message into a running turn.
+/// Queue (#433): one parked follow-up in the composer card. `id == 0` is a
+/// transient cut-in (no controls). `can_cut_in` is false for ACP sessions.
+/// Reorder controls stay hidden when the queue has only one item.
 #[component]
 pub(crate) fn QueuedMessage(
     id: u64,
     text: String,
+    user_index: usize,
     can_cut_in: bool,
+    can_reorder: bool,
     on_queue: Callback<QueueOp>,
 ) -> impl IntoView {
     let locale = use_locale();
     let show_controls = id != 0;
+    let preview = text.clone();
     view! {
-        <div class="role">{move || t(locale.get(), "composer.queued")}</div>
-        <div class="user-bubble queued-bubble">
-            <div class="body">{text}</div>
-            {show_controls.then(|| view! {
-                <div class="queue-actions">
-                    <button type="button" class="tool-btn queue-move"
-                        title=move || t(locale.get(), "queue.move_up")
-                        on:click=move |_| on_queue.call(QueueOp::MoveUp(id))>
-                        {compose_icon("up")}
-                    </button>
-                    <button type="button" class="tool-btn queue-move"
-                        title=move || t(locale.get(), "queue.move_down")
-                        on:click=move |_| on_queue.call(QueueOp::MoveDown(id))>
-                        {compose_icon("chevron-down")}
-                    </button>
-                    {can_cut_in.then(|| view! {
-                        <button type="button" class="tool-btn"
-                            on:click=move |_| on_queue.call(QueueOp::CutIn(id))>
-                            {move || t(locale.get(), "queue.cut_in")}
+        <div class="msg user queued" data-user-index=user_index.to_string()>
+            <div class="queued-card">
+                <div class="body" title=preview>{text}</div>
+                {show_controls.then(move || view! {
+                    <div class="queue-actions">
+                        {can_cut_in.then(|| view! {
+                            <button type="button" class="queue-cut-in"
+                                on:click=move |_| on_queue.call(QueueOp::CutIn(id))>
+                                {compose_icon("bolt")}
+                                <span>{move || t(locale.get(), "queue.cut_in")}</span>
+                            </button>
+                        })}
+                        {can_reorder.then(|| view! {
+                            <button type="button" class="msg-icon-btn"
+                                title=move || t(locale.get(), "queue.move_up")
+                                aria-label=move || t(locale.get(), "queue.move_up")
+                                on:click=move |_| on_queue.call(QueueOp::MoveUp(id))>
+                                {compose_icon("up")}
+                            </button>
+                            <button type="button" class="msg-icon-btn"
+                                title=move || t(locale.get(), "queue.move_down")
+                                aria-label=move || t(locale.get(), "queue.move_down")
+                                on:click=move |_| on_queue.call(QueueOp::MoveDown(id))>
+                                {compose_icon("chevron-down")}
+                            </button>
+                        })}
+                        <button type="button" class="msg-icon-btn"
+                            title=move || t(locale.get(), "queue.edit")
+                            aria-label=move || t(locale.get(), "queue.edit")
+                            on:click=move |_| on_queue.call(QueueOp::Edit(id))>
+                            {compose_icon("edit")}
                         </button>
-                    })}
-                    <button type="button" class="tool-btn"
-                        on:click=move |_| on_queue.call(QueueOp::Edit(id))>
-                        {move || t(locale.get(), "queue.edit")}
-                    </button>
-                    <button type="button" class="tool-btn"
-                        on:click=move |_| on_queue.call(QueueOp::Cancel(id))>
-                        {move || t(locale.get(), "settings.cancel")}
-                    </button>
-                </div>
-            })}
+                        <button type="button" class="msg-icon-btn queue-remove"
+                            title=move || t(locale.get(), "queue.remove")
+                            aria-label=move || t(locale.get(), "queue.remove")
+                            on:click=move |_| on_queue.call(QueueOp::Cancel(id))>
+                            {compose_icon("trash")}
+                        </button>
+                    </div>
+                })}
+            </div>
         </div>
+    }
+}
+
+/// Compact card above the composer: parked follow-ups sit with the input
+/// instead of as dashed transcript bubbles.
+#[component]
+pub(crate) fn ComposerQueue(
+    items: RwSignal<Vec<ChatItem>>,
+    user_offset: Signal<usize>,
+    can_cut_in: Signal<bool>,
+    on_queue: Callback<QueueOp>,
+) -> impl IntoView {
+    let locale = use_locale();
+    view! {
+        {move || {
+            let rows = queued_turn_rows(&items.get(), user_offset.get());
+            let len = rows.len();
+            let can_cut_in = can_cut_in.get();
+            let can_reorder = len > 1;
+            let loc = locale.get();
+            (!rows.is_empty()).then(move || view! {
+                <div class="composer-queue" data-testid="composer-queue"
+                    role="region"
+                    aria-label=t(loc, "queue.region")>
+                    <div class="composer-queue-head">
+                        <span class="composer-queue-dot" aria-hidden="true"></span>
+                        <span>{tf(loc, "queue.header", &[("n", &len.to_string())])}</span>
+                    </div>
+                    <div class="composer-queue-list">
+                        {rows.into_iter().map(|row| {
+                            view! {
+                                <QueuedMessage
+                                    id=row.id
+                                    text=row.text
+                                    user_index=row.user_index
+                                    can_cut_in=can_cut_in
+                                    can_reorder=can_reorder
+                                    on_queue=on_queue
+                                />
+                            }
+                        }).collect_view()}
+                    </div>
+                </div>
+            })
+        }}
     }
 }
 

--- a/ui/src/app_support/transcript.rs
+++ b/ui/src/app_support/transcript.rs
@@ -217,6 +217,35 @@ pub(crate) fn user_message_index(items: &[ChatItem], ui_index: usize) -> Option<
     )
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct QueuedTurnRow {
+    pub id: u64,
+    pub text: String,
+    pub user_index: usize,
+}
+
+/// Parked follow-ups for the composer card, with outline `data-user-index`
+/// values that stay aligned with `user_turn_index`.
+pub(crate) fn queued_turn_rows(items: &[ChatItem], user_offset: usize) -> Vec<QueuedTurnRow> {
+    let mut n = 0;
+    let mut rows = Vec::new();
+    for item in items {
+        match item {
+            ChatItem::User(_) => n += 1,
+            ChatItem::QueuedUser { id, text } => {
+                rows.push(QueuedTurnRow {
+                    id: *id,
+                    text: text.clone(),
+                    user_index: user_offset + n,
+                });
+                n += 1;
+            }
+            _ => {}
+        }
+    }
+    rows
+}
+
 pub(crate) fn user_turn_index(items: &[ChatItem], ui_index: usize) -> Option<usize> {
     if !matches!(
         items.get(ui_index),
@@ -468,7 +497,8 @@ mod transcript_render_window_tests {
 mod conversation_outline_tests {
     use super::{
         conversation_outline_target_is_loaded, merge_conversation_outline, owning_user_turn_index,
-        transcript_item_timestamp, turn_duration_ms, user_turn_index,
+        queued_turn_rows, transcript_item_timestamp, turn_duration_ms, user_turn_index,
+        QueuedTurnRow,
     };
     use crate::dto::{ChatItem, SessionOutlineItem};
 
@@ -536,6 +566,50 @@ mod conversation_outline_tests {
         assert_eq!(owning_user_turn_index(&items, 2), Some(1));
         assert!(conversation_outline_target_is_loaded(&items, 1, 2));
         assert!(!conversation_outline_target_is_loaded(&items, 1, 0));
+        assert_eq!(
+            queued_turn_rows(&items, 1),
+            vec![QueuedTurnRow {
+                id: 7,
+                text: "third".into(),
+                user_index: 2,
+            }]
+        );
+    }
+
+    #[test]
+    fn composer_queue_rows_skip_sent_turns_and_keep_fifo_order() {
+        let items = vec![
+            ChatItem::User("already sent".into()),
+            ChatItem::Assistant {
+                text: "working".into(),
+                model: None,
+                resources: Vec::new(),
+            },
+            ChatItem::QueuedUser {
+                id: 2,
+                text: "first".into(),
+            },
+            ChatItem::QueuedUser {
+                id: 3,
+                text: "second".into(),
+            },
+        ];
+        assert_eq!(
+            queued_turn_rows(&items, 4),
+            vec![
+                QueuedTurnRow {
+                    id: 2,
+                    text: "first".into(),
+                    user_index: 5,
+                },
+                QueuedTurnRow {
+                    id: 3,
+                    text: "second".into(),
+                    user_index: 6,
+                },
+            ]
+        );
+        assert!(queued_turn_rows(&[ChatItem::User("only sent".into())], 0).is_empty());
     }
 
     #[test]

--- a/ui/src/chat_render.rs
+++ b/ui/src/chat_render.rs
@@ -17,6 +17,7 @@ pub(crate) fn renders_nothing(item: &ChatItem) -> bool {
     matches!(item, ChatItem::Assistant { text, .. } if text.trim().is_empty())
         || matches!(item, ChatItem::Tool { name, .. } if name == "attempt_completion")
         || matches!(item, ChatItem::FileChanged(_))
+        || matches!(item, ChatItem::QueuedUser { .. })
 }
 
 pub(crate) fn class_for(item: &ChatItem) -> &'static str {
@@ -158,6 +159,7 @@ pub(crate) fn context_usage_detail_text(details: &ContextUsageDetails, color: &s
 mod token_format_tests {
     use super::{
         context_percent, context_usage_rows, fmt_context_limit, fmt_context_tokens, fmt_tokens,
+        renders_nothing,
     };
     use crate::dto::{ContextUsage, ContextUsageSnapshot};
     use crate::i18n::Locale;
@@ -166,6 +168,16 @@ mod token_format_tests {
     fn small_counts_are_not_rounded_to_zero() {
         assert_eq!(fmt_tokens(81), "81");
         assert_eq!(fmt_tokens(136_286), "136.3k");
+    }
+
+    #[test]
+    fn queued_turns_do_not_occupy_a_transcript_row() {
+        use crate::dto::ChatItem;
+        assert!(renders_nothing(&ChatItem::QueuedUser {
+            id: 1,
+            text: "later".into(),
+        }));
+        assert!(!renders_nothing(&ChatItem::User("sent".into())));
     }
 
     #[test]
@@ -1355,7 +1367,6 @@ pub(crate) fn render_item(
     on_review: Callback<String>,
     on_approval: Callback<(String, bool, Option<String>, String)>,
     on_resume: Callback<usize>,
-    on_queue: Callback<QueueOp>,
     disclosure_state: RwSignal<HashMap<String, bool>>,
     plan_mode_active: Signal<bool>,
     plan_compat: Signal<bool>,
@@ -1381,14 +1392,7 @@ pub(crate) fn render_item(
                 on_file=on_file
             />
         }.into_view(),
-        ChatItem::QueuedUser { id, text } => view! {
-            <QueuedMessage
-                id=*id
-                text=text.clone()
-                can_cut_in=can_modify
-                on_queue=on_queue
-            />
-        }.into_view(),
+        ChatItem::QueuedUser { .. } => view! {}.into_view(),
         ChatItem::Assistant { text, .. } if text.trim().is_empty() => view! {}.into_view(),
         ChatItem::Assistant { text, .. } if text.starts_with("Error: ") => {
             let msg = text.strip_prefix("Error: ").unwrap_or(text.as_str()).to_string();

--- a/ui/src/i18n.rs
+++ b/ui/src/i18n.rs
@@ -292,8 +292,11 @@ fn lookup(locale: Locale, key: &str) -> Option<&'static str> {
         (Locale::En, "composer.interrupt_replace") => Some("Interrupt & replace"),
         (Locale::En, "queue.cut_in") => Some("Guide now"),
         (Locale::En, "queue.edit") => Some("Edit"),
+        (Locale::En, "queue.remove") => Some("Remove"),
         (Locale::En, "queue.move_up") => Some("Move up"),
         (Locale::En, "queue.move_down") => Some("Move down"),
+        (Locale::En, "queue.header") => Some("{n} queued"),
+        (Locale::En, "queue.region") => Some("Queued messages"),
         (Locale::En, "composer.send_options") => Some("Message options"),
         (Locale::En, "composer.plan_first") => Some("Plan first"),
         (Locale::En, "composer.full_permission") => Some("Full Permission"),
@@ -2534,8 +2537,11 @@ Do not leave generated files in the project root.",
         (Locale::Zh, "composer.interrupt_replace") => Some("中断并替换"),
         (Locale::Zh, "queue.cut_in") => Some("立刻引导"),
         (Locale::Zh, "queue.edit") => Some("编辑"),
+        (Locale::Zh, "queue.remove") => Some("移除"),
         (Locale::Zh, "queue.move_up") => Some("上移"),
         (Locale::Zh, "queue.move_down") => Some("下移"),
+        (Locale::Zh, "queue.header") => Some("{n} 条排队"),
+        (Locale::Zh, "queue.region") => Some("排队消息"),
         (Locale::Zh, "composer.send_options") => Some("消息选项"),
         (Locale::Zh, "composer.plan_first") => Some("先计划"),
         (Locale::Zh, "composer.full_permission") => Some("完全权限"),
@@ -5010,6 +5016,12 @@ mod queue_label_tests {
         assert_eq!(t(Locale::En, "queue.cut_in"), "Guide now");
         assert_eq!(t(Locale::Zh, "queue.edit"), "编辑");
         assert_eq!(t(Locale::En, "queue.edit"), "Edit");
+        assert_eq!(t(Locale::Zh, "queue.remove"), "移除");
+        assert_eq!(t(Locale::En, "queue.remove"), "Remove");
+        assert_eq!(tf(Locale::En, "queue.header", &[("n", "1")]), "1 queued");
+        assert_eq!(tf(Locale::Zh, "queue.header", &[("n", "2")]), "2 条排队");
+        assert_eq!(t(Locale::En, "queue.region"), "Queued messages");
+        assert_eq!(t(Locale::Zh, "queue.region"), "排队消息");
         // Sent-message rewind keeps its own label.
         assert_eq!(t(Locale::Zh, "msg.edit"), "回溯");
         assert_eq!(t(Locale::En, "msg.edit"), "Rewind");

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -900,7 +900,7 @@ fn App() -> impl IntoView {
         });
     });
     let send_mode_menu_open = create_rw_signal(false);
-    // Queue (#433): monotonic key for optimistic queued bubbles, shared with the
+    // Queue (#433): monotonic key for optimistic queued follow-ups, shared with the
     // backend queue item so edit/cancel/cut-in target the same row.
     let queue_seq = create_rw_signal(0u64);
     let side_chat_input = create_rw_signal(String::new());
@@ -4106,7 +4106,7 @@ fn App() -> impl IntoView {
         }
     };
 
-    // Queue (#433): edit / cancel / cut-in a parked follow-up from its bubble.
+    // Queue (#433): edit / cancel / cut-in a parked follow-up from the composer card.
     let on_queue = Callback::new(move |op: QueueOp| {
         let sid = active_session.get_untracked().unwrap_or_default();
         if sid.is_empty() {
@@ -4177,6 +4177,19 @@ fn App() -> impl IntoView {
             .unwrap();
             let _ = invoke("queued_turn_action", args).await;
         });
+    });
+    let composer_queue_offset = Signal::derive(move || {
+        active_session
+            .get()
+            .and_then(|id| transcript_pages.with(|pages| pages.get(&id).copied()))
+            .map_or(0, |page| page.user_offset)
+    });
+    let composer_queue_can_cut_in = Signal::derive(move || {
+        active_acp_agent_id.get().is_none()
+            && !matches!(
+                active_branch_state.get().as_deref(),
+                Some("merged" | "orphaned")
+            )
     });
 
     let resume_turn = {
@@ -11152,7 +11165,7 @@ fn App() -> impl IntoView {
                                                     active_acp_agent_id.get().is_none()
                                                         && !matches!(active_branch_state.get_untracked().as_deref(), Some("merged" | "orphaned")),
                                                     can_branch, show_actions, can_undo, show_explore, can_explore, edit_message, branch_message, undo_message, explore_turn_index.unwrap_or_default(), start_exploration_from_head, session_id,
-                                                    request_turn_memory, request_session_review, respond_confirm, on_resume, on_queue,
+                                                    request_turn_memory, request_session_review, respond_confirm, on_resume,
                                                     step_disclosure_state,
                                                     plan_mode_active, plan_compat, on_plan_decision,
                                                     on_question_answer, jump_to_review_message,
@@ -11578,6 +11591,14 @@ fn App() -> impl IntoView {
                             }
                         })
                 }}
+                {move || (!demo_mode.get()).then(|| view! {
+                    <ComposerQueue
+                        items=items
+                        user_offset=composer_queue_offset
+                        can_cut_in=composer_queue_can_cut_in
+                        on_queue=on_queue
+                    />
+                })}
                 <div class="composer-inner"
                     class:composer-dragover=move || drag_over.get()
                     on:dragover=on_drag_over

--- a/ui/src/styles/chat.css
+++ b/ui/src/styles/chat.css
@@ -480,8 +480,6 @@
 /* 长消息默认截断（截断在 Rust 侧做，避免 line-clamp 在 padding 区漏出半行） */
 .msg.user .body-toggle { align-self: flex-end; margin-top: -4px; opacity: 1; }
 .msg.user .user-message-time { align-self: flex-end; margin: -2px 4px -3px 0; }
-.msg.user.queued .role { color: var(--clay); }
-.msg.user.queued .body { border-style: dashed; color: var(--text-muted); background: color-mix(in srgb, var(--bg-panel) 70%, var(--clay) 6%); }
 .msg.user.outline-target .body { box-shadow: inset 0 0 0 1px var(--clay), 0 0 0 3px var(--clay-soft); }
 .msg .msg-actions { display: flex; gap: 2px; margin-top: 4px; opacity: 0; transition: opacity .15s ease; }
 .msg.user .msg-actions { justify-content: flex-end; }
@@ -612,9 +610,54 @@ button.msg-icon-btn svg { width: 14px; height: 14px; }
 button.tool-btn { background: var(--bg-app); color: var(--text-muted); border: 1px solid var(--border); border-radius: var(--radius-xs); padding: 4px 10px; font: inherit; font-size: 11.5px; cursor: pointer; }
 button.tool-btn:hover { color: var(--text); border-color: var(--border-strong); }
 button.tool-btn.card-copy { margin-left: auto; flex: 0 0 auto; padding: 2px 8px; font-size: 11px; }
-/* Queue (#433): actions on a parked follow-up bubble. */
-.queued-bubble .queue-actions { display: flex; gap: 6px; margin-top: 6px; flex-wrap: wrap; align-items: center; }
-.queued-bubble .queue-move { padding: 4px 6px; display: inline-flex; align-items: center; }
+/* Queue (#433): parked follow-ups sit in a card above the composer. */
+.composer-queue {
+  max-width: var(--chat-col-max); width: 100%; box-sizing: border-box; margin: 0 auto 8px;
+  padding: 8px; border: 1px solid color-mix(in srgb, var(--clay) 20%, var(--border));
+  border-radius: var(--radius); background: color-mix(in srgb, var(--bg-elev) 82%, var(--clay-soft));
+  box-shadow: var(--shadow-sm);
+}
+.composer.demo-read-only .composer-queue { display: none; }
+.composer-queue-head {
+  display: flex; align-items: center; gap: 7px; padding: 2px 6px 7px;
+  color: var(--clay-strong); font-size: 11px; font-weight: 600;
+}
+.composer-queue-dot {
+  width: 6px; height: 6px; border-radius: 50%; background: var(--clay);
+  box-shadow: 0 0 0 3px var(--clay-soft);
+  animation: queue-dot-pulse 1.8s ease-in-out infinite;
+}
+@keyframes queue-dot-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: .4; transform: scale(.82); }
+}
+.composer-queue-list { display: flex; flex-direction: column; gap: 6px; }
+.composer-queue .msg.user.queued { align-self: stretch; width: 100%; max-width: none; }
+.queued-card {
+  display: flex; align-items: flex-start; gap: 10px; min-width: 0;
+  padding: 8px 8px 8px 10px; border: 1px solid var(--border);
+  border-radius: var(--radius-sm); background: var(--bg-elev);
+}
+.composer-queue .msg.user .body {
+  flex: 1 1 auto; min-width: 0; padding: 2px 0; border: 0; border-radius: 0;
+  background: transparent; box-shadow: none; color: var(--text); text-align: left;
+  display: -webkit-box; -webkit-line-clamp: 4; -webkit-box-orient: vertical; overflow: hidden;
+  font-size: calc(var(--ui-font-size, 14px) - 0.5px); line-height: 1.45;
+}
+.composer-queue .queue-actions {
+  display: flex; align-items: center; gap: 2px; flex: 0 0 auto; margin: 0;
+}
+.composer-queue .queue-actions .msg-icon-btn { width: 28px; height: 28px; opacity: .72; }
+.composer-queue .queue-actions .msg-icon-btn:hover { opacity: 1; }
+.composer-queue .queue-actions svg { width: 15px; height: 15px; }
+.composer-queue .queue-cut-in {
+  display: inline-flex; align-items: center; gap: 5px; height: 28px; padding: 0 10px;
+  margin-right: 2px; border: 0; border-radius: 999px; background: var(--clay-soft);
+  color: var(--clay-strong); font: inherit; font-size: 11.5px; font-weight: 600; cursor: pointer;
+}
+.composer-queue .queue-cut-in:hover { background: var(--clay); color: var(--on-clay); }
+.composer-queue .queue-cut-in svg { width: 14px; height: 14px; }
+.composer-queue .queue-remove:hover { color: var(--err); }
 .tool-input, .tool-output { color: var(--text-muted); white-space: pre-wrap; max-height: 260px; overflow: auto; font-family: var(--font-mono); font-size: 12px; line-height: 1.5; margin: 0 0 8px; padding: 8px 10px; background: var(--bg-app); border: 1px solid var(--border); border-radius: var(--radius-xs); }
 .tool-output { margin-bottom: 0; }
 .tool .content { color: var(--text-muted); margin-top: 8px; white-space: pre-wrap; max-height: 260px; overflow: auto; font-family: var(--font-mono); font-size: 12px; line-height: 1.5; }
@@ -1672,7 +1715,8 @@ button.stop:disabled { opacity: .6; cursor: default; }
   .topbar { padding-left: 10px; padding-right: 10px; }
   .thread { padding: 18px 12px 26px; gap: 16px; }
   .composer { padding-bottom: 8px; }
-  .composer-inner { border-radius: var(--radius-sm); padding-left: 12px; padding-right: 10px; }
+  .composer-inner, .composer-queue { border-radius: var(--radius-sm); }
+  .composer-inner { padding-left: 12px; padding-right: 10px; }
   .composer-actions { gap: 8px; }
   .model-picker-btn { max-width: 126px; }
   .composer-hint { display: none; }
@@ -1682,6 +1726,7 @@ button.stop:disabled { opacity: .6; cursor: default; }
 
 @media (prefers-reduced-motion: reduce) {
   .context-usage-panel { animation: none; }
+  .composer-queue-dot { animation: none; }
 }
 
 /* Saved-excerpt marks (CSS Custom Highlight API). Literal teal so it reads in


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Queued follow-ups looked unfinished: a dashed chat bubble plus a row of five bordered text buttons (`↑` `↓` 立刻引导 / 编辑 / 取消). The queue sat in the transcript instead of with the input, so it felt like an add-on rather than part of sending.

## Change

Park waiting turns in a compact card **above the composer**:

- Count header with a quiet pulse (`1 queued` / `2 条排队`)
- Message text in a light row, not a dashed user bubble
- **Guide now** stays a labeled clay pill (the distinctive action)
- Edit / remove are icon buttons with `title` + `aria-label`
- Move up/down only appear when two or more items are waiting
- Transient cut-in rows (`id == 0`) still have no controls

Queued items no longer occupy transcript rows, so the jump-to-last-message pill targets the last *sent* user turn.

## Files

- `ui/src/app_support/messages.rs` — `ComposerQueue` + restyled `QueuedMessage`
- `ui/src/app_support/transcript.rs` — `queued_turn_rows()` for outline indices
- `ui/src/chat_render.rs` — queued turns render nothing in the thread
- `ui/src/main.rs` — mount the card above `.composer-inner`
- `ui/src/styles/chat.css` — card / row / action styles
- `ui/src/i18n.rs` — `queue.header`, `queue.region`, `queue.remove`
- `docs/ui-design-principles.md` — queued follow-up rules

## Tests

- Unit: queue row indexing, `renders_nothing` for queued turns, i18n labels
- Playwright: queue lives in `.composer-queue`, not `.thread`; single item hides Move up; two items still reorder

## Verification

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cd ui && cargo test` (248 passed)
- `cd ui && cargo check --target wasm32-unknown-unknown`
- `npx playwright test -g queue` (3 passed)

## Smoke

1. Send a long turn, then queue a follow-up — card appears above the input.
2. One item: Guide now / edit / remove only.
3. Two items: reorder, then edit one back into the composer.
4. Escape is unchanged (no new overlay).

## Limits

- Long queued text clamps to 4 lines (full text in `title`).
- Outline highlight (`outline-target`) is not applied on composer rows.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-73c546e9-bc6e-4a60-994d-f68ecaa05391?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-73c546e9-bc6e-4a60-994d-f68ecaa05391&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

