### PR TITLE
fix(llm): fail fast leftover proxy hangs

### DIFF
--- a/crates/wisp-llm/src/lib.rs
+++ b/crates/wisp-llm/src/lib.rs
@@ -21,7 +21,9 @@ pub use message::{
     Completion, Content, FunctionCall, ImageUrl, Message, Part, Role, ToolCall, ToolSchema, Usage,
 };
 pub use provider::{
-    build, is_retriable, NullSink, Provider, ProviderConfig, ProviderKind, StreamSink,
+    ambient_proxy_env, annotate_transport_error, build, is_fail_fast_transport,
+    is_model_transport_failure, is_retriable, leftover_proxy_note, NullSink, Provider,
+    ProviderConfig, ProviderKind, StreamSink,
 };
 pub use provider::{LlmError, Result};
 pub use routed::RoutedProvider;

--- a/crates/wisp-llm/src/provider.rs
+++ b/crates/wisp-llm/src/provider.rs
@@ -99,6 +99,86 @@ impl LlmError {
     }
 }
 
+const PROXY_ENV_KEYS: [&str; 6] = [
+    "HTTPS_PROXY",
+    "https_proxy",
+    "HTTP_PROXY",
+    "http_proxy",
+    "ALL_PROXY",
+    "all_proxy",
+];
+
+/// Process environment proxy vars reqwest follows when Settings proxy is empty.
+pub fn ambient_proxy_env() -> Vec<(String, String)> {
+    PROXY_ENV_KEYS
+        .iter()
+        .filter_map(|key| {
+            std::env::var(key)
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+                .map(|value| ((*key).to_string(), value))
+        })
+        .collect()
+}
+
+/// How the current proxy setting / leftover env should be named in an error.
+pub fn leftover_proxy_note(configured: Option<&str>, env: &[(String, String)]) -> Option<String> {
+    match configured.map(str::trim) {
+        Some("none") => None,
+        Some(url) if !url.is_empty() => Some(format!("via Model API proxy {url}")),
+        _ => env
+            .iter()
+            .find(|(_, value)| !value.trim().is_empty())
+            .map(|(key, value)| format!("via leftover {key}={value}")),
+    }
+}
+
+/// Connect failures (and leftover-proxy refusals) that look like `http: ...`.
+pub fn is_model_transport_failure(message: &str) -> bool {
+    let m = message.to_ascii_lowercase();
+    m.contains("http: ")
+        && (m.contains("connect")
+            || m.contains("timed out")
+            || m.contains("deadline has elapsed")
+            || m.contains("dns")
+            || m.contains("refused")
+            || m.contains("proxy")
+            || m.contains("socks")
+            || m.contains("tunnel")
+            || m.contains("unreachable"))
+}
+
+/// Dead local proxies and connection-refused should fail the turn immediately.
+/// Retrying them is how a leftover `HTTPS_PROXY` becomes minutes of silence.
+pub fn is_fail_fast_transport(message: &str) -> bool {
+    let m = message.to_ascii_lowercase();
+    m.contains("connection refused")
+        || m.contains("actively refused")
+        || m.contains("os error 10061")
+        || m.contains("os error 111")
+        || (m.contains("proxy")
+            && (m.contains("refused") || m.contains("tunnel") || m.contains("unreachable")))
+        || m.contains("via leftover")
+}
+
+/// Append the active / leftover proxy so the UI can point at Settings.
+pub fn annotate_transport_error(
+    message: &str,
+    configured: Option<&str>,
+    env: &[(String, String)],
+) -> String {
+    if !is_model_transport_failure(message) {
+        return message.to_string();
+    }
+    let Some(note) = leftover_proxy_note(configured, env) else {
+        return message.to_string();
+    };
+    if message.contains(&note) {
+        return message.to_string();
+    }
+    format!("{message} ({note})")
+}
+
 /// True for transient provider failures worth retrying (rate limits, overload, 5xx).
 pub fn is_retriable(err: &LlmError) -> bool {
     match err {
@@ -112,7 +192,16 @@ pub fn is_retriable(err: &LlmError) -> bool {
                 || lower.contains("too many requests")
                 || lower.contains("访问量过大")
         }
-        LlmError::Http(e) => e.is_timeout() || e.is_connect() || e.is_request(),
+        LlmError::Http(e) => {
+            // Connect failures include leftover local proxies. On Windows a
+            // closed Clash/V2Ray port is often `deadline has elapsed`, not
+            // ECONNREFUSED — retrying that looks like "sent, no reply".
+            if e.is_connect() || is_fail_fast_transport(&error_chain(e)) {
+                false
+            } else {
+                e.is_timeout() || e.is_request()
+            }
+        }
         _ => false,
     }
 }
