### PR TITLE
fix(store): survive version-skip upgrades with missing keys

### DIFF
--- a/crates/wisp-dto/src/lib.rs
+++ b/crates/wisp-dto/src/lib.rs
@@ -2576,6 +2576,7 @@ impl SessionStatusKind {
 #[derive(Clone, Deserialize)]
 pub struct ModelProfile {
     pub id: String,
+    #[serde(default)]
     pub label: String,
     #[serde(default)]
     pub provider: String,

--- a/crates/wisp-store/src/lib.rs
+++ b/crates/wisp-store/src/lib.rs
@@ -695,6 +695,134 @@ impl Store {
             .await?;
             Self::record_migration(pool, ORPHAN_FILE_RETENTION_MIGRATION).await?;
         }
+        // Re-apply additive DDL even when a migration marker is already
+        // recorded. Jumping many releases can leave a table/column that was
+        // later folded into 0000_init.sql (or into an already-shipped apply_*
+        // body) missing, and the next query then fails with "no such column".
+        Self::ensure_schema_compat(pool).await?;
+        Ok(())
+    }
+
+    /// Idempotent repair for schema objects that numbered migrations can miss
+    /// after a large version skip. Only CREATE IF NOT EXISTS / ADD COLUMN.
+    async fn ensure_schema_compat(pool: &SqlitePool) -> Result<()> {
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS folders (\
+             id TEXT PRIMARY KEY, \
+             project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE, \
+             name TEXT NOT NULL, \
+             created_at INTEGER NOT NULL, \
+             updated_at INTEGER NOT NULL)",
+        )
+        .execute(pool)
+        .await?;
+        sqlx::query("CREATE INDEX IF NOT EXISTS ix_folders_project ON folders(project_id)")
+            .execute(pool)
+            .await?;
+
+        Self::add_columns_if_missing(
+            pool,
+            "projects",
+            &[
+                ("workspace_dir", "TEXT NOT NULL DEFAULT ''"),
+                ("run_retention_days", "INTEGER"),
+                ("failed_run_retention_days", "INTEGER"),
+                ("orphan_file_retention_days", "INTEGER"),
+            ],
+        )
+        .await?;
+        Self::add_columns_if_missing(pool, "messages", &[("model_name", "TEXT")]).await?;
+        Self::add_columns_if_missing(
+            pool,
+            "frames",
+            &[
+                ("title", "TEXT"),
+                ("folder_id", "TEXT"),
+                ("seen_at", "INTEGER NOT NULL DEFAULT 0"),
+                ("pinned", "INTEGER NOT NULL DEFAULT 0"),
+                ("branched_from", "TEXT"),
+                ("reasoning_effort", "TEXT"),
+                ("branch_point_user_index", "INTEGER"),
+                ("branch_point_kind", "TEXT"),
+                ("exploration_id", "TEXT"),
+            ],
+        )
+        .await?;
+        Self::add_columns_if_missing(
+            pool,
+            "artifacts",
+            &[
+                ("latest_version_id", "TEXT"),
+                ("logical_key", "TEXT"),
+                ("exploration_id", "TEXT"),
+            ],
+        )
+        .await?;
+        Self::add_columns_if_missing(
+            pool,
+            "artifact_versions",
+            &[
+                ("materialization", "TEXT NOT NULL DEFAULT 'reference'"),
+                ("capture_timing", "TEXT NOT NULL DEFAULT 'unknown'"),
+                ("source_discarded_at", "INTEGER"),
+            ],
+        )
+        .await?;
+        Self::add_columns_if_missing(
+            pool,
+            "artifact_dependencies",
+            &[
+                ("basis", "TEXT NOT NULL DEFAULT 'inferred'"),
+                ("confidence", "TEXT NOT NULL DEFAULT 'uncertain'"),
+            ],
+        )
+        .await?;
+        Self::add_columns_if_missing(
+            pool,
+            "env_snapshots",
+            &[
+                ("snapshot_json", "TEXT NOT NULL DEFAULT '{}'"),
+                ("hash_algorithm", "TEXT NOT NULL DEFAULT 'legacy'"),
+            ],
+        )
+        .await?;
+        Self::add_columns_if_missing(
+            pool,
+            "runs",
+            &[
+                ("remote_handle_json", "TEXT"),
+                ("timeout_secs", "INTEGER"),
+                ("last_polled_at", "INTEGER"),
+                ("last_poll_error", "TEXT"),
+                ("lifecycle_owner", "TEXT"),
+                ("lifecycle_lease_until", "INTEGER"),
+                ("progress_json", "TEXT NOT NULL DEFAULT '{}'"),
+                ("harvested_at", "INTEGER"),
+                ("cleaned_at", "INTEGER"),
+                ("cleanup_error", "TEXT"),
+                ("logs_path", "TEXT"),
+                ("exploration_id", "TEXT"),
+            ],
+        )
+        .await?;
+        for table in ["research_nodes", "research_edges", "external_resources"] {
+            Self::add_columns_if_missing(pool, table, &[("exploration_id", "TEXT")]).await?;
+        }
+        Self::add_columns_if_missing(
+            pool,
+            "message_resource_links",
+            &[
+                ("created_artifact", "INTEGER NOT NULL DEFAULT 0"),
+                ("created_version", "INTEGER NOT NULL DEFAULT 0"),
+            ],
+        )
+        .await?;
+        Self::add_columns_if_missing(
+            pool,
+            "method_search_runs",
+            &[("control_state", "TEXT NOT NULL DEFAULT 'run'")],
+        )
+        .await?;
         Ok(())
     }
 

