### PR TITLE
feat(ui): show live context-usage percent with warn/danger colors (#931)

### DIFF
--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -4935,6 +4935,44 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
                 }, 1_200);
               });
             }
+            if (String(arg("message") ?? "").includes("CONTEXTUSAGEWARN")) {
+              setTimeout(() => {
+                emit("agent", { kind: "User", frame_id: fid, text: msg });
+                emit("agent", { kind: "Text", frame_id: fid, delta: "Context is getting full." });
+                emit("agent", {
+                  kind: "Usage",
+                  frame_id: fid,
+                  round: 1,
+                  input: 90_000,
+                  output: 1_520,
+                  reasoning: 0,
+                  cached: 0,
+                  ctx_tokens: 91_520,
+                  max_context: 128_000,
+                });
+                emit("agent", { kind: "Done", frame_id: fid });
+              }, 30);
+              return fid;
+            }
+            if (String(arg("message") ?? "").includes("CONTEXTUSAGEDANGER")) {
+              setTimeout(() => {
+                emit("agent", { kind: "User", frame_id: fid, text: msg });
+                emit("agent", { kind: "Text", frame_id: fid, delta: "Context is almost full." });
+                emit("agent", {
+                  kind: "Usage",
+                  frame_id: fid,
+                  round: 1,
+                  input: 114_000,
+                  output: 1_840,
+                  reasoning: 0,
+                  cached: 0,
+                  ctx_tokens: 115_840,
+                  max_context: 128_000,
+                });
+                emit("agent", { kind: "Done", frame_id: fid });
+              }, 30);
+              return fid;
+            }
             if (String(arg("message") ?? "").includes("CONTEXTUSAGE")) {
               setTimeout(() => {
                 emit("agent", { kind: "User", frame_id: fid, text: msg });

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -1262,7 +1262,8 @@ test("ACP turn maps config, overlapping tools, plan, usage, and exact permission
   });
   await expect(permission).toHaveCount(0);
   const contextTrigger = page.getByTestId("context-usage-trigger");
-  await expect(contextTrigger).toHaveText("");
+  await expect(contextTrigger).toHaveText("15%");
+  await expect(contextTrigger).toHaveAttribute("data-tone", "ok");
   await expect.poll(() => contextTrigger.evaluate((el) =>
     getComputedStyle(el).getPropertyValue("--context-gauge-angle").trim())).toBe("-76.5deg");
   await expect(page.locator(".topbar .hint")).toHaveCount(0);
@@ -2565,7 +2566,9 @@ test("context usage moves out of the topbar and opens a categorized detail panel
   await page.getByRole("button", { name: "Send", exact: true }).click();
 
   const trigger = page.getByTestId("context-usage-trigger");
-  await expect(trigger).toHaveText("");
+  await expect(trigger).toHaveText("62%");
+  await expect(trigger).toHaveAttribute("data-tone", "ok");
+  await expect(trigger).toHaveAttribute("title", /79\.9K \/ 128K tokens/);
   await expect.poll(() => trigger.evaluate((el) =>
     getComputedStyle(el).getPropertyValue("--context-gauge-angle").trim())).toBe("-34.2deg");
   await expect.poll(() => trigger.locator("svg path").first().evaluate((el) =>
@@ -2655,7 +2658,8 @@ test("legacy native usage totals fall back to Conversation, not Agent-managed", 
   await page.getByRole("button", { name: "Send", exact: true }).click();
 
   const trigger = page.getByTestId("context-usage-trigger");
-  await expect(trigger).toHaveText("");
+  await expect(trigger).toHaveText("20%");
+  await expect(trigger).toHaveAttribute("data-tone", "ok");
   await expect.poll(() => trigger.evaluate((el) =>
     getComputedStyle(el).getPropertyValue("--context-gauge-angle").trim())).toBe("-72.0deg");
   await trigger.click();
@@ -2688,8 +2692,27 @@ test("context usage limit follows the session's current model", async ({ page })
   await expect(page.locator(".model-picker-label")).toHaveText("opus-4.8");
   await expect.poll(() => trigger.evaluate((el) =>
     getComputedStyle(el).getPropertyValue("--context-gauge-angle").trim())).toBe("-54.0deg");
+  await expect(trigger).toHaveText("40%");
   await trigger.click();
   await expect(page.getByTestId("context-usage-panel")).toContainText("~79.9K / 200K Tokens");
+});
+
+test("context usage trigger colors the live percent at warn and danger thresholds (#931)", async ({ page }) => {
+  await enterApp(page);
+
+  await page.locator("#composer-input").fill("CONTEXTUSAGEWARN");
+  await page.getByRole("button", { name: "Send", exact: true }).click();
+  const trigger = page.getByTestId("context-usage-trigger");
+  await expect(trigger).toHaveText("72%");
+  await expect(trigger).toHaveAttribute("data-tone", "warn");
+  await expect(trigger).toHaveClass(/is-warn/);
+
+  await newSessionButton(page).click();
+  await page.locator("#composer-input").fill("CONTEXTUSAGEDANGER");
+  await page.getByRole("button", { name: "Send", exact: true }).click();
+  await expect(trigger).toHaveText("91%");
+  await expect(trigger).toHaveAttribute("data-tone", "danger");
+  await expect(trigger).toHaveClass(/is-danger/);
 });
 
 test("context usage keeps the running agent window until a model switch boundary", async ({ page }) => {

--- a/ui/src/chat_render.rs
+++ b/ui/src/chat_render.rs
@@ -66,6 +66,69 @@ pub(crate) fn context_percent(used: usize, max: usize) -> usize {
     }
 }
 
+/// Default bands from #931: under 70% is idle, 70–90% is a warning, above
+/// 90% is danger. A missing window must not look like 0%.
+pub(crate) const CONTEXT_USAGE_WARN_PCT: usize = 70;
+pub(crate) const CONTEXT_USAGE_DANGER_PCT: usize = 90;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ContextUsageTone {
+    Unknown,
+    Ok,
+    Warn,
+    Danger,
+}
+
+impl ContextUsageTone {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Unknown => "unknown",
+            Self::Ok => "ok",
+            Self::Warn => "warn",
+            Self::Danger => "danger",
+        }
+    }
+}
+
+pub(crate) fn context_usage_tone(used: usize, max: usize) -> ContextUsageTone {
+    if max == 0 {
+        return ContextUsageTone::Unknown;
+    }
+    let pct = context_percent(used, max);
+    if pct > CONTEXT_USAGE_DANGER_PCT {
+        ContextUsageTone::Danger
+    } else if pct >= CONTEXT_USAGE_WARN_PCT {
+        ContextUsageTone::Warn
+    } else {
+        ContextUsageTone::Ok
+    }
+}
+
+pub(crate) fn context_usage_percent_label(used: usize, max: usize) -> String {
+    if max == 0 {
+        "—".into()
+    } else {
+        format!("{}%", context_percent(used, max))
+    }
+}
+
+pub(crate) fn context_usage_tooltip(snapshot: &ContextUsageSnapshot, locale: Locale) -> String {
+    if snapshot.max == 0 {
+        return t(locale, "context_usage.tooltip_unknown").into();
+    }
+    let used = fmt_context_tokens(snapshot.used);
+    let max = fmt_context_limit(snapshot.max);
+    tf(
+        locale,
+        if snapshot.estimated {
+            "context_usage.tooltip_estimated"
+        } else {
+            "context_usage.tooltip_exact"
+        },
+        &[("used", &used), ("max", &max)],
+    )
+}
+
 pub(crate) fn fmt_context_tokens(tokens: usize) -> String {
     if tokens < 1_000 {
         tokens.to_string()
@@ -161,8 +224,9 @@ pub(crate) fn context_usage_detail_text(details: &ContextUsageDetails, color: &s
 #[cfg(test)]
 mod token_format_tests {
     use super::{
-        context_percent, context_usage_rows, fmt_context_limit, fmt_context_tokens, fmt_tokens,
-        renders_nothing,
+        context_percent, context_usage_percent_label, context_usage_rows, context_usage_tone,
+        context_usage_tooltip, fmt_context_limit, fmt_context_tokens, fmt_tokens, renders_nothing,
+        ContextUsageTone,
     };
     use crate::dto::{ContextUsage, ContextUsageSnapshot};
     use crate::i18n::Locale;
@@ -189,6 +253,40 @@ mod token_format_tests {
         assert_eq!(fmt_context_tokens(6_000), "6.0K");
         assert_eq!(fmt_context_tokens(79_900), "79.9K");
         assert_eq!(fmt_context_limit(300_000), "300K");
+    }
+
+    #[test]
+    fn context_usage_tone_uses_warn_and_danger_bands() {
+        assert_eq!(context_usage_tone(0, 0), ContextUsageTone::Unknown);
+        assert_eq!(context_usage_tone(69, 100), ContextUsageTone::Ok);
+        assert_eq!(context_usage_tone(70, 100), ContextUsageTone::Warn);
+        assert_eq!(context_usage_tone(90, 100), ContextUsageTone::Warn);
+        assert_eq!(context_usage_tone(91, 100), ContextUsageTone::Danger);
+        assert_eq!(context_usage_percent_label(0, 0), "—");
+        assert_eq!(context_usage_percent_label(79_900, 128_000), "62%");
+        let tooltip = context_usage_tooltip(
+            &ContextUsageSnapshot {
+                used: 79_900,
+                max: 128_000,
+                breakdown: None,
+                estimated: true,
+            },
+            Locale::En,
+        );
+        assert!(tooltip.contains("79.9K"));
+        assert!(tooltip.contains("128K"));
+        assert_eq!(
+            context_usage_tooltip(
+                &ContextUsageSnapshot {
+                    used: 1_200,
+                    max: 0,
+                    breakdown: None,
+                    estimated: false,
+                },
+                Locale::En,
+            ),
+            "Context window unknown for this model"
+        );
     }
 
     #[test]

--- a/ui/src/i18n.rs
+++ b/ui/src/i18n.rs
@@ -1829,6 +1829,17 @@ fn lookup(locale: Locale, key: &str) -> Option<&'static str> {
         (Locale::En, "context_usage.total_exact") => Some("{used} / {max} Tokens"),
         (Locale::En, "context_usage.total_used") => Some("{used} Tokens"),
         (Locale::En, "context_usage.open") => Some("Open context usage"),
+        (Locale::En, "context_usage.open_pct") => Some("Open context usage, {pct}%"),
+        (Locale::En, "context_usage.open_unknown") => Some("Open context usage, window unknown"),
+        (Locale::En, "context_usage.tooltip_estimated") => {
+            Some("~{used} / {max} tokens (current model context window)")
+        }
+        (Locale::En, "context_usage.tooltip_exact") => {
+            Some("{used} / {max} tokens (current model context window)")
+        }
+        (Locale::En, "context_usage.tooltip_unknown") => {
+            Some("Context window unknown for this model")
+        }
         (Locale::En, "context_usage.close") => Some("Close context usage"),
         (Locale::En, "context_usage.dock") => Some("Dock panel"),
         (Locale::En, "context_usage.resize") => Some("Resize panel"),
@@ -4173,6 +4184,15 @@ Do not leave generated files in the project root.",
         (Locale::Zh, "context_usage.total_exact") => Some("{used} / {max} Tokens"),
         (Locale::Zh, "context_usage.total_used") => Some("{used} Tokens"),
         (Locale::Zh, "context_usage.open") => Some("查看上下文用量"),
+        (Locale::Zh, "context_usage.open_pct") => Some("查看上下文用量，已用 {pct}%"),
+        (Locale::Zh, "context_usage.open_unknown") => Some("查看上下文用量，窗口未知"),
+        (Locale::Zh, "context_usage.tooltip_estimated") => {
+            Some("约 {used} / {max} tokens（当前模型上下文窗口）")
+        }
+        (Locale::Zh, "context_usage.tooltip_exact") => {
+            Some("{used} / {max} tokens（当前模型上下文窗口）")
+        }
+        (Locale::Zh, "context_usage.tooltip_unknown") => Some("当前模型上下文窗口未知"),
         (Locale::Zh, "context_usage.close") => Some("关闭上下文用量"),
         (Locale::Zh, "context_usage.dock") => Some("停靠面板"),
         (Locale::Zh, "context_usage.resize") => Some("调整面板大小"),

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -623,6 +623,24 @@ fn App() -> impl IntoView {
             })
         }
     });
+    let context_usage_flash = create_rw_signal(false);
+    {
+        let last_used = Rc::new(Cell::new(None::<usize>));
+        create_effect(move |_| {
+            let Some(snapshot) = active_context_usage.get() else {
+                last_used.set(None);
+                return;
+            };
+            let previous = last_used.replace(Some(snapshot.used));
+            if previous.is_some_and(|previous| snapshot.used < previous) {
+                context_usage_flash.set(true);
+                set_timeout(
+                    move || context_usage_flash.set(false),
+                    std::time::Duration::from_millis(700),
+                );
+            }
+        });
+    }
     create_effect(move |_| {
         let _ = active_session.get();
         context_usage_open.set(false);
@@ -12000,12 +12018,32 @@ fn App() -> impl IntoView {
                             {move || active_context_usage.get().map(|snapshot| {
                                 let pct = context_percent(snapshot.used, snapshot.max);
                                 let gauge_angle = -90.0 + pct as f64 * 0.9;
+                                let tone = context_usage_tone(snapshot.used, snapshot.max);
+                                let percent_label = context_usage_percent_label(snapshot.used, snapshot.max);
+                                let tooltip = context_usage_tooltip(&snapshot, locale.get());
+                                let aria = if snapshot.max == 0 {
+                                    t(locale.get(), "context_usage.open_unknown")
+                                } else {
+                                    tf(
+                                        locale.get(),
+                                        "context_usage.open_pct",
+                                        &[("pct", &pct.to_string())],
+                                    )
+                                };
+                                let tone_warn = tone == ContextUsageTone::Warn;
+                                let tone_danger = tone == ContextUsageTone::Danger;
+                                let tone_unknown = tone == ContextUsageTone::Unknown;
                                 view! {
                                     <button type="button" class="context-usage-trigger"
+                                        class:is-warn=tone_warn
+                                        class:is-danger=tone_danger
+                                        class:is-unknown=tone_unknown
+                                        class:is-compacted=move || context_usage_flash.get()
                                         data-testid="context-usage-trigger"
+                                        data-tone=tone.as_str()
                                         style=format!("--context-gauge-angle:{gauge_angle:.1}deg")
-                                        title=move || t(locale.get(), "context_usage.open")
-                                        aria-label=move || t(locale.get(), "context_usage.open")
+                                        title=tooltip
+                                        aria-label=aria
                                         aria-expanded=move || context_usage_open.get().to_string()
                                         aria-controls="context-usage-panel"
                                         on:click=move |event| {
@@ -12030,6 +12068,7 @@ fn App() -> impl IntoView {
                                             }
                                         }>
                                         {compose_icon("gauge")}
+                                        <span class="context-usage-pct" data-testid="context-usage-percent">{percent_label}</span>
                                     </button>
                                 }
                             })}

--- a/ui/src/styles/chat.css
+++ b/ui/src/styles/chat.css
@@ -1260,17 +1260,33 @@ details.tool:not([open]) > summary.head .run-dot { animation: tool-pulse 1.1s ea
 .composer-hint { min-width: 0; padding: 0 2px 0 54px; font-size: 11px; line-height: 1.35; color: var(--text-faint); user-select: none; text-align: center; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; opacity: 0; transition: opacity .15s ease; }
 .composer-inner:focus-within .composer-hint, .composer-inner:hover .composer-hint { opacity: 1; }
 .context-usage-trigger {
-  display: inline-flex; flex: 0 0 auto; align-items: center; justify-content: center; width: 28px; height: 32px; padding: 0;
+  display: inline-flex; flex: 0 0 auto; align-items: center; justify-content: center; gap: 4px;
+  width: auto; min-width: 28px; height: 32px; padding: 0 6px 0 4px;
   border: 0; border-radius: var(--radius-xs); background: transparent; color: var(--text-faint);
   cursor: pointer;
   transition: color .12s ease, background .12s ease;
 }
+.context-usage-pct {
+  font-size: 11px; font-weight: 600; font-variant-numeric: tabular-nums; letter-spacing: -.02em; line-height: 1;
+}
 .context-usage-trigger:hover, .context-usage-trigger[aria-expanded="true"] { color: var(--text); background: var(--surface-hover); }
+.context-usage-trigger.is-warn { color: var(--warn); }
+.context-usage-trigger.is-warn:hover, .context-usage-trigger.is-warn[aria-expanded="true"] { color: var(--warn); }
+.context-usage-trigger.is-danger { color: var(--err); }
+.context-usage-trigger.is-danger:hover, .context-usage-trigger.is-danger[aria-expanded="true"] { color: var(--err); }
 .context-usage-trigger svg { width: 18px; height: 18px; }
 .context-usage-trigger svg path:first-child {
   transform-box: view-box; transform-origin: 12px 14px;
   transform: rotate(var(--context-gauge-angle, -90deg));
   transition: transform .2s var(--motion-ease-standard);
+}
+.context-usage-trigger.is-compacted {
+  animation: context-usage-compact-pulse .7s var(--motion-ease-standard);
+}
+@keyframes context-usage-compact-pulse {
+  0% { transform: scale(1); }
+  35% { transform: scale(1.08); }
+  100% { transform: scale(1); }
 }
 .context-usage-slot {
   flex: 0 0 auto; max-width: var(--chat-col-max); width: 100%; margin: 0 auto 8px;
@@ -1530,6 +1546,8 @@ button.send:disabled { opacity: .45; cursor: default; }
   .composer-plus, .composer-compute { width: 28px; height: 28px; }
   .composer-plus svg, .composer-compute svg { width: 15px; height: 15px; }
   .model-picker-btn { max-width: 104px; height: 28px; padding-inline: 8px; }
+  .context-usage-trigger { height: 28px; padding: 0 5px 0 3px; gap: 3px; }
+  .context-usage-pct { font-size: 10px; }
   button.send { min-width: 44px; height: 28px; padding-inline: 10px; font-size: 12px; }
   .send-menu-toggle { width: 28px; height: 28px; }
   .send-menu-toggle svg { width: 14px; height: 14px; }


### PR DESCRIPTION
## User-facing problem

Context usage was hidden behind a click on the gauge icon. In long research conversations that is easy to miss: people only notice the window is full when the model starts dropping context. #931 asks for a live percent next to the icon, colored by how full the window is.

## What changed

- The composer gauge now always shows the latest percent (`62%`), not just an unlabeled icon.
- Color bands: under 70% follows the theme, 70–90% is warn (`--warn`), above 90% is danger (`--err`).
- Hover tooltip shows used / max tokens for the current model window. If the window is unknown, the label is `—` instead of a fake `0%`.
- Auto-compact that drops the used count plays a short pulse so the drop does not look like a stats glitch.
- Clicking the control still opens the existing categorized panel.

## Tests

- Existing context-usage Playwright tests now assert the live percent and `data-tone`.
- New test covers warn (72%) and danger (91%) classes.
- Unit tests cover the 70 / 90 bands, the em-dash unknown label, and the tooltip copy.

`cd ui && cargo check --target wasm32-unknown-unknown` passed.
Playwright `context usage` / ACP usage / legacy usage tests passed.

## Manual smoke

1. Send a turn and confirm the gauge shows a percent without opening the panel.
2. Hover it: used / max tokens should match the panel header.
3. Drive usage past 70% and 90% (or use `CONTEXTUSAGEWARN` / `CONTEXTUSAGEDANGER` in the mock) and check warn then danger color.
4. Open the panel with a click; Escape still closes only that layer.

## Limitations / follow-up

- No system notification or `summarize / new session` shortcut at the threshold. The issue listed that as optional.
- Category breakdown stays in the click-to-open panel, not the hover tooltip.

Fixes #931