### PR TITLE
fix(skills): improve multilingual search recall

### DIFF
--- a/crates/wisp-core/src/system_prompt.rs
+++ b/crates/wisp-core/src/system_prompt.rs
@@ -127,6 +127,7 @@ If a named workflow is disabled or unavailable, follow the same principles direc
             "## Skills Selection Guidelines\n\n\
 {count} {availability} currently configured, enabled, and searchable for this project/session. Their catalog and bodies are not preloaded.\n\n\
 - When a task may match an installed workflow, call `search_skills` with concise task or domain keywords.\n\
+- Preserve important terms from the user's original language. If the first search has no confident match, retry once with common English domain synonyms, or with the user's language when the first query was English.\n\
 - When a task needs a specific model ability (e.g. image understanding), call `search_models` with a capability keyword like `vision` to find a suitable model, then pass its id to `create_workflow` via `params.model_id`.\n\
 - When the user asks how many Skills are configured, enabled, effective, shadowed, or broken, use `list_skill_catalog` and read its explicitly named count fields.\n\
 - Treat `current_configured_enabled_count` as authoritative for this Agent snapshot. If the user cites a different UI or remembered count, report the discrepancy; do not accept, relabel, or explain the user's number without supporting inventory data.\n\
@@ -567,6 +568,10 @@ mod tests {
             "{out}"
         );
         assert!(out.contains("`search_skills`"), "{out}");
+        assert!(
+            out.contains("retry once with common English domain synonyms"),
+            "{out}"
+        );
         assert!(out.contains("do not accept, relabel, or explain"), "{out}");
         assert!(!out.contains("secret-skill"), "{out}");
         assert!(!out.contains("SHOULD_NOT_BE_IN_SYSTEM_PROMPT"), "{out}");

--- a/crates/wisp-skills/src/tool.rs
+++ b/crates/wisp-skills/src/tool.rs
@@ -11,6 +11,51 @@ const DEFAULT_SEARCH_LIMIT: usize = 5;
 const MAX_SEARCH_LIMIT: usize = 10;
 const MAX_DESCRIPTION_CHARS: usize = 512;
 
