### PR TITLE
fix(ssh): keep terminal askpass files until SSH exits

### DIFF
--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -12,7 +12,9 @@ conversation and right panel, keeping the active research context visible.
   distributions before opening one.
 - `ssh:<alias>` starts the system OpenSSH client with a remote PTY. OpenSSH
   continues to honor SSH config, ssh-agent, ProxyJump, host-key prompts, and
-  interactive authentication.
+  interactive authentication. When the host is configured for password auth,
+  the stored keyring password is supplied through OpenSSH ASKPASS for the
+  whole login — the helper files stay on disk until the SSH process exits.
 
 Each **Open terminal** action creates an independent live terminal, including
 when another terminal already uses the same context. The dock keeps concurrent

--- a/src-tauri/src/ssh_hosts.rs
+++ b/src-tauri/src/ssh_hosts.rs
@@ -198,6 +198,11 @@ impl SshConnection {
                 "PubkeyAuthentication=no".into(),
                 "-o".into(),
                 "NumberOfPasswordPrompts=1".into(),
+                // SSH_ASKPASS_REQUIRE=force sends every prompt through askpass,
+                // including host-key confirmation. Accept new keys the same way
+                // file browsing does so the stored password is not used as "yes".
+                "-o".into(),
+                "StrictHostKeyChecking=accept-new".into(),
             ]);
         }
         if let Some(port) = self.port {
@@ -281,7 +286,10 @@ impl SshConnection {
     }
 
     /// Build env vars that force OpenSSH to read a one-shot password via ASKPASS.
-    /// Caller must run `cleanup_password_auth_env` after the process exits.
+    /// Caller must run `cleanup_password_auth_env` after the process exits —
+    /// not after spawn. OpenSSH reads ASKPASS during authentication, which
+    /// happens after the child is running. Deleting the script earlier yields
+    /// `CreateProcessW failed error:2` / `ssh_askpass: posix_spawnp`.
     pub fn password_auth_env(&self) -> Result<Vec<(String, String)>, String> {
         if !self.uses_password() {
             return Ok(Vec::new());
@@ -1781,6 +1789,61 @@ Host -unsafe bad/name !negated
             .any(|w| w == ["-o", "PubkeyAuthentication=no"]));
         assert!(!args.iter().any(|a| a == "-i"));
         assert!(connection.assert_ready_to_connect().is_err());
+    }
+
+    #[test]
+    fn interactive_password_args_keep_tty_and_accept_new_host_keys() {
+        let connection = SshConnection {
+            alias: "lab".into(),
+            host_name: Some("gpu.example.test".into()),
+            user: Some("alice".into()),
+            port: None,
+            identity_file: None,
+            auth_method: SshAuthMethod::Password,
+        };
+        let args = connection.interactive_ssh_args().unwrap();
+        assert_eq!(args.first().map(String::as_str), Some("-tt"));
+        assert!(args.windows(2).any(|w| w
+            == [
+                "-o",
+                "PreferredAuthentications=password,keyboard-interactive"
+            ]));
+        assert!(args
+            .windows(2)
+            .any(|w| w == ["-o", "PubkeyAuthentication=no"]));
+        assert!(args
+            .windows(2)
+            .any(|w| w == ["-o", "StrictHostKeyChecking=accept-new"]));
+        assert!(!args.iter().any(|arg| arg.contains("BatchMode")));
+        assert_eq!(
+            args.last().map(String::as_str),
+            Some("alice@gpu.example.test")
+        );
+    }
+
+    #[test]
+    fn password_askpass_files_exist_until_explicit_cleanup() {
+        let envs = build_password_askpass_env("test-password").unwrap();
+        let askpass = envs
+            .iter()
+            .find(|(key, _)| key == "SSH_ASKPASS")
+            .map(|(_, value)| PathBuf::from(value))
+            .expect("SSH_ASKPASS");
+        let passfile = envs
+            .iter()
+            .find(|(key, _)| key == PASSFILE_ENV)
+            .map(|(_, value)| PathBuf::from(value))
+            .expect("passfile");
+        assert!(askpass.is_file(), "askpass missing: {}", askpass.display());
+        assert!(
+            passfile.is_file(),
+            "passfile missing: {}",
+            passfile.display()
+        );
+        assert_eq!(std::fs::read_to_string(&passfile).unwrap(), "test-password");
+        cleanup_password_auth_env(&envs);
+        assert!(!askpass.exists());
+        assert!(!passfile.exists());
     }
 
     #[test]

--- a/src-tauri/src/terminal_sessions.rs
+++ b/src-tauri/src/terminal_sessions.rs
@@ -85,6 +85,15 @@ struct TerminalSession {
     writer: Mutex<Box<dyn Write + Send>>,
     killer: Mutex<Box<dyn ChildKiller + Send + Sync>>,
     output: Mutex<TerminalOutputState>,
+    /// One-shot OpenSSH askpass files. Must stay on disk until the child
+    /// exits — authentication happens after spawn, not at spawn.
+    auth_cleanup_envs: Vec<(String, String)>,
+}
+
+impl Drop for TerminalSession {
+    fn drop(&mut self) {
+        crate::ssh_hosts::cleanup_password_auth_env(&self.auth_cleanup_envs);
+    }
 }
 
 impl TerminalSession {
@@ -178,6 +187,7 @@ impl TerminalSession {
         if output.exit_code.replace(exit_code).is_some() {
             return;
         }
+        crate::ssh_hosts::cleanup_password_auth_env(&self.auth_cleanup_envs);
         let event = TerminalEvent::Exit { exit_code };
         output
             .subscribers
@@ -310,18 +320,22 @@ fn spawn_session(
         crate::ssh_hosts::cleanup_password_auth_env(&spec.envs);
         format!("failed to start {} terminal: {error}", context.id)
     })?;
-    // Password askpass is only needed while OpenSSH authenticates.
-    crate::ssh_hosts::cleanup_password_auth_env(&spec.envs);
     drop(pair.slave);
 
-    let reader = pair
-        .master
-        .try_clone_reader()
-        .map_err(|error| format!("failed to read terminal PTY: {error}"))?;
-    let writer = pair
-        .master
-        .take_writer()
-        .map_err(|error| format!("failed to write terminal PTY: {error}"))?;
+    let reader = match pair.master.try_clone_reader() {
+        Ok(reader) => reader,
+        Err(error) => {
+            crate::ssh_hosts::cleanup_password_auth_env(&spec.envs);
+            return Err(format!("failed to read terminal PTY: {error}"));
+        }
+    };
+    let writer = match pair.master.take_writer() {
+        Ok(writer) => writer,
+        Err(error) => {
+            crate::ssh_hosts::cleanup_password_auth_env(&spec.envs);
+            return Err(format!("failed to write terminal PTY: {error}"));
+        }
+    };
     let process_id = child.process_id();
     let killer = child.clone_killer();
     let label = if context.label.trim().is_empty() {
@@ -342,6 +356,7 @@ fn spawn_session(
         writer: Mutex::new(writer),
         killer: Mutex::new(killer),
         output: Mutex::new(TerminalOutputState::new()),
+        auth_cleanup_envs: spec.envs,
     });
     Ok((session, reader, child))
 }
@@ -576,7 +591,25 @@ mod tests {
             ]
         );
         assert!(!spec.args.iter().any(|arg| arg.contains("BatchMode")));
