### PR TITLE
fix(browser): 修复联网检索成功后仍弹出「未联网检索」提示

### DIFF
--- a/docs/real-browser-automation.md
+++ b/docs/real-browser-automation.md
@@ -37,6 +37,14 @@ instead of answering from memory. After Chrome is open and the popup shows
 **Connected to Wisp**, use **Retry after connecting** to run the same
 request again.
 
+The banner describes the answer on screen, not the session. It is derived from
+the browser tool results of the latest turn only, and a single successful
+`web_scan`, `web_open_tab`, `web_execute_js`, or `web_screenshot` clears it: the
+extension's service worker sleeps and reconnects on a one-minute alarm, so a
+turn can mix refused attempts with successful ones and still be a live answer.
+A connected extension also counts as connected even when a build cannot verify
+its own bundled `browser-extension/` copy.
+
 The unpacked extension remains installed in that browser profile across Wisp
 and browser restarts. After updating Wisp, click **Reload** on the extension
 card in `chrome://extensions` so the service worker picks up `wait_tab.js`.

--- a/skills/browser-use/SKILL.md
+++ b/skills/browser-use/SKILL.md
@@ -25,6 +25,12 @@ this turn contains no live web retrieval and wait until the popup shows
 *Connected to Wisp*. Only continue from memory if they explicitly ask
 for a knowledge-only answer. Never invent the path.
 
