### PR TITLE
fix(windows): restore Snap Layouts and edge snap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7347,6 +7347,7 @@ dependencies = [
  "uuid",
  "walkdir",
  "which",
+ "windows",
  "winreg 0.55.0",
  "wisp-acp",
  "wisp-core",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -73,6 +73,13 @@ futures-util.workspace = true
 [target.'cfg(windows)'.dependencies]
 winreg = "0.55"
 tauri-winrt-notification = "0.7.3"
+windows = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_Graphics_Gdi",
+    "Win32_System_LibraryLoader",
+    "Win32_UI_Input_KeyboardAndMouse",
+    "Win32_UI_WindowsAndMessaging",
+] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 mac-notification-sys = "0.6.15"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -100,6 +100,7 @@ mod storage_prefs;
 mod terminal_sessions;
 mod turn_memory;
 mod turn_undo;
+mod windows_snap;
 mod workspace_manifest;
 mod workspace_scan;
 mod wsl_contexts;
@@ -7864,6 +7865,7 @@ pub fn run() {
                 if let Some(window) = app.get_webview_window("main") {
                     let _ = window.set_decorations(false);
                     let _ = window.set_shadow(true);
+                    windows_snap::install_for_window(&window);
                 }
             }
             #[cfg(target_os = "macos")]
