### PR TITLE
fix: reserve run-review auto-prompt for submitted tasks at turn end (#897)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,7 +89,21 @@ jobs:
             -o Acquire::http::Timeout=30
             -o Acquire::https::Timeout=30
           )
-          sudo timeout 2m apt-get "${APT_OPTS[@]}" update
+          # azure.archive.ubuntu.com also hangs on the index fetch itself,
+          # burning the whole `apt-get update` budget on Ign retries. Point
+          # the runner's mirror list at the canonical archive and retry the
+          # update, so one slow mirror cannot fail the job.
+          if [ -f /etc/apt/apt-mirrors.txt ]; then
+            sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu/|https://archive.ubuntu.com/ubuntu/|g' /etc/apt/apt-mirrors.txt
+          fi
+          for attempt in 1 2 3; do
+            sudo timeout 4m apt-get "${APT_OPTS[@]}" update && break
+            if [ "$attempt" = 3 ]; then
+              echo "apt-get update failed after ${attempt} attempts" >&2
+              exit 1
+            fi
+            sleep 10
+          done
           sudo timeout 20m apt-get "${APT_OPTS[@]}" install -y \
             libwebkit2gtk-4.1-dev \
             libayatana-appindicator3-dev \

--- a/crates/wisp-store/src/lib.rs
+++ b/crates/wisp-store/src/lib.rs
@@ -166,6 +166,7 @@ const SCHEDULES_MIGRATION: &str = "0048_schedules";
 const ARTIFACT_SOURCE_DISCARDED_MIGRATION: &str = "0049_artifact_source_discarded";
 const RUN_LOG_PULL_MIGRATION: &str = "0050_run_log_pull";
 const ORPHAN_FILE_RETENTION_MIGRATION: &str = "0051_orphan_file_retention";
+const RUN_REVIEW_DISMISSED_MIGRATION: &str = "0052_run_review_dismissed";
 
 #[derive(Clone)]
 pub struct Store {
@@ -695,6 +696,11 @@ impl Store {
             .await?;
             Self::record_migration(pool, ORPHAN_FILE_RETENTION_MIGRATION).await?;
         }
+        if !Self::migration_applied(pool, RUN_REVIEW_DISMISSED_MIGRATION).await? {
+            Self::add_columns_if_missing(pool, "runs", &[("review_dismissed_at", "INTEGER")])
+                .await?;
+            Self::record_migration(pool, RUN_REVIEW_DISMISSED_MIGRATION).await?;
+        }
         // Re-apply additive DDL even when a migration marker is already
         // recorded. Jumping many releases can leave a table/column that was
         // later folded into 0000_init.sql (or into an already-shipped apply_*
@@ -802,6 +808,7 @@ impl Store {
                 ("cleanup_error", "TEXT"),
                 ("logs_path", "TEXT"),
                 ("exploration_id", "TEXT"),
+                ("review_dismissed_at", "INTEGER"),
             ],
         )
         .await?;

--- a/crates/wisp-store/src/runs.rs
+++ b/crates/wisp-store/src/runs.rs
@@ -812,6 +812,31 @@ impl Store {
         Ok(updated.rows_affected() == 1)
     }
 
