### PR TITLE
feat: kernel-reported writes; attribute runtime-computed filenames (#937)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,18 @@ jobs:
       - name: Run MCP process-tree shutdown regression
         run: cargo test -p wisp-mcp --test process_tree_shutdown
 
+      # The kernel worker is Python, so its tests are too. Run them on all
+      # three OSes: the worker's write reporting and its process handling are
+      # exactly the parts that differ per platform.
+      - name: Run Python kernel worker tests (Unix)
+        if: runner.os != 'Windows'
+        run: python3 -m unittest discover -s python -p "test_kernel_worker.py" -v
+
+      # python3 is not on PATH on windows-latest; the launcher is `python`.
+      - name: Run Python kernel worker tests (Windows)
+        if: runner.os == 'Windows'
+        run: python -m unittest discover -s python -p "test_kernel_worker.py" -v
+
       - name: Run deterministic headless agent suite
         run: cargo run -p wisp-cli -- eval --artifacts target/headless-agent-eval --save target/headless-agent-eval/report.json
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7244,6 +7244,7 @@ version = "1.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "dunce",
  "serde",
  "serde_json",
  "tokio",

--- a/crates/wisp-core/src/agent.rs
+++ b/crates/wisp-core/src/agent.rs
@@ -515,6 +515,9 @@ async fn agent_loop_inner(
             };
             let t0 = std::time::Instant::now();
             let result = tools.run(&name, &args, &env).await;
+            // Drain even for non-producing calls so a stale kernel report
+            // cannot leak into the next call's provenance record.
+            let reported = env.take_reported_writes();
             let control = result.control;
             let duration_ms = t0.elapsed().as_millis() as u64;
             if let Some(root) = &root {
@@ -541,6 +544,10 @@ async fn agent_loop_inner(
                     &preimages,
                     &mut written,
                 );
+                // After retain: a kernel-reported path survives an ambiguity
+                // drop, and a report never widens what retain kept for
+                // unreported paths.
+                provenance::union_paths_by_identity(&mut written, &reported);
                 read.retain(|path| !written.contains(path));
                 if !written.is_empty() {
                     let file_changes =

--- a/crates/wisp-core/src/output.rs
+++ b/crates/wisp-core/src/output.rs
@@ -147,6 +147,14 @@ pub struct ToolEnvAdapter<'a> {
     /// Mid-turn guidance queue (`GuidanceQueue`). Typed as the mutex so this
     /// module does not depend on `agent`.
     guidance: Option<&'a std::sync::Mutex<Vec<(u64, String)>>>,
+    /// Kernel-reported writes for the in-flight tool call.
+    ///
+    /// Tool calls within one agent loop run strictly sequentially, so
+    /// drain-per-call is race-free; parallel subagent loops each construct
+    /// their own adapter, so reports cannot cross loops. The buffer must be
+    /// drained unconditionally after every tool call so a stale report can
+    /// never leak into the next call's record.
+    reported_writes: std::sync::Mutex<Vec<String>>,
 }
 
 impl<'a> ToolEnvAdapter<'a> {
@@ -156,6 +164,7 @@ impl<'a> ToolEnvAdapter<'a> {
             out,
             cancel: None,
             guidance: None,
+            reported_writes: std::sync::Mutex::new(Vec::new()),
         }
     }
     /// Like `new`, but tools can poll `is_cancelled()` to stop mid-execution.
@@ -169,7 +178,17 @@ impl<'a> ToolEnvAdapter<'a> {
             out,
             cancel: Some(cancel),
             guidance: None,
+            reported_writes: std::sync::Mutex::new(Vec::new()),
         }
+    }
+    /// Drain kernel-reported writes accumulated during the current tool call.
+    pub(crate) fn take_reported_writes(&self) -> Vec<String> {
+        std::mem::take(
+            &mut *self
+                .reported_writes
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()),
+        )
     }
     /// Let long-running tools see that the host has queued mid-turn guidance
     /// without draining it. The agent loop still injects at the iteration
@@ -237,15 +256,23 @@ impl<'a> wisp_tools::ToolEnv for ToolEnvAdapter<'a> {
     fn note_shell_outcome(&self, cmd: &str, success: bool, detail: &str) {
         self.out.note_shell_outcome(cmd, success, detail);
     }
+    fn report_written_paths(&self, paths: &[String]) {
+        self.reported_writes
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .extend(paths.iter().cloned());
+    }
     async fn emit(&self, event: wisp_tools::ToolEvent) {
         match event {
             wisp_tools::ToolEvent::Call { name, preview } => self.out.tool_call(&name, &preview),
             wisp_tools::ToolEvent::Diff { path, old, new } => self.out.diff(&path, &old, &new),
             wisp_tools::ToolEvent::FileChanged { path } => self.out.file_changed(&path),
             wisp_tools::ToolEvent::Stdout { chunk } => self.out.stdout_chunk(&chunk),
-            wisp_tools::ToolEvent::Presentation { kind, payload, server } => {
-                self.out.tool_presentation(&kind, &payload, server)
-            }
+            wisp_tools::ToolEvent::Presentation {
+                kind,
+                payload,
+                server,
+            } => self.out.tool_presentation(&kind, &payload, server),
             wisp_tools::ToolEvent::Result { ok: _ } => {}
         }
         let _ = Value::Null;
@@ -382,5 +409,22 @@ mod tests {
         assert!(!wisp_tools::ToolEnv::guidance_pending(
             &ToolEnvAdapter::new(std::path::PathBuf::from("."), &out)
         ));
+    }
+
+    #[test]
+    fn reported_writes_accumulate_then_drain_empty() {
+        let out = NullOutput;
+        let env = ToolEnvAdapter::new(std::path::PathBuf::from("."), &out);
+        wisp_tools::ToolEnv::report_written_paths(&env, &["a.txt".into(), "b.txt".into()]);
+        wisp_tools::ToolEnv::report_written_paths(&env, &["c.txt".into()]);
+        assert_eq!(
+            env.take_reported_writes(),
+            vec![
+                "a.txt".to_string(),
+                "b.txt".to_string(),
+                "c.txt".to_string()
+            ]
+        );
+        assert!(env.take_reported_writes().is_empty());
     }
 }

--- a/crates/wisp-core/src/provenance.rs
+++ b/crates/wisp-core/src/provenance.rs
@@ -1,7 +1,7 @@
 //! Best-effort artifact provenance: snapshot the workspace around a producing
 //! tool call and diff to learn which files it wrote and read.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -314,6 +314,33 @@ fn path_identity(path: &Path) -> String {
     #[cfg(not(windows))]
     {
         path
+    }
+}
+
+fn relative_identity(path: &str) -> String {
+    path_identity(Path::new(path))
+}
+
+/// Union `extra` into `paths`, keeping the spelling already present when
+/// two spellings resolve to one file (`out\b.txt` vs `out/b.txt`; case
+/// variants on Windows). Every merge of written paths goes through here so
+/// the equality rule cannot drift between call sites.
+pub fn union_paths_by_identity(paths: &mut Vec<String>, extra: &[String]) {
+    if extra.is_empty() {
+        return;
+    }
+    let mut seen: HashSet<String> = paths.iter().map(|p| relative_identity(p)).collect();
+    let mut inserted = false;
+    for path in extra {
+        if seen.insert(relative_identity(path)) {
+            paths.push(path.clone());
+            inserted = true;
+        }
+    }
+    // Only re-sort when something was added: a report that covers nothing
+    // new must leave the record byte-identical to the pre-report behavior.
+    if inserted {
+        paths.sort();
     }
 }
 
@@ -1017,6 +1044,99 @@ mod tests {
         );
         assert_eq!(written, vec!["final_results.csv".to_string()]);
         std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    /// #937: a computed-name path dropped by foreign overlap is restored
