### PR TITLE
fix(kernel): make the write report mean "changed", and stop bytecode from evicting real outputs

### DIFF
--- a/docs/superpowers/plans/2026-08-20-kernel-reported-writes-implementation-notes.md
+++ b/docs/superpowers/plans/2026-08-20-kernel-reported-writes-implementation-notes.md
@@ -63,6 +63,43 @@ credit for rewrites the mtime-granularity snapshot cannot see.
   removed union, removed skip filter, removed report call, ungated context,
   non-draining buffer — now fail a test.
 
+## Report precision (2026-08-21, #947 gaps 1 and 2)
+
+- **Bytecode no longer evicts real outputs.** `MAX_REPORTED_WRITES` is counted
+  in the worker, before the host filters, so `__pycache__` paths the host was
+  always going to discard consumed the cap. Measured: one cell importing 300
+  project-local modules and writing 250 CSVs reported *nothing* — 550 > 512, so
+  the field was omitted and the cell fell back to snapshot inference, i.e. #911
+  case 1 reproduced again. `_is_bytecode_cache` now drops those paths before the
+  cap is consulted. The other `SKIP_DIRS` entries stay a host concern: the
+  worker has first-hand knowledge of its own bytecode, not of project layout,
+  and duplicating that list would give it two sources of truth.
+- **`files_written` means "changed", not "opened with write intent".** The
+  `open` audit event carries intent, and it fires *before* the OS call
+  completes — so `_note` samples `(size, st_mtime_ns)` at that moment and
+  `finish` compares it again. A cell that opens a file `'r+'` or `'a'` and
+  writes nothing is no longer credited with it; `h5py.File(p, "a")` and
+  `zarr.open(p, mode="a")` are the idiomatic way to open a store you then only
+  read. This is not the intersect-with-the-diff approach #942 rejected: the
+  comparison happens inside the worker across the open itself, so a
+  same-length in-place rewrite — invisible to size, and to the host's
+  coarser-grained snapshot — keeps its credit through `st_mtime_ns`.
+- Overhead is two extra `os.stat` calls per distinct candidate path. Measured
+  on 500 writes with every path under the cap: 0.024 s median baseline vs
+  0.028 s with the hook, about 8 µs per file.
+
+**Not done: #947 gap 3 (WSL).** The gap as filed assumed WSL kernels run in the
+project directory and only needed a `/mnt/<drive>/…` prefix translation. They do
+not: `build_attached_command` runs `cd {runtime_workdir} && exec …` where
+`runtime_workdir` is the context's configured workdir, else the probed
+`pwd`/`home`, else `~` — and `project_root` is unused in that branch
+(`src-tauri/src/runtime_launcher.rs`). So a WSL cell's relative writes land
+outside the project entirely, which also means the host's workspace snapshot
+cannot see them either. Making reports work there requires first deciding
+whether WSL kernels should `cd` into the project (WSL *terminals* already do,
+via `wsl.exe --cd`); that is a user-visible behavior change, not a path-mapping
+fix.
+
 ## Deviations
 
 - Windows CI invokes `python` instead of `python3` (sibling step on the same matrix job). `python3` is not on PATH on `windows-latest`; Unix steps keep the planned `python3` command so the worker tests still run on all three OSes.

