### PR TITLE
fix(windows): restore title-bar double-click maximize after snap

### DIFF
--- a/src-tauri/src/windows_snap.rs
+++ b/src-tauri/src/windows_snap.rs
@@ -5,7 +5,9 @@
 //! moves the window without a caption-style `SC_MOVE`.
 //!
 //! This module:
-//! - starts a caption move (`SC_MOVE | HTCAPTION`) so drag-to-edge snap works;
+//! - starts a caption move (`SC_MOVE | HTCAPTION`) so drag-to-edge snap works
+//!   (the UI arms that move only after the pointer travels `SM_CXDRAG`, so a
+//!   title-bar double-click can still maximize / restore);
 //! - places a transparent native child over the maximize button that returns
 //!   `HTMAXBUTTON`, which is what Windows 11 uses for the Snap Layouts flyout.
 //!
@@ -71,8 +73,14 @@ fn start_caption_move(window: &WebviewWindow) -> Result<(), String> {
 
     let hwnd = window.hwnd().map_err(|error| error.to_string())?;
     let hwnd_bits = hwnd.0 as isize;
+    let window = window.clone();
     window
         .run_on_main_thread(move || {
+            // Native caption drag from a maximized window restores first so
+            // the user can pull it off the screen edge.
+            if window.is_maximized().unwrap_or(false) {
+                let _ = window.unmaximize();
+            }
             let hwnd = HWND(hwnd_bits as *mut core::ffi::c_void);
             unsafe {
                 let _ = ReleaseCapture();

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -5153,6 +5153,15 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
         startDragging: async () => {
           (window as any).__petDragStarted = true;
         },
+        toggleMaximize: async () => {
+          ((window as any).__skillInvokeLog ??= []).push({ cmd: "toggle-maximize" });
+        },
+        minimize: async () => {
+          ((window as any).__skillInvokeLog ??= []).push({ cmd: "minimize" });
+        },
+        close: async () => {
+          ((window as any).__skillInvokeLog ??= []).push({ cmd: "close" });
+        },
       }),
     },
   };

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -9908,10 +9908,6 @@ test("Windows uses the integrated title bar without covering the project landing
   await expect(page.locator("#titlebar-maximize")).toHaveAttribute("aria-label", "Maximize");
   await expect(page.locator(".window-titlebar [data-tauri-drag-region]")).toHaveCount(0);
   await expect(page.getByTestId("window-snap-drag")).toHaveCount(2);
-  await page.getByTestId("window-snap-drag").nth(1).dispatchEvent("mousedown", { button: 0 });
-  await expect.poll(async () => page.evaluate(() =>
-    ((window as any).__skillInvokeLog ?? []).some((call: any) => call.cmd === "start_window_move")
-  )).toBeTruthy();
   await expect.poll(async () => page.locator(".projects-screen").evaluate((el) =>
     Math.round(el.getBoundingClientRect().top)
   )).toBe(38);
@@ -10005,6 +10001,43 @@ test("Windows uses the integrated title bar without covering the project landing
       .filter((c: any) => c.cmd === "open_external_url")
       .map((c: any) => (c.args instanceof Map ? c.args.get("url") : c.args?.url))
   )).toContain("https://github.com/xuzhougeng/wisp-science#readme");