+    /// Record that the user closed this Run's results-review prompt so it is
+    /// never auto-opened again. Manual review stays available. Idempotent:
+    /// returns false when already dismissed.
+    pub async fn mark_run_review_dismissed(&self, id: &str) -> Result<bool> {
+        let now = chrono::Utc::now().timestamp();
+        let updated = sqlx::query(
+            "UPDATE runs SET review_dismissed_at=? WHERE id=? AND review_dismissed_at IS NULL",
+        )
+        .bind(now)
+        .bind(id)
+        .execute(&self.pool)
+        .await?;
+        Ok(updated.rows_affected() == 1)
+    }
+
+    /// Whether the user already closed this Run's results-review prompt.
+    pub async fn run_review_dismissed(&self, id: &str) -> Result<bool> {
+        let row: Option<(Option<i64>,)> =
+            sqlx::query_as("SELECT review_dismissed_at FROM runs WHERE id=?")
+                .bind(id)
+                .fetch_optional(&self.pool)
+                .await?;
+        Ok(row.is_some_and(|(dismissed,)| dismissed.is_some()))
+    }
+
     pub async fn mark_run_cleaned(&self, id: &str) -> Result<bool> {
         let now = chrono::Utc::now().timestamp();
         let updated = sqlx::query(

--- a/crates/wisp-store/src/store_tests.rs
+++ b/crates/wisp-store/src/store_tests.rs
@@ -3554,6 +3554,7 @@ async fn store_open_records_migrations_and_seeds_local_context() {
             ARTIFACT_SOURCE_DISCARDED_MIGRATION.to_string(),
             RUN_LOG_PULL_MIGRATION.to_string(),
             ORPHAN_FILE_RETENTION_MIGRATION.to_string(),
+            RUN_REVIEW_DISMISSED_MIGRATION.to_string(),
         ]
     );
     let first_open_migrations = store.schema_migrations().await.unwrap();

--- a/docs/superpowers/plans/2026-08-14-server-task-loop-closure.md
+++ b/docs/superpowers/plans/2026-08-14-server-task-loop-closure.md
@@ -353,6 +353,12 @@ harvest + 整目录清理"两个极端。
   PR 3 的删除通道；全目录删除仍走 `cleanup_run_workspace`。
 - Modal（UI）：run 进入终态后，RunMonitorCard/run 详情出现"结果与清理"操作打开
   modal；当前会话内前台监控的 run 完成时自动打开一次。内容：
+  - （#897 修订）自动打开只保留给**前台 `monitor_run` 监控**的 run（AutoRun
+    卡片代表的探索型命令 run 永不自动弹），且延迟到**回合结束**（会话空闲）才
+    触发；触发前后端 `should_prompt_run_review` 判定是否存在未决产物问题——
+    已声明 `output_specs` 但 harvest 未完成，或未声明 specs 且工作目录非空。
+    关闭 modal 通过 `dismiss_run_review` 持久化（`runs.review_dismissed_at`），
+    该 run 此后永不自动弹出；手动入口不受影响。
   - 懒加载文件树 + 过滤框 + 复选框（目录可整体勾选，显示文件数与总大小），
     命中 `output_specs` 的项预勾选并标注"已自动取回"状态；
   - "下载所选"（可跳过）；"删除所选 / 清理整个工作目录"（可跳过）；关闭即什么都不做。

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6219,6 +6219,8 @@ pub fn run() {
             runtime_commands::list_run_workspace_files,
             runtime_commands::download_run_files,
             runtime_commands::delete_run_files,
+            runtime_commands::should_prompt_run_review,
+            runtime_commands::dismiss_run_review,
             runtime_commands::list_remote_files,
             runtime_commands::remove_remote_files,
             runtime_commands::context_disposal_report,

--- a/src-tauri/src/run_context.rs
+++ b/src-tauri/src/run_context.rs
@@ -1506,6 +1506,52 @@ impl RunManager {
         Ok(remote)
     }
 
+    /// Whether the results-review modal is worth auto-opening for this Run.
+    /// The prompt is reserved for submitted-task Runs with an unresolved
+    /// product decision: declared outputs that were never harvested (data at
+    /// risk on the server), or no declared outputs but files present in the
+    /// workspace. Exploratory command Runs, harvested Runs, cleaned Runs, and
+    /// Runs whose prompt the user already closed all return false.
+    pub async fn should_prompt_run_review(
+        &self,
+        store: &wisp_store::Store,
+        run_id: &str,
+    ) -> Result<bool, String> {
+        let run = store
+            .get_run(run_id)
+            .await
+            .map_err(|e| e.to_string())?
+            .ok_or_else(|| format!("Run not found: {run_id}"))?;
+        if run.kind != "ssh_direct"
+            || run.status != wisp_store::RunStatus::Succeeded
+            || run.cleaned_at.is_some()
+            || run.remote_workdir.is_none()
+        {
+            return Ok(false);
+        }
+        if store
+            .run_review_dismissed(run_id)
+            .await
+            .map_err(|e| e.to_string())?
+        {
+            return Ok(false);
+        }
+        let has_output_specs = !matches!(run.output_specs_json.trim(), "" | "[]");
+        if has_output_specs {
+            // Harvest already registered the declared products locally; the
+            // remaining cleanup decision is not worth an interruption. An
+            // unharvested Run means results only exist on the server.
+            return Ok(run.harvested_at.is_none());
+        }
+        // No declared products: interrupt only when the workspace actually
+        // holds files to review. Listing errors (host unreachable) suppress
+        // the prompt rather than surfacing a modal that cannot browse.
+        let listing = self
+            .list_run_workspace_files(store, run_id, "", "", 0, 1)
+            .await?;
+        Ok(!listing.entries.is_empty())
+    }
+
     /// One page of one directory level of a finished Run's server workspace.
     /// Ephemeral data — nothing here is persisted.
     pub async fn list_run_workspace_files(

--- a/src-tauri/src/run_context/tests.rs
+++ b/src-tauri/src/run_context/tests.rs
@@ -4154,6 +4154,130 @@ async fn run_review_browse_and_delete_require_a_terminal_ssh_run() {
     let _ = std::fs::remove_dir_all(&tmp);
 }
 
+#[tokio::test]
+async fn review_prompt_reserved_for_unresolved_product_decisions() {
+    let tmp = std::env::temp_dir().join(format!("wisp_review_prompt_{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&tmp).unwrap();
+    let store = wisp_store::Store::open(&tmp.join("wisp.sqlite"))
+        .await
+        .unwrap();
+    store
+        .create_project("p", "proj", &tmp.to_string_lossy())
+        .await
+        .unwrap();
+    store.create_frame("f", "p", "OPERON", "m").await.unwrap();
+    store
+        .upsert_execution_context(&harvest_test_context())
+        .await
+        .unwrap();
+
+    let specs = r#"[{"glob":"results/*.tsv","kind":"table"}]"#;
+    seed_cleanup_run(
+        &store,
+        "run-unharvested",
+        wisp_store::RunStatus::Succeeded,
+        specs,
+        false,
+    )
+    .await;
+    seed_cleanup_run(
+        &store,
+        "run-harvested",
+        wisp_store::RunStatus::Succeeded,
+        specs,
+        true,
+    )
+    .await;
+    seed_cleanup_run(
+        &store,
+        "run-active",
+        wisp_store::RunStatus::Running,
+        "[]",
+        false,
+    )
+    .await;
+    seed_cleanup_run(
+        &store,
+        "run-files",
+        wisp_store::RunStatus::Succeeded,
+        "[]",
+        false,
+    )
+    .await;
+    seed_cleanup_run(
+        &store,
+        "run-empty",
+        wisp_store::RunStatus::Succeeded,
+        "[]",
+        false,
+    )
+    .await;
+
+    let runner = Arc::new(ScriptedRunRunner::new(vec![
+        ok_output("__WISP_LS__:file:1024::out.tsv\n__WISP_LS_DONE__\n"),
+        ok_output("__WISP_LS_DONE__\n"),
+    ]));
+    let manager = RunManager::with_runner(runner.clone());
+
+    // Declared outputs never harvested: results only exist on the server, so
+    // the prompt is warranted — decided from the record alone, no SSH call.
+    assert!(manager
+        .should_prompt_run_review(&store, "run-unharvested")
+        .await
+        .unwrap());
+    // Harvested products are already local; the leftover cleanup decision is
+    // not worth an interruption.
+    assert!(!manager
+        .should_prompt_run_review(&store, "run-harvested")
+        .await
+        .unwrap());
+    // Non-terminal runs never prompt.
+    assert!(!manager
+        .should_prompt_run_review(&store, "run-active")
+        .await
+        .unwrap());
+    assert_eq!(runner.commands.lock().unwrap().len(), 0);
+
+    // No declared outputs: the workspace listing decides. Files present →
+    // prompt; empty workspace → stay silent.
+    assert!(manager
+        .should_prompt_run_review(&store, "run-files")
+        .await
+        .unwrap());
+    assert!(!manager
+        .should_prompt_run_review(&store, "run-empty")
+        .await
+        .unwrap());
+    assert_eq!(runner.commands.lock().unwrap().len(), 2);
+
+    // A dismissed prompt stays dismissed, and dismissal is idempotent.
+    assert!(store
+        .mark_run_review_dismissed("run-unharvested")
+        .await
+        .unwrap());
+    assert!(!store
+        .mark_run_review_dismissed("run-unharvested")
+        .await
+        .unwrap());
+    assert!(store.run_review_dismissed("run-unharvested").await.unwrap());
+    assert!(!manager
+        .should_prompt_run_review(&store, "run-unharvested")
+        .await
+        .unwrap());
+
+    // Exploratory local command runs are out of scope regardless of state.
+    let mut local = wisp_store::RunRecord::new("run-local", "p", "local", "Local", "command");
+    local.frame_id = Some("f".into());
+    local.status = wisp_store::RunStatus::Succeeded;
+    store.create_run(&local).await.unwrap();
+    assert!(!manager
+        .should_prompt_run_review(&store, "run-local")
+        .await
+        .unwrap());
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
 // --- retention sweep ---------------------------------------------------------
 
 async fn seed_retention_run(

--- a/src-tauri/src/runtime_commands.rs
+++ b/src-tauri/src/runtime_commands.rs
@@ -524,6 +524,40 @@ pub(super) async fn download_run_files(
         .await
 }
 
+/// Whether the results-review modal is worth auto-opening for this Run: an
+/// unresolved product decision exists (unharvested declared outputs, or no
+/// declared outputs but files present in the workspace) and the user has not
+/// dismissed the prompt. The UI asks this once per candidate at turn end.
+#[tauri::command]
+pub(super) async fn should_prompt_run_review(
+    state: State<'_, AppState>,
+    window: tauri::WebviewWindow,
+    run_id: String,
+) -> Result<bool, String> {
+    scoped_run(&state, &window, &run_id).await?;
+    state
+        .run_manager
+        .should_prompt_run_review(&state.store, &run_id)
+        .await
+}
+
+/// Persist that the user closed this Run's results-review prompt so it never
+/// auto-opens again. Manual review from the run card stays available.
+#[tauri::command]
+pub(super) async fn dismiss_run_review(
+    state: State<'_, AppState>,
+    window: tauri::WebviewWindow,
+    run_id: String,
+) -> Result<(), String> {
+    scoped_run(&state, &window, &run_id).await?;
+    state
+        .store
+        .mark_run_review_dismissed(&run_id)
+        .await
+        .map(|_| ())
+        .map_err(|e| e.to_string())
+}
+
 /// Delete the user's selection inside a finished Run's workspace.
 #[tauri::command]
 pub(super) async fn delete_run_files(

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -1237,6 +1237,7 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
       ],
     },
   };
+  const runReviewDismissed = new Set<string>();
   let defaultExecutionContext: string | null = null;
   let runtimeInfos: any[] = [
     {
@@ -1379,6 +1380,20 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
     });
   }
   (window as any).__mockRuns = runs;
+  (window as any).__mockRunWorkspaceFiles = runWorkspaceFiles;
+  // Finish a pending MONITORRUN turn without changing the run's state: the
+  // test drives the run's status itself, then ends the turn to observe the
+  // deferred review prompt.
+  (window as any).__finishMonitorRun = () => {
+    if (!monitorRunFrameId) return;
+    const frameId = monitorRunFrameId;
+    const run = runs.find((item) => item.id === "run-local-002");
+    emit("agent", { kind: "ToolResult", frame_id: frameId, name: "monitor_run", ok: true, content: JSON.stringify(run) });
+    emit("agent", { kind: "Done", frame_id: frameId, stop_reason: "end_turn" });
+    resolveMonitorRun?.(frameId);
+    resolveMonitorRun = null;
+    monitorRunFrameId = null;
+  };
   const mockMethodSearchDetails = () => ({
     run: runs.find((item) => item.id === "method-search-001"),
     state: {
@@ -3310,6 +3325,26 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
             for (const p of paths) delete levels[p];
             return null;
           }
+          case "should_prompt_run_review": {
+            const runId = String(arg("runId") ?? "");
+            const run = runs.find((item) => item.id === runId);
+            if (!run) throw new Error("Run not found");
+            if (
+              run.kind !== "ssh_direct" ||
+              run.status !== "succeeded" ||
+              run.cleaned_at ||
+              runReviewDismissed.has(runId)
+            ) {
+              return false;
+            }
+            const specs = JSON.parse(String(run.output_specs_json ?? "[]"));
+            if (Array.isArray(specs) && specs.length > 0) return !run.harvested_at;
+            return ((runWorkspaceFiles[runId] ?? {})[""] ?? []).length > 0;
+          }
+          case "dismiss_run_review": {
+            runReviewDismissed.add(String(arg("runId") ?? ""));
+            return null;
+          }
           case "cleanup_run_workspace": {
             const run = runs.find((item) => item.id === String(arg("runId") ?? ""));
             if (!run) throw new Error("Run not found");
@@ -4614,6 +4649,10 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
               return await new Promise<string>((resolve) => {
                 monitorRunFrameId = fid;
                 resolveMonitorRun = resolve;
+                // The monitored run belongs to the session that submitted it,
+                // like the real backend records frame_id at submission.
+                const monitored = runs.find((item) => item.id === "run-local-002");
+                if (monitored) monitored.frame_id = fid;
                 setTimeout(() => {
                   emit("agent", { kind: "User", frame_id: fid, text: msg });
                   emit("agent", { kind: "Reasoning", frame_id: fid, delta: "Attach the existing Run monitor." });

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -6203,6 +6203,98 @@ test("monitor_run renders a live Run card from summary polls and on-demand detai
   await expect(card).toHaveCount(0);
 });
 
+test("review prompt waits for turn end and dismissal persists (#897)", async ({ page }) => {
+  await enterApp(page);
+  await page.evaluate(() => {
+    const run = (window as any).__mockRuns.find((item: any) => item.id === "run-local-002");
+    Object.assign(run, {
+      context_id: "ssh:gpu-server",
+      title: "Genome assembly",
+      kind: "ssh_direct",
+      status: "running",
+      created_at: Math.floor(Date.now() / 1000) - 300,
+      started_at: Math.floor(Date.now() / 1000) - 295,
+      remote_workdir: "~/.wisp-science/runs/run-local-002",
+      remote_handle_json: '{"kind":"ssh_direct"}',
+      progress_json: "{}",
+    });
+    (window as any).__mockRunWorkspaceFiles["run-local-002"] = {
+      "": [{ path: "assembly.fasta", kind: "file", size_bytes: 4096, file_count: null }],
+    };
+  });
+
+  await composer(page).fill("MONITORRUN");
+  await page.getByRole("button", { name: "Send" }).click();
+  const card = page.getByTestId("run-monitor-card");
+  await expect(card).toBeVisible();
+
+  // The run succeeds while the turn is still working: no interruption yet.
+  await page.evaluate(() => {
+    const run = (window as any).__mockRuns.find((item: any) => item.id === "run-local-002");
+    Object.assign(run, {
+      status: "succeeded",
+      ended_at: Math.floor(Date.now() / 1000),
+      exit_code: 0,
+    });
+  });
+  await expect(card).toContainText("Succeeded", { timeout: 7_000 });
+  const review = page.getByTestId("run-review-modal");
+  await expect(review).toHaveCount(0);
+
+  // Turn ends: the prompt opens for the unresolved server-side files.
+  await page.evaluate(() => (window as any).__finishMonitorRun());
+  await expect(review).toBeVisible({ timeout: 7_000 });
+  await expect(review).toContainText("assembly.fasta");
+
+  // Escape immediately: one press closes the prompt and persists the
+  // dismissal so this run never auto-prompts again.
+  await page.keyboard.press("Escape");
+  await expect(review).toHaveCount(0);
+  await expect.poll(() => lastInvokeArgs(page, "dismiss_run_review")).toMatchObject({
+    runId: "run-local-002",
+  });
+});
+
+test("unmonitored exploratory run success never auto-opens the review prompt (#897)", async ({ page }) => {
+  await page.goto("/");
+  await page.evaluate(() => {
+    const now = Math.floor(Date.now() / 1000);
+    const run = (window as any).__mockRuns.find((item: any) => item.id === "run-local-002");
+    Object.assign(run, {
+      frame_id: "s-complete",
+      context_id: "ssh:gpu-server",
+      title: "Quick check",
+      kind: "ssh_direct",
+      status: "running",
+      created_at: now - 30,
+      started_at: now - 29,
+      remote_workdir: "~/.wisp-science/runs/run-local-002",
+      remote_handle_json: '{"kind":"ssh_direct"}',
+    });
+    (window as any).__mockRunWorkspaceFiles["run-local-002"] = {
+      "": [{ path: "notes.txt", kind: "file", size_bytes: 128, file_count: null }],
+    };
+  });
+
+  await page.getByTestId("recent-session-card").nth(1).click();
+  const automatic = page.getByTestId("auto-run-monitor");
+  await expect(automatic).toBeVisible();
+
+  await page.evaluate(() => {
+    const run = (window as any).__mockRuns.find((item: any) => item.id === "run-local-002");
+    Object.assign(run, {
+      status: "succeeded",
+      ended_at: Math.floor(Date.now() / 1000),
+      exit_code: 0,
+    });
+  });
+  await expect(automatic).toContainText("Succeeded", { timeout: 7_000 });
+  // Exploratory command runs never nominate themselves for review, even with
+  // files present and the session idle: cleanup stays on the manual entry
+  // points and retention.
+  await expect(page.getByTestId("run-review-modal")).toHaveCount(0);
+});
+
 test("run monitor output stays pinned to the tail across poll rebuilds (#654)", async ({ page }) => {
   // Eight long logical lines wrap far past the 150px pre, so it scrolls.
   const longOutput = (tag: string) =>

--- a/ui/src/chat_render.rs
+++ b/ui/src/chat_render.rs
@@ -1057,6 +1057,11 @@ pub(crate) fn RunMonitorCard(
     tool_ok: Option<bool>,
     tool_output: String,
     dismissed_runs: RwSignal<HashSet<String>>,
+    /// Only foreground `monitor_run` cards nominate their Run for the
+    /// results-review prompt. AutoRun cards cover exploratory command Runs,
+    /// which must never interrupt with a review modal (#897).
+    #[prop(optional)]
+    auto_review: bool,
 ) -> impl IntoView {
     let locale = use_locale();
     let fallback = serde_json::from_str::<RunRecord>(&tool_output).ok();
@@ -1113,11 +1118,18 @@ pub(crate) fn RunMonitorCard(
     // body every few seconds, which would snap a native `<details>` shut while
     // the user is reading it.
     let env_open = create_rw_signal(false);
-    // When a foreground-monitored SSH Run finishes successfully in this
-    // session, open the results-review modal once so the user can pick what to
-    // download and what to delete from the server.
+    // Manual entry point: the review button on the card opens the modal
+    // directly, for any card.
     let review_modal = use_context::<crate::overlays::RunReviewModal>().map(|modal| modal.0);
-    if let Some(review_modal) = review_modal {
+    // When a foreground-monitored SSH Run finishes successfully in this
+    // session, nominate it for the results-review prompt. The root drains the
+    // queue once the session goes idle and asks the backend whether the Run
+    // has an unresolved product decision before opening the modal, so work in
+    // progress is never interrupted and empty workspaces never prompt (#897).
+    let review_queue = auto_review
+        .then(|| use_context::<crate::overlays::PendingRunReviews>().map(|queue| queue.0))
+        .flatten();
+    if let Some(review_queue) = review_queue {
         let prompted = Rc::new(Cell::new(false));
         create_effect(move |previous: Option<Option<String>>| {
             let Some(run) = selected_run.get() else {
@@ -1135,7 +1147,11 @@ pub(crate) fn RunMonitorCard(
                 && !prompted.get()
             {
                 prompted.set(true);
-                review_modal.set(Some(run.id.clone()));
+                review_queue.update(|ids| {
+                    if !ids.contains(&run.id) {
+                        ids.push(run.id.clone());
+                    }
+                });
             }
             Some(status)
         });
@@ -1502,6 +1518,7 @@ pub(crate) fn render_item(
                 tool_ok=*ok
                 tool_output=output.clone()
                 dismissed_runs=dismissed_runs
+                auto_review=true
             />
         }.into_view(),
         ChatItem::Tool { name, ok, input, output, .. } if is_image_generation_tool(name) => view! {

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -6584,6 +6584,64 @@ fn App() -> impl IntoView {
     let storage_prefs_form = create_rw_signal(None::<StoragePrefsForm>);
     let run_review_modal = create_rw_signal(None::<String>);
     provide_context(RunReviewModal(run_review_modal));
+    // Deferred results-review prompting (#897): monitored run cards nominate
+    // candidates here; this root effect waits until the owning session is
+    // idle, asks the backend whether each candidate has an unresolved product
+    // decision, and opens the modal for the newest one that does. Exploratory
+    // command runs never enter the queue, and dismissed or empty workspaces
+    // never prompt.
+    let pending_run_reviews = create_rw_signal(Vec::<String>::new());
+    provide_context(crate::overlays::PendingRunReviews(pending_run_reviews));
+    create_effect(move |_| {
+        if run_review_modal.get().is_some() {
+            return;
+        }
+        let running_now = running.get();
+        let ready: Vec<String> = pending_run_reviews.with(|ids| {
+            ids.iter()
+                .filter(|id| {
+                    run_records.with(|runs| {
+                        runs.iter()
+                            .find(|run| run.id == **id)
+                            .and_then(|run| run.frame_id.clone())
+                            .is_none_or(|frame| !running_now.contains(&frame))
+                    })
+                })
+                .cloned()
+                .collect()
+        });
+        if ready.is_empty() {
+            return;
+        }
+        pending_run_reviews.update(|ids| ids.retain(|id| !ready.contains(id)));
+        spawn_local(async move {
+            for id in ready.iter().rev() {
+                let args = to_value(&serde_json::json!({ "runId": id })).unwrap();
+                match invoke_checked("should_prompt_run_review", args).await {
+                    Ok(value) if value.as_bool() == Some(true) => {
+                        run_review_modal.set(Some(id.clone()));
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+        });
+    });
+    // Closing the review modal (X, Escape, or after cleanup) persists the
+    // dismissal so this run never auto-prompts again; the manual entry points
+    // on run cards and the runs panel stay available.
+    create_effect(move |previous: Option<Option<String>>| {
+        let current = run_review_modal.get();
+        if let Some(Some(previous_id)) = previous {
+            if current.as_deref() != Some(previous_id.as_str()) {
+                spawn_local(async move {
+                    let args = to_value(&serde_json::json!({ "runId": previous_id })).unwrap();
+                    let _ = invoke_checked("dismiss_run_review", args).await;
+                });
+            }
+        }
+        current
+    });
     let runtime_environment = create_rw_signal(None::<RuntimeSlot>);
     let runtime_environment_pinned = create_rw_signal(false);
     let runtime_environment_position = create_rw_signal((16, 16));

--- a/ui/src/overlays.rs
+++ b/ui/src/overlays.rs
@@ -613,6 +613,14 @@ pub(super) fn RuntimeInterpreterOverlay(
 #[derive(Clone, Copy)]
 pub(crate) struct RunReviewModal(pub(crate) RwSignal<Option<String>>);
 
+/// Run ids whose foreground-monitored success is awaiting a review prompt.
+/// Cards push candidates here while the turn is still running; the root
+/// drains the queue once the owning session goes idle, asks the backend
+/// whether each Run has an unresolved product decision, and only then opens
+/// the modal — never mid-work (#897).
+#[derive(Clone, Copy)]
+pub(crate) struct PendingRunReviews(pub(crate) RwSignal<Vec<String>>);
+
 fn run_review_subtitle_label(title: Option<&str>, run_id: &str) -> (String, bool) {
     if let Some(title) = title.map(str::trim).filter(|title| !title.is_empty()) {
         (title.to_string(), false)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题

Fixes #897。

SSH 远程工作时"任务结果与清理"弹窗反复出现:自动弹出绑定在**每条** `ssh_direct` run 的成功事件上,而 SSH 上下文中每条命令(包括探索型的快速命令)都是一条独立 run;AutoRun 卡片和 `monitor_run` 卡片共用同一组件,导致本应只对"前台监控的投递型长任务"生效的自动弹窗(PR 5 / `ec3ececa` 声明的意图)扩散到了所有 run。叠加"关闭不持久化"与"弹出条件不看有无文件",一个正常工作会话会被弹十几次,且常见"这里没有文件"的空弹窗。

## 方案

触发语义重构为:**只有投递任务型 run,在回合结束时,存在未决产物问题,且未被用户关闭过,才自动弹出。**

- **L1 触发源收窄**:`RunMonitorCard` 新增 `auto_review` prop(默认 false),只有 `monitor_run` 工具行卡片传 true;AutoRun 卡片(探索型命令 run)永不提名。
- **L2 回合结束才弹**:卡片不再直接开 modal,而是把 run id 推入根级 `PendingRunReviews` 队列;根级 effect 等 run 所属会话退出 `running` 集合后才逐个评估,工作中的回合永不被打断。
- **后端谓词** `should_prompt_run_review`(新 Tauri 命令):`ssh_direct` + `succeeded` + 未清理 + 未 dismiss,且——已声明 `output_specs` 但 harvest 未完成(数据滞留服务器,必须提示);或未声明 specs 且工作目录探测非空(一次单行 listing)。specs 已 harvest 的 run 产物已在本地,不打断;探测失败(主机不可达)静默不弹。
- **关闭持久化**:新迁移 `0052_run_review_dismissed` 给 runs 表加 `review_dismissed_at`(幂等、向后兼容);modal 任意方式关闭(X/Escape/清理完成)都经 `dismiss_run_review` 落库,该 run 此后永不自动弹。手动入口(run 卡片按钮、Runs 面板)完全不受影响。

## 变更文件

- `crates/wisp-store/src/lib.rs`:迁移 0052 + `ensure_schema_compat` 列清单
- `crates/wisp-store/src/runs.rs`:`mark_run_review_dismissed` / `run_review_dismissed`
- `src-tauri/src/run_context.rs`:`RunManager::should_prompt_run_review` 谓词
- `src-tauri/src/runtime_commands.rs` + `lib.rs`:`should_prompt_run_review`、`dismiss_run_review` 命令
- `ui/src/overlays.rs`:`PendingRunReviews` 根级队列 context
- `ui/src/chat_render.rs`:`auto_review` prop;成功转移改为提名入队
- `ui/src/main.rs`:回合结束 drain effect + 关闭持久化 effect
- `ui-tests/tests/mock-tauri.ts` / `ui.spec.ts`:mock 两个新命令 + `__finishMonitorRun` 钩子 + 两个新用例
- `docs/superpowers/plans/2026-08-14-server-task-loop-closure.md`:触发语义修订注记

## 测试

- Rust:`review_prompt_reserved_for_unresolved_product_decisions`(fake runner,覆盖 harvest 未完成/已完成、无 specs 空目录/非空目录、dismiss 幂等、非终态、非 ssh_direct 共 8 种分支,并断言 SSH 调用次数)
- Playwright:`review prompt waits for turn end and dismissal persists (#897)`(run 在回合中成功不弹 → 回合结束弹 → Escape 立即按下只关弹窗并落库 dismiss);`unmonitored exploratory run success never auto-opens the review prompt (#897)`(AutoRun 卡片 + 空闲会话 + 有文件也不弹)
- 既有相关用例回归通过:run review modal 手动流程、monitor_run 卡片、AutoRun #593/#663、cleanup、#654

## 手动冒烟

1. SSH 上下文让 agent 连续执行若干短命令(探索型):工作全程无弹窗。
2. 投递一个声明了 `output_specs` 的长任务并 `monitor_run`,等待成功:harvest 成功则回合结束无弹窗(run 卡片手动按钮仍可开);人为使 harvest 失败则回合结束弹出。
3. 关闭弹窗后重启应用、再次进入会话:不再自动弹出。

## 已知限制与后续

- 探索型 run 的服务器 workdir 仍靠 retention 扫描/模型 `cleanup_run_workspace` 回收;"回合结束静默回收空脚手架目录"(讨论中的 L3)留作后续 PR。
- 一回合内多个监控 run 都有未决产物时只弹最新一条,其余保留手动入口(未 dismiss)。
- review 列表仍只扫 `inputs/`,不含 workdir 根的日志文件;扩大扫描范围留作后续。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-434e51ee-2818-48eb-9743-de07c9bb316a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-434e51ee-2818-48eb-9743-de07c9bb316a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

