### PR TITLE
fix(runtime): give a conda/pixi interpreter its prefix on the worker PATH (#941)

### DIFF
--- a/crates/wisp-runtime/src/env.rs
+++ b/crates/wisp-runtime/src/env.rs
@@ -1,6 +1,7 @@
 //! uv-managed Python environment provisioning.
 
 use anyhow::{anyhow, Result};
+use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -168,6 +169,84 @@ fn windows_direct_rscript(configured: &str, exists: impl Fn(&Path) -> bool) -> O
         .into_iter()
         .map(|arch| format!("{directory}{arch}{separator}{name}"))
         .find(|candidate| exists(Path::new(candidate)))
+}
+
+/// Environment a child needs to run an interpreter that lives inside a
+/// conda-style prefix (conda, mamba, or pixi), or empty when it does not.
+///
+/// Only the child's `PATH` is set; the host environment is never modified. On
+/// Windows an interpreter's shared libraries live in the prefix rather than
+/// beside the executable, so without this a conda-forge `Rscript.exe` exits
+/// immediately with `STATUS_DLL_NOT_FOUND` (`0xC0000135`), or picks up a
+/// mismatched DLL from an unrelated `PATH` entry and faults (#941).
+pub fn conda_prefix_envs(interpreter: &Path) -> Vec<(String, String)> {
+    let Some(prefix) = conda_prefix(interpreter) else {
+        return Vec::new();
+    };
+    let entries = prefix_path_entries(&prefix, cfg!(target_os = "windows"));
+    let path = prepend_path(&entries, std::env::var_os("PATH").as_deref());
+    vec![("PATH".into(), path.to_string_lossy().into_owned())]
+}
+
+/// Nearest ancestor of `interpreter` that is a conda-style environment prefix.
+/// `conda-meta` is written by conda, mamba, and pixi alike, so it identifies a
+/// prefix exactly instead of guessing from directory names.
+fn conda_prefix(interpreter: &Path) -> Option<PathBuf> {
+    interpreter
+        .ancestors()
+        .skip(1)
+        .find(|directory| directory.join("conda-meta").is_dir())
+        .map(Path::to_path_buf)
+}
+
+/// Directories a conda-style prefix contributes to `PATH`, in the order conda's
+/// own activation uses them. The Windows entries are spelled out rather than
+/// joined through `Path`, so the layout stays unit-testable on any host.
+fn prefix_path_entries(prefix: &Path, windows: bool) -> Vec<PathBuf> {
+    if !windows {
+        return vec![prefix.join("bin")];
+    }
+    let prefix = prefix.to_string_lossy();
+    std::iter::once(prefix.to_string())
+        .chain(
+            [
+                r"Library\mingw-w64\bin",
+                r"Library\usr\bin",
+                r"Library\bin",
+                "Scripts",
+                "bin",
+            ]
+            .into_iter()
+            .map(|entry| format!(r"{prefix}\{entry}")),
+        )
+        .map(PathBuf::from)
+        .collect()
+}
+
+fn prepend_path(entries: &[PathBuf], current: Option<&OsStr>) -> OsString {
+    let inherited = current.filter(|value| !value.is_empty());
+    let mut path = OsString::new();
+    for entry in entries {
+        if !path.is_empty() {
+            path.push(path_separator());
+        }
+        path.push(entry);
+    }
+    if let Some(inherited) = inherited {
+        if !path.is_empty() {
+            path.push(path_separator());
+        }
+        path.push(inherited);
+    }
+    path
+}
+
+fn path_separator() -> &'static str {
+    if cfg!(target_os = "windows") {
+        ";"
+    } else {
+        ":"
+    }
 }
 
 /// Candidate `Rscript` paths in well-known install locations, most preferred
