### PR TITLE
fix(runtime): bound worker shutdown so stopping a REPL cannot hang (#941)

### DIFF
--- a/crates/wisp-runtime/Cargo.toml
+++ b/crates/wisp-runtime/Cargo.toml
@@ -17,3 +17,7 @@ wisp-llm = { workspace = true }
 wisp-tools = { workspace = true }
 wisp-paths = { workspace = true }
 dunce = { workspace = true }
+
+[dev-dependencies]
+# test-util enables tokio::time::pause so stop-budget tests skip real waits.
+tokio = { workspace = true, features = ["test-util"] }

--- a/crates/wisp-runtime/src/kernel.rs
+++ b/crates/wisp-runtime/src/kernel.rs
@@ -16,6 +16,13 @@ pub const PROTOCOL_VERSION: u32 = 1;
 pub const MAX_CODE_BYTES: usize = 1024 * 1024;
 const STARTUP_TIMEOUT: Duration = Duration::from_secs(10);
 const MAX_WORKER_STDERR_BYTES: usize = 32 * 1024;
+/// Stopping a worker is bounded by these three budgets in sequence. Every step
+/// has a way to overrun on a real host: a worker can ignore stdin EOF, a
+/// wrapper process can outlive its own kill, and a descendant that inherited
+/// the stderr pipe can hold its write end open indefinitely.
+const WORKER_EXIT_GRACE: Duration = Duration::from_secs(2);
+const WORKER_KILL_WAIT: Duration = Duration::from_secs(2);
+const WORKER_STDERR_DRAIN: Duration = Duration::from_millis(500);
 
 type WorkerStderrTail = Arc<Mutex<Vec<u8>>>;
 
@@ -94,7 +101,10 @@ struct RawObjects {
 
 pub struct KernelClient {
     child: Child,
-    stdin: ChildStdin,
+    /// Held as `Option` so shutdown can drop the handle. Closing the write end
+    /// is the only way the worker ever sees stdin EOF: tokio's
+    /// `ChildStdin::shutdown` is a no-op on both Unix and Windows.
+    stdin: Option<ChildStdin>,
     stdout: BufReader<ChildStdout>,
     stderr_tail: WorkerStderrTail,
     stderr_task: Option<JoinHandle<()>>,
@@ -168,16 +178,16 @@ impl KernelClient {
         let ready = match read_ready(&mut stdout, expected_language, STARTUP_TIMEOUT).await {
             Ok(ready) => ready,
             Err(error) => {
-                let _ = child.kill().await;
-                let status = child.wait().await.ok();
-                let _ = stderr_task.await;
+                drop(stdin);
+                let status = kill_worker(&mut child).await.ok();
+                drain_stderr(stderr_task).await;
                 let detail = worker_failure_detail(status.as_ref(), &stderr_tail).await;
                 return Err(anyhow!("kernel worker handshake: {error}; {detail}"));
             }
         };
         Ok(Self {
             child,
-            stdin,
+            stdin: Some(stdin),
             stdout,
             stderr_tail,
             stderr_task: Some(stderr_task),
@@ -203,10 +213,8 @@ impl KernelClient {
             let detail = worker_failure_detail(Some(&status), &self.stderr_tail).await;
             bail!("kernel worker exited before execution request '{id}'; {detail}");
         }
-        let request = serde_json::json!({ "type": "execute", "id": id, "code": code });
-        self.stdin.write_all(request.to_string().as_bytes()).await?;
-        self.stdin.write_all(b"\n").await?;
-        self.stdin.flush().await?;
+        self.send(serde_json::json!({ "type": "execute", "id": id, "code": code }))
+            .await?;
         match read_response(&mut self.stdout, id, output).await {
             Ok(response) => Ok(response),
             Err(error) => {
@@ -224,10 +232,8 @@ impl KernelClient {
             let detail = worker_failure_detail(Some(&status), &self.stderr_tail).await;
             bail!("kernel worker exited before inspection request '{id}'; {detail}");
         }
-        let request = serde_json::json!({ "type": "inspect", "id": id });
-        self.stdin.write_all(request.to_string().as_bytes()).await?;
-        self.stdin.write_all(b"\n").await?;
-        self.stdin.flush().await?;
+        self.send(serde_json::json!({ "type": "inspect", "id": id }))
+            .await?;
         match read_objects(&mut self.stdout, id).await {
             Ok(objects) => Ok(objects),
             Err(error) => {
@@ -239,19 +245,28 @@ impl KernelClient {
         }
     }
 
-    async fn shutdown_worker(&mut self) -> Result<()> {
-        let _ = self.stdin.shutdown().await;
-        match tokio::time::timeout(Duration::from_millis(750), self.child.wait()).await {
-            Ok(status) => {
-                status?;
-            }
-            Err(_) => {
-                self.child.kill().await?;
-                let _ = self.child.wait().await?;
-            }
-        }
-        self.finish_stderr_capture().await;
+    async fn send(&mut self, request: serde_json::Value) -> Result<()> {
+        let stdin = self
+            .stdin
+            .as_mut()
+            .ok_or_else(|| anyhow!("kernel worker stdin is already closed"))?;
+        stdin.write_all(request.to_string().as_bytes()).await?;
+        stdin.write_all(b"\n").await?;
+        stdin.flush().await?;
         Ok(())
+    }
+
+    /// Stop the worker within a bounded budget. Dropping stdin gives the worker
+    /// EOF so it can exit on its own and take its own descendants with it;
+    /// anything slower is killed and reaped under a deadline.
+    async fn shutdown_worker(&mut self) -> Result<()> {
+        drop(self.stdin.take());
+        let stopped = match tokio::time::timeout(WORKER_EXIT_GRACE, self.child.wait()).await {
+            Ok(status) => status.map(|_| ()).map_err(anyhow::Error::from),
+            Err(_) => kill_worker(&mut self.child).await.map(|_| ()),
+        };
+        self.finish_stderr_capture().await;
+        stopped
     }
 
     async fn failure_detail(&mut self, action: &str) -> String {
@@ -268,8 +283,32 @@ impl KernelClient {
 
     async fn finish_stderr_capture(&mut self) {
         if let Some(task) = self.stderr_task.take() {
-            let _ = task.await;
+            drain_stderr(task).await;
         }
+    }
+}
+
+/// Kill the direct child and reap it under a deadline. This cannot reach
+/// grandchildren: on Windows `Rscript.exe` is a wrapper that re-launches
+/// `bin\x64\Rscript.exe` through `cmd.exe`, and only the wrapper dies here.
+async fn kill_worker(child: &mut Child) -> Result<std::process::ExitStatus> {
+    child.start_kill()?;
+    tokio::time::timeout(WORKER_KILL_WAIT, child.wait())
+        .await
+        .map_err(|_| anyhow!("kernel worker did not exit within {WORKER_KILL_WAIT:?} of kill"))?
+        .map_err(Into::into)
+}
+
+/// Collect whatever stderr the worker already produced, then stop waiting. The
+/// write end of that pipe is inherited by every descendant the worker started,
+/// so EOF can arrive long after the worker itself is gone — or never.
+async fn drain_stderr(task: JoinHandle<()>) {
+    let abort = task.abort_handle();
+    if tokio::time::timeout(WORKER_STDERR_DRAIN, task)
+        .await
+        .is_err()
+    {
+        abort.abort();
     }
 }
 
@@ -608,6 +647,74 @@ mod tests {
         assert!(detail.contains("closed protocol stdout"), "{detail}");
         assert!(detail.contains("native runtime crash"), "{detail}");
         assert!(detail.contains("23"), "{detail}");
+    }
+
+    const READY_FRAME: &str =
+        r#"{"type":"ready","protocol":1,"language":"python","pid":1,"version":"test"}"#;
+
+    /// A worker that completes its handshake and then behaves like `tail`.
+    #[cfg(unix)]
+    fn fake_worker(tail: &str) -> Vec<OsString> {
+        vec![
+            OsString::from("-c"),
+            OsString::from(format!("printf '%s\\n' '{READY_FRAME}'; {tail}")),
+        ]
+    }
+
+    /// Dropping the handle is the only thing that closes the pipe: tokio's
+    /// `ChildStdin::poll_shutdown` returns `Ready(Ok(()))` without touching the
+    /// file descriptor on both Unix and Windows, so a worker waiting on stdin
+    /// used to be killed on every stop instead of exiting on its own.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn closing_stdin_lets_a_worker_exit_before_the_kill_deadline() {
+        let mut client = KernelClient::spawn_command(
+            Path::new("sh"),
+            &fake_worker("cat > /dev/null"),
+            &[],
+            None,
+            "python",
+        )
+        .await
+        .unwrap();
+
+        let started = std::time::Instant::now();
+        client.shutdown().await.unwrap();
+        assert!(
+            started.elapsed() < WORKER_EXIT_GRACE,
+            "worker should exit on stdin EOF rather than wait out the grace period"
+        );
+    }
+
+    /// On Windows `Rscript.exe` is a wrapper that re-launches
+    /// `bin\x64\Rscript.exe` through `cmd.exe`, so killing the direct child
+    /// leaves a grandchild holding the inherited stderr pipe and its EOF never
+    /// arrives (#941). A shell process tree reproduces that shape portably.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn shutdown_is_bounded_when_a_descendant_holds_the_stderr_pipe_open() {
+        let mut client = KernelClient::spawn_command(
+            Path::new("sh"),
+            &fake_worker("sleep 30 & sleep 30"),
+            &[],
+            None,
+            "python",
+        )
+        .await
+        .unwrap();
+
+        let budget = WORKER_EXIT_GRACE + WORKER_KILL_WAIT + WORKER_STDERR_DRAIN;
+        tokio::time::timeout(budget + Duration::from_secs(5), client.shutdown())
+            .await
+            .expect("shutdown must not wait for a surviving descendant")
+            .unwrap();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn stderr_drain_gives_up_on_a_reader_that_never_reaches_eof() {
+        let started = tokio::time::Instant::now();
+        drain_stderr(tokio::spawn(std::future::pending())).await;
+        assert!(started.elapsed() >= WORKER_STDERR_DRAIN);
     }
 
     #[test]

--- a/crates/wisp-runtime/src/manager.rs
+++ b/crates/wisp-runtime/src/manager.rs
@@ -9,12 +9,16 @@ use std::{
     ffi::OsString,
     path::{Path, PathBuf},
     sync::{Arc, Mutex},
-    time::{SystemTime, UNIX_EPOCH},
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 use tokio::sync::{mpsc, oneshot, watch};
 
 pub const LOCAL_CONTEXT_ID: &str = "local";
 pub const MAINLINE_RUNTIME_SCOPE: &str = "mainline";
+/// Total budget for one stop request, however many runtimes it covers. Stopping
+/// runs on agent tool calls, project switches, and app exit, so a worker that
+/// refuses to die must cost a bounded wait rather than the whole turn.
+const STOP_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -312,6 +316,15 @@ impl RuntimeSession {
             }
         }
     }
+
+    /// Wait for `Dead` until `deadline`, then report the last known state. The
+    /// caller keeps going either way: a driver still stuck in worker shutdown
+    /// must not hold up the conversation, the project switch, or app exit.
+    async fn wait_dead_until(&self, deadline: tokio::time::Instant) -> RuntimeInfo {
+        tokio::time::timeout_at(deadline, self.wait_dead())
+            .await
+            .unwrap_or_else(|_| self.info())
+    }
 }
 
 impl RuntimeManager {
@@ -410,55 +423,26 @@ impl RuntimeManager {
         infos
     }
 
+    /// Stop one runtime but keep its dead record, so the next call reports the
+    /// stop instead of silently starting a replacement.
     pub async fn stop(&self, key: &RuntimeKey) -> Option<RuntimeInfo> {
-        let session = self.registry().sessions.get(key).cloned()?;
-        session.request_stop();
-        Some(session.wait_dead().await)
+        let session = { self.registry().sessions.get(key).cloned()? };
+        self.stop_sessions(&[(key.clone(), session)]).await.pop()
     }
 
     pub async fn restart(&self, key: RuntimeKey, cwd: PathBuf) -> Result<RuntimeInfo> {
         let current = { self.registry().sessions.get(&key).cloned() };
         if let Some(session) = current {
-            session.request_stop();
-            session.wait_dead().await;
-            let mut registry = self.registry();
-            if registry
-                .sessions
-                .get(&key)
-                .is_some_and(|current| Arc::ptr_eq(current, &session))
-            {
-                registry.sessions.remove(&key);
-            }
+            let sessions = [(key.clone(), session)];
+            self.stop_sessions(&sessions).await;
+            self.forget_sessions(&sessions);
         }
         self.start(key, cwd).await
     }
 
     pub async fn stop_project(&self, project_id: &str) {
-        let sessions = {
-            let registry = self.registry();
-            registry
-                .sessions
-                .iter()
-                .filter(|(key, _)| key.project_id == project_id)
-                .map(|(key, session)| (key.clone(), session.clone()))
-                .collect::<Vec<_>>()
-        };
-        for (_, session) in &sessions {
-            session.request_stop();
-        }
-        for (_, session) in &sessions {
-            session.wait_dead().await;
-        }
-        let mut registry = self.registry();
-        for (key, session) in sessions {
-            if registry
-                .sessions
-                .get(&key)
-                .is_some_and(|current| Arc::ptr_eq(current, &session))
-            {
-                registry.sessions.remove(&key);
-            }
-        }
+        self.stop_and_forget(|key| key.project_id == project_id)
+            .await;
     }
 
     /// Stop every runtime owned by one conversation, e.g. when the session is
@@ -468,75 +452,61 @@ impl RuntimeManager {
         if session_id.is_empty() {
             return;
         }
-        let sessions = {
-            let registry = self.registry();
-            registry
-                .sessions
-                .iter()
-                .filter(|(key, _)| key.project_id == project_id && key.session_id == session_id)
-                .map(|(key, session)| (key.clone(), session.clone()))
-                .collect::<Vec<_>>()
-        };
-        for (_, session) in &sessions {
-            session.request_stop();
-        }
-        for (_, session) in &sessions {
-            session.wait_dead().await;
-        }
-        let mut registry = self.registry();
-        for (key, session) in sessions {
-            if registry
-                .sessions
-                .get(&key)
-                .is_some_and(|current| Arc::ptr_eq(current, &session))
-            {
-                registry.sessions.remove(&key);
-            }
-        }
+        self.stop_and_forget(|key| key.project_id == project_id && key.session_id == session_id)
+            .await;
     }
 
     pub async fn stop_scope(&self, project_id: &str, scope_key: &str) {
+        self.stop_and_forget(|key| key.project_id == project_id && key.scope_key == scope_key)
+            .await;
+    }
+
+    pub async fn shutdown_all(&self) {
+        self.stop_and_forget(|_| true).await;
+    }
+
+    async fn stop_and_forget(&self, matches: impl Fn(&RuntimeKey) -> bool) {
         let sessions = {
-            let registry = self.registry();
-            registry
+            self.registry()
                 .sessions
                 .iter()
-                .filter(|(key, _)| key.project_id == project_id && key.scope_key == scope_key)
+                .filter(|(key, _)| matches(key))
                 .map(|(key, session)| (key.clone(), session.clone()))
                 .collect::<Vec<_>>()
         };
-        for (_, session) in &sessions {
+        self.stop_sessions(&sessions).await;
+        self.forget_sessions(&sessions);
+    }
+
+    /// Ask every session to stop and wait out one shared budget. Returning on
+    /// the deadline is what keeps a worker that refuses to exit from blocking
+    /// the agent turn, the project switch, or app exit.
+    async fn stop_sessions(
+        &self,
+        sessions: &[(RuntimeKey, Arc<RuntimeSession>)],
+    ) -> Vec<RuntimeInfo> {
+        for (_, session) in sessions {
             session.request_stop();
         }
-        for (_, session) in &sessions {
-            session.wait_dead().await;
+        let deadline = tokio::time::Instant::now() + STOP_TIMEOUT;
+        let mut stopped = Vec::with_capacity(sessions.len());
+        for (_, session) in sessions {
+            stopped.push(session.wait_dead_until(deadline).await);
         }
+        stopped
+    }
+
+    fn forget_sessions(&self, sessions: &[(RuntimeKey, Arc<RuntimeSession>)]) {
         let mut registry = self.registry();
         for (key, session) in sessions {
             if registry
                 .sessions
-                .get(&key)
-                .is_some_and(|current| Arc::ptr_eq(current, &session))
+                .get(key)
+                .is_some_and(|current| Arc::ptr_eq(current, session))
             {
-                registry.sessions.remove(&key);
+                registry.sessions.remove(key);
             }
         }
-    }
-
-    pub async fn shutdown_all(&self) {
-        let sessions = self
-            .registry()
-            .sessions
-            .values()
-            .cloned()
-            .collect::<Vec<_>>();
-        for session in &sessions {
-            session.request_stop();
-        }
-        for session in sessions {
-            session.wait_dead().await;
-        }
-        self.registry().sessions.clear();
     }
 
     fn session(&self, key: RuntimeKey, cwd: PathBuf) -> Result<Arc<RuntimeSession>> {
@@ -886,6 +856,7 @@ mod tests {
         active: Arc<AtomicUsize>,
         max_active: Arc<AtomicUsize>,
         exited: Arc<AtomicBool>,
+        stuck_shutdown: Arc<AtomicBool>,
         launch_cwds: Arc<Mutex<Vec<PathBuf>>>,
         launch_delay: Duration,
     }
@@ -903,6 +874,7 @@ mod tests {
                     active: self.active.clone(),
                     max_active: self.max_active.clone(),
                     exited: self.exited.clone(),
+                    stuck_shutdown: self.stuck_shutdown.clone(),
                 }),
                 RuntimeMetadata {
                     interpreter: Some("fake-python".into()),
@@ -919,6 +891,7 @@ mod tests {
         active: Arc<AtomicUsize>,
         max_active: Arc<AtomicUsize>,
         exited: Arc<AtomicBool>,
+        stuck_shutdown: Arc<AtomicBool>,
     }
 
     struct ActiveCall(Arc<AtomicUsize>);
@@ -984,6 +957,11 @@ mod tests {
         }
 
         async fn shutdown(&mut self) -> Result<()> {
+            if self.stuck_shutdown.load(Ordering::SeqCst) {
+                // A worker whose descendants keep the inherited stderr pipe
+                // open never reports that it finished shutting down (#941).
+                std::future::pending::<()>().await;
+            }
             self.shutdowns.fetch_add(1, Ordering::SeqCst);
             Ok(())
         }
@@ -1268,6 +1246,66 @@ mod tests {
         assert_eq!(finished(get).await.unwrap().stdout, "0");
         assert_eq!(launcher.launches.load(Ordering::SeqCst), 2);
         manager.shutdown_all().await;
+    }
+
+    /// Stopping runs inside agent tool calls, project switches, and app exit,
+    /// so it must complete on a budget even when the worker never does (#941).
+    #[tokio::test(start_paused = true)]
+    async fn stopping_a_stuck_worker_gives_up_on_the_budget() {
+        let launcher = FakeLauncher::default();
+        let manager = manager(&launcher);
+        let key = RuntimeKey::local_python("project-a");
+        let cwd = PathBuf::from("project-a");
+        manager.start(key.clone(), cwd.clone()).await.unwrap();
+        launcher.stuck_shutdown.store(true, Ordering::SeqCst);
+
+        let started = tokio::time::Instant::now();
+        let stopped = manager.stop(&key).await.unwrap();
+        assert!(started.elapsed() >= STOP_TIMEOUT);
+        assert_eq!(stopped.status, RuntimeStatus::Stopping);
+        assert_eq!(launcher.shutdowns.load(Ordering::SeqCst), 0);
+
+        // An explicit stop keeps its record, so the next call reports the stop
+        // instead of quietly starting a second interpreter.
+        assert!(manager.execute(&key, &cwd, "get").await.is_err());
+        assert_eq!(launcher.launches.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn restarting_past_a_stuck_worker_still_yields_a_fresh_runtime() {
+        let launcher = FakeLauncher::default();
+        let manager = manager(&launcher);
+        let key = RuntimeKey::local_python("project-a");
+        let cwd = PathBuf::from("project-a");
+        let first = manager.start(key.clone(), cwd.clone()).await.unwrap();
+        launcher.stuck_shutdown.store(true, Ordering::SeqCst);
+
+        let restarted = manager.restart(key.clone(), cwd.clone()).await.unwrap();
+        assert_eq!(restarted.generation, first.generation + 1);
+        assert_eq!(restarted.status, RuntimeStatus::Ready);
+        assert_eq!(manager.list().len(), 1);
+        assert_eq!(launcher.launches.load(Ordering::SeqCst), 2);
+    }
+
+    /// One stuck worker per project must not add up: app exit spends a single
+    /// budget for every runtime it stops.
+    #[tokio::test(start_paused = true)]
+    async fn app_exit_shares_one_budget_across_stuck_runtimes() {
+        let launcher = FakeLauncher::default();
+        let manager = manager(&launcher);
+        for project in ["project-a", "project-b", "project-c"] {
+            manager
+                .start(RuntimeKey::local_python(project), PathBuf::from(project))
+                .await
+                .unwrap();
+        }
+        launcher.stuck_shutdown.store(true, Ordering::SeqCst);
+
+        let started = tokio::time::Instant::now();
+        manager.shutdown_all().await;
+        assert!(started.elapsed() >= STOP_TIMEOUT);
+        assert!(started.elapsed() < STOP_TIMEOUT * 2);
+        assert!(manager.list().is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes the hang half of #941. Second and third PRs (Windows process-tree kill / direct `x64\Rscript.exe` spawn, and conda/pixi prefix PATH injection) follow separately.

## User-facing problem

On Windows, `set_runtime_interpreter` for R could hang a conversation for hours — the reporter measured tool cards at **74m 25s** and **347m 38s** — while leaving orphaned `kernel_worker.R` process trees behind. R itself started fine in ~180 ms; the hang was entirely in stopping the *old* kernel.

Three defects compounded:

1. **`stdin.shutdown()` never closes the pipe.** tokio's `ChildStdin::poll_shutdown` returns `Ready(Ok(()))` without touching the file descriptor on [Unix](https://github.com/tokio-rs/tokio/blob/tokio-1.52.3/tokio/src/process/unix/mod.rs#L314) and on [Windows](https://github.com/tokio-rs/tokio/blob/tokio-1.52.3/tokio/src/io/blocking.rs#L178). The worker therefore never saw stdin EOF, `kernel_worker.R`'s `readLines` loop never broke, and every stop fell through to the kill path after burning the full grace period. (`Child::wait()` does drop `self.stdin`, but spawn already took it out of the `Child`.)
2. **Awaiting the stderr-capture task is unbounded.** It reads until EOF, and the write end of that pipe is inherited by every descendant. On Windows `Rscript.exe` is a wrapper that re-launches `bin\x64\Rscript.exe` through `cmd.exe`, so `child.kill()` killed only the shim and the surviving grandchild held stderr open — the `await` never returned. This also explains why the reported durations were long but finite: the tool card completed at the moment the reporter killed the orphans by hand.
3. **`RuntimeManager::wait_dead()` had no deadline**, so a driver stuck in worker shutdown blocked whatever called it: the agent turn, `restart_runtime`/`stop_runtime`, project switches, session deletion, exploration promotion, and `block_on(shutdown_all())` at app exit (the app could not quit).

Not Windows-only: any REPL cell that leaves a background child process (`subprocess.Popen`, `system()`, a spawned server) inherits stderr and reproduces the same hang on macOS and Linux.

## Changes

`crates/wisp-runtime/src/kernel.rs`

- `KernelClient.stdin` is now `Option<ChildStdin>`; `shutdown_worker` drops the handle so the worker actually gets EOF and can exit on its own, taking its own descendants with it. Request writes go through one `send()` helper.
- New `kill_worker()` uses `start_kill()` + a deadline on `wait()` instead of `Child::kill().await`, which awaits `wait()` unbounded.
- New `drain_stderr()` bounds the stderr tail collection and aborts a reader that never reaches EOF. Used by both `shutdown_worker` and the handshake-failure path in `spawn_command`, which had the same unbounded `await`.
- Three named budgets: `WORKER_EXIT_GRACE` 2s, `WORKER_KILL_WAIT` 2s, `WORKER_STDERR_DRAIN` 500ms. Worst case ~4.5s instead of unbounded. (The old grace was 750ms, raised because it is now a path that actually succeeds and must cover three process exits on the Windows chain.)

`crates/wisp-runtime/src/manager.rs`

- `RuntimeSession::wait_dead_until(deadline)` reports the last known state when the driver overruns.
- `STOP_TIMEOUT` of 10s is one budget per stop *request*, not per runtime, so N stuck workers cannot multiply the wait at app exit.
- `stop`, `restart`, `stop_project`, `stop_session`, `stop_scope`, and `shutdown_all` had five copies of the same request-stop / wait / deregister loop and all needed the deadline; they now share `stop_sessions` + `forget_sessions`. Existing semantics are preserved deliberately: `stop` keeps its dead record so the next call reports the stop rather than silently starting a replacement, while the others deregister.

## Tests

`crates/wisp-runtime/src/kernel.rs`

- `closing_stdin_lets_a_worker_exit_before_the_kill_deadline` — a worker blocked on stdin must exit on EOF rather than be killed. Verified to **hang past 60s** against the old `stdin.shutdown()` code.
- `shutdown_is_bounded_when_a_descendant_holds_the_stderr_pipe_open` — a shell process tree stands in for `Rscript.exe -> cmd.exe -> x64\Rscript.exe`. Verified to **fail** against the old unbounded drain.
- `stderr_drain_gives_up_on_a_reader_that_never_reaches_eof` — platform-independent, paused clock. Verified to **hang** against `task.await`.

The two process-tree tests are `#[cfg(unix)]`: the mechanism is platform-independent (tokio's no-op shutdown and pipe-handle inheritance apply to both), and a `cmd.exe`/`start /B` equivalent could not be validated from this environment, so a flaky Windows-only test seemed worse than none. macOS is covered.

`crates/wisp-runtime/src/manager.rs` — a `FakeKernel` whose `shutdown()` never completes drives three tests on a paused clock: `stopping_a_stuck_worker_gives_up_on_the_budget`, `restarting_past_a_stuck_worker_still_yields_a_fresh_runtime`, and `app_exit_shares_one_budget_across_stuck_runtimes`.

`crates/wisp-runtime/Cargo.toml` gains a dev-dependency on tokio's `test-util` for the paused clock, matching `wisp-core`.

## Manual smoke steps (Windows, needs a host I do not have)

1. Open a project, run something with the `r` tool so the local R REPL is live.
2. Call `set_runtime_interpreter` with `context_id=local`, `language=r`, and a different `Rscript.exe`. It should return within seconds.
3. Check Task Manager: no leftover `kernel_worker.R` tree from the previous kernel.
4. Quit the app with a live R REPL and confirm `wisp-tauri.exe` exits.

## Known limitations / follow-ups

- **Orphan escape is not fixed here.** When the wrapper chain outlives its kill, this PR stops waiting on it — it does not reach the grandchild. `bin\x64\Rscript.exe` can still survive a stop, only now without blocking anything. The next PR attaches the worker to a Windows Job Object (reusing `ProcessTree` from `crates/wisp-mcp/src/process_tree.rs`) and spawns `bin\x64\Rscript.exe` directly to avoid the shim entirely.
- Pointing R at a pixi/conda `Rscript.exe` still fails with `0xC0000135`, because local R gets an empty extra env and nothing derives the prefix's `Library\bin`. Third PR.
- `set_runtime_interpreter` still gates its tool result on the restart. Now bounded to seconds, but reporting "config saved" separately from "REPL restarted" (or restarting lazily on the next call) is the better shape.
- `r/kernel_worker.R`'s `execute_cell` still has no per-cell timeout or interrupt.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-19712d53-24cc-4955-a303-4358bd6033ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-19712d53-24cc-4955-a303-4358bd6033ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

