### PR TITLE
fix(ui): restyle appearance custom CSS import to match settings card

### DIFF
--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -7472,6 +7472,11 @@ test("appearance custom CSS can be pasted, imported, and cleared", async ({ page
   await enterApp(page);
   await openSettingsSection(page, "Appearance");
 
+  const card = page.getByTestId("appearance-custom-css-card");
+  await expect(card).toHaveClass(/appearance-config-card/);
+  await expect(card.getByTestId("appearance-custom-css")).toBeVisible();
+  await expect(card.getByTestId("appearance-custom-css-clear")).toBeDisabled();
+
   const css = ":root { --md-lead-bar-width: 0; --md-lead-bar-pad: 0; }";
   await page.getByTestId("appearance-custom-css").fill(css);
   await expect.poll(() => page.evaluate(() =>

--- a/ui/src/settings_view.rs
+++ b/ui/src/settings_view.rs
@@ -2447,9 +2447,35 @@ pub(super) fn SettingsView(
                                 </section>
                             }
                         }}
-                        <section class="appearance-custom-css-section">
-                            <h3>{move || t(locale.get(), "appearance.custom_css")}</h3>
-                            <p class="hint">{move || t(locale.get(), "appearance.custom_css_hint")}</p>
+                        <section class="appearance-config-card appearance-custom-css-card" data-testid="appearance-custom-css-card">
+                            <div class="appearance-custom-css-head">
+                                <div class="appearance-config-row">
+                                    <strong>{move || t(locale.get(), "appearance.custom_css")}</strong>
+                                    <div class="appearance-custom-css-actions">
+                                        <label class="appearance-custom-css-import">
+                                            <input
+                                                type="file"
+                                                accept=".css,text/css"
+                                                data-testid="appearance-custom-css-file"
+                                                on:change=move |ev| import_custom_css_from_input(&ev, custom_css)
+                                            />
+                                            {compose_icon("upload")}
+                                            {move || t(locale.get(), "appearance.custom_css_import")}
+                                        </label>
+                                        <button type="button" data-testid="appearance-custom-css-clear"
+                                            disabled=move || custom_css.get().is_empty()
+                                            on:click=move |_| custom_css.set(String::new())>
+                                            {move || t(locale.get(), "appearance.custom_css_clear")}
+                                        </button>
+                                    </div>
+                                </div>
+                                <div class="appearance-custom-css-meta">
+                                    <span>{move || t(locale.get(), "appearance.custom_css_hint")}</span>
+                                    <span data-testid="appearance-custom-css-status">
+                                        {move || tf(locale.get(), "appearance.custom_css_bytes", &[("n", &custom_css.get().len().to_string())])}
+                                    </span>
+                                </div>
+                            </div>
                             <textarea
                                 data-testid="appearance-custom-css"
                                 spellcheck="false"
@@ -2457,25 +2483,6 @@ pub(super) fn SettingsView(
                                 prop:value=move || custom_css.get()
                                 on:input=move |ev| custom_css.set(event_target_value(&ev))>
                             </textarea>
-                            <div class="appearance-custom-css-actions">
-                                <label class="appearance-custom-css-import">
-                                    <input
-                                        type="file"
-                                        accept=".css,text/css"
-                                        data-testid="appearance-custom-css-file"
-                                        on:change=move |ev| import_custom_css_from_input(&ev, custom_css)
-                                    />
-                                    {compose_icon("upload")}
-                                    {move || t(locale.get(), "appearance.custom_css_import")}
-                                </label>
-                                <button type="button" data-testid="appearance-custom-css-clear"
-                                    on:click=move |_| custom_css.set(String::new())>
-                                    {move || t(locale.get(), "appearance.custom_css_clear")}
-                                </button>
-                                <span data-testid="appearance-custom-css-status">
-                                    {move || tf(locale.get(), "appearance.custom_css_bytes", &[("n", &custom_css.get().len().to_string())])}
-                                </span>
-                            </div>
                         </section>
                     </div>
                 }.into_view())}

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -1717,31 +1717,45 @@ button.workflow-graph-port.output.active {
   background: var(--bg-input); color: var(--text); font: inherit; font-size: 12.5px;
 }
 .appearance-font-input:focus { border-color: var(--clay); outline: none; box-shadow: 0 0 0 3px var(--focus-ring); }
-.appearance-custom-css-section { display: flex; flex-direction: column; gap: 10px; margin-top: 8px; }
-.appearance-custom-css-section h3 { margin: 0; font-size: 14px; }
-.appearance-custom-css-section .hint { margin: 0; color: var(--text-muted); font-size: 12.5px; line-height: 1.5; }
-.appearance-custom-css-section textarea {
-  width: 100%; min-height: 140px; resize: vertical; box-sizing: border-box;
-  padding: 10px 12px; border: 1px solid var(--border-strong); border-radius: var(--radius-sm);
-  background: var(--bg-input); color: var(--text); font-family: var(--font-mono); font-size: 12.5px; line-height: 1.45;
+.appearance-custom-css-card { padding-bottom: 0; }
+.appearance-custom-css-head { padding: 8px 0 14px; border-bottom: 1px solid var(--border); }
+.appearance-custom-css-head .appearance-config-row { min-height: 0; padding: 8px 0 6px; border-bottom: none; }
+.appearance-custom-css-meta {
+  display: flex; align-items: flex-start; justify-content: space-between; gap: 24px;
 }
-.appearance-custom-css-section textarea:focus { border-color: var(--clay); outline: none; box-shadow: 0 0 0 3px var(--focus-ring); }
-.appearance-custom-css-actions { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
-.appearance-custom-css-import {
-  display: inline-flex; align-items: center; gap: 6px; height: 32px; padding: 0 12px;
-  border: 1px solid var(--border-strong); border-radius: var(--radius-xs);
-  background: var(--bg-elev); color: var(--text); font-size: 12.5px; font-weight: 600; cursor: pointer;
+.appearance-custom-css-meta > span:first-child { color: var(--text-faint); font-size: 12px; line-height: 1.5; }
+.appearance-config-row > .appearance-custom-css-actions {
+  display: flex; flex-direction: row; align-items: center; justify-content: flex-end;
+  gap: 8px; flex: 0 0 auto; flex-wrap: nowrap; min-width: auto;
 }
-.appearance-custom-css-import:hover { border-color: var(--clay); color: var(--clay-strong); }
-.appearance-custom-css-import input { display: none; }
-.appearance-custom-css-import svg,
-.appearance-custom-css-actions button svg { width: 16px; height: 16px; }
+.settings-page label.appearance-custom-css-import {
+  display: inline-flex; flex-direction: row; align-items: center; gap: 7px;
+  margin: 0; font: inherit; font-size: 13.5px; font-weight: 500; color: var(--text);
+  padding: 8px 14px; border: 1px solid var(--border-strong); border-radius: var(--radius-sm);
+  background: var(--bg-input); cursor: pointer; white-space: nowrap;
+  transition: border-color .12s ease, background .12s ease, color .12s ease;
+}
+.settings-page label.appearance-custom-css-import:hover { border-color: var(--text-faint); }
+.settings-page label.appearance-custom-css-import input { display: none; }
+.settings-page label.appearance-custom-css-import svg { width: 16px; height: 16px; }
 .appearance-custom-css-actions button {
-  height: 32px; padding: 0 12px; border: 1px solid var(--border-strong); border-radius: var(--radius-xs);
-  background: transparent; color: var(--text-muted); font: inherit; font-size: 12.5px; cursor: pointer;
+  font: inherit; font-size: 13.5px; font-weight: 500; padding: 8px 14px;
+  border: 1px solid var(--border-strong); border-radius: var(--radius-sm);
+  background: var(--bg-input); color: var(--text); cursor: pointer; white-space: nowrap;
+  transition: border-color .12s ease, background .12s ease, color .12s ease;
 }
-.appearance-custom-css-actions button:hover { color: var(--text); border-color: var(--border); }
-.appearance-custom-css-actions span { color: var(--text-faint); font-size: 12px; font-variant-numeric: tabular-nums; }
+.appearance-custom-css-actions button:hover:not(:disabled) { border-color: var(--text-faint); }
+.appearance-custom-css-actions button:disabled { opacity: .5; cursor: default; }
+.appearance-custom-css-meta > span:last-child { color: var(--text-faint); font-size: 12px; font-variant-numeric: tabular-nums; white-space: nowrap; }
+.appearance-custom-css-card textarea {
+  display: block; width: calc(100% + 48px); margin: 0 -24px; min-height: 168px; resize: vertical;
+  box-sizing: border-box; padding: 16px 24px; border: none; border-radius: 0;
+  background: var(--bg-sunken); color: var(--text);
+  font-family: var(--font-mono); line-height: 1.5;
+}
+.appearance-custom-css-card textarea:focus {
+  outline: none; box-shadow: inset 0 0 0 2px var(--clay);
+}
 .settings-form-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -2728,6 +2742,8 @@ button.workflow-graph-port.output.active {
   .appearance-config-head, .appearance-config-row { align-items: flex-start; flex-direction: column; gap: 10px; padding: 14px 0; }
   .appearance-config-head select, .appearance-color-value { width: 100%; }
   .appearance-font-input { width: 100%; }
+  .appearance-custom-css-actions { justify-content: flex-start; width: 100%; }
+  .appearance-custom-css-meta { flex-direction: column; gap: 8px; }
   .settings-page label.font-size-control { width: 100%; grid-template-columns: 1fr 54px; }
   .settings-form-grid .span-2 { grid-column: auto; }
   .settings-toolbar { grid-template-columns: 1fr; }


### PR DESCRIPTION
## Problem

The Appearance custom-theme importer sat below the palette/font card as a loose heading, a floating white textarea, and a separate Import/Clear row. It did not share the card, row, or control language of the rest of the page.

## Change

- Fold custom CSS into an `appearance-config-card`: title and Import/Clear on one row, hint plus byte count below, sunken editor inside the card.
- Match Import/Clear to the existing settings secondary-button style, and disable Clear when the stylesheet is empty.
- Keep paste, file import, sanitization, and persistence behavior unchanged.

## Tests

- Extended `appearance custom CSS can be pasted, imported, and cleared` to assert the card wrapper and that Clear starts disabled.
- Existing paste/import/clear and sanitization Playwright coverage still passes.

## Manual smoke

- Open Settings → Appearance (light and dark).
- Confirm the custom theme block matches the palette/font card.
- Paste CSS, import a `.css` file, then Clear.
- Check the Chinese locale and a narrow viewport.

## Limitations

- The editor is still a plain textarea, not a highlighted code editor.
- Clear is disabled only when the field is empty; there is no confirmation dialog.