+
+  await context.close();
+});
+
+test("Windows titlebar double-click maximizes and drag waits for movement", async ({ browser }) => {
+  const context = await browser.newContext({
+    userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/136 Safari/537.36",
+  });
+  const page = await context.newPage();
+  await page.addInitScript(tauriMock);
+  await page.goto("/");
+
+  const drag = page.getByTestId("window-snap-drag").nth(1);
+  const box = await drag.boundingBox();
+  expect(box).not.toBeNull();
+  const x = box!.x + box!.width / 2;
+  const y = box!.y + box!.height / 2;
+
+  await page.mouse.move(x, y);
+  await page.mouse.down();
+  expect(await page.evaluate(() =>
+    ((window as any).__skillInvokeLog ?? []).some((call: any) => call.cmd === "start_window_move")
+  )).toBe(false);
+  await page.mouse.move(x + 8, y);
+  await expect.poll(() => page.evaluate(() =>
+    ((window as any).__skillInvokeLog ?? []).some((call: any) => call.cmd === "start_window_move")
+  )).toBeTruthy();
+  await page.mouse.up();
+
+  await page.evaluate(() => { (window as any).__skillInvokeLog = []; });
+  await drag.dblclick();
+  await expect.poll(() => page.evaluate(() =>
+    ((window as any).__skillInvokeLog ?? []).some((call: any) => call.cmd === "toggle-maximize")
+  )).toBeTruthy();
+  expect(await page.evaluate(() =>
+    ((window as any).__skillInvokeLog ?? []).some((call: any) => call.cmd === "start_window_move")
+  )).toBe(false);
 
   await context.close();
 });

--- a/ui/src/api.js
+++ b/ui/src/api.js
@@ -40,6 +40,39 @@ export async function start_window_move() {
   }
 }
 
+/** Typical Windows `SM_CXDRAG` / `SM_CYDRAG`. Keep in sync with `window_titlebar.rs`. */
+export const CAPTION_DRAG_THRESHOLD_PX = 4;
+
+/**
+ * Wait for the pointer to move past the drag threshold before starting a
+ * caption move. A bare mousedown must not send `SC_MOVE`, or Windows eats the
+ * second click of a title-bar double-click (maximize / restore).
+ */
+export async function arm_caption_drag(startX, startY) {
+  await new Promise((resolve) => {
+    let settled = false;
+    const finish = (startMove) => {
+      if (settled) return;
+      settled = true;
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+      if (startMove) void start_window_move();
+      resolve();
+    };
+    const onMove = (event) => {
+      if (
+        Math.abs(event.clientX - startX) >= CAPTION_DRAG_THRESHOLD_PX
+        || Math.abs(event.clientY - startY) >= CAPTION_DRAG_THRESHOLD_PX
+      ) {
+        finish(true);
+      }
+    };
+    const onUp = () => finish(false);
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+  });
+}
+
 function missingBridgeError(cmd) {
   return new Error(`Tauri bridge is not available while calling ${cmd}. Open the app with 'cargo tauri dev', not the raw Trunk URL.`);
 }

--- a/ui/src/bindings.rs
+++ b/ui/src/bindings.rs
@@ -62,6 +62,8 @@ extern "C" {
     pub(crate) fn is_mac() -> bool;
     pub(crate) async fn window_control(action: &str);
     pub(crate) async fn start_window_move();
+    #[wasm_bindgen(js_name = arm_caption_drag)]
+    pub(crate) async fn arm_caption_drag(start_x: f64, start_y: f64);
     #[wasm_bindgen(js_name = upload_pasted_images)]
     pub(crate) async fn upload_pasted_images(event: JsValue) -> JsValue;
     #[wasm_bindgen(js_name = native_drop_in_composer)]

--- a/ui/src/window_titlebar.rs
+++ b/ui/src/window_titlebar.rs
@@ -1,6 +1,6 @@
 //! Windows integrated title bar: brand, File/Edit/View/Help menus, window controls.
 
-use crate::bindings::{open_external_url, start_window_move, window_control};
+use crate::bindings::{arm_caption_drag, open_external_url, window_control};
 use crate::i18n::{t, Locale};
 use leptos::{ev, window_event_listener, *};
 use wasm_bindgen::JsCast;
@@ -202,10 +202,80 @@ pub(super) fn WindowTitlebar(
     }
 }
 
