### PR TITLE
fix(browser): keep live-retrieval mark after a later successful scan

### DIFF
--- a/src-tauri/src/browser_bridge.rs
+++ b/src-tauri/src/browser_bridge.rs
@@ -35,6 +35,7 @@ use crate::browser_url_filters::{self, BrowserUrlFilters};
 const BRIDGE_ADDR: &str = "127.0.0.1:18765";
 const EXTENSION_ORIGIN: &str = "chrome-extension://gnkjgagleagkgdlkkcianolobfdoocnp";
 const BROWSER_DISCONNECTED_KIND: &str = "browser_disconnected";
+const BROWSER_CONNECTED_KIND: &str = "browser_connected";
 const BROWSER_DISCONNECTED_CODE: &str = "browser_extension_disconnected";
 const BROWSER_DISCONNECTED_MARKER: &str = "WISP_BROWSER_DISCONNECTED";
 const DISCONNECTED_ASSISTANT_INSTRUCTION: &str = "Live web retrieval is unavailable. Do not answer live, latest, current, or URL-specific questions from prior knowledge. Tell the user this turn contains no live web retrieval, relay the install steps, and wait until status is connected. Only continue from memory if they explicitly ask for a knowledge-only answer.";
@@ -431,6 +432,16 @@ async fn emit_disconnected(env: &dyn ToolEnv) {
     .await;
 }
 
+async fn emit_live_retrieval(env: &dyn ToolEnv) {
+    env.emit(ToolEvent::Presentation {
+        kind: BROWSER_CONNECTED_KIND.into(),
+        payload: json!({
+            "live_retrieval": true,
+        }),
+    })
+    .await;
+}
+
 async fn fail_bridge(env: &dyn ToolEnv, error: String) -> ToolResult {
     if is_bridge_unavailable(&error) {
         emit_disconnected(env).await;
@@ -672,6 +683,8 @@ impl Tool for BrowserSetupTool {
         });
         if info["status"] != "connected" {
             emit_disconnected(env).await;
+        } else {
+            emit_live_retrieval(env).await;
         }
         ToolResult::ok(render_json(&info))
     }