--- a/python/kernel_worker.py
+++ b/python/kernel_worker.py
@@ -12,6 +12,9 @@ Response: {"type": "result", "id": "<uuid>", "stdout": "...", "stderr": "...",
            "usage": {"wall_s": 0.0, "cpu_s": 0.0, "rss_kb": 0},
            "files_written": ["<abs path>", ...]  # omitted if unobserved/truncated}
 
+`files_written` lists the files this cell actually changed, not the ones it
+opened for writing; see `_WriteObserver`.
+
 This is a Windows-friendly port of the upstream wisp-science
 `kernels/kernel_worker.py`: the POSIX-only `resource`, `/proc`, and
 delivered-SIGINT discipline are dropped. RSS comes from `psutil` when
@@ -24,6 +27,7 @@ from collections import deque
 import io
 import json
 import os
+import stat
 import sys
 import time
 import traceback
@@ -61,6 +65,21 @@ def _open_has_write_intent(mode, flags) -> bool:
     return False
 
 
+def _file_state(path):
+    """`(size, mtime_ns)` of a regular file, or None when it is not one.
+
+    Sampled twice per candidate path — once when the audit event fires and
+    once after the cell — so an unchanged pair proves the bytes never moved.
+    """
+    try:
+        info = os.stat(path)
+    except Exception:
+        return None
+    if not stat.S_ISREG(info.st_mode):
+        return None
+    return (info.st_size, info.st_mtime_ns)
+
+
 def _is_bytecode_cache(path) -> bool:
     """True for anything under a `__pycache__` directory.
 
@@ -76,41 +95,52 @@ def _is_bytecode_cache(path) -> bool:
 
 
 class _WriteObserver:
-    """Collect paths this interpreter opened for writing during one cell.
+    """Collect the paths this interpreter changed during one cell.
 
     Audit hooks cannot be unregistered, so per-cell collection is toggled
     with begin() / finish(). The hook body is wrapped in a broad
     try/except and returns immediately while collection is off: a raise
     would propagate into arbitrary user code, including C-extension I/O.
+
+    The `open` audit event carries write *intent*, not proof of a write, and
+    it fires before the OS call completes. So each candidate's pre-open state
+    is sampled when the event arrives and compared again in finish(): a cell
+    that opens a file `'r+'` or `'a'` and writes nothing must not be credited
+    with it (`h5py.File(p, "a")` is the idiomatic way to open a store you
+    then only read).
     """
 
     def __init__(self):
         self._active = False
         self._paths = []
-        self._seen = set()
+        self._before = {}
         self._truncated = False
 
     def begin(self):
         self._active = True
         self._paths = []
-        self._seen = set()
+        self._before = {}
         self._truncated = False
 
     def finish(self):
         self._active = False
         if self._truncated:
             self._paths = []
-            self._seen = set()
+            self._before = {}
             return None
         out = []
         for path in self._paths:
             try:
-                if os.path.isfile(path):
-                    out.append(path)
+                after = _file_state(path)
+                # Gone or never created (a failed open fires the event too),
+                # or byte-for-byte the file we saw before the open.
+                if after is None or after == self._before[path]:
+                    continue
+                out.append(path)
             except Exception:
                 pass
         self._paths = []
-        self._seen = set()
+        self._before = {}
         return out
 
     def _note(self, path):
@@ -128,7 +158,7 @@ class _WriteObserver:
             resolved.encode("utf-8", "strict")
         except Exception:
             return
-        if resolved in self._seen:
+        if resolved in self._before:
             return
         # Filtered before the cap so paths that can never be reported do not
         # evict the ones that can.
@@ -137,7 +167,7 @@ class _WriteObserver:
         if len(self._paths) >= MAX_REPORTED_WRITES:
             self._truncated = True
             return
-        self._seen.add(resolved)
+        self._before[resolved] = _file_state(resolved)
         self._paths.append(resolved)
 
     def hook(self, event, args):

--- a/python/kernel_worker.py
+++ b/python/kernel_worker.py
@@ -61,6 +61,20 @@ def _open_has_write_intent(mode, flags) -> bool:
     return False
 
 
+def _is_bytecode_cache(path) -> bool:
+    """True for anything under a `__pycache__` directory.
+
+    Importing a project-local module writes bytecode through `os.replace`,
+    which the hook sees. The host discards those paths anyway (its workspace
+    snapshot skips the directory), but they used to consume the report cap
+    first, so a cell that imported enough modules lost its real outputs.
+    Separators are normalized only on Windows: on Unix a literal `\\` is a
+    legal filename character.
+    """
+    normalized = path.replace("\\", "/") if os.name == "nt" else path
+    return "__pycache__" in normalized.split("/")[:-1]
+
+
 class _WriteObserver:
     """Collect paths this interpreter opened for writing during one cell.
 
@@ -115,6 +129,10 @@ class _WriteObserver:
         except Exception:
             return
         if resolved in self._seen:
+            return
+        # Filtered before the cap so paths that can never be reported do not
+        # evict the ones that can.
+        if _is_bytecode_cache(resolved):
             return
         if len(self._paths) >= MAX_REPORTED_WRITES:
             self._truncated = True

--- a/python/test_kernel_worker.py
+++ b/python/test_kernel_worker.py
@@ -323,6 +323,56 @@ class KernelWorkerTests(unittest.TestCase):
             finally:
                 self._close(worker)
 
+    def test_bytecode_cache_is_not_reported(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "helper_mod.py").write_text("V = 1\n", encoding="utf-8")
+            worker = self._spawn(cwd=tmp)
+            try:
+                response = self._exec(
+                    worker,
+                    "import sys\nsys.path.insert(0, '.')\nimport helper_mod",
+                    rid="pycache",
+                )
+                self.assertIsNone(response.get("error"), response.get("error"))
+                written = response.get("files_written")
+                self.assertIsNotNone(written)
+                self.assertFalse(
+                    [path for path in written if "__pycache__" in path],
+                    written,
+                )
+            finally:
+                self._close(worker)
+
+    def test_bytecode_cache_does_not_consume_the_cap(self):
+        # The host discards `__pycache__` paths, so they must not evict the
+        # real outputs of the same cell from the report.
+        with tempfile.TemporaryDirectory() as tmp:
+            for index in range(300):
+                Path(tmp, f"mod_{index}.py").write_text(f"V = {index}\n", encoding="utf-8")
+            worker = self._spawn(cwd=tmp)
+            try:
+                response = self._exec(
+                    worker,
+                    "\n".join(
+                        [
+                            "import os, sys",
+                            "sys.path.insert(0, '.')",
+                            "for i in range(300):",
+                            "    __import__(f'mod_{i}')",
+                            "os.makedirs('results', exist_ok=True)",
+                            "for i in range(250):",
+                            "    open(f'results/out_{i}.csv', 'w').write('x')",
+                        ]
+                    ),
+                    rid="pycache-cap",
+                )
+                self.assertIsNone(response.get("error"), response.get("error"))
+                written = response.get("files_written")
+                self.assertIsNotNone(written, "300 discarded .pyc paths exhausted the cap")
+                self.assertEqual(len(written), 250, written)
+            finally:
+                self._close(worker)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/test_kernel_worker.py
+++ b/python/test_kernel_worker.py
@@ -373,6 +373,64 @@ class KernelWorkerTests(unittest.TestCase):
             finally:
                 self._close(worker)
 
+    def test_write_intent_without_a_write_is_not_reported(self):
+        # `r+` and a bare `a` carry write intent but change nothing. Opening a
+        # store read-only through such a mode is idiomatic (`h5py.File(p, "a")`).
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "data.h5").write_text("existing", encoding="utf-8")
+            Path(tmp, "run.log").write_text("log\n", encoding="utf-8")
+            worker = self._spawn(cwd=tmp)
+            try:
+                response = self._exec(
+                    worker,
+                    "open('data.h5', 'r+').read()\nopen('run.log', 'a').close()",
+                    rid="intent-only",
+                )
+                self.assertIsNone(response.get("error"), response.get("error"))
+                self.assertEqual(response.get("files_written"), [])
+            finally:
+                self._close(worker)
+
+    def test_write_through_an_intent_mode_is_still_reported(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "data.h5").write_text("existing", encoding="utf-8")
+            Path(tmp, "run.log").write_text("log\n", encoding="utf-8")
+            worker = self._spawn(cwd=tmp)
+            try:
+                expected = {
+                    self._worker_abspath(worker, "data.h5"),
+                    self._worker_abspath(worker, "run.log"),
+                }
+                response = self._exec(
+                    worker,
+                    "open('data.h5', 'r+').write('mutated')\n"
+                    "open('run.log', 'a').write('more\\n')",
+                    rid="intent-write",
+                )
+                self.assertIsNone(response.get("error"), response.get("error"))
+                self.assertEqual(set(response.get("files_written") or []), expected)
+            finally:
+                self._close(worker)
+
+    def test_same_length_rewrite_is_reported(self):
+        # Size alone cannot see this write; the mtime half of the pre/post
+        # comparison is what keeps the credit.
+        with tempfile.TemporaryDirectory() as tmp:
+            Path(tmp, "same.csv").write_text("AAAAAAAAAAA", encoding="utf-8")
+            worker = self._spawn(cwd=tmp)
+            try:
+                expected = self._worker_abspath(worker, "same.csv")
+                response = self._exec(
+                    worker,
+                    "open('same.csv', 'w').write('BBBBBBBBBBB')",
+                    rid="same-length",
+                )
+                self.assertIsNone(response.get("error"), response.get("error"))
+                self.assertIn(expected, response.get("files_written") or [])
+                self.assertEqual(Path(tmp, "same.csv").stat().st_size, 11)
+            finally:
+                self._close(worker)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Addresses gaps 1 and 2 of #947. Gap 3 is deliberately left open — the gap as filed rests on a wrong assumption, explained at the bottom.

Worker-only change. No protocol change, no host change, no `src-tauri` diff.

## Gap 1 — bytecode evicted a cell's real outputs

`MAX_REPORTED_WRITES = 512` is counted in the worker, *before* the host filters. Since #946 the host discards reported paths under the directories its snapshot skips, but those paths still consumed the cap first — and importing a project-local module writes `__pycache__` bytecode through `os.replace`, which the audit hook sees.

Measured on `main` before this PR, one cell importing 300 project-local modules and writing 250 CSVs:

```
error: None
has files_written field: False
reported count: 0
```

550 > 512, so the field was omitted and the whole cell fell back to snapshot inference — exactly the state #942 fixed. Under a foreign overlap those 250 computed-name outputs disappear from Generated again, i.e. #911 case 1 reproduces.

After:

```
field present: True | count: 250
all under results/: True
any __pycache__: False
```

`_is_bytecode_cache` drops those paths before the cap is consulted. The other `SKIP_DIRS` entries stay a host concern: the worker has first-hand knowledge of its own bytecode, not of project layout, and duplicating that list would give it a second source of truth.

## Gap 2 — write intent is not proof of a write

The `open` audit event carries *intent* — any mode with `w a x +`, or flags intersecting the write set. A cell that opened an existing file `'r+'` and only read it, or `'a'` and wrote nothing, was credited with writing it. This is reachable through ordinary library use, not contrived code: `h5py.File(p, "a")` and `zarr.open(p, mode="a")` are the idiomatic way to open a store you then only read. The path then entered `files_written`, `execution_log`, session exports, and publication capsules, claiming a write that never happened.

The event fires *before* the OS call completes, which is what makes this fixable inside the worker: `_note` samples `(size, st_mtime_ns)` of the file as it was before the open, and `finish` compares it again.

This is **not** the intersect-with-the-diff approach #942 rejected. That would have forfeited credit for in-place rewrites the host's coarser-grained snapshot cannot see. Here the comparison happens across the open itself, so a same-length rewrite — invisible to size, and to the host — keeps its credit through `st_mtime_ns`:

```
size unchanged: True
reported: ['same.csv']
```

Measured behavior after the change:

| Cell | Reported |
| --- | --- |
| `open('data.h5','r+').read()` | nothing |
| `open('run.log','a').close()` | nothing |
| `open('data.h5','r+').write('mutated')` | `data.h5` |
| `open('run.log','a').write('more\n')` | `run.log` |
| `open('same.csv','w').write(<same length>)` | `same.csv` |
| `name = f'fig_{1}.png'; open(name,'w')` (#937) | `fig_1.png` |

Cost is two extra `os.stat` calls per distinct candidate path. Measured over 500 writes with every path under the cap (three runs each), so every path is stat'd twice:

| | 500 writes |
| --- | --- |
| baseline | 0.017 s / 0.025 s / 0.024 s |
| with hook | 0.029 s / 0.028 s / 0.024 s |

About 8 µs per file at the median — below the noise floor of the 2000-write loop in `scripts/probe_write_audit_hook.py`, which exceeds the cap and therefore stops stat'ing after 512 paths.

## Tests

`python/test_kernel_worker.py` grows from 11 to 16 tests, all against a real spawned worker:

- `test_bytecode_cache_is_not_reported` — importing a project-local module reports no `__pycache__` path.
- `test_bytecode_cache_does_not_consume_the_cap` — the 300-import / 250-output reproduction above reports exactly 250 paths.
- `test_write_intent_without_a_write_is_not_reported` — `'r+'` that only reads and a bare `'a'` report `[]`.
- `test_write_through_an_intent_mode_is_still_reported` — the same modes, actually writing, report both files.
- `test_same_length_rewrite_is_reported` — guards the `st_mtime_ns` half of the comparison; a size-only check would let this regress silently.

All pre-existing worker tests are untouched and green, including the ones that pin the semantics this PR narrows: read-only opens, failed opens, write-then-raise, the `sqlite3` blind spot, bytes paths, undecodable filenames, and the 512 cap.

## Verification

- `python3 -m unittest discover -s python -p "test_kernel_worker.py"` — 16 passed
- `cargo fmt --all -- --check` clean
- `cargo test -p wisp-core -p wisp-runtime -p wisp-tools` — 164 / 42 / 55 green (no Rust change; run to confirm the host contract is untouched)
- CI covers macOS and Windows for the worker suite

## Manual smoke steps

1. In one project, run a cell that writes a helper module, then a second cell that adds `.` to `sys.path` and imports it. The Generated card lists the helper `.py` only — no `__pycache__` entry, which was already true after #946; what changes is that the report survives at all when many modules are imported.
2. Run a cell that opens an existing CSV with `open(p, 'r+')` and only reads it. Nothing appears on the Generated card.
3. Run a cell that opens the same file `'r+'` and writes to it. It appears.
4. Re-run the #937 two-session repro (A sleeping, B writing a computed name during the overlap): both `fig_1.png` and `fig_2.png` still appear on B's card and on nobody else's.

## Gap 3 is not addressed, and #947 needs correcting

I filed gap 3 assuming WSL kernels run in the project directory and only needed a `/mnt/<drive>/…` prefix translation before `report_local_writes` could accept them. That assumption is wrong.

`build_attached_command` in `src-tauri/src/runtime_launcher.rs` launches WSL and SSH kernels with `cd {runtime_workdir} && exec {interpreter} {worker}`, where `runtime_workdir` is the context's configured `workdir`, else the probed `pwd`/`home`, else `~`. `project_root` is unused in that branch. So a WSL cell's relative writes do not land in the project at all — which also means the host's workspace snapshot never sees them, and attribution under WSL is not merely missing the kernel report, it has no working source of truth. (WSL *terminals* do land in the project, via `wsl.exe --cd`; kernels deliberately do not.)

Deciding whether WSL kernels should `cd` into the project is a user-visible behavior change affecting what a relative path means in a WSL cell, and it should be settled before any report plumbing is added. Recommend updating gap 3 in #947 to describe that instead, and keeping it open.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7208616a-a597-41d0-81c1-680bf29a7a42?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7208616a-a597-41d0-81c1-680bf29a7a42&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