+    /// when the kernel reports it; the literal-named sibling stays too.
+    #[test]
+    fn kernel_reported_computed_name_survives_foreign_overlap() {
+        let tmp = unique_tmp("937_repro");
+        std::fs::write(tmp.join("fig_1.png"), b"computed").unwrap();
+        std::fs::write(tmp.join("fig_2.png"), b"literal").unwrap();
+        let after = snapshot(&tmp);
+        let mtime = after[&tmp.join("fig_1.png")];
+        let window = window_over(
+            mtime,
+            vec![(
+                mtime - Duration::from_secs(1),
+                mtime + Duration::from_secs(1),
+            )],
+        );
+        let mut written = vec!["fig_1.png".to_string(), "fig_2.png".to_string()];
+        retain_unambiguous_writes(
+            &mut written,
+            &after,
+            &tmp,
+            "open('fig_2.png','w'); name = f'fig_{1}.png'; open(name,'w')",
+            &window,
+        );
+        assert_eq!(written, vec!["fig_2.png".to_string()]);
+        union_paths_by_identity(&mut written, &["fig_1.png".to_string()]);
+        assert_eq!(
+            written,
+            vec!["fig_1.png".to_string(), "fig_2.png".to_string()]
+        );
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    /// Reports must not weaken #935 for paths they do not cover.
+    #[test]
+    fn unreported_ambiguous_path_stays_dropped() {
+        let tmp = unique_tmp("937_control");
+        std::fs::write(tmp.join("fig_1.png"), b"computed").unwrap();
+        std::fs::write(tmp.join("fig_2.png"), b"literal").unwrap();
+        let after = snapshot(&tmp);
+        let mtime = after[&tmp.join("fig_1.png")];
+        let window = window_over(
+            mtime,
+            vec![(
+                mtime - Duration::from_secs(1),
+                mtime + Duration::from_secs(1),
+            )],
+        );
+        let mut written = vec!["fig_1.png".to_string(), "fig_2.png".to_string()];
+        retain_unambiguous_writes(
+            &mut written,
+            &after,
+            &tmp,
+            "open('fig_2.png','w'); name = f'fig_{1}.png'; open(name,'w')",
+            &window,
+        );
+        assert_eq!(written, vec!["fig_2.png".to_string()]);
+        union_paths_by_identity(&mut written, &[]);
+        assert_eq!(written, vec!["fig_2.png".to_string()]);
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn union_keeps_diff_spelling_for_the_same_identity() {
+        let mut written = vec!["out/b.txt".to_string()];
+        union_paths_by_identity(&mut written, &[r"out\b.txt".to_string()]);
+        assert_eq!(written, vec!["out/b.txt".to_string()]);
+    }
+
+    #[test]
+    fn all_duplicate_report_leaves_written_byte_identical() {
+        let mut written = vec![
+            "c.txt".to_string(),
+            "a.txt".to_string(),
+            r"b\d.txt".to_string(),
+        ];
+        let before = written.clone();
+        union_paths_by_identity(&mut written, &["a.txt".to_string(), "b/d.txt".to_string()]);
+        assert_eq!(written, before);
+    }
+
+    #[test]
+    fn empty_report_leaves_written_byte_identical() {
+        let mut written = vec![
+            "a.txt".to_string(),
+            "c.txt".to_string(),
+            "b.txt".to_string(),
+        ];
+        let before = written.clone();
+        union_paths_by_identity(&mut written, &[]);
+        assert_eq!(written, before);
     }
 
     #[test]

--- a/crates/wisp-runtime/Cargo.toml
+++ b/crates/wisp-runtime/Cargo.toml
@@ -16,3 +16,4 @@ uuid = { workspace = true }
 wisp-llm = { workspace = true }
 wisp-tools = { workspace = true }
 wisp-paths = { workspace = true }
+dunce = { workspace = true }

--- a/crates/wisp-runtime/src/kernel.rs
+++ b/crates/wisp-runtime/src/kernel.rs
@@ -28,6 +28,10 @@ pub struct KernelResp {
     pub wall_s: f64,
     pub cpu_s: f64,
     pub rss_kb: u64,
+    /// Absolute paths the worker observed this cell write. `None` means the
+    /// worker did not (or could not) observe; `Some([])` means it observed
+    /// and the cell wrote nothing. Never conflate the two.
+    pub files_written: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone)]
@@ -66,6 +70,8 @@ struct RawResp {
     interrupted: bool,
     #[serde(default)]
     usage: RawUsage,
+    #[serde(default)]
+    files_written: Option<Vec<String>>,
 }
 
 #[derive(Deserialize, Debug, Default)]
@@ -431,6 +437,7 @@ async fn read_response<R: AsyncBufRead + Unpin>(
                     wall_s: response.usage.wall_s,
                     cpu_s: response.usage.cpu_s,
                     rss_kb: response.usage.rss_kb,
+                    files_written: response.files_written,
                 });
             }
             other => bail!("unexpected protocol frame '{other}' during execution"),