--- a/crates/wisp-store/src/store_tests.rs
+++ b/crates/wisp-store/src/store_tests.rs
@@ -3075,6 +3075,86 @@ async fn migrate_adds_folder_id_on_legacy_db() {
     let _ = std::fs::remove_file(&tmp);
 }
 
+/// A v0-era database that already recorded `0000_initial_schema`, so the
+/// current 0000_init.sql (folders, extra columns) never runs. Opening it
+/// after jumping to HEAD must still list sessions and folders.
+#[tokio::test]
+async fn upgrade_from_recorded_initial_schema_can_list_sessions() {
+    let tmp = std::env::temp_dir().join(format!("wisp_store_jump_{}.sqlite", uuid::Uuid::new_v4()));
+    {
+        let opts = SqliteConnectOptions::from_str(&format!("sqlite://{}", tmp.display()))
+            .unwrap()
+            .create_if_missing(true);
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(opts)
+            .await
+            .unwrap();
+        sqlx::query(
+            "CREATE TABLE wisp_schema_migrations (\
+             version TEXT PRIMARY KEY, applied_at INTEGER NOT NULL)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query("INSERT INTO wisp_schema_migrations(version,applied_at) VALUES(?,1)")
+            .bind(INITIAL_SCHEMA_MIGRATION)
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "CREATE TABLE projects (id TEXT PRIMARY KEY, name TEXT, description TEXT, \
+             created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "CREATE TABLE frames (id TEXT PRIMARY KEY, parent_frame_id TEXT, root_frame_id TEXT, \
+             agent_name TEXT NOT NULL, status TEXT NOT NULL, project_id TEXT, model TEXT, \
+             input_tokens INTEGER, output_tokens INTEGER, created_at INTEGER NOT NULL, \
+             updated_at INTEGER NOT NULL, completed_at INTEGER)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "CREATE TABLE messages (id TEXT PRIMARY KEY, frame_id TEXT NOT NULL, seq INTEGER NOT NULL, \
+             role TEXT NOT NULL, content TEXT, tool_calls TEXT, tool_call_id TEXT, tool_name TEXT, \
+             reasoning TEXT, ts INTEGER NOT NULL, UNIQUE(frame_id, seq))",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query("CREATE TABLE settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "CREATE TABLE artifacts (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, \
+             root_frame_id TEXT NOT NULL, filename TEXT NOT NULL, content_type TEXT NOT NULL, \
+             storage_path TEXT NOT NULL, created_at INTEGER NOT NULL)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        pool.close().await;
+    }
+
+    let store = Store::open(&tmp).await.unwrap();
+    store.create_project("p", "proj", "").await.unwrap();
+    store.create_frame("f1", "p", "OPERON", "m").await.unwrap();
+    store
+        .append_message("f1", 1, &Message::user("jumped versions"))
+        .await
+        .unwrap();
+    let sessions = store.list_sessions("p").await.unwrap();
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(sessions[0].0, "f1");
+    assert!(store.list_folders("p").await.unwrap().is_empty());
+    let _ = std::fs::remove_file(&tmp);
+}
+
 #[tokio::test]
 async fn folder_crud_and_move() {
     let tmp =

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -137,6 +137,7 @@ enum AgentEvent {
     },
     Resources {
         frame_id: String,
+        #[serde(default)]
         seq: i64,
         resources: Vec<resource_refs::UiMessageResource>,
     },
@@ -158,6 +159,8 @@ enum AgentEvent {
         name: String,
         ok: bool,
         content: String,
+        /// Added after UI events started being persisted; older rows omit it.
+        #[serde(default)]
         duration_ms: u64,
     },
     ToolPresentation {
@@ -169,6 +172,7 @@ enum AgentEvent {
     },
     Usage {
         frame_id: String,
+        #[serde(default)]
         round: u64,
         #[serde(default)]
         model: String,
@@ -176,7 +180,9 @@ enum AgentEvent {
         created_at: i64,
         input: u64,
         output: u64,
+        #[serde(default)]
         reasoning: u64,
+        #[serde(default)]
         cached: u64,
         ctx_tokens: usize,
         max_context: usize,
@@ -191,6 +197,7 @@ enum AgentEvent {
     },
     CompactionStarted {
         frame_id: String,
+        #[serde(default)]
         strategy: String,
     },
     /// The context estimate crossed the warning threshold and remains high.

--- a/src-tauri/src/lib_tests.rs
+++ b/src-tauri/src/lib_tests.rs
@@ -1292,6 +1292,43 @@ fn transcript_page_reconstructs_legacy_prefix_before_persisted_events() {
 }
 
 #[test]
+fn persisted_ui_events_from_older_builds_keep_the_transcript() {
+    let page = wisp_store::SessionTranscriptPage {
+        messages: vec![(1, wisp_llm::Message::user("hello"))],
+        branch_merges: vec![],
+        reviews: vec![],
+        resources: vec![],
+        ui_events: vec![
+            r#"{"kind":"User","frame_id":"f","text":"hello"}"#.into(),
+            // Pre-duration ToolResult (v0 shape).
+            r#"{"kind":"ToolResult","frame_id":"f","name":"python","ok":true,"content":"ok"}"#
+                .into(),
+            // Usage before reasoning/cached/round became required on read.
+            r#"{"kind":"Usage","frame_id":"f","input":10,"output":4,"ctx_tokens":20,"max_context":128000}"#
+                .into(),
+            // Completely unknown later/corrupt kind must not abort the page.
+            r#"{"kind":"FutureKind","frame_id":"f","mystery":true}"#.into(),
+            r#"{"kind":"MessageBoundary","frame_id":"f","seq":1}"#.into(),
+        ],
+        next_before_seq: None,
+        user_offset: 0,
+        latest_seq: 1,
+    };
+
+    let items = transcript_page_items(&page).expect("legacy UI events must not fail load_session");
+    assert!(
+        items
+            .iter()
+            .any(|item| item.role == "user" && item.text == "hello"),
+        "user turn survived a version skip"
+    );
+    assert!(
+        items.iter().any(|item| item.role == "usage"),
+        "old Usage without reasoning/cached must still fold"
+    );
+}
+
+#[test]
 fn branch_merge_projection_never_relabels_the_previous_answer() {
     let page = wisp_store::SessionTranscriptPage {
         messages: vec![

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -19,6 +19,7 @@ fn default_context_window() -> u64 {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelProfile {
     pub id: String,
+    #[serde(default)]
     pub label: String,
     pub provider: String,
     /// Shared credential root. Protocol-specific paths live in
@@ -1636,6 +1637,17 @@ mod tests {
             "use_for_image_generation dropped on deserialize"
         );
         assert_eq!(p.context_window, DEFAULT_CONTEXT_WINDOW);
+    }
+
+    #[test]
+    fn older_profiles_without_label_still_load() {
+        let profiles: Vec<ModelProfile> = serde_json::from_str(
+            r#"[{"id":"m1","provider":"openai","api_url":"https://api.deepseek.com","model":"deepseek-v4-flash"}]"#,
+        )
+        .unwrap();
+        assert_eq!(profiles.len(), 1);
+        assert_eq!(profiles[0].id, "m1");
+        assert!(profiles[0].label.is_empty());
     }
 
     #[test]

--- a/src-tauri/src/session_commands.rs
+++ b/src-tauri/src/session_commands.rs
@@ -990,12 +990,24 @@ pub(super) fn transcript_page_items(
         .iter()
         .map(|(_, message)| message.clone())
         .collect::<Vec<_>>();
+    // Older builds persisted a slimmer AgentEvent shape. A single unknown
+    // field or later-added required key must not blank the whole transcript
+    // (or look like a launch crash when resume-last-session reopens it).
     let events: Vec<AgentEvent> = page
         .ui_events
         .iter()
-        .map(|json| serde_json::from_str(json))
-        .collect::<Result<_, _>>()
-        .map_err(|e| format!("invalid persisted UI event: {e}"))?;
+        .filter_map(|json| match serde_json::from_str(json) {
+            Ok(event) => Some(event),
+            Err(error) => {
+                tracing::warn!(
+                    target: "wisp",
+                    %error,
+                    "skipping unreadable persisted UI event"
+                );
+                None
+            }
+        })
+        .collect();
     let (mut items, boundaries) = if events.is_empty() {
         (messages_to_items(&msgs), HashMap::new())
     } else {
@@ -1151,9 +1163,7 @@ pub(super) async fn load_session(
             .load_latest_session_ui_event(&id, "ToolPresentation")
             .await
             .map_err(|e| format!("{e}"))?
-            .map(|json| serde_json::from_str::<AgentEvent>(&json))
-            .transpose()
-            .map_err(|e| format!("invalid persisted tool presentation: {e}"))?
+            .and_then(|json| serde_json::from_str::<AgentEvent>(&json).ok())
             .and_then(|event| match event {
                 AgentEvent::ToolPresentation {
                     presentation_id,


### PR DESCRIPTION
## User-facing problem

Fixes #912. Jumping from an old Wisp install to the latest build can refuse to open and surface a missing-key / `missing field` error. Resume-last-session then reloads a transcript whose persisted UI events (or SQLite columns) predate later required fields.

## What changed

- **Persisted events:** `AgentEvent` additive fields (`duration_ms`, `reasoning`, `cached`, `round`, `seq`, `strategy`) now default on read. Unreadable UI events are skipped with a warning instead of failing the whole `load_session`.
- **Model profiles:** missing `label` no longer drops every saved profile.
- **Schema:** `ensure_schema_compat()` runs after numbered migrations and idempotently creates `folders` plus columns that later landed in `0000_init.sql` (so a recorded `0000_initial_schema` cannot leave `no such column` behind).

## Tests

- `upgrade_from_recorded_initial_schema_can_list_sessions` — v0 schema with only `0000` recorded still opens, lists sessions, and has `folders`.
- `persisted_ui_events_from_older_builds_keep_the_transcript` — old `ToolResult`/`Usage` plus an unknown `kind` still load.
- `older_profiles_without_label_still_load`
- `cargo test --workspace`
- `cd ui && cargo check --target wasm32-unknown-unknown`

## Manual smoke

1. Keep a data dir from an older release (or copy `%APPDATA%\science.wisp-science` / `~/Library/Application Support/science.wisp-science`).
2. Launch this build.
3. Confirm the window opens, the last conversation reloads, and Settings › Models still lists existing profiles.

## Known limitations / follow-up

- Events with a completely unknown `kind` are dropped from replay (messages remain).
- A database that is actually corrupt still fails `Store::open`; Windows logs stay in `%APPDATA%\science.wisp-science\wisp-science\logs\wisp.log`.