@@ -346,6 +425,88 @@ mod tests {
 
         // A bare command has no directory to rewrite.
         assert_eq!(windows_direct_rscript("Rscript", |_| true), None);
+    }
+
+    /// A pixi env is a conda prefix, and `conda-meta` is what says so. Walking
+    /// up from the interpreter is what lets a saved
+    /// `.pixi/envs/default/lib/R/bin/x64/Rscript.exe` find its own DLLs.
+    #[test]
+    fn conda_prefix_is_found_from_a_nested_interpreter_path() {
+        let root = std::env::temp_dir().join(format!("wisp-conda-{}", uuid::Uuid::new_v4()));
+        let prefix = root.join(".pixi").join("envs").join("default");
+        let bin = prefix.join("lib").join("R").join("bin").join("x64");
+        std::fs::create_dir_all(&bin).unwrap();
+        std::fs::create_dir_all(prefix.join("conda-meta")).unwrap();
+        let interpreter = bin.join("Rscript.exe");
+
+        assert_eq!(conda_prefix(&interpreter), Some(prefix.clone()));
+        // The prefix directory itself is never its own parent match.
+        assert_eq!(conda_prefix(&prefix), None);
+
+        // A plain system install is not a prefix and must be left alone.
+        let system = root.join("R-4.5.3").join("bin").join("x64");
+        std::fs::create_dir_all(&system).unwrap();
+        assert_eq!(conda_prefix(&system.join("Rscript.exe")), None);
+        assert!(conda_prefix_envs(&system.join("Rscript.exe")).is_empty());
+
+        let envs = conda_prefix_envs(&interpreter);
+        assert_eq!(envs.len(), 1);
+        assert_eq!(envs[0].0, "PATH");
+        let expected = prefix_path_entries(&prefix, cfg!(target_os = "windows"))[0]
+            .to_string_lossy()
+            .into_owned();
+        assert!(envs[0].1.starts_with(&expected), "{}", envs[0].1);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// Windows resolves an executable's shared libraries through PATH, and a
+    /// conda-forge prefix keeps them under `Library`. Missing these is what
+    /// makes a pixi `Rscript.exe` exit with 0xC0000135.
+    #[test]
+    fn windows_prefix_contributes_the_library_directories_conda_activates() {
+        let prefix = Path::new(r"E:\plot\.pixi\envs\default");
+        let entries = prefix_path_entries(prefix, true)
+            .iter()
+            .map(|entry| entry.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            entries,
+            [
+                r"E:\plot\.pixi\envs\default",
+                r"E:\plot\.pixi\envs\default\Library\mingw-w64\bin",
+                r"E:\plot\.pixi\envs\default\Library\usr\bin",
+                r"E:\plot\.pixi\envs\default\Library\bin",
+                r"E:\plot\.pixi\envs\default\Scripts",
+                r"E:\plot\.pixi\envs\default\bin",
+            ]
+        );
+        assert_eq!(
+            prefix_path_entries(Path::new("/opt/conda/envs/research"), false),
+            [PathBuf::from("/opt/conda/envs/research/bin")]
+        );
+    }
+
+    /// The prefix must win over whatever the host happens to have on PATH: a
+    /// mismatched DLL found first is the 0xC0000005 variant of the same bug.
+    #[test]
+    fn prefix_entries_are_prepended_and_never_drop_the_inherited_path() {
+        let entries = [PathBuf::from("/opt/conda/bin"), PathBuf::from("/opt/extra")];
+        let separator = path_separator();
+        assert_eq!(
+            prepend_path(&entries, Some(OsStr::new("/usr/bin"))),
+            OsString::from(format!(
+                "/opt/conda/bin{separator}/opt/extra{separator}/usr/bin"
+            ))
+        );
+        assert_eq!(
+            prepend_path(&entries, None),
+            OsString::from(format!("/opt/conda/bin{separator}/opt/extra"))
+        );
+        assert_eq!(
+            prepend_path(&entries, Some(OsStr::new(""))),
+            OsString::from(format!("/opt/conda/bin{separator}/opt/extra"))
+        );
+        assert_eq!(prepend_path(&[], Some(OsStr::new("/usr/bin"))), "/usr/bin");
     }
 
     #[test]

--- a/crates/wisp-runtime/src/lib.rs
+++ b/crates/wisp-runtime/src/lib.rs
@@ -6,8 +6,8 @@ pub mod manager;
 pub mod tool;
 
 pub use env::{
-    bundled_mock_mcp_path, bundled_r_worker_path, bundled_worker_path, direct_rscript,
-    find_rscript, resolve_bundled_script, PythonEnv,
+    bundled_mock_mcp_path, bundled_r_worker_path, bundled_worker_path, conda_prefix_envs,
+    direct_rscript, find_rscript, resolve_bundled_script, PythonEnv,
 };
 pub use kernel::{KernelClient, KernelReady, KernelResp, MAX_CODE_BYTES, PROTOCOL_VERSION};
 pub use manager::{

--- a/crates/wisp-runtime/src/manager.rs
+++ b/crates/wisp-runtime/src/manager.rs
@@ -602,7 +602,7 @@ impl RuntimeLauncher for LocalRuntimeLauncher {
                 (
                     python,
                     vec![self.python_worker.as_os_str().to_os_string()],
-                    self.envs.as_slice(),
+                    self.envs.clone(),
                     "python",
                 )
             }
@@ -622,19 +622,20 @@ impl RuntimeLauncher for LocalRuntimeLauncher {
                         worker.display()
                     ));
                 }
