### PR TITLE
test(ui): correct skill counts after a fourth mock skill was added

### DIFF
--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -8409,7 +8409,7 @@ test("skill manager reloads manually copied skills and shows their scope", async
   await expect(fresh).toContainText("Project");
   await expect(fresh.locator('input[type="checkbox"]')).toBeChecked();
   await expect(fresh.getByRole("button", { name: "Delete skill" })).toHaveCount(0);
-  await expect(page.getByText("Skills reloaded. 4 available.")).toBeVisible();
+  await expect(page.getByText("Skills reloaded. 5 available.")).toBeVisible();
 });
 
 test("skill manager updates and deletes user-added skills", async ({ page }) => {
@@ -11633,7 +11633,7 @@ test("specialist skills whitelist uses a searchable picker instead of a full lis
   const options = page.getByTestId("specialist-skill-option");
   await expect(options).toHaveCount(0);
   const search = page.getByTestId("specialist-skill-search");
-  await expect(page.getByTestId("specialist-skill-results")).toContainText("3 available skills");
+  await expect(page.getByTestId("specialist-skill-results")).toContainText("4 available skills");
 
   await search.fill("narrative");
   await expect(options).toHaveCount(1);


### PR DESCRIPTION
## Problem

`main`'s Playwright suite has been red since 92b3434c ("feat(share): open long-image export first and add a topbar entry"): that commit added a fourth skill (`xiaohongshu-note`, since renamed `social-note` by 66eab4ef) to the mock skill fixture in `ui-tests/tests/mock-tauri.ts`, but left two hardcoded count assertions at their old values. Two specs fail deterministically on every run:

- `skill manager reloads manually copied skills and shows their scope` — expects the toast "Skills reloaded. 4 available.", but the reload mock pushes `fresh-project-skill` on top of the fixture's four (the Motif plugin is disabled and contributes nothing), so the app correctly reports 5.
- `specialist skills whitelist uses a searchable picker instead of a full list` — expects "3 available skills", but the picker lists the fixture  as-is: 4.

This is a test-only defect; app behavior was always correct.

## Change

`ui-tests/tests/ui.spec.ts`, 2 lines: `4 available.` → `5 available.` and `"3 available skills"` → `"4 available skills"`.

## Tests

Both specs re-run in isolation on Windows: 2 passed. No app code touched, so no store/wasm impact.

## Why a separate PR

Landing this first turns `main`'s CI green, so the concurrently open #888 PR (`fix/session-rename-draft-888`) shows a trustworthy CI signal instead of inheriting these failures.

## Follow-up (not in scope)

The counts are still hardcoded, so the next fixture change will break them again the same way. Consider deriving the expected numbers from the mock's skills array, or asserting on a data-testid count the mock computes.