+fn is_cjk(ch: char) -> bool {
+    matches!(
+        ch as u32,
+        0x3400..=0x4DBF | 0x4E00..=0x9FFF | 0xF900..=0xFAFF
+    )
+}
+
+fn normalize_search_text(value: &str) -> String {
+    value
+        .chars()
+        .flat_map(char::to_lowercase)
+        .map(|ch| {
+            if ch.is_alphanumeric() || is_cjk(ch) {
+                ch
+            } else {
+                ' '
+            }
+        })
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn search_terms(value: &str) -> Vec<String> {
+    let normalized = normalize_search_text(value);
+    let mut terms = normalized
+        .split_whitespace()
+        .filter(|term| term.chars().count() >= 2)
+        .map(str::to_owned)
+        .collect::<Vec<_>>();
+    let cjk = normalized
+        .chars()
+        .filter(|ch| is_cjk(*ch))
+        .collect::<Vec<_>>();
+    for size in [2, 3, 4] {
+        for window in cjk.windows(size) {
+            terms.push(window.iter().collect());
+        }
+    }
+    terms.sort();
+    terms.dedup();
+    terms
+}
+
 pub struct SearchSkillsTool {
     skills: Arc<SkillIndex>,
 }
@@ -80,22 +125,25 @@ impl SearchSkillsTool {
             .map(|limit| limit as usize)
             .unwrap_or(DEFAULT_SEARCH_LIMIT)
             .clamp(1, MAX_SEARCH_LIMIT);
-        let query = query.to_lowercase();
         let browse = query == "*";
-        let terms: Vec<_> = query.split_whitespace().collect();
+        let normalized_query = normalize_search_text(query);
+        let terms = search_terms(query);
         let mut matches = vec![];
         for skill in self.skills.all() {
-            let name = skill.name.to_lowercase();
-            let description = skill.description.to_lowercase();
-            let tags = skill.tags.join(" ").to_lowercase();
+            let name = normalize_search_text(&skill.name);
+            let description = normalize_search_text(&skill.description);
+            let tags = normalize_search_text(&skill.tags.join(" "));
             let mut score = usize::from(browse);
-            if name == query {
+            if name == normalized_query {
                 score += 1_000;
-            } else if name.contains(&query) {
+            } else if !normalized_query.is_empty() && name.contains(&normalized_query) {
                 score += 100;
             }
-            if description.contains(&query) || tags.contains(&query) {
+            if !normalized_query.is_empty() && description.contains(&normalized_query) {
                 score += 50;
+            }
+            if !normalized_query.is_empty() && tags.contains(&normalized_query) {
+                score += 60;
             }
             for term in &terms {
                 if name.contains(term) {
@@ -411,6 +459,54 @@ mod tests {
         let output: serde_json::Value = serde_json::from_str(&result.content).unwrap();
         assert_eq!(output["results"][0]["name"], "pubmed-review");
         assert_eq!(output["results"][0]["tags"][0], "systematic-evidence");
+
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn search_normalizes_separators_and_continuous_cjk_queries() {
+        assert_eq!(normalize_search_text("Single-Cell_QC"), "single cell qc");
+        let terms = search_terms("请检查论文图片是否重复");
+        assert!(terms.contains(&"图片".to_string()));
+        assert!(terms.contains(&"重复".to_string()));
+
+        let root = std::env::temp_dir().join(format!(
+            "wisp-skill-multilingual-search-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        for (name, description) in [
+            (
+                "singlecell-qc",
+                "Design single cell RNA sequencing quality control.",
+            ),
+            ("figure-duplicate-audit", "审核论文图片重复和图片查重。"),
+            ("literature-review", "Retrieve and synthesize papers."),
+        ] {
+            let dir = root.join(name);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(
+                dir.join("SKILL.md"),
+                format!("---\nname: {name}\ndescription: {description}\n---\nbody"),
+            )
+            .unwrap();
+        }
+        let search = SearchSkillsTool::new(Arc::new(SkillIndex::load(&[root.clone()])));
+
+        let result = search.search(&json!({ "query": "single-cell_QC" }));
+        let output: serde_json::Value = serde_json::from_str(&result.content).unwrap();
+        assert_eq!(output["results"][0]["name"], "singlecell-qc");
+
+        let result = search.search(&json!({ "query": "singlecell" }));
+        let output: serde_json::Value = serde_json::from_str(&result.content).unwrap();
+        assert_eq!(output["results"][0]["name"], "singlecell-qc");
+
+        let result = search.search(&json!({ "query": "请检查论文图片是否重复" }));
+        let output: serde_json::Value = serde_json::from_str(&result.content).unwrap();
+        assert_eq!(output["results"][0]["name"], "figure-duplicate-audit");
 
         std::fs::remove_dir_all(root).ok();
     }

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -46,6 +46,14 @@ Tags declared in `SKILL.md` appear automatically. Tags edited in Settings are a
 user override and are also applied to Agent `search_skills` queries after the
 next idle-Agent rebuild.
 
+`search_skills` normalizes case and common separators before matching names,
+descriptions, and tags. Continuous CJK queries also contribute bounded 2–4
+character terms, so ordinary Chinese task descriptions do not have to contain
+spaces to find matching Chinese metadata. Agent guidance asks for one retry
+with cross-language domain synonyms when the first query has no confident
+match. Search is still local lexical retrieval; it does not call an embedding
+service or send the Skill catalog to a third party.
+
 The **Capabilities** summary uses the same current enabled Skill inventory and
 splits it into bundled and project-added counts. Project-added includes project,
 global, extra-path, and project-enabled plugin Skills. MCP counts are split into


### PR DESCRIPTION
## Problem

Reproduced in Wisp Science v1.6.0. An enabled Skill can remain undiscovered when the model's query and the Skill metadata use different separators or when a Chinese request is sent without whitespace.

The v1.6.0 search path lowercases the query, splits only on whitespace, and scores raw substring matches:

```rust
let query = query.to_lowercase();
let terms: Vec<_> = query.split_whitespace().collect();

let name = skill.name.to_lowercase();
let description = skill.description.to_lowercase();
let tags = skill.tags.join(" ").to_lowercase();
```

That means `single-cell_QC` is not normalized to `single cell qc`, and a query such as `请检查论文图片是否重复` remains one opaque term. The Skill may be configured, enabled, and effective but never enter the top results.

This targets the current `main` branch while preserving the v1.6.0 exact-name, substring, enabled-filter, and result-limit behavior.

## Changes

- `crates/wisp-skills/src/tool.rs`
  - Normalize case and common separators before scoring names, descriptions, and tags.
  - Derive bounded 2–4 character terms from continuous CJK queries.
  - Keep exact-name priority and the existing substring scoring path.
  - Add regression coverage for separator normalization, continuous Chinese queries, partial-name lookup, and the existing enabled inventory.
- `crates/wisp-core/src/system_prompt.rs`
  - Preserve important terms from the user's language.
  - Ask the Agent to retry once with cross-language domain synonyms when the first search has no confident match.
- `docs/skills.md`
  - Document normalized local lexical retrieval, bounded CJK terms, the retry guidance, and the fact that no embedding service or third party receives the catalog.

The core replacement is deterministic and local:

```rust
let browse = query == "*";
let normalized_query = normalize_search_text(query);
let terms = search_terms(query);

let name = normalize_search_text(&skill.name);
let description = normalize_search_text(&skill.description);
let tags = normalize_search_text(&skill.tags.join(" "));
```

`search_terms` retains whitespace-delimited terms and adds only bounded CJK windows:

```rust
for size in [2, 3, 4] {
    for window in cjk.windows(size) {
        terms.push(window.iter().collect());
    }
}
```

## Tests

Passed:

- `cargo fmt --all -- --check`
- `cargo test -p wisp-skills` — 20 passed
- `cargo test -p wisp-core prompt_keeps_skill_catalog_out_of_context`
- `git diff --check`

The full `cargo test --workspace` reached the existing Windows/Tauri baseline with all tests related to this change passing. `wisp-tauri` reported 846 passed and three unrelated failures, reproducible in isolation without this code path:

- `resource_leases::tests::tool_requests_normalize_project_relative_paths`: Windows case-normalization assertion expected `plot.R` but received `plot.r`.
- `publication_commands::tests::artifact_binding_resolves_latest_version_once`: Windows file-lock error 32.
- `publication_commands::tests::run_binding_and_workspace_are_project_scoped`: Windows file-lock error 32.

The build-time models.dev request also timed out and used the checked-in snapshot as designed.

## Manual smoke

1. Reload Skills with an enabled Skill whose metadata contains `single cell QC`.
2. Search for `single-cell_QC` and confirm the Skill is returned.
3. Add a Skill description containing `论文图片重复和图片查重`.
4. Search with `请检查论文图片是否重复` and confirm the Skill is returned.
5. Disable the Skill and confirm it no longer appears.
6. Select the Skill manually and confirm `use_skill` rendering is unchanged.

## Known limitations / follow-ups

- This improves local lexical recall; it does not claim full semantic retrieval.
- CJK n-grams require shared CJK text between the query and metadata.
- Cross-language recall still depends on one model-generated synonym retry.
- This PR intentionally does not add embeddings, a vector database, network calls, or new model configuration.
- A separate proposal can evaluate hybrid lexical/semantic retrieval if deterministic recall remains insufficient.