+                let envs = crate::conda_prefix_envs(&rscript);
                 (
                     rscript,
                     vec![
                         OsString::from("--vanilla"),
                         worker.as_os_str().to_os_string(),
                     ],
-                    &[][..],
+                    envs,
                     "r",
                 )
             }
         };
         let client =
-            KernelClient::spawn_command(&interpreter, &args, envs, Some(cwd), language).await?;
+            KernelClient::spawn_command(&interpreter, &args, &envs, Some(cwd), language).await?;
         let ready = client.ready().clone();
         Ok(LaunchedRuntime::new(
             Box::new(client),

--- a/docs/superpowers/specs/2026-07-14-wisp-runtime-design.md
+++ b/docs/superpowers/specs/2026-07-14-wisp-runtime-design.md
@@ -401,6 +401,19 @@ Project-specific pixi, conda, virtualenv, or `renv` profiles are future environm
 selection work. A v1 user may explicitly configure the interpreter from such an
 environment.
 
+An explicitly configured interpreter must actually be launchable. When it lives
+inside a conda-style prefix — a directory containing `conda-meta`, which conda,
+mamba, and pixi all write — the worker is launched with that prefix on its own
+`PATH`. On Windows an interpreter's shared libraries live in the prefix rather than
+beside the executable, so without this a conda-forge `Rscript.exe` exits with
+`STATUS_DLL_NOT_FOUND`, or faults on a mismatched library found elsewhere on `PATH`.
+This is the launched child's environment only; the host environment is never
+modified, and remote contexts keep whatever their own shell provides.
+
+On Windows, `<R>\bin\Rscript.exe` is an architecture shim that re-launches
+`<R>\bin\x64\Rscript.exe` through `cmd.exe`. Local launches resolve to the real
+binary so the interpreter is the app's direct child.
+
 ## 11. Worker protocol
 
 Python and R use one versioned, newline-delimited JSON protocol over stdio. Reusing

--- a/src-tauri/src/runtime_config_tool.rs
+++ b/src-tauri/src/runtime_config_tool.rs
@@ -55,7 +55,7 @@ impl Tool for SetRuntimeInterpreterTool {
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(
             "set_runtime_interpreter",
-            "Save the Python or R executable for an existing execution context. This writes Wisp's persisted context settings; it does not set host environment variables or install software. If this project's matching REPL already exists, it is restarted and its in-memory variables are cleared.",
+            "Save the Python or R executable for an existing execution context. This writes Wisp's persisted context settings; it does not set host environment variables or install software. An interpreter inside a conda, mamba, or pixi environment prefix is launched with that prefix on the worker's own PATH, so it can load its own libraries. If this project's matching REPL already exists, it is restarted and its in-memory variables are cleared.",
             serde_json::json!({
                 "type": "object",
                 "properties": {

--- a/src-tauri/src/runtime_launcher.rs
+++ b/src-tauri/src/runtime_launcher.rs
@@ -225,24 +225,13 @@ impl RuntimeLauncher for TauriRuntimeLauncher {
             project_root,
         )
         .map_err(anyhow::Error::msg)?;
-        let mut envs = if context.kind == wisp_store::ExecutionContextKind::Local
-            && key.language == RuntimeLanguage::Python
-        {
-            self.envs.clone()
-        } else {
-            Vec::new()
-        };
-        if context.kind == wisp_store::ExecutionContextKind::Local
-            && key.language == RuntimeLanguage::Python
-        {
-            for (name, value) in crate::models::service_env() {
-                if let Some((_, current)) = envs.iter_mut().find(|(current, _)| current == &name) {
-                    *current = value;
-                } else {
-                    envs.push((name, value));
-                }
-            }
-        }
+        let mut envs = launch_envs(
+            &context,
+            key.language,
+            &interpreter,
+            &self.envs,
+            crate::models::service_env(),
+        );
         let ssh_auth_envs = if context.kind == wisp_store::ExecutionContextKind::Ssh {
             let connection =
                 SshConnection::from_execution_context(&context).map_err(anyhow::Error::msg)?;
@@ -346,6 +335,38 @@ fn resolve_r_interpreter(context: &wisp_store::ExecutionContext) -> Result<Strin
         "Rscript interpreter is unknown for {}; probe the context or configure rscript_executable",
         context.id
     ))
+}
+
+/// Environment for one launched worker, over and above what the child inherits.
+///
+/// A local interpreter that lives inside a conda/pixi prefix needs that prefix
+/// on the child's `PATH` to load its own shared libraries; the host environment
+/// is never touched. API credentials stay limited to local Python, and remote
+/// contexts get neither: their environment is the remote shell's business.
+fn launch_envs(
+    context: &wisp_store::ExecutionContext,
+    language: RuntimeLanguage,
+    interpreter: &str,
+    base: &[(String, String)],
+    service: Vec<(String, String)>,
+) -> Vec<(String, String)> {
+    if context.kind != wisp_store::ExecutionContextKind::Local {
+        return Vec::new();
+    }
+    let mut envs = wisp_runtime::conda_prefix_envs(Path::new(interpreter));
+    if language == RuntimeLanguage::Python {
+        for (name, value) in base.iter().cloned().chain(service) {
+            upsert_env(&mut envs, name, value);
+        }
+    }
+    envs
+}
+
+fn upsert_env(envs: &mut Vec<(String, String)>, name: String, value: String) {
+    match envs.iter_mut().find(|(current, _)| current == &name) {
+        Some((_, current)) => *current = value,
+        None => envs.push((name, value)),
+    }
 }
 
 /// Resolve the configured `Rscript`, then on a local Windows context launch the
@@ -821,6 +842,69 @@ mod tests {
             .unwrap()
             .to_string_lossy()
             .contains("--vanilla"));
+    }
+
+    /// A pixi/conda interpreter cannot find its own shared libraries without
+    /// its prefix on PATH; on Windows that is the difference between a working
+    /// R kernel and an immediate 0xC0000135 exit (#941).
+    #[test]
+    fn local_launches_add_the_interpreter_prefix_to_the_child_path() {
+        let prefix = std::env::temp_dir().join(format!("wisp-launch-env-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(prefix.join("conda-meta")).unwrap();
+        let rscript = prefix
+            .join("lib")
+            .join("R")
+            .join("bin")
+            .join("Rscript")
+            .to_string_lossy()
+            .into_owned();
+        let local = wisp_store::ExecutionContext::new("local", "Local").unwrap();
+        let credentials = vec![("OPENAI_API_KEY".to_string(), "secret".to_string())];
+
+        let r_envs = launch_envs(
+            &local,
+            RuntimeLanguage::R,
+            &rscript,
+            &[],
+            credentials.clone(),
+        );
+        assert_eq!(r_envs.len(), 1, "{r_envs:?}");
+        assert_eq!(r_envs[0].0, "PATH");
+        assert!(r_envs[0].1.contains(&prefix.to_string_lossy().into_owned()));
+
+        // Python keeps its credentials and gains the same prefix PATH.
+        let python_envs = launch_envs(
+            &local,
+            RuntimeLanguage::Python,
+            &prefix.join("python").to_string_lossy(),
+            &[],
+            credentials.clone(),
+        );
+        assert!(python_envs.iter().any(|(name, _)| name == "PATH"));
+        assert!(python_envs.contains(&credentials[0]));
+
+        // A remote context's environment belongs to the remote shell.
+        let mut ssh = wisp_store::ExecutionContext::new("ssh:cpu2", "CPU2").unwrap();
+        ssh.kind = wisp_store::ExecutionContextKind::Ssh;
+        assert!(launch_envs(
+            &ssh,
+            RuntimeLanguage::Python,
+            &rscript,
+            &[],
+            credentials.clone()
+        )
+        .is_empty());
+
+        // An interpreter outside any prefix must not gain a PATH override.
+        let system = launch_envs(
+            &local,
+            RuntimeLanguage::Python,
+            "/usr/bin/python3",
+            &[],
+            credentials.clone(),
+        );
+        assert_eq!(system, credentials);
+        let _ = std::fs::remove_dir_all(&prefix);
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Last of three PRs for #941. Stacked on [#956](https://github.com/xuzhougeng/wisp-science/pull/956), which is stacked on [#955](https://github.com/xuzhougeng/wisp-science/pull/955); this PR's diff is its single extra commit.

## User-facing problem

Saving a pixi R interpreter left the runtime unusable. The reporter's `Rscript.exe` exited immediately with `0xC0000135` (`STATUS_DLL_NOT_FOUND`), and sometimes `0xC0000005` (access violation) instead, with these unresolved dependencies:

```
libgcc_s_seh-1.dll, icuin78.dll, icuuc78.dll, deflate.dll, libbz2.dll,
liblzma.dll, pcre2-8.dll, zlib.dll, zstd.dll, and several api-ms-win-crt-*.dll
```

A conda-forge interpreter loads its shared libraries from its environment prefix, not from beside the executable, and local R was launched with no extra environment at all — `runtime_launcher.rs` passed `self.envs` for local Python and an empty `Vec` for everything else. Nothing in the codebase derived a prefix from an interpreter path.

The two failure codes are the same bug: `0xC0000135` when the library is nowhere on `PATH`, `0xC0000005` when a *different* build of it is found first somewhere else.

## Changes

`crates/wisp-runtime/src/env.rs` gains `conda_prefix_envs(interpreter)`. It walks up from the interpreter for the nearest ancestor containing `conda-meta`, then prepends the directories conda's own activation uses:

| Host | Entries prepended |
| --- | --- |
| Windows | `<prefix>`, `<prefix>\Library\mingw-w64\bin`, `<prefix>\Library\usr\bin`, `<prefix>\Library\bin`, `<prefix>\Scripts`, `<prefix>\bin` |
| Unix | `<prefix>/bin` |

`conda-meta` is the marker because conda, mamba, and pixi all write it into an environment prefix, so the prefix is identified rather than guessed from directory names — `.pixi/envs/default` and `/opt/conda/envs/research` are both recognised, while `C:\Program Files\R\R-4.5.3` correctly is not and gets no `PATH` override.

Only the launched child's `PATH` is set, and the inherited value is always appended rather than replaced. The `set_runtime_interpreter` promise not to set host environment variables still holds; its schema description now says so explicitly and mentions that a prefixed interpreter is launched with its own prefix on `PATH`, so the model can stop treating this as unsupported. Nothing else is injected: `R_HOME` and `CONDA_PREFIX` are deliberately left alone, since `bin\x64\Rscript.exe` derives `R_HOME` from its own location and setting it wrongly would break more than it fixes.

Both launchers use it — `TauriRuntimeLauncher` for local contexts of either language, and `LocalRuntimeLauncher`'s R branch. Remote contexts get nothing: their environment is the remote shell's business.

`src-tauri/src/runtime_launcher.rs` moves the environment assembly out of `launch()` into `launch_envs()`, which is what makes the wiring testable at all — `launch()` itself needs a real spawn. It also puts the "credentials are local-Python-only" rule in one place instead of two consecutive identical `if` conditions, and merges through `upsert_env` so a caller-supplied `PATH` could never end up duplicated.

## Tests

`crates/wisp-runtime/src/env.rs`:

- `conda_prefix_is_found_from_a_nested_interpreter_path` builds a real `.pixi/envs/default` layout with `conda-meta` in a temp dir and asserts the prefix is found from five levels down at `lib/R/bin/x64/Rscript.exe`, that a prefix is not its own parent match, and that a plain `R-4.5.3/bin/x64` install yields no environment at all.
- `windows_prefix_contributes_the_library_directories_conda_activates` pins the exact Windows entry list and order. The entries are built as strings rather than through `Path::join`, so real `E:\...` layouts stay assertable on a Linux host.
- `prefix_entries_are_prepended_and_never_drop_the_inherited_path` covers prepend order, an absent `PATH`, an empty `PATH`, and no entries.

`src-tauri/src/runtime_launcher.rs`:

- `local_launches_add_the_interpreter_prefix_to_the_child_path` covers local R (prefix `PATH`, no credentials), local Python (both), an SSH context (nothing), and a local interpreter outside any prefix (credentials only, no `PATH`).

No test needs conda, pixi, R, or network access — the prefix marker is just a directory.

Full `cargo test --workspace` is green (1398 tests), `cargo fmt --all --check` clean, `cd ui && cargo check --target wasm32-unknown-unknown` clean.

## Docs

`docs/superpowers/specs/2026-07-14-wisp-runtime-design.md` §10 said only that configuring an interpreter from a pixi/conda environment was something "a v1 user may" do. Added what it takes for that to actually work: the prefix `PATH` rule with the Windows rationale, the child-only scope, and the `bin\Rscript.exe` shim resolution from [#956](https://github.com/xuzhougeng/wisp-science/pull/956).

## Manual smoke steps (Windows, needs a host I do not have)

1. `pixi init` a project, `pixi add r-base`, then `set_runtime_interpreter` with `context_id=local`, `language=r`, `executable=<project>\.pixi\envs\default\lib\R\bin\x64\Rscript.exe`.
2. Run an `r` cell. It should reach `ready` instead of exiting with `0xC0000135`.
3. Confirm the app's own `PATH` is unchanged (`$env:PATH` in a new terminal, and the Wisp shell tool).
4. A system `C:\Program Files\R\...` interpreter must keep working unchanged.
5. A conda Python (`<prefix>\python.exe`) should also start, with API credentials still present in the REPL.

## Known limitations / follow-ups

- `jsonlite` still has to be installed in the target R environment; that failure is already reported clearly by `ensure_jsonlite_available`.
- Only `PATH` is injected. An environment that needs `R_LIBS_USER`, `GDAL_DATA`, `PROJ_LIB`, or another conda activation variable will still fall short. Full activation-script support belongs with the "explicit pixi/conda/venv/renv identities" work the spec defers.
- A prefix without `conda-meta` (a hand-copied environment) is not detected, by design.
- With all three PRs in, the remaining #941 item is presentational: `set_runtime_interpreter` still gates its tool result on the restart instead of reporting "config saved" and "REPL restarted" separately, and `r/kernel_worker.R` still has no per-cell timeout or interrupt.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-19712d53-24cc-4955-a303-4358bd6033ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-19712d53-24cc-4955-a303-4358bd6033ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

