### PR TITLE
fix(browser): stop reporting a workspace window whose extension cannot load (#952)

### DIFF
--- a/docs/browser-runtime-architecture.md
+++ b/docs/browser-runtime-architecture.md
@@ -16,9 +16,41 @@ Agent tools
 | Session | Browser | Login state | Port |
 |---|---|---|---|
 | `shared` | User's existing Chrome/Edge profile | Daily cookies and extensions | 18765 |
-| `workspace` | System Chrome launched with `%APPDATA%/science.wisp-science/browser-workspace` | Clean until the user signs in there | 18766 |
+| `workspace` | Chrome-family build launched with `%APPDATA%/science.wisp-science/browser-workspace` | Clean until the user signs in there | 18766 |
 
 Both can be connected at once. If they are, tools must pass `session`.
+
+### Workspace mode needs a build that still loads unpacked extensions
+
+The workspace window is launched with `--load-extension` pointed at a copy
+of `browser-extension/` whose `session_config.js` targets port 18766.
+**Official Google Chrome removed that flag in version 137** and now only
+logs `--load-extension is not allowed in Google Chrome, ignoring`, so the
+window opens with no Wisp extension. Chromium and Chrome for Testing keep
+the flag.
+
+So `resolve_browser()` prefers a build that honors the flag (Chromium,
+Chrome for Testing, or whatever `WISP_WORKSPACE_BROWSER` points at) and
+falls back to branded Chrome only because releases older than 137 still
+work. `start_workspace` then **waits up to 20 s for the workspace
+extension to connect**; if it never does it closes the window and fails
+with `WORKSPACE_EXTENSION_BLOCKED` explaining the flag removal and the
+shared-session alternative. It never reports a spawned process as ready,
+which used to leave the agent driving a blank `about:blank` window (#952).
+
+Shared mode is unaffected: the user loads the extension once from
+`chrome://extensions` in the browser they already use.
+
+### When a connected extension is not a usable session
+
+The extension popup only reports whether its own socket is open, so it can
+read *Connected to Wisp* while Wisp reports `connected=false`.
+`browser_setup` therefore names the cause instead of only the symptom:
+
+| Field | Meaning |
+|---|---|
+| `refused_connection` | A client reached a bridge port and was refused — a foreign extension id, or another loopback bridge on the port. Carries the observed `origin`, the `expected_origin`, and the handshake error. |
+| `reload_required` | A connected extension is below `protocol_version` 2 or reported no capabilities. Chrome never auto-updates an unpacked extension, so the user must Reload it from `extension_path`. |
 
 ## What the extension does
 
@@ -36,7 +68,8 @@ The extension never writes project directories and never returns large base64 fi
 - Multiplexes two WebSocket listeners
 - Browser Task Lease (`last_session` + explicit `session`)
 - Copies staged files into the project and hashes SHA-256
-- Starts/stops the workspace Chrome window
+- Starts/stops the workspace browser window and verifies it connected
+- Records the last refused connection so an unclaimed extension has a reason
 - ChatGPT one-shot send/wait/read on an already-logged-in tab
 
 Playwright is not used. The user's daily Chrome User Data directory is never passed as `--user-data-dir`.

--- a/skills/browser-use/SKILL.md
+++ b/skills/browser-use/SKILL.md
@@ -16,6 +16,15 @@ default) and no extension is connected, Wisp may start the installed
 Chrome/Chromium/Edge so the extension can reconnect. That is still the
 user's profile, not Playwright or Selenium.
 
+**Shared is the default; workspace is not a fallback.** Google Chrome 137
+and later ignore `--load-extension`, so on a machine with only branded
+Chrome the workspace window cannot load the Wisp extension at all.
+`browser_setup {"action":"start_workspace"}` therefore returns only once
+the workspace extension has connected, and otherwise closes the window
+and fails with `WORKSPACE_EXTENSION_BLOCKED`. On that error: relay the
+message, do not retry `start_workspace`, do not claim any workspace page
+was opened or read, and get the shared session working instead.
+
 For figures/code extraction use `web_scan` with `mode: "article"` then
 `web_save_assets`. For ChatGPT web one-shot use `web_agent_send`,
 `web_agent_wait`, `web_agent_read` on an already-logged-in tab.
@@ -32,6 +41,18 @@ current, or URL-specific questions from prior knowledge. Tell the user
 this turn contains no live web retrieval and wait until the popup shows
 *Connected to Wisp*. Only continue from memory if they explicitly ask
 for a knowledge-only answer. Never invent the path.
+
+Two fields say *why* a browser that looks connected is not usable —
+never report a bare "not connected" when either is set:
+
+- `refused_connection` — something reached the bridge port and Wisp
+  refused it (usually a different extension id, or another loopback
+  bridge holding the port). Its popup can still read *Connected to Wisp*.
+  Relay `refused_connection.explanation`.
+- `reload_required` — a connected extension is older than the protocol
+  this build needs. Have the user open `chrome://extensions` and
+  **Reload** Wisp Real Browser Bridge from `extension_path`; Chrome does
+  not auto-update an unpacked extension.
 
 One exception: the user says the extension is already installed. Chrome
 suspends its service worker when idle and reconnects on a one-minute

--- a/src-tauri/src/browser_bridge/errors.rs
+++ b/src-tauri/src/browser_bridge/errors.rs
@@ -6,6 +6,7 @@ pub const EXTENSION_STALE: &str = "EXTENSION_STALE";
 pub const SESSION_REQUIRED: &str = "SESSION_REQUIRED";
 pub const USER_CONTROLLING: &str = "USER_CONTROLLING";
 pub const ASSET_BLOCKED: &str = "ASSET_BLOCKED";
+pub const WORKSPACE_EXTENSION_BLOCKED: &str = "WORKSPACE_EXTENSION_BLOCKED";
 
 pub fn structured(code: &str, message: &str, retryable: bool) -> String {
     json!({

--- a/src-tauri/src/browser_bridge/mod.rs
+++ b/src-tauri/src/browser_bridge/mod.rs
@@ -45,9 +45,13 @@ const EXTENSION_ORIGIN: &str = "chrome-extension://gnkjgagleagkgdlkkcianolobfdoo
 const BROWSER_DISCONNECTED_CODE: &str = "browser_extension_disconnected";
 const BROWSER_DISCONNECTED_MARKER: &str = "WISP_BROWSER_DISCONNECTED";
 const DISCONNECTED_ASSISTANT_INSTRUCTION: &str = "Live web retrieval is unavailable. Do not answer live, latest, current, or URL-specific questions from prior knowledge. Tell the user this turn contains no live web retrieval, relay the install steps, and wait until status is connected. Only continue from memory if they explicitly ask for a knowledge-only answer.";
+const STALE_ASSISTANT_INSTRUCTION: &str = "A connected extension is older than the protocol this build needs, so parts of the browser toolset will fail. Tell the user which session needs it, have them open chrome://extensions and Reload Wisp Real Browser Bridge from extension_path, and do not claim the newer tools exist.";
 const DEFAULT_TIMEOUT_MS: u64 = 15_000;
 const MAX_TIMEOUT_MS: u64 = 60_000;
 const AUTO_LAUNCH_WAIT: Duration = Duration::from_secs(15);
+/// How long `start_workspace` waits for the launched browser's extension to
+/// reach the workspace port before declaring the window unusable.
+const WORKSPACE_CONNECT_WAIT: Duration = Duration::from_secs(20);
 const MAX_SCRIPT_BYTES: usize = 64 * 1024;
 const MAX_RESULT_CHARS: usize = 200_000;
 /// Base64 payload ceiling for one screenshot, matching the shared image path's
@@ -88,12 +92,23 @@ struct SessionState {
     meta: SessionMeta,
 }
 
+/// A client that reached a bridge port but was never claimed as the Wisp
+/// extension. Kept so `browser_setup` can say *why* the extension popup shows
+/// "Connected to Wisp" while Wisp reports `connected=false`.
+#[derive(Clone, Debug)]
+struct RefusedConnection {
+    session: String,
+    origin: Option<String>,
+    reason: String,
+}
+
 #[derive(Default)]
 struct BridgeState {
     sessions: HashMap<String, SessionState>,
     last_session: Option<String>,
     startup_error: Option<String>,
     workspace_pid: Option<u32>,
+    last_refusal: Option<RefusedConnection>,
 }
 
 pub struct BrowserBridge {
@@ -142,6 +157,30 @@ fn session_summary(state: &BridgeState, name: &str) -> Value {
         "paused": meta.map(|meta| meta.paused).unwrap_or(false),
         "tabs": slot.map(|session| session.tabs.len()).unwrap_or(0),
         "reload_required": reload_required
+    })
+}
+
+/// Explain a refused connection in the terms the user sees: the popup says
+/// connected, Wisp says it is not.
+fn refusal_summary(refusal: Option<&RefusedConnection>) -> Value {
+    let Some(refusal) = refusal else {
+        return Value::Null;
+    };
+    let session = &refusal.session;
+    let explanation = match refusal.origin.as_deref() {
+        Some(origin) if !origin.is_empty() => format!(
+            "An extension at {origin} reached the {session} port and Wisp refused it, because this bridge only accepts {EXTENSION_ORIGIN}. Its own popup can still read Connected to Wisp while Wisp reports connected=false. Load the bundled extension from extension_path (a repacked or third-party copy gets a different id), and remove any other loopback bridge extension."
+        ),
+        _ => format!(
+            "A client reached the {session} port without completing the Wisp extension handshake, so no session was claimed and Wisp reports connected=false. Another browser bridge or a plain HTTP client is probably using this port; stop it, then reload the Wisp extension."
+        ),
+    };
+    json!({
+        "session": session,
+        "origin": refusal.origin,
+        "expected_origin": EXTENSION_ORIGIN,
+        "reason": refusal.reason,
+        "explanation": explanation
     })
 }
 
@@ -285,11 +324,6 @@ impl BrowserBridge {
         } else {
             "The running Wisp build has no verified bundled extension path. Do not invent a path or claim the extension exists."
         };
-        let assistant_instruction = if live_retrieval {
-            path_instruction.to_string()
-        } else {
-            format!("{DISCONNECTED_ASSISTANT_INSTRUCTION} {path_instruction}")
-        };
         let connected_tabs = ["shared", "workspace"]
             .into_iter()
             .filter_map(|name| state.sessions.get(name))
@@ -297,6 +331,14 @@ impl BrowserBridge {
             .sum::<usize>();
         let shared = session_summary(&state, "shared");
         let workspace = session_summary(&state, "workspace");
+        let reload_required = [&shared, &workspace]
+            .into_iter()
+            .any(|session| session["reload_required"] == Value::Bool(true));
+        let assistant_instruction = match (live_retrieval, reload_required) {
+            (true, false) => path_instruction.to_string(),
+            (true, true) => format!("{STALE_ASSISTANT_INSTRUCTION} {path_instruction}"),
+            (false, _) => format!("{DISCONNECTED_ASSISTANT_INSTRUCTION} {path_instruction}"),
+        };
         let bundled_extension_version = bundled_manifest_version(&self.extension_dir);
         let reported_extension_version = state
             .sessions
@@ -319,6 +361,8 @@ impl BrowserBridge {
             "bundled_extension_version": bundled_extension_version,
             "workspace_endpoint": format!("ws://{WORKSPACE_ADDR}"),
             "required_protocol": REQUIRED_PROTOCOL,
+            "reload_required": reload_required,
+            "refused_connection": refusal_summary(state.last_refusal.as_ref()),
             "workspace": workspace::status_json(workspace_connected, workspace_running),
             "sessions": {
                 "shared": shared,
@@ -380,20 +424,7 @@ impl BrowserBridge {
         self: Arc<Self>,
         stream: TcpStream,
     ) -> Result<(), tokio_tungstenite::tungstenite::Error> {
-        let socket = accept_hdr_async(stream, |request: &Request, response: Response| {
-            let origin = request
-                .headers()
-                .get("origin")
-                .and_then(|value| value.to_str().ok());
-            if allowed_extension_origin(origin) {
-                Ok(response)
-            } else {
-                Err(forbidden_response())
-            }
-        })
-        .await?;
-        self.serve_connection_on(socket, "shared".into()).await;
-        Ok(())
+        self.accept_connection_on(stream, "shared".into()).await
     }
 
     async fn accept_connection_on(
@@ -401,18 +432,40 @@ impl BrowserBridge {
         stream: TcpStream,
         session: String,
     ) -> Result<(), tokio_tungstenite::tungstenite::Error> {
-        let socket = accept_hdr_async(stream, |request: &Request, response: Response| {
+        // The handshake callback is synchronous, so the refused origin is parked
+        // here and folded into bridge state once the await returns. Without it a
+        // rejected extension is only a log line and the user is told nothing but
+        // `connected=false` (#952).
+        let refused: Arc<std::sync::Mutex<Option<String>>> = Arc::default();
+        let seen = refused.clone();
+        let handshake = accept_hdr_async(stream, move |request: &Request, response: Response| {
             let origin = request
                 .headers()
                 .get("origin")
-                .and_then(|value| value.to_str().ok());
-            if allowed_extension_origin(origin) {
+                .and_then(|value| value.to_str().ok())
+                .map(str::to_string);
+            if allowed_extension_origin(origin.as_deref()) {
                 Ok(response)
             } else {
+                if let Ok(mut slot) = seen.lock() {
+                    *slot = Some(origin.unwrap_or_default());
+                }
                 Err(forbidden_response())
             }
         })
-        .await?;
+        .await;
+        let socket = match handshake {
+            Ok(socket) => socket,
+            Err(error) => {
+                let origin = refused.lock().ok().and_then(|slot| slot.clone());
+                self.state.lock().await.last_refusal = Some(RefusedConnection {
+                    session,
+                    origin,
+                    reason: error.to_string(),
+                });
+                return Err(error);
+            }
+        };
         self.serve_connection_on(socket, session).await;
         Ok(())
     }
@@ -762,35 +815,87 @@ impl BrowserBridge {
     }
 
     async fn start_workspace(&self) -> Result<Value, String> {
-        let source = PathBuf::from(self.verified_extension_path().ok_or_else(|| {
+        let extension_path = self.verified_extension_path().ok_or_else(|| {
             "bundled browser-extension path is not available; cannot materialize workspace copy"
                 .to_string()
-        })?);
-        let extension = workspace::materialize_extension(&source)?;
-        let child = workspace::launch_chrome(&workspace::profile_dir(), &extension)?;
-        let pid = child.id();
-        std::mem::forget(child);
+        })?;
+        let extension = workspace::materialize_extension(Path::new(&extension_path))?;
+        self.start_workspace_with(
+            workspace::resolve_browser()?,
+            &extension_path,
+            &extension,
+            WORKSPACE_CONNECT_WAIT,
+            |browser, profile, extension| {
+                let child = workspace::launch_browser(browser, profile, extension)?;
+                let pid = child.id();
+                std::mem::forget(child);
+                Ok(pid)
+            },
+            workspace::terminate,
+        )
+        .await
+    }
+
+    /// Launch the workspace browser and only report success once its extension
+    /// has actually connected. Chrome 137+ ignores `--load-extension`, so
+    /// reporting the spawned process as ready left the agent driving a blank
+    /// window that could never answer (#952).
+    async fn start_workspace_with<L, T>(
+        &self,
+        browser: workspace::WorkspaceBrowser,
+        extension_path: &str,
+        extension: &Path,
+        wait: Duration,
+        launch: L,
+        terminate: T,
+    ) -> Result<Value, String>
+    where
+        L: FnOnce(&workspace::WorkspaceBrowser, &Path, &Path) -> Result<u32, String>,
+        T: FnOnce(u32),
+    {
+        let pid = launch(&browser, &workspace::profile_dir(), extension)?;
         self.state.lock().await.workspace_pid = Some(pid);
-        Ok(workspace::status_json(false, true))
+        if self.wait_for_session("workspace", wait).await {
+            return Ok(workspace::status_json(true, true));
+        }
+        self.state.lock().await.workspace_pid = None;
+        terminate(pid);
+        Err(errors::structured(
+            errors::WORKSPACE_EXTENSION_BLOCKED,
+            &workspace::extension_blocked_message(&browser, extension_path, wait),
+            false,
+        ))
     }
 
     async fn stop_workspace(&self) -> Result<Value, String> {
         let pid = self.state.lock().await.workspace_pid.take();
         if let Some(pid) = pid {
-            #[cfg(windows)]
-            {
-                let _ = std::process::Command::new("taskkill")
-                    .args(["/PID", &pid.to_string(), "/T", "/F"])
-                    .status();
-            }
-            #[cfg(not(windows))]
-            {
-                let _ = std::process::Command::new("kill")
-                    .args(["-TERM", &pid.to_string()])
-                    .status();
-            }
+            workspace::terminate(pid);
         }
         Ok(workspace::status_json(false, false))
+    }
+
+    async fn wait_for_session(&self, session: &str, wait: Duration) -> bool {
+        let deadline = tokio::time::Instant::now() + wait;
+        loop {
+            if self.session_connected(session).await {
+                return true;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return false;
+            }
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+    }
+
+    async fn session_connected(&self, session: &str) -> bool {
+        self.state
+            .lock()
+            .await
+            .sessions
+            .get(session)
+            .and_then(|slot| slot.client.as_ref())
+            .is_some()
     }
 
     async fn tabs(&self) -> Result<Vec<BrowserTab>, String> {
@@ -1344,11 +1449,11 @@ impl Tool for BrowserSetupTool {
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(
             self.name(),
-            "Call when the user asks to configure, install, set up, or connect the real browser, and before any live page retrieval. The result is derived from the running Wisp binary's native Tauri resource directory and includes the manual settings required for unattended single and multiple downloads. Copy extension_path character-for-character and never convert it between Windows, WSL, macOS, or Linux. If status is not connected, live_retrieval is false: do not answer live, latest, current, or URL-specific questions from prior knowledge; relay the steps and wait. If extension_path_verified is false, report the missing bundled extension and never invent a path.",
+            "Call when the user asks to configure, install, set up, or connect the real browser, and before any live page retrieval. The result is derived from the running Wisp binary's native Tauri resource directory and includes the manual settings required for unattended single and multiple downloads. Copy extension_path character-for-character and never convert it between Windows, WSL, macOS, or Linux. If status is not connected, live_retrieval is false: do not answer live, latest, current, or URL-specific questions from prior knowledge; relay the steps and wait. If refused_connection is present, relay its explanation: the extension popup can read Connected to Wisp while Wisp refuses that socket. If reload_required is true, have the user reload the extension. If extension_path_verified is false, report the missing bundled extension and never invent a path.",
             json!({
                 "type": "object",
                 "properties": {
-                    "action": { "type": "string", "description": "Optional: start_workspace or stop_workspace" }
+                    "action": { "type": "string", "description": "Optional: start_workspace (returns only once the workspace extension connects, and fails with WORKSPACE_EXTENSION_BLOCKED when the launched browser cannot load it) or stop_workspace" }
                 },
                 "additionalProperties": false
             }),
@@ -2972,6 +3077,122 @@ mod tests {
         assert!(info["code"].is_null());
         assert_eq!(info["extension_path_verified"], false);
         assert_eq!(info["auto_launch_browser"], false);
+    }
+
+    fn fake_browser(loads_unpacked_extensions: bool) -> workspace::WorkspaceBrowser {
+        workspace::WorkspaceBrowser {
+            name: "Google Chrome".into(),
+            path: PathBuf::from("/opt/chrome"),
+            loads_unpacked_extensions,
+        }
+    }
+
+    #[tokio::test]
+    async fn workspace_start_closes_a_window_whose_extension_never_connects() {
+        let bridge = Arc::new(BrowserBridge::new(PathBuf::from("extension")));
+        let terminated = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let recorder = terminated.clone();
+
+        let error = bridge
+            .start_workspace_with(
+                fake_browser(false),
+                "/opt/wisp/browser-extension",
+                Path::new("/tmp/workspace-extension"),
+                Duration::from_millis(10),
+                |_, _, _| Ok(4242),
+                move |pid| recorder.lock().unwrap().push(pid),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(error.contains(errors::WORKSPACE_EXTENSION_BLOCKED));
+        assert!(error.contains("--load-extension"));
+        assert!(error.contains("chrome://extensions"));
+        // The doomed about:blank window is closed and forgotten, so a later
+        // stop_workspace cannot kill an unrelated process id.
+        assert_eq!(*terminated.lock().unwrap(), vec![4242]);
+        assert!(bridge.state.lock().await.workspace_pid.is_none());
+    }
+
+    #[tokio::test]
+    async fn workspace_start_reports_ready_only_after_the_extension_connects() {
+        let bridge = Arc::new(BrowserBridge::new(PathBuf::from("extension")));
+        let (tx, _rx) = mpsc::unbounded_channel();
+        bridge.install_client_on(1, tx, "workspace").await;
+
+        let status = bridge
+            .start_workspace_with(
+                fake_browser(true),
+                "/opt/wisp/browser-extension",
+                Path::new("/tmp/workspace-extension"),
+                Duration::from_millis(10),
+                |_, _, _| Ok(4242),
+                |pid| panic!("a connected workspace must not be terminated, got {pid}"),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(status["connected"], true);
+        assert_eq!(status["process_running"], true);
+        assert_eq!(bridge.state.lock().await.workspace_pid, Some(4242));
+    }
+
+    #[test]
+    fn refused_connection_explains_why_a_connected_popup_is_not_claimed() {
+        assert!(refusal_summary(None).is_null());
+
+        let foreign = refusal_summary(Some(&RefusedConnection {
+            session: "shared".into(),
+            origin: Some("chrome-extension://aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".into()),
+            reason: "HTTP error: 403 Forbidden".into(),
+        }));
+        assert_eq!(foreign["session"], "shared");
+        assert_eq!(foreign["expected_origin"], EXTENSION_ORIGIN);
+        assert_eq!(foreign["reason"], "HTTP error: 403 Forbidden");
+        let explanation = foreign["explanation"].as_str().unwrap();
+        assert!(explanation.contains("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
+        assert!(explanation.contains("Connected to Wisp"));
+
+        let unfinished = refusal_summary(Some(&RefusedConnection {
+            session: "workspace".into(),
+            origin: None,
+            reason: "WebSocket protocol error: Handshake not finished".into(),
+        }));
+        assert!(unfinished["explanation"]
+            .as_str()
+            .unwrap()
+            .contains("without completing the Wisp extension handshake"));
+    }
+
+    #[tokio::test]
+    async fn setup_names_the_refusal_and_the_stale_reload_instead_of_only_connected_false() {
+        let bridge = Arc::new(BrowserBridge::new(PathBuf::from("extension")));
+        bridge.state.lock().await.last_refusal = Some(RefusedConnection {
+            session: "shared".into(),
+            origin: Some("chrome-extension://other".into()),
+            reason: "HTTP error: 403 Forbidden".into(),
+        });
+        let info = bridge.setup_info().await;
+        assert_eq!(
+            info["refused_connection"]["origin"],
+            "chrome-extension://other"
+        );
+        assert_eq!(info["reload_required"], false);
+
+        // A protocol-1 extension connects and its popup reads Connected, so the
+        // status must name the reload rather than looking healthy.
+        let (tx, _rx) = mpsc::unbounded_channel();
+        bridge.install_client(1, tx).await;
+        bridge
+            .handle_text(1, r#"{"type":"ext_ready","protocol_version":1,"tabs":[]}"#)
+            .await;
+        let info = bridge.setup_info().await;
+        assert_eq!(info["reload_required"], true);
+        assert_eq!(info["sessions"]["shared"]["reload_required"], true);
+        assert!(info["assistant_instruction"]
+            .as_str()
+            .unwrap()
+            .contains("Reload Wisp Real Browser Bridge"));
     }
 
     #[test]

--- a/src-tauri/src/browser_bridge/workspace.rs
+++ b/src-tauri/src/browser_bridge/workspace.rs
@@ -2,10 +2,39 @@ use serde_json::{json, Value};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
+use std::time::Duration;
 
 pub const WORKSPACE_PROFILE_DIRNAME: &str = "browser-workspace";
 pub const WORKSPACE_EXTENSION_DIRNAME: &str = "browser-workspace-extension";
 pub const WORKSPACE_ENDPOINT: &str = "ws://127.0.0.1:18766";
+/// Points the workspace session at one browser executable, so a user who keeps
+/// Chromium or Chrome for Testing outside the standard install paths can still
+/// use workspace mode.
+pub const BROWSER_ENV_OVERRIDE: &str = "WISP_WORKSPACE_BROWSER";
+
+/// A Chrome-family build the workspace session can launch.
+///
+/// `loads_unpacked_extensions` records whether the build still honors
+/// `--load-extension`. Official Google Chrome removed that flag in 137 and now
+/// only logs `--load-extension is not allowed in Google Chrome, ignoring`, so a
+/// workspace window opens with no Wisp extension and can never connect.
+/// Chromium and Chrome for Testing keep the flag.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WorkspaceBrowser {
+    pub name: String,
+    pub path: PathBuf,
+    pub loads_unpacked_extensions: bool,
+}
+
+impl WorkspaceBrowser {
+    fn new(name: &str, path: impl Into<PathBuf>, loads_unpacked_extensions: bool) -> Self {
+        Self {
+            name: name.to_string(),
+            path: path.into(),
+            loads_unpacked_extensions,
+        }
+    }
+}
 
 pub fn app_data_root() -> PathBuf {
     dirs::data_dir()
@@ -21,22 +50,107 @@ pub fn extension_copy_dir() -> PathBuf {
     app_data_root().join(WORKSPACE_EXTENSION_DIRNAME)
 }
 
-pub fn chrome_executable() -> Result<PathBuf, String> {
-    let candidates = [
-        PathBuf::from(r"C:\Program Files\Google\Chrome\Application\chrome.exe"),
-        PathBuf::from(r"C:\Program Files (x86)\Google\Chrome\Application\chrome.exe"),
-    ];
-    for path in candidates {
-        if path.is_file() {
-            return Ok(path);
+/// Every build the workspace session knows about, in install-path order. Paths
+/// with a single component are looked up on `PATH`.
+pub fn browser_candidates() -> Vec<WorkspaceBrowser> {
+    let mut candidates = Vec::new();
+    if let Some(path) = std::env::var_os(BROWSER_ENV_OVERRIDE) {
+        // The user named this build on purpose, so trust it to load the copy.
+        let path = PathBuf::from(path);
+        let name = path
+            .file_stem()
+            .map(|stem| stem.to_string_lossy().to_string())
+            .unwrap_or_else(|| BROWSER_ENV_OVERRIDE.to_string());
+        candidates.push(WorkspaceBrowser::new(&name, path, true));
+    }
+    #[cfg(windows)]
+    {
+        for root in [
+            std::env::var_os("LOCALAPPDATA"),
+            std::env::var_os("PROGRAMFILES"),
+            std::env::var_os("PROGRAMFILES(X86)"),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            let root = PathBuf::from(root);
+            candidates.push(WorkspaceBrowser::new(
+                "Chromium",
+                root.join(r"Chromium\Application\chrome.exe"),
+                true,
+            ));
+            candidates.push(WorkspaceBrowser::new(
+                "Chrome for Testing",
+                root.join(r"Google\Chrome for Testing\chrome.exe"),
+                true,
+            ));
+            candidates.push(WorkspaceBrowser::new(
+                "Google Chrome",
+                root.join(r"Google\Chrome\Application\chrome.exe"),
+                false,
+            ));
         }
     }
-    which::which("chrome")
-        .or_else(|_| which::which("google-chrome"))
-        .map_err(|_| {
-            "Chrome executable not found at C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe"
-                .into()
+    #[cfg(target_os = "macos")]
+    {
+        candidates.push(WorkspaceBrowser::new(
+            "Chromium",
+            "/Applications/Chromium.app/Contents/MacOS/Chromium",
+            true,
+        ));
+        candidates.push(WorkspaceBrowser::new(
+            "Chrome for Testing",
+            "/Applications/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing",
+            true,
+        ));
+        candidates.push(WorkspaceBrowser::new(
+            "Google Chrome",
+            "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+            false,
+        ));
+    }
+    #[cfg(not(any(windows, target_os = "macos")))]
+    {
+        for name in ["chromium", "chromium-browser"] {
+            candidates.push(WorkspaceBrowser::new("Chromium", name, true));
+        }
+        for name in ["google-chrome-stable", "google-chrome", "chrome"] {
+            candidates.push(WorkspaceBrowser::new("Google Chrome", name, false));
+        }
+    }
+    candidates
+}
+
+/// Pick the build most likely to load the workspace extension copy. A build
+/// that still honors `--load-extension` always wins; branded Chrome is a last
+/// resort because only releases older than 137 can work.
+pub fn preferred_browser(installed: Vec<WorkspaceBrowser>) -> Option<WorkspaceBrowser> {
+    installed
+        .iter()
+        .find(|browser| browser.loads_unpacked_extensions)
+        .or_else(|| installed.first())
+        .cloned()
+}
+
+pub fn resolve_browser() -> Result<WorkspaceBrowser, String> {
+    let installed = browser_candidates()
+        .into_iter()
+        .filter_map(|browser| {
+            locate(&browser.path).map(|path| WorkspaceBrowser { path, ..browser })
         })
+        .collect();
+    preferred_browser(installed).ok_or_else(|| {
+        format!(
+            "no Chrome-family browser found for the workspace session; install Chromium or Chrome for Testing, or set {BROWSER_ENV_OVERRIDE} to a browser executable"
+        )
+    })
+}
+
+fn locate(program: &Path) -> Option<PathBuf> {
+    if program.components().count() > 1 {
+        return program.is_file().then(|| program.to_path_buf());
+    }
+    which::which(program).ok()
 }
 
 pub fn materialize_extension(source: &Path) -> Result<PathBuf, String> {
@@ -78,10 +192,13 @@ fn copy_dir(src: &Path, dest: &Path) -> Result<(), String> {
     Ok(())
 }
 
-pub fn launch_chrome(profile: &Path, extension: &Path) -> Result<Child, String> {
-    let chrome = chrome_executable()?;
+pub fn launch_browser(
+    browser: &WorkspaceBrowser,
+    profile: &Path,
+    extension: &Path,
+) -> Result<Child, String> {
     fs::create_dir_all(profile).map_err(|error| format!("create workspace profile: {error}"))?;
-    let mut command = Command::new(chrome);
+    let mut command = Command::new(&browser.path);
     command
         .arg(format!("--user-data-dir={}", profile.display()))
         .arg(format!("--load-extension={}", extension.display()))
@@ -92,12 +209,59 @@ pub fn launch_chrome(profile: &Path, extension: &Path) -> Result<Child, String> 
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null());
-    command
-        .spawn()
-        .map_err(|error| format!("failed to launch workspace Chrome: {error}"))
+    command.spawn().map_err(|error| {
+        format!(
+            "failed to launch workspace {} at '{}': {error}",
+            browser.name,
+            browser.path.display()
+        )
+    })
+}
+
+pub fn terminate(pid: u32) {
+    #[cfg(windows)]
+    {
+        let _ = Command::new("taskkill")
+            .args(["/PID", &pid.to_string(), "/T", "/F"])
+            .status();
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = Command::new("kill")
+            .args(["-TERM", &pid.to_string()])
+            .status();
+    }
+}
+
+/// Why a launched workspace window never produced a bridge connection, and what
+/// the user can do instead. Returned to the model so it stops rather than
+/// browsing an empty `about:blank` window it cannot see.
+pub fn extension_blocked_message(
+    browser: &WorkspaceBrowser,
+    extension_path: &str,
+    waited: Duration,
+) -> String {
+    let cause = if browser.loads_unpacked_extensions {
+        format!(
+            "{} did load the workspace extension copy from '{extension_path}' on the command line, so check that this build is not blocking extensions by policy.",
+            browser.name
+        )
+    } else {
+        format!(
+            "Official Google Chrome builds since version 137 ignore --load-extension and only log \"--load-extension is not allowed in Google Chrome, ignoring\", so {} cannot load the workspace copy at all and the window stays extension-less.",
+            browser.name
+        )
+    };
+    format!(
+        "workspace {} at '{}' started but the Wisp extension never connected to {WORKSPACE_ENDPOINT} within {}s, so Wisp closed that window instead of leaving it on about:blank. {cause} Use the shared session instead: in the browser you already use open chrome://extensions, enable Developer mode, Load unpacked from this exact path '{extension_path}', and wait until the popup shows Connected to Wisp. To keep using workspace mode, install Chromium or Chrome for Testing, or set {BROWSER_ENV_OVERRIDE} to such a build, then call start_workspace again. Do not retry start_workspace with the same browser, and never claim a workspace page was opened or read.",
+        browser.name,
+        browser.path.display(),
+        waited.as_secs()
+    )
 }
 
 pub fn status_json(connected: bool, child_running: bool) -> Value {
+    let browser = resolve_browser().ok();
     json!({
         "session": "workspace",
         "connected": connected,
@@ -105,6 +269,77 @@ pub fn status_json(connected: bool, child_running: bool) -> Value {
         "profile_dir": profile_dir().display().to_string(),
         "extension_dir": extension_copy_dir().display().to_string(),
         "endpoint": WORKSPACE_ENDPOINT,
-        "chrome": chrome_executable().ok().map(|path| path.display().to_string()),
+        "browser": browser.as_ref().map(|browser| json!({
+            "name": browser.name,
+            "path": browser.path.display().to_string(),
+            "loads_unpacked_extensions": browser.loads_unpacked_extensions,
+            "note": if browser.loads_unpacked_extensions {
+                Value::Null
+            } else {
+                json!("Google Chrome 137+ ignores --load-extension, so start_workspace can only work on an older build. Prefer the shared session or install Chromium / Chrome for Testing.")
+            }
+        })),
+        "chrome": browser.as_ref().map(|browser| browser.path.display().to_string()),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn candidates_prefer_a_build_that_still_loads_unpacked_extensions() {
+        let chrome = WorkspaceBrowser::new("Google Chrome", "/opt/chrome", false);
+        let chromium = WorkspaceBrowser::new("Chromium", "/opt/chromium", true);
+
+        assert_eq!(
+            preferred_browser(vec![chrome.clone(), chromium.clone()]),
+            Some(chromium)
+        );
+        // Branded Chrome is still tried when it is the only build installed:
+        // releases older than 137 honor --load-extension.
+        assert_eq!(preferred_browser(vec![chrome.clone()]), Some(chrome));
+        assert_eq!(preferred_browser(Vec::new()), None);
+    }
+
+    #[test]
+    fn branded_chrome_is_never_marked_as_loading_unpacked_extensions() {
+        let candidates = browser_candidates();
+        assert!(!candidates.is_empty());
+        assert!(candidates
+            .iter()
+            .any(|browser| browser.loads_unpacked_extensions));
+        for browser in candidates {
+            if browser.name == "Google Chrome" {
+                assert!(
+                    !browser.loads_unpacked_extensions,
+                    "branded Chrome 137+ ignores --load-extension: {browser:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn blocked_message_names_the_chrome_flag_removal_and_the_shared_fallback() {
+        let message = extension_blocked_message(
+            &WorkspaceBrowser::new("Google Chrome", "/opt/chrome", false),
+            "/opt/wisp/browser-extension",
+            Duration::from_secs(20),
+        );
+
+        assert!(message.contains("137"));
+        assert!(message.contains("--load-extension"));
+        assert!(message.contains("chrome://extensions"));
+        assert!(message.contains("/opt/wisp/browser-extension"));
+        assert!(message.contains("20s"));
+        assert!(message.contains("Do not retry start_workspace"));
+
+        let chromium = extension_blocked_message(
+            &WorkspaceBrowser::new("Chromium", "/opt/chromium", true),
+            "/opt/wisp/browser-extension",
+            Duration::from_secs(20),
+        );
+        assert!(!chromium.contains("137"));
+        assert!(chromium.contains("blocking extensions by policy"));
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #952.

## Problem

`browser_setup {"action":"start_workspace"}` launched Chrome with `--load-extension=<workspace copy>` and then immediately reported `process_running: true`. **Official Google Chrome removed `--load-extension` in version 137** and now only logs `--load-extension is not allowed in Google Chrome, ignoring`, so on any current Chrome the workspace profile opens on a bare `about:blank` with no Wisp extension, nothing ever connects to `ws://127.0.0.1:18766`, and browser-use hangs. The reporter's forensics match exactly: the `browser-workspace` profile contained only Chrome's built-in extensions, the `session_config.js` copy existed but was never loaded, and port 18766 had no client.

Two smaller gaps in the same report:

- The extension popup only reports whether *its own* socket is open, so it can read "Connected to Wisp" while Wisp reports `connected=false`. Refused handshakes (403 on a foreign extension origin, unfinished upgrades) were only `tracing::warn!` lines, so the user was told the symptom and never the cause.
- A connected-but-stale extension set `sessions.<name>.reload_required` but nothing summarised it, so a status that needed a Reload looked healthy.

## Changes

`src-tauri/src/browser_bridge/workspace.rs`

- New `WorkspaceBrowser { name, path, loads_unpacked_extensions }`. `browser_candidates()` lists every known Chrome-family build with that flag-support bit; `preferred_browser()` picks a build that still honors `--load-extension` (Chromium, Chrome for Testing, or `WISP_WORKSPACE_BROWSER`) and falls back to branded Chrome only because releases older than 137 still work.
- Adds the macOS install paths, which were missing entirely (`which chrome` never resolves there).
- `extension_blocked_message()` is a pure function that explains the flag removal, the shared-session alternative, and the "do not retry / do not claim you read the page" instruction.
- `terminate()` now owns the platform kill, shared by the failure path and `stop_workspace`.

`src-tauri/src/browser_bridge/mod.rs`

- `start_workspace` waits up to 20 s for the workspace session to connect. On success it reports `connected: true`; on timeout it clears the pid, closes the window, and fails with `WORKSPACE_EXTENSION_BLOCKED`. `start_workspace_with` takes the browser, wait duration, launch, and terminate as parameters so the failure path is testable without spawning a browser.
- `accept_connection_on` parks the refused origin from the synchronous handshake callback and folds it into `BridgeState::last_refusal`; `accept_connection` now delegates to it instead of duplicating the origin check.
- `setup_info` gains `refused_connection` (observed origin, expected origin, handshake error, plain-language explanation) and a `reload_required` rollup, and switches `assistant_instruction` to a stale-reload variant when a connected extension is below protocol 2.

`src-tauri/src/browser_bridge/errors.rs`: adds `WORKSPACE_EXTENSION_BLOCKED`.

## Tests

`cargo fmt --all -- --check` and `cargo test --workspace` pass. No test launches a browser, opens a socket to a real host, or needs network.

New:

- `candidates_prefer_a_build_that_still_loads_unpacked_extensions`
- `branded_chrome_is_never_marked_as_loading_unpacked_extensions`
- `blocked_message_names_the_chrome_flag_removal_and_the_shared_fallback`
- `workspace_start_closes_a_window_whose_extension_never_connects` — asserts the structured code, that the fake pid was terminated, and that `workspace_pid` was cleared so a later `stop_workspace` cannot kill an unrelated process
- `workspace_start_reports_ready_only_after_the_extension_connects`
- `refused_connection_explains_why_a_connected_popup_is_not_claimed`
- `setup_names_the_refusal_and_the_stale_reload_instead_of_only_connected_false`

## Manual smoke steps

1. On a machine with only Google Chrome ≥ 137, run `browser_setup {"action":"start_workspace"}`. A window opens, closes after ~20 s, and the tool fails with `WORKSPACE_EXTENSION_BLOCKED` naming Chrome 137 and the shared-session steps.
2. Install Chromium (or set `WISP_WORKSPACE_BROWSER` to a Chrome for Testing binary) and repeat: the extension connects and the tool returns `connected: true`.
3. With no extension loaded, point another loopback bridge extension at port 18765 and run `browser_setup`: `refused_connection` reports that origin against `expected_origin`.
4. Load an older unpacked build into the daily browser and run `browser_setup`: `reload_required` is true and `assistant_instruction` asks for a Reload.

## Known limitations and follow-ups

- On a machine with only branded Chrome ≥ 137, workspace mode still cannot work — it now fails clearly instead of pretending. Actually loading an extension into branded Chrome requires `--remote-debugging-pipe` plus `--enable-unsafe-extension-debugging` and a CDP `Extensions.loadUnpacked` client. That needs a real CDP pipe implementation, including the Windows CRT handle-inheritance path, and belongs in its own change.
- `loads_unpacked_extensions` is a static property of the build, not a probe of the installed version, so an old Chrome (< 137) is merely deprioritized rather than treated as capable. The connect-verification step makes that safe either way.
- Edge and Brave are deliberately not listed as workspace candidates: their flag behavior is not documented the way Google documented Chromium and Chrome for Testing, and `WISP_WORKSPACE_BROWSER` covers users who want to try one.
- Refusal state keeps only the most recent event; that is enough to explain the current status without adding a table.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-293c0128-ba58-4bee-97cb-0abb406a9647?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-293c0128-ba58-4bee-97cb-0abb406a9647&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

