### PR TITLE
test(mcp): cover parallel MCP App instance bridge routing (#773)

### DIFF
--- a/src-tauri/src/app_state.rs
+++ b/src-tauri/src/app_state.rs
@@ -251,6 +251,35 @@ pub(crate) const MCP_APP_MAX_CONCURRENT_CALLS: usize = 4;
 pub(crate) const MCP_APP_MAX_CALLS_PER_WINDOW: usize = 20;
 pub(crate) const MCP_APP_CALL_WINDOW: std::time::Duration = std::time::Duration::from_secs(10);
 
+/// Live `serverTools` bridges keyed by app instance id. Kept as its own type
+/// so instance routing (two parallel Apps, teardown, session delete) is
+/// testable without building a whole `AppState`.
+#[derive(Default)]
+pub(crate) struct McpAppBridges {
+    bridges: StdMutex<HashMap<String, McpAppToolBridge>>,
+}
+
+impl McpAppBridges {
+    pub(crate) fn register(&self, instance_id: String, bridge: McpAppToolBridge) {
+        self.bridges.lock().unwrap().insert(instance_id, bridge);
+    }
+
+    pub(crate) fn get(&self, instance_id: &str) -> Option<McpAppToolBridge> {
+        self.bridges.lock().unwrap().get(instance_id).cloned()
+    }
+
+    pub(crate) fn close(&self, instance_id: &str) -> bool {
+        self.bridges.lock().unwrap().remove(instance_id).is_some()
+    }
+
+    pub(crate) fn remove_for_frame(&self, frame_id: &str) {
+        self.bridges
+            .lock()
+            .unwrap()
+            .retain(|_, bridge| bridge.frame_id != frame_id);
+    }
+}
+
 #[derive(Debug)]
 pub(crate) struct McpAppCallLimiter {
     max_concurrent: usize,
@@ -392,7 +421,7 @@ pub(crate) struct AppState {
     /// URLs, commands, or credentials. Instances are revoked on teardown or
     /// session delete; after an agent rebuild the embedded `Weak` client dies
     /// and further calls fail with a stale-instance error.
-    pub(crate) mcp_app_tool_bridges: StdMutex<HashMap<String, McpAppToolBridge>>,
+    pub(crate) mcp_app_tool_bridges: McpAppBridges,
     /// The frame id the UI is currently viewing. Drives artifact attachment
     /// (`upload_file`/`register_artifact`) and `list_artifacts` fallback.
     /// Written only by view-navigation commands (`load_session`/`new_session`/
@@ -500,31 +529,17 @@ impl AppState {
         self.notification_window.write().unwrap().remove(frame_id);
     }
     pub(crate) fn register_mcp_app_bridge(&self, instance_id: String, bridge: McpAppToolBridge) {
-        self.mcp_app_tool_bridges
-            .lock()
-            .unwrap()
-            .insert(instance_id, bridge);
+        self.mcp_app_tool_bridges.register(instance_id, bridge);
     }
     pub(crate) fn mcp_app_bridge(&self, instance_id: &str) -> Option<McpAppToolBridge> {
-        self.mcp_app_tool_bridges
-            .lock()
-            .unwrap()
-            .get(instance_id)
-            .cloned()
+        self.mcp_app_tool_bridges.get(instance_id)
     }
     pub(crate) fn close_mcp_app_bridge(&self, instance_id: &str) -> bool {
-        self.mcp_app_tool_bridges
-            .lock()
-            .unwrap()
-            .remove(instance_id)
-            .is_some()
+        self.mcp_app_tool_bridges.close(instance_id)
     }
     /// Revoke every app bridge owned by a conversation (session delete).
     pub(crate) fn remove_mcp_app_bridges_for_frame(&self, frame_id: &str) {
-        self.mcp_app_tool_bridges
-            .lock()
-            .unwrap()
-            .retain(|_, bridge| bridge.frame_id != frame_id);
+        self.mcp_app_tool_bridges.remove_for_frame(frame_id);
     }
     pub(crate) fn preferred_notification_window(
         &self,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6448,7 +6448,7 @@ pub fn run() {
                 completion_dispatches: tokio::sync::Mutex::new(HashSet::new()),
                 project_activity: ProjectActivityLocks::default(),
                 resource_leases: resource_leases::ProjectResourceCoordinator::default(),
-                mcp_app_tool_bridges: StdMutex::new(HashMap::new()),
+                mcp_app_tool_bridges: McpAppBridges::default(),
                 active_frame: std::sync::RwLock::new(HashMap::new()),
                 notification_window: std::sync::RwLock::new(HashMap::new()),
                 confirms: Arc::new(StdMutex::new(HashMap::new())),

--- a/src-tauri/src/lib_tests.rs
+++ b/src-tauri/src/lib_tests.rs
@@ -112,6 +112,111 @@ fn mcp_app_tool_confirm_payload_parses_and_keys_a_grant() {
     assert_eq!(tool, "python");
 }
 
+/// One MCP server behind an App bridge: answers only its own tool and reports
+/// which connector served the call, so a crossed route is visible in the result.
+struct FakeAppServer {
+    connector_id: String,
+    tool: String,
+}
+
+#[async_trait::async_trait]
+impl wisp_tools::McpAppServer for FakeAppServer {
+    fn connector_id(&self) -> &str {
+        &self.connector_id
+    }
+    fn app_name(&self) -> &str {
+        &self.connector_id
+    }
+    fn require_approval(&self) -> bool {
+        false
+    }
+    fn tools(&self) -> Vec<serde_json::Value> {
+        vec![serde_json::json!({ "name": self.tool, "inputSchema": { "type": "object" } })]
+    }
+    fn visible_to_app(&self, name: &str) -> bool {
+        name == self.tool
+    }
+    fn read_only(&self, _name: &str) -> bool {
+        true
+    }
+    async fn call_tool(
+        &self,
+        name: &str,
+        _arguments: &serde_json::Value,
+    ) -> Result<serde_json::Value, String> {
+        if name != self.tool {
+            return Err(format!("tool '{name}' is not on this server"));
+        }
+        Ok(serde_json::json!({
+            "content": [],
+            "structuredContent": { "servedBy": self.connector_id },
+            "isError": false,
+        }))
+    }
+}
+
+fn fake_app_bridge(frame_id: &str, connector_id: &str, tool: &str) -> super::McpAppToolBridge {
+    super::McpAppToolBridge {
+        frame_id: frame_id.into(),
+        server: Arc::new(FakeAppServer {
+            connector_id: connector_id.into(),
+            tool: tool.into(),
+        }),
+        limiter: super::McpAppCallLimiter::with_limits(1, 8, std::time::Duration::from_secs(10)),
+    }
+}
+
+#[tokio::test]
+async fn parallel_mcp_app_instances_keep_separate_bridges() {
+    let bridges = super::McpAppBridges::default();
+    let figures = "mcp-app:session-a:figures";
+    let motif = "mcp-app:session-b:motif";
+    bridges.register(
+        figures.into(),
+        fake_app_bridge("session-a", "figure-library", "figure_preview_exact"),
+    );
+    bridges.register(
+        motif.into(),
+        fake_app_bridge("session-b", "motif", "motif_refresh"),
+    );
+
+    // Each instance resolves to the connection that presented it, and neither
+    // can reach the sibling App's tool.
+    let first = bridges.get(figures).unwrap();
+    let second = bridges.get(motif).unwrap();
+    assert_eq!(first.frame_id, "session-a");
+    assert_eq!(second.frame_id, "session-b");
+    assert!(first.server.visible_to_app("figure_preview_exact"));
+    assert!(!first.server.visible_to_app("motif_refresh"));
+    let served = first
+        .server
+        .call_tool("figure_preview_exact", &serde_json::json!({}))
+        .await
+        .unwrap();
+    assert_eq!(served["structuredContent"]["servedBy"], "figure-library");
+    let served = second
+        .server
+        .call_tool("motif_refresh", &serde_json::json!({}))
+        .await
+        .unwrap();
+    assert_eq!(served["structuredContent"]["servedBy"], "motif");
+
+    // Limiters are per instance: saturating one App must not rate-limit another.
+    let _busy = first.limiter.try_acquire().unwrap();
+    assert!(first.limiter.try_acquire().is_err());
+    assert!(second.limiter.try_acquire().is_ok());
+
+    // Teardown revokes only that instance; deleting a session revokes only its
+    // own frame's bridges.
+    assert!(bridges.close(figures));
+    assert!(bridges.get(figures).is_none());
+    assert!(bridges.get(motif).is_some());
+    bridges.remove_for_frame("session-a");
+    assert!(bridges.get(motif).is_some());
+    bridges.remove_for_frame("session-b");
+    assert!(bridges.get(motif).is_none());
+}
+
 #[test]
 fn mcp_app_call_limiter_caps_concurrency() {
     let limiter = super::McpAppCallLimiter::with_limits(2, 8, std::time::Duration::from_secs(10));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### User-facing problem

Acceptance item 6 of #773 ("多实例隔离测试": two parallel App instances must not cross connections or responses) was the one follow-up checkbox with no direct test. Routing lived in an inline `HashMap` inside `AppState`, so it could only be exercised indirectly through the `wisp-mcp` catalog tests — a regression that made one instance reachable through another instance id, or that revoked the wrong bridge on teardown, would not have been caught.

### Changes

- `src-tauri/src/app_state.rs`: extract the inline bridge map into an `McpAppBridges` type with `register`/`get`/`close`/`remove_for_frame`. This is purely a test boundary; `AppState`'s four existing methods delegate to it, so no call site changes.
- `src-tauri/src/lib.rs`: construct `McpAppBridges::default()` in `AppState`.
- `src-tauri/src/lib_tests.rs`: new `parallel_mcp_app_instances_keep_separate_bridges`, using a `FakeAppServer` that reports which connector served a call.

### Tests

`parallel_mcp_app_instances_keep_separate_bridges` asserts, with two registered instances from different sessions and servers:

- each instance id resolves to the bridge and frame that presented it;
- neither instance can see or call the sibling App's tool, and results carry the serving connector;
- limiters are per instance, so saturating one App does not rate-limit another;
- `close` revokes only that instance, and `remove_for_frame` (session delete) revokes only that frame's bridges.

Verified: `cargo fmt --all -- --check`, `cargo test --workspace` (all green), `cd ui && cargo check --target wasm32-unknown-unknown`, and `cd ui-tests && npx playwright test tests/ui.spec.ts -g "MCP App"` (3 passed, 1 skipped acceptance test that needs `WISP_MOTIF_APP_HTML`).

### Manual smoke

No behavior change, so no new steps. The existing #773 smoke path still applies: open two MCP Apps from different connectors in parallel, click an in-app action in each, and confirm each result comes from its own server.

### Known limitations / follow-ups for #773

These remain open after this PR and need a product decision rather than a test:

- No App-specific per-call timeout. App calls inherit the transport timeouts (stdio and HTTP both 120s), and a stdio timeout tears down the whole MCP server process — now reachable from an iframe, not just from an agent turn.
- `mcp_app_approval_grant_key` falls back to `_` when `connector_id` is empty. Registration passes a real connector id for user-configured connectors (the ones that host Apps), but `dev-mcp` and the `mcp_bio` aggregate register with `""`, so their App grants would share the `_:{tool}` key.
- `validate_tool_arguments` is a deliberate subset of JSON Schema (type, `required`, `properties`, `additionalProperties: false`, `items`); `enum`, numeric bounds, `pattern`, and combinators are not enforced.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c11d1db6-4273-4619-921c-39f3c67721be?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c11d1db6-4273-4619-921c-39f3c67721be&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

