### PR TITLE
Strengthen test quality: remove tautologies, tighten fakes, fix flaky timing

### DIFF
--- a/crates/wisp-core/Cargo.toml
+++ b/crates/wisp-core/Cargo.toml
@@ -22,3 +22,7 @@ sha2 = { workspace = true }
 wisp-llm = { workspace = true }
 wisp-tools = { workspace = true }
 wisp-skills = { workspace = true }
+
+[dev-dependencies]
+# test-util enables tokio::time::pause so retry-backoff tests skip real sleeps.
+tokio = { workspace = true, features = ["test-util"] }

--- a/crates/wisp-core/src/agent.rs
+++ b/crates/wisp-core/src/agent.rs
@@ -2097,9 +2097,9 @@ mod tests {
         assert!(primary.stream_messages.lock().unwrap().is_empty());
     }
 
-    static SPY_RAN: AtomicBool = AtomicBool::new(false);
-
-    struct SpyTool;
+    struct SpyTool {
+        ran: Arc<AtomicBool>,
+    }
 
     #[async_trait]
     impl Tool for SpyTool {
@@ -2116,14 +2116,14 @@ mod tests {
         }
 
         async fn run(&self, _args: &serde_json::Value, _env: &dyn ToolEnv) -> ToolResult {
-            SPY_RAN.store(true, Ordering::SeqCst);
+            self.ran.store(true, Ordering::SeqCst);
             ToolResult::ok("ran")
         }
     }
 
     #[tokio::test]
     async fn truncated_tool_call_is_not_executed() {
-        SPY_RAN.store(false, Ordering::SeqCst);
+        let spy_ran = Arc::new(AtomicBool::new(false));
         let provider = FixedProvider {
             completion: Completion {
                 tool_calls: vec![ToolCall {
@@ -2140,7 +2140,9 @@ mod tests {
             },
         };
         let mut tools = Registry::builtins();
-        tools.add(Box::new(SpyTool));
+        tools.add(Box::new(SpyTool {
+            ran: spy_ran.clone(),
+        }));
         let mut ctx = ContextManager::new(100_000);
         let root = std::env::temp_dir().join(format!(
             "wisp-core-truncated-tool-test-{}",
@@ -2166,7 +2168,7 @@ mod tests {
             err.to_string().contains("output truncated at max_tokens"),
             "unexpected error: {err}"
         );
-        assert!(!SPY_RAN.load(Ordering::SeqCst), "truncated tool ran");
+        assert!(!spy_ran.load(Ordering::SeqCst), "truncated tool ran");
         assert_eq!(ctx.messages.len(), 1, "only the user message is persisted");
         std::fs::remove_dir_all(root).ok();
     }
@@ -2486,8 +2488,7 @@ mod tests {
     async fn identical_successful_tool_call_repeated_breaks_the_loop() {
         // Provider that returns the SAME successful tool call forever. With
         // max_iter=0 the iteration cap is disabled, so only the stuck-loop guard
-        // can stop it. Uses a side-effect-free tool (not SpyTool) to avoid the
-        // shared SPY_RAN static, keeping the test hermetic under parallel runs.
+        // can stop it. Uses a side-effect-free tool.
         let provider = FixedProvider {
             completion: Completion {
                 tool_calls: vec![ToolCall {
@@ -2623,5 +2624,231 @@ mod tests {
             "unexpected error: {err}"
         );
         std::fs::remove_dir_all(root).ok();
+    }
+
+    /// Streams like a real provider: each turn's content is pushed into the
+    /// sink as small text deltas and tool-call argument fragments *before* the
+    /// assembled completion is returned, exercising the streaming path the
+    /// other fakes skip.
+    struct StreamingSequenceProvider {
+        completions: Mutex<VecDeque<Completion>>,
+        stream_calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl Provider for StreamingSequenceProvider {
+        fn name(&self) -> &str {
+            "streaming-sequence"
+        }
+
+        fn model(&self) -> &str {
+            "streaming-sequence"
+        }
+
+        async fn complete(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSchema],
+        ) -> wisp_llm::Result<Completion> {
+            Err(LlmError::Config("complete is not used".into()))
+        }
+
+        async fn stream(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSchema],
+            sink: &mut dyn wisp_llm::StreamSink,
+        ) -> wisp_llm::Result<Completion> {
+            self.stream_calls.fetch_add(1, Ordering::SeqCst);
+            let completion = self
+                .completions
+                .lock()
+                .unwrap()
+                .pop_front()
+                .ok_or(LlmError::Incomplete)?;
+            // Text arrives in small multi-character deltas, like SSE chunks.
+            let mut rest = completion.content.as_str();
+            while !rest.is_empty() {
+                let cut = rest
+                    .char_indices()
+                    .nth(3)
+                    .map(|(i, c)| i + c.len_utf8())
+                    .unwrap_or(rest.len());
+                let (chunk, tail) = rest.split_at(cut);
+                sink.on_text(chunk);
+                rest = tail;
+            }
+            // Tool-call arguments accumulate across fragments.
+            for (index, tool_call) in completion.tool_calls.iter().enumerate() {
+                let arguments = &tool_call.function.arguments;
+                let mid = arguments.len() / 2;
+                sink.on_tool_call(index, &tool_call.function.name, &arguments[..mid]);
+                sink.on_tool_call(index, &tool_call.function.name, arguments);
+            }
+            sink.on_usage(completion.usage.clone());
+            Ok(completion)
+        }
+    }
+
+    /// Records the text deltas the agent loop forwards through its sink.
+    struct RecordingDeltaOutput {
+        text: Mutex<String>,
+    }
+
+    impl Output for RecordingDeltaOutput {
+        fn assistant_text(&self, delta: &str) {
+            self.text.lock().unwrap().push_str(delta);
+        }
+    }
+
+    #[tokio::test]
+    async fn streamed_deltas_reach_the_sink_and_the_tool_still_executes() {
+        let runs = Arc::new(AtomicUsize::new(0));
+        let provider = StreamingSequenceProvider {
+            completions: Mutex::new(VecDeque::from([
+                Completion {
+                    content: "Running the counter now.".into(),
+                    tool_calls: vec![call("count-1", "counter", serde_json::json!({}))],
+                    finish_reason: Some("tool_calls".into()),
+                    ..Completion::default()
+                },
+                Completion {
+                    content: "计数完成 — the tool ran.".into(),
+                    finish_reason: Some("stop".into()),
+                    ..Completion::default()
+                },
+            ])),
+            stream_calls: AtomicUsize::new(0),
+        };
+        let mut tools = Registry::builtins();
+        tools.add(Box::new(CountingTool {
+            name: "counter",
+            runs: runs.clone(),
+        }));
+        let output = RecordingDeltaOutput {
+            text: Mutex::new(String::new()),
+        };
+        let mut ctx = ContextManager::new(100_000);
+
+        let outcome = agent_loop(
+            &mut ctx,
+            &provider,
+            None,
+            &tools,
+            Path::new("."),
+            &output,
+            "count once",
+            0,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome, AgentLoopOutcome::Completed);
+        assert_eq!(provider.stream_calls.load(Ordering::SeqCst), 2);
+        assert_eq!(
+            runs.load(Ordering::SeqCst),
+            1,
+            "the streamed tool call must execute exactly once"
+        );
+        assert_eq!(
+            *output.text.lock().unwrap(),
+            "Running the counter now.计数完成 — the tool ran.",
+            "every text delta must reach the sink in order, multi-byte intact"
+        );
+        let last = ctx.messages.last().unwrap();
+        assert_eq!(last.role, wisp_llm::Role::Assistant);
+        assert_eq!(last.content.as_text(), "计数完成 — the tool ran.");
+    }
+
+    /// Fails with a retriable 503 `fail_times` times (the same error shape as
+    /// `RetriableStreamProvider`), then plays the queued completions.
+    struct FlakyThenOkProvider {
+        fail_times: usize,
+        stream_calls: AtomicUsize,
+        completions: Mutex<VecDeque<Completion>>,
+    }
+
+    #[async_trait]
+    impl Provider for FlakyThenOkProvider {
+        fn name(&self) -> &str {
+            "flaky-then-ok"
+        }
+
+        fn model(&self) -> &str {
+            "flaky-then-ok"
+        }
+
+        async fn complete(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSchema],
+        ) -> wisp_llm::Result<Completion> {
+            Err(LlmError::Config("complete is not used".into()))
+        }
+
+        async fn stream(
+            &self,
+            _messages: &[Message],
+            _tools: &[ToolSchema],
+            _sink: &mut dyn wisp_llm::StreamSink,
+        ) -> wisp_llm::Result<Completion> {
+            let attempt = self.stream_calls.fetch_add(1, Ordering::SeqCst);
+            if attempt < self.fail_times {
+                return Err(LlmError::Api {
+                    status: 503,
+                    body: "overloaded".into(),
+                });
+            }
+            self.completions
+                .lock()
+                .unwrap()
+                .pop_front()
+                .ok_or(LlmError::Incomplete)
+        }
+    }
+
+    // start_paused: retry backoff sleeps (2s + 10s here) auto-advance instead
+    // of stalling the test in real time.
+    #[tokio::test(start_paused = true)]
+    async fn transient_provider_overload_is_retried_until_recovery() {
+        let provider = FlakyThenOkProvider {
+            fail_times: 2,
+            stream_calls: AtomicUsize::new(0),
+            completions: Mutex::new(VecDeque::from([Completion {
+                content: "recovered after overload".into(),
+                finish_reason: Some("stop".into()),
+                ..Completion::default()
+            }])),
+        };
+        let mut ctx = ContextManager::new(100_000);
+
+        let outcome = agent_loop(
+            &mut ctx,
+            &provider,
+            None,
+            &Registry::builtins().filtered(&[]),
+            Path::new("."),
+            &NullOutput,
+            "keep going through the blip",
+            0,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome, AgentLoopOutcome::Completed);
+        assert_eq!(
+            provider.stream_calls.load(Ordering::SeqCst),
+            3,
+            "two retriable 503s, then the successful attempt"
+        );
+        let last = ctx.messages.last().unwrap();
+        assert_eq!(last.role, wisp_llm::Role::Assistant);
+        assert_eq!(
+            last.content.as_text(),
+            "recovered after overload",
+            "the recovered turn's content must land in context intact"
+        );
     }
 }

--- a/crates/wisp-core/src/provenance.rs
+++ b/crates/wisp-core/src/provenance.rs
@@ -447,10 +447,20 @@ pub fn diff(
 mod tests {
     use super::*;
 
+    /// Unique per-test directory so parallel test runs never collide.
+    fn unique_tmp(tag: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "wisp_prov_{tag}_{}_{}",
+            std::process::id(),
+            uuid::Uuid::new_v4().simple()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
     #[test]
     fn detects_written_and_read_and_skips_git() {
-        let tmp = std::env::temp_dir().join("wisp_prov_snap_test");
-        std::fs::remove_dir_all(&tmp).ok();
+        let tmp = unique_tmp("snap");
         std::fs::create_dir_all(tmp.join(".git")).unwrap();
         std::fs::write(tmp.join("data.csv"), b"x").unwrap();
         std::fs::write(tmp.join(".git/HEAD"), b"x").unwrap();
@@ -495,9 +505,7 @@ mod tests {
 
     #[test]
     fn snapshot_caps_entries_inside_a_wide_directory() {
-        let tmp = std::env::temp_dir().join("wisp_prov_wide_test");
-        std::fs::remove_dir_all(&tmp).ok();
-        std::fs::create_dir_all(&tmp).unwrap();
+        let tmp = unique_tmp("wide");
         for name in ["a", "b", "c"] {
             std::fs::write(tmp.join(name), b"x").unwrap();
         }
@@ -508,9 +516,7 @@ mod tests {
 
     #[test]
     fn undo_captures_existing_and_new_markdown_but_not_word() {
-        let tmp = std::env::temp_dir().join("wisp_prov_undo_text_test");
-        std::fs::remove_dir_all(&tmp).ok();
-        std::fs::create_dir_all(&tmp).unwrap();
+        let tmp = unique_tmp("undo_text");
         std::fs::write(tmp.join("notes.md"), "before\n").unwrap();
         let before = snapshot(&tmp);
         let preimages = capture_text_preimages(&before, &tmp, "edit notes.md");
@@ -532,9 +538,7 @@ mod tests {
 
     #[test]
     fn existing_text_with_a_dynamic_destination_is_not_guessed() {
-        let tmp = std::env::temp_dir().join("wisp_prov_undo_dynamic_test");
-        std::fs::remove_dir_all(&tmp).ok();
-        std::fs::create_dir_all(&tmp).unwrap();
+        let tmp = unique_tmp("undo_dynamic");
         std::fs::write(tmp.join("notes.md"), "before\n").unwrap();
         let before = snapshot(&tmp);
         let preimages = capture_text_preimages(&before, &tmp, "run generated destination");
@@ -552,9 +556,7 @@ mod tests {
 
     #[test]
     fn changed_preimages_do_not_depend_on_mtime_resolution() {
-        let tmp = std::env::temp_dir().join("wisp_prov_undo_timestamp_test");
-        std::fs::remove_dir_all(&tmp).ok();
-        std::fs::create_dir_all(&tmp).unwrap();
+        let tmp = unique_tmp("undo_timestamp");
         std::fs::write(tmp.join("notes.md"), "before\n").unwrap();
         let before = snapshot(&tmp);
         let preimages = capture_text_preimages(&before, &tmp, "notes.md");

--- a/crates/wisp-store/src/schedules.rs
+++ b/crates/wisp-store/src/schedules.rs
@@ -287,6 +287,15 @@ mod tests {
             .await
             .unwrap());
 
+        // Close and reopen: the disabled state and slot must be durable,
+        // not an artifact of the still-open connection pool.
+        store.pool.close().await;
+        let store = Store::open(&root.join("store.sqlite")).await.unwrap();
+        let reloaded = store.get_schedule("s1").await.unwrap().unwrap();
+        assert!(!reloaded.enabled, "enabled=false must survive reopen");
+        assert_eq!(reloaded.next_run_at, 500, "next_run_at must survive reopen");
+        assert_eq!(reloaded, disabled);
+
         store.delete_schedule("s1").await.unwrap();
         assert_eq!(store.get_schedule("s1").await.unwrap(), None);
 

--- a/crates/wisp-store/src/secrets.rs
+++ b/crates/wisp-store/src/secrets.rs
@@ -94,12 +94,15 @@ mod backend {
 mod tests {
     use super::Secret;
 
+    // Exercises only the debug file backend (cargo test builds with
+    // debug_assertions), so no OS keyring daemon is ever required. The entry
+    // name is UUID-scoped so parallel test runs sharing $HOME never collide.
     #[test]
     fn set_get_delete_roundtrip() {
-        let name = "test:roundtrip";
-        Secret::set(name, "abc123").unwrap();
-        assert_eq!(Secret::get(name).unwrap(), "abc123");
-        Secret::delete(name).unwrap();
-        assert!(Secret::get(name).is_err());
+        let name = format!("test:roundtrip:{}", uuid::Uuid::new_v4());
+        Secret::set(&name, "abc123").unwrap();
+        assert_eq!(Secret::get(&name).unwrap(), "abc123");
+        Secret::delete(&name).unwrap();
+        assert!(Secret::get(&name).is_err());
     }
 }

--- a/crates/wisp-store/src/store_tests.rs
+++ b/crates/wisp-store/src/store_tests.rs
@@ -111,6 +111,16 @@ async fn roundtrip() {
         [0, 1]
     );
     assert_eq!(sequenced[1].1.content.as_text(), "hello");
+
+    // Durability: close every connection and reopen the same file — the
+    // writes must come back from disk, not from the live pool's cache.
+    store.pool.close().await;
+    let store = Store::open(&tmp).await.unwrap();
+    let msgs = store.load_messages("f1").await.unwrap();
+    assert_eq!(msgs.len(), 2, "messages must survive close + reopen");
+    assert_eq!(msgs[0].content.as_text(), "hi");
+    assert_eq!(msgs[1].content.as_text(), "hello");
+
     // list_sessions derives a title from the first user message and skips
     // frames with no user turn.
     store.create_frame("f2", "p1", "OPERON", "m").await.unwrap();
@@ -130,6 +140,96 @@ async fn roundtrip() {
     assert_eq!(sessions[0].1, "Renamed chat");
     store.delete_session("f1", "p1").await.unwrap();
     assert!(store.list_sessions("p1").await.unwrap().is_empty());
+    let _ = std::fs::remove_file(&tmp);
+}
+
+#[tokio::test]
+async fn duplicate_seq_in_a_frame_is_rejected_and_leaves_rows_unchanged() {
+    let tmp =
+        std::env::temp_dir().join(format!("wisp_store_dupseq_{}.sqlite", uuid::Uuid::new_v4()));
+    let store = Store::open(&tmp).await.unwrap();
+    store.create_project("p1", "proj", "").await.unwrap();
+    store.create_frame("f1", "p1", "OPERON", "m").await.unwrap();
+    store
+        .append_message("f1", 0, &Message::user("first"))
+        .await
+        .unwrap();
+
+    // The schema enforces UNIQUE(frame_id, seq): a second append with the
+    // same explicit seq must error instead of silently replacing the row.
+    let err = store
+        .append_message("f1", 0, &Message::user("imposter"))
+        .await
+        .expect_err("duplicate (frame_id, seq) must be rejected");
+    assert!(
+        err.to_string().to_ascii_lowercase().contains("unique"),
+        "unexpected error: {err}"
+    );
+
+    let msgs = store.load_messages_with_seq("f1").await.unwrap();
+    assert_eq!(msgs.len(), 1, "the failed insert must not add a row");
+    assert_eq!(msgs[0].0, 0);
+    assert_eq!(msgs[0].1.content.as_text(), "first");
+
+    // The same seq in a different frame is fine — uniqueness is per frame.
+    store.create_frame("f2", "p1", "OPERON", "m").await.unwrap();
+    store
+        .append_message("f2", 0, &Message::user("other frame"))
+        .await
+        .unwrap();
+
+    let _ = std::fs::remove_file(&tmp);
+}
+
+#[tokio::test]
+async fn concurrent_writers_on_two_pools_all_land() {
+    let tmp = std::env::temp_dir().join(format!(
+        "wisp_store_concurrent_{}.sqlite",
+        uuid::Uuid::new_v4()
+    ));
+    let store_a = Store::open(&tmp).await.unwrap();
+    let store_b = Store::open(&tmp).await.unwrap();
+    store_a.create_project("p1", "proj", "").await.unwrap();
+    store_a
+        .create_frame("fa", "p1", "OPERON", "m")
+        .await
+        .unwrap();
+    store_a
+        .create_frame("fb", "p1", "OPERON", "m")
+        .await
+        .unwrap();
+
+    // Two independent pools on the same file, interleaving writes to
+    // different frames — exercises WAL + busy_timeout instead of failing
+    // with SQLITE_BUSY.
+    const PER_WRITER: i64 = 20;
+    let writer = |store: Store, frame: &'static str| async move {
+        for seq in 0..PER_WRITER {
+            store
+                .append_message(frame, seq, &Message::user(format!("{frame} {seq}")))
+                .await?;
+            tokio::task::yield_now().await;
+        }
+        anyhow::Ok(())
+    };
+    let task_a = tokio::spawn(writer(store_a.clone(), "fa"));
+    let task_b = tokio::spawn(writer(store_b.clone(), "fb"));
+    task_a.await.unwrap().unwrap();
+    task_b.await.unwrap().unwrap();
+
+    for (store, frame) in [(&store_a, "fb"), (&store_b, "fa")] {
+        let msgs = store.load_messages_with_seq(frame).await.unwrap();
+        assert_eq!(
+            msgs.len(),
+            PER_WRITER as usize,
+            "every {frame} append must land"
+        );
+        assert_eq!(
+            msgs.iter().map(|(seq, _)| *seq).collect::<Vec<_>>(),
+            (0..PER_WRITER).collect::<Vec<_>>()
+        );
+    }
+
     let _ = std::fs::remove_file(&tmp);
 }
 
@@ -3281,6 +3381,25 @@ async fn store_open_records_migrations_and_seeds_local_context() {
             ORPHAN_FILE_RETENTION_MIGRATION.to_string(),
         ]
     );
+    let first_open_migrations = store.schema_migrations().await.unwrap();
+
+    // Idempotency: opening the same file again must neither re-run migrations
+    // nor seed a second `local` execution context.
+    store.pool.close().await;
+    let store = Store::open(&tmp).await.unwrap();
+    assert_eq!(
+        store.schema_migrations().await.unwrap(),
+        first_open_migrations,
+        "a second open must leave the recorded migration set unchanged"
+    );
+    let locals = store
+        .list_execution_contexts()
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|ctx| ctx.id == "local")
+        .count();
+    assert_eq!(locals, 1, "the seeded local context must not be duplicated");
 
     let _ = std::fs::remove_file(&tmp);
 }

--- a/crates/wisp-tools/src/edit.rs
+++ b/crates/wisp-tools/src/edit.rs
@@ -255,6 +255,45 @@ mod tests {
         std::fs::remove_dir_all(&tmp).ok();
     }
 
+    #[tokio::test]
+    async fn crlf_multibyte_edit_preserves_line_endings_and_applies_once() {
+        let tmp = std::env::temp_dir().join(format!("wisp_edit_crlf_{}", std::process::id()));
+        std::fs::remove_dir_all(&tmp).ok();
+        std::fs::create_dir_all(&tmp).unwrap();
+        let original = "第一行：概要\r\n実験結果：陽性\r\n最終行：完了\r\n";
+        std::fs::write(tmp.join("report.txt"), original.as_bytes()).unwrap();
+
+        let result = EditTool
+            .run(
+                &json!({
+                    "path": "report.txt",
+                    "old": "実験結果：陽性",
+                    "new": "実験結果：陰性"
+                }),
+                &TestEnv(tmp.clone()),
+            )
+            .await;
+
+        assert!(result.success, "{}", result.content);
+        assert!(
+            result.content.contains("1 replacement"),
+            "{}",
+            result.content
+        );
+        let bytes = std::fs::read(tmp.join("report.txt")).unwrap();
+        assert_eq!(
+            bytes,
+            "第一行：概要\r\n実験結果：陰性\r\n最終行：完了\r\n".as_bytes(),
+            "CRLF endings and surrounding CJK text must survive the edit byte-for-byte"
+        );
+        assert_eq!(
+            bytes.windows(2).filter(|w| w == b"\r\n").count(),
+            3,
+            "all three CRLF terminators preserved"
+        );
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
     #[test]
     fn replacement_size_is_checked_before_allocating() {
         assert_eq!(replaced_len("aaa", "a", "bb", true), Some(6));

--- a/crates/wisp-tools/src/lib.rs
+++ b/crates/wisp-tools/src/lib.rs
@@ -854,7 +854,11 @@ mod approval_tests {
 
     #[tokio::test]
     async fn plan_mode_blocks_writers_and_lets_readers_through() {
-        let dir = std::env::temp_dir().join("wisp-plan-mode-gate");
+        let dir = std::env::temp_dir().join(format!(
+            "wisp-plan-mode-gate-{}-{}",
+            std::process::id(),
+            line!()
+        ));
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(dir.join("note.txt"), "hello").unwrap();
         let reg = Registry::builtins();
@@ -885,7 +889,11 @@ mod approval_tests {
 
     #[tokio::test]
     async fn project_write_lock_blocks_mutations_but_keeps_conversation_retrieval_available() {
-        let dir = std::env::temp_dir().join("wisp-project-write-lock-gate");
+        let dir = std::env::temp_dir().join(format!(
+            "wisp-project-write-lock-gate-{}-{}",
+            std::process::id(),
+            line!()
+        ));
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(dir.join("note.txt"), "hello").unwrap();
         let reg = Registry::builtins();

--- a/crates/wisp-tools/src/safety.rs
+++ b/crates/wisp-tools/src/safety.rs
@@ -224,11 +224,156 @@ pub const FILTERED_DIRS: &[&str] = &[
 mod tests {
     use super::*;
 
+    /// Unique per-test sandbox so parallel tests never share a directory.
+    fn unique_dir(tag: &str) -> PathBuf {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let dir = std::env::temp_dir().join(format!(
+            "wisp_safety_{tag}_{}_{}",
+            std::process::id(),
+            COUNTER.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
     #[test]
     fn delegated_glob_patterns_cannot_escape_the_project() {
         assert!(validate_relative_pattern("src/**/*.rs").is_ok());
         assert!(validate_relative_pattern("../**/*").is_err());
         assert!(validate_relative_pattern(&std::env::temp_dir().to_string_lossy()).is_err());
+    }
+
+    #[test]
+    fn validate_file_path_enforces_the_sandbox_boundary() {
+        let root = unique_dir("vfp");
+        std::fs::create_dir_all(root.join("sub")).unwrap();
+        std::fs::write(root.join("inside.txt"), "in").unwrap();
+        std::fs::write(root.join("sub/nested.txt"), "in").unwrap();
+        let outside = unique_dir("vfp_outside");
+        std::fs::write(outside.join("secret.txt"), "out").unwrap();
+        let root_real = dunce::canonicalize(&root).unwrap();
+
+        struct Case {
+            name: &'static str,
+            path: String,
+            expect_ok: bool,
+        }
+        let cases = vec![
+            Case {
+                name: "relative path inside root accepted",
+                path: "inside.txt".into(),
+                expect_ok: true,
+            },
+            Case {
+                name: "absolute path inside root accepted",
+                path: root.join("sub/nested.txt").to_string_lossy().into_owned(),
+                expect_ok: true,
+            },
+            Case {
+                name: "../ traversal escape rejected",
+                path: format!(
+                    "../{}/secret.txt",
+                    outside.file_name().unwrap().to_string_lossy()
+                ),
+                expect_ok: false,
+            },
+            Case {
+                name: "absolute path outside root rejected",
+                path: outside.join("secret.txt").to_string_lossy().into_owned(),
+                expect_ok: false,
+            },
+            Case {
+                name: "new file with an existing parent accepted (write target)",
+                path: "sub/not_yet_written.txt".into(),
+                expect_ok: true,
+            },
+            Case {
+                name: "new file whose parent does not exist rejected",
+                path: "missing_dir/new.txt".into(),
+                expect_ok: false,
+            },
+            Case {
+                name: "directory target rejected (write/edit are file-only)",
+                path: "sub".into(),
+                expect_ok: false,
+            },
+        ];
+        for case in cases {
+            let got = validate_file_path(&root, &case.path);
+            assert_eq!(got.is_ok(), case.expect_ok, "{}: {:?}", case.name, got);
+            if let Ok(resolved) = got {
+                assert!(
+                    resolved.starts_with(&root_real),
+                    "{}: resolved path {resolved:?} must stay under root",
+                    case.name
+                );
+            }
+        }
+
+        std::fs::remove_dir_all(&root).ok();
+        std::fs::remove_dir_all(&outside).ok();
+    }
+
+    #[test]
+    fn resolve_under_root_allows_directories_but_not_escapes() {
+        let root = unique_dir("rur");
+        std::fs::create_dir_all(root.join("sub")).unwrap();
+        std::fs::write(root.join("inside.txt"), "in").unwrap();
+        let outside = unique_dir("rur_outside");
+        std::fs::write(outside.join("secret.txt"), "out").unwrap();
+
+        assert!(resolve_under_root(&root, "inside.txt").is_ok());
+        assert!(resolve_under_root(&root, "sub").is_ok(), "dirs are allowed");
+        assert!(
+            resolve_under_root(&root, &root.join("sub").to_string_lossy()).is_ok(),
+            "absolute path inside root accepted"
+        );
+        assert!(
+            resolve_under_root(&root, &outside.join("secret.txt").to_string_lossy()).is_err(),
+            "absolute path outside root rejected"
+        );
+        assert!(
+            resolve_under_root(
+                &root,
+                &format!(
+                    "../{}/secret.txt",
+                    outside.file_name().unwrap().to_string_lossy()
+                )
+            )
+            .is_err(),
+            "../ traversal escape rejected"
+        );
+        assert!(
+            resolve_under_root(&root, "does_not_exist.txt").is_err(),
+            "nonexistent paths are rejected (list/read need an existing target)"
+        );
+
+        std::fs::remove_dir_all(&root).ok();
+        std::fs::remove_dir_all(&outside).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_pointing_outside_the_root_is_rejected() {
+        let root = unique_dir("symlink");
+        let outside = unique_dir("symlink_outside");
+        std::fs::write(outside.join("secret.txt"), "out").unwrap();
+        std::os::unix::fs::symlink(outside.join("secret.txt"), root.join("sneaky.txt")).unwrap();
+
+        let via_validate = validate_file_path(&root, "sneaky.txt");
+        assert!(
+            via_validate.is_err(),
+            "validate_file_path must resolve symlinks: {via_validate:?}"
+        );
+        let via_resolve = resolve_under_root(&root, "sneaky.txt");
+        assert!(
+            via_resolve.is_err(),
+            "resolve_under_root must resolve symlinks: {via_resolve:?}"
+        );
+
+        std::fs::remove_dir_all(&root).ok();
+        std::fs::remove_dir_all(&outside).ok();
     }
 }
 

--- a/src-tauri/src/context_probe.rs
+++ b/src-tauri/src/context_probe.rs
@@ -910,6 +910,22 @@ mod tests {
                 "'/opt/R 4.5/bin/Rscript' --vanilla -e 'cat(requireNamespace(\"jsonlite\", quietly=TRUE))' 2>/dev/null".into(),
                 "TRUE".into(),
             ),
+            // Capabilities this host genuinely lacks: explicit empty output.
+            ("getconf _NPROCESSORS_ONLN".into(), String::new()),
+            ("nvidia-smi -L".into(), String::new()),
+            (
+                "command -v sbatch || command -v qsub || command -v bsub".into(),
+                String::new(),
+            ),
+            ("command -v conda".into(), String::new()),
+            ("command -v mamba".into(), String::new()),
+            ("command -v modulecmd".into(), String::new()),
+            ("printf '%s' \"$HOME\"".into(), String::new()),
+            ("pwd".into(), String::new()),
+            (
+                "if [ \"$(id -u)\" = 0 ]; then printf root; elif command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then printf sudo; else printf unprivileged; fi".into(),
+                String::new(),
+            ),
         ]);
 
         let probe = probe_context_with_runner(&ctx, &mut runner).unwrap();
@@ -923,6 +939,26 @@ mod tests {
             Some("/opt/R 4.5/bin/Rscript")
         );
         assert_eq!(probe.r_jsonlite, Some(true));
+    }
+
+    #[test]
+    fn empty_probe_output_marks_capabilities_absent_instead_of_failing() {
+        let ctx = wisp_store::ExecutionContext::new("wsl:Ubuntu", "Empty").unwrap();
+        let (specs, _) = probe_specs(&ctx).unwrap();
+        let mut runner = FakeRunner::new(
+            specs
+                .iter()
+                .map(|spec| (spec.script.clone(), String::new()))
+                .collect(),
+        );
+
+        let probe = probe_context_with_runner(&ctx, &mut runner).unwrap();
+        assert_eq!(probe.os, None);
+        assert_eq!(probe.cpu_count, None);
+        assert_eq!(probe.gpu_summary, None);
+        assert_eq!(probe.scheduler, None);
+        assert_eq!(probe.python_executable, None);
+        assert_eq!(probe.rscript_executable, None);
     }
 
     #[test]
@@ -1128,14 +1164,17 @@ mod tests {
 
     impl ProbeRunner for FakeRunner {
         fn run(&mut self, command: &ProbeCommand) -> Result<ProbeCommandOutput, String> {
+            // A forgotten probe must fail loudly instead of silently reading
+            // as "capability absent" (empty stdout).
+            let stdout = self.outputs.get(&command.script).unwrap_or_else(|| {
+                panic!(
+                    "FakeRunner received an unscripted probe command: {}",
+                    command.script
+                )
+            });
             Ok(ProbeCommandOutput {
                 status: 0,
-                stdout: self
-                    .outputs
-                    .get(&command.script)
-                    .cloned()
-                    .unwrap_or_default()
-                    .into_bytes(),
+                stdout: stdout.clone().into_bytes(),
                 stderr: String::new(),
             })
         }

--- a/src-tauri/src/desktop_lifecycle.rs
+++ b/src-tauri/src/desktop_lifecycle.rs
@@ -9,9 +9,9 @@ use tauri::{AppHandle, Emitter, Manager};
 #[cfg(target_os = "windows")]
 pub(crate) const PET_WINDOW_LABEL: &str = "pet";
 
-#[cfg(any(target_os = "windows", test))]
+#[cfg(target_os = "windows")]
 pub(crate) const PET_WINDOW_WIDTH: u32 = 128;
-#[cfg(any(target_os = "windows", test))]
+#[cfg(target_os = "windows")]
 pub(crate) const PET_WINDOW_HEIGHT: u32 = 176;
 
 #[cfg(target_os = "windows")]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3826,6 +3826,15 @@ fn specialist_prompt_section(spec: &specialists::Specialist) -> String {
     format!("\n\n## Specialist: {}\n{}", spec.name, spec.instructions)
 }
 
+/// Append the specialist section unless the prompt already carries one.
+/// Idempotent: a reloaded seeded session already carries the section
+/// (runtime rebuilt after restart/eviction).
+fn append_specialist_section_once(prompt: &mut String, section: &str) {
+    if !prompt.contains("\n\n## Specialist: ") {
+        prompt.push_str(section);
+    }
+}
+
 /// Idempotently add or remove a delimited system-prompt section. The prompt is
 /// persisted as message 0 and reloaded on every runtime rebuild, so a toggled-off
 /// capability has to strip whatever an earlier turn appended (including a
@@ -5694,11 +5703,7 @@ async fn send_message_inner(
                 let section = specialist_prompt_section(spec);
                 if let Some(m) = agent.ctx.messages.first_mut() {
                     if let wisp_llm::Content::Text(t) = &mut m.content {
-                        // Idempotent: a reloaded seeded session already carries
-                        // the section (runtime rebuilt after restart/eviction).
-                        if !t.contains("\n\n## Specialist: ") {
-                            t.push_str(&section);
-                        }
+                        append_specialist_section_once(t, &section);
                     }
                 }
             }
@@ -6357,6 +6362,22 @@ fn begin_queued_cutin(rt: &SessionRuntime, id: u64) -> Option<(u64, QueuedItem)>
     Some((guidance_id, item))
 }
 
+/// Reorder within the queue (#433): swap the item with its neighbour (`up`
+/// toward the front), clamped at both ends. FIFO order is the Vec order,
+/// which the driver drains front-first.
+fn swap_queued_toward(q: &mut Vec<QueuedItem>, id: u64, up: bool) {
+    if let Some(i) = q.iter().position(|it| it.id == id) {
+        let target = if up {
+            i.checked_sub(1)
+        } else {
+            (i + 1 < q.len()).then_some(i + 1)
+        };
+        if let Some(j) = target {
+            q.swap(i, j);
+        }
+    }
+}
+
 fn reclaim_unconsumed_cutin(rt: &SessionRuntime, guidance_id: u64, item: QueuedItem) -> bool {
     let mut pending = rt.pending_guidance.lock().unwrap();
     let before = pending.len();
@@ -6427,16 +6448,7 @@ async fn queued_turn_action(
         // the ends. FIFO order is the Vec order, which the driver drains front-first.
         "move_up" | "move_down" => {
             let mut q = rt.queued.lock().unwrap();
-            if let Some(i) = q.iter().position(|it| it.id == id) {
-                let target = if action == "move_up" {
-                    i.checked_sub(1)
-                } else {
-                    (i + 1 < q.len()).then_some(i + 1)
-                };
-                if let Some(j) = target {
-                    q.swap(i, j);
-                }
-            }
+            swap_queued_toward(&mut q, id, action == "move_up");
         }
         other => return Err(format!("unknown queued action: {other}")),
     }

--- a/src-tauri/src/lib_tests.rs
+++ b/src-tauri/src/lib_tests.rs
@@ -1,9 +1,6 @@
 use super::app_commands::parse_ssh_artifact_uri;
 use super::app_updates::{update_check_from_release, GithubRelease};
-use super::desktop_lifecycle::{
-    should_activate_workspace_window, should_hide_workspace_on_close, PET_WINDOW_HEIGHT,
-    PET_WINDOW_WIDTH,
-};
+use super::desktop_lifecycle::{should_activate_workspace_window, should_hide_workspace_on_close};
 use super::session_commands::transcript_page_items;
 use super::{
     begin_queued_cutin, branch_title, client_turn_error, coalesce_live_agent_events,
@@ -1491,7 +1488,7 @@ fn resolve_workspace_prefers_env_then_setting_then_default() {
     );
     assert!(!default.exists());
 
-    let base = std::env::temp_dir().join(format!("wisp_ws_test_{}", std::process::id()));
+    let base = std::env::temp_dir().join(format!("wisp_ws_test_{}", uuid::Uuid::new_v4()));
     let env_dir = base.join("env");
     let set_dir = base.join("set");
     // A creatable env path wins over the setting, and gets created.
@@ -1632,13 +1629,10 @@ fn specialist_section_marker_detects_prior_append() {
     let mut prompt = String::from("base prompt");
     let section = crate::specialist_prompt_section(&spec);
     // First append happens; a second pass sees the marker and skips.
-    if !prompt.contains("\n\n## Specialist: ") {
-        prompt.push_str(&section);
-    }
-    if !prompt.contains("\n\n## Specialist: ") {
-        prompt.push_str(&section);
-    }
+    crate::append_specialist_section_once(&mut prompt, &section);
+    crate::append_specialist_section_once(&mut prompt, &section);
     assert_eq!(prompt.matches("## Specialist: Paper hunter").count(), 1);
+    assert!(prompt.starts_with("base prompt"));
 }
 
 #[test]
@@ -1709,11 +1703,6 @@ fn windows_close_to_tray_applies_only_to_the_main_window() {
     assert!(should_hide_workspace_on_close("main"));
     assert!(!should_hide_workspace_on_close("proj-default"));
     assert!(!should_hide_workspace_on_close("pet"));
-}
-
-#[test]
-fn windows_pet_window_uses_the_label_safe_viewport() {
-    assert_eq!((PET_WINDOW_WIDTH, PET_WINDOW_HEIGHT), (128, 176));
 }
 
 #[test]
@@ -1998,28 +1987,18 @@ fn queue_reorder_swaps_and_clamps() {
         attachments: vec![],
         references: vec![],
     };
-    let swap_toward = |q: &mut Vec<QueuedItem>, id: u64, up: bool| {
-        if let Some(i) = q.iter().position(|it| it.id == id) {
-            let target = if up {
-                i.checked_sub(1)
-            } else {
-                (i + 1 < q.len()).then_some(i + 1)
-            };
-            if let Some(j) = target {
-                q.swap(i, j);
-            }
-        }
-    };
     let ids = |q: &[QueuedItem]| q.iter().map(|it| it.id).collect::<Vec<_>>();
 
     let mut q = vec![item(1), item(2), item(3)]; // A, B, C
-    swap_toward(&mut q, 3, true); // C up → A, C, B
+    super::swap_queued_toward(&mut q, 3, true); // C up → A, C, B
     assert_eq!(ids(&q), [1, 3, 2]);
-    swap_toward(&mut q, 1, false); // A down → C, A, B
+    super::swap_queued_toward(&mut q, 1, false); // A down → C, A, B
     assert_eq!(ids(&q), [3, 1, 2]);
-    swap_toward(&mut q, 3, true); // C already first → no-op
+    super::swap_queued_toward(&mut q, 3, true); // C already first → no-op
     assert_eq!(ids(&q), [3, 1, 2]);
-    swap_toward(&mut q, 2, false); // B already last → no-op
+    super::swap_queued_toward(&mut q, 2, false); // B already last → no-op
+    assert_eq!(ids(&q), [3, 1, 2]);
+    super::swap_queued_toward(&mut q, 99, true); // unknown id → no-op
     assert_eq!(ids(&q), [3, 1, 2]);
 }
 
@@ -2036,22 +2015,24 @@ fn follow_up_questions_parse_exactly_three_distinct_options() {
 fn startup_timeline_returns_phase_results_and_names_the_slowest_phase() {
     let mut timeline = StartupTimeline::default();
     let fast = timeline.record("fast", || 1_u32);
-    let slow = timeline.record("slow", || {
-        std::thread::sleep(std::time::Duration::from_millis(20));
-        "store"
-    });
-
+    let slow = timeline.record("slow", || "store");
     assert_eq!(fast, 1);
     assert_eq!(slow, "store");
+
+    // Pin the measured durations instead of racing wall-clock sleeps, so the
+    // ordering assertions below are deterministic.
+    timeline.phases[0].1 = std::time::Duration::from_millis(1);
+    timeline.phases[1].1 = std::time::Duration::from_millis(20);
+
     let summary = timeline.summary();
-    assert!(summary.starts_with("total="), "{summary}");
-    let slow_at = summary.find("slow=").expect("slow phase reported");
-    let fast_at = summary.find("fast=").expect("fast phase reported");
+    assert!(summary.starts_with("total=21ms"), "{summary}");
+    let slow_at = summary.find("slow=20ms").expect("slow phase reported");
+    let fast_at = summary.find("fast=1ms").expect("fast phase reported");
     assert!(
         slow_at < fast_at,
         "slowest phase must come first: {summary}"
     );
-    assert!(timeline.total() >= std::time::Duration::from_millis(20));
+    assert_eq!(timeline.total(), std::time::Duration::from_millis(21));
 }
 
 #[test]

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -1562,19 +1562,60 @@ mod tests {
 
     // The write-through cache must stay coherent: a set is readable without a
     // fresh keyring hit, and a delete reads back as absent (not the old value).
+    // `cargo test` builds with debug_assertions, so the secret backend is the
+    // dev secrets file in $HOME, never a real OS keyring; the UUID-scoped name
+    // keeps concurrent or leftover runs sharing $HOME from colliding.
     #[test]
     fn secret_cache_write_through() {
-        let name = "model_key:__cache_coherence_test__";
-        secret_set(name, "sk-abc").unwrap();
-        assert_eq!(secret_get(name), "sk-abc");
-        secret_del(name).unwrap();
-        assert_eq!(secret_get(name), "");
+        let name = format!(
+            "model_key:__cache_coherence_test_{}__",
+            uuid::Uuid::new_v4()
+        );
+        secret_set(&name, "sk-abc").unwrap();
+        assert_eq!(secret_get(&name), "sk-abc");
+        secret_del(&name).unwrap();
+        assert_eq!(secret_get(&name), "");
+    }
+
+    /// Restores each captured secret on drop (even when an assert panics), so
+    /// the test never clobbers values a developer keeps in the shared dev
+    /// secrets file.
+    struct RestoreSecrets(Vec<(String, String)>);
+
+    impl RestoreSecrets {
+        fn capture(ids: &[&str]) -> Self {
+            Self(
+                ids.iter()
+                    .map(|id| {
+                        let secret = credential(id).unwrap().secret.to_string();
+                        let prior = secret_get(&secret);
+                        (secret, prior)
+                    })
+                    .collect(),
+            )
+        }
+    }
+
+    impl Drop for RestoreSecrets {
+        fn drop(&mut self) {
+            for (secret, prior) in &self.0 {
+                if prior.is_empty() {
+                    let _ = secret_del(secret);
+                } else {
+                    let _ = secret_set(secret, prior);
+                }
+            }
+        }
     }
 
     // Storing a credential surfaces it in service_env under its env var;
-    // clearing removes it; an unknown id is rejected.
+    // clearing removes it; an unknown id is rejected. Registry ids are fixed
+    // production names, so prior values are captured and restored on exit.
     #[test]
     fn credential_registry_roundtrip() {
+        let _restore =
+            RestoreSecrets::capture(&["ncbi_email", "infinisynapse_api_key", "scimaster_api_key"]);
+
         store_credential("ncbi_email", "me@lab.org").unwrap();
         assert!(credential_status()
             .iter()

--- a/src-tauri/src/run_context/harvest_remote.rs
+++ b/src-tauri/src/run_context/harvest_remote.rs
@@ -1252,8 +1252,20 @@ mod tests {
         assert!(payload.contains("mv \"$f\" \"$dest\""));
         assert!(payload.contains("persist=\"$HOME/wisp/proj/data/artifacts/r1\""));
         assert!(payload.contains("__WISP_HARVEST_DONE__"));
-        // Remote residency always relocates: the test is constant-true.
-        assert!(payload.contains("[ \"$size\" -gt 0 ]"));
+        // Residency picks the relocation predicate: Remote relocates every
+        // non-empty file (threshold 0), while Auto relocates only files above
+        // the default snapshot limit. Exactly one spec (idx 2, Remote) may
+        // carry the always-move threshold.
+        assert_eq!(payload.matches("[ \"$size\" -gt 0 ]").count(), 1);
+        assert_eq!(
+            payload
+                .matches(&format!(
+                    "[ \"$size\" -gt {} ]",
+                    crate::snapshot_store::DEFAULT_SNAPSHOT_LIMIT
+                ))
+                .count(),
+            1
+        );
     }
 
     #[test]

--- a/src-tauri/src/run_context/tests.rs
+++ b/src-tauri/src/run_context/tests.rs
@@ -266,13 +266,11 @@ async fn run_in_context_preflight_blocks_missing_packages_before_creating_a_run(
         .create_project("p", "project", &tmp.to_string_lossy())
         .await
         .unwrap();
-    let manager = RunManager::with_runner(Arc::new(FakeRunRunner {
-        output: Ok(RunCommandOutput {
-            exit_code: 9,
-            stdout: "3.12.4\n".into(),
-            stderr: "missing modules: decoupler".into(),
-        }),
-    }));
+    let manager = RunManager::with_runner(Arc::new(FakeRunRunner::new(Ok(RunCommandOutput {
+        exit_code: 9,
+        stdout: "3.12.4\n".into(),
+        stderr: "missing modules: decoupler".into(),
+    }))));
     let tool = RunInContextTool::new(store.clone(), manager, "p".into(), None);
 
     let result = tool
@@ -380,11 +378,10 @@ async fn run_in_context_rejects_nested_ssh_transfer_commands() {
         .upsert_execution_context(&wisp_store::ExecutionContext::new("local", "Local").unwrap())
         .await
         .unwrap();
+    let runner = Arc::new(FakeRunRunner::new(ok_output("should not run")));
     let tool = RunInContextTool::new(
         store.clone(),
-        RunManager::with_runner(Arc::new(FakeRunRunner {
-            output: ok_output("should not run"),
-        })),
+        RunManager::with_runner(runner.clone()),
         "p".into(),
         None,
     );
@@ -401,6 +398,10 @@ async fn run_in_context_rejects_nested_ssh_transfer_commands() {
     assert!(!result.success);
     assert!(result.content.contains("transfer_between_contexts"));
     assert!(store.list_runs_by_project("p").await.unwrap().is_empty());
+    assert!(
+        runner.commands.lock().unwrap().is_empty(),
+        "the guard must reject before anything reaches the runner"
+    );
     let _ = std::fs::remove_dir_all(tmp);
 }
 
@@ -498,13 +499,11 @@ async fn submit_run_records_success() {
         .upsert_execution_context(&wisp_store::ExecutionContext::new("local", "Local").unwrap())
         .await
         .unwrap();
-    let runner = FakeRunRunner {
-        output: Ok(RunCommandOutput {
-            exit_code: 0,
-            stdout: "hello\n".into(),
-            stderr: String::new(),
-        }),
-    };
+    let runner = FakeRunRunner::new(Ok(RunCommandOutput {
+        exit_code: 0,
+        stdout: "hello\n".into(),
+        stderr: String::new(),
+    }));
 
     let res = submit_run_with_runner(
         &store,
@@ -532,6 +531,17 @@ async fn submit_run_records_success() {
     assert_eq!(run.command.as_deref(), Some("echo hello"));
     assert_eq!(run.title, "Hello");
     assert_eq!(run.status, wisp_store::RunStatus::Succeeded);
+    // The success must come from executing the submitted command, not a
+    // preloaded result short-circuiting the runner.
+    let commands = runner.commands.lock().unwrap();
+    assert_eq!(commands.len(), 1);
+    assert_eq!(commands[0].context_id, "local");
+    assert!(
+        commands[0].script.contains("echo hello"),
+        "unexpected script: {}",
+        commands[0].script
+    );
+    drop(commands);
 
     let _ = std::fs::remove_file(&tmp);
 }
@@ -549,13 +559,11 @@ async fn local_run_binds_inputs_before_execution_and_snapshots_environment() {
         .await
         .unwrap();
     store.create_frame("f", "p", "OPERON", "m").await.unwrap();
-    let runner = FakeRunRunner {
-        output: Ok(RunCommandOutput {
-            exit_code: 0,
-            stdout: "ok".into(),
-            stderr: String::new(),
-        }),
-    };
+    let runner = FakeRunRunner::new(Ok(RunCommandOutput {
+        exit_code: 0,
+        stdout: "ok".into(),
+        stderr: String::new(),
+    }));
 
     let result = submit_run_with_runner(
         &store,
@@ -616,9 +624,7 @@ async fn submit_run_records_failure() {
         .upsert_execution_context(&wisp_store::ExecutionContext::new("local", "Local").unwrap())
         .await
         .unwrap();
-    let runner = FakeRunRunner {
-        output: Err("timed out".into()),
-    };
+    let runner = FakeRunRunner::new(Err("timed out".into()));
 
     let res = submit_run_with_runner(
         &store,
@@ -663,13 +669,11 @@ async fn submit_run_harvests_output_specs_on_success() {
         .upsert_execution_context(&wisp_store::ExecutionContext::new("local", "Local").unwrap())
         .await
         .unwrap();
-    let runner = FakeRunRunner {
-        output: Ok(RunCommandOutput {
-            exit_code: 0,
-            stdout: "done".into(),
-            stderr: String::new(),
-        }),
-    };
+    let runner = FakeRunRunner::new(Ok(RunCommandOutput {
+        exit_code: 0,
+        stdout: "done".into(),
+        stderr: String::new(),
+    }));
 
     let res = submit_run_with_runner(
         &store,
@@ -804,13 +808,11 @@ async fn remote_run_is_rejected_when_not_selected_for_its_session() {
         input_paths: None,
         output_specs: None,
     };
-    let runner = FakeRunRunner {
-        output: Ok(RunCommandOutput {
-            exit_code: 0,
-            stdout: String::new(),
-            stderr: String::new(),
-        }),
-    };
+    let runner = FakeRunRunner::new(Ok(RunCommandOutput {
+        exit_code: 0,
+        stdout: String::new(),
+        stderr: String::new(),
+    }));
 
     let error = submit_run_with_runner(&store, "p", Some("f"), request.clone(), &runner, None)
         .await
@@ -1382,11 +1384,30 @@ fn remote_compute_skill_uses_the_real_wisp_run_contract() {
     assert!(skill.contains("Scheduler lifecycle is not implemented yet"));
 }
 
+/// Single-response fake that records every command it receives, so tests can
+/// assert what actually reached the runner (or that nothing did).
 struct FakeRunRunner {
     output: Result<RunCommandOutput, String>,
+    commands: StdMutex<Vec<RunCommand>>,
 }
 
-struct StreamingRunRunner;
+impl FakeRunRunner {
+    fn new(output: Result<RunCommandOutput, String>) -> Self {
+        Self {
+            output,
+            commands: StdMutex::new(Vec::new()),
+        }
+    }
+}
+
+/// Streaming fake with explicit synchronization instead of wall-clock sleeps:
+/// it signals `first_chunk_sent` after emitting the stdout chunk, then blocks
+/// until the test grants a `finish` permit, so the test can assert the
+/// persisted mid-run state without racing the lifecycle task.
+struct StreamingRunRunner {
+    first_chunk_sent: Arc<tokio::sync::Notify>,
+    finish: Arc<tokio::sync::Semaphore>,
+}
 
 #[async_trait::async_trait]
 impl RunCommandRunner for StreamingRunRunner {
@@ -1410,14 +1431,14 @@ impl RunCommandRunner for StreamingRunRunner {
                 chunk: b"phase 1 complete\n".to_vec(),
             })
             .unwrap();
-        tokio::time::sleep(Duration::from_millis(1_300)).await;
+        self.first_chunk_sent.notify_one();
+        let _permit = self.finish.acquire().await.unwrap();
         updates
             .send(RunOutputUpdate {
                 stream: RunOutputStream::Stderr,
                 chunk: b"warning: slow API\n".to_vec(),
             })
             .unwrap();
-        tokio::time::sleep(Duration::from_millis(100)).await;
         Ok(RunCommandOutput {
             exit_code: 0,
             stdout: "phase 1 complete\n".into(),
@@ -1449,13 +1470,19 @@ async fn local_run_streams_bounded_output_and_heartbeat_before_completion() {
         .await
         .unwrap());
 
+    let first_chunk_sent = Arc::new(tokio::sync::Notify::new());
+    let finish = Arc::new(tokio::sync::Semaphore::new(0));
+    let runner = StreamingRunRunner {
+        first_chunk_sent: first_chunk_sent.clone(),
+        finish: finish.clone(),
+    };
     let task_store = store.clone();
     let task = tokio::spawn(async move {
         run_with_lifecycle_lease(
             &task_store,
             "streaming",
             "stream-owner",
-            &StreamingRunRunner,
+            &runner,
             RunCommand {
                 context_id: "local".into(),
                 program: "unused".into(),
@@ -1470,12 +1497,27 @@ async fn local_run_streams_bounded_output_and_heartbeat_before_completion() {
         .await
     });
 
-    tokio::time::sleep(Duration::from_millis(1_100)).await;
-    let live = store.get_run("streaming").await.unwrap().unwrap();
+    // The runner holds mid-run until the test releases it, so waiting for the
+    // lifecycle task to flush the first chunk is bounded, not a race.
+    tokio::time::timeout(Duration::from_secs(5), first_chunk_sent.notified())
+        .await
+        .expect("runner never emitted its first chunk");
+    let live = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let run = store.get_run("streaming").await.unwrap().unwrap();
+            if run.stdout_tail.is_some() && run.last_polled_at.is_some() {
+                return run;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("first chunk was never flushed to the store");
     assert_eq!(live.status, wisp_store::RunStatus::Running);
     assert_eq!(live.stdout_tail.as_deref(), Some("phase 1 complete\n"));
     assert!(live.last_polled_at.is_some(), "heartbeat was not recorded");
 
+    finish.add_permits(1);
     let output = task.await.unwrap().unwrap();
     assert_eq!(output.exit_code, 0);
     let _ = std::fs::remove_dir_all(tmp);
@@ -1485,9 +1527,10 @@ async fn local_run_streams_bounded_output_and_heartbeat_before_completion() {
 impl RunCommandRunner for FakeRunRunner {
     async fn run(
         &self,
-        _command: RunCommand,
+        command: RunCommand,
         _timeout: Duration,
     ) -> Result<RunCommandOutput, String> {
+        self.commands.lock().unwrap().push(command);
         self.output.clone()
     }
 }
@@ -1610,7 +1653,7 @@ async fn ssh_download_uses_context_connection_options() {
     })
     .to_string();
     context.last_probe_status = Some("ok".into());
-    let destination = std::env::temp_dir().join("results.tar.gz");
+    let destination = tmp.join("results.tar.gz");
 
     manager
         .download_ssh_file(
@@ -2648,13 +2691,11 @@ async fn ssh_submit_rejects_shell_unsafe_output_globs() {
         .set_session_execution_context_enabled("f", "ssh:gpu", true)
         .await
         .unwrap();
-    let runner = FakeRunRunner {
-        output: Ok(RunCommandOutput {
-            exit_code: 0,
-            stdout: String::new(),
-            stderr: String::new(),
-        }),
-    };
+    let runner = FakeRunRunner::new(Ok(RunCommandOutput {
+        exit_code: 0,
+        stdout: String::new(),
+        stderr: String::new(),
+    }));
 
     let error = submit_run_with_runner(
         &store,
@@ -2721,13 +2762,11 @@ async fn ssh_run_workdir_honors_stored_workdir_root_pref() {
         })
         .await
         .unwrap();
-    let runner = FakeRunRunner {
-        output: Ok(RunCommandOutput {
-            exit_code: 0,
-            stdout: String::new(),
-            stderr: String::new(),
-        }),
-    };
+    let runner = FakeRunRunner::new(Ok(RunCommandOutput {
+        exit_code: 0,
+        stdout: String::new(),
+        stderr: String::new(),
+    }));
 
     let result = submit_run_with_runner(
         &store,

--- a/src-tauri/src/run_context/transfer.rs
+++ b/src-tauri/src/run_context/transfer.rs
@@ -2652,6 +2652,71 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn relay_transfer_fails_when_the_scp_step_exits_nonzero() {
+        let (root, store) = test_store().await;
+        let runner = Arc::new(RecordingRunner {
+            outputs: StdMutex::new(
+                vec![Ok(RunCommandOutput {
+                    exit_code: 1,
+                    stdout: String::new(),
+                    stderr: "scp: /data/result.txt: No such file or directory".into(),
+                })]
+                .into(),
+            ),
+            commands: StdMutex::new(Vec::new()),
+        });
+        let manager = RunManager::with_runner(runner.clone());
+        let response = submit_transfer(
+            &store,
+            &manager,
+            "p",
+            Some("f"),
+            &root,
+            TransferRequest {
+                source_context_id: "ssh:a".into(),
+                source_path: "/data/result.txt".into(),
+                destination_context_id: "ssh:b".into(),
+                destination_path: Some("/results/".into()),
+                route: "auto".into(),
+                transport: "auto".into(),
+                resume: false,
+                timeout_secs: Some(30),
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(response["route"], "relay");
+        let run_id = response["run_id"].as_str().unwrap();
+        let run = loop {
+            let run = store.get_run(run_id).await.unwrap().unwrap();
+            if run.status.is_terminal() {
+                break run;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        };
+        assert_eq!(run.status, wisp_store::RunStatus::Failed);
+        assert_eq!(run.kind, "file_transfer");
+        assert_eq!(run.exit_code, Some(-1));
+        let progress: wisp_store::RunProgress = serde_json::from_str(&run.progress_json).unwrap();
+        assert_eq!(progress.phase, "failed");
+        let stderr = run.stderr_tail.as_deref().unwrap();
+        assert!(
+            stderr.contains("SSH download failed with exit 1"),
+            "{stderr}"
+        );
+        assert!(stderr.contains("No such file or directory"), "{stderr}");
+        let commands = runner.commands.lock().unwrap();
+        assert_eq!(
+            commands.len(),
+            1,
+            "a failed download must stop before the upload step"
+        );
+        assert_eq!(commands[0].script, "relay download");
+        drop(commands);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
     async fn local_source_uploads_to_selected_ssh_without_shell_transfer() {
         let (root, store) = test_store().await;
         let source = root.join("sample data.bam");

--- a/ui-tests/tests/exploration.spec.ts
+++ b/ui-tests/tests/exploration.spec.ts
@@ -65,6 +65,24 @@ test("exploration sidebar, banners, diff tabs, and Escape stack remain distinct 
   await expect(page.getByTestId("exploration-banner")).toContainText("Exploration B");
 });
 
+test("Escape immediately after opening the diff overlay closes only that layer", async ({ page }) => {
+  await enterExplorationProject(page);
+  await page.getByTestId("exploration-message-card").nth(0).click();
+  const banner = page.getByTestId("exploration-banner");
+  await expect(banner).toContainText("Exploration A");
+
+  await banner.getByRole("button", { name: "View diff" }).click();
+  const diff = page.getByTestId("exploration-diff-overlay");
+  await expect(diff).toBeVisible();
+  // Escape stack rule: press Escape immediately, before any focus moves into
+  // the overlay. One press closes only the topmost layer; the exploration
+  // view underneath must stay open.
+  await page.keyboard.press("Escape");
+  await expect(diff).toBeHidden();
+  await expect(banner).toBeVisible();
+  await expect(page.getByText("Exploration A result")).toBeVisible();
+});
+
 test("an exploration round banner and checkpoint cards stay scoped to its source session", async ({ page }) => {
   await page.goto("/?mockExplorations=1&mockOtherExplorationSession=1");
   await page.locator(".proj-card-main").first().click();

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -5059,10 +5059,24 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
   };
 }
 
-// Variant for parallel-session tests: each `send_message` streams an `echo:<msg>`
-// reply immediately but delays `Done` so the session stays "running" while the
-// test starts a second conversation. `list_sessions` reports every session that
-// received a user turn so the sidebar can list them.
+// Expected assistant reply text for a message sent under `parallelMock`.
+// Specs that must pin exact reply content derive it from these helpers so the
+// `echo:` convention stays an internal detail of this mock. (`parallelMock`
+// itself is serialized into the page by addInitScript, so it cannot call
+// these; its inline template below must stay in sync.)
+export function parallelReplyText(message: string): string {
+  return `echo:${message}`;
+}
+
+export function parallelReplyTailText(message: string): string {
+  return `${parallelReplyText(message)}:tail`;
+}
+
+// Variant for parallel-session tests: each `send_message` streams a reply
+// quoting the message (see `parallelReplyText`) immediately but delays `Done`
+// so the session stays "running" while the test starts a second conversation.
+// `list_sessions` reports every session that received a user turn so the
+// sidebar can list them.
 export function parallelMock(): void {
   const params = new URLSearchParams(window.location.search);
   const listeners: Record<string, ((e: { payload: unknown }) => void) | undefined> = {};
@@ -5094,6 +5108,10 @@ export function parallelMock(): void {
           case "load_session": {
             const delay = Number((window as any).__parallelLoadDelayMs ?? 0);
             if (delay > 0) await new Promise((resolve) => setTimeout(resolve, delay));
+            // Counts loads whose (possibly delayed) snapshot has been handed to
+            // the UI, so tests can wait for the late snapshot instead of sleeping.
+            (window as any).__parallelLoadsResolved =
+              ((window as any).__parallelLoadsResolved ?? 0) + 1;
             return { items: [], next_before_seq: null, user_offset: 0 };
           }
           case "list_sessions_page": return {

--- a/ui-tests/tests/pptx-preview-width.spec.ts
+++ b/ui-tests/tests/pptx-preview-width.spec.ts
@@ -26,8 +26,13 @@ test("PPTX preview width stays pinned in a narrow modal", async ({ page }) => {
     const m = (content?.style.transform || "").match(/scale\(([\d.]+)\)/);
     return { cw: c.clientWidth, figW: fig.offsetWidth, scale: m ? parseFloat(m[1]) : null };
   });
-  await page.waitForTimeout(500);
+  // Wait for the slide content to actually render (its scale transform is set
+  // by the sizing pass) instead of sleeping and hoping it has.
+  await expect.poll(async () => (await measure(page)).scale).not.toBeNull();
   const a = await measure(page);
+  // Deliberate observation window: the regression is a feedback loop that
+  // drifts the width over time, so hold still and re-measure — there is no
+  // condition to await for "nothing changed".
   await page.waitForTimeout(700);
   const b = await measure(page);
 

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -6459,13 +6459,16 @@ test("runtime inspector lists object metadata without loading object contents", 
     clientY: startY,
   });
   await expect(rEnvironment).toHaveClass(/is-dragging/);
-  await dragHandle.dispatchEvent("pointermove", {
-    buttons: 1,
-    pointerId: 7,
-    clientX: startX - 120,
-    clientY: startY + 48,
-  });
+  // Re-dispatch the move inside the poll: a single pointermove right after the
+  // drag state flips can still be batched away by Leptos on a busy CI worker,
+  // leaving the panel unmoved even though is-dragging is set.
   await expect.poll(async () => {
+    await dragHandle.dispatchEvent("pointermove", {
+      buttons: 1,
+      pointerId: 7,
+      clientX: startX - 120,
+      clientY: startY + 48,
+    });
     const afterDrag = await rEnvironment.boundingBox();
     return beforeDrag && afterDrag ? Math.round(beforeDrag.x - afterDrag.x) : 0;
   }).toBeGreaterThan(100);

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect, type Locator, type Page } from "@playwright/test";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { tauriMock, parallelMock } from "./mock-tauri";
+import { tauriMock, parallelMock, parallelReplyTailText } from "./mock-tauri";
 
 const officeFixtures = {
   xlsxBase64: readFileSync(resolve(__dirname, "../fixtures/office-preview.xlsx")).toString("base64"),
@@ -86,6 +86,35 @@ function composer(page: Page) {
   return page.locator("#composer-input");
 }
 
+// Transcript-scoped locators for parallelMock conversations. The mock replies
+// to each user turn with a single assistant bubble quoting the message text,
+// so specs assert on the user's own text landing in the right session's rows
+// instead of depending on the mock's internal reply format.
+function userTurn(page: Page, text: string) {
+  return page.locator(".msg.user .body", { hasText: text });
+}
+
+function assistantReplyQuoting(page: Page, text: string) {
+  return page.locator(".msg.assistant .body", { hasText: text });
+}
+
+// Shortcut labels come from the UI's platform detection (`is_mac` in
+// ui/src/api.js reads navigator.userAgent/platform), so any test asserting
+// literal "Ctrl+…" text must pin a non-mac platform first or it renders
+// "⌘…" on macOS hosts. Call before the first page.goto().
+async function pinNonMacPlatform(page: Page) {
+  await page.addInitScript(() => {
+    Object.defineProperty(navigator, "userAgent", {
+      configurable: true,
+      value: "wisp-science/Tauri",
+    });
+    Object.defineProperty(navigator, "platform", {
+      configurable: true,
+      value: "Linux x86_64",
+    });
+  });
+}
+
 async function selectAssistantReplyText(
   page: Page,
   eventType: "mouseup" | "contextmenu" = "mouseup",
@@ -168,6 +197,15 @@ async function lastInvokeArgs(page: Page, cmd: string) {
     const calls = ((window as any).__skillInvokeLog ?? []).filter((c: any) => c.cmd === name);
     return plain(calls.at(-1)?.args ?? null);
   }, cmd);
+}
+
+// How many run-list refreshes the UI has performed. The app polls `list_runs`
+// on a ticker (every second while a turn is busy or a transfer is active),
+// so "wait until N more polls happened" replaces fixed sleeps in tests that
+// assert the UI survives a poll-driven rebuild.
+async function runListPollCount(page: Page) {
+  return page.evaluate(() =>
+    ((window as any).__skillInvokeLog ?? []).filter((c: any) => c.cmd === "list_runs").length);
 }
 
 async function invokeArgsList(page: Page, cmd: string) {
@@ -489,16 +527,7 @@ test("undo returns the latest prompt and keeps unsupported Word files", async ({
 });
 
 test("general settings can use Ctrl+Enter to send and Enter for newline", async ({ page }) => {
-  await page.addInitScript(() => {
-    Object.defineProperty(navigator, "userAgent", {
-      configurable: true,
-      value: "wisp-science/Tauri",
-    });
-    Object.defineProperty(navigator, "platform", {
-      configurable: true,
-      value: "Linux x86_64",
-    });
-  });
+  await pinNonMacPlatform(page);
   await enterApp(page);
   await openSettingsSection(page, "General");
   const shortcut = page.getByTestId("send-shortcut");
@@ -2288,16 +2317,7 @@ test("Ctrl+K opens the unified command palette and Shift+Enter attaches", async 
 });
 
 test("Ctrl+K opens in place and Ctrl+Enter opens a project window", async ({ page }) => {
-  await page.addInitScript(() => {
-    Object.defineProperty(navigator, "userAgent", {
-      configurable: true,
-      value: "wisp-science/Tauri",
-    });
-    Object.defineProperty(navigator, "platform", {
-      configurable: true,
-      value: "Linux x86_64",
-    });
-  });
+  await pinNonMacPlatform(page);
   await enterApp(page);
   await page.keyboard.press("Control+k");
   const search = commandPalette(page);
@@ -2789,6 +2809,7 @@ test("Cmd+Enter sends when the modifier shortcut is selected on macOS", async ({
 });
 
 test("Ctrl+P command palette runs commands and switches themes", async ({ page }) => {
+  await pinNonMacPlatform(page);
   await enterApp(page);
   await page.keyboard.press("Control+p");
   const palette = page.getByRole("dialog", { name: "Command Palette" });
@@ -2879,6 +2900,7 @@ test("Ctrl+P command palette runs commands and switches themes", async ({ page }
 });
 
 test("privacy mode hides selected projects and recent sessions, then restores them", async ({ page }) => {
+  await pinNonMacPlatform(page);
   await page.goto("/");
   const privateProject = page.locator(".proj-card", { hasText: "wisp-science" });
   const otherProject = page.locator(".proj-card", { hasText: "Other project" });
@@ -3031,7 +3053,7 @@ test("rename session modal autofocuses so Ctrl+A selects the title", async ({ pa
 
   await composer(page).fill("rename-me");
   await page.getByRole("button", { name: "Send" }).click();
-  await expect(page.getByText("echo:rename-me")).toBeVisible({ timeout: 10_000 });
+  await expect(assistantReplyQuoting(page, "rename-me")).toBeVisible({ timeout: 10_000 });
 
   await page.locator(".side-item.ses", { hasText: "rename-me" }).dblclick();
   const input = page.locator("#rename-session-input");
@@ -3063,7 +3085,7 @@ test("conversation action button renames, transfers, and deletes sessions (#557)
 
   await composer(page).fill("actions-manage-me");
   await page.getByRole("button", { name: "Send" }).click();
-  await expect(page.getByText("echo:actions-manage-me")).toBeVisible({ timeout: 10_000 });
+  await expect(assistantReplyQuoting(page, "actions-manage-me")).toBeVisible({ timeout: 10_000 });
   let session = page.locator(".side-item.ses", { hasText: "actions-manage-me" });
   await expect(session).toBeVisible({ timeout: 10_000 });
 
@@ -3143,7 +3165,7 @@ test("conversation action button renames, transfers, and deletes sessions (#557)
   await newSessionButton(page).click();
   await composer(page).fill("actions-delete-me");
   await page.getByRole("button", { name: "Send" }).click();
-  await expect(page.getByText("echo:actions-delete-me")).toBeVisible({ timeout: 10_000 });
+  await expect(assistantReplyQuoting(page, "actions-delete-me")).toBeVisible({ timeout: 10_000 });
   session = page.locator(".side-item.ses", { hasText: "actions-delete-me" });
   await expect(session).toBeVisible({ timeout: 10_000 });
   await openActions();
@@ -3167,7 +3189,7 @@ test("stale project rules can be reloaded from the session context menu", async 
   await newSessionButton(page).click();
   await composer(page).fill("fresh rules chat");
   await page.getByRole("button", { name: "Send" }).click();
-  await expect(page.getByText("echo:fresh rules chat")).toBeVisible({ timeout: 10_000 });
+  await expect(assistantReplyQuoting(page, "fresh rules chat")).toBeVisible({ timeout: 10_000 });
   const fresh = page.locator(".side-item.ses", { hasText: "fresh rules chat" });
   await expect(fresh).toBeVisible({ timeout: 10_000 });
   await fresh.click({ button: "right" });
@@ -5971,10 +5993,15 @@ test("monitor_run renders a live Run card from summary polls and on-demand detai
   // Starting another turn remounts settled transcript rows. A manual
   // dismissal must survive that remount instead of flashing back until the
   // next run-list refresh.
+  const pollsBeforeRemount = await runListPollCount(page);
   await composer(page).fill("continue after dismiss");
   await page.getByRole("button", { name: "Send" }).click();
   await expect(card).toHaveCount(0);
-  await page.waitForTimeout(1_500);
+  // The flash-back regression appeared on the run-list refresh after the
+  // remount, so wait for that refresh to actually happen before re-checking.
+  await expect
+    .poll(() => runListPollCount(page), { timeout: 15_000 })
+    .toBeGreaterThan(pollsBeforeRemount);
   await expect(card).toHaveCount(0);
 });
 
@@ -6024,9 +6051,14 @@ test("run monitor output stays pinned to the tail across poll rebuilds (#654)", 
   await output.evaluate((el) => {
     el.scrollTop = 0;
   });
+  const pollsBeforeBatch3 = await runListPollCount(page);
   await setOutput("batch-3");
   await expect(output).toContainText("batch-3");
-  await page.waitForTimeout(1_500);
+  // The yank would happen on a poll rebuild after the content update, so wait
+  // for another refresh to complete before asserting the scroll position held.
+  await expect
+    .poll(() => runListPollCount(page), { timeout: 10_000 })
+    .toBeGreaterThan(pollsBeforeBatch3 + 1);
   expect(await output.evaluate((el) => el.scrollTop)).toBeLessThanOrEqual(2);
 
   // Scrolling back to the bottom re-engages follow.
@@ -6080,10 +6112,15 @@ test("a settled run card stops rebuilding itself on every poll (#654)", async ({
 
   // Tag the live node. Identical poll results must leave it in place: replacing
   // it is what reset the panel to its top edge for a frame, once per second.
+  const pollsBeforeProbe = await runListPollCount(page);
   await output.evaluate((el) => {
     (el as any).__stableProbe = true;
   });
-  await page.waitForTimeout(3_000);
+  // Wait for several identical poll results to come back, then verify none of
+  // them replaced the tagged node.
+  await expect
+    .poll(() => runListPollCount(page), { timeout: 15_000 })
+    .toBeGreaterThanOrEqual(pollsBeforeProbe + 3);
   expect(await output.evaluate((el) => (el as any).__stableProbe === true)).toBe(true);
   expect(await bottomGap()).toBeLessThanOrEqual(2);
 });
@@ -8760,6 +8797,7 @@ test("session history loads older pages with a stable cursor", async ({ page }) 
 });
 
 test("sidebar search opens the Ctrl+K palette and finds sessions beyond loaded history", async ({ page }) => {
+  await pinNonMacPlatform(page);
   await page.goto("/?mockManySessions=1");
   await page.locator(".proj-card-main").first().click();
 
@@ -10277,11 +10315,12 @@ test("a second conversation can run in parallel without interleaving transcripts
   await page.locator(".proj-card-main").first().click();
   await expect(newSessionButton(page)).toBeVisible();
 
-  // Start conversation A. The mock streams "echo:alpha" at once but delays Done,
+  // Start conversation A. The mock streams A's reply at once but delays Done,
   // so A stays "running".
   await composer(page).fill("alpha");
   await page.getByRole("button", { name: "Send" }).click();
-  await expect(page.getByText("echo:alpha")).toBeVisible({ timeout: 10_000 });
+  await expect(userTurn(page, "alpha")).toBeVisible({ timeout: 10_000 });
+  await expect(assistantReplyQuoting(page, "alpha")).toBeVisible({ timeout: 10_000 });
 
   // While A is still running, open a fresh session. The composer must be usable
   // (per-session busy: A running does NOT block B).
@@ -10289,18 +10328,22 @@ test("a second conversation can run in parallel without interleaving transcripts
   await expect(composer(page)).toBeEmpty();
   await composer(page).fill("beta");
   await page.getByRole("button", { name: "Send" }).click();
-  await expect(page.getByText("echo:beta")).toBeVisible({ timeout: 10_000 });
+  await expect(userTurn(page, "beta")).toBeVisible({ timeout: 10_000 });
+  await expect(assistantReplyQuoting(page, "beta")).toBeVisible({ timeout: 10_000 });
 
   // A's transcript must not leak into B's view.
-  await expect(page.getByText("echo:alpha")).toHaveCount(0);
+  await expect(userTurn(page, "alpha")).toHaveCount(0);
+  await expect(assistantReplyQuoting(page, "alpha")).toHaveCount(0);
 
   // A is still running → its sidebar entry shows the running indicator.
   await expect(page.locator(".side-item.ses.running", { hasText: "alpha" })).toBeVisible();
 
   // Switch back to A: the cached (live) transcript renders, B's does not.
   await page.locator(".side-item.ses", { hasText: "alpha" }).click();
-  await expect(page.getByText("echo:alpha")).toBeVisible({ timeout: 10_000 });
-  await expect(page.getByText("echo:beta")).toHaveCount(0);
+  await expect(userTurn(page, "alpha")).toBeVisible({ timeout: 10_000 });
+  await expect(assistantReplyQuoting(page, "alpha")).toBeVisible({ timeout: 10_000 });
+  await expect(userTurn(page, "beta")).toHaveCount(0);
+  await expect(assistantReplyQuoting(page, "beta")).toHaveCount(0);
 });
 
 test("delayed session loads cannot expose or overwrite another live transcript (#595)", async ({ page }) => {
@@ -10313,35 +10356,41 @@ test("delayed session loads cannot expose or overwrite another live transcript (
   // takes the asynchronous idle-session load path.
   await composer(page).fill("alpha");
   await page.getByRole("button", { name: "Send" }).click();
-  await expect(page.getByText("echo:alpha")).toBeVisible({ timeout: 10_000 });
+  await expect(assistantReplyQuoting(page, "alpha")).toBeVisible({ timeout: 10_000 });
   await newSessionButton(page).click();
   await composer(page).fill("actions-beta");
   await page.getByRole("button", { name: "Send" }).click();
-  await expect(page.getByText("echo:actions-beta")).toBeVisible();
+  await expect(assistantReplyQuoting(page, "actions-beta")).toBeVisible();
   await expect(page.locator(".side-item.ses", { hasText: "actions-beta" })).toBeVisible();
 
   await page.locator(".side-item.ses", { hasText: "alpha" }).click();
-  await expect(page.getByText("echo:alpha")).toBeVisible();
+  await expect(assistantReplyQuoting(page, "alpha")).toBeVisible();
   await page.evaluate(() => { (window as any).__parallelLoadDelayMs = 800; });
 
   // The target cache must be installed before active_session changes. Under the
   // old ordering, A remained visible here until B's delayed load completed.
+  const loadsBeforeSwitch = await page.evaluate(() =>
+    Number((window as any).__parallelLoadsResolved ?? 0));
   await page.locator(".side-item.ses", { hasText: "actions-beta" }).click();
-  await expect(page.getByText("echo:alpha")).toHaveCount(0);
-  await expect(page.getByText("echo:actions-beta")).toBeVisible();
+  await expect(assistantReplyQuoting(page, "alpha")).toHaveCount(0);
+  await expect(assistantReplyQuoting(page, "actions-beta")).toBeVisible();
 
   // Start a live B turn while its old DB page is still loading. The late empty
   // snapshot must not erase the streamed result.
   await composer(page).fill("gamma");
   await page.getByRole("button", { name: "Send" }).click();
-  await expect(page.getByText("echo:gamma")).toBeVisible();
-  await page.waitForTimeout(1_000);
-  await expect(page.getByText("echo:gamma")).toBeVisible();
-  await expect(page.getByText("echo:alpha")).toHaveCount(0);
+  await expect(assistantReplyQuoting(page, "gamma")).toBeVisible();
+  // Wait for the delayed snapshot to actually arrive before asserting it did
+  // not erase the live turn (not a fixed sleep hoping it has landed).
+  await expect
+    .poll(() => page.evaluate(() => Number((window as any).__parallelLoadsResolved ?? 0)))
+    .toBeGreaterThan(loadsBeforeSwitch);
+  await expect(assistantReplyQuoting(page, "gamma")).toBeVisible();
+  await expect(assistantReplyQuoting(page, "alpha")).toHaveCount(0);
 
   await page.locator(".side-item.ses", { hasText: "alpha" }).click();
-  await expect(page.getByText("echo:alpha")).toBeVisible();
-  await expect(page.getByText("echo:gamma")).toHaveCount(0);
+  await expect(assistantReplyQuoting(page, "alpha")).toBeVisible();
+  await expect(assistantReplyQuoting(page, "gamma")).toHaveCount(0);
 });
 
 test("a running conversation accepts another message for queueing", async ({ page }) => {
@@ -10352,7 +10401,7 @@ test("a running conversation accepts another message for queueing", async ({ pag
 
   await composer(page).fill("alpha");
   await page.getByRole("button", { name: "Send" }).click();
-  await expect(page.getByText("echo:alpha")).toBeVisible({ timeout: 10_000 });
+  await expect(assistantReplyQuoting(page, "alpha")).toBeVisible({ timeout: 10_000 });
 
   await composer(page).fill("queued");
   // Queue (#433): sending into a busy session queues directly — no dialog. The
@@ -10377,9 +10426,10 @@ test("a running conversation accepts another message for queueing", async ({ pag
   // The first turn keeps streaming after the second is queued. Its tail must
   // stay attached to the first assistant row instead of leaking into a hidden
   // placeholder after the queued user message (#143). "queued" must NOT run yet.
-  await expect(page.getByText("echo:alpha:tail", { exact: true })).toBeVisible({ timeout: 3_000 });
+  await expect(page.getByText(parallelReplyTailText("alpha"), { exact: true }))
+    .toBeVisible({ timeout: 3_000 });
   await expect(queued).toBeVisible();
-  await expect(page.getByText("echo:queued")).toHaveCount(0);
+  await expect(assistantReplyQuoting(page, "queued")).toHaveCount(0);
 
   // Only "alpha" ran as a live turn; the queue waits behind it.
   await expect.poll(async () => page.evaluate(() =>
@@ -10390,7 +10440,7 @@ test("a running conversation accepts another message for queueing", async ({ pag
 
   // Once alpha finishes, the driver drains the queue: "queued" now runs and its
   // optimistic bubble promotes to a live turn (#433).
-  await expect(page.getByText("echo:queued")).toBeVisible({ timeout: 10_000 });
+  await expect(assistantReplyQuoting(page, "queued")).toBeVisible({ timeout: 10_000 });
 });
 
 test("queued follow-ups can be reordered up and down (#433)", async ({ page }) => {
@@ -10402,7 +10452,7 @@ test("queued follow-ups can be reordered up and down (#433)", async ({ page }) =
   // alpha stays running ~5s, keeping the session busy while we queue two more.
   await composer(page).fill("alpha");
   await page.getByRole("button", { name: "Send" }).click();
-  await expect(page.getByText("echo:alpha")).toBeVisible({ timeout: 10_000 });
+  await expect(assistantReplyQuoting(page, "alpha")).toBeVisible({ timeout: 10_000 });
 
   for (const msg of ["bravo", "charlie"]) {
     await composer(page).fill(msg);
@@ -10439,7 +10489,7 @@ test("editing a queued follow-up restores it to the composer", async ({ page }) 
 
   await composer(page).fill("alpha");
   await page.getByRole("button", { name: "Send" }).click();
-  await expect(page.getByText("echo:alpha")).toBeVisible({ timeout: 10_000 });
+  await expect(assistantReplyQuoting(page, "alpha")).toBeVisible({ timeout: 10_000 });
 
   await composer(page).fill("what is QC?");
   await page.getByRole("button", { name: "Queue…" }).click();

--- a/ui-tests/tests/visual-polish.spec.ts
+++ b/ui-tests/tests/visual-polish.spec.ts
@@ -20,21 +20,41 @@ test("composer rests on a hairline border and small shadow until focused", async
   const inner = page.locator(".composer-inner").first();
   const input = page.locator(".composer-inner textarea").first();
 
-  await input.blur();
-  const resting = await inner.evaluate((el) => {
-    const cs = getComputedStyle(el);
-    return { borderColor: cs.borderTopColor, boxShadow: cs.boxShadow };
+  // Structural assertions against theme tokens rather than exact palette
+  // values, so a token tweak does not break the test: the resting composer
+  // uses the soft --border hairline (not --border-strong), and focus is the
+  // only state that adds the big --shadow lift on top of --shadow-sm.
+  const largestBlur = () => inner.evaluate((el) => {
+    const shadow = getComputedStyle(el).boxShadow;
+    if (!shadow || shadow === "none") return 0;
+    // Split layers at top-level commas (not the ones inside rgb()/rgba()).
+    return Math.max(...shadow.split(/,(?![^(]*\))/).map((layer) => {
+      const lengths = layer.match(/-?\d+(?:\.\d+)?px/g) ?? [];
+      // offset-x offset-y blur [spread]
+      return parseFloat(lengths[2] ?? "0");
+    }));
   });
-  // --border (rgba(60,55,45,.1) in the paper palette), not --border-strong (#d6d4cc).
-  expect(resting.borderColor).toBe("rgba(60, 55, 45, 0.1)");
-  // Only --shadow-sm; the big --shadow lift (32px blur) is reserved for focus.
-  // Poll past the .15s box-shadow transition, which pads lists with zero layers.
-  await expect.poll(() => inner.evaluate((el) => getComputedStyle(el).boxShadow))
-    .not.toContain("32px");
+
+  await input.blur();
+  const border = await inner.evaluate((el) => {
+    const swatch = document.createElement("span");
+    document.body.appendChild(swatch);
+    swatch.style.color = "var(--border)";
+    const soft = getComputedStyle(swatch).color;
+    swatch.style.color = "var(--border-strong)";
+    const strong = getComputedStyle(swatch).color;
+    swatch.remove();
+    return { resting: getComputedStyle(el).borderTopColor, soft, strong };
+  });
+  expect(border.resting).toBe(border.soft);
+  expect(border.resting).not.toBe(border.strong);
+
+  // Poll past the .15s box-shadow transition before reading the resting blur.
+  await expect.poll(largestBlur).toBeGreaterThan(0);
+  const restingBlur = await largestBlur();
 
   await input.focus();
-  await expect.poll(() => inner.evaluate((el) => getComputedStyle(el).boxShadow))
-    .toContain("32px");
+  await expect.poll(largestBlur).toBeGreaterThan(restingBlur);
 });
 
 test("composer shortcut hint appears only while the composer is focused or hovered", async ({ page }) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

A coverage-guided test-quality audit (cargo llvm-cov: 71.6% line coverage, 1187 tests) found that a meaningful slice of "covered" code was not actually verified: tautological tests that reimplement production logic in the test body, always-success fakes that pass regardless of what command they receive, wall-clock sleeps racing the scheduler, fixed shared temp paths, and store CRUD tests that never reopen the database to prove durability. The Playwright suite also had real failures on macOS from hard-coded `Ctrl+` shortcut labels.

## Changes

### crates (test-only, plus `tokio/test-util` dev-dependency in wisp-core)
- `wisp-tools/safety.rs`: table-driven sandbox tests for `validate_file_path`/`resolve_under_root` — `../` traversal, absolute escapes, missing parents, and a unix symlink-escape case
- `wisp-tools/edit.rs`: CRLF + CJK exact-string edit preserves line endings byte-for-byte
- `wisp-core/agent.rs`: `SpyTool` uses a per-test flag instead of a process-global static; new `StreamingSequenceProvider` actually drives `StreamSink` deltas (text, fragmented tool calls, usage); new retry-recovery test (two 503s then success) using a paused tokio clock
- `wisp-store`: `roundtrip` and migration tests close and reopen the DB before re-asserting; duplicate `(frame_id, seq)` rejection test; two-pool concurrent-writer test exercising WAL/busy_timeout; schedule persistence verified across reopen; UUID-scoped secret entry names
- `wisp-core/provenance.rs`, `wisp-tools/lib.rs`: unique temp dirs replace fixed shared paths

### src-tauri (test-focused; two behavior-preserving helper extractions)
- Tautologies removed: queue-reorder and specialist-marker tests now drive extracted production helpers (`swap_queued_toward`, `append_specialist_section_once`) that the real command paths call; constants-only pet-window test deleted
- `FakeRunRunner` records every command it receives and key tests assert the sequence (wrong/missing commands can no longer pass silently)
- `context_probe.rs` `FakeRunner` panics on unmatched scripts instead of silently returning empty success; explicit empty-output probe test added
- Streaming heartbeat test synchronizes via `Notify`/`Semaphore` instead of 1300ms/1100ms sleeps; startup-timeline test pins durations instead of sleeping
- New transfer failure-path test: nonzero scp exit persists `Failed` with stderr tail
- `harvest_remote.rs`: constant-true relocation assert replaced with residency-specific threshold assertions
- `models.rs`: keyring tests UUID-scoped; credential registry test restores prior values via a Drop guard

### ui-tests (Playwright)
- Platform-aware shortcut label assertions via a shared `pinNonMacPlatform` helper (fixes the macOS failures recorded in `test-results/.last-run.json` where the UI renders `⌘N` instead of `Ctrl+N`)
- `waitForTimeout` races replaced with condition polls (run-list refresh counts, load-resolution counters, rendered transforms)
- Parallel-session specs assert UI-owned outcomes via transcript-scoped locators; the mock's `echo:` convention now lives only inside `mock-tauri.ts`
- New immediate-Escape test for the exploration diff overlay per the window-level Escape stack rule
- `visual-polish.spec.ts` asserts border tokens and structural shadow changes instead of hard-coded palette values

## Tests
- `cargo test --workspace`: **1194 passed, 0 failed**
- `cargo fmt --all -- --check`: clean
- `cd ui && cargo check --target wasm32-unknown-unknown`: clean (pre-existing `proc-macro-error2` future-incompat note only)
- Playwright full suite: **390 passed, 1 skipped (pre-existing env-gated release test), 0 failed**

## Manual smoke steps
None needed — no user-visible behavior changes; the two extracted src-tauri helpers are verbatim moves called from the original command paths.

## Known limitations / follow-ups
- Deliberately out of scope (subjective/lower value): collapsing `system_prompt.rs` contains-based prompt lint, `context.rs` summary-marker asserts, skills markdown lint, wisp-llm sanitize-test dedup, wisp-runtime manager timing
- `delegation_runtime.rs` Drop-cleanup poll test unchanged (needs a production test hook to be fully deterministic)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-17296f0a-7a64-4f87-a539-5b18432c35f6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-17296f0a-7a64-4f87-a539-5b18432c35f6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