@@ -733,7 +746,10 @@ impl Tool for WebScanTool {
             .unwrap_or(false)
         {
             return match self.bridge.tabs().await {
-                Ok(tabs) => ToolResult::ok(render_json(&json!({ "tabs": tabs }))),
+                Ok(tabs) => {
+                    emit_live_retrieval(env).await;
+                    ToolResult::ok(render_json(&json!({ "tabs": tabs })))
+                }
                 Err(error) => fail_bridge(env, error).await,
             };
         }
@@ -759,6 +775,7 @@ impl Tool for WebScanTool {
             .await
         {
             Ok(execution) => {
+                emit_live_retrieval(env).await;
                 let handoff = human_verification_handoff(&execution.value);
                 ToolResult::ok(render_json(&json!({
                     "human_intervention": handoff,
@@ -855,10 +872,13 @@ impl Tool for WebExecuteJsTool {
             .execute(tab_id, script, Duration::from_millis(timeout_ms))
             .await
         {
-            Ok(execution) => ToolResult::ok(render_json(&json!({
-                "tab_id": execution.tab_id,
-                "result": execution.value
-            }))),
+            Ok(execution) => {
+                emit_live_retrieval(env).await;
+                ToolResult::ok(render_json(&json!({
+                    "tab_id": execution.tab_id,
+                    "result": execution.value
+                })))
+            }
             Err(error) => fail_bridge(env, error).await,
         }
     }
@@ -923,7 +943,10 @@ impl Tool for WebOpenTabTool {
         }
         let active = args.get("active").and_then(Value::as_bool).unwrap_or(false);
         match self.bridge.open_tab(url, active).await {
-            Ok(tab) => ToolResult::ok(render_json(&open_tab_result(tab, url, &filters))),
+            Ok(tab) => {
+                emit_live_retrieval(env).await;
+                ToolResult::ok(render_json(&open_tab_result(tab, url, &filters)))
+            }
             Err(error) => fail_bridge(env, error).await,
         }
     }
@@ -1005,6 +1028,7 @@ impl Tool for WebScreenshotTool {
                 data.len()
             ));
         }
+        emit_live_retrieval(env).await;
         ToolResult::image(ImageData {
             mime: "image/jpeg".into(),
             data_url: format!("data:image/jpeg;base64,{data}"),
@@ -1426,6 +1450,32 @@ mod tests {
                 assert_eq!(payload["live_retrieval"], false);
             }
             other => panic!("expected one disconnected presentation, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn live_retrieval_presentation_replaces_a_prior_disconnect() {
+        let env = RecordingEnv {
+            root: PathBuf::from("."),
+            events: std::sync::Mutex::new(Vec::new()),
+        };
+        emit_disconnected(&env).await;
+        emit_live_retrieval(&env).await;
+        let events = env.events.lock().unwrap();
+        match events.as_slice() {
+            [ToolEvent::Presentation {
+                kind: first,
+                payload: first_payload,
+            }, ToolEvent::Presentation {
+                kind: second,
+                payload: second_payload,
+            }] => {
+                assert_eq!(first, BROWSER_DISCONNECTED_KIND);
+                assert_eq!(first_payload["live_retrieval"], false);
+                assert_eq!(second, BROWSER_CONNECTED_KIND);
+                assert_eq!(second_payload["live_retrieval"], true);
+            }
+            other => panic!("expected disconnect then connect presentations, got {other:?}"),
         }
     }
 }

--- a/src-tauri/src/lib_tests.rs
+++ b/src-tauri/src/lib_tests.rs
@@ -2122,9 +2122,9 @@ fn desktop_app_icon_is_full_bleed_with_an_inset_mark() {
         "icon generation must use the desktop master, not the in-app logo"
     );
     assert!(
-        script
-            .lines()
-            .any(|line| line.contains("Resolve-Path") && line.contains("icons/app-icon-rounded.svg")),
+        script.lines().any(
+            |line| line.contains("Resolve-Path") && line.contains("icons/app-icon-rounded.svg")
+        ),
         "Windows/Linux icons must come from the rounded master"
     );
     assert!(

--- a/ui-tests/tests/browser-offline.spec.ts
+++ b/ui-tests/tests/browser-offline.spec.ts
@@ -91,3 +91,72 @@ test("browser offline banner stays under Settings in the Escape stack and can re
     message: "latest rustc version",
   });
 });
+
+test("a later connected browser_setup clears the offline banner", async ({ page }) => {
+  await enterApp(page);
+  const sessionId = await startLiveRetrievalTurn(page);
+
+  await emitTauriEvent(page, "agent", {
+    kind: "ToolPresentation",
+    frame_id: sessionId,
+    presentation_kind: "browser_disconnected",
+    payload: { code: "browser_extension_disconnected", live_retrieval: false },
+  });
+  const banner = page.getByTestId("browser-offline-banner");
+  await expect(banner).toBeVisible();
+
+  await emitTauriEvent(page, "agent", {
+    kind: "ToolResult",
+    frame_id: sessionId,
+    name: "browser_setup",
+    ok: true,
+    content: JSON.stringify({ status: "connected", live_retrieval: true, connected_tabs: 1 }),
+  });
+  await expect(banner).toHaveCount(0);
+});
+
+test("successful live retrieval survives a stream disconnect error", async ({ page }) => {
+  await enterApp(page);
+  const sessionId = await startLiveRetrievalTurn(page);
+
+  await emitTauriEvent(page, "agent", {
+    kind: "ToolPresentation",
+    frame_id: sessionId,
+    presentation_kind: "browser_disconnected",
+    payload: { code: "browser_extension_disconnected", live_retrieval: false },
+  });
+  await expect(page.getByTestId("browser-offline-banner")).toBeVisible();
+
+  await emitTauriEvent(page, "agent", {
+    kind: "ToolResult",
+    frame_id: sessionId,
+    name: "web_scan",
+    ok: true,
+    content: JSON.stringify({ tabs: [{ title: "PubMed CLEC12A" }] }),
+  });
+  await emitTauriEvent(page, "agent", {
+    kind: "ToolPresentation",
+    frame_id: sessionId,
+    presentation_kind: "browser_connected",
+    payload: { live_retrieval: true },
+  });
+  await expect(page.getByTestId("browser-offline-banner")).toHaveCount(0);
+
+  await emitTauriEvent(page, "agent", {
+    kind: "Error",
+    frame_id: sessionId,
+    message: "api: 200 stream error: stream disconnected before completion: stream closed before response.completed",
+  });
+  await expect(page.getByText(/stream disconnected before completion/)).toBeVisible();
+  await expect(page.getByTestId("browser-offline-banner")).toHaveCount(0);
+});
+
+test("reopening a session does not revive a stale disconnected presentation", async ({ page }) => {
+  await page.goto("/?mockBrowserRestore=1");
+  await page.locator(".proj-card-main").first().click();
+  const session = page.locator('[data-session-id="browser-restore-session"]');
+  await expect(session).toBeVisible();
+  await session.click();
+  await expect(page.getByText("PubMed currently lists live hits for CLEC12A.")).toBeVisible();
+  await expect(page.getByTestId("browser-offline-banner")).toHaveCount(0);
+});

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -147,6 +147,7 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
   const mockLongSession = query.get("mockLongSession") === "1" || mockLongPages > 0;
   const mockResourceSession = query.get("mockResourceSession") === "1";
   const mockMcpAppSession = query.get("mockMcpAppSession") === "1";
+  const mockBrowserRestore = query.get("mockBrowserRestore") === "1";
   const mockOAuthPending = query.get("mockOAuthPending") === "1";
   const mockOnboarding = query.get("mockOnboarding") === "1";
   const mockSyncUnconfigured = query.get("mockSyncUnconfigured") === "1";
@@ -187,6 +188,8 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
       ? [{ id: "long-session", title: "Long transcript", ts: 2000, running: false }]
       : mockMcpAppSession
         ? [{ id: "mcp-app-session", title: "Saved MCP App", ts: 2000, running: false }]
+      : mockBrowserRestore
+        ? [{ id: "browser-restore-session", title: "Live PubMed retrieval", ts: 2000, running: false }]
       : query.has("mockAgentWorkflow")
         ? [{ id: "s-current", title: "Agent workflow conversation", ts: 2000, running: false }]
         : query.get("mockSessionModels") === "1"
@@ -1969,6 +1972,39 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
                 ],
                 next_before_seq: null,
                 user_offset: 0,
+              };
+            }
+            if (mockBrowserRestore && String(arg("id") ?? "") === "browser-restore-session") {
+              return {
+                items: [
+                  { role: "user", text: "CLEC12A PubMed", tool_name: null, ok: null },
+                  {
+                    role: "tool",
+                    text: "{\n  \"status\": \"disconnected\",\n  \"live_retrieval\": false\n}",
+                    tool_name: "browser_setup",
+                    ok: true,
+                  },
+                  {
+                    role: "tool",
+                    text: "{\n  \"status\": \"connected\",\n  \"live_retrieval\": true,\n  \"connected_tabs\": 1\n}",
+                    tool_name: "browser_setup",
+                    ok: true,
+                  },
+                  {
+                    role: "tool",
+                    text: "{\"tabs\":[{\"title\":\"PubMed CLEC12A\",\"url\":\"https://pubmed.ncbi.nlm.nih.gov\"}]}",
+                    tool_name: "web_scan",
+                    ok: true,
+                  },
+                  { role: "assistant", text: "PubMed currently lists live hits for CLEC12A.", tool_name: null, ok: null },
+                ],
+                next_before_seq: null,
+                user_offset: 0,
+                presentations: [{
+                  presentation_id: "",
+                  presentation_kind: "browser_disconnected",
+                  payload: { code: "browser_extension_disconnected", live_retrieval: false },
+                }],
               };
             }
             if (mockMcpAppSession) {

--- a/ui/src/app_support/transcript.rs
+++ b/ui/src/app_support/transcript.rs
@@ -225,9 +225,74 @@ mod review_jump_tests {
         });
         assert!(browser_offline_notice_from_items("s1", &items).is_none());
     }
