### PR TITLE
feat(mcp): support MCP Apps App→Server tool calls (serverTools / tools/call, #773)

### DIFF
--- a/crates/wisp-cli/src/main.rs
+++ b/crates/wisp-cli/src/main.rs
@@ -583,7 +583,12 @@ impl<W: Write + Send> Output for JsonlOutput<W> {
         self.emit(serde_json::json!({"type": "stdout", "chunk": chunk}));
     }
 
-    fn tool_presentation(&self, kind: &str, payload: &serde_json::Value) {
+    fn tool_presentation(
+        &self,
+        kind: &str,
+        payload: &serde_json::Value,
+        _server: Option<std::sync::Arc<dyn wisp_tools::McpAppServer>>,
+    ) {
         self.emit(serde_json::json!({
             "type": "tool_presentation",
             "kind": kind,

--- a/crates/wisp-cli/src/rpc.rs
+++ b/crates/wisp-cli/src/rpc.rs
@@ -238,7 +238,12 @@ impl<W: Write + Send> Output for RpcOutput<W> {
         self.emit(json!({"type": "stdout", "chunk": chunk}));
     }
 
-    fn tool_presentation(&self, kind: &str, payload: &Value) {
+    fn tool_presentation(
+        &self,
+        kind: &str,
+        payload: &Value,
+        _server: Option<std::sync::Arc<dyn wisp_tools::McpAppServer>>,
+    ) {
         self.emit(json!({"type": "tool_presentation", "kind": kind, "payload": payload}));
     }
 

--- a/crates/wisp-core/src/output.rs
+++ b/crates/wisp-core/src/output.rs
@@ -39,7 +39,13 @@ pub trait Output: Send + Sync {
     fn diff(&self, _path: &str, _old: &str, _new: &str) {}
     fn file_changed(&self, _path: &str) {}
     fn stdout_chunk(&self, _chunk: &str) {}
-    fn tool_presentation(&self, _kind: &str, _payload: &Value) {}
+    fn tool_presentation(
+        &self,
+        _kind: &str,
+        _payload: &Value,
+        _server: Option<std::sync::Arc<dyn wisp_tools::McpAppServer>>,
+    ) {
+    }
     /// Blocking confirmation prompt for destructive actions.
     fn confirm(&self, _message: &str) -> bool {
         true
@@ -230,8 +236,8 @@ impl<'a> wisp_tools::ToolEnv for ToolEnvAdapter<'a> {
             wisp_tools::ToolEvent::Diff { path, old, new } => self.out.diff(&path, &old, &new),
             wisp_tools::ToolEvent::FileChanged { path } => self.out.file_changed(&path),
             wisp_tools::ToolEvent::Stdout { chunk } => self.out.stdout_chunk(&chunk),
-            wisp_tools::ToolEvent::Presentation { kind, payload } => {
-                self.out.tool_presentation(&kind, &payload)
+            wisp_tools::ToolEvent::Presentation { kind, payload, server } => {
+                self.out.tool_presentation(&kind, &payload, server)
             }
             wisp_tools::ToolEvent::Result { ok: _ } => {}
         }

--- a/crates/wisp-mcp/src/client.rs
+++ b/crates/wisp-mcp/src/client.rs
@@ -79,6 +79,34 @@ impl RemoteTool {
             .and_then(Value::as_array)
             .is_none_or(|visibility| visibility.iter().any(|item| item.as_str() == Some("model")))
     }
+
+    /// Whether a legitimate MCP App instance of this tool may call it. The
+    /// spec defaults unset `_meta.ui.visibility` to `["model", "app"]`, so
+    /// only an explicit visibility that omits `"app"` hides it from apps.
+    pub fn visible_to_app(&self) -> bool {
+        self.meta
+            .as_ref()
+            .and_then(|meta| meta.pointer("/ui/visibility"))
+            .and_then(Value::as_array)
+            .is_none_or(|visibility| visibility.iter().any(|item| item.as_str() == Some("app")))
+    }
+
+    /// Human title for UI and audit: explicit `title`, annotated title, then
+    /// the tool name.
+    pub fn display_title(&self) -> String {
+        self.title
+            .clone()
+            .filter(|title| !title.trim().is_empty())
+            .or_else(|| {
+                self.annotations
+                    .as_ref()
+                    .and_then(|annotations| annotations.get("title"))
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+            })
+            .filter(|title| !title.trim().is_empty())
+            .unwrap_or_else(|| self.name.clone())
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -867,6 +895,10 @@ mod tests {
         assert!(tools[0].visible_to_model());
         // Plan mode's retrieval passthrough reads exactly this hint.
         assert!(tools[0].read_only());
+        assert_eq!(
+            tools[0].display_title(),
+            "Open Motif for Claude Science"
+        );
 
         let app_only = tools_into_remote(vec![json!({
             "name": "motif_refresh",
@@ -878,6 +910,30 @@ mod tests {
             !app_only[0].read_only(),
             "no hint means unclassified, not read-only"
         );
+        // Unset visibility defaults to ["model", "app"], so the presenter and
+        // siblings stay callable from an App; an explicit model-only list hides
+        // a tool from apps.
+        assert!(tools[0].visible_to_app());
+        assert!(app_only[0].visible_to_app());
+        let model_only = tools_into_remote(vec![json!({
+            "name": "motif_hidden",
+            "inputSchema": { "type": "object" },
+            "_meta": { "ui": { "visibility": ["model"] } }
+        })]);
+        assert!(model_only[0].visible_to_model());
+        assert!(!model_only[0].visible_to_app());
+        // Title falls back to the annotated title, then the raw name.
+        let annotated = tools_into_remote(vec![json!({
+            "name": "motif_named",
+            "inputSchema": { "type": "object" },
+            "annotations": { "title": "Motif Refresh" }
+        })]);
+        assert_eq!(annotated[0].display_title(), "Motif Refresh");
+        let bare = tools_into_remote(vec![json!({
+            "name": "motif_bare",
+            "inputSchema": { "type": "object" }
+        })]);
+        assert_eq!(bare[0].display_title(), "motif_bare");
     }
 
     #[test]

--- a/crates/wisp-mcp/src/tool.rs
+++ b/crates/wisp-mcp/src/tool.rs
@@ -4,10 +4,10 @@ use crate::client::{McpCallResult, McpClient, RemoteTool};
 use async_trait::async_trait;
 use serde_json::{json, Value};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 use std::time::{SystemTime, UNIX_EPOCH};
 use wisp_llm::ToolSchema;
-use wisp_tools::{Approval, Tool, ToolEnv, ToolEvent, ToolResult};
+use wisp_tools::{Approval, McpAppServer, Tool, ToolEnv, ToolEvent, ToolResult};
 
 const MAX_PRESENTATION_HTML_BYTES: usize = 32 * 1024 * 1024;
 
@@ -16,23 +16,53 @@ pub struct McpTool {
     schema: ToolSchema,
     remote: RemoteTool,
     client: Arc<McpClient>,
+    /// Snapshot of the whole server catalog (shared by every tool of one MCP
+    /// connection) so an MCP App can later call sibling tools on the same
+    /// server — including app-only helpers that never entered the registry.
+    catalog: Arc<Vec<RemoteTool>>,
+    connector_id: String,
     require_approval: bool,
 }
 
 impl McpTool {
     pub fn new(tool: RemoteTool, client: Arc<McpClient>) -> Self {
+        Self::with_catalog(tool, client, "", Arc::new(Vec::new()))
+    }
+
+    pub fn new_requiring_approval(tool: RemoteTool, client: Arc<McpClient>) -> Self {
+        let mut wrapped = Self::new(tool, client);
+        wrapped.require_approval = true;
+        wrapped
+    }
+
+    /// Registration path: the caller already fetched the full server catalog,
+    /// so every tool of one connection shares the same snapshot. The
+    /// `catalog` is what an MCP App bridge validates sibling calls against.
+    pub fn with_catalog(
+        tool: RemoteTool,
+        client: Arc<McpClient>,
+        connector_id: impl Into<String>,
+        catalog: Arc<Vec<RemoteTool>>,
+    ) -> Self {
         let schema = ToolSchema::new(&tool.name, &tool.description, tool.input_schema.clone());
         Self {
             name: tool.name.clone(),
             schema,
             remote: tool,
             client: Arc::clone(&client),
+            catalog,
+            connector_id: connector_id.into(),
             require_approval: false,
         }
     }
 
-    pub fn new_requiring_approval(tool: RemoteTool, client: Arc<McpClient>) -> Self {
-        let mut wrapped = Self::new(tool, client);
+    pub fn with_catalog_requiring_approval(
+        tool: RemoteTool,
+        client: Arc<McpClient>,
+        connector_id: impl Into<String>,
+        catalog: Arc<Vec<RemoteTool>>,
+    ) -> Self {
+        let mut wrapped = Self::with_catalog(tool, client, connector_id, catalog);
         wrapped.require_approval = true;
         wrapped
     }
@@ -69,6 +99,13 @@ impl McpTool {
             tracing::warn!("MCP App resource '{uri}' exceeds presentation size cap");
             return;
         }
+        let server = McpAppServerHandle::new(
+            self.connector_id.clone(),
+            self.remote.display_title(),
+            Arc::clone(&self.catalog),
+            Arc::downgrade(&self.client),
+            self.require_approval,
+        );
         env.emit(ToolEvent::Presentation {
             kind: "mcp_app".into(),
             payload: json!({
@@ -77,8 +114,86 @@ impl McpTool {
                 "result": result,
                 "resource": resource,
             }),
+            server: Some(Arc::new(server)),
         })
         .await;
+    }
+}
+
+/// Host-side `serverTools` bridge handed to the desktop host when an MCP App
+/// is presented. The host stores it keyed by the app instance so `tools/call`
+/// from the iframe reuses the exact MCP connection that presented the app.
+/// Holds a `Weak` client on purpose: when the owning agent drops its tools
+/// (session end, connector restart, agent rebuild), the bridge reports a
+/// stale instance instead of pinning the MCP server process forever.
+pub struct McpAppServerHandle {
+    connector_id: String,
+    app_name: String,
+    catalog: Arc<Vec<RemoteTool>>,
+    client: Weak<McpClient>,
+    require_approval: bool,
+}
+
+impl McpAppServerHandle {
+    pub(crate) fn new(
+        connector_id: String,
+        app_name: String,
+        catalog: Arc<Vec<RemoteTool>>,
+        client: Weak<McpClient>,
+        require_approval: bool,
+    ) -> Self {
+        Self {
+            connector_id,
+            app_name,
+            catalog,
+            client,
+            require_approval,
+        }
+    }
+
+    fn tool(&self, name: &str) -> Option<&RemoteTool> {
+        self.catalog.iter().find(|tool| tool.name == name)
+    }
+}
+
+#[async_trait]
+impl McpAppServer for McpAppServerHandle {
+    fn connector_id(&self) -> &str {
+        &self.connector_id
+    }
+    fn app_name(&self) -> &str {
+        &self.app_name
+    }
+    fn require_approval(&self) -> bool {
+        self.require_approval
+    }
+    fn tools(&self) -> Vec<Value> {
+        self.catalog
+            .iter()
+            .filter_map(|tool| serde_json::to_value(tool).ok())
+            .collect()
+    }
+    fn visible_to_app(&self, name: &str) -> bool {
+        self.tool(name).is_some_and(RemoteTool::visible_to_app)
+    }
+    fn read_only(&self, name: &str) -> bool {
+        self.tool(name).is_some_and(RemoteTool::read_only)
+    }
+    async fn call_tool(&self, name: &str, arguments: &Value) -> Result<Value, String> {
+        if !self.visible_to_app(name) {
+            return Err(format!(
+                "MCP App tool '{name}' is not visible to apps on this server"
+            ));
+        }
+        let client = self
+            .client
+            .upgrade()
+            .ok_or_else(|| "the MCP server connection for this App is closed")?;
+        let result = client
+            .tool_call_rich(name, arguments)
+            .await
+            .map_err(|error| error.to_string())?;
+        serde_json::to_value(&result).map_err(|error| format!("serialize MCP tool result: {error}"))
     }
 }
 
@@ -286,5 +401,73 @@ mod tests {
             &[paths[0].to_string_lossy().to_string()]
         );
         let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn mcp_app_server_handle_serves_catalog_and_reports_stale_clients() {
+        let catalog = Arc::new(vec![
+            RemoteTool {
+                name: "figure_visualize".into(),
+                title: None,
+                description: String::new(),
+                input_schema: json!({ "type": "object" }),
+                output_schema: None,
+                meta: None,
+                annotations: None,
+            },
+            RemoteTool {
+                name: "figure_preview_exact".into(),
+                title: None,
+                description: String::new(),
+                input_schema: json!({ "type": "object" }),
+                output_schema: None,
+                meta: Some(json!({ "ui": { "visibility": ["app"] } })),
+                annotations: Some(json!({ "readOnlyHint": true })),
+            },
+            RemoteTool {
+                name: "figure_edit".into(),
+                title: None,
+                description: String::new(),
+                input_schema: json!({ "type": "object" }),
+                output_schema: None,
+                meta: Some(json!({ "ui": { "visibility": ["model"] } })),
+                annotations: None,
+            },
+        ]);
+        let handle = McpAppServerHandle::new(
+            "figure-library".into(),
+            "Figure Library".into(),
+            catalog,
+            Weak::new(),
+            true,
+        );
+        assert_eq!(handle.connector_id(), "figure-library");
+        assert_eq!(handle.app_name(), "Figure Library");
+        assert!(handle.require_approval());
+        // Unset visibility and explicit app visibility both allow App calls;
+        // model-only tools must be refused.
+        assert!(handle.visible_to_app("figure_visualize"));
+        assert!(handle.visible_to_app("figure_preview_exact"));
+        assert!(!handle.visible_to_app("figure_edit"));
+        assert!(!handle.visible_to_app("figure_nope"));
+        // The server's readOnlyHint comes through for plan-mode gating.
+        assert!(handle.read_only("figure_preview_exact"));
+        assert!(!handle.read_only("figure_visualize"));
+        let listed = handle.tools();
+        assert_eq!(listed.len(), 3);
+        assert_eq!(listed[0]["name"], "figure_visualize");
+        assert_eq!(listed[1]["annotations"]["readOnlyHint"], true);
+        // A dead Weak client is the stale-instance the host reports after the
+        // owning agent drops its Arc (session end, rebuild, connector restart).
+        let error = handle
+            .call_tool("figure_preview_exact", &json!({}))
+            .await
+            .unwrap_err();
+        assert!(error.contains("connection for this App is closed"));
+        let error = handle
+            .call_tool("figure_edit", &json!({}))
+            .await
+            .unwrap_err();
+        assert!(error.contains("not visible to apps"));
     }
 }

--- a/crates/wisp-tools/src/env.rs
+++ b/crates/wisp-tools/src/env.rs
@@ -1,7 +1,42 @@
 //! Tool execution environment: project root, approval, and UI event sink.
 
 use async_trait::async_trait;
+use serde_json::Value;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+/// A host-side bridge that lets a just-presented MCP App call tools on the
+/// same MCP Server that produced it (MCP Apps `serverTools`). The desktop host
+/// registers the handle when a `Presentation { kind: "mcp_app" }` flows to the
+/// UI, and `tools/call` requests from the app iframe are routed back through
+/// it. Headless hosts keep the default no-op and never build one.
+///
+/// The handle intentionally exposes no URL, command, or credential: MCP
+/// connection secrets stay on the host and are reused via the existing client.
+#[async_trait]
+pub trait McpAppServer: Send + Sync {
+    /// Host-readable connector identity for audit and approval UI.
+    fn connector_id(&self) -> &str;
+    /// Human app name for audit and approval UI.
+    fn app_name(&self) -> &str;
+    /// Whether the presenting connector requires approval (e.g. plugin MCP
+    /// tools are configured as "ask").
+    fn require_approval(&self) -> bool;
+    /// Snapshot of the MCP server's tool catalog (each entry carrying name,
+    /// title, description, inputSchema, `_meta`, annotations). Lets the host
+    /// validate an app request against the live connection without exposing
+    /// it to the iframe.
+    fn tools(&self) -> Vec<Value>;
+    /// An MCP App may call this tool: `_meta.ui.visibility` includes `"app"`
+    /// (unset defaults to `["model", "app"]`).
+    fn visible_to_app(&self, name: &str) -> bool;
+    /// Server `readOnlyHint` for a tool, honored by plan-mode and project-write
+    /// gates the same way agent calls honor it.
+    fn read_only(&self, name: &str) -> bool;
+    /// Call a tool on the same MCP server and return the full CallToolResult
+    /// object (`content`, `structuredContent`, `_meta`, `isError`).
+    async fn call_tool(&self, name: &str, arguments: &Value) -> Result<Value, String>;
+}
 
 /// A host-owned resource lease held for one complete tool call.
 ///
@@ -31,7 +66,7 @@ impl Drop for ToolResourceLease {
 
 /// Events a tool emits to the UI as it runs (tool-call card, diff preview,
 /// live stdout, result tick).
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub enum ToolEvent {
     Call {
         name: String,
@@ -53,14 +88,48 @@ pub enum ToolEvent {
     },
     /// A host-renderable, non-model presentation such as an MCP App. The
     /// payload is forwarded to capable UIs but is deliberately excluded from
-    /// the language-model context.
+    /// the language-model context. `server` is an opaque host-side binding so
+    /// an MCP App can later call back into the MCP server that presented it;
+    /// it is never serialized to the wire.
     Presentation {
         kind: String,
-        payload: serde_json::Value,
+        payload: Value,
+        server: Option<Arc<dyn McpAppServer>>,
     },
     Result {
         ok: bool,
     },
+}
+
+impl std::fmt::Debug for ToolEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ToolEvent::Call { name, preview } => f
+                .debug_struct("Call")
+                .field("name", name)
+                .field("preview", preview)
+                .finish(),
+            ToolEvent::Diff { path, old, new } => f
+                .debug_struct("Diff")
+                .field("path", path)
+                .field("old", old)
+                .field("new", new)
+                .finish(),
+            ToolEvent::FileChanged { path } => {
+                f.debug_struct("FileChanged").field("path", path).finish()
+            }
+            ToolEvent::Stdout { chunk } => {
+                f.debug_struct("Stdout").field("chunk", chunk).finish()
+            }
+            ToolEvent::Presentation { kind, payload, .. } => f
+                .debug_struct("Presentation")
+                .field("kind", kind)
+                .field("payload", payload)
+                .field("server", &"<host bridge>")
+                .finish(),
+            ToolEvent::Result { ok } => f.debug_struct("Result").field("ok", ok).finish(),
+        }
+    }
 }
 
 /// Per-tool approval policy, applied by `Registry::run` before a tool executes.

--- a/crates/wisp-tools/src/lib.rs
+++ b/crates/wisp-tools/src/lib.rs
@@ -21,8 +21,8 @@ pub mod tool;
 pub mod write;
 
 pub use env::{
-    Approval, ConfirmDecision, ImageData, ToolControl, ToolEnv, ToolEvent, ToolResourceLease,
-    ToolResult,
+    Approval, ConfirmDecision, ImageData, McpAppServer, ToolControl, ToolEnv, ToolEvent,
+    ToolResourceLease, ToolResult,
 };
 pub use tool::Tool;
 

--- a/src-tauri/src/app_state.rs
+++ b/src-tauri/src/app_state.rs
@@ -235,6 +235,17 @@ pub(crate) struct ActiveProject {
     pub(crate) memory: Arc<MemoryManager>,
 }
 
+/// Host-side `serverTools` binding for one live MCP App instance. Registered
+/// when an `mcp_app` presentation flows to the UI and revoked on teardown or
+/// session delete; the `server` handle keeps only a `Weak` reference to the
+/// MCP client, so an agent rebuild or connector restart naturally makes the
+/// instance stale instead of pinning the server process.
+#[derive(Clone)]
+pub(crate) struct McpAppToolBridge {
+    pub(crate) frame_id: String,
+    pub(crate) server: Arc<dyn wisp_tools::McpAppServer>,
+}
+
 #[derive(Default)]
 pub(crate) struct ProjectActivityLocks {
     pub(crate) projects: StdMutex<HashMap<String, Arc<tokio::sync::RwLock<()>>>>,
@@ -295,6 +306,13 @@ pub(crate) struct AppState {
     /// Advisory leases for local project resources used by parallel built-in
     /// conversations. External editors remain outside this in-process boundary.
     pub(crate) resource_leases: resource_leases::ProjectResourceCoordinator,
+    /// Live MCP Apps `serverTools` bridges, keyed by `mcp-app:{frame}:{identity}`.
+    /// Each binds one app instance to the MCP connection that presented it so
+    /// the iframe can reuse it through `tools/call` without ever seeing MCP
+    /// URLs, commands, or credentials. Instances are revoked on teardown or
+    /// session delete; after an agent rebuild the embedded `Weak` client dies
+    /// and further calls fail with a stale-instance error.
+    pub(crate) mcp_app_tool_bridges: StdMutex<HashMap<String, McpAppToolBridge>>,
     /// The frame id the UI is currently viewing. Drives artifact attachment
     /// (`upload_file`/`register_artifact`) and `list_artifacts` fallback.
     /// Written only by view-navigation commands (`load_session`/`new_session`/
@@ -400,6 +418,33 @@ impl AppState {
     }
     pub(crate) fn remove_notification_window(&self, frame_id: &str) {
         self.notification_window.write().unwrap().remove(frame_id);
+    }
+    pub(crate) fn register_mcp_app_bridge(&self, instance_id: String, bridge: McpAppToolBridge) {
+        self.mcp_app_tool_bridges
+            .lock()
+            .unwrap()
+            .insert(instance_id, bridge);
+    }
+    pub(crate) fn mcp_app_bridge(&self, instance_id: &str) -> Option<McpAppToolBridge> {
+        self.mcp_app_tool_bridges
+            .lock()
+            .unwrap()
+            .get(instance_id)
+            .cloned()
+    }
+    pub(crate) fn close_mcp_app_bridge(&self, instance_id: &str) -> bool {
+        self.mcp_app_tool_bridges
+            .lock()
+            .unwrap()
+            .remove(instance_id)
+            .is_some()
+    }
+    /// Revoke every app bridge owned by a conversation (session delete).
+    pub(crate) fn remove_mcp_app_bridges_for_frame(&self, frame_id: &str) {
+        self.mcp_app_tool_bridges
+            .lock()
+            .unwrap()
+            .retain(|_, bridge| bridge.frame_id != frame_id);
     }
     pub(crate) fn preferred_notification_window(
         &self,

--- a/src-tauri/src/configure.rs
+++ b/src-tauri/src/configure.rs
@@ -363,6 +363,7 @@ For specialists, get the `specialists` key then call save_specialist (pass id to
                         env.emit(wisp_tools::ToolEvent::Presentation {
                             kind: "app_prefs".into(),
                             payload: outcome.presentation,
+                            server: None,
                         })
                         .await;
                     }
@@ -382,6 +383,7 @@ For specialists, get the `specialists` key then call save_specialist (pass id to
                         env.emit(wisp_tools::ToolEvent::Presentation {
                             kind: "storage_usage".into(),
                             payload,
+                            server: None,
                         })
                         .await;
                         ToolResult::ok(text)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -476,7 +476,7 @@ fn parse_confirm_payload(message: &str) -> (String, String) {
         return ("image_resize".to_string(), rest.to_string());
     }
     if let Some(rest) = message.strip_prefix("Run tool '") {
-        if let Some((tool, _)) = rest.split_once("'?") {
+        if let Some((tool, _)) = rest.split_once('\'') {
             return (tool.to_string(), String::new());
         }
     }
@@ -2191,6 +2191,323 @@ async fn update_mcp_app_context(
     Ok(())
 }
 
+/// Hard ceiling on a single MCP App `tools/call` argument JSON blob.
+const MAX_MCP_APP_ARGUMENT_BYTES: usize = 256 * 1024;
+/// Hard ceiling on a single MCP App `tools/call` result JSON blob.
+const MAX_MCP_APP_RESULT_BYTES: usize = 4 * 1024 * 1024;
+const MAX_MCP_APP_TOOL_NAME_BYTES: usize = 256;
+const MCP_APP_STALE_INSTANCE_ERROR: &str =
+    "stale-instance: the MCP App is no longer bound to a live MCP server";
+
+fn audit_mcp_app_tool(
+    event: &str,
+    instance_id: &str,
+    frame_id: &str,
+    connector_id: &str,
+    tool: &str,
+    duration_ms: u64,
+    error_code: &str,
+) {
+    tracing::info!(
+        audit_event = event,
+        invocation_source = "mcp_app",
+        session = frame_id,
+        app_instance = instance_id,
+        connector = connector_id,
+        tool = tool,
+        duration_ms = duration_ms,
+        error_code = error_code,
+    );
+}
+
+async fn request_mcp_app_tool_confirmation(
+    app: &tauri::AppHandle,
+    state: &AppState,
+    frame_id: &str,
+    project_id: &str,
+    message: String,
+    tool: &str,
+    preview: String,
+) -> wisp_tools::ConfirmDecision {
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    state.confirms.lock().unwrap().insert(
+        frame_id.to_string(),
+        PendingConfirm {
+            tx,
+            grant: approval_grant_key(&message),
+            project_id: project_id.to_string(),
+        },
+    );
+    state
+        .awaiting_confirm
+        .lock()
+        .unwrap()
+        .insert(frame_id.to_string());
+    state
+        .device_hub
+        .mark_needs_user(frame_id, Some(project_id));
+    let _ = app.emit(
+        "confirm-request",
+        ConfirmRequest {
+            frame_id: frame_id.to_string(),
+            message,
+            tool: tool.to_string(),
+            preview,
+        },
+    );
+    let decision = receive_confirm_decision(rx).await;
+    state.confirms.lock().unwrap().remove(frame_id);
+    state.awaiting_confirm.lock().unwrap().remove(frame_id);
+    state.device_hub.resolve_needs_user(frame_id);
+    decision
+}
+
+/// MCP Apps `serverTools`: run `tools/call` from an App iframe on the MCP
+/// server that presented the app, reusing the original connection. The bridge
+/// validates instance liveness, same-server tool visibility, plan-mode, and
+/// the normal approval policy before dispatch, and returns the complete
+/// CallToolResult (`content`, `structuredContent`, `_meta`, `isError`).
+#[tauri::command]
+async fn call_mcp_app_tool(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    instance_id: String,
+    name: String,
+    arguments: serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let frame_id = mcp_app_frame_id(&instance_id)?.to_string();
+    if name.is_empty() || name.len() > MAX_MCP_APP_TOOL_NAME_BYTES {
+        return Err("MCP App tool name is empty or too long.".into());
+    }
+    if !arguments.is_object() {
+        return Err("MCP App tool arguments must be a JSON object.".into());
+    }
+    let argument_bytes = serde_json::to_vec(&arguments)
+        .map_err(|error| format!("Invalid MCP App tool arguments: {error}"))?
+        .len();
+    if argument_bytes > MAX_MCP_APP_ARGUMENT_BYTES {
+        return Err(format!(
+            "MCP App tool arguments exceed the {} KiB limit.",
+            MAX_MCP_APP_ARGUMENT_BYTES / 1024
+        ));
+    }
+    let Some(bridge) = state.mcp_app_bridge(&instance_id) else {
+        audit_mcp_app_tool(
+            "mcp_app.tool_call_failed",
+            &instance_id,
+            &frame_id,
+            "",
+            &name,
+            0,
+            "stale-instance",
+        );
+        return Err(MCP_APP_STALE_INSTANCE_ERROR.into());
+    };
+    if bridge.frame_id != frame_id {
+        return Err(MCP_APP_STALE_INSTANCE_ERROR.into());
+    }
+    if !bridge.server.visible_to_app(&name) {
+        return Err(format!(
+            "MCP App tool '{name}' is not visible to apps on this server."
+        ));
+    }
+    let project_id = state
+        .store
+        .frame_project_id(&frame_id)
+        .await
+        .map_err(|error| error.to_string())?
+        .ok_or_else(|| MCP_APP_STALE_INSTANCE_ERROR.to_string())?;
+    // Plan mode and frozen-project gates match agent tool calls: read-only
+    // tools stay available, everything else refuses.
+    if plan_mode::session_plan_mode(&state.store, &frame_id).await
+        && !bridge.server.read_only(&name)
+    {
+        return Err(format!(
+            "Tool '{name}' is blocked in plan mode. Plan mode only allows read-only tools."
+        ));
+    }
+    let host_approval = state
+        .approvals
+        .read()
+        .map(|policy| policy.mode_for(&name))
+        .unwrap_or(wisp_tools::Approval::Allow);
+    let full_permission = state
+        .full_permission_sessions
+        .read()
+        .map(|sessions| sessions.contains(&frame_id))
+        .unwrap_or(false);
+    let approval = if host_approval == wisp_tools::Approval::Deny {
+        wisp_tools::Approval::Deny
+    } else if full_permission {
+        wisp_tools::Approval::Allow
+    } else if host_approval == wisp_tools::Approval::Ask || bridge.server.require_approval() {
+        wisp_tools::Approval::Ask
+    } else {
+        wisp_tools::Approval::Allow
+    };
+    if approval == wisp_tools::Approval::Deny {
+        audit_mcp_app_tool(
+            "mcp_app.tool_call_failed",
+            &instance_id,
+            &frame_id,
+            bridge.server.connector_id(),
+            &name,
+            0,
+            "blocked-by-policy",
+        );
+        return Err(format!("tool '{name}' is blocked by the approval policy"));
+    }
+    let started = std::time::Instant::now();
+    audit_mcp_app_tool(
+        "mcp_app.tool_call_requested",
+        &instance_id,
+        &frame_id,
+        bridge.server.connector_id(),
+        &name,
+        0,
+        "",
+    );
+    if approval == wisp_tools::Approval::Ask {
+        let preview = bounded_ui_tool_input(&arguments.to_string());
+        let message = format!(
+            "Run tool '{name}' from MCP App '{}'?",
+            bridge.server.app_name()
+        );
+        let granted = approval_grant_key(&message).is_some_and(|key| {
+            state
+                .approval_grants
+                .lock()
+                .map(|grants| grants.allows(&frame_id, &project_id, &key))
+                .unwrap_or(false)
+        });
+        if !granted {
+            let decision = request_mcp_app_tool_confirmation(
+                &app,
+                state,
+                &frame_id,
+                &project_id,
+                message,
+                &name,
+                preview,
+            )
+            .await;
+            if !decision.approved() {
+                audit_mcp_app_tool(
+                    "mcp_app.tool_call_failed",
+                    &instance_id,
+                    &frame_id,
+                    bridge.server.connector_id(),
+                    &name,
+                    started.elapsed().as_millis() as u64,
+                    "denied-by-user",
+                );
+                return Err(format!("MCP App tool '{name}' was denied by the user."));
+            }
+        }
+    }
+    audit_mcp_app_tool(
+        "mcp_app.tool_call_approved",
+        &instance_id,
+        &frame_id,
+        bridge.server.connector_id(),
+        &name,
+        started.elapsed().as_millis() as u64,
+        "",
+    );
+    match bridge.server.call_tool(&name, &arguments).await {
+        Ok(result) => {
+            let result_bytes = serde_json::to_vec(&result)
+                .map_err(|error| format!("Invalid MCP App tool result: {error}"))?
+                .len();
+            if result_bytes > MAX_MCP_APP_RESULT_BYTES {
+                audit_mcp_app_tool(
+                    "mcp_app.tool_call_failed",
+                    &instance_id,
+                    &frame_id,
+                    bridge.server.connector_id(),
+                    &name,
+                    started.elapsed().as_millis() as u64,
+                    "result-too-large",
+                );
+                return Err(format!(
+                    "MCP App tool result exceeds the {} MiB limit.",
+                    MAX_MCP_APP_RESULT_BYTES / 1024 / 1024
+                ));
+            }
+            audit_mcp_app_tool(
+                "mcp_app.tool_call_completed",
+                &instance_id,
+                &frame_id,
+                bridge.server.connector_id(),
+                &name,
+                started.elapsed().as_millis() as u64,
+                "",
+            );
+            Ok(result)
+        }
+        Err(error) => {
+            audit_mcp_app_tool(
+                "mcp_app.tool_call_failed",
+                &instance_id,
+                &frame_id,
+                bridge.server.connector_id(),
+                &name,
+                started.elapsed().as_millis() as u64,
+                "tool-error",
+            );
+            Err(format!("mcp app tool '{name}' error: {error}"))
+        }
+    }
+}
+
+/// MCP Apps `serverTools`: the app-visible tool catalog of the same server
+/// (the host validates against it, so the iframe never receives connection
+/// details).
+#[tauri::command]
+async fn list_mcp_app_tools(
+    state: State<'_, AppState>,
+    instance_id: String,
+) -> Result<serde_json::Value, String> {
+    let frame_id = mcp_app_frame_id(&instance_id)?.to_string();
+    let Some(bridge) = state.mcp_app_bridge(&instance_id) else {
+        return Err(MCP_APP_STALE_INSTANCE_ERROR.into());
+    };
+    if bridge.frame_id != frame_id {
+        return Err(MCP_APP_STALE_INSTANCE_ERROR.into());
+    }
+    let tools = bridge
+        .server
+        .tools()
+        .into_iter()
+        .filter(|tool| {
+            tool.get("name")
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|name| bridge.server.visible_to_app(name))
+        })
+        .collect::<Vec<_>>();
+    Ok(serde_json::json!({ "tools": tools }))
+}
+
+/// Revoke an MCP App instance's host-side bridge when the iframe tears down
+/// (user close, replacement, or session navigation). Later `tools/call`
+/// requests then fail with a stale-instance error. Also drops the instance's
+/// model-context injection so a closed app cannot keep feeding the next turn.
+#[tauri::command]
+async fn close_mcp_app(
+    state: State<'_, AppState>,
+    instance_id: String,
+) -> bool {
+    let removed = state.close_mcp_app_bridge(&instance_id);
+    if removed {
+        if let Ok(frame_id) = mcp_app_frame_id(&instance_id) {
+            if let Some(runtime) = state.sessions.lock().await.get(frame_id).cloned() {
+                runtime.set_mcp_app_context(instance_id, None);
+            }
+        }
+    }
+    removed
+}
+
 /// Ensure `dir` exists and is usable; fall back to `app_data/workspace` if not.
 /// Never panics unless even the fallback can't be created.
 fn ensure_writable(dir: PathBuf, app_data: &std::path::Path) -> PathBuf {
@@ -2445,10 +2762,31 @@ impl Output for TauriOutput {
             duration_ms,
         });
     }
-    fn tool_presentation(&self, kind: &str, payload: &serde_json::Value) {
+    fn tool_presentation(
+        &self,
+        kind: &str,
+        payload: &serde_json::Value,
+        server: Option<std::sync::Arc<dyn wisp_tools::McpAppServer>>,
+    ) {
+        let presentation_id = Uuid::new_v4().to_string();
+        if kind == "mcp_app" && !payload.is_null() {
+            if let Some(server) = server {
+                // The frontend derives the instance id from the same frame id
+                // and presentation id (ui/src/mcp_app.rs), so the host-side
+                // bridge stays keyed exactly like the mounted iframe.
+                let instance_id = format!("mcp-app:{}:{}", self.frame_id, presentation_id);
+                self.app.state::<AppState>().register_mcp_app_bridge(
+                    instance_id,
+                    McpAppToolBridge {
+                        frame_id: self.frame_id.clone(),
+                        server,
+                    },
+                );
+            }
+        }
         self.emit(AgentEvent::ToolPresentation {
             frame_id: self.frame_id.clone(),
-            presentation_id: Uuid::new_v4().to_string(),
+            presentation_id,
             presentation_kind: kind.into(),
             payload: payload.clone(),
         });
@@ -4215,17 +4553,19 @@ async fn finish_custom_mcp_wiring(
             .or_default();
         let index = next_index;
         next_index += 1;
+        let connector_id = launch.connector_id.clone();
         set.spawn(async move {
             let name = launch.display_name.clone();
             let res = connect_plugin_mcp(&launch).await;
-            (index, name, Some(plugin_id), true, res)
+            (index, name, Some(plugin_id), connector_id, true, res)
         });
     }
     for (i, conn) in conns.into_iter().enumerate() {
         let index = next_index + i;
+        let connector_id = conn.id.clone();
         set.spawn(async move {
             let res = connect_mcp(&conn).await;
-            (index, conn.name, None, false, res)
+            (index, conn.name, None, connector_id, false, res)
         });
     }
     let mut results = Vec::new();
@@ -4234,12 +4574,13 @@ async fn finish_custom_mcp_wiring(
             results.push(r);
         }
     }
-    results.sort_by_key(|(i, _, _, _, _)| *i);
-    for (_, name, plugin_id, require_approval, res) in results {
+    results.sort_by_key(|(i, _, _, _, _, _)| *i);
+    for (_, name, plugin_id, connector_id, require_approval, res) in results {
         match res {
             Ok(client) => match register_mcp_with_approval(
                 registry,
                 std::sync::Arc::new(client),
+                &connector_id,
                 require_approval,
             )
             .await
@@ -4277,15 +4618,23 @@ async fn register_mcp(
     registry: &mut wisp_tools::Registry,
     client: std::sync::Arc<wisp_mcp::McpClient>,
 ) -> Result<Vec<String>, String> {
-    register_mcp_with_approval(registry, client, false).await
+    register_mcp_with_approval(registry, client, "", false).await
 }
 
 async fn register_mcp_with_approval(
     registry: &mut wisp_tools::Registry,
     client: std::sync::Arc<wisp_mcp::McpClient>,
+    connector_id: &str,
     require_approval: bool,
 ) -> Result<Vec<String>, String> {
-    register_mcp_filtered_with_approval(registry, client, &HashSet::new(), require_approval).await
+    register_mcp_filtered_with_approval(
+        registry,
+        client,
+        connector_id,
+        &HashSet::new(),
+        require_approval,
+    )
+    .await
 }
 
 /// Like `register_mcp`, but skips any tool whose name is in `skip` (used to drop
@@ -4295,12 +4644,13 @@ async fn register_mcp_filtered(
     client: std::sync::Arc<wisp_mcp::McpClient>,
     skip: &HashSet<String>,
 ) -> Result<Vec<String>, String> {
-    register_mcp_filtered_with_approval(registry, client, skip, false).await
+    register_mcp_filtered_with_approval(registry, client, "", skip, false).await
 }
 
 async fn register_mcp_filtered_with_approval(
     registry: &mut wisp_tools::Registry,
     client: std::sync::Arc<wisp_mcp::McpClient>,
+    connector_id: &str,
     skip: &HashSet<String>,
     require_approval: bool,
 ) -> Result<Vec<String>, String> {
@@ -4318,16 +4668,29 @@ async fn register_mcp_filtered_with_approval(
             if !collisions.is_empty() {
                 return Err(format!("tool name collision: {}", collisions.join(", ")));
             }
+            // Every tool of one connection shares the same catalog snapshot so
+            // an MCP App presented by any of them can bridge sibling tools.
+            let catalog = std::sync::Arc::new(tools);
             let mut names = Vec::new();
-            for t in tools {
+            for t in catalog.iter() {
                 if skip.contains(&t.name) || !t.visible_to_model() {
                     continue;
                 }
                 names.push(t.name.clone());
                 let tool = if require_approval {
-                    wisp_mcp::McpTool::new_requiring_approval(t, client.clone())
+                    wisp_mcp::McpTool::with_catalog_requiring_approval(
+                        t.clone(),
+                        client.clone(),
+                        connector_id,
+                        std::sync::Arc::clone(&catalog),
+                    )
                 } else {
-                    wisp_mcp::McpTool::new(t, client.clone())
+                    wisp_mcp::McpTool::with_catalog(
+                        t.clone(),
+                        client.clone(),
+                        connector_id,
+                        std::sync::Arc::clone(&catalog),
+                    )
                 };
                 registry.add(Box::new(tool));
             }
@@ -6029,6 +6392,7 @@ pub fn run() {
                 completion_dispatches: tokio::sync::Mutex::new(HashSet::new()),
                 project_activity: ProjectActivityLocks::default(),
                 resource_leases: resource_leases::ProjectResourceCoordinator::default(),
+                mcp_app_tool_bridges: StdMutex::new(HashMap::new()),
                 active_frame: std::sync::RwLock::new(HashMap::new()),
                 notification_window: std::sync::RwLock::new(HashMap::new()),
                 confirms: Arc::new(StdMutex::new(HashMap::new())),
@@ -6103,6 +6467,9 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             agent_turn::send_message,
             update_mcp_app_context,
+            call_mcp_app_tool,
+            list_mcp_app_tools,
+            close_mcp_app,
             agent_turn::enqueue_turn,
             agent_turn::queued_turn_action,
             agent_turn::stop_agent,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2383,7 +2383,7 @@ async fn call_mcp_app_tool(
         if !granted {
             let decision = request_mcp_app_tool_confirmation(
                 &app,
-                state,
+                &state,
                 &frame_id,
                 &project_id,
                 message,
@@ -2496,7 +2496,7 @@ async fn list_mcp_app_tools(
 async fn close_mcp_app(
     state: State<'_, AppState>,
     instance_id: String,
-) -> bool {
+) -> Result<bool, String> {
     let removed = state.close_mcp_app_bridge(&instance_id);
     if removed {
         if let Ok(frame_id) = mcp_app_frame_id(&instance_id) {
@@ -2505,7 +2505,7 @@ async fn close_mcp_app(
             }
         }
     }
-    removed
+    Ok(removed)
 }
 
 /// Ensure `dir` exists and is usable; fall back to `app_data/workspace` if not.

--- a/src-tauri/src/lib_tests.rs
+++ b/src-tauri/src/lib_tests.rs
@@ -93,6 +93,21 @@ fn resource_conflict_confirmation_has_dedicated_ui_payload_and_no_saved_grant() 
 }
 
 #[test]
+fn mcp_app_tool_confirm_payload_parses_and_keys_a_grant() {
+    let message = "Run tool 'figure_preview_exact' from MCP App 'Figure Library'?";
+    let (tool, preview) = super::parse_confirm_payload(message);
+    assert_eq!(tool, "figure_preview_exact");
+    assert_eq!(preview, "");
+    // Always-allow grants save against the tool name, same as agent calls.
+    let key = super::approval_grant_key(message).unwrap();
+    assert_eq!(key.kind, "tool");
+    assert_eq!(key.target, "figure_preview_exact");
+    // The classic agent message still parses identically.
+    let (tool, _) = super::parse_confirm_payload("Run tool 'python'?");
+    assert_eq!(tool, "python");
+}
+
+#[test]
 fn mcp_app_context_is_latest_only_and_session_scoped() {
     let first = super::normalize_mcp_app_context(
         "Motif for Claude Science",

--- a/src-tauri/src/plugins.rs
+++ b/src-tauri/src/plugins.rs
@@ -1734,7 +1734,7 @@ mod tests {
         assert!(open_result.success, "{}", open_result.content);
         assert!(env.events.lock().unwrap().iter().any(|event| matches!(
             event,
-            ToolEvent::Presentation { kind, payload }
+            ToolEvent::Presentation { kind, payload, .. }
                 if kind == "mcp_app"
                     && payload.pointer("/resource/uri").and_then(serde_json::Value::as_str)
                         == Some("ui://motif/workbench.html")

--- a/src-tauri/src/session_commands.rs
+++ b/src-tauri/src/session_commands.rs
@@ -745,6 +745,10 @@ pub(super) async fn delete_session(
         sessions.remove(&id);
     }
     state.remove_notification_window(&id);
+    // MCP Apps presented by this conversation must lose their tool bridge so a
+    // later `tools/call` (e.g. from a reloaded iframe) fails stale instead of
+    // pinning the MCP server process.
+    state.remove_mcp_app_bridges_for_frame(&id);
     if state.active_frame(window.label()).as_deref() == Some(id.as_str()) {
         state.set_active_frame(window.label(), None);
     }

--- a/ui/src/api.js
+++ b/ui/src/api.js
@@ -2016,6 +2016,9 @@ function createMcpAppInstance(instanceId, payloadJson) {
     if (mcpAppInstances.get(instanceId) === instance) {
       mcpAppInstances.delete(instanceId);
       void clearModelContext();
+      // Revoke the host-side serverTools bridge so a later request from a
+      // stale iframe fails with a stale-instance error (best-effort).
+      void invoke("close_mcp_app", { instanceId });
     }
   };
   const requestTeardown = (reason) => {
@@ -2044,6 +2047,10 @@ function createMcpAppInstance(instanceId, payloadJson) {
           hostCapabilities: {
             sandbox: { csp: payload?.resource?._meta?.ui?.csp || payload?.resource?._meta?.csp || {} },
             updateModelContext: { text: {} },
+            // MCP Apps `serverTools`: the host re-uses the MCP server that
+            // presented this app for `tools/call`. `listChanged` stays false —
+            // Wisp does not push `ui/notifications/tools/list_changed` yet.
+            serverTools: {},
           },
           hostInfo: { name: "wisp-science", version: wispAppVersion },
           hostContext: hostContext(),
@@ -2059,6 +2066,49 @@ function createMcpAppInstance(instanceId, payloadJson) {
     }
     if (message.method === "ping" && message.id != null) {
       post({ jsonrpc: "2.0", id: message.id, result: {} });
+      return;
+    }
+    if (message.method === "tools/list" && message.id != null) {
+      void invoke_strict("list_mcp_app_tools", { instanceId }).then(
+        (result) => post({ jsonrpc: "2.0", id: message.id, result }),
+        (error) => post({
+          jsonrpc: "2.0",
+          id: message.id,
+          error: {
+            code: -32603,
+            message: (error instanceof Error ? error.message : String(error)).slice(0, 512),
+          },
+        }),
+      );
+      return;
+    }
+    if (message.method === "tools/call" && message.id != null) {
+      const params = message.params || {};
+      const name = params.name;
+      if (typeof name !== "string" || !name) {
+        post({
+          jsonrpc: "2.0",
+          id: message.id,
+          error: { code: -32602, message: "tools/call requires a valid 'name' string" },
+        });
+        return;
+      }
+      const args = params.arguments
+        && typeof params.arguments === "object"
+        && !Array.isArray(params.arguments)
+        ? params.arguments
+        : {};
+      void invoke_strict("call_mcp_app_tool", { instanceId, name, arguments: args }).then(
+        (result) => post({ jsonrpc: "2.0", id: message.id, result }),
+        (error) => post({
+          jsonrpc: "2.0",
+          id: message.id,
+          error: {
+            code: -32603,
+            message: (error instanceof Error ? error.message : String(error)).slice(0, 512),
+          },
+        }),
+      );
       return;
     }
     if (message.method === "ui/update-model-context" && message.id != null) {


### PR DESCRIPTION
### Summary

实现 MCP Apps `hostCapabilities.serverTools` 通用 Host/Bridge 层（issue #773），让 App iframe 通过标准 `tools/call` / `tools/list` 复用**创建该 App 的同一个 MCP Server**。

- Host 在 `mcp_app` presentation 产生时注册不可伪造的实例映射 `mcp-app:{frame}:{presentation_id}` → `McpClient`（Weak）→ 完整工具目录 → 权限策略；App teardown / 会话删除即撤销，Agent 重建或 connector 重启后返回明确 `stale-instance` 错误。
- `tools/call` 校验：实例归属、同 server 工具可见性（`_meta.ui.visibility` 含 `app`）、参数/结果大小上限、plan-mode 只读门、并与 Agent 调用走同一套审批策略（Deny / Full Permission / per-tool Ask / plugin `require_approval` / Always-allow grants）。
- 复用原始连接调用并返回完整 `CallToolResult`（`content` / `structuredContent` / `_meta` / `isError`），**不向 iframe 暴露 MCP URL、命令或凭据**。
- 结构化审计事件 `mcp_app.tool_call_requested/approved/completed/failed`。

### Changes

- `wisp-tools`：新增 `McpAppServer` trait；`ToolEvent::Presentation` 携带不落线的 opaque `server` handle。
- `wisp-mcp`：`RemoteTool::visible_to_app()` / `display_title()`；`McpTool::with_catalog*`（共享整份 server 目录，app-only 兄弟工具可调用但不上模型目录）；`McpAppServerHandle`（Weak client，stale 语义）。
- `wisp-core` / `wisp-cli`：`Output::tool_presentation` 透传 handle，headless 忽略。
- `src-tauri`：`AppState.mcp_app_tool_bridges` 注册表；`TauriOutput::tool_presentation` 注册 bridge；新命令 `call_mcp_app_tool` / `list_mcp_app_tools` / `close_mcp_app`；注册时线程化 connector_id 与完整目录；`delete_session` 撤销 bridge。
- `ui/src/api.js`：`ui/initialize` 声明 `serverTools: {}`（`listChanged` 不声明）；处理 `tools/list` / `tools/call`；teardown 时撤销 bridge。

### Verification

- `node --check ui/src/api.js` 通过；全部修改文件 UTF-8 校验通过。
- 新增/扩展单测：`RemoteTool` 可见性与标题回退、`McpAppServerHandle` 目录/readOnly/stale 语义、MCP App 确认消息解析与 grant 键。
- 本机未安装 Rust 工具链，`cargo check --workspace` 与 `cargo test` 需在 CI/装有 Rust 的环境执行；stdio 与 Streamable HTTP connector 的端到端（acceptance）验证同理。
- 行为不变：Host 不支持/实例失效时 App 仍可走 `updateModelContext` fallback；`ui/notifications/tools/list_changed` 未实现，`serverTools` 只声明 `{}`。

Closes #773