@@ -422,5 +511,66 @@ mod tests {
             status: 400,
             body: "invalid request".into(),
         }));
+    }
+
+    #[test]
+    fn leftover_proxy_note_names_env_or_setting() {
+        assert_eq!(leftover_proxy_note(Some("none"), &[]), None);
+        assert_eq!(
+            leftover_proxy_note(Some("http://127.0.0.1:7890"), &[]).as_deref(),
+            Some("via Model API proxy http://127.0.0.1:7890")
+        );
+        let env = vec![("HTTPS_PROXY".into(), "http://127.0.0.1:7890".into())];
+        assert_eq!(
+            leftover_proxy_note(None, &env).as_deref(),
+            Some("via leftover HTTPS_PROXY=http://127.0.0.1:7890")
+        );
+        assert_eq!(leftover_proxy_note(Some("none"), &env), None);
+    }
+
+    #[test]
+    fn connection_refused_fails_fast_and_is_annotated() {
+        let raw =
+            "http: error sending request: tcp connect error: Connection refused (os error 111)";
+        assert!(is_model_transport_failure(raw));
+        assert!(is_fail_fast_transport(raw));
+        let env = vec![("HTTPS_PROXY".into(), "http://127.0.0.1:7890".into())];
+        let annotated = annotate_transport_error(raw, None, &env);
+        assert!(annotated.contains("via leftover HTTPS_PROXY=http://127.0.0.1:7890"));
+        assert_eq!(
+            annotate_transport_error("api: 401 invalid key", None, &env),
+            "api: 401 invalid key"
+        );
+    }
+
+    #[test]
+    fn windows_proxy_refusal_fails_fast() {
+        assert!(is_fail_fast_transport(
+            "http: error sending request: No connection could be made because the target machine actively refused it. (os error 10061)"
+        ));
+        assert!(is_model_transport_failure(
+            "http: error sending request for url (https://api.example.com/v1/chat/completions): client error (Connect): tcp connect error: deadline has elapsed"
+        ));
+    }
+
+    #[tokio::test]
+    async fn live_connection_refused_is_not_retriable() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        drop(listener);
+        let err = reqwest::Client::builder()
+            .no_proxy()
+            .connect_timeout(std::time::Duration::from_secs(2))
+            .build()
+            .expect("client")
+            .get(format!("http://{addr}/"))
+            .send()
+            .await
+            .expect_err("closed port should refuse");
+        let wrapped = LlmError::Http(err);
+        assert!(
+            !is_retriable(&wrapped),
+            "a dead listener must not enter the multi-minute retry window: {wrapped}"
+        );
     }
 }