@@ -8114,6 +8116,7 @@ pub fn run() {
             pet_commands::get_pet_runtime_status,
             pet_commands::open_pet_session,
             desktop_lifecycle::set_pet_window_visible,
+            windows_snap::start_window_move,
             models::list_models,
             models::get_session_model,
             models::get_session_reasoning_effort,

--- a/src-tauri/src/project_commands.rs
+++ b/src-tauri/src/project_commands.rs
@@ -353,6 +353,7 @@ pub(super) async fn spawn_project_window(
     #[cfg(target_os = "windows")]
     let builder = builder.decorations(false).shadow(true);
     let win = builder.build().map_err(|e| e.to_string())?;
+    crate::windows_snap::install_for_window(&win);
     #[cfg(target_os = "macos")]
     wire_macos_menu_events(&win);
     let evt_app = app.clone();

--- a/src-tauri/src/windows_snap.rs
+++ b/src-tauri/src/windows_snap.rs
@@ -1,0 +1,330 @@
+//! Windows snap for the custom title bar.
+//!
+//! Undecorated WebView2 windows do not participate in Aero Snap or Windows 11
+//! Snap Layouts: the child webview eats `WM_NCHITTEST`, and JS `startDragging`
+//! moves the window without a caption-style `SC_MOVE`.
+//!
+//! This module:
+//! - starts a caption move (`SC_MOVE | HTCAPTION`) so drag-to-edge snap works;
+//! - places a transparent native child over the maximize button that returns
+//!   `HTMAXBUTTON`, which is what Windows 11 uses for the Snap Layouts flyout.
+//!
+//! Geometry is platform-agnostic so tests do not need a real HWND.
+
+use tauri::WebviewWindow;
+
+/// Must match `.window-titlebar { height }` in `ui/src/styles/base.css`.
+pub const TITLEBAR_HEIGHT: u32 = 38;
+/// Must match `.window-controls button { width }` in `ui/src/styles/base.css`.
+pub const CONTROL_BUTTON_WIDTH: u32 = 46;
+pub const CONTROL_BUTTON_COUNT: u32 = 3;
+/// Close is 1, maximize is 2, minimize is 3, counting from the right edge.
+pub const MAXIMIZE_INDEX_FROM_RIGHT: u32 = 2;
+/// `SC_MOVE | HTCAPTION` — native move that participates in Aero Snap.
+pub const SYSCOMMAND_MOVE_CAPTION: usize = 0xF012;
+
+/// Logical maximize-button rect `(x, y, w, h)` inside the window client area.
+pub fn maximize_button_rect(inner_width: u32, inner_height: u32) -> Option<(u32, u32, u32, u32)> {
+    let min_width = CONTROL_BUTTON_WIDTH.saturating_mul(CONTROL_BUTTON_COUNT);
+    if inner_width < min_width || inner_height < TITLEBAR_HEIGHT {
+        return None;
+    }
+    let x =
+        inner_width.saturating_sub(CONTROL_BUTTON_WIDTH.saturating_mul(MAXIMIZE_INDEX_FROM_RIGHT));
+    Some((x, 0, CONTROL_BUTTON_WIDTH, TITLEBAR_HEIGHT))
+}
+
+pub fn should_install_snap(window_label: &str) -> bool {
+    window_label != "pet"
+}
+
+#[tauri::command]
+pub fn start_window_move(window: WebviewWindow) -> Result<(), String> {
+    #[cfg(windows)]
+    {
+        return start_caption_move(&window);
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = window;
+        Ok(())
+    }
+}
+
+pub fn install_for_window(window: &WebviewWindow) {
+    if !should_install_snap(window.label()) {
+        return;
+    }
+    #[cfg(windows)]
+    if let Err(error) = attach_maximize_overlay(window) {
+        tracing::warn!(label = %window.label(), %error, "windows snap overlay was not installed");
+    }
+    #[cfg(not(windows))]
+    let _ = window;
+}
+
+#[cfg(windows)]
+fn start_caption_move(window: &WebviewWindow) -> Result<(), String> {
+    use windows::Win32::Foundation::{HWND, LPARAM, WPARAM};
+    use windows::Win32::UI::Input::KeyboardAndMouse::ReleaseCapture;
+    use windows::Win32::UI::WindowsAndMessaging::{SendMessageW, WM_SYSCOMMAND};
+
+    let hwnd = window.hwnd().map_err(|error| error.to_string())?;
+    let hwnd_bits = hwnd.0 as isize;
+    window
+        .run_on_main_thread(move || {
+            let hwnd = HWND(hwnd_bits as *mut core::ffi::c_void);
+            unsafe {
+                let _ = ReleaseCapture();
+                let _ = SendMessageW(
+                    hwnd,
+                    WM_SYSCOMMAND,
+                    Some(WPARAM(SYSCOMMAND_MOVE_CAPTION)),
+                    Some(LPARAM(0)),
+                );
+            }
+        })
+        .map_err(|error| error.to_string())
+}
+
+#[cfg(windows)]
+fn attach_maximize_overlay(window: &WebviewWindow) -> Result<(), String> {
+    use std::collections::HashMap;
+    use std::sync::{Mutex, OnceLock};
+
+    use tauri::Manager;
+    use windows::core::w;
+    use windows::Win32::Foundation::{HWND, LPARAM, LRESULT, WPARAM};
+    use windows::Win32::System::LibraryLoader::GetModuleHandleW;
+    use windows::Win32::UI::WindowsAndMessaging::{
+        CreateWindowExW, DefWindowProcW, DestroyWindow, GetClassInfoExW, GetWindowLongPtrW,
+        LoadCursorW, RegisterClassExW, SetLayeredWindowAttributes, SetWindowLongPtrW, SetWindowPos,
+        ShowWindow, CREATESTRUCTW, CS_HREDRAW, CS_VREDRAW, GWLP_USERDATA, HTMAXBUTTON, HWND_TOP,
+        IDC_ARROW, LWA_ALPHA, SWP_NOACTIVATE, SWP_SHOWWINDOW, SW_HIDE, SW_SHOWNA, WM_CREATE,
+        WM_DESTROY, WM_LBUTTONDOWN, WM_NCHITTEST, WM_NCLBUTTONDOWN, WNDCLASSEXW, WS_CHILD,
+        WS_EX_LAYERED, WS_EX_NOACTIVATE, WS_VISIBLE,
+    };
+
+    const CLASS: windows::core::PCWSTR = w!("WispSnapMaxButton");
+
+    struct OverlayState {
+        app: tauri::AppHandle,
+        label: String,
+    }
+
+    unsafe extern "system" fn wnd_proc(
+        hwnd: HWND,
+        msg: u32,
+        wparam: WPARAM,
+        lparam: LPARAM,
+    ) -> LRESULT {
+        match msg {
+            WM_CREATE => {
+                let create = lparam.0 as *const CREATESTRUCTW;
+                if !create.is_null() {
+                    SetWindowLongPtrW(hwnd, GWLP_USERDATA, (*create).lpCreateParams as isize);
+                }
+                LRESULT(0)
+            }
+            WM_NCHITTEST => LRESULT(HTMAXBUTTON as isize),
+            WM_NCLBUTTONDOWN | WM_LBUTTONDOWN => {
+                toggle_parent_maximize(hwnd);
+                LRESULT(0)
+            }
+            WM_DESTROY => {
+                let raw = GetWindowLongPtrW(hwnd, GWLP_USERDATA);
+                if raw != 0 {
+                    drop(Box::from_raw(raw as *mut OverlayState));
+                    SetWindowLongPtrW(hwnd, GWLP_USERDATA, 0);
+                }
+                LRESULT(0)
+            }
+            _ => DefWindowProcW(hwnd, msg, wparam, lparam),
+        }
+    }
+
+    fn state<'a>(hwnd: HWND) -> Option<&'a OverlayState> {
+        let raw = unsafe { GetWindowLongPtrW(hwnd, GWLP_USERDATA) };
+        if raw == 0 {
+            None
+        } else {
+            Some(unsafe { &*(raw as *const OverlayState) })
+        }
+    }
+
+    fn toggle_parent_maximize(hwnd: HWND) {
+        let Some(state) = state(hwnd) else {
+            return;
+        };
+        let Some(window) = state.app.get_webview_window(&state.label) else {
+            return;
+        };
+        if window.is_maximized().unwrap_or(false) {
+            let _ = window.unmaximize();
+        } else {
+            let _ = window.maximize();
+        }
+    }
+
+    fn logical_inner_size(window: &WebviewWindow) -> Option<(u32, u32, f64)> {
+        let scale = window.scale_factor().ok()?;
+        let size = window.inner_size().ok()?;
+        let width = (f64::from(size.width) / scale).round() as u32;
+        let height = (f64::from(size.height) / scale).round() as u32;
+        Some((width, height, scale))
+    }
+
+    fn place(overlay: HWND, window: &WebviewWindow) {
+        let Some((width, height, scale)) = logical_inner_size(window) else {
+            return;
+        };
+        match maximize_button_rect(width, height) {
+            Some((x, y, w, h)) => {
+                let px = (f64::from(x) * scale).round() as i32;
+                let py = (f64::from(y) * scale).round() as i32;
+                let pw = (f64::from(w) * scale).round() as i32;
+                let ph = (f64::from(h) * scale).round() as i32;
+                unsafe {
+                    let _ = ShowWindow(overlay, SW_SHOWNA);
+                    let _ = SetWindowPos(
+                        overlay,
+                        Some(HWND_TOP),
+                        px,
+                        py,
+                        pw,
+                        ph,
+                        SWP_NOACTIVATE | SWP_SHOWWINDOW,
+                    );
+                }
+            }
+            None => unsafe {
+                let _ = ShowWindow(overlay, SW_HIDE);
+            },
+        }
+    }
+
+    fn overlays() -> std::sync::MutexGuard<'static, HashMap<String, isize>> {
+        static OVERLAYS: OnceLock<Mutex<HashMap<String, isize>>> = OnceLock::new();
+        OVERLAYS
+            .get_or_init(|| Mutex::new(HashMap::new()))
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    let parent = window.hwnd().map_err(|error| error.to_string())?;
+    let label = window.label().to_string();
+
+    if let Some(existing) = overlays().remove(&label) {
+        unsafe {
+            let _ = DestroyWindow(HWND(existing as *mut core::ffi::c_void));
+        }
+    }
+
+    let instance = unsafe { GetModuleHandleW(None).map_err(|error| error.to_string())? };
+    unsafe {
+        let mut info = std::mem::zeroed::<WNDCLASSEXW>();
+        if GetClassInfoExW(Some(instance.into()), CLASS, &mut info).is_err() {
+            let class = WNDCLASSEXW {
+                cbSize: std::mem::size_of::<WNDCLASSEXW>() as u32,
+                style: CS_HREDRAW | CS_VREDRAW,
+                lpfnWndProc: Some(wnd_proc),
+                hInstance: instance.into(),
+                hCursor: LoadCursorW(None, IDC_ARROW).unwrap_or_default(),
+                lpszClassName: CLASS,
+                ..Default::default()
+            };
+            if RegisterClassExW(&class) == 0 {
+                return Err("could not register snap overlay class".into());
+            }
+        }
+    }
+
+    let state = Box::new(OverlayState {
+        app: window.app_handle().clone(),
+        label: label.clone(),
+    });
+    let state_ptr = Box::into_raw(state);
+
+    let overlay = unsafe {
+        CreateWindowExW(
+            WS_EX_LAYERED | WS_EX_NOACTIVATE,
+            CLASS,
+            w!(""),
+            WS_CHILD | WS_VISIBLE,
+            0,
+            0,
+            CONTROL_BUTTON_WIDTH as i32,
+            TITLEBAR_HEIGHT as i32,
+            Some(parent),
+            None,
+            Some(instance.into()),
+            Some(state_ptr as *const core::ffi::c_void),
+        )
+    }
+    .map_err(|error| {
+        unsafe {
+            drop(Box::from_raw(state_ptr));
+        }
+        error.to_string()
+    })?;
+
+    unsafe {
+        let _ = SetLayeredWindowAttributes(overlay, Default::default(), 1, LWA_ALPHA);
+    }
+    place(overlay, window);
+
+    let overlay_bits = overlay.0 as isize;
+    overlays().insert(label.clone(), overlay_bits);
+
+    let event_window = window.clone();
+    let event_label = label;
+    window.on_window_event(move |event| match event {
+        tauri::WindowEvent::Resized(_)
+        | tauri::WindowEvent::ScaleFactorChanged { .. }
+        | tauri::WindowEvent::Moved(_) => {
+            place(HWND(overlay_bits as *mut core::ffi::c_void), &event_window)
+        }
+        tauri::WindowEvent::Destroyed => {
+            overlays().remove(&event_label);
+        }
+        _ => {}
+    });
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maximize_button_sits_left_of_close() {
+        let (x, y, w, h) = maximize_button_rect(1100, 760).expect("room for controls");
+        assert_eq!((y, w, h), (0, 46, 38));
+        assert_eq!(x, 1100 - 46 * 2);
+        assert_eq!(x + w, 1100 - 46, "must not cover the close button");
+        assert!(x >= 46, "must not cover the minimize button");
+    }
+
+    #[test]
+    fn maximize_button_is_absent_when_the_window_is_too_narrow() {
+        assert_eq!(maximize_button_rect(100, 760), None);
+        assert_eq!(maximize_button_rect(1100, 20), None);
+        assert_eq!(
+            maximize_button_rect(CONTROL_BUTTON_WIDTH * CONTROL_BUTTON_COUNT - 1, 760),
+            None
+        );
+    }
+
+    #[test]
+    fn caption_move_uses_the_aero_snap_syscommand() {
+        assert_eq!(SYSCOMMAND_MOVE_CAPTION, 0xF012);
+    }
+
+    #[test]
+    fn pet_window_does_not_get_a_snap_overlay() {
+        assert!(!should_install_snap("pet"));
+        assert!(should_install_snap("main"));
+        assert!(should_install_snap("proj-abc"));
+    }
+}

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -1614,6 +1614,8 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
           return value;
         };
         switch (cmd) {
+          case "start_window_move":
+            return null;
           case "review_session": {
             const delay = Number((window as any).__reviewDelayMs ?? 0);
             if (delay > 0) await new Promise((resolve) => setTimeout(resolve, delay));

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -9666,6 +9666,14 @@ test("Windows uses the integrated title bar without covering the project landing
 
   await expect(page.locator(".window-titlebar")).toBeVisible();
   await expect(page.getByRole("button", { name: "Minimize" })).toBeVisible();
+  await expect(page.getByTestId("window-maximize")).toBeVisible();
+  await expect(page.locator("#titlebar-maximize")).toHaveAttribute("aria-label", "Maximize");
+  await expect(page.locator(".window-titlebar [data-tauri-drag-region]")).toHaveCount(0);
+  await expect(page.getByTestId("window-snap-drag")).toHaveCount(2);
+  await page.getByTestId("window-snap-drag").nth(1).dispatchEvent("mousedown", { button: 0 });
+  await expect.poll(async () => page.evaluate(() =>
+    ((window as any).__skillInvokeLog ?? []).some((call: any) => call.cmd === "start_window_move")
+  )).toBeTruthy();
   await expect.poll(async () => page.locator(".projects-screen").evaluate((el) =>
     Math.round(el.getBoundingClientRect().top)
   )).toBe(38);

--- a/ui/src/api.js
+++ b/ui/src/api.js
@@ -28,6 +28,18 @@ export async function window_control(action) {
   if (action === "close") return current.close();
 }
 
+/** Caption-style move so Windows Aero Snap / edge snap can engage. */
+export async function start_window_move() {
+  const core = tauriCore();
+  if (!core) return;
+  try {
+    return await core.invoke("start_window_move");
+  } catch (err) {
+    const current = window.__TAURI__?.window?.getCurrentWindow?.();
+    return current?.startDragging?.();
+  }
+}
+
 function missingBridgeError(cmd) {
   return new Error(`Tauri bridge is not available while calling ${cmd}. Open the app with 'cargo tauri dev', not the raw Trunk URL.`);
 }

--- a/ui/src/bindings.rs
+++ b/ui/src/bindings.rs
@@ -61,6 +61,7 @@ extern "C" {
     pub(crate) fn is_windows() -> bool;
     pub(crate) fn is_mac() -> bool;
     pub(crate) async fn window_control(action: &str);
+    pub(crate) async fn start_window_move();
     #[wasm_bindgen(js_name = upload_pasted_images)]
     pub(crate) async fn upload_pasted_images(event: JsValue) -> JsValue;
     #[wasm_bindgen(js_name = native_drop_in_composer)]

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -354,6 +354,7 @@ body { display: flex; flex-direction: column; overflow: hidden; }
 }
 
 .window-titlebar {
+  /* Keep 38px in sync with windows_snap::TITLEBAR_HEIGHT. */
   height: 38px; display: flex; align-items: center; flex: 0 0 auto;
   color: var(--text-muted); background: var(--bg-app);
   border-bottom: 1px solid var(--border); user-select: none;
@@ -390,6 +391,7 @@ body { display: flex; flex-direction: column; overflow: hidden; }
 .window-drag { flex: 1; align-self: stretch; }
 .window-controls { display: flex; align-self: stretch; }
 .window-controls button {
+  /* Keep 46px in sync with windows_snap::CONTROL_BUTTON_WIDTH. */
   width: 46px; border: 0; border-radius: 0; background: transparent; color: var(--text);
   font: 18px/1 var(--font-ui); cursor: default;
 }

--- a/ui/src/window_titlebar.rs
+++ b/ui/src/window_titlebar.rs
@@ -1,6 +1,6 @@
 //! Windows integrated title bar: brand, File/Edit/View/Help menus, window controls.
 
-use crate::bindings::{open_external_url, window_control};
+use crate::bindings::{open_external_url, start_window_move, window_control};
 use crate::i18n::{t, Locale};
 use leptos::{ev, window_event_listener, *};
 use wasm_bindgen::JsCast;
@@ -126,8 +126,9 @@ pub(super) fn WindowTitlebar(
     });
 
     view! {
-        <header class="window-titlebar" data-tauri-drag-region>
-            <div class="window-brand" data-tauri-drag-region>
+        <header class="window-titlebar">
+            <div class="window-brand" data-testid="window-snap-drag"
+                on:mousedown=begin_window_move>
                 <span class="window-brand-icon"></span>
                 <span>"wisp science"</span>
                 <span class="window-brand-version">{concat!("v", env!("CARGO_PKG_VERSION"))}</span>
@@ -186,15 +187,25 @@ pub(super) fn WindowTitlebar(
             {move || open.get().is_some().then(|| view! {
                 <div class="window-menu-backdrop" on:click=move |_| open.set(None)></div>
             })}
-            <div class="window-drag" data-tauri-drag-region></div>
+            <div class="window-drag" data-testid="window-snap-drag"
+                on:mousedown=begin_window_move></div>
             <div class="window-controls">
                 <button type="button" aria-label="Minimize"
                     on:click=move |_| spawn_local(async { window_control("minimize").await })>"−"</button>
-                <button type="button" aria-label="Maximize"
+                <button type="button" id="titlebar-maximize" data-testid="window-maximize"
+                    aria-label="Maximize"
                     on:click=move |_| spawn_local(async { window_control("toggle-maximize").await })>"□"</button>
                 <button type="button" class="window-close" aria-label="Close"
                     on:click=move |_| spawn_local(async { window_control("close").await })>"×"</button>
             </div>
         </header>
     }
+}
+
+fn begin_window_move(ev: web_sys::MouseEvent) {
+    if ev.button() != 0 {
+        return;
+    }
+    ev.prevent_default();
+    spawn_local(async { start_window_move().await });
 }


### PR DESCRIPTION
## Summary
- Custom undecorated title bar now starts a caption `SC_MOVE` so drag-to-edge Aero Snap works.
- A transparent native overlay over the maximize button returns `HTMAXBUTTON`, which is what Windows 11 uses for Snap Layouts.
- Pet window is unchanged. Fixes #868.

## Test plan
- [ ] Hover the maximize button on Windows 11 and confirm the Snap Layouts flyout appears
- [ ] Drag the title bar to a screen edge and confirm the window snaps
- [ ] Click maximize still toggles; File/Edit/View menus still open
- [ ] Pet window still drags with `data-tauri-drag-region`
- [ ] `cargo test -p wisp-tauri --lib windows_snap`
- [ ] Playwright: `Windows uses the integrated title bar without covering the project landing`

Made with [Cursor](https://cursor.com)