### PR TITLE
fix(runs): interrupt monitor waits on mid-turn guidance

### DIFF
--- a/crates/wisp-core/src/agent.rs
+++ b/crates/wisp-core/src/agent.rs
@@ -276,9 +276,15 @@ async fn agent_loop_inner(
     cancel: Option<&AtomicBool>,
     guidance: Option<&GuidanceQueue>,
 ) -> Result<AgentLoopOutcome> {
-    let env = match cancel {
-        Some(c) => ToolEnvAdapter::with_cancel(root.to_path_buf(), output, c),
-        None => ToolEnvAdapter::new(root.to_path_buf(), output),
+    let env = {
+        let adapter = match cancel {
+            Some(c) => ToolEnvAdapter::with_cancel(root.to_path_buf(), output, c),
+            None => ToolEnvAdapter::new(root.to_path_buf(), output),
+        };
+        match guidance {
+            Some(queue) => adapter.with_guidance(queue),
+            None => adapter,
+        }
     };
     let mut iteration = 0usize;
     let mut auto_continues = 0usize;
@@ -292,6 +298,12 @@ async fn agent_loop_inner(
         // persists the row and emits the User event the UI promotes on.
         if let Some(queue) = guidance {
             let drained: Vec<(u64, String)> = std::mem::take(&mut *queue.lock().unwrap());
+            if !drained.is_empty() {
+                // User injection is new information. Re-issuing monitor_run
+                // after a wait_interrupted return is expected progress, not a
+                // stuck loop (#907).
+                recent_sigs.clear();
+            }
             for (_, text) in drained {
                 ctx.append_user(&text);
                 if let Some(m) = ctx.messages.last() {
@@ -908,7 +920,8 @@ mod tests {
     use async_trait::async_trait;
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
-    use wisp_llm::{FunctionCall, ToolCall};
+    use std::time::Duration;
+    use wisp_llm::{FunctionCall, Role, ToolCall};
     use wisp_tools::ask_user::ASK_USER;
     use wisp_tools::{Approval, Registry, Tool, ToolEnv, ToolResult};
 
@@ -2539,6 +2552,179 @@ mod tests {
             err.to_string().contains("identical tool call"),
             "unexpected error: {err}"
         );
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    struct InterruptibleMonitorTool {
+        calls: Arc<AtomicUsize>,
+        queue: Arc<GuidanceQueue>,
+        succeed_after: usize,
+    }
+
+    #[async_trait]
+    impl Tool for InterruptibleMonitorTool {
+        fn name(&self) -> &str {
+            "monitor_run"
+        }
+
+        fn schema(&self) -> ToolSchema {
+            ToolSchema::new(
+                "monitor_run",
+                "wait for a run",
+                serde_json::json!({
+                    "type": "object",
+                    "properties": { "run_id": { "type": "string" } }
+                }),
+            )
+        }
+
+        async fn run(&self, _args: &serde_json::Value, env: &dyn ToolEnv) -> ToolResult {
+            let n = self.calls.fetch_add(1, Ordering::SeqCst) + 1;
+            if n >= self.succeed_after {
+                return ToolResult::ok(r#"{"id":"run-1","status":"succeeded"}"#);
+            }
+            // Simulate the host pushing mid-turn guidance while this wait is
+            // blocked. The wait must observe it without draining.
+            self.queue
+                .lock()
+                .unwrap()
+                .push((n as u64, format!("progress check {n}")));
+            assert!(
+                env.guidance_pending(),
+                "monitor_run must see pending guidance through ToolEnv"
+            );
+            ToolResult::ok(
+                r#"{"id":"run-1","status":"running","wait_interrupted":true,"next_action":"respond then call monitor_run again"}"#,
+            )
+        }
+    }
+
+    struct RemonitorProvider {
+        stream_calls: AtomicUsize,
+    }
+
+    impl RemonitorProvider {
+        fn next(&self, messages: &[Message]) -> Completion {
+            let saw_success = messages.iter().any(|message| {
+                message.role == Role::Tool
+                    && message
+                        .content
+                        .as_text()
+                        .contains(r#""status":"succeeded""#)
+            });
+            if saw_success {
+                return Completion {
+                    content: "the run finished after the progress update".into(),
+                    finish_reason: Some("stop".into()),
+                    ..Completion::default()
+                };
+            }
+            let saw_interrupt = messages.iter().any(|message| {
+                message.role == Role::Tool
+                    && message
+                        .content
+                        .as_text()
+                        .contains(r#""wait_interrupted":true"#)
+            });
+            Completion {
+                content: if saw_interrupt {
+                    "still on phase 2; continuing to wait".into()
+                } else {
+                    String::new()
+                },
+                tool_calls: vec![call(
+                    "mon",
+                    "monitor_run",
+                    serde_json::json!({ "run_id": "run-1" }),
+                )],
+                finish_reason: Some("tool_calls".into()),
+                ..Completion::default()
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Provider for RemonitorProvider {
+        fn name(&self) -> &str {
+            "remonitor"
+        }
+        fn model(&self) -> &str {
+            "remonitor"
+        }
+        async fn complete(
+            &self,
+            messages: &[Message],
+            _tools: &[ToolSchema],
+        ) -> wisp_llm::Result<Completion> {
+            Ok(self.next(messages))
+        }
+        async fn stream(
+            &self,
+            messages: &[Message],
+            _tools: &[ToolSchema],
+            _sink: &mut dyn wisp_llm::StreamSink,
+        ) -> wisp_llm::Result<Completion> {
+            self.stream_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(self.next(messages))
+        }
+    }
+
+    #[tokio::test]
+    async fn mid_turn_guidance_interrupts_monitor_wait_and_does_not_trip_stuck_detection() {
+        let interrupts = STUCK_REPEAT_LIMIT;
+        let calls = Arc::new(AtomicUsize::new(0));
+        let queue = Arc::new(GuidanceQueue::default());
+        let mut tools = Registry::builtins().filtered(&[]);
+        tools.add(Box::new(InterruptibleMonitorTool {
+            calls: calls.clone(),
+            queue: queue.clone(),
+            succeed_after: interrupts + 1,
+        }));
+        let provider = RemonitorProvider {
+            stream_calls: AtomicUsize::new(0),
+        };
+        let mut ctx = ContextManager::new(100_000);
+        let root = std::env::temp_dir().join(format!(
+            "wisp-core-guidance-interrupt-{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+
+        let outcome = agent_loop_with_images(
+            &mut ctx,
+            &provider,
+            None,
+            &tools,
+            &root,
+            &NullOutput,
+            "run the long job",
+            &[],
+            false,
+            0,
+            None,
+            Some(queue.as_ref()),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome, AgentLoopOutcome::Completed);
+        assert_eq!(calls.load(Ordering::SeqCst), interrupts + 1);
+        let guidance_count = ctx
+            .messages
+            .iter()
+            .filter(|message| {
+                message.role == Role::User && message.content.as_text().contains("progress check")
+            })
+            .count();
+        assert_eq!(guidance_count, interrupts);
+        assert!(ctx.messages.iter().any(|message| {
+            message.role == Role::Assistant
+                && message
+                    .content
+                    .as_text()
+                    .contains("still on phase 2; continuing to wait")
+        }));
+        assert!(provider.stream_calls.load(Ordering::SeqCst) >= interrupts + 2);
         std::fs::remove_dir_all(root).ok();
     }
 

--- a/crates/wisp-core/src/output.rs
+++ b/crates/wisp-core/src/output.rs
@@ -131,6 +131,9 @@ pub struct ToolEnvAdapter<'a> {
     root: std::path::PathBuf,
     out: &'a dyn Output,
     cancel: Option<&'a std::sync::atomic::AtomicBool>,
+    /// Mid-turn guidance queue (`GuidanceQueue`). Typed as the mutex so this
+    /// module does not depend on `agent`.
+    guidance: Option<&'a std::sync::Mutex<Vec<(u64, String)>>>,
 }
 
 impl<'a> ToolEnvAdapter<'a> {
@@ -139,6 +142,7 @@ impl<'a> ToolEnvAdapter<'a> {
             root,
             out,
             cancel: None,
+            guidance: None,
         }
     }
     /// Like `new`, but tools can poll `is_cancelled()` to stop mid-execution.
@@ -151,7 +155,15 @@ impl<'a> ToolEnvAdapter<'a> {
             root,
             out,
             cancel: Some(cancel),
+            guidance: None,
         }
+    }
+    /// Let long-running tools see that the host has queued mid-turn guidance
+    /// without draining it. The agent loop still injects at the iteration
+    /// boundary.
+    pub fn with_guidance(mut self, queue: &'a std::sync::Mutex<Vec<(u64, String)>>) -> Self {
+        self.guidance = Some(queue);
+        self
     }
 }
 
@@ -194,6 +206,11 @@ impl<'a> wisp_tools::ToolEnv for ToolEnvAdapter<'a> {
     fn is_cancelled(&self) -> bool {
         self.cancel
             .is_some_and(|c| c.load(std::sync::atomic::Ordering::Relaxed))
+    }
+    fn guidance_pending(&self) -> bool {
+        self.guidance
+            .and_then(|queue| queue.lock().ok())
+            .is_some_and(|pending| !pending.is_empty())
     }
     fn cancel_flag(&self) -> Option<&std::sync::atomic::AtomicBool> {
         self.cancel
@@ -328,5 +345,29 @@ mod tests {
             !output.sync_called.load(Ordering::SeqCst),
             "the adapter must not fall back to the runtime-blocking sync hook"
         );
+    }
+
+    #[test]
+    fn tool_env_adapter_reports_pending_guidance_without_draining() {
+        let out = NullOutput;
+        let queue = std::sync::Mutex::new(Vec::<(u64, String)>::new());
+        let env = ToolEnvAdapter::new(std::path::PathBuf::from("."), &out).with_guidance(&queue);
+        assert!(
+            !wisp_tools::ToolEnv::guidance_pending(&env),
+            "empty queue is not pending"
+        );
+        queue.lock().unwrap().push((1, "how far?".into()));
+        assert!(
+            wisp_tools::ToolEnv::guidance_pending(&env),
+            "queued guidance must be visible to long waits"
+        );
+        assert_eq!(
+            queue.lock().unwrap().len(),
+            1,
+            "peeking must not drain the queue; the agent loop injects at the iteration boundary"
+        );
+        assert!(!wisp_tools::ToolEnv::guidance_pending(
+            &ToolEnvAdapter::new(std::path::PathBuf::from("."), &out)
+        ));
     }
 }

--- a/crates/wisp-tools/src/env.rs
+++ b/crates/wisp-tools/src/env.rs
@@ -198,6 +198,13 @@ pub trait ToolEnv: Send + Sync {
     fn is_cancelled(&self) -> bool {
         false
     }
+    /// Whether mid-turn user guidance is waiting to be injected at the next
+    /// agent-loop iteration. Long waits such as `monitor_run` poll this so they
+    /// can return a live snapshot instead of holding the turn until the Run
+    /// finishes. Default `false`; does not drain the queue.
+    fn guidance_pending(&self) -> bool {
+        false
+    }
     /// The raw cancel flag, when the env has one. Lets a tool that runs a
     /// nested agent loop (subagents) pass the SAME Stop flag through, so the
     /// user's Stop also interrupts the inner loop. Default `None`.

--- a/skills/compute-env-setup/SKILL.md
+++ b/skills/compute-env-setup/SKILL.md
@@ -57,8 +57,8 @@ replace container-specific paths with paths valid on the selected context.
 ```
 
 6. Replace all example paths with probed absolute paths. Call `monitor_run`
-   exactly once when waiting is useful. Use one `get_run` snapshot later or
-   `cancel_run` when requested.
+   when waiting is useful (again after `wait_interrupted`; do not resubmit).
+   Use one `get_run` snapshot later or `cancel_run` when requested.
 7. Record the validated activation command, versions, cache paths, GPU witness,
    date, and known limitations in a normal project file such as
    `environments/<context>/<name>.md`. This file is documentation, not a hidden

--- a/skills/remote-compute-ssh/SKILL.md
+++ b/skills/remote-compute-ssh/SKILL.md
@@ -20,11 +20,14 @@ or Wisp restarts.
    assume a `python` alias exists when the probe found `python3`.
 2. Put the real command in one `run_in_context` call. Include environment
    activation in the command so the Run is reproducible.
-3. To watch the Run or wait for later work, call `monitor_run` exactly once with
-   the returned Run id. Wisp inserts a live card in the conversation, suspends
+3. To watch the Run or wait for later work, call `monitor_run` with the
+   returned Run id. Wisp inserts a live card in the conversation, suspends
    the tool without additional model calls, and resumes the same agent turn
-   with the terminal result. For fire-and-forget work, report the Run id and end
-   the turn instead.
+   with the terminal result. If the result has `wait_interrupted: true`, the
+   remote process is still running: answer the user from the snapshot, then
+   call `monitor_run` again with the same id. Do not resubmit. Use `cancel_run`
+   only when the user asked to stop. For fire-and-forget work, report the Run id
+   and end the turn instead.
 4. Use `get_run` only for one explicit status snapshot; never call it repeatedly
    to wait. Use `cancel_run` when the user asks to stop.
 
@@ -50,8 +53,10 @@ Then, when live monitoring is needed:
 { "run_id": "<id returned by run_in_context>" }
 ```
 
-Pass that object to `monitor_run` once. The call may remain suspended for hours;
+Pass that object to `monitor_run`. The call may remain suspended for hours;
 it does not consume model tokens while the Run Manager watches the job.
+If `wait_interrupted` is true, respond from the snapshot and call `monitor_run`
+again with the same id; do not resubmit.
 
 `input_paths` are project-relative local files. Wisp validates them, copies
 them into an isolated `inputs/` directory, and flattens them to their basenames.
@@ -153,14 +158,14 @@ destination.
 Omit `destination_path` to place the file under the project's configured
 remote data directory for that server. Wisp rejects globs, symlinks, special
 files, and existing remote destinations, and ledgers every successful upload
-so retracted files can be found and removed later. Call `monitor_run` once
-with the returned Run id.
+so retracted files can be found and removed later. Call `monitor_run`
+with the returned Run id; call it again after `wait_interrupted`.
 
 For a local download, set `destination_context_id` to `local` and provide the
 exact new absolute local path. Ask the user when that path is unspecified.
 Wisp stages the item beside the destination, never overwrites an existing
 path, and removes partial staging data after failure or cancellation. Call
-`monitor_run` once with the returned Run id.
+`monitor_run` with the returned Run id; call it again after `wait_interrupted`.
 
 When the user approves persistent A→B trust, call `configure_ssh_trust` first.
 It creates a dedicated key on A, carries only the public key through Wisp,

--- a/skills/self-awareness/SKILL.md
+++ b/skills/self-awareness/SKILL.md
@@ -45,7 +45,7 @@ corresponding Wisp tool instead.
 | Read a truncated delegated result | `get_delegated_result` | Desktop-only and available with delegation. Use only when the compact result lacks necessary detail. |
 | Submit long-running work | `run_in_context` | Persist a Run in `local`, `ssh:<alias>`, or `wsl:<distro>`. Prefer this over extending `shell` timeouts. |
 | Read one Run snapshot | `get_run` | Call once for an immediate status check; never poll it in a loop. |
-| Wait for a Run | `monitor_run` | Call exactly once with the Run id. Wisp waits without repeated model calls. |
+| Wait for a Run | `monitor_run` | Call with the Run id to wait without polling `get_run`. If `wait_interrupted` is true, respond, then call `monitor_run` again; do not resubmit. |
 | Cancel a Run | `cancel_run` | Request cancellation through the persisted Run lifecycle. |
 | Record project research objects | `research_graph` | Desktop-only. Record data assets, papers, or decisions and link existing graph nodes; it is not a generic artifact browser. |
 | Read or change app preferences, or show disk storage | `configure` | Desktop-only. `get` / `set` cover allowlisted appearance and general settings (font size, theme, `custom_css`, locale, compaction). `storage` reports this project's workspace plus app-data usage in the conversation. Secrets, API keys, model profiles, workspace directory, and proxy are not writable. For a restyle, load `custom-theme` then set `custom_css`. |
@@ -60,8 +60,9 @@ corresponding Wisp tool instead.
 1. Use `python` or `r` for interactive analysis whose next step depends on the
    computed result.
 2. Use `run_in_context` for persisted, recoverable, or long-running work. Use
-   `monitor_run` once when the result is needed in the current task, or return
-   the Run id for fire-and-forget work.
+   `monitor_run` when the result is needed in the current task (again after
+   `wait_interrupted`; do not resubmit), or return the Run id for fire-and-forget
+   work.
 3. Use `explore` when codebase understanding requires more than a couple of
    reads. Use `delegate_tasks` only when desktop delegation is currently
    advertised and the work benefits from independent or parallel Agents.

--- a/src-tauri/src/mcp_bridge.rs
+++ b/src-tauri/src/mcp_bridge.rs
@@ -1208,7 +1208,7 @@ fn list_execution_contexts_tool_schema() -> Value {
 fn run_in_context_tool_schema() -> Value {
     json!({
         "name": "wisp_run_in_context",
-        "description": "Submit a persisted background Wisp Run in an execution context (`local`, `ssh:<alias>`, or `wsl:<distro>`). For Python/R work, declare a safe preflight for interpreter, package, file, and syntax checks; it never installs packages or executes the requested command as a dry run. Set wait_for_completion=true for direct model-free waiting, or call wisp_monitor_run exactly once with the returned id. Never poll with wisp_get_run. Dangerous commands require approval and are rejected in this non-interactive bridge.",
+        "description": "Submit a persisted background Wisp Run in an execution context (`local`, `ssh:<alias>`, or `wsl:<distro>`). For Python/R work, declare a safe preflight for interpreter, package, file, and syntax checks; it never installs packages or executes the requested command as a dry run. Set wait_for_completion=true for direct model-free waiting, or call wisp_monitor_run with the returned id. If wisp_monitor_run returns wait_interrupted, the Run is still running: respond, then call it again with the same id. Do not resubmit. Never poll with wisp_get_run. Dangerous commands require approval and are rejected in this non-interactive bridge.",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -1216,7 +1216,7 @@ fn run_in_context_tool_schema() -> Value {
                 "command": { "type": "string", "description": "Command to execute in that context" },
                 "title": { "type": "string", "description": "Short run title" },
                 "timeout_secs": { "type": "integer", "description": "Job wall timeout in seconds: 1s..7d (default 4h) for local, WSL, and SSH" },
-                "wait_for_completion": { "type": "boolean", "description": "Suspend the tool until the Run is terminal without repeatedly calling wisp_get_run (default false)" },
+                "wait_for_completion": { "type": "boolean", "description": "Suspend the tool until the Run is terminal or mid-turn user guidance arrives, without repeatedly calling wisp_get_run (default false). If wait_interrupted, respond then call wisp_monitor_run to resume waiting." },
                 "preflight": {
                     "type": "object",
                     "description": "Safe declarative Python/R checks performed before Run submission",
@@ -1277,7 +1277,7 @@ fn run_in_context_tool_schema() -> Value {
 fn get_run_tool_schema() -> Value {
     json!({
         "name": "wisp_get_run",
-        "description": "Read one immediate Run status snapshot. Do not call repeatedly to wait; call wisp_monitor_run exactly once for live monitoring.",
+        "description": "Read one immediate Run status snapshot. Do not call repeatedly to wait; call wisp_monitor_run for live monitoring until completion or mid-turn guidance.",
         "inputSchema": {
             "type": "object",
             "properties": { "run_id": { "type": "string" } },
@@ -1290,7 +1290,7 @@ fn get_run_tool_schema() -> Value {
 fn monitor_run_tool_schema() -> Value {
     json!({
         "name": "wisp_monitor_run",
-        "description": "Monitor one existing long-running Run until it finishes. Call once instead of repeatedly calling wisp_get_run; Wisp waits without repeated model calls or token use.",
+        "description": "Monitor one existing long-running Run until it finishes or mid-turn user guidance arrives. Call this instead of repeatedly calling wisp_get_run; Wisp waits without repeated model calls or token use. If wait_interrupted is true, the Run is still running: respond, then call wisp_monitor_run again with the same id. Do not resubmit.",
         "inputSchema": {
             "type": "object",
             "properties": { "run_id": { "type": "string" } },

--- a/src-tauri/src/run_context/tests.rs
+++ b/src-tauri/src/run_context/tests.rs
@@ -140,6 +140,31 @@ impl wisp_tools::ToolEnv for DenyRunToolEnv {
     async fn emit(&self, _event: wisp_tools::ToolEvent) {}
 }
 
+struct GuidanceRunToolEnv {
+    root: PathBuf,
+    queue: Arc<wisp_core::GuidanceQueue>,
+}
+
+#[async_trait::async_trait]
+impl wisp_tools::ToolEnv for GuidanceRunToolEnv {
+    fn project_root(&self) -> &std::path::Path {
+        &self.root
+    }
+
+    async fn confirm(&self, _message: &str) -> bool {
+        true
+    }
+
+    async fn emit(&self, _event: wisp_tools::ToolEvent) {}
+
+    fn guidance_pending(&self) -> bool {
+        self.queue
+            .lock()
+            .map(|pending| !pending.is_empty())
+            .unwrap_or(false)
+    }
+}
+
 #[tokio::test]
 async fn denied_dangerous_run_stops_the_model_batch() {
     use wisp_tools::{Tool, ToolControl};
@@ -435,7 +460,9 @@ async fn monitor_run_waits_once_for_an_existing_run() {
         )
         .await;
     assert!(snapshot.success, "{}", snapshot.content);
-    assert!(snapshot.content.contains("Call monitor_run exactly once"));
+    assert!(snapshot
+        .content
+        .contains("Call monitor_run with this run_id"));
 
     let finishing_store = store.clone();
     tokio::spawn(async move {
@@ -466,6 +493,72 @@ async fn monitor_run_waits_once_for_an_existing_run() {
     assert!(result.success, "{}", result.content);
     let run: wisp_store::RunRecord = serde_json::from_str(&result.content).unwrap();
     assert_eq!(run.status, wisp_store::RunStatus::Succeeded);
+    let _ = std::fs::remove_dir_all(tmp);
+}
+
+#[tokio::test]
+async fn monitor_run_returns_early_when_mid_turn_guidance_is_pending() {
+    use wisp_tools::Tool;
+    let tmp = std::env::temp_dir().join(format!(
+        "wisp_monitor_run_guidance_{}",
+        uuid::Uuid::new_v4()
+    ));
+    std::fs::create_dir_all(&tmp).unwrap();
+    let store = wisp_store::Store::open(&tmp.join("wisp.sqlite"))
+        .await
+        .unwrap();
+    store
+        .create_project("p", "project", &tmp.to_string_lossy())
+        .await
+        .unwrap();
+    let mut run = wisp_store::RunRecord::new("long-run", "p", "ssh:gpu", "Long run", "ssh_direct");
+    run.command = Some("sleep 3600".into());
+    run.stdout_tail = Some("phase 2 of 9\n".into());
+    run.last_polled_at = Some(chrono::Utc::now().timestamp());
+    store.create_run(&run).await.unwrap();
+    assert!(store
+        .activate_run_lifecycle(
+            "long-run",
+            wisp_store::RunStatus::Running,
+            "monitor-owner",
+            60,
+        )
+        .await
+        .unwrap());
+
+    let queue = Arc::new(wisp_core::GuidanceQueue::default());
+    let env = GuidanceRunToolEnv {
+        root: tmp.clone(),
+        queue: queue.clone(),
+    };
+    let tool = MonitorRunTool::new(store.clone(), "p".into());
+    let waiting = tokio::spawn(async move {
+        tool.run(&serde_json::json!({ "run_id": "long-run" }), &env)
+            .await
+    });
+    tokio::time::sleep(Duration::from_millis(25)).await;
+    queue.lock().unwrap().push((1, "你在进行哪一步？".into()));
+    let result = tokio::time::timeout(Duration::from_secs(2), waiting)
+        .await
+        .expect("monitor_run should return once guidance is pending")
+        .unwrap();
+
+    assert!(result.success, "{}", result.content);
+    let value: serde_json::Value = serde_json::from_str(&result.content).unwrap();
+    assert_eq!(value["wait_interrupted"], true);
+    assert_eq!(value["status"], "running");
+    assert_eq!(value["stdout_tail"], "phase 2 of 9\n");
+    assert!(
+        value["next_action"]
+            .as_str()
+            .unwrap()
+            .contains("call monitor_run again"),
+        "{}",
+        value["next_action"]
+    );
+    assert!(value["wait_detached"].is_null());
+    let still = store.get_run("long-run").await.unwrap().unwrap();
+    assert_eq!(still.status, wisp_store::RunStatus::Running);
     let _ = std::fs::remove_dir_all(tmp);
 }
 
@@ -1378,7 +1471,8 @@ fn remote_compute_skill_uses_the_real_wisp_run_contract() {
     ] {
         assert!(!skill.contains(stale), "stale API remains: {stale}");
     }
-    assert!(skill.contains("call `monitor_run` exactly once"));
+    assert!(skill.contains("wait_interrupted"));
+    assert!(skill.contains("call `monitor_run` again"));
     assert!(skill.contains("never call it repeatedly"));
     assert!(!skill.contains("ssh <alias>"));
     assert!(skill.contains("Scheduler lifecycle is not implemented yet"));

--- a/src-tauri/src/run_context/tools.rs
+++ b/src-tauri/src/run_context/tools.rs
@@ -36,7 +36,7 @@ impl Tool for RunInContextTool {
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(
             "run_in_context",
-            "Submit a persisted background Run in an execution context (`local`, `ssh:<alias>`, or `wsl:<distro>`). For Python/R work, declare a preflight to check the interpreter, explicit import modules/packages, project-relative files, and syntax before submission. Preflight never installs packages or executes the requested command as a dry run. Set wait_for_completion=true for direct model-free waiting, or submit normally and call monitor_run exactly once with the returned Run id to show an inline live card. Never poll with get_run.",
+            "Submit a persisted background Run in an execution context (`local`, `ssh:<alias>`, or `wsl:<distro>`). For Python/R work, declare a preflight to check the interpreter, explicit import modules/packages, project-relative files, and syntax before submission. Preflight never installs packages or executes the requested command as a dry run. Set wait_for_completion=true for direct model-free waiting, or submit normally and call monitor_run with the returned Run id to show an inline live card. If monitor_run returns wait_interrupted, the Run is still running: respond, then call monitor_run again with the same id. Do not resubmit. Never poll with get_run.",
             serde_json::json!({
                 "type": "object",
                 "properties": {
@@ -44,7 +44,7 @@ impl Tool for RunInContextTool {
                     "command": { "type": "string", "description": "Command to execute in that context" },
                     "title": { "type": "string", "description": "Short run title" },
                     "timeout_secs": { "type": "integer", "description": "Job wall timeout in seconds: 1s..7d (default 4h) for local, WSL, and SSH" },
-                    "wait_for_completion": { "type": "boolean", "description": "Suspend this tool until the Run reaches a terminal state, without consuming model tokens or repeatedly calling get_run (default false)" },
+                    "wait_for_completion": { "type": "boolean", "description": "Suspend this tool until the Run reaches a terminal state or mid-turn user guidance arrives, without consuming model tokens or repeatedly calling get_run (default false). If wait_interrupted, respond then call monitor_run to resume waiting." },
                     "preflight": {
                         "type": "object",
                         "description": "Safe declarative Python/R environment checks performed before Run submission",
@@ -276,7 +276,7 @@ impl Tool for RunInContextTool {
         match submission {
             Ok(res) if wait_for_completion => {
                 match wait_for_terminal(&self.store, &res.run_id, env).await {
-                    Ok((run, detached)) => run_wait_result(run, detached),
+                    Ok((run, outcome)) => run_wait_result(run, outcome),
                     Err(error) => ToolResult::fail(format!("run_in_context wait error: {error}")),
                 }
             }
@@ -333,7 +333,7 @@ impl Tool for GetRunTool {
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(
             "get_run",
-            "Read one immediate status snapshot for a Run. Never call this repeatedly to wait; call monitor_run exactly once for live monitoring until completion.",
+            "Read one immediate status snapshot for a Run. Never call this repeatedly to wait; call monitor_run for live monitoring until completion or mid-turn guidance.",
             serde_json::json!({
                 "type": "object",
                 "properties": { "run_id": { "type": "string" } },
@@ -364,7 +364,7 @@ impl Tool for GetRunTool {
                 let mut value = serde_json::to_value(run).unwrap_or_default();
                 if active {
                     value["next_action"] = serde_json::Value::String(
-                        "Do not call get_run again. Call monitor_run exactly once with this run_id."
+                        "Do not poll with get_run. Call monitor_run with this run_id to wait; if wait_interrupted, respond then call monitor_run again."
                             .into(),
                     );
                 }
@@ -403,7 +403,7 @@ impl Tool for MonitorRunTool {
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(
             "monitor_run",
-            "Monitor one existing long-running Run until it finishes. Call this exactly once instead of repeatedly calling get_run. Wisp shows a live Run card, suspends the agent without model calls or token use, and resumes it with the terminal result.",
+            "Monitor one existing long-running Run until it finishes or mid-turn user guidance arrives. Call this instead of repeatedly calling get_run. Wisp shows a live Run card and suspends without model calls or token use. If the result has wait_interrupted=true, the Run is still running: answer the user from this snapshot, then call monitor_run again with the same run_id. Do not resubmit the Run. Use cancel_run only when the user asked to stop.",
             serde_json::json!({
                 "type": "object",
                 "properties": { "run_id": { "type": "string" } },
@@ -429,17 +429,29 @@ impl Tool for MonitorRunTool {
             Err(error) => return ToolResult::fail(format!("monitor_run error: {error}")),
         }
         match wait_for_terminal(&self.store, run_id, env).await {
-            Ok((run, detached)) => run_wait_result(run, detached),
+            Ok((run, outcome)) => run_wait_result(run, outcome),
             Err(error) => ToolResult::fail(format!("monitor_run error: {error}")),
         }
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WaitOutcome {
+    Terminal,
+    Detached,
+    GuidanceInterrupt,
+}
+
+const WAIT_INTERRUPTED_NEXT_ACTION: &str = "The Run is still executing and was not cancelled or \
+     resubmitted. Respond to the user's mid-turn message using this snapshot (status, heartbeat, \
+     log tails). Then call monitor_run again with the same run_id to resume waiting. Call \
+     cancel_run only if the user asked to stop the Run.";
+
 async fn wait_for_terminal(
     store: &wisp_store::Store,
     run_id: &str,
     env: &dyn ToolEnv,
-) -> Result<(wisp_store::RunRecord, bool), String> {
+) -> Result<(wisp_store::RunRecord, WaitOutcome), String> {
     loop {
         let run = store
             .get_run(run_id)
@@ -447,10 +459,13 @@ async fn wait_for_terminal(
             .map_err(|error| error.to_string())?
             .ok_or_else(|| format!("Run not found: {run_id}"))?;
         if run.status.is_terminal() {
-            return Ok((run, false));
+            return Ok((run, WaitOutcome::Terminal));
         }
         if env.is_cancelled() {
-            return Ok((run, true));
+            return Ok((run, WaitOutcome::Detached));
+        }
+        if env.guidance_pending() {
+            return Ok((run, WaitOutcome::GuidanceInterrupt));
         }
         tokio::time::sleep(if cfg!(test) {
             std::time::Duration::from_millis(10)
@@ -461,28 +476,36 @@ async fn wait_for_terminal(
     }
 }
 
-fn run_wait_result(run: wisp_store::RunRecord, detached: bool) -> ToolResult {
+fn run_wait_result(run: wisp_store::RunRecord, outcome: WaitOutcome) -> ToolResult {
     let succeeded = run.status == wisp_store::RunStatus::Succeeded;
-    let cleanable = run.status.is_terminal()
+    let cleanable = outcome == WaitOutcome::Terminal
+        && run.status.is_terminal()
         && run.remote_workdir.is_some()
         && run.cleaned_at.is_none()
         && run.kind != "file_transfer";
     let mut value = serde_json::to_value(run).unwrap_or_default();
-    if detached {
-        value["wait_detached"] = serde_json::Value::Bool(true);
-    }
-    if cleanable && !detached {
-        value["next_action"] = serde_json::Value::String(
-            "When the server workspace is no longer needed, call cleanup_run_workspace to \
-             reclaim it (harvested outputs and logs stay in the project)."
-                .into(),
-        );
+    match outcome {
+        WaitOutcome::Detached => {
+            value["wait_detached"] = serde_json::Value::Bool(true);
+        }
+        WaitOutcome::GuidanceInterrupt => {
+            value["wait_interrupted"] = serde_json::Value::Bool(true);
+            value["next_action"] = serde_json::Value::String(WAIT_INTERRUPTED_NEXT_ACTION.into());
+        }
+        WaitOutcome::Terminal if cleanable => {
+            value["next_action"] = serde_json::Value::String(
+                "When the server workspace is no longer needed, call cleanup_run_workspace to \
+                 reclaim it (harvested outputs and logs stay in the project)."
+                    .into(),
+            );
+        }
+        WaitOutcome::Terminal => {}
     }
     let content = value.to_string();
-    if detached || succeeded {
-        ToolResult::ok(content)
-    } else {
-        ToolResult::fail(content)
+    match outcome {
+        WaitOutcome::Detached | WaitOutcome::GuidanceInterrupt => ToolResult::ok(content),
+        WaitOutcome::Terminal if succeeded => ToolResult::ok(content),
+        WaitOutcome::Terminal => ToolResult::fail(content),
     }
 }
 

--- a/src-tauri/src/run_context/transfer.rs
+++ b/src-tauri/src/run_context/transfer.rs
@@ -1059,7 +1059,7 @@ async fn submit_transfer(
             "transport": transport_label(transport),
             "source_path": source_path,
             "destination_path": destination_path,
-            "next_action": "Call monitor_run exactly once to wait for completion."
+            "next_action": "Call monitor_run to wait for completion; if wait_interrupted, respond then call it again with the same run_id. Do not resubmit."
         }));
     }
 
@@ -1096,7 +1096,7 @@ async fn submit_transfer(
             "route": "local",
             "transport": transport_label(transport),
             "destination_path": destination,
-            "next_action": "Call monitor_run exactly once to wait for completion."
+            "next_action": "Call monitor_run to wait for completion; if wait_interrupted, respond then call it again with the same run_id. Do not resubmit."
         }));
     }
 
@@ -1202,7 +1202,7 @@ async fn submit_transfer(
         "status": response.status,
         "route": route,
         "transport": if route == "relay" { "scp" } else { request.transport.as_str() },
-        "next_action": "Call monitor_run exactly once to wait for completion."
+        "next_action": "Call monitor_run to wait for completion; if wait_interrupted, respond then call it again with the same run_id. Do not resubmit."
     }))
 }
 

--- a/src-tauri/src/ssh_hosts.rs
+++ b/src-tauri/src/ssh_hosts.rs
@@ -639,7 +639,9 @@ compute when they fit the task. Submit remote discovery, real work, and all long
 `nohup`, background `&`, or polling loops to monitor work. After submission, \
 observe or cancel it through the Runs control plane. Remote paths are not local \
 paths. To watch a submitted Run or wait for its result, call `monitor_run` \
-exactly once instead of repeatedly calling `get_run`. For persistent interactive analysis, call `python` or `r` with the \
+instead of repeatedly calling `get_run`. If `monitor_run` returns `wait_interrupted`, \
+the Run is still running: answer the user, then call `monitor_run` again with the same id. \
+Do not resubmit. For persistent interactive analysis, call `python` or `r` with the \
 matching `context_id`; omitting it uses the default analysis environment below when one is \
 configured, otherwise `local`. Interpreter paths come from \
 the execution context's saved settings or probe result, not shell environment \


### PR DESCRIPTION
## User-facing problem

During a long SSH Run, “立刻引导” appeared to do nothing (#907). Guidance only injects at the agent-loop iteration boundary, but `monitor_run` / `wait_for_completion` blocked inside `wait_for_terminal` until the Run finished, so the queued message never reached the model.

## What changed

- `ToolEnv::guidance_pending()` peeks the mid-turn guidance queue (default false). `ToolEnvAdapter` is wired to that queue when the agent loop starts.
- `wait_for_terminal` now has a third exit: pending guidance. The tool returns a live Run snapshot with `wait_interrupted: true` and tells the model to respond, then call `monitor_run` again. It does not cancel, restart, or resubmit the remote job.
- `monitor_run` / `get_run` / `wait_for_completion` schemas and compute-context skills no longer say “call exactly once,” so remonitoring after an interrupt is allowed.
- Draining real guidance clears the stuck-loop signature window so interrupt → answer → remonitor is not treated as a stuck identical-call loop.

No UI change: once the wait returns, the next iteration drains guidance and emits the existing User event, so the queued bubble promotes under #410.

## Tests

- Store-level: spawn `monitor_run` on a still-running Run, push guidance, assert an early `wait_interrupted` snapshot; the Run stays `running`.
- Agent-loop: interrupt → answer → remonitor more times than the stuck window without tripping stuck detection.
- Existing wait-until-terminal and stuck-loop tests still pass.

`cargo fmt --all -- --check` and `cargo test --workspace` passed.

## Manual smoke

1. Start a long `ssh_direct` Run and wait until it is running.
2. Queue a progress question and click **立刻引导**.
3. Within about a second the message should leave the queue, the agent should answer from the snapshot, and the remote job should keep running.
4. An explicit stop request should still go through `cancel_run`.

## Limitations / follow-up

- Interrupt latency is one poll tick (1s in production).
- Repeated `monitor_run` cards may appear in the transcript after each interrupt; no UI change in this PR.
- Structured suspend/resume of the turn lifecycle is still future Run Manager work.

Closes #907