### PR TITLE
fix: confine kernel-reported writes to the snapshot's rules, and test the wiring

### DIFF
--- a/crates/wisp-core/src/agent.rs
+++ b/crates/wisp-core/src/agent.rs
@@ -547,7 +547,7 @@ async fn agent_loop_inner(
                 // After retain: a kernel-reported path survives an ambiguity
                 // drop, and a report never widens what retain kept for
                 // unreported paths.
-                provenance::union_paths_by_identity(&mut written, &reported);
+                provenance::union_reported_writes(&mut written, &reported);
                 read.retain(|path| !written.contains(path));
                 if !written.is_empty() {
                     let file_changes =
@@ -3059,5 +3059,163 @@ mod tests {
             "recovered after overload",
             "the recovered turn's content must land in context intact"
         );
+    }
+
+    /// Stands in for the `python` tool: reports paths the way a local kernel
+    /// does, without touching the filesystem.
+    struct ReportingTool {
+        paths: Vec<String>,
+    }
+
+    #[async_trait]
+    impl Tool for ReportingTool {
+        fn name(&self) -> &str {
+            "python"
+        }
+
+        fn schema(&self) -> ToolSchema {
+            ToolSchema::new(
+                "python",
+                "run python",
+                serde_json::json!({"type": "object"}),
+            )
+        }
+
+        async fn run(&self, _args: &serde_json::Value, env: &dyn ToolEnv) -> ToolResult {
+            env.report_written_paths(&self.paths);
+            ToolResult::ok("ran")
+        }
+    }
+
+    #[derive(Default)]
+    struct ProvenanceRecorder {
+        records: Mutex<Vec<provenance::ProvenanceRecord>>,
+    }
+
+    impl Output for ProvenanceRecorder {
+        fn provenance(&self, rec: &provenance::ProvenanceRecord) {
+            self.records.lock().unwrap().push(rec.clone());
+        }
+    }
+
+    impl ProvenanceRecorder {
+        fn recorded_tools(&self) -> Vec<String> {
+            self.records
+                .lock()
+                .unwrap()
+                .iter()
+                .map(|rec| rec.tool.clone())
+                .collect()
+        }
+    }
+
+    fn tool_call_turn(id: &str, name: &str) -> Completion {
+        Completion {
+            tool_calls: vec![call(id, name, serde_json::json!({"code": "import helper"}))],
+            finish_reason: Some("tool_calls".into()),
+            ..Completion::default()
+        }
+    }
+
+    fn final_turn() -> Completion {
+        Completion {
+            content: "done".into(),
+            finish_reason: Some("stop".into()),
+            ..Completion::default()
+        }
+    }
+
+    /// A root whose `notes.txt` is older than the turn — the snapshot diff
+    /// finds nothing to attribute — plus bytecode under a snapshot-skipped
+    /// directory.
+    fn reported_writes_root(tag: &str) -> PathBuf {
+        let root =
+            std::env::temp_dir().join(format!("wisp-reported-{tag}-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(root.join("__pycache__")).unwrap();
+        std::fs::write(root.join("notes.txt"), b"unchanged").unwrap();
+        std::fs::write(root.join("__pycache__/helper.cpython-312.pyc"), b"bytecode").unwrap();
+        root
+    }
+
+    /// End-to-end fold-in (#937): a record exists at all only because the loop
+    /// unions the kernel report into the diff-derived list. The reported
+    /// `__pycache__` bytecode, which the snapshot deliberately skips, must not
+    /// ride along.
+    #[tokio::test]
+    async fn kernel_report_reaches_the_record_without_snapshot_skipped_paths() {
+        let root = reported_writes_root("foldin");
+        let provider = SequenceProvider::new([tool_call_turn("call_1", "python"), final_turn()]);
+        let mut tools = Registry::builtins();
+        tools.add(Box::new(ReportingTool {
+            paths: vec![
+                "notes.txt".into(),
+                "__pycache__/helper.cpython-312.pyc".into(),
+            ],
+        }));
+        let output = ProvenanceRecorder::default();
+        let mut ctx = ContextManager::new(100_000);
+
+        agent_loop(
+            &mut ctx,
+            &provider,
+            None,
+            &tools,
+            &root,
+            &output,
+            "write the notes",
+            10,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let records = output.records.lock().unwrap();
+        assert_eq!(records.len(), 1, "the fold-in must produce one record");
+        assert_eq!(records[0].tool, "python");
+        assert_eq!(records[0].files_written, vec!["notes.txt".to_string()]);
+        drop(records);
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// The loop drains the report buffer after every tool call, so the second
+    /// producing call — which reported nothing and wrote nothing — must not
+    /// inherit the first call's paths.
+    #[tokio::test]
+    async fn a_kernel_report_never_leaks_into_the_next_tool_call() {
+        let root = reported_writes_root("drain");
+        let provider = SequenceProvider::new([
+            tool_call_turn("call_1", "python"),
+            tool_call_turn("call_2", "r"),
+            final_turn(),
+        ]);
+        let mut tools = Registry::builtins();
+        tools.add(Box::new(ReportingTool {
+            paths: vec!["notes.txt".into()],
+        }));
+        let runs = Arc::new(AtomicUsize::new(0));
+        tools.add(Box::new(CountingTool {
+            name: "r",
+            runs: runs.clone(),
+        }));
+        let output = ProvenanceRecorder::default();
+        let mut ctx = ContextManager::new(100_000);
+
+        agent_loop(
+            &mut ctx,
+            &provider,
+            None,
+            &tools,
+            &root,
+            &output,
+            "write the notes",
+            10,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(runs.load(Ordering::SeqCst), 1, "the r tool must have run");
+        assert_eq!(output.recorded_tools(), vec!["python".to_string()]);
+        std::fs::remove_dir_all(&root).ok();
     }
 }

--- a/crates/wisp-core/src/provenance.rs
+++ b/crates/wisp-core/src/provenance.rs
@@ -321,6 +321,32 @@ fn relative_identity(path: &str) -> String {
     path_identity(Path::new(path))
 }
 
+/// True when [`snapshot`] would never have reported `relative`, because one
+/// of its parent directories is in `SKIP_DIRS`. Applies the snapshot's own
+/// rule — a directory is skipped by name at any depth — so the two cannot
+/// drift.
+fn is_snapshot_skipped(relative: &str) -> bool {
+    match relative.rsplit_once('/') {
+        Some((parents, _)) => parents.split('/').any(|dir| SKIP_DIRS.contains(&dir)),
+        None => false,
+    }
+}
+
+/// Union interpreter-reported writes into the diff-derived list.
+///
+/// A report bypasses the workspace snapshot, so it must be confined by the
+/// snapshot's exclusions first: otherwise a cell that merely imports a
+/// project-local module credits itself with the `__pycache__` bytecode the
+/// import wrote, and the record names paths the diff could never produce.
+pub fn union_reported_writes(paths: &mut Vec<String>, reported: &[String]) {
+    let kept: Vec<String> = reported
+        .iter()
+        .filter(|path| !is_snapshot_skipped(path))
+        .cloned()
+        .collect();
+    union_paths_by_identity(paths, &kept);
+}
+
 /// Union `extra` into `paths`, keeping the spelling already present when
 /// two spellings resolve to one file (`out\b.txt` vs `out/b.txt`; case
 /// variants on Windows). Every merge of written paths goes through here so
@@ -1071,7 +1097,7 @@ mod tests {
             &window,
         );
         assert_eq!(written, vec!["fig_2.png".to_string()]);
-        union_paths_by_identity(&mut written, &["fig_1.png".to_string()]);
+        union_reported_writes(&mut written, &["fig_1.png".to_string()]);
         assert_eq!(
             written,
             vec!["fig_1.png".to_string(), "fig_2.png".to_string()]
@@ -1103,9 +1129,50 @@ mod tests {
             &window,
         );
         assert_eq!(written, vec!["fig_2.png".to_string()]);
-        union_paths_by_identity(&mut written, &[]);
+        union_reported_writes(&mut written, &[]);
         assert_eq!(written, vec!["fig_2.png".to_string()]);
         std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    /// A report bypasses the snapshot, so every directory the snapshot skips
+    /// must be skipped here too. `__pycache__` is the one that fires in
+    /// ordinary use: importing a project-local module writes bytecode the
+    /// diff would never have shown.
+    #[test]
+    fn reported_writes_under_skipped_dirs_never_enter_the_record() {
+        let mut written = vec!["out/fig.png".to_string()];
+        union_reported_writes(
+            &mut written,
+            &[
+                "__pycache__/helper.cpython-312.pyc".to_string(),
+                "src/__pycache__/helper.cpython-312.pyc".to_string(),
+                ".venv/lib/python3.12/site-packages/pkg/mod.py".to_string(),
+                ".git/index".to_string(),
+                ".wisp/tool-output/spill.txt".to_string(),
+                "uploads/raw.csv".to_string(),
+                "node_modules/x/index.js".to_string(),
+                "results/table.csv".to_string(),
+            ],
+        );
+        assert_eq!(
+            written,
+            vec!["out/fig.png".to_string(), "results/table.csv".to_string()]
+        );
+    }
+
+    /// Only parent directories gate inclusion. A file whose own name matches
+    /// a skipped directory is a normal project file.
+    #[test]
+    fn reported_leaf_named_like_a_skipped_dir_is_kept() {
+        let mut written = Vec::new();
+        union_reported_writes(
+            &mut written,
+            &["uploads".to_string(), "notes/.git".to_string()],
+        );
+        assert_eq!(
+            written,
+            vec!["notes/.git".to_string(), "uploads".to_string()]
+        );
     }
 
     #[test]

--- a/crates/wisp-runtime/src/tool.rs
+++ b/crates/wisp-runtime/src/tool.rs
@@ -59,6 +59,23 @@ fn project_relative_writes(root: &Path, reported: &[String]) -> Vec<String> {
     out
 }
 
+/// Hand a finished cell's self-reported writes to the running tool
+/// environment. Only local kernels report: a remote or WSL worker's absolute
+/// paths describe another machine's filesystem. An absent report means the
+/// worker could not observe, so the host keeps inferring from its snapshot.
+fn report_local_writes(env: &dyn ToolEnv, context_id: &str, response: &KernelResp) {
+    if context_id != LOCAL_CONTEXT_ID {
+        return;
+    }
+    let Some(reported) = &response.files_written else {
+        return;
+    };
+    let paths = project_relative_writes(env.project_root(), reported);
+    if !paths.is_empty() {
+        env.report_written_paths(&paths);
+    }
+}
+
 pub struct ReplTool {
     manager: RuntimeManager,
     project_id: String,
@@ -201,14 +218,7 @@ async fn run_runtime(
                     env.emit(ToolEvent::Stdout { chunk }).await;
                 }
                 Some(RuntimeEvent::Finished(Ok(response))) => {
-                    if key.context_id == LOCAL_CONTEXT_ID {
-                        if let Some(reported) = &response.files_written {
-                            let paths = project_relative_writes(env.project_root(), reported);
-                            if !paths.is_empty() {
-                                env.report_written_paths(&paths);
-                            }
-                        }
-                    }
+                    report_local_writes(env, &key.context_id, &response);
                     let success = response.error.is_none();
                     return ToolResult {
                         success,
@@ -342,10 +352,13 @@ impl Tool for RTool {
 #[cfg(test)]
 mod tests {
     use super::{
-        code_arg, context_id, project_relative_writes, PYTHON_TOOL_DESCRIPTION, R_TOOL_DESCRIPTION,
+        code_arg, context_id, project_relative_writes, report_local_writes,
+        PYTHON_TOOL_DESCRIPTION, R_TOOL_DESCRIPTION,
     };
-    use crate::MAX_CODE_BYTES;
-    use std::path::PathBuf;
+    use crate::{KernelResp, LOCAL_CONTEXT_ID, MAX_CODE_BYTES};
+    use std::path::{Path, PathBuf};
+    use std::sync::Mutex;
+    use wisp_tools::{ToolEnv, ToolEvent};
 
     #[test]
     fn python_description_keeps_package_setup_out_of_the_repl() {
@@ -466,6 +479,76 @@ mod tests {
             std::path::MAIN_SEPARATOR
         );
         assert!(project_relative_writes(&root, &[escape]).is_empty());
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// Captures what the finished-cell branch of `run_runtime` hands to the
+    /// agent loop.
+    struct RecordingEnv {
+        root: PathBuf,
+        reported: Mutex<Vec<Vec<String>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl ToolEnv for RecordingEnv {
+        fn project_root(&self) -> &Path {
+            &self.root
+        }
+        async fn confirm(&self, _message: &str) -> bool {
+            true
+        }
+        async fn emit(&self, _event: ToolEvent) {}
+        fn report_written_paths(&self, paths: &[String]) {
+            self.reported.lock().unwrap().push(paths.to_vec());
+        }
+    }
+
+    fn recording_env(root: PathBuf) -> RecordingEnv {
+        RecordingEnv {
+            root,
+            reported: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn response_with(files_written: Option<Vec<String>>) -> KernelResp {
+        KernelResp {
+            files_written,
+            ..KernelResp::default()
+        }
+    }
+
+    #[test]
+    fn local_kernel_report_reaches_the_tool_environment() {
+        let root = unique_tmp("report_local");
+        std::fs::write(root.join("fig_1.png"), b"x").unwrap();
+        let env = recording_env(root.clone());
+        let reported = vec![root.join("fig_1.png").to_string_lossy().into_owned()];
+
+        report_local_writes(&env, LOCAL_CONTEXT_ID, &response_with(Some(reported)));
+
+        assert_eq!(
+            *env.reported.lock().unwrap(),
+            vec![vec!["fig_1.png".to_string()]]
+        );
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// A remote or WSL worker's absolute paths describe another filesystem,
+    /// and an absent report means "host, keep inferring". Neither may reach
+    /// the record.
+    #[test]
+    fn only_local_kernels_with_an_actual_report_are_forwarded() {
+        let root = unique_tmp("report_gates");
+        std::fs::write(root.join("fig_1.png"), b"x").unwrap();
+        let inside = vec![root.join("fig_1.png").to_string_lossy().into_owned()];
+        let env = recording_env(root.clone());
+
+        report_local_writes(&env, "ssh:gpu-box", &response_with(Some(inside.clone())));
+        report_local_writes(&env, "wsl:Ubuntu", &response_with(Some(inside)));
+        report_local_writes(&env, LOCAL_CONTEXT_ID, &response_with(None));
+        report_local_writes(&env, LOCAL_CONTEXT_ID, &response_with(Some(Vec::new())));
+
+        assert!(env.reported.lock().unwrap().is_empty());
         std::fs::remove_dir_all(&root).ok();
     }
 }

--- a/docs/superpowers/plans/2026-08-20-kernel-reported-writes-implementation-notes.md
+++ b/docs/superpowers/plans/2026-08-20-kernel-reported-writes-implementation-notes.md
@@ -40,6 +40,29 @@ written) is still credited. Same-conversation only, and undo marks it
 non-reversible. Intersecting reports with the diff would forfeit real
 credit for rewrites the mtime-granularity snapshot cannot see.
 
+## Post-merge fixes (2026-08-21)
+
+- **Reports bypassed the snapshot's skipped directories.** A cell that only
+  imported a project-local module reported the `__pycache__` bytecode the
+  import wrote, and `project_relative_writes` confines to the project root
+  but knows nothing about `SKIP_DIRS`. The path reached the Generated card,
+  `execution_log`, session exports, and publication capsules — places the
+  snapshot diff could never put it. `provenance::union_reported_writes` now
+  applies the snapshot's own rule (skip by directory name at any depth, only
+  parent components gate inclusion) before the identity union, and
+  `agent_loop_inner` calls it instead of `union_paths_by_identity`.
+- **Neither wiring point was covered.** Deleting the `agent.rs` union left all
+  160 `wisp-core` tests green, and deleting `env.report_written_paths(&paths)`
+  left all 40 `wisp-runtime` tests green: the whole feature could stop working
+  silently. The `#937` engine test called `retain_unambiguous_writes` and the
+  union directly rather than driving the loop. Added two `agent_loop` tests
+  (report folded into the record, snapshot-skipped paths excluded, no leak into
+  the next tool call) and lifted the runtime's forwarding branch into
+  `report_local_writes` so the local-only gate and the absent-vs-empty
+  distinction are testable against a recording `ToolEnv`. All five mutants —
+  removed union, removed skip filter, removed report call, ungated context,
+  non-draining buffer — now fail a test.
+
 ## Deviations
 
 - Windows CI invokes `python` instead of `python3` (sibling step on the same matrix job). `python3` is not on PATH on `windows-latest`; Unix steps keep the planned `python3` command so the worker tests still run on all three OSes.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #942 (kernel-reported writes for #937). Two defects found reviewing that PR after merge.

Closes #911. Remaining gaps tracked in #947.

`#911` tracked five attribution cases: cases 2–5 were fixed in #935 and case 1 in #942, on top of the per-conversation kernels from #919. This PR closes the last gap in that chain — #942's fold-in credited paths the snapshot deliberately excludes, and neither of its two wiring points was covered by a test — so with it merged all five cases of #911 are fixed and guarded.

## User-facing problem

**1. `__pycache__` bytecode now shows up on the Generated card.** Interpreter reports bypass the workspace snapshot, and `project_relative_writes` confines them to the project root but knows nothing about `provenance::SKIP_DIRS`. So a Python cell that merely imports a project-local module credits itself with the bytecode the import wrote. Reproduced against the merged worker:

```
cell: sys.path.insert(0, '.'); import helper_mod
files_written: ['/…/proj/__pycache__/helper_mod.cpython-312.pyc']
```

Because `provenance_ui_file_changes` forwards `files_written` verbatim for `python`/`r`/`shell`, that path reached the Generated card, `execution_log`, session exports, and publication capsules — none of which had ever seen such a path, since the snapshot skips those directories on purpose. The same hole applies to `.git`, `.venv`, `.wisp`, `uploads`, and `node_modules`.

**2. Neither wiring point had a test.** The `#937` engine test called `retain_unambiguous_writes` and then the union directly, without driving `agent_loop_inner`, so it passed whether or not the loop was wired up. Mutation-testing the merged code:

| Mutation | Result before this PR |
| --- | --- |
| delete the `agent.rs` union | 160/160 `wisp-core` tests still green |
| delete `env.report_written_paths(&paths)` | 40/40 `wisp-runtime` tests still green |

The whole feature could stop working and CI would not notice.

## Changes

- `crates/wisp-core/src/provenance.rs`: new `is_snapshot_skipped` + `union_reported_writes`. The filter applies the snapshot's own rule — a directory is skipped by name at any depth, and only parent components gate inclusion, so a project file literally named `uploads` is still kept. `union_paths_by_identity` stays the single identity rule underneath.
- `crates/wisp-core/src/agent.rs`: the loop calls `union_reported_writes`. One choke point, so the confinement cannot be bypassed by a future reporter.
- `crates/wisp-runtime/src/tool.rs`: the finished-cell forwarding branch becomes `report_local_writes(env, context_id, response)` so the local-only gate and the absent-vs-empty distinction can be driven directly.
- `docs/superpowers/plans/2026-08-20-kernel-reported-writes-implementation-notes.md`: post-merge section.

No behavior change for reported paths outside skipped directories; no protocol, worker, DTO, or `src-tauri` change.

## Tests

Added:

- `provenance`: `reported_writes_under_skipped_dirs_never_enter_the_record` (all six skip dirs, nested and top-level), `reported_leaf_named_like_a_skipped_dir_is_kept`.
- `agent` (end-to-end through `agent_loop`, `SequenceProvider` + a fake `python` tool + a recording `Output`): `kernel_report_reaches_the_record_without_snapshot_skipped_paths` — `notes.txt` predates the turn and its mtime never advances, so the diff finds nothing and a record exists at all only because the loop folded the report in, while the reported `__pycache__` path is excluded; `a_kernel_report_never_leaks_into_the_next_tool_call` — a second producing call that reports nothing produces no record.
- `runtime`: `local_kernel_report_reaches_the_tool_environment`, `only_local_kernels_with_an_actual_report_are_forwarded` (ssh, wsl, `None`, `Some([])`).

Updated the two existing `#937` provenance tests to go through `union_reported_writes`, i.e. the path the loop actually takes.

Every mutant now fails a test: removed union, removed skip filter, removed report call, ungated context, non-draining buffer.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo test --workspace` green (includes the 852-test `src-tauri` suite)
- `python3 -m unittest discover -s python -p "test_kernel_worker.py"` — 11 passed, worker untouched

## Manual smoke steps

1. Open a project, run a cell that writes a helper module, then in a second cell `sys.path.insert(0, '.')` and import it.
2. The Generated card lists only the helper `.py`; no `__pycache__/*.pyc` entry.
3. Re-run the #937 two-session repro (A sleeping, B writing a computed name during the overlap): both `fig_1.png` and `fig_2.png` still appear on B's card and on nobody else's.
4. Re-check the remaining #911 cases — Windows backslash paths (case 2), backdated tar mtimes (case 3), the `results.csv` / `final_results.csv` substring pair (case 4), and parallel subagents of one conversation (case 5) — all still attribute correctly.

## Known limitations

All three are filed with reproductions and proposed directions in #947; none is a regression from this PR.

- The worker still reports skipped-directory paths and the host drops them, so they keep consuming the worker's 512-path cap. A first-time import storm inside the project root can push a cell over it and omit the report entirely — the pre-#942 inference fallback, not a wrong record (#947 gap 1).
- `open(p, 'r+')` or `'a'` with nothing written is still self-credited, as documented in #942 (#947 gap 2).
- WSL kernels run the same worker and do emit reports, but the gate is `LOCAL_CONTEXT_ID`, so #937's computed-name case still reproduces under WSL (#947 gap 3).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7208616a-a597-41d0-81c1-680bf29a7a42?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7208616a-a597-41d0-81c1-680bf29a7a42&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

