### PR TITLE
fix: make renaming a fresh session take effect immediately

### DIFF
--- a/crates/wisp-store/src/projects.rs
+++ b/crates/wisp-store/src/projects.rs
@@ -54,8 +54,8 @@ impl Store {
     }
 
     /// All projects, newest-updated first, each with its session count
-    /// (root frames that have at least one user turn — matches `list_sessions`)
-    /// and artifact count.
+    /// (root frames with a user turn or an explicit title — matches
+    /// `list_sessions_page`, #888) and artifact count.
     pub async fn list_projects(
         &self,
     ) -> Result<Vec<(String, String, String, i64, i64, i64, String, i64)>> {
@@ -65,7 +65,8 @@ impl Store {
                     COALESCE(p.description,'') AS description, \
                     (SELECT COUNT(*) FROM frames f WHERE f.project_id = p.id AND f.parent_frame_id = f.id \
                        AND f.exploration_id IS NULL \
-                       AND EXISTS (SELECT 1 FROM messages m WHERE m.frame_id = f.id AND m.role='user')) AS sessions, \
+                       AND (EXISTS (SELECT 1 FROM messages m WHERE m.frame_id = f.id AND m.role='user') \
+                            OR TRIM(COALESCE(f.title, '')) <> '')) AS sessions, \
                     (SELECT COUNT(*) FROM artifacts a WHERE a.project_id = p.id \
                        AND a.exploration_id IS NULL) AS artifacts \
              FROM projects p \

--- a/crates/wisp-store/src/sessions.rs
+++ b/crates/wisp-store/src/sessions.rs
@@ -545,6 +545,9 @@ impl Store {
     }
 
     /// Recent sessions with last-turn metadata for the projects dashboard.
+    ///
+    /// Deliberately requires a user turn, unlike `list_sessions_page` (#888):
+    /// a named-but-unused draft has no activity to rank as "recent".
     pub async fn list_recent_sessions_detail(
         &self,
         limit: i64,
@@ -591,6 +594,10 @@ impl Store {
 
     /// Last message role and unseen flag per saved session in a project (for
     /// dashboard counts).
+    ///
+    /// Deliberately requires a user turn, unlike `list_sessions_page` (#888):
+    /// a message-less draft has no last role, and `last_role_needs_you(None)`
+    /// is false anyway, so including it could only add noise.
     pub async fn list_session_last_roles(
         &self,
         project_id: &str,
@@ -2281,7 +2288,8 @@ impl Store {
                 WHERE f.parent_frame_id=f.id \
                   AND f.exploration_id IS NULL \
                   AND f.project_id NOT LIKE 'scratch:%' \
-                  AND EXISTS (SELECT 1 FROM messages mm WHERE mm.frame_id=f.id AND mm.role='user') \
+                  AND (EXISTS (SELECT 1 FROM messages mm WHERE mm.frame_id=f.id AND mm.role='user') \
+                       OR TRIM(COALESCE(f.title,'')) <> '') \
                   AND (? IS NULL OR f.project_id=?) \
                   AND (? IS NULL OR f.id=?) \
              ) \

--- a/crates/wisp-store/src/sessions.rs
+++ b/crates/wisp-store/src/sessions.rs
@@ -1531,7 +1531,8 @@ impl Store {
                 FROM frames f \
                 WHERE f.project_id = ? AND f.parent_frame_id = f.id \
                   AND f.exploration_id IS NULL \
-                  AND EXISTS (SELECT 1 FROM messages mm WHERE mm.frame_id = f.id AND mm.role = 'user') \
+                  AND (EXISTS (SELECT 1 FROM messages mm WHERE mm.frame_id = f.id AND mm.role = 'user') \
+                       OR TRIM(COALESCE(f.title, '')) <> '') \
              ) sessions \
              WHERE (? IS NULL OR activity_at < ? OR (activity_at = ? AND id < ?)) \
              ORDER BY activity_at DESC, id DESC LIMIT ?",
@@ -1574,7 +1575,8 @@ impl Store {
              FROM frames f \
              WHERE f.project_id = ? AND f.parent_frame_id = f.id AND COALESCE(f.pinned, 0) = 1 \
                AND f.exploration_id IS NULL \
-               AND EXISTS (SELECT 1 FROM messages mm WHERE mm.frame_id = f.id AND mm.role = 'user') \
+               AND (EXISTS (SELECT 1 FROM messages mm WHERE mm.frame_id = f.id AND mm.role = 'user') \
+                    OR TRIM(COALESCE(f.title, '')) <> '') \
              ORDER BY activity_at DESC, f.id DESC",
         )
         .bind(project_id)

--- a/crates/wisp-store/src/store_tests.rs
+++ b/crates/wisp-store/src/store_tests.rs
@@ -156,6 +156,27 @@ async fn roundtrip() {
     assert_eq!(sessions.len(), 1, "named draft must be listed");
     assert_eq!(sessions[0].0, "f3");
     assert_eq!(sessions[0].1, "Named draft");
+
+    // The named draft is a real session everywhere the sidebar predicate
+    // reaches: it counts on the project card and is findable by search, while
+    // the untitled message-less f2 stays excluded from both (#888).
+    let projs = store.list_projects().await.unwrap();
+    let p1 = projs.iter().find(|p| p.0 == "p1").unwrap();
+    assert_eq!(p1.5, 1, "named draft counts; untitled empty f2 does not");
+    let found = store
+        .search_sessions(None, "named draft", 10, None, None)
+        .await
+        .unwrap();
+    assert_eq!(found.len(), 1, "named draft must be searchable by title");
+    assert_eq!(found[0].id, "f3");
+    let all = store
+        .search_sessions(None, "", 10, None, None)
+        .await
+        .unwrap();
+    assert!(
+        all.iter().all(|s| s.id != "f2"),
+        "untitled message-less frame stays unsearchable"
+    );
     let _ = std::fs::remove_file(&tmp);
 }
 

--- a/crates/wisp-store/src/store_tests.rs
+++ b/crates/wisp-store/src/store_tests.rs
@@ -140,6 +140,22 @@ async fn roundtrip() {
     assert_eq!(sessions[0].1, "Renamed chat");
     store.delete_session("f1", "p1").await.unwrap();
     assert!(store.list_sessions("p1").await.unwrap().is_empty());
+
+    // A message-less draft becomes listable the moment the user names it, so a
+    // rename done before the first turn shows up immediately (#888).
+    store.create_frame("f3", "p1", "OPERON", "m").await.unwrap();
+    assert!(
+        store.list_sessions("p1").await.unwrap().is_empty(),
+        "untitled draft stays hidden"
+    );
+    store
+        .rename_session("f3", "p1", "Named draft")
+        .await
+        .unwrap();
+    let sessions = store.list_sessions("p1").await.unwrap();
+    assert_eq!(sessions.len(), 1, "named draft must be listed");
+    assert_eq!(sessions[0].0, "f3");
+    assert_eq!(sessions[0].1, "Named draft");
     let _ = std::fs::remove_file(&tmp);
 }
 

--- a/src-tauri/src/session_commands.rs
+++ b/src-tauri/src/session_commands.rs
@@ -10,8 +10,9 @@ pub(super) async fn new_session(
     // Create a fresh frame and hand its id to the UI up front, so the UI can
     // route streamed events to the right transcript *before* the first delta
     // arrives. Does NOT cancel any running turn — parallel conversations keep
-    // running. Persisted history still ignores empty frames; the UI keeps the
-    // currently active draft visible until its first user turn is stored.
+    // running. Persisted history still ignores empty untitled frames; the UI
+    // keeps the currently active draft visible until its first user turn is
+    // stored, and an explicit rename makes the draft listable right away (#888).
     let active = state.active(window.label());
     let ap = project_commands::load_active_project(&state, &active.id)
         .await?

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -5343,7 +5343,16 @@ export function parallelMock(): void {
           }
           case "rename_session": {
             const session = sessions.find((entry) => entry.id === arg("id"));
-            if (session) session.title = String(arg("title") ?? session.title);
+            if (session) {
+              session.title = String(arg("title") ?? session.title);
+            } else {
+              // Mirrors the store: naming a message-less draft makes it
+              // listable before its first user turn (#888).
+              sessions.unshift({
+                id: String(arg("id")), title: String(arg("title") ?? ""),
+                ts: Date.now(), folder_id: null,
+              });
+            }
             return null;
           }
           case "delete_session": {

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -3143,6 +3143,28 @@ test("rename session modal autofocuses so Ctrl+A selects the title", async ({ pa
   )).toBe(true);
 });
 
+test("renaming a fresh session takes effect before its first message (#888)", async ({ page }) => {
+  await page.addInitScript(parallelMock);
+  await page.goto("/");
+  await page.locator(".proj-card-main").first().click();
+  await expect(newSessionButton(page)).toBeVisible();
+
+  await newSessionButton(page).click();
+  const draft = page.locator(".side-item.ses", { hasText: "Untitled session" }).first();
+  await expect(draft).toBeVisible();
+
+  await draft.dblclick();
+  const input = page.locator("#rename-session-input");
+  await expect(input).toBeVisible();
+  await input.fill("Named before first turn");
+  await page.locator(".modal", { has: input }).getByRole("button", { name: "Save" }).click();
+
+  // The rename must show up without sending any message first.
+  await expect(page.locator(".side-item.ses", { hasText: "Named before first turn" })).toBeVisible();
+  await expect(page.locator(".side-item.ses", { hasText: "Untitled session" })).toHaveCount(0);
+  expect((await invokeArgsList(page, "send_message")).length).toBe(0);
+});
+
 test("conversation action button renames, transfers, and deletes sessions (#557)", async ({ page }) => {
   await page.addInitScript(parallelMock);
   await page.goto("/");

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -14156,7 +14156,17 @@ fn App() -> impl IntoView {
 
         <RenameSessionOverlay
             state=RenameSessionOverlayState { locale, rename_session_target, rename_session_input }
-            on_renamed=Callback::new(move |_: ()| refresh_session_history())
+            on_renamed=Callback::new(move |(id, title): (String, String)| {
+                // Patch the cached row first so a draft session — which the
+                // backend list omits until its first user turn — shows the new
+                // name immediately instead of after the next turn completes.
+                sessions.update(|rows| {
+                    if let Some(row) = rows.iter_mut().find(|row| row.id == id) {
+                        row.title = title;
+                    }
+                });
+                refresh_session_history();
+            })
         />
 
         <FolderModalOverlay

--- a/ui/src/session_modals.rs
+++ b/ui/src/session_modals.rs
@@ -132,7 +132,7 @@ pub(crate) struct RenameSessionOverlayState {
 #[component]
 pub(crate) fn RenameSessionOverlay(
     state: RenameSessionOverlayState,
-    on_renamed: Callback<()>,
+    on_renamed: Callback<(String, String)>,
 ) -> impl IntoView {
     let RenameSessionOverlayState {
         locale,
@@ -173,9 +173,9 @@ pub(crate) fn RenameSessionOverlay(
                                     let id = id_key.clone();
                                     rename_session_target.set(None);
                                     spawn_local(async move {
-                                        let arg = to_value(&serde_json::json!({ "id": id, "title": title })).unwrap();
+                                        let arg = to_value(&serde_json::json!({ "id": id.clone(), "title": title.clone() })).unwrap();
                                         if invoke_checked("rename_session", arg).await.is_ok() {
-                                            on_renamed.call(());
+                                            on_renamed.call((id, title));
                                         }
                                     });
                                 }
@@ -190,9 +190,9 @@ pub(crate) fn RenameSessionOverlay(
                             let id = id_btn.clone();
                             rename_session_target.set(None);
                             spawn_local(async move {
-                                let arg = to_value(&serde_json::json!({ "id": id, "title": title })).unwrap();
+                                let arg = to_value(&serde_json::json!({ "id": id.clone(), "title": title.clone() })).unwrap();
                                 if invoke_checked("rename_session", arg).await.is_ok() {
-                                    on_renamed.call(());
+                                    on_renamed.call((id, title));
                                 }
                             });
                         }>{move || t(locale.get(), "settings.save")}</button>


### PR DESCRIPTION
Fixes #888.

## Problem

A new session is a draft frame that `list_sessions_page` hides until its first user turn; the sidebar row is synthesized from the UI's stale cache. Renaming a fresh session persisted the title but the new name stayed invisible until the first reply made the frame listable.

## Change

- **store**: `list_sessions_page` / `list_pinned_sessions` also admit frames with a non-empty trimmed title, so an explicitly named draft gets a real list row that survives refreshes and restarts.
- **store (follow-up commit)**: the project card's session count (`list_projects`) and `search_sessions` use the same titled-or-used
  predicate. Without this, a named draft was visible in the sidebar but uncounted on the front page and unfindable by title.
- **ui**: the rename callback carries `(id, title)` and patches the cached row optimistically before re-fetching.
- **deliberately unchanged**: `list_recent_sessions_detail` and `list_session_last_roles` still require a user turn — a never-used draft has no activity to rank as "recent" and no last role to badge. Doc comments in `sessions.rs` record the asymmetry.

## Design note

Empty frames have always been persisted: the row is inserted the moment "New session" is clicked and nothing deletes it. The user-message predicate only ever governed *visibility*. This PR therefore doesn't add persistence — it makes existing persistence coherent: naming a draft is treated as intent to keep it, and a named draft is then consistently visible, counted, and searchable. Untitled empty drafts remain invisible-and-inert, exactly as before.

Consequence worth knowing: a named-but-never-used draft persists until explicitly deleted, and can be the session "resume last conversation" lands on. Search reports it as status `complete` (runtime-derived; it can never be `needs_you`, so it cannot reach the inbox badge).

## Tests

- `store_tests::roundtrip`: named-draft listability, project count, and search assertions; untitled message-less frames stay excluded everywhere.
- Playwright regression `renaming a fresh session takes effect before its first message (#888)` with the mock mirroring the new backend behavior.

## Verification (Windows 11, cold toolchain)

- `cargo fmt --all -- --check` clean
- `cargo test -p wisp-store`: 131/131
- `cargo check --target wasm32-unknown-unknown` (ui) clean
- Playwright: 403 passed; the 3 failures are pre-existing on main (2 stale skill-count assertions broken by 92b3434c (fixed in a separate PR) and 1 order-dependent flake that passes in isolation)
- `cargo test --workspace`: 5 pre-existing Windows-environment failures, bisect-proven unrelated (R-not-installed assumption in `wisp-runtime env::tests::rscript_candidates...`; path-separator assertions in publication/lease/staging tests)
- Manual smoke: rename-before-first-message updates the sidebar instantly, survives restart; project card count and title search now agree with the sidebar.

## Known limitations/follow-ups (separate issues)

- `frames.status` is a write-only column — every frame is permanently `'running'`; nothing reads it. Candidate for removal.
- No GC for untitled empty frames (pre-existing; they are invisible and  ~200 bytes each).