+
+    fn setup_item(live: bool) -> ChatItem {
+        ChatItem::Tool {
+            name: "browser_setup".into(),
+            ok: Some(true),
+            input: String::new(),
+            output: format!(
+                "{{\n  \"status\": \"{}\",\n  \"live_retrieval\": {}\n}}",
+                if live { "connected" } else { "disconnected" },
+                live
+            ),
+            started_at_ms: None,
+            duration_ms: None,
+        }
+    }
+
+    #[test]
+    fn browser_setup_json_is_the_block_and_restore_signal() {
+        let blocked = vec![ChatItem::User("latest rustc".into()), setup_item(false)];
+        assert!(browser_offline_notice_from_items("s1", &blocked).is_some());
+
+        let restored = vec![
+            ChatItem::User("latest rustc".into()),
+            setup_item(false),
+            setup_item(true),
+        ];
+        assert!(
+            browser_offline_notice_from_items("s1", &restored).is_none(),
+            "connected browser_setup must clear an earlier disconnect"
+        );
+    }
+
+    #[test]
+    fn successful_live_tools_override_an_earlier_disconnected_setup() {
+        let items = vec![
+            ChatItem::User("CLEC12A pubmed".into()),
+            setup_item(false),
+            ChatItem::Tool {
+                name: "web_scan".into(),
+                ok: Some(true),
+                input: "tabs".into(),
+                output: "{\"tabs\":[{\"title\":\"PubMed\"}]}".into(),
+                started_at_ms: None,
+                duration_ms: None,
+            },
+            ChatItem::Tool {
+                name: "web_execute_js".into(),
+                ok: Some(true),
+                input: "Date()".into(),
+                output: "{\"result\":\"ok\"}".into(),
+                started_at_ms: None,
+                duration_ms: None,
+            },
+            ChatItem::Assistant {
+                text: "PubMed currently lists hits for CLEC12A.".into(),
+                model: None,
+                resources: Vec::new(),
+            },
+        ];
+        assert!(
+            browser_offline_notice_from_items("s1", &items).is_none(),
+            "a later successful scan must not keep the offline banner (#887)"
+        );
+    }
 }
 
 pub(crate) const BROWSER_DISCONNECTED_KIND: &str = "browser_disconnected";
