### PR TITLE
fix(ui): show the real send-failed error instead of {msg}

### DIFF
--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -340,6 +340,7 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
   let nextSessionImportDelayMs = 0;
   const nextProjectTransferDelayMs: Record<string, number> = {};
   let failNextProjectOpenId: string | null = null;
+  let failNextNewSession: string | null = null;
   (window as any).__delayNextProjectOpen = (projectId: string, milliseconds: number) => {
     nextProjectOpenDelayMs[String(projectId)] = Math.max(0, Number(milliseconds) || 0);
   };
@@ -354,6 +355,9 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
   };
   (window as any).__failNextProjectOpen = (projectId: string) => {
     failNextProjectOpenId = String(projectId);
+  };
+  (window as any).__failNextNewSession = (message?: string) => {
+    failNextNewSession = String(message || "Project not found");
   };
   (window as any).__setMockUpdateCheck = (value: Record<string, unknown>) => {
     mockUpdateCheck = { ...mockUpdateCheck, ...(value ?? {}) };
@@ -4164,6 +4168,11 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
             return memoryFilesFor(resolveMemoryProjectId(args, arg))
               .find((file) => file.name === arg("name"))?.preview ?? "";
           case "new_session": {
+            if (failNextNewSession) {
+              const message = failNextNewSession;
+              failNextNewSession = null;
+              throw new Error(message);
+            }
             const id = `s-${Math.random().toString(36).slice(2)}`;
             sessionModels[id] = activeHttpModelId();
             return id;

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -694,6 +694,21 @@ test("sidebar Feedback opens a blank conversation and waits for the user's first
   await expect(userBubble).not.toContainText("GitHub issue");
 });
 
+test("Feedback send shows the new_session error instead of a {msg} placeholder", async ({ page }) => {
+  await enterApp(page);
+  await page.getByTestId("report-problem-entry").click();
+  await expect(page.getByTestId("feedback-context")).toContainText("System information");
+  await page.evaluate(() => {
+    (window as any).__failNextNewSession("Project not found");
+  });
+  await page.locator("#composer-input").fill("The send button does nothing");
+  await page.getByRole("button", { name: "Send" }).click();
+  await expect(page.locator(".topbar .hint")).toHaveText("Send failed: Project not found");
+  await expect(page.locator(".topbar .hint")).not.toContainText("{msg}");
+  await expect(page.getByTestId("feedback-context")).toBeVisible();
+  await expect(page.locator("#composer-input")).toHaveValue("The send button does nothing");
+});
+
 test("Memory settings show the active project name", async ({ page }) => {
   await enterApp(page);
   await openSettingsSection(page, "Memory");

--- a/ui/src/app_support/prefs.rs
+++ b/ui/src/app_support/prefs.rs
@@ -266,24 +266,20 @@ pub(crate) fn parse_app_prefs_payload(payload: &serde_json::Value) -> AppPrefsPa
             .map(str::to_string),
         selection_popup_enabled: payload.get("selection_popup_enabled").and_then(|value| {
             value.as_bool().or_else(|| {
-                value
-                    .as_str()
-                    .and_then(|text| match text {
-                        "true" => Some(true),
-                        "false" => Some(false),
-                        _ => None,
-                    })
+                value.as_str().and_then(|text| match text {
+                    "true" => Some(true),
+                    "false" => Some(false),
+                    _ => None,
+                })
             })
         }),
         send_with_modifier: payload.get("send_with_modifier").and_then(|value| {
             value.as_bool().or_else(|| {
-                value
-                    .as_str()
-                    .and_then(|text| match text {
-                        "true" => Some(true),
-                        "false" => Some(false),
-                        _ => None,
-                    })
+                value.as_str().and_then(|text| match text {
+                    "true" => Some(true),
+                    "false" => Some(false),
+                    _ => None,
+                })
             })
         }),
         locale: payload
@@ -291,7 +287,9 @@ pub(crate) fn parse_app_prefs_payload(payload: &serde_json::Value) -> AppPrefsPa
             .and_then(|value| value.as_str())
             .map(str::to_string),
         max_iter: payload.get("max_iter").and_then(|value| value.as_i64()),
-        auto_compact: payload.get("auto_compact").and_then(|value| value.as_bool()),
+        auto_compact: payload
+            .get("auto_compact")
+            .and_then(|value| value.as_bool()),
         auto_continue: payload
             .get("auto_continue")
             .and_then(|value| value.as_bool()),

--- a/ui/src/app_support/sessions.rs
+++ b/ui/src/app_support/sessions.rs
@@ -1,5 +1,19 @@
 use super::*;
 
+pub(crate) async fn invoke_string_id(cmd: &str, args: JsValue) -> Result<String, String> {
+    match invoke_checked(cmd, args).await {
+        Ok(value) => value
+            .as_string()
+            .filter(|id| !id.is_empty())
+            .ok_or_else(String::new),
+        Err(error) => Err(js_error_text(error)),
+    }
+}
+
+pub(crate) async fn invoke_new_session() -> Result<String, String> {
+    invoke_string_id("new_session", JsValue::UNDEFINED).await
+}
+
 pub(crate) fn refresh_sessions(
     sessions: RwSignal<Vec<SessionInfo>>,
     pending: RwSignal<HashMap<String, usize>>,

--- a/ui/src/i18n.rs
+++ b/ui/src/i18n.rs
@@ -4603,6 +4603,20 @@ pub fn tab_count(locale: Locale, base: &str, n: usize) -> String {
     }
 }
 
+/// Format a send/session-start failure. Callers that used `t("status.send_failed")`
+/// left the `{msg}` placeholder on screen; this always interpolates a detail.
+pub fn send_failed(locale: Locale, msg: &str) -> String {
+    let detail = {
+        let trimmed = msg.trim();
+        if trimmed.is_empty() {
+            t(locale, "err.unknown")
+        } else {
+            localize_backend(locale, trimmed)
+        }
+    };
+    tf(locale, "status.send_failed", &[("msg", &detail)])
+}
+
 pub fn localize_backend(locale: Locale, msg: &str) -> String {
     match msg {
         "API URL is required." => t(locale, "err.api_url_required"),
@@ -5034,6 +5048,36 @@ mod api_error_hint_tests {
         let out = localize_backend(Locale::Zh, msg);
         assert!(out.starts_with(msg), "raw error must stay visible");
         assert!(out.contains(&t(Locale::Zh, "err.hint.balance")));
+    }
+
+    #[test]
+    fn send_failed_interpolates_backend_error() {
+        assert_eq!(
+            send_failed(Locale::Zh, "Project not found"),
+            "发送失败：Project not found"
+        );
+        assert_eq!(
+            send_failed(Locale::En, "Project not found"),
+            "Send failed: Project not found"
+        );
+    }
+
+    #[test]
+    fn send_failed_never_leaves_placeholder() {
+        assert_eq!(
+            send_failed(Locale::Zh, ""),
+            format!("发送失败：{}", t(Locale::Zh, "err.unknown"))
+        );
+        assert_eq!(
+            send_failed(Locale::En, "   "),
+            format!("Send failed: {}", t(Locale::En, "err.unknown"))
+        );
+        assert!(!send_failed(Locale::Zh, "").contains("{msg}"));
+        assert_eq!(
+            t(Locale::Zh, "status.send_failed"),
+            "发送失败：{msg}",
+            "raw t() still has a placeholder; send_failed must be used"
+        );
     }
 }
 

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -42,8 +42,8 @@ use bindings::{
 use context_menu::{ContextMenuPortal, CtxMenu};
 use dto::*;
 use i18n::{
-    empty_subtitle, empty_title, localize_backend, set_document_lang, t, tab_count, tf, Locale,
-    EMPTY_SUBTITLE_COUNT, EMPTY_TITLE_COUNT,
+    empty_subtitle, empty_title, localize_backend, send_failed, set_document_lang, t, tab_count,
+    tf, Locale, EMPTY_SUBTITLE_COUNT, EMPTY_TITLE_COUNT,
 };
 use leptos::{ev, window_event_listener, *};
 use library::{refresh_library, refresh_session_library, HighlightsPane, LibraryScreen};
@@ -1634,7 +1634,7 @@ fn App() -> impl IntoView {
         spawn_local(async move {
             let v = invoke("start_scratch_chat", JsValue::UNDEFINED).await;
             let Ok(info) = serde_wasm_bindgen::from_value::<ScratchChatInfo>(v) else {
-                status.set(t(locale.get(), "status.send_failed").into());
+                status.set(send_failed(locale.get(), ""));
                 return;
             };
             scratch_open.set(true);
@@ -3566,14 +3566,14 @@ fn App() -> impl IntoView {
                     references: reference_args,
                 })
                 .unwrap();
-                if invoke_checked("enqueue_turn", args).await.is_err() {
+                if let Err(error) = invoke_checked("enqueue_turn", args).await {
                     route_items(active_session, items, transcripts, &session, |rows| {
                         remove_optimistic_send_rows(rows, &enqueue_msg);
                     });
                     transcript_projection_epoch.update(|revision| {
                         *revision = revision.wrapping_add(1);
                     });
-                    status.set(t(locale.get(), "status.send_failed").into());
+                    status.set(send_failed(locale.get(), &js_error_text(error)));
                 }
             });
             return;
@@ -3604,30 +3604,30 @@ fn App() -> impl IntoView {
                     Some("after_response"),
                 ))
                 .unwrap();
-                match invoke("branch_session", args).await.as_string() {
-                    Some(id) => id,
-                    None => {
+                match invoke_string_id("branch_session", args).await {
+                    Ok(id) => id,
+                    Err(error) => {
                         input.set(message);
                         attachments.set(saved_attachments);
                         composer_references.set(refs);
                         composer_quotes.set(quotes);
                         feedback_context.set(attached_feedback.clone());
-                        status.set(t(locale.get(), "status.send_failed").into());
+                        status.set(send_failed(locale.get(), &error));
                         return;
                     }
                 }
             } else if let Some(id) = active {
                 id
             } else {
-                match invoke("new_session", JsValue::UNDEFINED).await.as_string() {
-                    Some(id) => id,
-                    None => {
+                match invoke_new_session().await {
+                    Ok(id) => id,
+                    Err(error) => {
                         input.set(message);
                         attachments.set(saved_attachments);
                         composer_references.set(refs);
                         composer_quotes.set(quotes);
                         feedback_context.set(attached_feedback.clone());
-                        status.set(t(locale.get(), "status.send_failed").into());
+                        status.set(send_failed(locale.get(), &error));
                         return;
                     }
                 }
@@ -4086,10 +4086,12 @@ fn App() -> impl IntoView {
                     Some(checkpoint_kind),
                 ))
                 .unwrap();
-                let Some(id) = invoke("branch_session", arg).await.as_string() else {
-                    let loc = locale.get();
-                    status.set(t(loc, "status.send_failed").into());
-                    return;
+                let id = match invoke_string_id("branch_session", arg).await {
+                    Ok(id) => id,
+                    Err(error) => {
+                        status.set(send_failed(locale.get(), &error));
+                        return;
+                    }
                 };
                 if let Some(source_id) = sid.clone() {
                     conversation_branches.update(|branches| {
@@ -4451,10 +4453,13 @@ fn App() -> impl IntoView {
         context_recovery_busy.set(true);
         context_recovery_error.set(None);
         spawn_local(async move {
-            let Some(id) = invoke("new_session", JsValue::UNDEFINED).await.as_string() else {
-                context_recovery_error.set(Some(t(locale.get_untracked(), "status.send_failed")));
-                context_recovery_busy.set(false);
-                return;
+            let id = match invoke_new_session().await {
+                Ok(id) => id,
+                Err(error) => {
+                    context_recovery_error.set(Some(send_failed(locale.get_untracked(), &error)));
+                    context_recovery_busy.set(false);
+                    return;
+                }
             };
 
             let prompt = t(locale.get_untracked(), "context_recovery.new_prompt");
@@ -5346,12 +5351,14 @@ fn App() -> impl IntoView {
         sel_artifact.set(0);
         right_tab.set(RightTab::Artifacts);
         spawn_local(async move {
-            let v = invoke("new_session", JsValue::UNDEFINED).await;
             // Guard the malformed-response case before moving the visible
             // transcript, so failure leaves the current session untouched (#15).
-            let Some(id) = v.as_string() else {
-                status.set(t(locale.get(), "status.send_failed").into());
-                return;
+            let id = match invoke_new_session().await {
+                Ok(id) => id,
+                Err(error) => {
+                    status.set(send_failed(locale.get(), &error));
+                    return;
+                }
             };
             restore_chat_session_scroll(&id);
             replace_visible_transcript(
@@ -5399,13 +5406,13 @@ fn App() -> impl IntoView {
             force_chat_bottom();
             spawn_local(async move {
                 // Fresh frame for the setup turn; route events to it.
-                let v = invoke("new_session", JsValue::UNDEFINED).await;
-                let id = v.as_string().unwrap_or_default();
-                if id.is_empty() {
-                    let loc = locale.get();
-                    status.set(t(loc, "status.send_failed").into());
-                    return;
-                }
+                let id = match invoke_new_session().await {
+                    Ok(id) => id,
+                    Err(error) => {
+                        status.set(send_failed(locale.get(), &error));
+                        return;
+                    }
+                };
                 active_session.set(Some(id.clone()));
                 running.update(|r| {
                     r.insert(id.clone());
@@ -5538,10 +5545,12 @@ fn App() -> impl IntoView {
                     refresh_skills();
                 }
 
-                let Some(session_id) = invoke("new_session", JsValue::UNDEFINED).await.as_string()
-                else {
-                    status.set(t(locale.get(), "status.send_failed").into());
-                    return;
+                let session_id = match invoke_new_session().await {
+                    Ok(session_id) => session_id,
+                    Err(error) => {
+                        status.set(send_failed(locale.get(), &error));
+                        return;
+                    }
                 };
                 let initial = vec![
                     ChatItem::User(prompt.clone()),
@@ -6759,10 +6768,12 @@ fn App() -> impl IntoView {
         let loc = locale.get();
         let prompt = t(loc, "specialists.chat_prompt").to_string();
         spawn_local(async move {
-            let v = invoke("new_session", JsValue::UNDEFINED).await;
-            let Some(id) = v.as_string() else {
-                status.set(t(loc, "status.send_failed").into());
-                return;
+            let id = match invoke_new_session().await {
+                Ok(id) => id,
+                Err(error) => {
+                    status.set(send_failed(loc, &error));
+                    return;
+                }
             };
             active_session.set(Some(id.clone()));
             items.set(vec![]);
@@ -7360,14 +7371,10 @@ fn App() -> impl IntoView {
                 let prefs_context_id = context_id.clone();
                 let (session_id, created) = match active_session.get_untracked() {
                     Some(session_id) => (session_id, false),
-                    None => match invoke_checked("new_session", JsValue::UNDEFINED)
-                        .await
-                        .ok()
-                        .and_then(|value| value.as_string())
-                    {
-                        Some(session_id) => (session_id, true),
-                        None => {
-                            show_toast(&t(locale.get_untracked(), "status.send_failed"));
+                    None => match invoke_new_session().await {
+                        Ok(session_id) => (session_id, true),
+                        Err(error) => {
+                            show_toast(&send_failed(locale.get_untracked(), &error));
                             return;
                         }
                     },
@@ -9365,9 +9372,12 @@ fn App() -> impl IntoView {
         sel_artifact.set(0);
         right_tab.set(RightTab::Artifacts);
         spawn_local(async move {
-            let Some(id) = invoke("new_session", JsValue::UNDEFINED).await.as_string() else {
-                status.set(t(locale.get(), "status.send_failed").into());
-                return;
+            let id = match invoke_new_session().await {
+                Ok(id) => id,
+                Err(error) => {
+                    status.set(send_failed(locale.get(), &error));
+                    return;
+                }
             };
             replace_visible_transcript(
                 active_session.get_untracked(),
@@ -12780,9 +12790,12 @@ fn App() -> impl IntoView {
                                                                     sel_artifact.set(0);
                                                                     right_tab.set(RightTab::Artifacts);
                                                                     spawn_local(async move {
-                                                                        let Some(frame_id) = invoke("new_session", JsValue::UNDEFINED).await.as_string() else {
-                                                                            status.set(t(locale.get(), "status.send_failed").into());
-                                                                            return;
+                                                                        let frame_id = match invoke_new_session().await {
+                                                                            Ok(frame_id) => frame_id,
+                                                                            Err(error) => {
+                                                                                status.set(send_failed(locale.get(), &error));
+                                                                                return;
+                                                                            }
                                                                         };
                                                                         replace_visible_transcript(
                                                                             active_session.get_untracked(),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In 1.3.0, clicking **发送** on a conversation that still has no session (the Feedback / 系统信息 chip is the usual case) can show a literal `发送失败：{msg}` toast.

That happens when `new_session` fails *before* the turn starts. The UI called `t("status.send_failed")`, which leaves the `{msg}` placeholder, and used swallowing `invoke()` so the backend error never reached the toast.

`new_session` fails when the active project cannot be loaded, the project is locked by another operation, or creating the SQLite frame fails.

## Change

- Add `send_failed()` so `{msg}` is always replaced (falls back to “未知错误” / “Unknown error”).
- Use `invoke_checked` for `new_session` / `branch_session` / `enqueue_turn` on those start-failed paths and show the real backend text.
- Cover interpolation in unit tests and the Feedback send path in Playwright.

## Tests

- `ui` unit: `send_failed` interpolates and never leaves `{msg}`
- Playwright: Feedback send with a failing `new_session` shows `Send failed: Project not found`

## Smoke

1. Open 反馈 so the composer shows 系统信息 / 已自动附加.
2. Type a message and send while the project cannot create a session (busy export, missing project, etc.).
3. The top-right hint should include the real error, not `{msg}`.
4. The draft and system-info chip stay in the composer.

## Follow-up

Other `new_session` call sites (delegation / full-permission toggles) still swallow errors silently; they do not show this toast.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e441f117-9c59-4f63-bbb6-645bf2e7bc78?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e441f117-9c59-4f63-bbb6-645bf2e7bc78&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

