### PR TITLE
fix(browser): close ChatGPT host spoofing and project path traversal

### DIFF
--- a/browser-extension/background.js
+++ b/browser-extension/background.js
@@ -307,8 +307,22 @@ async function runChatgpt(tabId, method, payload) {
   return injected[0] && injected[0].result;
 }
 
+function isControlCommand(command) {
+  return typeof command === "object" && command !== null && command.cmd === "control";
+}
+
 async function handleRequest(request) {
-  if (paused && !(request.op === "control" || (typeof request.code === "string" && request.code.indexOf('"cmd":"control"') >= 0))) {
+  var parsed = parseIncomingRequest(request);
+  var command;
+  if (parsed.kind === "v2") {
+    if (parsed.op === "eval") command = parsed.payload && parsed.payload.code != null ? parsed.payload.code : parsed.payload;
+    else command = Object.assign({ cmd: parsed.op }, parsed.payload || {});
+    if (parsed.wait) command.wait = parsed.wait;
+  } else {
+    command = parseCommand(request.code);
+  }
+
+  if (paused && !isControlCommand(command)) {
     send({
       type: "error",
       id: request.id,
@@ -323,16 +337,6 @@ async function handleRequest(request) {
   var deadline = requestDeadline(request);
   var waitMeta = null;
   try {
-    var parsed = parseIncomingRequest(request);
-    var command;
-    if (parsed.kind === "v2") {
-      if (parsed.op === "eval") command = parsed.payload && parsed.payload.code != null ? parsed.payload.code : parsed.payload;
-      else command = Object.assign({ cmd: parsed.op }, parsed.payload || {});
-      if (parsed.wait) command.wait = parsed.wait;
-    } else {
-      command = parseCommand(request.code);
-    }
-
     if (request.tabId && !isTabCloseCommand(command) && !(typeof command === "object" && command.cmd === "wait")) {
       var spec = (typeof command === "object" && command.wait) || { until: "complete" };
       waitMeta = await waitEngine.waitFor(request.tabId, spec, deadline);

--- a/docs/browser-runtime-architecture.md
+++ b/docs/browser-runtime-architecture.md
@@ -40,3 +40,16 @@ The extension never writes project directories and never returns large base64 fi
 - ChatGPT one-shot send/wait/read on an already-logged-in tab
 
 Playwright is not used. The user's daily Chrome User Data directory is never passed as `--user-data-dir`.
+
+## Safety checks
+
+- `web_agent_*` accepts only tabs whose parsed URL host is exactly
+  `chatgpt.com` / `chat.openai.com` (optionally `www.`) over HTTPS. Lookalike
+  hosts such as `chatgpt.com.evil.com` are rejected before any prompt is
+  filled.
+- `web_save_assets` `dest_dir` and `web_screenshot` `save_path` must be
+  project-relative: absolute paths and `..` segments are rejected, so tool
+  arguments cannot write outside the project root.
+- The extension's pause gate parses each incoming command and lets only
+  `cmd:"control"` through while paused; it never sniffs the raw request
+  string.

--- a/src-tauri/src/browser_bridge/mod.rs
+++ b/src-tauri/src/browser_bridge/mod.rs
@@ -1203,9 +1203,43 @@ fn render_json(value: &Value) -> String {
     clipped
 }
 
+/// Exact-host check so `https://chatgpt.com.evil.com/` or a `chatgpt.com`
+/// substring in the path/query never passes as an official ChatGPT tab.
 fn is_chatgpt_url(url: &str) -> bool {
-    let lower = url.to_ascii_lowercase();
-    lower.contains("chatgpt.com") || lower.contains("chat.openai.com")
+    let Ok(parsed) = url::Url::parse(url) else {
+        return false;
+    };
+    if parsed.scheme() != "https" {
+        return false;
+    }
+    let Some(host) = parsed.host_str() else {
+        return false;
+    };
+    let host = host.to_ascii_lowercase();
+    let host = host.strip_prefix("www.").unwrap_or(&host);
+    matches!(host, "chatgpt.com" | "chat.openai.com")
+}
+
+/// Resolve a user-supplied project-relative path. Rejects absolute paths and
+/// any `..`/prefix component, so tool arguments cannot escape the project
+/// root ("path traversal").
+fn project_relative_path(root: &Path, rel: &str) -> Result<PathBuf, String> {
+    use std::path::Component;
+    let trimmed = rel.trim();
+    if trimmed.is_empty() {
+        return Err("path must be a non-empty project-relative path".into());
+    }
+    let path = Path::new(trimmed);
+    let inside_root = !path.is_absolute()
+        && path
+            .components()
+            .all(|part| matches!(part, Component::Normal(_) | Component::CurDir));
+    if !inside_root {
+        return Err(format!(
+            "path must stay inside the project (no absolute paths or '..' segments): {trimmed}"
+        ));
+    }
+    Ok(root.join(path))
 }
 
 fn chatgpt_tab_error(tabs: &[BrowserTab], requested: Option<i64>) -> Result<i64, String> {
@@ -1770,8 +1804,11 @@ impl Tool for WebScreenshotTool {
                     Ok(bytes) => bytes,
                     Err(error) => return ToolResult::fail(format!("decode screenshot: {error}")),
                 };
-            let target = match save_path {
-                Some(rel) if !rel.trim().is_empty() => env.project_root().join(rel),
+            let target = match save_path.map(str::trim).filter(|rel| !rel.is_empty()) {
+                Some(rel) => match project_relative_path(env.project_root(), rel) {
+                    Ok(path) => path,
+                    Err(error) => return ToolResult::fail(format!("save_path: {error}")),
+                },
                 _ => {
                     let dir = env
                         .project_root()
@@ -1881,7 +1918,10 @@ impl Tool for WebSaveAssetsTool {
             .get("dest_dir")
             .and_then(Value::as_str)
             .unwrap_or("browser-assets");
-        let dest = env.project_root().join(dest_rel);
+        let dest = match project_relative_path(env.project_root(), dest_rel) {
+            Ok(dest) => dest,
+            Err(error) => return ToolResult::fail(format!("dest_dir: {error}")),
+        };
         if let Err(error) = std::fs::create_dir_all(&dest) {
             return ToolResult::fail(format!("create dest dir: {error}"));
         }
@@ -2873,8 +2913,47 @@ mod tests {
     #[test]
     fn chatgpt_url_helper_accepts_official_hosts_only() {
         assert!(is_chatgpt_url("https://chatgpt.com/"));
+        assert!(is_chatgpt_url("https://www.chatgpt.com/"));
         assert!(is_chatgpt_url("https://chat.openai.com/c/abc"));
+        assert!(is_chatgpt_url("https://CHATGPT.com/c/abc"));
         assert!(!is_chatgpt_url("https://example.com/chatgpt"));
+        // Host suffix/lookalike bypasses must fail: web_agent_* would otherwise
+        // fill prompts into a phishing page.
+        assert!(!is_chatgpt_url("https://chatgpt.com.evil.com/"));
+        assert!(!is_chatgpt_url("https://evilchatgpt.com/"));
+        assert!(!is_chatgpt_url("https://evil.com/?next=chatgpt.com"));
+        assert!(!is_chatgpt_url("https://evil.com/chat.openai.com"));
+        assert!(!is_chatgpt_url("http://chatgpt.com/"));
+        assert!(!is_chatgpt_url("javascript:alert('chatgpt.com')"));
+        assert!(!is_chatgpt_url("not a url chatgpt.com"));
+    }
+
+    #[test]
+    fn project_relative_path_rejects_traversal_and_absolute_paths() {
+        let root = Path::new("/project");
+        assert_eq!(
+            project_relative_path(root, "browser-assets/shot.png").unwrap(),
+            root.join("browser-assets/shot.png")
+        );
+        assert_eq!(
+            project_relative_path(root, "./figures/a.png").unwrap(),
+            root.join("./figures/a.png")
+        );
+        assert!(project_relative_path(root, "../outside.png").is_err());
+        assert!(project_relative_path(root, "a/../../outside.png").is_err());
+        assert!(project_relative_path(root, "/etc/passwd").is_err());
+        assert!(project_relative_path(root, "").is_err());
+        assert!(project_relative_path(root, "   ").is_err());
+    }
+
+    #[test]
+    fn paused_check_parses_the_command_instead_of_sniffing_the_raw_string() {
+        let background_js = std::fs::read_to_string(
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../browser-extension/background.js"),
+        )
+        .unwrap();
+        assert!(!background_js.contains("indexOf('\"cmd\":\"control\"')"));
+        assert!(background_js.contains("isControlCommand(command)"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The Browser Runtime merged in [PR #926](https://github.com/xuzhougeng/wisp-science/pull/926) shipped with two security issues and one fragile enforcement path flagged in review:

1. **ChatGPT host spoofing** — `is_chatgpt_url` used `contains("chatgpt.com")`, so `https://chatgpt.com.evil.com/` (or `chatgpt.com` anywhere in a path/query) passed as an official tab, and `web_agent_*` would fill prompts into a phishing page.
2. **Path traversal** — `web_save_assets` `dest_dir` and `web_screenshot` `save_path` were joined onto the project root unchecked; `../../` escaped the project and wrote arbitrary files.
3. **Pause gate string sniffing** — `background.js` allowed requests through the paused state by searching the raw request string for `'"cmd":"control"'`; any serialization change would break enforcement.

## Changes

- `src-tauri/src/browser_bridge/mod.rs`
  - `is_chatgpt_url` parses with `url::Url` and compares the host exactly: HTTPS only, `chatgpt.com` / `chat.openai.com` with an optional `www.` prefix.
  - New `project_relative_path(root, rel)` helper rejects absolute paths and any `..`/prefix component (covers Windows drive prefixes and root-relative paths); applied to `web_save_assets.dest_dir` and `web_screenshot.save_path`.
- `browser-extension/background.js` — `handleRequest` parses the incoming request first, then gates on the parsed `cmd === "control"` via `isControlCommand`; the raw-string sniff is gone.
- `docs/browser-runtime-architecture.md` — new "Safety checks" section.

## Tests

- `chatgpt_url_helper_accepts_official_hosts_only` extended with the spoofing bypasses (`chatgpt.com.evil.com`, `evilchatgpt.com`, query/path lookalikes, `http:`, `javascript:`).
- New `project_relative_path_rejects_traversal_and_absolute_paths`.
- New source-contract test `paused_check_parses_the_command_instead_of_sniffing_the_raw_string` (same style as `article_scan_is_not_inlined_in_the_legacy_scan_script`).
- Full suite: `cargo fmt --all -- --check`, `cargo test --workspace` (all green), `node --test browser-extension/*.test.mjs` (13/13 pass).

## Manual smoke steps

- With the extension paused from the popup, send `web_scan` → expect `USER_CONTROLLING`; resume from the popup → works again.
- `web_screenshot` with `save_path: "../outside.png"` → fails with a project-relative-path error; `save_path: "figures/a.png"` → writes inside the project.
- Open a non-ChatGPT tab and call `web_agent_send` → rejected as not a chatgpt.com tab.

## Known limitations / follow-ups

- The `project_relative_path` check is lexical (no symlink resolution); a symlink already inside the project could still point outside it.
- Review items not in scope here: workspace Chrome process handling (`std::mem::forget(child)` / pid-based `taskkill`) and the ~180-line over-engineering cleanup list.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5d95e4c1-e0b2-4f22-9d57-10fec9d7d2c3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5d95e4c1-e0b2-4f22-9d57-10fec9d7d2c3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