--- a/src-tauri/src/agent_turn.rs
+++ b/src-tauri/src/agent_turn.rs
@@ -1175,7 +1175,11 @@ pub(crate) async fn send_message_inner(
             Ok(frame_id)
         }
         Err(e) => {
-            let message = format!("{e}");
+            let message = wisp_llm::annotate_transport_error(
+                &format!("{e}"),
+                llm_proxy().as_deref(),
+                &wisp_llm::ambient_proxy_env(),
+            );
             persist_and_emit_terminal_event(
                 state,
                 &app,

--- a/src-tauri/src/settings_commands.rs
+++ b/src-tauri/src/settings_commands.rs
@@ -21,11 +21,16 @@ pub(super) struct TokenUsageOverview {
     tools: Vec<wisp_store::ToolCallUsage>,
 }
 
+fn annotate_provider_error(error: impl ToString, proxy: Option<&str>) -> String {
+    wisp_llm::annotate_transport_error(&error.to_string(), proxy, &wisp_llm::ambient_proxy_env())
+}
+
 async fn validate_provider_config(
     provider_name: &str,
     mut cfg: wisp_llm::ProviderConfig,
     supports_vision: bool,
 ) -> Result<(), String> {
+    let proxy = cfg.proxy.clone();
     if models::is_image_generation_model(&cfg.model) {
         if !models::supports_image_generation(provider_name, &cfg.model) {
             return Err(models::IMAGE_GENERATION_UNSUPPORTED.into());
@@ -37,7 +42,8 @@ async fn validate_provider_config(
             cfg.proxy,
         )
         .validate_model_access()
-        .await;
+        .await
+        .map_err(|error| annotate_provider_error(error, proxy.as_deref()));
     }
 
     // Keep the ping cheap but respect API minimum (Responses API needs >= 16).
@@ -54,7 +60,7 @@ async fn validate_provider_config(
         .complete(&[probe], &[])
         .await
         .map(|_| ())
-        .map_err(|error| error.to_string())
+        .map_err(|error| annotate_provider_error(error, proxy.as_deref()))
 }
 
 #[tauri::command]
@@ -639,7 +645,7 @@ pub(super) async fn validate_settings(
         }
     };
     let api_key = effective_api_key(key, stored_key);
-    let cfg = build_provider_config(
+    let mut cfg = build_provider_config(
         &settings.provider,
         &settings.api_url,
         &api_key,
@@ -647,6 +653,10 @@ pub(super) async fn validate_settings(
         settings.max_tokens,
         &settings.reasoning_effort,
     )?;
+    let form_proxy = settings.proxy_url.trim();
+    if !form_proxy.is_empty() {
+        cfg.proxy = Some(form_proxy.to_string());
+    }
 
     tracing::info!(
         target: "wisp",

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -10818,6 +10818,25 @@ test("context-limit recovery can continue in a new session with the old one atta
   });
 });
 
+test("a leftover proxy connect error points at Model API proxy", async ({ page }) => {
+  await enterApp(page);
+  await composer(page).fill("hello");
+  await page.getByRole("button", { name: "Send" }).click();
+  await expect(page.getByText("Hello from mock wisp-science.")).toBeVisible();
+  const frameId = String((await lastInvokeArgs(page, "send_message")).sessionId);
+
+  await emitTauriEvent(page, "agent", {
+    kind: "Error",
+    frame_id: frameId,
+    message: "http: error sending request: tcp connect error: Connection refused (os error 111) (via leftover HTTPS_PROXY=http://127.0.0.1:7890)",
+  });
+
+  const card = page.locator(".finding.err");
+  await expect(card).toBeVisible();
+  await expect(card.locator(".finding-body")).toContainText("Model API proxy");
+  await expect(card.locator(".finding-body")).toContainText("none");
+});
+
 test("pet stays off until the user explicitly configures its directory", async ({ page }) => {
   await page.goto("/");
   await openSettingsSection(page, "Pet");

--- a/ui/src/i18n.rs
+++ b/ui/src/i18n.rs
@@ -1657,7 +1657,7 @@ fn lookup(locale: Locale, key: &str) -> Option<&'static str> {
         (Locale::En, "settings.resume_last_session") => Some("Resume the last conversation when opening a workspace"),
         (Locale::En, "settings.resume_last_session_hint") => Some("Enabled by default. Reopen the last conversation that has a user message, not a named unused draft or a blank session."),
         (Locale::En, "settings.proxy_url") => Some("Model API proxy"),
-        (Locale::En, "settings.proxy_url_hint") => Some("Empty follows the system proxy. Enter `none` to force a direct connection, or a proxy URL like http://127.0.0.1:7890 or socks5://127.0.0.1:1080. Applies to model API requests after saving."),
+        (Locale::En, "settings.proxy_url_hint") => Some("Empty follows the system proxy, including leftover HTTP_PROXY/HTTPS_PROXY. Enter `none` to force a direct connection, or a proxy URL like http://127.0.0.1:7890 or socks5://127.0.0.1:1080. Applies to model API requests after saving."),
         (Locale::En, "settings.send_shortcut") => Some("Send and newline shortcuts"),
         (Locale::En, "settings.send_shortcut.enter") => Some("Enter sends · Shift+Enter inserts a newline"),
         (Locale::En, "settings.send_shortcut.modifier_enter") => Some("{modifier}+Enter sends · Enter inserts a newline"),
@@ -1901,7 +1901,7 @@ fn lookup(locale: Locale, key: &str) -> Option<&'static str> {
         (Locale::En, "err.hint.model_name") => Some("The provider does not recognize the configured model name. Check the model name in Settings → Models."),
         (Locale::En, "err.hint.rate") => Some("Rate limited by the provider. Wait a moment and retry."),
         (Locale::En, "err.hint.server") => Some("The provider is temporarily overloaded or down. Retry in a bit."),
-        (Locale::En, "err.hint.network") => Some("Could not reach the API server. Check your network, API URL, and proxy settings."),
+        (Locale::En, "err.hint.network") => Some("Could not reach the model API. A leftover system proxy (HTTP_PROXY/HTTPS_PROXY) often intercepts requests after the proxy app has been closed. Open Settings → Model API proxy and set it to `none` to connect directly, or enter a proxy that is still running."),
         (Locale::En, "err.hint.bad_request") => Some("The provider rejected the request. Common causes: the conversation is too long, or a message contains content this model does not support (e.g. images). Try /compact or another model."),
         (Locale::En, "err.hint.tool_pairing") => Some("A tool call is missing its result in the conversation history (often after an interrupted or timed-out tool). Click Resume again after updating, or send /compact to repair the history."),
         (Locale::En, "outline.title") => Some("Conversation outline"),
@@ -3989,7 +3989,7 @@ Do not leave generated files in the project root.",
         (Locale::Zh, "settings.resume_last_session") => Some("打开工作区时继续上次对话"),
         (Locale::Zh, "settings.resume_last_session_hint") => Some("默认开启。打开工作区时恢复最近有过对话的会话，不会进入仅改了名、还没发过消息的草稿。"),
         (Locale::Zh, "settings.proxy_url") => Some("模型 API 代理"),
-        (Locale::Zh, "settings.proxy_url_hint") => Some("留空＝跟随系统代理；填 none＝强制直连（忽略系统代理）；或填代理地址，如 http://127.0.0.1:7890 或 socks5://127.0.0.1:1080。保存后对模型 API 请求生效。"),
+        (Locale::Zh, "settings.proxy_url_hint") => Some("留空＝跟随系统代理，也包括残留的 HTTP_PROXY/HTTPS_PROXY。填 none＝强制直连；或填代理地址，如 http://127.0.0.1:7890 或 socks5://127.0.0.1:1080。保存后对模型 API 请求生效。"),
         (Locale::Zh, "settings.send_shortcut") => Some("发送与换行快捷键"),
         (Locale::Zh, "settings.send_shortcut.enter") => Some("Enter 发送 · Shift+Enter 换行"),
         (Locale::Zh, "settings.send_shortcut.modifier_enter") => Some("{modifier}+Enter 发送 · Enter 换行"),
@@ -4230,7 +4230,7 @@ Do not leave generated files in the project root.",
         (Locale::Zh, "err.hint.model_name") => Some("服务商不识别所配置的模型名。请在 设置 → 模型 中核对模型名。"),
         (Locale::Zh, "err.hint.rate") => Some("请求过于频繁，被服务商限流。稍等片刻再重试。"),
         (Locale::Zh, "err.hint.server") => Some("服务商暂时过载或故障。请稍后重试。"),
-        (Locale::Zh, "err.hint.network") => Some("无法连接到 API 服务器。请检查网络、API 地址和代理设置。"),
+        (Locale::Zh, "err.hint.network") => Some("无法连接到模型 API。常见原因是本机代理软件已关闭，但系统仍残留 HTTP_PROXY/HTTPS_PROXY。请打开 设置 → 模型 API 代理：填 `none` 强制直连，或填入仍在运行的代理地址。"),
         (Locale::Zh, "err.hint.bad_request") => Some("请求被服务商拒绝。常见原因：对话过长，或消息包含该模型不支持的内容（如图片）。可尝试 /compact 或更换模型。"),
         (Locale::Zh, "err.hint.tool_pairing") => Some("对话历史里有一条工具调用缺少对应结果（常见于工具中断或超时后）。更新后请再点「继续执行」，或发送 /compact 修复历史。"),
         (Locale::Zh, "outline.title") => Some("对话目录"),
@@ -5102,7 +5102,16 @@ fn api_error_hint_key(msg: &str) -> Option<&'static str> {
     } else if m.contains("api: 5") || m.contains("overloaded") {
         "err.hint.server"
     } else if m.contains("http: ")
-        && (m.contains("connect") || m.contains("timed out") || m.contains("dns"))
+        && (m.contains("connect")
+            || m.contains("timed out")
+            || m.contains("deadline has elapsed")
+            || m.contains("dns")
+            || m.contains("refused")
+            || m.contains("via leftover")
+            || m.contains("via model api proxy")
+            || m.contains("socks")
+            || m.contains("tunnel")
+            || m.contains("unreachable"))
     {
         "err.hint.network"
     } else if m.contains("no tool output found for tool call")
@@ -5170,6 +5179,14 @@ mod api_error_hint_tests {
                 "http: error sending request: tcp connect error",
                 "err.hint.network",
             ),
+            (
+                "http: error sending request: Connection refused (os error 111) (via leftover HTTPS_PROXY=http://127.0.0.1:7890)",
+                "err.hint.network",
+            ),
+            (
+                "http: error sending request for url (https://api.example.com/v1/chat/completions): client error (Connect): tcp connect error: deadline has elapsed",
+                "err.hint.network",
+            ),
         ];
         for (msg, key) in cases {
             assert_eq!(hint_key(msg), Some(t(Locale::En, key)), "for: {msg}");
@@ -5215,6 +5232,20 @@ mod api_error_hint_tests {
         let out = localize_backend(Locale::Zh, msg);
         assert!(out.starts_with(msg), "raw error must stay visible");
         assert!(out.contains(&t(Locale::Zh, "err.hint.balance")));
+    }
+
+    #[test]
+    fn leftover_proxy_connect_points_at_model_api_proxy() {
+        let msg = "http: error sending request: tcp connect error: Connection refused (os error 111) (via leftover HTTPS_PROXY=http://127.0.0.1:7890)";
+        assert_eq!(
+            hint_key(msg),
+            Some(t(Locale::En, "err.hint.network"))
+        );
+        let zh = localize_backend(Locale::Zh, msg);
+        assert!(zh.contains("模型 API 代理"), "{zh}");
+        assert!(zh.contains("none"), "{zh}");
+        let en = localize_backend(Locale::En, msg);
+        assert!(en.contains("Model API proxy"), "{en}");
     }
 
     #[test]


### PR DESCRIPTION
## User-facing problem

Sending a message can look like it did nothing: the user bubble stays, Stop / Queue stay on, and no reply or error appears. A leftover `HTTP_PROXY` / `HTTPS_PROXY` (Clash, V2Ray, etc. already closed) is enough. That is not a Wisp bug, but the old retry loop treated a dead connect as transient and could wait about seven minutes (6 × 30s connect timeout plus 2+10+30+60+120s backoff). The generic network hint also never named **Settings → Model API proxy**.

## What changed

- **Fail fast:** connect failures (`is_connect()`, connection refused, Windows `deadline has elapsed`) no longer enter the multi-minute retry window. 429 / 5xx still retry.
- **Name the leftover proxy** on the error (`via leftover HTTPS_PROXY=…` or the configured Model API proxy URL).
- **Hint copy** points at Settings → Model API proxy and `none` for a direct connection.
- Settings validation uses the same annotation; a non-empty form `proxy_url` is honored when testing.

## Tests

- `leftover_proxy_note_names_env_or_setting`
- `connection_refused_fails_fast_and_is_annotated`
- `windows_proxy_refusal_fails_fast`
- `live_connection_refused_is_not_retriable` (bind-and-drop local port; no real API)
- i18n: leftover / deadline errors classify as `err.hint.network` and mention Model API proxy
- Playwright: `a leftover proxy connect error points at Model API proxy`

```bash
cargo test -p wisp-llm leftover_proxy
cargo test -p wisp-llm connection_refused
cargo test -p wisp-llm windows_proxy
cargo test -p wisp-llm live_connection_refused
cd ui-tests && npx playwright test tests/ui.spec.ts -g "leftover proxy connect error points at Model API proxy"
```

## Manual smoke

1. With a stale `HTTPS_PROXY=http://127.0.0.1:7890` and the proxy app closed, send `你好`.
2. After at most one connect timeout (~30s), an error card should appear naming the leftover proxy and **Settings → Model API proxy**.
3. Set Model API proxy to `none`, save, send again — the turn should reach the provider.

## Known limitations / follow-up

- Startup provider probes were deliberately not added (false slow/offline alarms; wrong moment).
- Mid-stream read timeouts still retry.
- Clearing the OS/user env vars is still the durable machine fix; Wisp only offers `none` to ignore them.