-fn begin_window_move(ev: web_sys::MouseEvent) {
-    if ev.button() != 0 {
-        return;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CaptionPointerDown {
+    Ignore,
+    ToggleMaximize,
+    ArmDrag,
+}
+
+fn caption_pointer_down(button: i16, detail: i32) -> CaptionPointerDown {
+    if button != 0 {
+        return CaptionPointerDown::Ignore;
     }
-    ev.prevent_default();
-    spawn_local(async { start_window_move().await });
+    if detail >= 2 {
+        CaptionPointerDown::ToggleMaximize
+    } else {
+        CaptionPointerDown::ArmDrag
+    }
+}
+
+fn begin_window_move(ev: web_sys::MouseEvent) {
+    match caption_pointer_down(ev.button(), ev.detail()) {
+        CaptionPointerDown::Ignore => {}
+        CaptionPointerDown::ToggleMaximize => {
+            ev.prevent_default();
+            spawn_local(async { window_control("toggle-maximize").await });
+        }
+        CaptionPointerDown::ArmDrag => {
+            ev.prevent_default();
+            let start_x = f64::from(ev.client_x());
+            let start_y = f64::from(ev.client_y());
+            spawn_local(async move { arm_caption_drag(start_x, start_y).await });
+        }
+    }
+}
+
+#[cfg(test)]
+mod caption_gesture_tests {
+    use super::*;
+
+    /// Typical Windows `SM_CXDRAG` / `SM_CYDRAG`. Keep in sync with `api.js`.
+    const CAPTION_DRAG_THRESHOLD_PX: f64 = 4.0;
+
+    fn caption_drag_ready(dx: f64, dy: f64) -> bool {
+        dx.abs() >= CAPTION_DRAG_THRESHOLD_PX || dy.abs() >= CAPTION_DRAG_THRESHOLD_PX
+    }
+
+    #[test]
+    fn left_click_arms_drag_instead_of_starting_a_move() {
+        assert_eq!(caption_pointer_down(0, 1), CaptionPointerDown::ArmDrag);
+    }
+
+    #[test]
+    fn double_click_toggles_maximize() {
+        assert_eq!(
+            caption_pointer_down(0, 2),
+            CaptionPointerDown::ToggleMaximize
+        );
+        assert_eq!(
+            caption_pointer_down(0, 3),
+            CaptionPointerDown::ToggleMaximize
+        );
+    }
+
+    #[test]
+    fn other_buttons_are_ignored() {
+        assert_eq!(caption_pointer_down(1, 1), CaptionPointerDown::Ignore);
+        assert_eq!(caption_pointer_down(2, 2), CaptionPointerDown::Ignore);
+    }
+
+    #[test]
+    fn drag_starts_only_after_the_windows_threshold() {
+        assert!(!caption_drag_ready(3.0, 0.0));
+        assert!(!caption_drag_ready(0.0, -3.0));
+        assert!(caption_drag_ready(4.0, 0.0));
+        assert!(caption_drag_ready(0.0, -4.0));
+        assert!(caption_drag_ready(3.0, 4.0));
+    }
 }


### PR DESCRIPTION
## Problem

#872 restored Aero Snap / Snap Layouts by sending `SC_MOVE | HTCAPTION` on the first title-bar mousedown. That modal move ate the second click, so Windows could no longer double-click the title bar to maximize or restore (#868 regression).

## Change

- Arm a caption drag only after the pointer travels 4px (`SM_CXDRAG`). A bare click does not start `SC_MOVE`.
- A double-click (`detail >= 2`) calls `toggle-maximize` (maximize and restore).
- Dragging a maximized window restores first so it can leave the screen edge.
- Snap-to-edge and the maximize-button Snap Layouts overlay are unchanged.

## Tests

- Rust: caption pointer-down / drag-threshold tests in `window_titlebar.rs`; existing `windows_snap` tests.
- Playwright: drag starts `start_window_move` only after movement; double-click logs `toggle-maximize` and does not start a move. Existing Windows titlebar layout/Escape tests still pass.

## Manual smoke (Windows)

1. Double-click the title-bar empty area → maximize.
2. Double-click again → restore to the previous size.
3. Drag the title bar to a screen edge → still snaps.
4. Hover the maximize button → Snap Layouts still appears.
5. Maximize, then drag the title bar → window restores and follows the pointer.
6. File/Edit/View menus still open.

## Known limitations

Playwright cannot maximize a real Tauri HWND; the E2E test checks the gesture contract against the mocked bridge. Please confirm the six smoke steps on a Windows box.