@@ -630,6 +637,7 @@ mod tests {
             .unwrap();
         assert_eq!(response.stdout, "done\n");
         assert_eq!(response.rss_kb, 123);
+        assert_eq!(response.files_written, None);
         assert!(matches!(
             rx.recv().await,
             Some(RuntimeEvent::Stdout(chunk)) if chunk == "loading\n"
@@ -654,6 +662,70 @@ mod tests {
         .await
         .unwrap_err();
         assert!(error.to_string().contains("does not match active request"));
+    }
+
+    #[tokio::test]
+    async fn result_frame_round_trips_files_written() {
+        let (reader, mut writer) = duplex(2048);
+        writer
+            .write_all(
+                br#"{"type":"result","id":"cell-1","stdout":"","stderr":"","error":null,"files_written":["/p/a.txt","/p/b.txt"]}
+"#,
+            )
+            .await
+            .unwrap();
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let response = read_response(
+            &mut BufReader::new(reader),
+            "cell-1",
+            &RuntimeOutput::new(tx),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            response.files_written,
+            Some(vec!["/p/a.txt".into(), "/p/b.txt".into()])
+        );
+    }
+
+    #[tokio::test]
+    async fn result_frame_without_files_written_is_none() {
+        let (reader, mut writer) = duplex(1024);
+        writer
+            .write_all(
+                b"{\"type\":\"result\",\"id\":\"cell-1\",\"stdout\":\"\",\"stderr\":\"\",\"error\":null}\n",
+            )
+            .await
+            .unwrap();
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let response = read_response(
+            &mut BufReader::new(reader),
+            "cell-1",
+            &RuntimeOutput::new(tx),
+        )
+        .await
+        .unwrap();
+        assert_eq!(response.files_written, None);
+    }
+
+    #[tokio::test]
+    async fn result_frame_with_empty_files_written_is_some_empty() {
+        let (reader, mut writer) = duplex(1024);
+        writer
+            .write_all(
+                b"{\"type\":\"result\",\"id\":\"cell-1\",\"stdout\":\"\",\"stderr\":\"\",\"error\":null,\"files_written\":[]}\n",
+            )
+            .await
+            .unwrap();
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let response = read_response(
+            &mut BufReader::new(reader),
+            "cell-1",
+            &RuntimeOutput::new(tx),
+        )
+        .await
+        .unwrap();
+        assert_eq!(response.files_written, Some(Vec::new()));
     }
 
     #[tokio::test]

--- a/crates/wisp-runtime/src/tool.rs
+++ b/crates/wisp-runtime/src/tool.rs
@@ -5,8 +5,59 @@ use crate::{
 };
 use async_trait::async_trait;
 use serde_json::json;
+use std::path::Path;
 use wisp_llm::ToolSchema;
 use wisp_tools::{Tool, ToolEnv, ToolEvent, ToolResult};
+
+/// Normalize path separators for comparison. Only meaningful on Windows,
+/// where `\` cannot appear in a filename; on Unix a literal `\` is a legal
+/// filename character and replacing it could redirect the path to a
+/// *different* existing file (`we\ird.txt` vs `we/ird.txt`), i.e. credit a
+/// file the cell never wrote.
+fn normalize_separators(path: &str) -> String {
+    if cfg!(windows) {
+        path.replace('\\', "/")
+    } else {
+        path.to_string()
+    }
+}
+
+/// Relativize worker-reported absolute writes to the project root.
+/// Outside-root paths, the root itself, and empty remainders are dropped;
+/// on Windows `\` is normalized to `/`; duplicates are collapsed; the
+/// result is sorted.
+fn project_relative_writes(root: &Path, reported: &[String]) -> Vec<String> {
+    let root = dunce::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
+    let mut out = Vec::new();
+    for raw in reported {
+        // Normalize separators before canonicalize/strip so a Windows-style
+        // `out\a.txt` still matches on hosts whose temp root is a symlink.
+        let normalized = normalize_separators(raw);
+        let path = Path::new(&normalized);
+        let abs = dunce::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+        let Ok(relative) = abs.strip_prefix(&root) else {
+            continue;
+        };
+        // When canonicalize failed above, `abs` is the raw reported path and
+        // the remainder could still climb out of the root (`/root/../etc`).
+        // Provenance records feed exports and undo — never let one name a
+        // path outside the root.
+        if relative
+            .components()
+            .any(|c| !matches!(c, std::path::Component::Normal(_)))
+        {
+            continue;
+        }
+        let relative = normalize_separators(&relative.to_string_lossy());
+        if relative.is_empty() {
+            continue;
+        }
+        out.push(relative);
+    }
+    out.sort();
+    out.dedup();
+    out
+}
 
 pub struct ReplTool {
     manager: RuntimeManager,
@@ -150,6 +201,14 @@ async fn run_runtime(
                     env.emit(ToolEvent::Stdout { chunk }).await;
                 }
                 Some(RuntimeEvent::Finished(Ok(response))) => {
+                    if key.context_id == LOCAL_CONTEXT_ID {
+                        if let Some(reported) = &response.files_written {
+                            let paths = project_relative_writes(env.project_root(), reported);
+                            if !paths.is_empty() {
+                                env.report_written_paths(&paths);
+                            }
+                        }
+                    }
                     let success = response.error.is_none();
                     return ToolResult {
                         success,
@@ -282,8 +341,11 @@ impl Tool for RTool {
 
 #[cfg(test)]
 mod tests {
-    use super::{code_arg, context_id, PYTHON_TOOL_DESCRIPTION, R_TOOL_DESCRIPTION};
+    use super::{
+        code_arg, context_id, project_relative_writes, PYTHON_TOOL_DESCRIPTION, R_TOOL_DESCRIPTION,
+    };
     use crate::MAX_CODE_BYTES;
+    use std::path::PathBuf;
 
     #[test]
     fn python_description_keeps_package_setup_out_of_the_repl() {
@@ -325,5 +387,85 @@ mod tests {
     fn code_size_is_rejected_before_runtime_dispatch() {
         let args = serde_json::json!({"code": "x".repeat(MAX_CODE_BYTES + 1)});
         assert!(code_arg(&args).unwrap_err().contains("byte limit"));
+    }
+
+    fn unique_tmp(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "wisp_rel_{tag}_{}_{}",
+            std::process::id(),
+            uuid::Uuid::new_v4().simple()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn project_relative_writes_drops_outside_root_and_normalizes() {
+        let root = unique_tmp("writes");
+        std::fs::create_dir_all(root.join("out")).unwrap();
+        std::fs::write(root.join("out/a.txt"), b"a").unwrap();
+        std::fs::write(root.join("out/c.txt"), b"c").unwrap();
+        let outside = unique_tmp("writes_out");
+        std::fs::write(outside.join("cache"), b"x").unwrap();
+
+        let a = root.join("out/a.txt").to_string_lossy().into_owned();
+        let c = root.join("out/c.txt").to_string_lossy().into_owned();
+        let mut reported = vec![
+            a.clone(),
+            a.clone(),
+            c,
+            outside.join("cache").to_string_lossy().into_owned(),
+            root.to_string_lossy().into_owned(),
+        ];
+        // Backslash spellings collapse into the same entries — but only on
+        // Windows, where `\` is a separator rather than a filename character.
+        if cfg!(windows) {
+            reported.push(format!(
+                "{}{}out\\a.txt",
+                root.display(),
+                std::path::MAIN_SEPARATOR
+            ));
+            reported.push(format!(
+                "{}{}out\\c.txt",
+                root.display(),
+                std::path::MAIN_SEPARATOR
+            ));
+        }
+        let got = project_relative_writes(&root, &reported);
+        assert_eq!(got, vec!["out/a.txt".to_string(), "out/c.txt".to_string()]);
+        std::fs::remove_dir_all(&root).ok();
+        std::fs::remove_dir_all(&outside).ok();
+    }
+
+    /// On Unix a literal `\` is a legal filename character; the spelling
+    /// must be preserved so the record names the file that was written,
+    /// not a same-identity sibling under a `we/` directory.
+    #[cfg(not(windows))]
+    #[test]
+    fn project_relative_writes_preserves_backslash_filenames_on_unix() {
+        let root = unique_tmp("writes_bs");
+        std::fs::write(root.join(r"we\ird.txt"), b"x").unwrap();
+        let reported = vec![root.join(r"we\ird.txt").to_string_lossy().into_owned()];
+        assert_eq!(
+            project_relative_writes(&root, &reported),
+            vec![r"we\ird.txt".to_string()]
+        );
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn project_relative_writes_rejects_parent_traversal_in_fallback() {
+        // A path that does not exist skips canonicalization, so the raw
+        // remainder is stripped verbatim; `..` must never survive into the
+        // provenance record, where undo would resolve it outside the root.
+        let root = unique_tmp("writes_dotdot");
+        let escape = format!(
+            "{}{}..{}escaped.txt",
+            root.display(),
+            std::path::MAIN_SEPARATOR,
+            std::path::MAIN_SEPARATOR
+        );
+        assert!(project_relative_writes(&root, &[escape]).is_empty());
+        std::fs::remove_dir_all(&root).ok();
     }
 }

--- a/crates/wisp-tools/src/env.rs
+++ b/crates/wisp-tools/src/env.rs
@@ -118,9 +118,7 @@ impl std::fmt::Debug for ToolEvent {
             ToolEvent::FileChanged { path } => {
                 f.debug_struct("FileChanged").field("path", path).finish()
             }
-            ToolEvent::Stdout { chunk } => {
-                f.debug_struct("Stdout").field("chunk", chunk).finish()
-            }
+            ToolEvent::Stdout { chunk } => f.debug_struct("Stdout").field("chunk", chunk).finish(),
             ToolEvent::Presentation { kind, payload, .. } => f
                 .debug_struct("Presentation")
                 .field("kind", kind)
@@ -294,6 +292,9 @@ pub trait ToolEnv: Send + Sync {
     /// Optional post-check after a shell command finishes so the host can open
     /// a connectivity gate without spawning another SSH attempt.
     fn note_shell_outcome(&self, _cmd: &str, _success: bool, _detail: &str) {}
+    /// Paths an interpreter reported writing during the current tool call.
+    /// Default: dropped — hosts that do not track attribution lose nothing.
+    fn report_written_paths(&self, _paths: &[String]) {}
 }
 
 #[derive(Debug, Clone)]
@@ -360,5 +361,29 @@ impl ToolResult {
     pub fn stop_turn(mut self) -> Self {
         self.control = ToolControl::StopTurn;
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    struct StubEnv;
+
+    #[async_trait::async_trait]
+    impl ToolEnv for StubEnv {
+        fn project_root(&self) -> &Path {
+            Path::new(".")
+        }
+        async fn confirm(&self, _message: &str) -> bool {
+            true
+        }
+        async fn emit(&self, _event: ToolEvent) {}
+    }
+
+    #[test]
+    fn report_written_paths_default_is_noop() {
+        StubEnv.report_written_paths(&["a.txt".into()]);
     }
 }

--- a/docs/superpowers/plans/2026-08-20-kernel-reported-writes-implementation-notes.md
+++ b/docs/superpowers/plans/2026-08-20-kernel-reported-writes-implementation-notes.md
@@ -1,0 +1,47 @@
+# Kernel-reported writes — implementation notes
+
+Tracking notes while implementing `docs/superpowers/plans/2026-08-20-kernel-reported-writes.md` (#937).
+
+## What landed
+
+- `python/kernel_worker.py` registers one `sys.addaudithook` at startup. Per-cell `begin()`/`finish()` collects write-intent `open` paths and `os.rename`/`os.replace` destinations, reports only paths that exist as files, and omits `files_written` entirely once 512 distinct paths are exceeded.
+- `python/test_kernel_worker.py` drives a real spawned worker for computed names, C-level saves (numpy/matplotlib present here), append, read-only, failed open, write-then-raise, sqlite3 blind spot, and the cap.
+- `KernelResp`/`RawResp`/`read_response` round-trip `files_written` as `Option`. Host `project_relative_writes` canonicalizes, drops outside-root and the root itself, normalizes `\`, sorts, and dedups. Only `LOCAL_CONTEXT_ID` kernels call `ToolEnv::report_written_paths`.
+- `ToolEnv::report_written_paths` default no-op. `ToolEnvAdapter` accumulates into an interior mutex and `take_reported_writes` drains it. `agent_loop_inner` drains after every `tools.run` and unions reported paths after unmodified `retain_unambiguous_writes`.
+- `union_paths_by_identity` keeps the first spelling for one identity. Engine tests cover the #937 repro, the unreported-path control, spelling, and empty-report no-op.
+- CI: Python worker tests on the 3-OS `headless-agent-eval` job after MCP regression. `scripts/probe_write_audit_hook.py` is a standalone probe.
+
+## Post-review fixes (2026-08-20)
+
+- **Bytes path killed the worker:** `open(b'x','wb')` left `bytes` in the
+  report and `json.dumps` raised, crashing the process and losing the
+  session's kernel. `_note` now `os.fsdecode`s bytes and requires strict
+  UTF-8 round-trip; unrepresentable paths are skipped (the host's snapshot
+  inference still covers them — reports only ever add).
+- **Non-UTF-8 filename broke the protocol:** a surrogate-escaped name
+  serialized as a lone `\udcff` escape, which serde_json rejects
+  ("lone leading surrogate in hex escape"), losing the whole result frame.
+  Covered by the same strict-UTF-8 gate. Both cases have worker tests.
+- **Traversal guard:** `project_relative_writes` drops any remainder with a
+  non-`Normal` component — when canonicalize fails (path deleted between
+  report and host processing), a raw `/root/../etc/x` could otherwise strip
+  to `../etc/x` and reach undo.
+- **Unix backslash filenames:** separator normalization is now
+  Windows-only. On Unix `\` is a legal filename character; replacing it
+  could canonicalize to a *different* existing file (`we\ird.txt` vs
+  `we/ird.txt`) and credit a file the cell never wrote.
+- `union_paths_by_identity` only re-sorts when it inserted something, so an
+  all-duplicate report leaves the record byte-identical.
+- CI worker-test steps renamed `(Unix)` / `(Windows)`.
+
+**Documented limitation for the PR body** (deliberately not "fixed"): a
+reported path that the diff never saw (e.g. `open(p, 'r+')` with nothing
+written) is still credited. Same-conversation only, and undo marks it
+non-reversible. Intersecting reports with the diff would forfeit real
+credit for rewrites the mtime-granularity snapshot cannot see.
+
+## Deviations
+
+- Windows CI invokes `python` instead of `python3` (sibling step on the same matrix job). `python3` is not on PATH on `windows-latest`; Unix steps keep the planned `python3` command so the worker tests still run on all three OSes.
+- Did not `cargo fmt --all` the workspace: check fails on pre-existing drift in `src-tauri/src/lib.rs` and `crates/wisp-mcp/src/client.rs`. Formatting those would violate the empty `src-tauri` diff. Touched crates were formatted with `cargo fmt -p wisp-core -p wisp-runtime -p wisp-tools`.
+- `cargo test -p wisp-tauri` failed here: `libsoup-3.0` / WebKit pkg-config missing. Crate-level tests in steps 2–5 are the accepted bar.

--- a/docs/superpowers/plans/2026-08-20-kernel-reported-writes.md
+++ b/docs/superpowers/plans/2026-08-20-kernel-reported-writes.md
@@ -1,0 +1,452 @@
+# Kernel-Reported Writes — attributing runtime-computed filenames (#937)
+
+> Governing principle, carried over from the #911 work: **wrong credit is worse
+> than missing credit.** Attribution records feed exports, publication
+> capsules, and "undo this turn", so a path must never be credited to a
+> conversation that cannot be proven to have written it. This plan adds the one
+> proof source that can end the last "missing credit" case without ever risking
+> wrong credit: the interpreter reporting the files it actually wrote.
+
+**Status:** active ·
+**Upstream issue:** #937 (open follow-up of #911, case 1) ·
+**Base:** `main` at `a27f3284` (contains merged #919 and #935) ·
+**Branch:** `feat/937-kernel-reported-writes` ·
+**Updated:** 2026-08-20
+
+## 1. Problem and context
+
+Two merged upstream fixes frame what remains:
+
+- **#919** (v1.5.0) gave every conversation and every subagent its own Python
+  kernel (`RuntimeKey.session_id`; subagent kernels under `agent-{request_id}`
+  frames). Cross-session variable leakage — the destructive incident class of
+  #911 — is gone.
+- **#935** (`b2b6fe49`) made snapshot-based attribution honest under overlap.
+  Every producing tool call registers a window per workspace root
+  (`provenance::begin_window(root, scope)`); windows carry a conversation
+  scope (`Output::provenance_scope()`, the root frame id), so a conversation
+  and its subagents are never foreign to each other. On completion,
+  `retain_unambiguous_writes` keeps a changed path only when the call's source
+  names it (whole-token matching via `normalize_path_text` /
+  `mentions_path_token`) or its mtime falls inside the call's own window and
+  outside every foreign one (±2 s slack).
+
+**What remains — #911 case 1, tracked as #937.** A file whose name is computed
+at runtime (`f"fig_{i}.png"`) is never named in the source, and under a
+genuine foreign overlap its mtime proves nothing. #935's rule therefore drops
+it — from *everyone's* Generated list. Reproduction from the issue: session B
+writes `fig_1.png` (computed name) and `fig_2.png` (literal) while session A
+sleeps in an overlapping call; only `fig_2.png` appears on B's card, and
+`fig_1.png` vanishes entirely.
+
+This is not a bug in #935 — it is the designed floor of the snapshot/diff
+approach. There is no safe guess left in mtimes or source text. The issue
+itself names the way out: interpreter-level write tracking, so the Python tool
+reports exact `files_written` instead of the host inferring them. The Python
+worker (`python/kernel_worker.py`) is the right place: `sys.addaudithook`
+observes file opens made from C extensions (matplotlib, numpy, pypdfium2,
+python-pptx) that patching `builtins.open` would miss, and the worker already
+instruments itself (it wraps `builtins.__import__` at startup), so this is an
+established pattern in that file.
+
+**Why a kernel report is safe to trust.** Since #919, every kernel belongs to
+exactly one conversation. A path reported by a kernel can therefore only ever
+credit the conversation that ran the cell — the report is a *stronger* proof
+than a source mention, and it can never produce wrong credit across
+conversations.
+
+## 2. Goal, deliverable, and acceptance criteria
+
+**Goal:** Python cells report the files they actually wrote; those reports
+survive overlap arbitration as proven attribution; #911 case 1 stops
+reproducing.
+
+**Deliverable:** one PR, fork → upstream, closing #937. Reviewable in the
+order of §4; each step compiles and passes tests on its own.
+
+**Acceptance criteria** (mirroring #937):
+
+1. **The repro is fixed:** session B writes `fig_1.png` (computed) and
+   `fig_2.png` (literal) during a foreign overlap → both files appear on B's
+   Generated card; neither appears on any other conversation's.
+2. **No regressions:** every #935 behavior is unchanged — token matching,
+   own-window mtime rule, same-scope non-contest — and the full existing test
+   suite stays green.
+3. **Executable evidence:** automated tests cover the
+   computed-name-under-foreign-overlap case at the engine level, the worker's
+   observation semantics, and the worker↔host protocol round-trip; CI runs the
+   worker tests on all three OSes.
+
+**Top-level verification:** the commands in §6, plus the manual smoke test:
+run the #937 two-session prompt against a build of this branch and confirm
+both files land on B's card.
+
+## 3. Design overview
+
+The pipeline gains one arrow; everything else is #935, untouched:
+
+```
+kernel worker (audit hook) ──files_written──▶ KernelResp        (§4.1, §4.2)
+        ──▶ ReplTool relativizes to the project root            (§4.2)
+        ──▶ ToolEnv::report_written_paths, accumulated per call (§4.3)
+        ──▶ agent loop: diff → retain_unambiguous_writes (#935, unchanged)
+                        → union reported paths in (proven, spelling-safe)
+                        → ProvenanceRecord                      (§4.4)
+```
+
+**The fold-in lives entirely in `wisp-core`.** The agent loop
+(`agent_loop_inner` in `crates/wisp-core/src/agent.rs`) already owns the
+per-call producing window, the retain step, and a per-loop `ToolEnvAdapter`.
+The adapter accumulates paths reported during `tools.run(...)`; the loop
+drains them right after the call and unions them into the written list
+**after** `retain_unambiguous_writes`. Consequences that make this the
+smallest correct design:
+
+- An ambiguity drop can never erase a reported path (the union comes after),
+  and a report never widens what retain keeps for *unreported* paths.
+- `run_native_agent` (delegated agents) drives this same loop, so mainline
+  turns, parallel subagents, and delegated agents all inherit the behavior
+  with **zero `src-tauri` changes**.
+- No new host-side attribution plumbing: #935's engine windows already answer
+  "who else was in flight"; this PR only adds "what my own interpreter saw".
+
+**Global constraints, binding on every step:**
+
+- The `Output` trait does not change. Hosts never see reported paths except
+  inside the final `ProvenanceRecord`.
+- `files_written` in the protocol is `Option`: **absent means "worker did not
+  or could not observe — host infers as before"; it is never conflated with an
+  empty list, which means "wrote nothing"**. Old workers and new hosts (and
+  vice versa) must interoperate.
+- A report that might be incomplete is not sent at all (see the cap in §4.1):
+  a truncated list would look authoritative while being wrong.
+- Only local-context kernels report (`LOCAL_CONTEXT_ID`): a remote worker's
+  absolute paths describe another machine's filesystem.
+- No timing-dependent tests — deterministic fakes only (Windows CI rejects
+  sleep-based tests as flaky).
+
+## 4. Implementation steps
+
+### 4.1 `python/kernel_worker.py` — the write observer
+
+**Goal:** each executed cell's response carries the project files the
+interpreter itself opened for writing, with no false positives and no
+partial-looking lists.
+
+**Changes.** Add a module-level observer and register one audit hook at
+startup (audit hooks cannot be removed, so per-cell collection is toggled on
+the observer, `begin()` before `exec`, `finish()` in the `finally`):
+
+- The hook watches two event families and nothing else:
+  - `open` with write intent: a string mode containing any of `w a x +`, or
+    integer flags intersecting
+    `os.O_WRONLY | os.O_RDWR | os.O_APPEND | os.O_CREAT | os.O_TRUNC`.
+  - `os.rename` / `os.replace` **destinations** (a rename creates its target
+    without opening it).
+  - Deliberately **not** mkdir/remove/`shutil.*`: probing showed matplotlib's
+    first import creates `~/.cache/matplotlib` and `~/.config/matplotlib`
+    (noise from outside the project), and the host already learns deletions
+    and directories from its own before/after snapshot.
+- Paths are resolved with `os.path.abspath(os.fspath(path))` and deduplicated
+  in insertion order.
+- The hook body is wrapped in a broad `try/except: return` and returns
+  immediately while collection is off — **an audit hook that raises would
+  propagate into arbitrary user code**, and it runs on every audited event.
+- **Failed opens:** the `open` audit event fires before the OS call completes,
+  so a failed `open()` still notes its path. `finish()` therefore reports only
+  paths that exist as files afterwards (`os.path.isfile`, exceptions treated
+  as "missing"). Omit, never guess.
+- **Cap:** `MAX_REPORTED_WRITES = 512`. Once exceeded, the observer marks
+  itself truncated and `finish()` returns `None` — the response then simply
+  omits the field and the host falls back to inference.
+- Response wiring: after the existing usage block, add
+  `if files_written is not None: resp["files_written"] = files_written`.
+  Absent ≠ empty, per §3.
+
+**Success criteria / verification** — `python/test_kernel_worker.py`
+(unittest, run via
+`python3 -m unittest discover -s python -p "test_kernel_worker.py" -v`) must
+cover, against a real spawned worker:
+
+| Case | Expected report |
+| --- | --- |
+| computed name: `name = f"fig_{1}.png"; open(name,'w')` | the file |
+| C-level library write (`matplotlib` `savefig` or `np.save`) | the file |
+| append mode | the file |
+| read-only `open` | not reported |
+| failed `open()` to a non-creatable path | not reported |
+| write then `raise` | the written path (error still reported) |
+| `sqlite3` database write | **not** reported — asserts the documented blind spot |
+| > 512 distinct paths | `files_written` **absent** from the response |
+
+Test pitfall, learned the hard way: compare against the worker's *resolved*
+paths — `tempfile.mkdtemp()` can sit behind a symlink and the worker reports
+`os.path.abspath` output.
+
+**Boundaries:** no other change to the worker; no attempt to observe
+subprocess or C-`sqlite3` writes (documented blind spot, §5); the worker never
+filters by project root — relativization and confinement are the host's job
+(§4.2), because only the host knows the root.
+
+### 4.2 `crates/wisp-runtime` — protocol and relativization
+
+**Goal:** the report crosses the worker↔host protocol tolerantly in both
+directions, and only project-internal paths, spelled the way every other
+provenance path is spelled, reach the engine.
+
+**Changes.**
+
+- `kernel.rs`: `KernelResp` gains
+  `pub files_written: Option<Vec<String>>`; the internal `RawResp` gains the
+  same field with `#[serde(default)]` so a frame without it deserializes as
+  `None`. `read_response` copies it through.
+- `tool.rs`: add
+
+  ```rust
+  fn project_relative_writes(root: &Path, reported: &[String]) -> Vec<String>
+  ```
+
+  which canonicalizes the root (`dunce::canonicalize`, falling back to the
+  raw root — add `dunce` to this crate's `Cargo.toml`; the workspace already
+  uses it elsewhere), keeps only paths that `strip_prefix(root)` to a
+  non-empty remainder, converts `\` to `/`, sorts, and dedups. Everything
+  outside the root — `/tmp`, home-directory caches — is silently dropped:
+  not part of the project's record.
+- In `run_runtime`, on `Finished(Ok(response))`: if
+  `response.files_written` is `Some` **and** `key.context_id ==
+  LOCAL_CONTEXT_ID`, relativize and, when non-empty, call
+  `env.report_written_paths(&paths)` (the `ToolEnv` method added in §4.3).
+
+**Success criteria / verification** — unit tests in the two files:
+
+- Protocol round-trips (in-memory duplex stream against `read_response`):
+  a result frame carrying `files_written` yields exactly those paths; a frame
+  without the field yields `None` ("absent must not be read as 'wrote
+  nothing'"); a frame with `[]` yields `Some([])` ("an explicit empty list
+  means 'wrote nothing', not 'ask the host'").
+- `project_relative_writes`: outside-root paths dropped, root itself dropped,
+  backslashes normalized, duplicates collapsed, output sorted.
+- `cargo test -p wisp-runtime` green.
+
+**Boundaries:** no changes to `RuntimeKey`, session identity, kernel
+lifecycle, tool descriptions, or the R tool (R has no comparable hook and
+stays on the conservative rule). Remote contexts never report.
+
+### 4.3 `crates/wisp-tools` + `ToolEnvAdapter` — the per-call channel
+
+**Goal:** a tool can hand reported paths to whoever is running it, without
+the host learning a new interface.
+
+**Changes.**
+
+- `crates/wisp-tools/src/env.rs`, on the `ToolEnv` trait — the entire
+  `wisp-tools` change:
+
+  ```rust
+  /// Paths an interpreter reported writing during the current tool call.
+  /// Default: dropped — hosts that do not track attribution lose nothing.
+  fn report_written_paths(&self, _paths: &[String]) {}
+  ```
+
+- `crates/wisp-core/src/output.rs`: `ToolEnvAdapter` implements it by pushing
+  into an interior `Mutex<Vec<String>>` (the adapter is shared as `&self`),
+  and gains a crate-visible `take_reported_writes(&self) -> Vec<String>` that
+  drains the buffer.
+
+**Success criteria / verification:** compiles with no `Output`-trait change
+and no `src-tauri` diff; a `wisp-core` unit test drives
+`report_written_paths` → `take_reported_writes` → empty-after-drain.
+
+**Boundaries / safety argument to record in code comments:** tool calls
+within one agent loop run strictly sequentially, so drain-per-call is
+race-free; parallel subagent loops each construct their own adapter, so
+reports cannot cross loops. The buffer must be drained **unconditionally
+after every tool call** (§4.4) so a stale report can never leak into the next
+call's record.
+
+### 4.4 `crates/wisp-core` — the fold-in
+
+**Goal:** reported paths enter the provenance record as proven attribution:
+they survive the ambiguity drop, dedup against diff-derived spellings, and
+change nothing when no report arrived.
+
+**Changes.**
+
+- `provenance.rs`: add the spelling-safe union (placed beside
+  `path_identity`, which already keys the window registry):
+
+  ```rust
+  fn relative_identity(path: &str) -> String {
+      path_identity(Path::new(path))
+  }
+
+  /// Union `extra` into `paths`, keeping the spelling already present when
+  /// two spellings resolve to one file (`out\b.txt` vs `out/b.txt`; case
+  /// variants on Windows). Every merge of written paths goes through here so
+  /// the equality rule cannot drift between call sites.
+  pub fn union_paths_by_identity(paths: &mut Vec<String>, extra: &[String])
+  ```
+
+  (insert-if-identity-unseen, then sort).
+- `agent.rs`, in the producing-call block of `agent_loop_inner`: immediately
+  after `tools.run(...)` returns, drain
+  `let reported = env.take_reported_writes();` — unconditionally, even for
+  non-producing calls. Then inside the `if let Some(root) = &root` block,
+  after `retain_unambiguous_writes` and `augment_written_paths`:
+
+  ```rust
+  provenance::union_paths_by_identity(&mut written, &reported);
+  ```
+
+  Ordering is the correctness argument: union after retain means a reported
+  path survives the drop; `read.retain(|p| !written.contains(p))` and
+  `undo_file_changes` already run after this point and need no change.
+
+**Success criteria / verification** — deterministic tests in
+`provenance.rs`/`agent.rs` test modules:
+
+- **The #937 reproduction, engine-level:** two foreign-scope windows overlap;
+  the diff yields a computed-name path the source never mentions;
+  `retain_unambiguous_writes` drops it; the reported union restores it. The
+  record ends with both the literal-named and the computed-name file.
+- **The control:** an *unreported* ambiguous path under the same overlap stays
+  dropped — reports must not weaken #935's rule for anything they don't cover.
+- **Spelling:** `out\b.txt` reported vs `out/b.txt` in the diff produces one
+  entry, keeping the diff's spelling.
+- **No-report no-op:** with an empty buffer the record is byte-identical to
+  #935 behavior.
+- `cargo test -p wisp-core` green, including every pre-existing #935 test
+  untouched.
+
+**Boundaries:** `retain_unambiguous_writes`, `begin_window`,
+`FinishedWindow`, and the matcher functions are not modified. No arbitration
+logic is added — the engine's retain step *is* the arbitration.
+
+### 4.5 CI and evidence
+
+**Goal:** the worker tests run where they can actually differ — per OS — and
+the PR body's claims are reproducible.
+
+**Changes.**
+
+- `.github/workflows/test.yml`, in the existing test job (runs on the 3-OS
+  matrix), after the MCP regression step:
+
+  ```yaml
+  # The kernel worker is Python, so its tests are too. Run them on all
+  # three OSes: the worker's write reporting and its process handling are
+  # exactly the parts that differ per platform.
+  - name: Run Python kernel worker tests
+    run: python3 -m unittest discover -s python -p "test_kernel_worker.py" -v
+  ```
+
+- `scripts/probe_write_audit_hook.py`: a standalone probe that registers the
+  same hook, runs a table of representative cells (write, read, append,
+  library save, subprocess, write-then-raise), prints what was observed, and
+  times a compute-bound cell and a 2000-file write loop with and without the
+  hook. It exists so the maintainer can reproduce the §7 numbers on any
+  machine.
+
+**Success criteria / verification:** CI green on all three OSes; the probe
+runs standalone with only the standard library plus optional
+numpy/matplotlib.
+
+**Boundaries:** no other workflow changes.
+
+## 5. Deliberately out of scope
+
+Stated here so the PR cannot be held up by adjacent ideas, and recorded in
+the PR body so reviewers don't re-propose the rejected ones:
+
+- **Subprocess and C-level `sqlite3` writes** escape the audit hook. They
+  fall back to #935's conservative rule — under overlap, missing rather than
+  wrong. Stated as a known limitation, with the test from §4.1 as proof it is
+  understood.
+- **R and shell self-reporting:** no comparable hook exists; both stay on the
+  conservative rule.
+- **Remote execution contexts** never report (§3 constraint).
+- **Deletions, directory creation:** the host's snapshot diff already sees
+  them; hooking them adds only user-cache noise (measured, §4.1).
+- **Rejected: patching `builtins.open`** — misses every C-level writer, which
+  is the dominant case (figures).
+- **Rejected: model-declared outputs** — moves truth to the layer the #911
+  forensics proved was not at fault.
+- **Rejected: any host-side attribution plumbing** (new `Output` methods,
+  host window registries) — #935's engine windows already exist; duplicating
+  them would create two sources of truth.
+- **Kernel identity and lifecycle** (per-helper kernels, idle reaping, panel
+  labeling, deletion records): orthogonal quality-of-life topics; none is
+  needed for case 1.
+
+## 6. Verification protocol
+
+Per-step verification is listed in §4; this is the whole-branch gate before
+the PR is opened:
+
+1. `cargo fmt --all -- --check`
+2. `cargo test -p wisp-core -p wisp-runtime -p wisp-tools -p wisp-dto`
+3. `python3 -m unittest discover -s python -p "test_kernel_worker.py" -v`
+4. `cargo test -p wisp-tauri` — **required even though this plan touches no
+   `src-tauri` file**: any accidental drift must be caught by a compile, not
+   a review. On a Linux box without root and without the dbus/GTK/WebKit dev
+   packages, build a local sysroot (`apt-get download` the `-dev` packages
+   and their pkg-config dependency closure, `dpkg -x` into one root), then
+   set `PKG_CONFIG_PATH` to the sysroot's pkgconfig dirs,
+   `PKG_CONFIG_SYSROOT_DIR` to the sysroot root,
+   `PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1`, `PKG_CONFIG_ALLOW_SYSTEM_LIBS=1`, and
+   — for the *test binary*, which links `libwebkit2gtk-4.1.so.0` at load
+   time — `LD_LIBRARY_PATH` to the sysroot's `lib/x86_64-linux-gnu` dirs.
+   Watch for a pipeline masking the exit code (`cargo test | tail` reports
+   tail's status, not cargo's). Known pre-existing flake, unrelated to this
+   work: `delegation_tool::tests::background_batch_returns_handle_then_delivers_one_internal_result`
+   can fail under full-suite load and passes alone.
+5. `cargo test --workspace` on a desktop machine (Windows) before opening
+   the PR, plus the manual smoke test: the #937 two-session prompt against a
+   build of this branch — both files on B's card, on nobody else's.
+6. CI (three OSes, stable + MSRV, Playwright) green on the PR.
+
+## 7. Measured evidence for the PR body
+
+Measurements taken with `scripts/probe_write_audit_hook.py` (Linux,
+Python 3.13.11); reproduce anywhere with the script.
+
+What the hook observes:
+
+| Cell | Reported |
+| --- | --- |
+| `open('a.txt','w')` | `a.txt` |
+| `open('a.txt')` (read) | nothing |
+| `open('a.txt','a')` (append) | `a.txt` |
+| `print('hello')` | nothing |
+| `plt.savefig('plot.png')` (C-level write) | `plot.png` |
+| `np.save('arr.npy', ...)` | `arr.npy` |
+| write then `raise` | the written path; error still reported |
+| `subprocess.run([...open(...,'w')...])` | **nothing** — the documented blind spot |
+
+Overhead (two runs each, alternating):
+
+| | Compute cell (2M-iteration loop) | 2000 file writes |
+| --- | --- | --- |
+| baseline | 0.230 s / 0.198 s | 0.154 s / 0.127 s |
+| with hook | 0.195 s / 0.194 s | 0.141 s / 0.155 s |
+
+Within run-to-run noise in both directions: the hook returns immediately for
+unaudited events and for every event while collection is off.
+
+## 8. PR body checklist (upstream house format)
+
+- User-facing problem: the #937 reproduction verbatim; **Fixes #937**,
+  references #911 and builds on #919/#935.
+- Changed files by layer (worker → protocol → env → engine → CI), tests, and
+  the manual smoke steps.
+- The §7 tables.
+- Known limitations from §5, stated plainly.
+- Rejected designs from §5, one line each.
+
+## 9. Sequencing
+
+1. §4.1 + §4.2 (worker, protocol, relativization) — independently testable
+   half; land their tests green first.
+2. §4.3 + §4.4 (env method, adapter, loop fold-in, union) with the engine
+   tests — this is the commit whose tests flip the #937 reproduction.
+3. §4.5 (CI step, probe script), then the full §6 gate, then the PR.

--- a/python/kernel_worker.py
+++ b/python/kernel_worker.py
@@ -9,7 +9,8 @@ Streamed: {"type": "stdout_chunk", "id": "<uuid>", "data": "<text>"}
 Response: {"type": "result", "id": "<uuid>", "stdout": "...", "stderr": "...",
            "error": null|"<traceback>", "interrupted": false,
            "trace": {"error_lineno": null, "error_call": null},
-           "usage": {"wall_s": 0.0, "cpu_s": 0.0, "rss_kb": 0}}
+           "usage": {"wall_s": 0.0, "cpu_s": 0.0, "rss_kb": 0},
+           "files_written": ["<abs path>", ...]  # omitted if unobserved/truncated}
 
 This is a Windows-friendly port of the upstream wisp-science
 `kernels/kernel_worker.py`: the POSIX-only `resource`, `/proc`, and
@@ -37,6 +38,12 @@ MAX_LINECACHE_BYTES = 8 * 1024 * 1024
 MAX_CODE_SIZE = 1024 * 1024
 MAX_CODE_LINES = 20_000
 MAX_REQUEST_SIZE = 8 * 1024 * 1024
+# Cap on distinct write paths reported per cell. Exceeding it omits the
+# field entirely: a truncated list would look authoritative while being wrong.
+MAX_REPORTED_WRITES = 512
+_WRITE_FLAGS = (
+    os.O_WRONLY | os.O_RDWR | os.O_APPEND | os.O_CREAT | os.O_TRUNC
+)
 
 # Force a non-interactive matplotlib backend before matplotlib is ever imported.
 # Without this, generated plotting code (plt.show(), scanpy sc.pl.*) selects the
@@ -44,6 +51,94 @@ MAX_REQUEST_SIZE = 8 * 1024 * 1024
 # the kernel until the user closes it, stalling the whole analysis (issue #37).
 # Figures are meant to be surfaced via savefig, never a GUI window.
 os.environ["MPLBACKEND"] = "Agg"
+
+
+def _open_has_write_intent(mode, flags) -> bool:
+    if isinstance(mode, str) and any(ch in mode for ch in "wax+"):
+        return True
+    if isinstance(flags, int) and flags & _WRITE_FLAGS:
+        return True
+    return False
+
+
+class _WriteObserver:
+    """Collect paths this interpreter opened for writing during one cell.
+
+    Audit hooks cannot be unregistered, so per-cell collection is toggled
+    with begin() / finish(). The hook body is wrapped in a broad
+    try/except and returns immediately while collection is off: a raise
+    would propagate into arbitrary user code, including C-extension I/O.
+    """
+
+    def __init__(self):
+        self._active = False
+        self._paths = []
+        self._seen = set()
+        self._truncated = False
+
+    def begin(self):
+        self._active = True
+        self._paths = []
+        self._seen = set()
+        self._truncated = False
+
+    def finish(self):
+        self._active = False
+        if self._truncated:
+            self._paths = []
+            self._seen = set()
+            return None
+        out = []
+        for path in self._paths:
+            try:
+                if os.path.isfile(path):
+                    out.append(path)
+            except Exception:
+                pass
+        self._paths = []
+        self._seen = set()
+        return out
+
+    def _note(self, path):
+        if not self._active or self._truncated:
+            return
+        try:
+            resolved = os.path.abspath(os.fspath(path))
+            if isinstance(resolved, bytes):
+                resolved = os.fsdecode(resolved)
+            # The path must survive the JSON protocol: bytes are not
+            # serializable at all, and surrogate escapes from undecodable
+            # filenames are rejected by the host's strict JSON parser.
+            # Skip such paths — the host's snapshot inference still covers
+            # them, and skipping can never suppress it (reports only add).
+            resolved.encode("utf-8", "strict")
+        except Exception:
+            return
+        if resolved in self._seen:
+            return
+        if len(self._paths) >= MAX_REPORTED_WRITES:
+            self._truncated = True
+            return
+        self._seen.add(resolved)
+        self._paths.append(resolved)
+
+    def hook(self, event, args):
+        try:
+            if not self._active or self._truncated:
+                return
+            if event == "open":
+                path = args[0] if args else None
+                mode = args[1] if len(args) > 1 else None
+                flags = args[2] if len(args) > 2 else None
+                if path is not None and _open_has_write_intent(mode, flags):
+                    self._note(path)
+            elif event in ("os.rename", "os.replace") and len(args) > 1:
+                self._note(args[1])
+        except Exception:
+            return
+
+
+_WRITE_OBSERVER = _WriteObserver()
 
 
 def _neutralize_pyplot_show() -> None:
@@ -307,6 +402,7 @@ def main():
         return mod
 
     builtins.__import__ = import_wrapper
+    sys.addaudithook(_WRITE_OBSERVER.hook)
     _kernel_init(namespace)
     protocol_out.write(json.dumps({
         "type": "ready",
@@ -393,6 +489,8 @@ def main():
         wall0 = time.perf_counter()
         cpu0 = time.process_time()
         old_out, old_err = sys.stdout, sys.stderr
+        files_written = None
+        _WRITE_OBSERVER.begin()
         try:
             sys.stdout = stdout_cap
             sys.stderr = stderr_cap
@@ -405,6 +503,7 @@ def main():
             stdout_cap._active = False
             sys.stdout = old_out
             sys.stderr = old_err
+            files_written = _WRITE_OBSERVER.finish()
 
         usage = {
             "wall_s": round(time.perf_counter() - wall0, 3),
@@ -421,6 +520,10 @@ def main():
             "trace": {"error_lineno": error_lineno, "error_call": None},
             "usage": usage,
         }
+        # Absent ≠ empty: omit the field when the observer could not produce a
+        # complete list (cap exceeded). An explicit [] means "wrote nothing".
+        if files_written is not None:
+            resp["files_written"] = files_written
         with protocol_lock:
             protocol_out.write(json.dumps(resp) + "\n")
             protocol_out.flush()

--- a/python/test_kernel_worker.py
+++ b/python/test_kernel_worker.py
@@ -1,11 +1,72 @@
 import json
+import os
 import subprocess
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
 
+def _c_level_writer_available():
+    for name in ("numpy", "matplotlib"):
+        try:
+            __import__(name)
+            return True
+        except Exception:
+            continue
+    return False
+
+
 class KernelWorkerTests(unittest.TestCase):
+    def _spawn(self, cwd=None):
+        worker = subprocess.Popen(
+            [sys.executable, str(Path(__file__).with_name("kernel_worker.py"))],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            cwd=cwd,
+        )
+        ready = json.loads(worker.stdout.readline())
+        self.assertEqual(ready.get("type"), "ready")
+        return worker
+
+    def _exec(self, worker, code, rid="cell"):
+        worker.stdin.write(json.dumps({"type": "execute", "id": rid, "code": code}) + "\n")
+        worker.stdin.flush()
+        while True:
+            line = worker.stdout.readline()
+            if not line:
+                self.fail("kernel worker closed protocol stdout")
+            response = json.loads(line)
+            if response.get("type") == "result" and response.get("id") == rid:
+                return response
+
+    def _close(self, worker):
+        if worker.poll() is None:
+            try:
+                worker.stdin.close()
+            except Exception:
+                pass
+            try:
+                self.assertEqual(worker.wait(timeout=5), 0)
+            except subprocess.TimeoutExpired:
+                worker.kill()
+                worker.wait()
+        if worker.stdin and not worker.stdin.closed:
+            worker.stdin.close()
+        if worker.stdout:
+            worker.stdout.close()
+
+    def _worker_abspath(self, worker, relative):
+        response = self._exec(
+            worker,
+            f"import os; print(os.path.abspath({relative!r}))",
+            rid=f"abs-{relative}",
+        )
+        self.assertIsNone(response.get("error"))
+        return response["stdout"].strip()
+
     def test_linecache_keeps_only_recent_cells(self):
         worker = subprocess.Popen(
             [sys.executable, str(Path(__file__).with_name("kernel_worker.py"))],
@@ -67,6 +128,200 @@ class KernelWorkerTests(unittest.TestCase):
             if not worker.stdin.closed:
                 worker.stdin.close()
             worker.stdout.close()
+
+    def test_computed_name_write_is_reported(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            worker = self._spawn(cwd=tmp)
+            try:
+                expected = self._worker_abspath(worker, "fig_1.png")
+                response = self._exec(
+                    worker,
+                    "name = f'fig_{1}.png'\nopen(name, 'w').write('x')",
+                    rid="computed",
+                )
+                self.assertIsNone(response.get("error"), response.get("error"))
+                self.assertIn(expected, response.get("files_written") or [])
+            finally:
+                self._close(worker)
+
+    @unittest.skipUnless(
+        _c_level_writer_available(),
+        "numpy and matplotlib are both unavailable",
+    )
+    def test_c_level_library_write_is_reported(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            worker = self._spawn(cwd=tmp)
+            try:
+                response = self._exec(
+                    worker,
+                    "\n".join(
+                        [
+                            "try:",
+                            "    import numpy as np",
+                            "    np.save('arr.npy', np.arange(3))",
+                            "except Exception:",
+                            "    import matplotlib",
+                            "    matplotlib.use('Agg')",
+                            "    import matplotlib.pyplot as plt",
+                            "    plt.plot([1, 2, 3])",
+                            "    plt.savefig('plot.png')",
+                        ]
+                    ),
+                    rid="c-level",
+                )
+                self.assertIsNone(response.get("error"), response.get("error"))
+                written = response.get("files_written") or []
+                expected_npy = self._worker_abspath(worker, "arr.npy")
+                expected_png = self._worker_abspath(worker, "plot.png")
+                self.assertTrue(
+                    expected_npy in written or expected_png in written,
+                    written,
+                )
+            finally:
+                self._close(worker)
+
+    def test_append_mode_is_reported(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            worker = self._spawn(cwd=tmp)
+            try:
+                expected = self._worker_abspath(worker, "a.txt")
+                response = self._exec(worker, "open('a.txt', 'a').write('x')", rid="append")
+                self.assertIsNone(response.get("error"), response.get("error"))
+                self.assertIn(expected, response.get("files_written") or [])
+            finally:
+                self._close(worker)
+
+    def test_readonly_open_is_not_reported(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "a.txt").write_text("hi", encoding="utf-8")
+            worker = self._spawn(cwd=tmp)
+            try:
+                expected = self._worker_abspath(worker, "a.txt")
+                response = self._exec(worker, "open('a.txt').read()", rid="read")
+                self.assertIsNone(response.get("error"), response.get("error"))
+                self.assertNotIn(expected, response.get("files_written") or [])
+            finally:
+                self._close(worker)
+
+    def test_failed_open_is_not_reported(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            worker = self._spawn(cwd=tmp)
+            try:
+                expected = self._worker_abspath(worker, os.path.join("missing_dir", "nope.txt"))
+                response = self._exec(
+                    worker,
+                    "open('missing_dir/nope.txt', 'w')",
+                    rid="failed",
+                )
+                self.assertIsNotNone(response.get("error"))
+                self.assertNotIn(expected, response.get("files_written") or [])
+            finally:
+                self._close(worker)
+
+    def test_write_then_raise_still_reports_the_path(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            worker = self._spawn(cwd=tmp)
+            try:
+                expected = self._worker_abspath(worker, "boom.txt")
+                response = self._exec(
+                    worker,
+                    "open('boom.txt', 'w').write('x')\nraise RuntimeError('nope')",
+                    rid="raise",
+                )
+                self.assertIsNotNone(response.get("error"))
+                self.assertIn(expected, response.get("files_written") or [])
+            finally:
+                self._close(worker)
+
+    def test_bytes_path_write_is_reported_and_does_not_kill_the_worker(self):
+        # Regression: a bytes path used to crash json.dumps (bytes are not
+        # serializable), killing the worker and the whole session's state.
+        with tempfile.TemporaryDirectory() as tmp:
+            worker = self._spawn(cwd=tmp)
+            try:
+                expected = self._worker_abspath(worker, "bytes_path.txt")
+                response = self._exec(
+                    worker,
+                    "open(b'bytes_path.txt', 'wb').write(b'x')",
+                    rid="bytes",
+                )
+                self.assertIsNone(response.get("error"), response.get("error"))
+                self.assertIn(expected, response.get("files_written") or [])
+                # The worker must survive to run another cell.
+                follow_up = self._exec(worker, "print('alive')", rid="bytes-2")
+                self.assertIsNone(follow_up.get("error"))
+            finally:
+                self._close(worker)
+
+    def test_undecodable_filename_is_skipped_not_reported(self):
+        # A surrogate-escaped name (non-UTF-8 filename) must never reach the
+        # protocol: the host's strict JSON parser rejects lone surrogates,
+        # which would lose the whole result frame. The path is skipped and
+        # falls back to host-side inference. The open itself may fail on
+        # filesystems that require valid UTF-8 names (macOS); either way the
+        # response must parse and must not carry the path.
+        with tempfile.TemporaryDirectory() as tmp:
+            worker = self._spawn(cwd=tmp)
+            try:
+                response = self._exec(
+                    worker,
+                    "open('f_\\udcff.txt', 'w').write('x')",
+                    rid="surrogate",
+                )
+                for path in response.get("files_written") or []:
+                    path.encode("utf-8", "strict")
+                    self.assertNotIn("f_", os.path.basename(path))
+                follow_up = self._exec(worker, "print('alive')", rid="surrogate-2")
+                self.assertIsNone(follow_up.get("error"))
+            finally:
+                self._close(worker)
+
+    def test_sqlite3_database_write_is_not_reported(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            worker = self._spawn(cwd=tmp)
+            try:
+                expected = self._worker_abspath(worker, "db.sqlite")
+                response = self._exec(
+                    worker,
+                    "\n".join(
+                        [
+                            "import sqlite3",
+                            "conn = sqlite3.connect('db.sqlite')",
+                            "conn.execute('create table t(x)')",
+                            "conn.execute('insert into t values (1)')",
+                            "conn.commit()",
+                            "conn.close()",
+                        ]
+                    ),
+                    rid="sqlite",
+                )
+                self.assertIsNone(response.get("error"), response.get("error"))
+                written = response.get("files_written")
+                self.assertIsNotNone(written)
+                self.assertFalse(
+                    any(
+                        path == expected
+                        or path.startswith(expected + "-")
+                        for path in written
+                    ),
+                    written,
+                )
+            finally:
+                self._close(worker)
+
+    def test_cap_omits_files_written_when_exceeded(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            worker = self._spawn(cwd=tmp)
+            try:
+                response = self._exec(
+                    worker,
+                    "for i in range(513):\n    open(f'f{i}.txt', 'w').write('x')",
+                    rid="cap",
+                )
+                self.assertIsNone(response.get("error"), response.get("error"))
+                self.assertNotIn("files_written", response)
+            finally:
+                self._close(worker)
 
 
 if __name__ == "__main__":

--- a/scripts/probe_write_audit_hook.py
+++ b/scripts/probe_write_audit_hook.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Standalone probe for the kernel write-audit hook.
+
+Registers the same observer used by python/kernel_worker.py, runs a table of
+representative cells, and times a compute-bound cell and a 2000-file write
+loop with and without the hook. Optional numpy/matplotlib are used when
+importable; stdlib-only runs skip those rows.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "python"))
+from kernel_worker import _WriteObserver  # noqa: E402
+
+
+def _run_cell(observer: _WriteObserver | None, cwd: str, source: str) -> tuple[list[str] | None, str | None]:
+    old = os.getcwd()
+    os.chdir(cwd)
+    try:
+        if observer is not None:
+            observer.begin()
+        error = None
+        try:
+            exec(compile(source, "<probe>", "exec"), {})
+        except Exception as exc:  # noqa: BLE001 — probe must survive the raise cell
+            error = f"{type(exc).__name__}: {exc}"
+        reported = observer.finish() if observer is not None else None
+        return reported, error
+    finally:
+        os.chdir(old)
+
+
+def _rel(root: str, paths: list[str] | None) -> str:
+    if paths is None:
+        return "(omitted)"
+    # tempfile roots can sit behind a symlink; abspath (what the observer
+    # stores) and realpath then disagree. Match either spelling.
+    roots = {os.path.abspath(root), os.path.realpath(root)}
+    out = []
+    for path in paths:
+        labeled = path
+        for candidate in roots:
+            prefix = candidate.rstrip(os.sep) + os.sep
+            abs_path = os.path.abspath(path)
+            if abs_path.startswith(prefix):
+                labeled = abs_path[len(prefix) :]
+                break
+            real_path = os.path.realpath(path)
+            real_prefix = os.path.realpath(candidate).rstrip(os.sep) + os.sep
+            if real_path.startswith(real_prefix):
+                labeled = real_path[len(real_prefix) :]
+                break
+        out.append(labeled.replace("\\", "/"))
+    return ", ".join(out) if out else "(none)"
+
+
+def main() -> int:
+    observer = _WriteObserver()
+    sys.addaudithook(observer.hook)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        print("What the hook observes:")
+        print()
+        cells = [
+            ("open('a.txt','w')", "open('a.txt', 'w').write('x')"),
+            ("open('a.txt') (read)", "open('a.txt').read()"),
+            ("open('a.txt','a') (append)", "open('a.txt', 'a').write('y')"),
+            ("print('hello')", "print('hello')"),
+        ]
+        try:
+            import matplotlib
+
+            matplotlib.use("Agg")
+            import matplotlib.pyplot as plt  # noqa: F401
+
+            cells.append(
+                (
+                    "plt.savefig('plot.png') (C-level write)",
+                    "import matplotlib\nmatplotlib.use('Agg')\n"
+                    "import matplotlib.pyplot as plt\nplt.plot([1, 2, 3])\nplt.savefig('plot.png')",
+                )
+            )
+        except Exception:
+            print("matplotlib not importable; skipping savefig row")
+        try:
+            import numpy as np  # noqa: F401
+
+            cells.append(
+                (
+                    "np.save('arr.npy', ...)",
+                    "import numpy as np\nnp.save('arr.npy', np.arange(3))",
+                )
+            )
+        except Exception:
+            print("numpy not importable; skipping np.save row")
+        cells.extend(
+            [
+                (
+                    "write then raise",
+                    "open('raised.txt', 'w').write('x')\nraise RuntimeError('nope')",
+                ),
+                (
+                    "subprocess.run([...open(...,'w')...])",
+                    "import subprocess, sys\n"
+                    "subprocess.run([sys.executable, '-c', \"open('sub.txt','w').write('x')\"], check=True)",
+                ),
+            ]
+        )
+        for label, source in cells:
+            reported, error = _run_cell(observer, tmp, source)
+            suffix = f" error={error}" if error else ""
+            print(f"  {label}: {_rel(tmp, reported)}{suffix}")
+
+        print()
+        print("Overhead (two runs each, alternating):")
+
+        def compute():
+            total = 0
+            for i in range(2_000_000):
+                total += i
+            return total
+
+        def write_many():
+            for i in range(2000):
+                path = os.path.join(tmp, f"bulk_{i}.txt")
+                with open(path, "w", encoding="utf-8") as handle:
+                    handle.write("x")
+
+        def time_once(fn, with_hook: bool) -> float:
+            if with_hook:
+                observer.begin()
+            t0 = time.perf_counter()
+            fn()
+            elapsed = time.perf_counter() - t0
+            if with_hook:
+                observer.finish()
+            return elapsed
+
+        compute_off = [time_once(compute, False) for _ in range(2)]
+        compute_on = [time_once(compute, True) for _ in range(2)]
+        writes_off = [time_once(write_many, False) for _ in range(2)]
+        writes_on = [time_once(write_many, True) for _ in range(2)]
+        print(
+            f"  compute baseline: {compute_off[0]:.3f} s / {compute_off[1]:.3f} s"
+        )
+        print(f"  compute with hook: {compute_on[0]:.3f} s / {compute_on[1]:.3f} s")
+        print(f"  2000 writes baseline: {writes_off[0]:.3f} s / {writes_off[1]:.3f} s")
+        print(f"  2000 writes with hook: {writes_on[0]:.3f} s / {writes_on[1]:.3f} s")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION

Fixes #937 (the remaining Case 1 of #911 )
Builds on #919 (per-conversation kernels) and #935 (window-based overlap arbitration)

## User-facing problem

Reproduction from #937: session A runs `time.sleep(60)` in a cell; during that sleep, session B runs code that writes `fig_1.png` with a runtime-computed name (`f"fig_{1}.png"`) and `fig_2.png` with a literal name. Only `fig_2.png` appears on B's Generated card — `fig_1.png` vanishes from *everyone's*.

This is the designed floor of #935's snapshot/diff approach: a computed name is never in the source, and under a genuine foreign overlap its mtime proves nothing, so the conservative rule ("wrong credit is worse than missing credit") drops it. The only proof source left is the interpreter itself.

## What this PR does

The Python worker registers one `sys.addaudithook` and reports, per cell, the files the interpreter opened with write intent (plus `os.rename`/`os.replace` destinations) as `files_written` on the result frame. The host relativizes the report to the project root and unions it into the provenance record **after** `retain_unambiguous_writes`, so a kernel-reported path survives the ambiguity drop while unreported paths keep #935's rule untouched.

Why the report is safe to trust: since #919 every kernel belongs to exactly one conversation, so a report can only ever credit the conversation that ran the cell — it is a stronger proof than a source mention and can never produce wrong credit across conversations.

## Changed files, by layer

- **Worker** (`python/kernel_worker.py`): `_WriteObserver`, one audit hook registered at startup, per-cell collection toggled `begin()`/`finish()`. Watches only `open` with write intent (`w a x +` modes or `O_WRONLY|O_RDWR|O_APPEND|O_CREAT|O_TRUNC` flags) and rename/replace destinations. Reports only paths that exist as files afterwards (a failed `open` fires the event too — omit, never guess). Strict-UTF-8 gate: bytes paths are `os.fsdecode`d and any path that does not round-trip UTF-8 is skipped (bytes would crash `json.dumps` and kill the worker; a lone-surrogate escape is rejected by the host's JSON parser and would lose the whole result frame). Past 512 distinct paths the field is omitted entirely — a truncated list would look authoritative while being wrong. Hook body is exception-proof: a raise would propagate into arbitrary user code.
- **Protocol** (`crates/wisp-runtime/src/kernel.rs`): `KernelResp.files_written: Option<Vec<String>>`. Absent means "worker did not/could not observe — host infers as before"; `[]` means "observed, wrote nothing". Old workers and new hosts interoperate in both directions.
- **Relativization** (`crates/wisp-runtime/src/tool.rs`): `project_relative_writes` canonicalizes, drops everything outside the root and the root itself, rejects any non-`Normal` component (`..` can appear only in the canonicalize-failure fallback and must never reach undo), normalizes `\` on Windows only (on Unix a backslash is a legal filename character; replacing it could credit a different existing file). Only `LOCAL_CONTEXT_ID` kernels report — a remote or WSL worker's absolute paths describe another filesystem.
- **Env channel** (`crates/wisp-tools/src/env.rs`, `crates/wisp-core/src/output.rs`): `ToolEnv::report_written_paths`, default no-op — hosts that do not track attribution lose nothing; no `Output`-trait change, zero `src-tauri` diff. `ToolEnvAdapter` accumulates into an interior mutex; tool calls in one loop are strictly sequential and parallel subagent loops each own an adapter, so drain-per-call is race-free.
- **Fold-in** (`crates/wisp-core/src/agent.rs`, `provenance.rs`): the loop drains the buffer unconditionally after every tool call (a stale report can never leak into the next call's record) and unions after retain via `union_paths_by_identity`, which keeps the spelling already present when two spellings resolve to one file and leaves the record byte-identical when the report adds nothing.
- **CI** (`.github/workflows/test.yml`): worker tests run on all three OSes (`python3` on Unix, `python` on Windows — `python3` is not on PATH on `windows-latest`). `scripts/probe_write_audit_hook.py` reproduces the tables below on any machine.

## Tests

- `python/test_kernel_worker.py` (11 tests, real spawned worker): computed name, C-level save (numpy/matplotlib), append, read-only, failed open, write-then-raise, bytes path (regression: used to kill the worker), undecodable filename (regression: used to break the host's protocol read), sqlite3 blind spot asserted, 512-cap omission, linecache bound.
- `crates/wisp-runtime`: protocol round-trips (present / absent / explicit `[]`), relativization (outside-root, root itself, duplicates, Windows separators, `..` rejection, Unix backslash-filename preservation).
- `crates/wisp-core`: the #937 reproduction at engine level (retain drops the computed name, the reported union restores it); the control (an *unreported* ambiguous path stays dropped — reports must not weaken #935 for anything they don't cover); spelling union; empty-report and all-duplicate-report no-ops. All pre-existing #935 tests untouched and green.

Full gate run locally: `cargo test -p wisp-core -p wisp-runtime -p wisp-tools` (160 + 40 + 55 pass) and the worker suite (11 pass) on Linux; CI covers macOS and Windows.

## Manual smoke test

1. Build this branch; open two conversations in one project.
2. A: run a cell with `time.sleep(60)`.
3. B, during the sleep: `import matplotlib.pyplot as plt; i = 1; plt.plot([1,2]); plt.savefig(f"fig_{i}.png"); open("fig_2.png","w").write("x")`.
4. Both `fig_1.png` and `fig_2.png` appear on B's Generated card; neither appears on A's.

## Measured evidence

Taken with `scripts/probe_write_audit_hook.py` (Linux, Python 3.13.11).

What the hook observes:

| Cell | Reported |
| --- | --- |
| `open('a.txt','w')` | `a.txt` |
| `open('a.txt')` (read) | nothing |
| `open('a.txt','a')` (append) | `a.txt` |
| `print('hello')` | nothing |
| `plt.savefig('plot.png')` (C-level write) | `plot.png` |
| `np.save('arr.npy', ...)` | `arr.npy` |
| write then `raise` | the written path; error still reported |
| `subprocess.run([...open(...,'w')...])` | **nothing** — the documented blind spot |

Overhead (two runs each, alternating):

| | Compute cell (2M-iteration loop) | 2000 file writes |
| --- | --- | --- |
| baseline | 0.230 s / 0.198 s | 0.154 s / 0.127 s |
| with hook | 0.195 s / 0.194 s | 0.141 s / 0.155 s |

Within run-to-run noise in both directions: the hook returns immediately for unaudited events and for every event while collection is off.

## Known limitations

- **Subprocess and C-level `sqlite3` writes** escape the audit hook and fall back to #935's conservative rule — under overlap, missing rather than wrong. The sqlite test asserts the blind spot so it is understood, not accidental.
- **Non-UTF-8 filenames** cannot cross the JSON protocol and are skipped; they too fall back to host inference. Skipping is safe because reports only ever add — they never suppress the diff.
- **The report is interpreter-observed, not host-verified.** Since #919 a kernel belongs to exactly one conversation, so a report can never mis-credit *across* conversations — but within its own, credit is self-declared: a cell that opens an existing file `'r+'`/`'a'` and writes nothing still gets it credited. Same-conversation only, non-destructive (undo marks the entry non-reversible). Intersecting reports with the diff would forfeit real credit for in-place rewrites the mtime-granularity snapshot cannot see, so this stays as-is.
- **R and shell** have no comparable hook and stay on the conservative rule; **remote contexts** never report; **deletions and directory creation** are already covered by the host's snapshot (hooking them adds only user-cache noise — matplotlib's first import creates `~/.cache/matplotlib`).

## Rejected designs

- **Patching `builtins.open`** — misses every C-level writer, which is the dominant case (figures).
- **Model-declared outputs** — moves truth to the layer the #911 forensics proved was not at fault.
- **Host-side attribution plumbing** (new `Output` methods, host window registries) — #935's engine windows already exist; duplicating them creates two sources of truth.
