### PR TITLE
fix(ui): keep DOCX preview controls visible

### DIFF
--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -7365,15 +7365,23 @@ test("DOCX artifacts render offline with headings, tables, and equations", async
   // The wrapping preview carries data-file-path so P2 selection/annotate works here too.
   await expect(page.locator('.rp-file-preview[data-file-path*="manuscript.docx"]')).toBeVisible();
 
-  // #274: a tall docx must be scrollable in the right pane (not trapped by a
-  // fixed-height .rp-docx). The .rp-view container owns the scroll.
+  // #274/#951: a tall docx must remain scrollable without carrying the preview
+  // header and its close action out of view. The document owns the scroll while
+  // the surrounding .rp-view stays fixed.
   const view = page.locator(".rp-view");
+  await expect(view).toHaveAttribute("data-preview-kind", "docx");
+  const closePreview = view.getByRole("button", { name: "Close preview" });
+  await expect(closePreview).toBeVisible();
   await docx.locator(".docx-wrapper").evaluate((el) => {
     (el as HTMLElement).style.minHeight = "4000px";
   });
-  await expect.poll(() => view.evaluate((el) => el.scrollHeight - el.clientHeight)).toBeGreaterThan(100);
-  await view.evaluate((el) => { el.scrollTop = 500; });
-  await expect.poll(() => view.evaluate((el) => el.scrollTop)).toBeGreaterThan(0);
+  await expect.poll(() => docx.evaluate((el) => el.scrollHeight - el.clientHeight)).toBeGreaterThan(100);
+  await docx.evaluate((el) => { el.scrollTop = 500; });
+  await expect.poll(() => docx.evaluate((el) => el.scrollTop)).toBeGreaterThan(0);
+  await expect.poll(() => view.evaluate((el) => el.scrollTop)).toBe(0);
+  await expect(closePreview).toBeVisible();
+  await closePreview.click();
+  await expect(view).toHaveCount(0);
 });
 
 test("DOCX opened from the Files browser scrolls inside the modal (#274)", async ({ page }) => {

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -13182,7 +13182,7 @@ fn App() -> impl IntoView {
                                                 None
                                             };
                                             view! {
-                                                <div class="rp-view">
+                                                <div class="rp-view" data-preview-kind=cur.kind>
                                                     <div class="rp-view-head">
                                                         <span class=format!("rp-badge {}", cur.kind)>{cur.kind.to_string()}</span>
                                                         <span class="rp-view-name">{cur.name.clone()}</span>

--- a/ui/src/styles/right-pane.css
+++ b/ui/src/styles/right-pane.css
@@ -410,6 +410,16 @@ button.run-status:hover { filter:brightness(0.96); }
 .rp-view-head .icon-btn { flex-shrink: 0; }
 .rp-view-name { font-size: 13px; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
 .rp-path { margin: 0; font-family: var(--font-mono); font-size: 11px; word-break: break-all; }
+/* Keep DOCX chrome available while the document scrolls. The explicit flex
+   chain gives the renderer a bounded viewport without returning to the #274
+   failure mode where a tall document was clipped instead of scrollable. */
+.rp-view[data-preview-kind="docx"] { overflow: hidden; }
+.rp-view[data-preview-kind="docx"] > :is(.rp-view-head, .rp-path) { flex: 0 0 auto; }
+.rp-view[data-preview-kind="docx"] > .rp-file-preview,
+.rp-view[data-preview-kind="docx"] > .rp-file-preview > .rp-heavy {
+  display: flex; flex: 1 1 auto; min-height: 0; flex-direction: column;
+}
+.rp-view[data-preview-kind="docx"] .rp-docx { flex: 1 1 auto; min-height: 0; overflow: auto; }
 /* Type labels stay mono + quiet; only tabular data keeps a clay accent. */
 .rp-badge {
   font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: .04em;


### PR DESCRIPTION
## Problem

The right-panel DOCX preview used the whole artifact view as its scroll container. Reading further into a document moved the file header and close control out of view, forcing users to scroll back to the top.

Closes #951.

## Changes

- mark artifact preview containers with their preview kind
- give right-panel DOCX previews a bounded flex layout so `.rp-docx` owns scrolling while the header and path remain fixed
- update the DOCX Playwright regression to scroll the document, verify the outer view stays fixed, and close the preview from the scrolled position

## Validation

- `cargo fmt --all -- --check`
- `cd ui && cargo check --target wasm32-unknown-unknown`
- targeted DOCX Playwright test: passed
- full Playwright suite: 443 passed, 1 skipped
- `cargo test --workspace --exclude wisp-mcp`: passed
- `cargo test --workspace`: the `wisp-mcp` process transport integration test is blocked on this macOS host by `Operation not permitted`; an isolated rerun reproduced the same environment failure

## Manual smoke

1. Open a DOCX artifact in the right panel.
2. Scroll into the middle of the document and confirm the DOCX header, path, and close control remain visible.
3. Close the preview without scrolling back to the top and confirm the artifact tiles return.

## Scope and limitations

- This changes only right-panel DOCX scroll ownership.
- It does not add or change multi-document opening behavior.