+One exception: the user says the extension is already installed. Chrome
+suspends its service worker when idle and reconnects on a one-minute
+alarm, so `disconnected` can just be a sleeping worker. Try `web_open_tab`
+or `web_scan` once — a successful call proves the bridge is live — and
+relay the install steps only if that call fails too.
+
 ## The loop
 
 1. **`web_open_tab`** `{url}` — open the page (works even with no tab

--- a/src-tauri/src/browser_bridge.rs
+++ b/src-tauri/src/browser_bridge.rs
@@ -28,14 +28,12 @@ use tokio_tungstenite::{accept_hdr_async, WebSocketStream};
 use uuid::Uuid;
 use wisp_llm::ToolSchema;
 use wisp_store::Store;
-use wisp_tools::{Approval, ImageData, Tool, ToolEnv, ToolEvent, ToolResult};
+use wisp_tools::{Approval, ImageData, Tool, ToolEnv, ToolResult};
 
 use crate::browser_url_filters::{self, BrowserUrlFilters};
 
 const BRIDGE_ADDR: &str = "127.0.0.1:18765";
 const EXTENSION_ORIGIN: &str = "chrome-extension://gnkjgagleagkgdlkkcianolobfdoocnp";
-const BROWSER_DISCONNECTED_KIND: &str = "browser_disconnected";
-const BROWSER_CONNECTED_KIND: &str = "browser_connected";
 const BROWSER_DISCONNECTED_CODE: &str = "browser_extension_disconnected";
 const BROWSER_DISCONNECTED_MARKER: &str = "WISP_BROWSER_DISCONNECTED";
 const DISCONNECTED_ASSISTANT_INSTRUCTION: &str = "Live web retrieval is unavailable. Do not answer live, latest, current, or URL-specific questions from prior knowledge. Tell the user this turn contains no live web retrieval, relay the install steps, and wait until status is connected. Only continue from memory if they explicitly ask for a knowledge-only answer.";
@@ -121,12 +119,17 @@ impl BrowserBridge {
         let state = self.state.lock().await;
         let extension_path = self.verified_extension_path();
         let extension_ready = extension_path.is_some();
-        let status = if state.startup_error.is_some() {
+        // A live extension connection is the only proof that live retrieval
+        // works. It outranks an unverifiable bundled copy: a user who loaded the
+        // extension from another folder still browses fine, and reporting
+        // extension_missing there told the model and the UI "no live retrieval"
+        // on every turn (#921).
+        let status = if state.client.is_some() {
+            "connected"
+        } else if state.startup_error.is_some() {
             "error"
         } else if !extension_ready {
             "extension_missing"
-        } else if state.client.is_some() {
-            "connected"
         } else {
             "disconnected"
         };
@@ -426,38 +429,6 @@ impl BrowserBridge {
     }
 }
 
-fn is_bridge_unavailable(error: &str) -> bool {
-    error.contains(BROWSER_DISCONNECTED_MARKER) || error.contains("real-browser bridge unavailable")
-}
-
-async fn emit_disconnected(env: &dyn ToolEnv) {
-    env.emit(ToolEvent::Presentation {
-        kind: BROWSER_DISCONNECTED_KIND.into(),
-        payload: json!({
-            "code": BROWSER_DISCONNECTED_CODE,
-            "live_retrieval": false,
-        }),
-    })
-    .await;
-}
-
-async fn emit_live_retrieval(env: &dyn ToolEnv) {
-    env.emit(ToolEvent::Presentation {
-        kind: BROWSER_CONNECTED_KIND.into(),
-        payload: json!({
-            "live_retrieval": true,
-        }),
-    })
-    .await;
-}
-
-async fn fail_bridge(env: &dyn ToolEnv, error: String) -> ToolResult {
-    if is_bridge_unavailable(&error) {
-        emit_disconnected(env).await;
-    }
-    ToolResult::fail(error)
-}
-
 fn allowed_extension_origin(origin: Option<&str>) -> bool {
     origin == Some(EXTENSION_ORIGIN)
 }
@@ -721,7 +692,7 @@ impl Tool for BrowserSetupTool {
         "show real-browser setup status and extension path".into()
     }
 
-    async fn run(&self, _args: &Value, env: &dyn ToolEnv) -> ToolResult {
+    async fn run(&self, _args: &Value, _env: &dyn ToolEnv) -> ToolResult {
         let mut info = self.bridge.setup_info().await;
         let filters = browser_url_filters::load(&self.store).await;
         info["url_filters"] = json!({
@@ -729,11 +700,6 @@ impl Tool for BrowserSetupTool {
             "prefer": filters.prefer,
             "matching": "host and subdomains; block is enforced; prefer is advisory for literature and similar tasks"
         });
-        if info["status"] != "connected" {
-            emit_disconnected(env).await;
-        } else {
-            emit_live_retrieval(env).await;
-        }
         ToolResult::ok(render_json(&info))
     }
 }
@@ -787,18 +753,15 @@ impl Tool for WebScanTool {
         }
     }
 
-    async fn run(&self, args: &Value, env: &dyn ToolEnv) -> ToolResult {
+    async fn run(&self, args: &Value, _env: &dyn ToolEnv) -> ToolResult {
         if args
             .get("tabs_only")
             .and_then(Value::as_bool)
             .unwrap_or(false)
         {
             return match self.bridge.tabs().await {
-                Ok(tabs) => {
-                    emit_live_retrieval(env).await;
-                    ToolResult::ok(render_json(&json!({ "tabs": tabs })))
-                }
-                Err(error) => fail_bridge(env, error).await,
+                Ok(tabs) => ToolResult::ok(render_json(&json!({ "tabs": tabs }))),
+                Err(error) => ToolResult::fail(error),
             };
         }
         let tab_id = match tab_id_arg(args) {
@@ -823,7 +786,6 @@ impl Tool for WebScanTool {
             .await
         {
             Ok(execution) => {
-                emit_live_retrieval(env).await;
                 let handoff = human_verification_handoff(&execution.value);
                 ToolResult::ok(render_json(&merge_ready_wait(
                     json!({
@@ -835,7 +797,7 @@ impl Tool for WebScanTool {
                     execution.wait,
                 )))
             }
-            Err(error) => fail_bridge(env, error).await,
+            Err(error) => ToolResult::fail(error),
         }
     }
 }
@@ -886,7 +848,7 @@ impl Tool for WebExecuteJsTool {
         preview
     }
 
-    async fn run(&self, args: &Value, env: &dyn ToolEnv) -> ToolResult {
+    async fn run(&self, args: &Value, _env: &dyn ToolEnv) -> ToolResult {
         let Some(script) = args
             .get("script")
             .and_then(Value::as_str)
@@ -924,18 +886,15 @@ impl Tool for WebExecuteJsTool {
             .execute(tab_id, script, Duration::from_millis(timeout_ms))
             .await
         {
-            Ok(execution) => {
-                emit_live_retrieval(env).await;
-                ToolResult::ok(render_json(&merge_ready_wait(
-                    json!({
-                        "tab_id": execution.tab_id,
-                        "result": execution.value
-                    }),
-                    execution.ready,
-                    execution.wait,
-                )))
-            }
-            Err(error) => fail_bridge(env, error).await,
+            Ok(execution) => ToolResult::ok(render_json(&merge_ready_wait(
+                json!({
+                    "tab_id": execution.tab_id,
+                    "result": execution.value
+                }),
+                execution.ready,
+                execution.wait,
+            ))),
+            Err(error) => ToolResult::fail(error),
         }
     }
 }
@@ -981,7 +940,7 @@ impl Tool for WebOpenTabTool {
         format!("open real-browser tab at {url}")
     }
 
-    async fn run(&self, args: &Value, env: &dyn ToolEnv) -> ToolResult {
+    async fn run(&self, args: &Value, _env: &dyn ToolEnv) -> ToolResult {
         let Some(url) = args
             .get("url")
             .and_then(Value::as_str)
@@ -999,11 +958,8 @@ impl Tool for WebOpenTabTool {
         }
         let active = args.get("active").and_then(Value::as_bool).unwrap_or(false);
         match self.bridge.open_tab(url, active).await {
-            Ok(reply) => {
-                emit_live_retrieval(env).await;
-                ToolResult::ok(render_json(&open_tab_result(reply, url, &filters)))
-            }
-            Err(error) => fail_bridge(env, error).await,
+            Ok(reply) => ToolResult::ok(render_json(&open_tab_result(reply, url, &filters))),
+            Err(error) => ToolResult::fail(error),
         }
     }
 }
@@ -1048,7 +1004,7 @@ impl Tool for WebScreenshotTool {
             .unwrap_or_else(|| "screenshot selected real-browser tab".into())
     }
 
-    async fn run(&self, args: &Value, env: &dyn ToolEnv) -> ToolResult {
+    async fn run(&self, args: &Value, _env: &dyn ToolEnv) -> ToolResult {
         let tab_id = match tab_id_arg(args) {
             Ok(tab_id) => tab_id,
             Err(error) => return ToolResult::fail(error),
@@ -1068,7 +1024,7 @@ impl Tool for WebScreenshotTool {
             .await
         {
             Ok(execution) => execution,
-            Err(error) => return fail_bridge(env, error).await,
+            Err(error) => return ToolResult::fail(error),
         };
         let Some(data) = execution
             .value
@@ -1084,7 +1040,6 @@ impl Tool for WebScreenshotTool {
                 data.len()
             ));
         }
-        emit_live_retrieval(env).await;
         ToolResult::image(ImageData {
             mime: "image/jpeg".into(),
             data_url: format!("data:image/jpeg;base64,{data}"),
@@ -1590,19 +1545,26 @@ mod tests {
         assert!(rendered.ends_with("browser result truncated"));
     }
 
-    #[test]
-    fn unavailable_errors_are_marked_for_the_ui() {
-        assert!(is_bridge_unavailable(
-            "real-browser bridge unavailable: browser extension is not connected. WISP_BROWSER_DISCONNECTED. stop"
-        ));
-        assert!(!is_bridge_unavailable(
-            "blocked by user URL filter: blocked.test"
-        ));
+    #[tokio::test]
+    async fn only_bridge_unavailability_carries_the_disconnect_marker() {
+        let bridge = Arc::new(BrowserBridge::new(PathBuf::from("extension")));
+        assert!(bridge
+            .unavailable_message("browser extension is not connected")
+            .contains(BROWSER_DISCONNECTED_MARKER));
+        // A tab-level failure is not a disconnect and must not raise the
+        // "no live retrieval" banner.
+        let (tx, _rx) = mpsc::unbounded_channel();
+        bridge.install_client(1, tx).await;
+        let result = WebScanTool::new(bridge)
+            .run(&json!({ "switch_tab_id": 9 }), &NoEnv(PathBuf::from(".")))
+            .await;
+        assert!(!result.success);
+        assert!(!result.content.contains(BROWSER_DISCONNECTED_MARKER));
     }
 
     struct RecordingEnv {
         root: PathBuf,
-        events: std::sync::Mutex<Vec<ToolEvent>>,
+        events: std::sync::Mutex<Vec<wisp_tools::ToolEvent>>,
     }
 
     #[async_trait]
@@ -1615,13 +1577,16 @@ mod tests {
             true
         }
 
-        async fn emit(&self, event: ToolEvent) {
+        async fn emit(&self, event: wisp_tools::ToolEvent) {
             self.events.lock().unwrap().push(event);
         }
     }
 
+    /// The tool result itself is the live-retrieval record the UI reads. A
+    /// separate presentation event outlived the turn it described and revived a
+    /// stale "no live retrieval" banner (#887, #921), so browser tools emit none.
     #[tokio::test]
-    async fn disconnected_tools_emit_a_browser_disconnected_presentation() {
+    async fn disconnected_tools_mark_the_result_without_a_presentation() {
         let bridge = Arc::new(BrowserBridge::new(PathBuf::from("extension")));
         let env = RecordingEnv {
             root: PathBuf::from("."),
@@ -1632,40 +1597,23 @@ mod tests {
             .await;
         assert!(!result.success);
         assert!(result.content.contains(BROWSER_DISCONNECTED_MARKER));
-        let events = env.events.lock().unwrap();
-        match events.as_slice() {
-            [ToolEvent::Presentation { kind, payload }] => {
-                assert_eq!(kind, BROWSER_DISCONNECTED_KIND);
-                assert_eq!(payload["code"], BROWSER_DISCONNECTED_CODE);
-                assert_eq!(payload["live_retrieval"], false);
-            }
-            other => panic!("expected one disconnected presentation, got {other:?}"),
-        }
+        assert!(env.events.lock().unwrap().is_empty());
     }
 
     #[tokio::test]
-    async fn live_retrieval_presentation_replaces_a_prior_disconnect() {
-        let env = RecordingEnv {
-            root: PathBuf::from("."),
-            events: std::sync::Mutex::new(Vec::new()),
-        };
-        emit_disconnected(&env).await;
-        emit_live_retrieval(&env).await;
-        let events = env.events.lock().unwrap();
-        match events.as_slice() {
-            [ToolEvent::Presentation {
-                kind: first,
-                payload: first_payload,
-            }, ToolEvent::Presentation {
-                kind: second,
-                payload: second_payload,
-            }] => {
-                assert_eq!(first, BROWSER_DISCONNECTED_KIND);
-                assert_eq!(first_payload["live_retrieval"], false);
-                assert_eq!(second, BROWSER_CONNECTED_KIND);
-                assert_eq!(second_payload["live_retrieval"], true);
-            }
-            other => panic!("expected disconnect then connect presentations, got {other:?}"),
-        }
+    async fn a_connected_extension_outranks_an_unverifiable_bundled_copy() {
+        let missing = std::env::temp_dir().join(format!(
+            "wisp-browser-extension-connected-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let bridge = Arc::new(BrowserBridge::new(missing));
+        let (tx, _rx) = mpsc::unbounded_channel();
+        bridge.install_client(1, tx).await;
+        let info = bridge.setup_info().await;
+
+        assert_eq!(info["status"], "connected");
+        assert_eq!(info["live_retrieval"], true);
+        assert!(info["code"].is_null());
+        assert_eq!(info["extension_path_verified"], false);
     }
 }

--- a/ui-tests/tests/browser-offline.spec.ts
+++ b/ui-tests/tests/browser-offline.spec.ts
@@ -43,16 +43,35 @@ async function startLiveRetrievalTurn(page: Page) {
   return sessionId;
 }
 
+const disconnectedScan = (sessionId: string) => ({
+  kind: "ToolResult",
+  frame_id: sessionId,
+  name: "web_scan",
+  ok: false,
+  content: "real-browser bridge unavailable: browser extension is not connected. WISP_BROWSER_DISCONNECTED",
+});
+
+const disconnectedSetup = (sessionId: string) => ({
+  kind: "ToolResult",
+  frame_id: sessionId,
+  name: "browser_setup",
+  ok: true,
+  content: JSON.stringify({ status: "disconnected", live_retrieval: false }),
+});
+
+const successfulScan = (sessionId: string) => ({
+  kind: "ToolResult",
+  frame_id: sessionId,
+  name: "web_scan",
+  ok: true,
+  content: JSON.stringify({ tabs: [{ title: "PubMed CLEC12A" }] }),
+});
+
 test("disconnected browser retrieval shows a banner that Escape dismisses without moving focus", async ({ page }) => {
   await enterApp(page);
   const sessionId = await startLiveRetrievalTurn(page);
 
-  await emitTauriEvent(page, "agent", {
-    kind: "ToolPresentation",
-    frame_id: sessionId,
-    presentation_kind: "browser_disconnected",
-    payload: { code: "browser_extension_disconnected", live_retrieval: false },
-  });
+  await emitTauriEvent(page, "agent", disconnectedSetup(sessionId));
 
   const banner = page.getByTestId("browser-offline-banner");
   await expect(banner).toBeVisible();
@@ -68,13 +87,7 @@ test("browser offline banner stays under Settings in the Escape stack and can re
   await enterApp(page);
   const sessionId = await startLiveRetrievalTurn(page);
 
-  await emitTauriEvent(page, "agent", {
-    kind: "ToolResult",
-    frame_id: sessionId,
-    name: "web_scan",
-    ok: false,
-    content: "real-browser bridge unavailable: browser extension is not connected. WISP_BROWSER_DISCONNECTED",
-  });
+  await emitTauriEvent(page, "agent", disconnectedScan(sessionId));
 
   const banner = page.getByTestId("browser-offline-banner");
   await expect(banner).toBeVisible();
@@ -96,12 +109,7 @@ test("a later connected browser_setup clears the offline banner", async ({ page 
   await enterApp(page);
   const sessionId = await startLiveRetrievalTurn(page);
 
-  await emitTauriEvent(page, "agent", {
-    kind: "ToolPresentation",
-    frame_id: sessionId,
-    presentation_kind: "browser_disconnected",
-    payload: { code: "browser_extension_disconnected", live_retrieval: false },
-  });
+  await emitTauriEvent(page, "agent", disconnectedSetup(sessionId));
   const banner = page.getByTestId("browser-offline-banner");
   await expect(banner).toBeVisible();
 
@@ -119,27 +127,10 @@ test("successful live retrieval survives a stream disconnect error", async ({ pa
   await enterApp(page);
   const sessionId = await startLiveRetrievalTurn(page);
 
-  await emitTauriEvent(page, "agent", {
-    kind: "ToolPresentation",
-    frame_id: sessionId,
-    presentation_kind: "browser_disconnected",
-    payload: { code: "browser_extension_disconnected", live_retrieval: false },
-  });
+  await emitTauriEvent(page, "agent", disconnectedSetup(sessionId));
   await expect(page.getByTestId("browser-offline-banner")).toBeVisible();
 
-  await emitTauriEvent(page, "agent", {
-    kind: "ToolResult",
-    frame_id: sessionId,
-    name: "web_scan",
-    ok: true,
-    content: JSON.stringify({ tabs: [{ title: "PubMed CLEC12A" }] }),
-  });
-  await emitTauriEvent(page, "agent", {
-    kind: "ToolPresentation",
-    frame_id: sessionId,
-    presentation_kind: "browser_connected",
-    payload: { live_retrieval: true },
-  });
+  await emitTauriEvent(page, "agent", successfulScan(sessionId));
   await expect(page.getByTestId("browser-offline-banner")).toHaveCount(0);
 
   await emitTauriEvent(page, "agent", {
@@ -148,6 +139,30 @@ test("successful live retrieval survives a stream disconnect error", async ({ pa
     message: "api: 200 stream error: stream disconnected before completion: stream closed before response.completed",
   });
   await expect(page.getByText(/stream disconnected before completion/)).toBeVisible();
+  await expect(page.getByTestId("browser-offline-banner")).toHaveCount(0);
+});
+
+test("a reconnecting extension after a successful scan keeps the turn marked live", async ({ page }) => {
+  await enterApp(page);
+  const sessionId = await startLiveRetrievalTurn(page);
+
+  await emitTauriEvent(page, "agent", successfulScan(sessionId));
+  await emitTauriEvent(page, "agent", disconnectedScan(sessionId));
+  await expect(page.getByTestId("browser-offline-banner")).toHaveCount(0);
+});
+
+test("the offline banner does not carry over to the next turn", async ({ page }) => {
+  await enterApp(page);
+  const sessionId = await startLiveRetrievalTurn(page);
+
+  await emitTauriEvent(page, "agent", disconnectedSetup(sessionId));
+  await expect(page.getByTestId("browser-offline-banner")).toBeVisible();
+
+  await emitTauriEvent(page, "agent", {
+    kind: "User",
+    frame_id: sessionId,
+    text: "read this page for me",
+  });
   await expect(page.getByTestId("browser-offline-banner")).toHaveCount(0);
 });
 

--- a/ui/src/app_support/transcript.rs
+++ b/ui/src/app_support/transcript.rs
@@ -137,8 +137,8 @@ pub(crate) fn review_message_ui_index(items: &[ChatItem], message_index: usize) 
 #[cfg(test)]
 mod review_jump_tests {
     use super::{
-        browser_offline_notice_from_items, composer_text_from_user_message,
-        last_user_composer_text, review_message_ui_index,
+        browser_offline_notice_from_items, browser_setup_live_retrieval,
+        composer_text_from_user_message, last_user_composer_text, review_message_ui_index,
     };
     use crate::dto::{ChatItem, ContextUsage, ReviewTransitionPhase};
 
@@ -262,14 +262,7 @@ mod review_jump_tests {
         let items = vec![
             ChatItem::User("CLEC12A pubmed".into()),
             setup_item(false),
-            ChatItem::Tool {
-                name: "web_scan".into(),
-                ok: Some(true),
-                input: "tabs".into(),
-                output: "{\"tabs\":[{\"title\":\"PubMed\"}]}".into(),
-                started_at_ms: None,
-                duration_ms: None,
-            },
+            scan_item(true),
             ChatItem::Tool {
                 name: "web_execute_js".into(),
                 ok: Some(true),
@@ -289,16 +282,94 @@ mod review_jump_tests {
             "a later successful scan must not keep the offline banner (#887)"
         );
     }
+
+    fn scan_item(ok: bool) -> ChatItem {
+        ChatItem::Tool {
+            name: "web_scan".into(),
+            ok: Some(ok),
+            input: "tabs".into(),
+            output: if ok {
+                "{\"tabs\":[{\"title\":\"PubMed\"}]}".into()
+            } else {
+                "real-browser bridge unavailable. WISP_BROWSER_DISCONNECTED".to_string()
+            },
+            started_at_ms: None,
+            duration_ms: None,
+        }
+    }
+
+    #[test]
+    fn a_reconnecting_extension_after_a_successful_scan_keeps_the_turn_live() {
+        let items = vec![
+            ChatItem::User("latest rustc".into()),
+            setup_item(false),
+            scan_item(true),
+            scan_item(false),
+        ];
+        assert!(
+            browser_offline_notice_from_items("s1", &items).is_none(),
+            "one successful retrieval means the answer has live results (#921)"
+        );
+    }
+
+    #[test]
+    fn the_notice_describes_the_latest_turn_only() {
+        let mut items = vec![
+            ChatItem::User("latest rustc".into()),
+            scan_item(false),
+            ChatItem::Assistant {
+                text: "Connect the extension first.".into(),
+                model: None,
+                resources: Vec::new(),
+            },
+        ];
+        assert!(browser_offline_notice_from_items("s1", &items).is_some());
+
+        items.push(ChatItem::User("read this page".into()));
+        assert!(
+            browser_offline_notice_from_items("s1", &items).is_none(),
+            "a new turn starts without an offline verdict"
+        );
+    }
+
+    #[test]
+    fn a_truncated_setup_dump_still_reports_live_retrieval() {
+        let truncated = format!(
+            "{{\n  \"status\": \"disconnected\",\n  \"live_retrieval\": false,\n  \"steps\": [\"{}",
+            "x".repeat(64)
+        );
+        assert_eq!(browser_setup_live_retrieval(&truncated), Some(false));
+        assert_eq!(
+            browser_setup_live_retrieval("{\"status\":\"connected\"}"),
+            Some(true)
+        );
+        assert_eq!(browser_setup_live_retrieval("not json"), None);
+    }
 }
 
-pub(crate) const BROWSER_DISCONNECTED_KIND: &str = "browser_disconnected";
-pub(crate) const BROWSER_CONNECTED_KIND: &str = "browser_connected";
 pub(crate) const BROWSER_DISCONNECTED_MARKER: &str = "WISP_BROWSER_DISCONNECTED";
 
 #[derive(Clone, PartialEq, Eq)]
 pub(crate) struct BrowserOfflineNotice {
     pub frame_id: String,
     pub retry_text: String,
+}
+
+/// Apply a recomputed verdict for one session without disturbing another
+/// session's banner.
+pub(crate) fn set_browser_offline_notice(
+    notice: RwSignal<Option<BrowserOfflineNotice>>,
+    frame_id: &str,
+    next: Option<BrowserOfflineNotice>,
+) {
+    match next {
+        Some(next) => notice.set(Some(next)),
+        None => notice.update(|current| {
+            if current.as_ref().is_some_and(|row| row.frame_id == frame_id) {
+                *current = None;
+            }
+        }),
+    }
 }
 
 pub(crate) fn last_user_composer_text(items: &[ChatItem]) -> String {
@@ -312,18 +383,30 @@ pub(crate) fn last_user_composer_text(items: &[ChatItem]) -> String {
         .unwrap_or_default()
 }
 
-fn is_browser_retrieval_tool(name: &str) -> bool {
+fn is_live_retrieval_tool(name: &str) -> bool {
     matches!(
         name,
-        "web_scan" | "web_open_tab" | "web_execute_js" | "web_screenshot" | "browser_setup"
+        "web_scan" | "web_open_tab" | "web_execute_js" | "web_screenshot"
     )
 }
 
+pub(crate) fn is_browser_retrieval_tool(name: &str) -> bool {
+    name == "browser_setup" || is_live_retrieval_tool(name)
+}
+
+/// `browser_setup` returns a long JSON dump that the transcript bounds, so read
+/// the flag as text: a truncated copy still carries the head fields.
 pub(crate) fn browser_setup_live_retrieval(content: &str) -> Option<bool> {
-    let value = serde_json::from_str::<serde_json::Value>(content).ok()?;
-    if let Some(live) = value.get("live_retrieval").and_then(|v| v.as_bool()) {
-        return Some(live);
+    if let Some((_, tail)) = content.split_once("\"live_retrieval\"") {
+        let value = tail.trim_start().trim_start_matches(':').trim_start();
+        if value.starts_with("true") {
+            return Some(true);
+        }
+        if value.starts_with("false") {
+            return Some(false);
+        }
     }
+    let value = serde_json::from_str::<serde_json::Value>(content).ok()?;
     match value.get("status").and_then(|v| v.as_str()) {
         Some("connected") => Some(true),
         Some(_) => Some(false),
@@ -331,41 +414,51 @@ pub(crate) fn browser_setup_live_retrieval(content: &str) -> Option<bool> {
     }
 }
 
-pub(crate) fn browser_retrieval_blocked(name: &str, ok: bool, content: &str) -> bool {
+/// A refused live-retrieval attempt: `browser_setup` reports it as data, the
+/// retrieval tools fail with the bridge's disconnect marker.
+fn browser_retrieval_blocked(name: &str, ok: bool, content: &str) -> bool {
     if name == "browser_setup" {
         return browser_setup_live_retrieval(content) == Some(false);
     }
-    is_browser_retrieval_tool(name) && !ok && content.contains(BROWSER_DISCONNECTED_MARKER)
+    is_live_retrieval_tool(name) && !ok && content.contains(BROWSER_DISCONNECTED_MARKER)
 }
 
-pub(crate) fn browser_retrieval_restored(name: &str, ok: bool, content: &str) -> bool {
-    if name == "browser_setup" {
-        return browser_setup_live_retrieval(content) == Some(true);
-    }
-    matches!(
-        name,
-        "web_scan" | "web_open_tab" | "web_execute_js" | "web_screenshot"
-    ) && ok
+/// Live page data actually reached this turn. The disconnect marker is checked
+/// because a replayed transcript reports every persisted tool row as ok.
+fn browser_retrieval_succeeded(name: &str, ok: bool, content: &str) -> bool {
+    is_live_retrieval_tool(name) && ok && !content.contains(BROWSER_DISCONNECTED_MARKER)
 }
 
+/// The banner speaks about the answer on screen, so only the latest turn counts.
+/// The extension's service worker sleeps and reconnects on a one-minute alarm, so
+/// a turn routinely mixes refused attempts with successful ones; one success
+/// means the answer does contain live results (#887, #921).
 pub(crate) fn browser_offline_notice_from_items(
     frame_id: &str,
     items: &[ChatItem],
 ) -> Option<BrowserOfflineNotice> {
+    let turn_start = items
+        .iter()
+        .rposition(|item| matches!(item, ChatItem::User(_)))
+        .map_or(0, |index| index + 1);
     let mut blocked = false;
-    for item in items {
-        if let ChatItem::Tool {
+    for item in &items[turn_start..] {
+        let ChatItem::Tool {
             name,
             ok: Some(ok),
             output,
             ..
         } = item
-        {
-            if browser_retrieval_restored(name, *ok, output) {
-                blocked = false;
-            } else if browser_retrieval_blocked(name, *ok, output) {
-                blocked = true;
-            }
+        else {
+            continue;
+        };
+        if browser_retrieval_succeeded(name, *ok, output) {
+            return None;
+        }
+        if browser_retrieval_blocked(name, *ok, output) {
+            blocked = true;
+        } else if name == "browser_setup" && browser_setup_live_retrieval(output) == Some(true) {
+            blocked = false;
         }
     }
     blocked.then(|| BrowserOfflineNotice {

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -2244,6 +2244,8 @@ fn App() -> impl IntoView {
             }
             AgentEvent::User { frame_id, text } => {
                 dismiss_follow_up_questions(follow_up_questions, follow_up_generation, &frame_id);
+                // The banner judges the answer on screen; a new turn has none yet.
+                set_browser_offline_notice(browser_offline_cb, &frame_id, None);
                 set_pet_activity(&frame_id, "running");
                 flush_now();
                 let outline_text = text.clone();
@@ -2428,28 +2430,24 @@ fn App() -> impl IntoView {
                         promote_assistant_text(v, &content);
                     }
                 });
-                if browser_retrieval_blocked(&name, ok, &content) {
-                    let retry_text =
+                // The tool rows of the running turn are the whole verdict, so
+                // recompute from them instead of latching one event: a refused
+                // attempt after a successful scan must not claim the answer has
+                // no live results (#921).
+                if is_browser_retrieval_tool(&name) {
+                    let notice =
                         if active_cb.get_untracked().as_deref() == Some(frame_id.as_str()) {
-                            items_cb.with_untracked(|rows| last_user_composer_text(rows))
+                            items_cb.with_untracked(|rows| {
+                                browser_offline_notice_from_items(&frame_id, rows)
+                            })
                         } else {
                             transcripts_cb.with_untracked(|cache| {
-                                cache
-                                    .get(&frame_id)
-                                    .map(|rows| last_user_composer_text(rows))
-                                    .unwrap_or_default()
+                                cache.get(&frame_id).and_then(|rows| {
+                                    browser_offline_notice_from_items(&frame_id, rows)
+                                })
                             })
                         };
-                    browser_offline_cb.set(Some(BrowserOfflineNotice {
-                        frame_id: frame_id.clone(),
-                        retry_text,
-                    }));
-                } else if browser_retrieval_restored(&name, ok, &content) {
-                    browser_offline_cb.update(|notice| {
-                        if notice.as_ref().is_some_and(|row| row.frame_id == frame_id) {
-                            *notice = None;
-                        }
-                    });
+                    set_browser_offline_notice(browser_offline_cb, &frame_id, notice);
                 }
                 refresh_transcript_projections(&frame_id);
             }
@@ -2479,28 +2477,6 @@ fn App() -> impl IntoView {
                     && active_cb.get_untracked().as_deref() == Some(frame_id.as_str())
                 {
                     show_mcp_app.call((frame_id, presentation_id, payload, true));
-                } else if presentation_kind == BROWSER_DISCONNECTED_KIND {
-                    let retry_text =
-                        if active_cb.get_untracked().as_deref() == Some(frame_id.as_str()) {
-                            items_cb.with_untracked(|rows| last_user_composer_text(rows))
-                        } else {
-                            transcripts_cb.with_untracked(|cache| {
-                                cache
-                                    .get(&frame_id)
-                                    .map(|rows| last_user_composer_text(rows))
-                                    .unwrap_or_default()
-                            })
-                        };
-                    browser_offline_cb.set(Some(BrowserOfflineNotice {
-                        frame_id,
-                        retry_text,
-                    }));
-                } else if presentation_kind == BROWSER_CONNECTED_KIND {
-                    browser_offline_cb.update(|notice| {
-                        if notice.as_ref().is_some_and(|row| row.frame_id == frame_id) {
-                            *notice = None;
-                        }
-                    });
                 }
             }
             AgentEvent::Usage {
@@ -5188,19 +5164,14 @@ fn App() -> impl IntoView {
                 // unguarded set would clobber the newer view with stale rows (#53).
                 if active_session.get().as_deref() == Some(&id) {
                     items.set(chats.clone());
-                    // Tool rows are the last word. A leftover disconnected
-                    // presentation from earlier in the session must not cover a
-                    // later successful scan when the stream ends or the page
-                    // reloads (#887).
-                    if let Some(notice) = browser_offline_notice_from_items(&id, &chats) {
-                        browser_offline_notice.set(Some(notice));
-                    } else {
-                        browser_offline_notice.update(|notice| {
-                            if notice.as_ref().is_some_and(|row| row.frame_id == id) {
-                                *notice = None;
-                            }
-                        });
-                    }
+                    // The latest turn's tool rows are the whole verdict, so a
+                    // reload cannot revive an offline banner the turn's own
+                    // successful retrieval already answered (#887).
+                    set_browser_offline_notice(
+                        browser_offline_notice,
+                        &id,
+                        browser_offline_notice_from_items(&id, &chats),
+                    );
                     for presentation in presentations {
                         if presentation.presentation_kind == "mcp_app" {
                             show_mcp_app.call((


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #921

## Problem

联网搜索成功、回答里确实带了实时信息，但每次都弹出「未联网检索 / 本次回答未包含任何联网检索结果」。这是 #869（PR）引入的横幅判定过于粗糙，#887 的修复也没有覆盖到根因。

两个原因：

1. **横幅由一个会话级的 presentation 事件锁定。** `browser_disconnected` / `browser_connected` 事件与工具行是两套信号、生命周期不同，判定取「本会话最后一个浏览器信号」。Chrome 会在扩展空闲时挂起 service worker，扩展靠一分钟一次的 alarm 重连，所以一个 turn 里经常是「成功抓取若干页 → 最后一次调用赶上重连窗口失败」，横幅因此在已经拿到实时数据的回答上亮起。
2. **`setup_info` 把 `extension_missing` 排在已连接之前。** 只要这个构建校验不到自带的 `browser-extension/` 目录（打包/自行加载扩展的情况），即使扩展实际已连接，`browser_setup` 也返回 `status=extension_missing`、`live_retrieval=false`，于是每一轮都告诉模型和 UI「没有联网检索」。

## Change

- `browser_offline_notice_from_items` 只看**最近一个 turn**（最后一条 user 行之后）的浏览器工具行，且**一次成功的检索即判定为联网回答**，与调用顺序无关。
- 新 turn 开始（`AgentEvent::User`）清空横幅：横幅描述的是屏幕上这条回答，新回答还没有结论。
- 直播流里改为在每个浏览器工具结果后按工具行重新计算，不再由单个事件锁定；`browser_setup`/`web_*` 不再发 `browser_disconnected` / `browser_connected` presentation。顺带修掉一个副作用：`load_session` 只读取**最新一条**持久化的 `ToolPresentation`，这些浏览器 presentation 会把需要恢复的 `mcp_app` 挤掉。
- `browser_setup_live_retrieval` 改为先按文本读 `live_retrieval` 字段：该 JSON 常常超过 UI 的 4000 字符上限被截断，截断后无法解析，此前既不能判定阻塞也不能解除阻塞。
- `setup_info` 中「已连接的扩展」优先于「无法校验的自带副本」：连接存在就是 `connected` / `live_retrieval=true`，同时保留 `extension_path_verified=false` 供模型说明安装路径。

## Tests

- Rust（`ui/src/app_support/transcript.rs`）：成功抓取后再次失败仍算联网（#921）；横幅只描述最近一个 turn；截断的 `browser_setup` 输出仍能读出 `live_retrieval`。
- Rust（`src-tauri/src/browser_bridge.rs`）：断连工具只在结果里带 marker、不再发 presentation；已连接的扩展优先于无法校验的自带副本；标签级失败不带 disconnect marker。
- Playwright（`ui-tests/tests/browser-offline.spec.ts`）：横幅由工具行触发；Escape 只关横幅、Settings 仍在其上；重试重发上一条用户消息；成功抓取后再失败不亮横幅；新 turn 不继承横幅；重开会话不会被旧的 disconnected presentation 唤起。
- `cargo fmt --all -- --check`、`cargo test --workspace`、`cd ui && cargo check --target wasm32-unknown-unknown`、`cd ui-tests && npx playwright test`（424 passed / 1 skipped）全绿。

## Manual smoke

1. 关闭 Chrome 提问「最新的 …」：横幅出现，Agent 要求先连接扩展。
2. 打开 Chrome、确认扩展弹窗显示 **Connected to Wisp**，点 **Retry after connecting**：抓取成功后横幅不再出现。
3. 让 Agent 连续抓多页，直到某次调用赶上扩展重连窗口失败：回答仍带实时信息，横幅不出现。
4. 把自带 `browser-extension/` 目录移走、从别处加载同一扩展：`browser_setup` 仍报 `connected`，横幅不出现。

## Limitations / follow-up

- 判定只用最近一个 turn 的工具行。若同一 turn 里先成功抓取、随后扩展真的掉线导致后半段回答来自记忆，横幅不会亮；这是有意的取舍——误报比漏报更破坏信任。
- 旧会话里已持久化的 `browser_disconnected` presentation 仍留在库里，只是被忽略；没有做数据清理。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5835b89-d71a-44e0-86c6-f816b1d73684?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5835b89-d71a-44e0-86c6-f816b1d73684&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