+pub(crate) const BROWSER_CONNECTED_KIND: &str = "browser_connected";
 pub(crate) const BROWSER_DISCONNECTED_MARKER: &str = "WISP_BROWSER_DISCONNECTED";
 
 #[derive(Clone, PartialEq, Eq)]
@@ -254,11 +319,29 @@ fn is_browser_retrieval_tool(name: &str) -> bool {
     )
 }
 
+pub(crate) fn browser_setup_live_retrieval(content: &str) -> Option<bool> {
+    let value = serde_json::from_str::<serde_json::Value>(content).ok()?;
+    if let Some(live) = value.get("live_retrieval").and_then(|v| v.as_bool()) {
+        return Some(live);
+    }
+    match value.get("status").and_then(|v| v.as_str()) {
+        Some("connected") => Some(true),
+        Some(_) => Some(false),
+        None => None,
+    }
+}
+
 pub(crate) fn browser_retrieval_blocked(name: &str, ok: bool, content: &str) -> bool {
+    if name == "browser_setup" {
+        return browser_setup_live_retrieval(content) == Some(false);
+    }
     is_browser_retrieval_tool(name) && !ok && content.contains(BROWSER_DISCONNECTED_MARKER)
 }
 
-pub(crate) fn browser_retrieval_restored(name: &str, ok: bool) -> bool {
+pub(crate) fn browser_retrieval_restored(name: &str, ok: bool, content: &str) -> bool {
+    if name == "browser_setup" {
+        return browser_setup_live_retrieval(content) == Some(true);
+    }
     matches!(
         name,
         "web_scan" | "web_open_tab" | "web_execute_js" | "web_screenshot"
@@ -278,7 +361,7 @@ pub(crate) fn browser_offline_notice_from_items(
             ..
         } = item
         {
-            if browser_retrieval_restored(name, *ok) {
+            if browser_retrieval_restored(name, *ok, output) {
                 blocked = false;
             } else if browser_retrieval_blocked(name, *ok, output) {
                 blocked = true;

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -2442,7 +2442,7 @@ fn App() -> impl IntoView {
                         frame_id: frame_id.clone(),
                         retry_text,
                     }));
-                } else if browser_retrieval_restored(&name, ok) {
+                } else if browser_retrieval_restored(&name, ok, &content) {
                     browser_offline_cb.update(|notice| {
                         if notice.as_ref().is_some_and(|row| row.frame_id == frame_id) {
                             *notice = None;
@@ -2493,6 +2493,12 @@ fn App() -> impl IntoView {
                         frame_id,
                         retry_text,
                     }));
+                } else if presentation_kind == BROWSER_CONNECTED_KIND {
+                    browser_offline_cb.update(|notice| {
+                        if notice.as_ref().is_some_and(|row| row.frame_id == frame_id) {
+                            *notice = None;
+                        }
+                    });
                 }
             }
             AgentEvent::Usage {
@@ -5180,15 +5186,18 @@ fn App() -> impl IntoView {
                 // unguarded set would clobber the newer view with stale rows (#53).
                 if active_session.get().as_deref() == Some(&id) {
                     items.set(chats.clone());
+                    // Tool rows are the last word. A leftover disconnected
+                    // presentation from earlier in the session must not cover a
+                    // later successful scan when the stream ends or the page
+                    // reloads (#887).
                     if let Some(notice) = browser_offline_notice_from_items(&id, &chats) {
                         browser_offline_notice.set(Some(notice));
-                    } else if presentations.iter().any(|presentation| {
-                        presentation.presentation_kind == BROWSER_DISCONNECTED_KIND
-                    }) {
-                        browser_offline_notice.set(Some(BrowserOfflineNotice {
-                            frame_id: id.clone(),
-                            retry_text: last_user_composer_text(&chats),
-                        }));
+                    } else {
+                        browser_offline_notice.update(|notice| {
+                            if notice.as_ref().is_some_and(|row| row.frame_id == id) {
+                                *notice = None;
+                            }
+                        });
                     }
                     for presentation in presentations {
                         if presentation.presentation_kind == "mcp_app" {


### PR DESCRIPTION
Fixes #887

## Problem

A conversation could briefly lose the Real Browser Bridge, reconnect, then successfully run `browser_setup` (`status=connected`, `live_retrieval=true`) plus `web_scan` / `web_execute_js` — and the composer still showed **未联网检索 / 浏览器扩展未连接**. Reloading or a long-answer `stream closed before response.completed` error made the wrong banner come back.

Two causes:

1. `browser_setup` always returns `ok`, so the UI ignored its JSON and never treated a later connected setup as a restore.
2. Session load reused the latest `browser_disconnected` presentation. Successful scans do not replace that event, so an earlier disconnect covered later live retrieval.

## Change

- Read `live_retrieval` / `status` from `browser_setup` output. Connected setup clears the banner; disconnected setup still raises it.
- Emit a `browser_connected` presentation after a successful setup/scan/tab/js/screenshot so the persisted latest presentation matches live retrieval.
- On session load, tool rows are the last word. A leftover disconnected presentation cannot override a later successful scan.

## Tests

- Rust: setup JSON is a block/restore signal; a later successful scan wins; connected presentation follows a disconnect.
- Playwright: connected `browser_setup` clears the banner; a stream-disconnect Error after a successful scan leaves the banner down; reopening a session with a stale disconnected presentation and a later successful scan does not revive the banner.

## Manual smoke

1. Disconnect the extension, ask a live question → banner appears.
2. Reconnect, let `browser_setup` report connected and `web_scan` succeed → banner is gone.
3. If the model stream dies with `response.completed` missing, the banner stays gone.
4. Leave the conversation and come back → still no offline banner.

## Known limitations

The provider-side `api: 200 stream error: stream closed before response.completed` on long answers is unchanged. This PR only keeps already-successful browser evidence from being rewritten as “not networked.”