+        assert!(spec.envs.is_empty());
         assert_eq!(spec.display_cwd, "~");
+    }
+
+    #[test]
+    fn password_ssh_terminal_requires_stored_password_before_spawn() {
+        let mut context = wisp_store::ExecutionContext::new("ssh:lab", "Lab").unwrap();
+        context.config_json = serde_json::json!({
+            "alias": "lab",
+            "user": "alice",
+            "auth_method": "password"
+        })
+        .to_string();
+
+        let error = build_terminal_launch_spec(&context, Path::new("/local/project")).unwrap_err();
+        assert!(
+            error.contains("password"),
+            "expected a stored-password error, got {error}"
+        );
     }
 
     #[test]

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -1558,7 +1558,9 @@ test("ACP turns retain explicitly selected Wisp skills", async ({ page }) => {
   await page.locator(".model-picker-btn").click();
   await page.getByRole("button", { name: /Test ACP Agent/ }).click();
   await composer(page).pressSequentially("/lit");
-  await page.locator(".mention-menu .mention-item").first().click();
+  await page.locator(".mention-menu .mention-item")
+    .filter({ hasText: "literature-review" })
+    .click();
   await composer(page).fill("use this skill");
   await page.getByRole("button", { name: "Send" }).click();
 
@@ -1876,7 +1878,9 @@ test("composer @ # and / add typed context references", async ({ page }) => {
 
   await composerInput.pressSequentially("/lit");
   await expect(page.locator(".mention-menu")).toContainText("literature-review");
-  await page.locator(".mention-menu .mention-item").first().click();
+  await page.locator(".mention-menu .mention-item")
+    .filter({ hasText: "literature-review" })
+    .click();
 
   await composerInput.pressSequentially("/round");
   const workflowItem = page.locator(".mention-menu .mention-item")
@@ -2183,10 +2187,12 @@ test("composer / menu layers sections and gives each command its own icon", asyn
   expect(new Set(svgs).size).toBe(svgs.length);
 
   // A query matching no command keeps the remaining sections layered.
+  // `/lit` hits both the literature skill and the literature-evidence workflow.
   await composerInput.fill("");
   await composerInput.pressSequentially("/lit");
-  await expect(menu.locator(".mention-group-label")).toHaveText(["Skills"]);
+  await expect(menu.locator(".mention-group-label")).toHaveText(["Workflows", "Skills"]);
   await expect(menu).toContainText("literature-review");
+  await expect(menu).toContainText("Literature evidence review");
 });
 
 test("composer /plan and /permission drive the session mode flags", async ({ page }) => {
@@ -11400,7 +11406,7 @@ test("specialist skills whitelist uses a searchable picker instead of a full lis
   const search = page.getByTestId("specialist-skill-search");
   await expect(page.getByTestId("specialist-skill-results")).toContainText("3 available skills");
 
-  await search.fill("alpha");
+  await search.fill("narrative");
   await expect(options).toHaveCount(1);
   await options.first().click();
   await expect(selected).toHaveCount(3);


### PR DESCRIPTION
## Problem

The Files panel can browse an SSH host with a saved password, but opening an xterm.js terminal for the same host fails during login:

- `CreateProcessW failed error:2`
- `ssh_askpass: posix_spawnp: No such file or directory`
- `Permission denied (publickey,password)`

File browsing keeps the one-shot OpenSSH ASKPASS helper until the SSH process finishes. The terminal PTY deleted that helper immediately after spawn, so OpenSSH tried to read the password from a path that no longer existed.

## Changes

- Keep ASKPASS/passfile on disk until the terminal child exits (and on Drop / setup failure).
- For password-mode interactive SSH, set `StrictHostKeyChecking=accept-new` so `SSH_ASKPASS_REQUIRE=force` does not send the stored password as a host-key answer.
- Document the ASKPASS lifetime for SSH terminals.

## Tests

- Interactive password args include `-tt`, password-only auth, and `accept-new`.
- ASKPASS files exist until `cleanup_password_auth_env`.
- Password terminals refuse to launch when no password is stored.
- Fixtures use generic `alice@gpu.example.test` values only.

## Manual smoke

1. Register an SSH host with password auth and confirm Files can list the remote home directory.
2. Open a terminal for that context.
3. Confirm login succeeds without `CreateProcessW` / `ssh_askpass` errors and a remote shell prompt appears.
4. Open a key-auth SSH terminal and a local terminal; both should still work.

## Limitations / follow-up

- The passfile remains on disk for the life of the SSH process (0600 in a temp dir). That matches the existing ASKPASS contract used by probe/file/run.
- Automated tests do not talk to a real SSH server.