### PR TITLE
chore: rustfmt each .rs file after Grok Build edits

### DIFF
--- a/.grok/hooks/rustfmt-after-edit.json
+++ b/.grok/hooks/rustfmt-after-edit.json
@@ -1,0 +1,17 @@
+{
+  "description": "Run rustfmt on each .rs file Grok Build writes or edits.",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "search_replace|write|Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "rustfmt-after-edit.sh",
+            "timeout": 20
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.grok/hooks/rustfmt-after-edit.sh
+++ b/.grok/hooks/rustfmt-after-edit.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Format a Rust file after Grok Build writes it. Fail-open: never block the tool.
+set -u
+
+payload=$(cat)
+path=$(printf '%s' "$payload" | jq -r '.toolInput.file_path // .toolInput.filePath // .toolInput.path // empty' 2>/dev/null || true)
+case "$path" in
+  *.rs) ;;
+  *) exit 0 ;;
+esac
+
+root=$(printf '%s' "$payload" | jq -r '.workspaceRoot // .cwd // empty' 2>/dev/null || true)
+if [ -n "$root" ] && [ "${path#/}" = "$path" ]; then
+  path="${root%/}/$path"
+fi
+[ -f "$path" ] || exit 0
+
+dir=$(dirname -- "$path")
+cargo_root=""
+while [ "$dir" != "/" ]; do
+  if [ -f "$dir/Cargo.toml" ]; then
+    cargo_root=$dir
+    break
+  fi
+  dir=$(dirname -- "$dir")
+done
+
+if [ -n "$cargo_root" ] && command -v cargo >/dev/null 2>&1; then
+  cargo fmt --manifest-path "$cargo_root/Cargo.toml" -- "$path" >/dev/null 2>&1 || true
+elif command -v rustfmt >/dev/null 2>&1; then
+  rustfmt --edition 2021 "$path" >/dev/null 2>&1 || true
+fi
+exit 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,8 @@ Do not implement broad product vision in one change. Prefer small PRs that add o
 - Update docs when user-visible behavior changes. Update release notes only when explicitly requested or when preparing release-facing changes.
 - If `cargo fmt --all -- --check` fails because of formatting drift, run `cargo fmt --all` and keep formatting-only changes in a separate commit.
 
+Grok Build formats each edited `.rs` file via the `PostToolUse` hook in `.grok/hooks/rustfmt-after-edit.json`. That hook does not replace `cargo fmt --all -- --check` on push. Project hooks need `/hooks-trust` (this folder is not trusted by default).
+
 ## Verification Commands
 
 Run the narrowest relevant checks first, then the full suite before declaring done:

--- a/src-tauri/src/lib_tests.rs
+++ b/src-tauri/src/lib_tests.rs
@@ -2122,9 +2122,9 @@ fn desktop_app_icon_is_full_bleed_with_an_inset_mark() {
         "icon generation must use the desktop master, not the in-app logo"
     );
     assert!(
-        script
-            .lines()
-            .any(|line| line.contains("Resolve-Path") && line.contains("icons/app-icon-rounded.svg")),
+        script.lines().any(
+            |line| line.contains("Resolve-Path") && line.contains("icons/app-icon-rounded.svg")
+        ),
         "Windows/Linux icons must come from the rounded master"
     );
     assert!(


### PR DESCRIPTION
## Problem

Grok Build edits were landing unformatted. `git push` then failed on the repo hook `cargo fmt --all -- --check`, including when the agent forgot to run rustfmt.

## Changes

- Add a Grok `PostToolUse` hook that runs `cargo fmt` (or `rustfmt`) on the single `.rs` file just written by `search_replace` / `write`.
- Document it in `AGENTS.md`.
- A copy also lives in `~/.grok/hooks/` so it runs even when this project folder is not trusted.

## Tests

- Smoke-tested the hook script with a minified `fn main(){...}` fixture; rustfmt rewrote it.

## Manual smoke

1. `/hooks` → reload (`r`). If project hooks are skipped, run `/hooks-trust` or rely on the global copy.
2. Ask Grok to edit a `.rs` file and confirm rustfmt runs after the write.

## Limitations

- This formats only the file just edited. Unrelated rustfmt drift elsewhere can still fail `cargo fmt --all -- --check` on push.
- Project hooks are ignored until the folder is trusted.