### PR TITLE
fix(ui): drop leftover stopping banner once the turn is idle

### DIFF
--- a/src-tauri/src/lib_tests.rs
+++ b/src-tauri/src/lib_tests.rs
@@ -2122,9 +2122,9 @@ fn desktop_app_icon_is_full_bleed_with_an_inset_mark() {
         "icon generation must use the desktop master, not the in-app logo"
     );
     assert!(
-        script
-            .lines()
-            .any(|line| line.contains("Resolve-Path") && line.contains("icons/app-icon-rounded.svg")),
+        script.lines().any(
+            |line| line.contains("Resolve-Path") && line.contains("icons/app-icon-rounded.svg")
+        ),
         "Windows/Linux icons must come from the rounded master"
     );
     assert!(

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -1056,6 +1056,13 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
   const acpLongResolvers: Record<string, (value: string) => void> = {};
   const nativeConfirmResolvers: Record<string, (value: string) => void> = {};
   (window as any).__nativeConfirmPending = {};
+  (window as any).__finishAcpLong = (frameId?: string) => {
+    const ids = frameId ? [frameId] : Object.keys(acpLongResolvers);
+    for (const id of ids) {
+      acpLongResolvers[id]?.(id);
+      delete acpLongResolvers[id];
+    }
+  };
   let mockCredentials: Record<string, boolean> = {
     openalex_api_key: false,
     infinisynapse_api_key: false,

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -1581,8 +1581,63 @@ test("ACP cancellation is scoped to the active bound frame", async ({ page }) =>
   await page.getByRole("button", { name: "Stop" }).click();
   await expect.poll(() => lastInvokeArgs(page, "stop_agent")).toMatchObject({ sessionId: expect.any(String) });
   await expect(page.getByRole("button", { name: "Send" })).toBeVisible();
+  await expect(page.getByTestId("stopping-toast")).toHaveCount(0);
   await page.waitForTimeout(100);
   expect(await invokeArgsList(page, "propose_turn_memory")).toHaveLength(0);
+});
+
+test("an idle composer dismisses a leftover stopping banner", async ({ page }) => {
+  await enterApp(page);
+  await newSessionButton(page).click();
+  await page.locator(".model-picker-btn").click();
+  await page.getByRole("button", { name: /Test ACP Agent/ }).click();
+  await composer(page).fill("ACP LONG");
+  await page.getByRole("button", { name: "Send" }).click();
+  await expect(page.getByRole("button", { name: "Stop" })).toBeVisible();
+
+  await page.evaluate(() => { (window as any).__holdStopAgent = true; });
+  await page.getByRole("button", { name: "Stop" }).click();
+  const toast = page.getByTestId("stopping-toast");
+  await expect(toast).toBeVisible();
+  const composerInner = page.locator(".composer-inner");
+  const toastBox = await toast.boundingBox();
+  const innerBox = await composerInner.boundingBox();
+  expect(toastBox).not.toBeNull();
+  expect(innerBox).not.toBeNull();
+  expect(toastBox!.y + toastBox!.height).toBeLessThanOrEqual(innerBox!.y + 1);
+
+  // The turn can become idle (Send returns) without another Done. The banner
+  // must not stay over the composer once the session is no longer running.
+  await page.evaluate(() => { (window as any).__finishAcpLong(); });
+  await expect(page.getByRole("button", { name: "Send" })).toBeVisible();
+  await expect(toast).toHaveCount(0);
+});
+
+test("stopping after a late Done does not leave the banner over Send", async ({ page }) => {
+  await enterApp(page);
+  await newSessionButton(page).click();
+  await page.locator(".model-picker-btn").click();
+  await page.getByRole("button", { name: /Test ACP Agent/ }).click();
+  await composer(page).fill("ACP LONG");
+  await page.getByRole("button", { name: "Send" }).click();
+  await expect(page.getByRole("button", { name: "Stop" })).toBeVisible();
+
+  const sessionId = await page.locator(".side-item.ses.active").getAttribute("data-session-id");
+  expect(sessionId).toBeTruthy();
+  // Done can land while send_message is still in flight, so Stop is still
+  // clickable. That click must not pin the banner after the turn goes idle.
+  await emitTauriEvent(page, "agent", {
+    kind: "Done",
+    frame_id: sessionId,
+    stop_reason: "end_turn",
+  });
+  await page.evaluate(() => { (window as any).__holdStopAgent = true; });
+  await page.getByRole("button", { name: "Stop" }).click();
+  await expect(page.getByTestId("stopping-toast")).toBeVisible();
+
+  await page.evaluate(() => { (window as any).__finishAcpLong(); });
+  await expect(page.getByRole("button", { name: "Send" })).toBeVisible();
+  await expect(page.getByTestId("stopping-toast")).toHaveCount(0);
 });
 
 test("switching conversations dismisses the previous conversation's stopping modal", async ({ page }) => {

--- a/ui/src/app_support/sessions.rs
+++ b/ui/src/app_support/sessions.rs
@@ -120,6 +120,18 @@ pub(crate) fn rebuilt_running_set(
     set
 }
 
+/// Keep the stopping banner only while that session is still the active
+/// running turn. A Stop click after Done (or a missed terminal event) must
+/// not leave "Stopping…" over an idle Send button.
+pub(crate) fn next_stopping_session(
+    stopping: Option<String>,
+    active: Option<&str>,
+    running: &HashSet<String>,
+) -> Option<String> {
+    let sid = stopping?;
+    (active == Some(sid.as_str()) && running.contains(&sid)).then_some(sid)
+}
+
 #[cfg(test)]
 mod rebuilt_running_set_tests {
     use super::*;
@@ -132,6 +144,26 @@ mod rebuilt_running_set_tests {
         assert!(set.contains("a"), "server-running kept");
         assert!(!set.contains("b"), "stale local state dropped");
         assert!(set.contains("c"), "local pending send kept");
+    }
+
+    #[test]
+    fn stopping_banner_clears_when_the_session_is_idle() {
+        let running = HashSet::from(["s1".to_string()]);
+        assert_eq!(
+            next_stopping_session(Some("s1".into()), Some("s1"), &running).as_deref(),
+            Some("s1")
+        );
+        assert_eq!(
+            next_stopping_session(Some("s1".into()), Some("s1"), &HashSet::new()),
+            None,
+            "idle session must not keep Stopping over Send"
+        );
+        assert_eq!(
+            next_stopping_session(Some("s1".into()), Some("s2"), &running),
+            None,
+            "another conversation must not inherit the banner"
+        );
+        assert_eq!(next_stopping_session(None, Some("s1"), &running), None);
     }
 }
 

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -421,15 +421,17 @@ fn App() -> impl IntoView {
     // Configured model profiles + the composer's bottom-right picker state.
     let models = create_rw_signal::<Vec<ModelProfile>>(vec![]);
     let active_session = create_rw_signal::<Option<String>>(None);
-    // The stopping toast is foreground UI owned by the session where Stop was
-    // clicked. The backend cancellation may continue after navigation, but its
-    // modal state must not follow the user into another conversation or block
-    // that conversation's own Stop action.
+    // The stopping banner belongs to the session where Stop was clicked, and
+    // only while that session is still running. Switching conversations must
+    // not carry it over; a missed or late Done must not leave it over Send.
     create_effect(move |_| {
-        let active = active_session.get();
-        let stopping = stopping_session.get();
-        if stopping.is_some() && active != stopping {
-            stopping_session.set(None);
+        let next = next_stopping_session(
+            stopping_session.get(),
+            active_session.get().as_deref(),
+            &running.get(),
+        );
+        if stopping_session.get() != next {
+            stopping_session.set(next);
         }
     });
     let sessions = create_rw_signal::<Vec<SessionInfo>>(vec![]);
@@ -10980,9 +10982,12 @@ fn App() -> impl IntoView {
                         {t(locale.get(), "projects.example_read_only")}
                     </div>
                 })}
-                {move || (active_session.get().is_some()
-                    && active_session.get() == stopping_session.get()).then(|| view! {
-                    <div class="stopping-toast">
+                {move || next_stopping_session(
+                    stopping_session.get(),
+                    active_session.get().as_deref(),
+                    &running.get(),
+                ).is_some().then(|| view! {
+                    <div class="stopping-toast" data-testid="stopping-toast" role="status">
                         <span class="stopping-spinner"></span>
                         <div class="stopping-text">
                             <strong>{move || t(locale.get(), "composer.stopping")}</strong>

--- a/ui/src/styles/chat.css
+++ b/ui/src/styles/chat.css
@@ -1576,12 +1576,15 @@ button.stop:disabled { opacity: .6; cursor: default; }
 .sidechat-send:disabled { opacity: .45; cursor: default; }
 .sidechat-send:hover:not(:disabled) { background: var(--clay-strong); }
 
-/* Non-blocking "stopping…" toast — interrupting the kernel isn't instant, so
-   this reassures the user the click landed. Anchored above the composer column. */
-.stopping-toast { position: absolute; z-index: 55; left: 50%; bottom: calc(100% + 10px); transform: translateX(-50%);
-  display: flex; align-items: center; gap: 12px; width: min(420px, calc(100% - 32px)); padding: 12px 16px;
-  background: var(--bg); border: 1px solid var(--border-strong); border-radius: var(--radius-sm);
-  box-shadow: 0 8px 28px hsl(215 25% 14% / 0.18); pointer-events: none; }
+/* In-flow "stopping…" banner — interrupting the kernel isn't instant, so this
+   reassures the user the click landed. It sits in the composer column instead
+   of floating over follow-ups / the last thread rows. */
+.stopping-toast { position: relative; z-index: 2;
+  display: flex; align-items: flex-start; gap: 12px;
+  max-width: var(--chat-col-max); width: 100%; box-sizing: border-box;
+  margin: 0 auto 10px; padding: 12px 16px;
+  background: var(--bg-elev); border: 1px solid var(--border-strong); border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-sm); }
 .stopping-text { display: flex; flex-direction: column; gap: 3px; }
 .stopping-text strong { font-size: 13.5px; color: var(--text); }
 .stopping-text span { font-size: 12px; color: var(--text-muted); line-height: 1.4; }


### PR DESCRIPTION
## Problem

Clicking Stop could leave the 「停止中…」 banner on screen after the turn was already idle: Send was available again, follow-up questions were visible, and only a reload cleared the overlay. The banner was also absolutely positioned above the composer, so it covered the last follow-up questions.

## Change

- Treat stopping as session-scoped UI that is valid only while that session is still in the running set. Switching conversations, a missed `Done`, or a Stop click after the turn already ended all drop the banner.
- Render the banner in the composer column (in flow) instead of floating over the thread.

## Tests

- Rust: `next_stopping_session` keeps the banner only for the active running session.
- Playwright: leftover banner dismisses when the turn goes idle; a Stop click after a late `Done` does not pin the banner over Send; the banner does not overlap the composer; existing stop / session-switch cases still pass.

## Manual smoke

1. Send a long turn, click Stop while it is still running → banner appears above the input, not over the last reply / follow-ups.
2. Wait until Send is back → banner is gone without reloading.
3. Click Stop just as the answer finishes → Send returns and the banner does not stick.
4. Switch conversations while stopping → the other conversation does not inherit the banner.

## Known limitations

None. Kernel interrupt can still take a moment; the banner is only meant to cover that window.

A second commit rustfmts a pre-existing `lib_tests.rs` drift so the push hook passes.