### PR TITLE
fix(trajectory): keep the list in place on selection and let the inspector scroll

### DIFF
--- a/docs/trajectory-view.md
+++ b/docs/trajectory-view.md
@@ -14,9 +14,10 @@ A session-level Gantt (Duration / Turns / Calls) sits above a split view:
 the event list on the left, a detail inspector on the right. Close the
 inspector with its × to give the list the full width; click a row or a
 Gantt segment to open it again. Clicking a Gantt segment also scrolls that
-event to the top of the list. The list uses colored **USER / ASSISTANT /
-TOOL** badges when it is wide, and compact icons when the inspector makes
-the list narrow.
+event to the top of the list; selecting a row from the list leaves the list
+where it is, so you keep watching the turn you were reading. The list uses
+colored **USER / ASSISTANT / TOOL** badges when it is wide, and compact icons
+when the inspector makes the list narrow.
 
 Events are grouped into turns — a turn starts at each of your messages and
 covers everything the agent did in response. Each row has a kind marker and a
@@ -37,6 +38,9 @@ Click a row (or a Gantt segment) to inspect it. The inspector has four tabs:
 - **Raw** — the stored cell as JSON.
 - **Source** — the original payload (message text, tool arguments, or usage
   record).
+
+The inspector scrolls independently of the list, so long tool arguments and
+results stay reachable in full.
 
 A search box at the top filters rows by their summary and detail text.
 

--- a/ui-tests/tests/trajectory.spec.ts
+++ b/ui-tests/tests/trajectory.spec.ts
@@ -227,35 +227,54 @@ test("selecting a row leaves the list scrolled where the reader left it", async 
   const list = view.getByTestId("traj-list");
   await expect(list.getByText("User turn 1", { exact: true })).toBeVisible();
 
-  // Scroll down to the newest turn, then click one of its rows: the list must
-  // not snap back to turn 1. `scrollIntoView` honours the row's
-  // `scroll-margin-top`, so the row clears the sticky turn header and
-  // Playwright's own actionability scroll is a no-op.
-  const latest = list.locator('[data-traj-key="20:2"]');
-  await latest.evaluate((el) => el.scrollIntoView({ block: "start" }));
-  expect(await list.evaluate((el) => el.scrollTop)).toBeGreaterThan(0);
+  // Scroll down to the newest turns, then pick whichever row the reader would
+  // see in the middle of the viewport. Hit testing the live layout avoids
+  // depending on row heights, which vary with the platform's fonts.
+  await list.evaluate((el) => {
+    el.scrollTop = el.scrollHeight - el.clientHeight * 1.5;
+  });
+  const key = await list.evaluate((el) => {
+    const rect = el.getBoundingClientRect();
+    const x = rect.left + rect.width / 2;
+    for (const frac of [0.5, 0.35, 0.65, 0.2, 0.8]) {
+      const row = document
+        .elementFromPoint(x, rect.top + rect.height * frac)
+        ?.closest("[data-traj-key]");
+      if (row) return row.getAttribute("data-traj-key");
+    }
+    return null;
+  });
+  expect(key).toBeTruthy();
+  const target = list.locator(`[data-traj-key="${key}"]`);
+  const before = await list.evaluate((el) => el.scrollTop);
+  expect(before).toBeGreaterThan(0);
 
-  // Where the row sits inside the list viewport, which is what the reader
-  // actually perceives. Row heights change slightly when the inspector opens
-  // or closes, so raw scrollTop drifts by a few pixels even when nothing moved.
-  const rowOffset = async () => {
-    const listBox = (await list.boundingBox())!;
-    const rowBox = (await latest.boundingBox())!;
-    return rowBox.y - listBox.y;
-  };
-  const before = await rowOffset();
-
-  await latest.click();
-  await expect(latest).toHaveClass(/selected/);
-  await expect(view.getByTestId("traj-meta-source")).toHaveText("Tool");
+  // A raw mouse click: `locator.click` scrolls the row into view on its own
+  // terms (it honours `scroll-margin-top`) and would move the list for us.
+  // Coordinates are only trustworthy once the modal's entry animation ends.
+  await view.evaluate((el) =>
+    Promise.all(el.closest(".modal")!.getAnimations().map((a) => a.finished)).then(() => undefined),
+  );
+  const box = (await target.boundingBox())!;
+  await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+  await expect(target).toHaveClass(/selected/);
+  await expect(view.getByTestId("traj-inspector")).toBeVisible();
   await page.waitForTimeout(250);
-  expect(Math.abs((await rowOffset()) - before)).toBeLessThanOrEqual(12);
+  expect(await list.evaluate((el) => el.scrollTop)).toBe(before);
 
   // Closing the inspector must not throw the reader back to the top either.
+  // Rows grow a little when badges replace icons, so assert the weaker property
+  // that actually matters: the row stays where the reader can see it.
   await view.getByTestId("traj-inspector-close").click();
   await expect(view.getByTestId("traj-inspector")).toHaveCount(0);
   await page.waitForTimeout(250);
-  expect(Math.abs((await rowOffset()) - before)).toBeLessThanOrEqual(12);
+  const stillVisible = await target.evaluate((el) => {
+    const listEl = el.closest("[data-testid='traj-list']")!;
+    const row = el.getBoundingClientRect();
+    const bounds = listEl.getBoundingClientRect();
+    return row.top >= bounds.top - 4 && row.bottom <= bounds.bottom + 4;
+  });
+  expect(stillVisible).toBe(true);
 });
 
 test("the inspector scrolls when a call has more content than fits", async ({ page }) => {

--- a/ui-tests/tests/trajectory.spec.ts
+++ b/ui-tests/tests/trajectory.spec.ts
@@ -23,6 +23,59 @@ async function openTrajectory(page: Page) {
   return overlay.getByTestId("trajectory-view");
 }
 
+async function runOneTurn(page: Page) {
+  await enterApp(page);
+  await page.locator("#composer-input").fill("analyze ESR1");
+  await page.getByRole("button", { name: "Send" }).click();
+  await expect(page.getByText("Hello from mock wisp-science.")).toBeVisible({ timeout: 10_000 });
+}
+
+// A 20-turn session: tall enough that the list has to scroll.
+async function seedTallTrajectory(page: Page) {
+  await page.evaluate(() => {
+    const cell = (kind: string, summary: string, index: number, extra: Record<string, unknown> = {}) => ({
+      kind,
+      summary,
+      detail_input: kind === "tool" ? `{"n":${index}}` : null,
+      detail_output: summary,
+      ok: kind === "tool" ? true : null,
+      is_error: false,
+      ts: 1755000000000 + index * 1000,
+      duration_ms: kind === "tool" ? 200 : 50,
+      usage: null,
+      ...extra,
+    });
+    const turns = Array.from({ length: 20 }, (_, i) => {
+      const n = i + 1;
+      return {
+        index: n,
+        started_at: 1755000000000 + n * 4000,
+        cells: [
+          cell("user", `User turn ${n}`, n),
+          cell("assistant", `Assistant turn ${n}`, n),
+          cell("tool", `late_tool_${n}`, n),
+        ],
+      };
+    });
+    (window as any).__trajectorySnapshot = {
+      frame_id: "",
+      model: "deepseek-v4-pro",
+      turns,
+      stats: {
+        turns: 20,
+        steps: 40,
+        llm_ms: 1000,
+        tool_ms: 4000,
+        input_tokens: 1000,
+        output_tokens: 1000,
+        cached_input_tokens: 0,
+        cache_hit_pct: null,
+        tokens_per_sec: 10,
+      },
+    };
+  });
+}
+
 test("trajectory modal renders turns, inspector tabs, usage lines, and stats", async ({ page }) => {
   await enterApp(page);
   await page.locator("#composer-input").fill("analyze ESR1");
@@ -147,52 +200,8 @@ test("trajectory modal shows the empty state when a session has no turns", async
 });
 
 test("clicking a Gantt segment selects that event and scrolls it to the top of the list", async ({ page }) => {
-  await enterApp(page);
-  await page.locator("#composer-input").fill("analyze ESR1");
-  await page.getByRole("button", { name: "Send" }).click();
-  await expect(page.getByText("Hello from mock wisp-science.")).toBeVisible({ timeout: 10_000 });
-  await page.evaluate(() => {
-    const cell = (kind: string, summary: string, index: number, extra: Record<string, unknown> = {}) => ({
-      kind,
-      summary,
-      detail_input: kind === "tool" ? `{"n":${index}}` : null,
-      detail_output: summary,
-      ok: kind === "tool" ? true : null,
-      is_error: false,
-      ts: 1755000000000 + index * 1000,
-      duration_ms: kind === "tool" ? 200 : 50,
-      usage: null,
-      ...extra,
-    });
-    const turns = Array.from({ length: 20 }, (_, i) => {
-      const n = i + 1;
-      return {
-        index: n,
-        started_at: 1755000000000 + n * 4000,
-        cells: [
-          cell("user", `User turn ${n}`, n),
-          cell("assistant", `Assistant turn ${n}`, n),
-          cell("tool", `late_tool_${n}`, n),
-        ],
-      };
-    });
-    (window as any).__trajectorySnapshot = {
-      frame_id: "",
-      model: "deepseek-v4-pro",
-      turns,
-      stats: {
-        turns: 20,
-        steps: 40,
-        llm_ms: 1000,
-        tool_ms: 4000,
-        input_tokens: 1000,
-        output_tokens: 1000,
-        cached_input_tokens: 0,
-        cache_hit_pct: null,
-        tokens_per_sec: 10,
-      },
-    };
-  });
+  await runOneTurn(page);
+  await seedTallTrajectory(page);
   const view = await openTrajectory(page);
   const list = view.getByTestId("traj-list");
   await expect(list.getByText("User turn 1", { exact: true })).toBeVisible();
@@ -209,4 +218,102 @@ test("clicking a Gantt segment selects that event and scrolls it to the top of t
       return rowBox.y - listBox.y;
     })
     .toBeLessThan(72);
+});
+
+test("selecting a row leaves the list scrolled where the reader left it", async ({ page }) => {
+  await runOneTurn(page);
+  await seedTallTrajectory(page);
+  const view = await openTrajectory(page);
+  const list = view.getByTestId("traj-list");
+  await expect(list.getByText("User turn 1", { exact: true })).toBeVisible();
+
+  // Scroll down to the newest turn, then click one of its rows: the list must
+  // not snap back to turn 1. `scrollIntoView` honours the row's
+  // `scroll-margin-top`, so the row clears the sticky turn header and
+  // Playwright's own actionability scroll is a no-op.
+  const latest = list.locator('[data-traj-key="20:2"]');
+  await latest.evaluate((el) => el.scrollIntoView({ block: "start" }));
+  expect(await list.evaluate((el) => el.scrollTop)).toBeGreaterThan(0);
+
+  // Where the row sits inside the list viewport, which is what the reader
+  // actually perceives. Row heights change slightly when the inspector opens
+  // or closes, so raw scrollTop drifts by a few pixels even when nothing moved.
+  const rowOffset = async () => {
+    const listBox = (await list.boundingBox())!;
+    const rowBox = (await latest.boundingBox())!;
+    return rowBox.y - listBox.y;
+  };
+  const before = await rowOffset();
+
+  await latest.click();
+  await expect(latest).toHaveClass(/selected/);
+  await expect(view.getByTestId("traj-meta-source")).toHaveText("Tool");
+  await page.waitForTimeout(250);
+  expect(Math.abs((await rowOffset()) - before)).toBeLessThanOrEqual(12);
+
+  // Closing the inspector must not throw the reader back to the top either.
+  await view.getByTestId("traj-inspector-close").click();
+  await expect(view.getByTestId("traj-inspector")).toHaveCount(0);
+  await page.waitForTimeout(250);
+  expect(Math.abs((await rowOffset()) - before)).toBeLessThanOrEqual(12);
+});
+
+test("the inspector scrolls when a call has more content than fits", async ({ page }) => {
+  await runOneTurn(page);
+  await page.evaluate(() => {
+    const long = Array.from({ length: 300 }, (_, i) => `web_scan result line ${i}`).join("\n");
+    (window as any).__trajectorySnapshot = {
+      frame_id: "",
+      model: "deepseek-v4-pro",
+      turns: [
+        {
+          index: 1,
+          started_at: 1755000000000,
+          cells: [
+            {
+              kind: "tool",
+              summary: "web_scan · long result",
+              detail_input: '{"url":"https://example.org"}',
+              detail_output: long,
+              ok: true,
+              is_error: false,
+              ts: 1755000000000,
+              duration_ms: 200,
+              usage: null,
+            },
+          ],
+        },
+      ],
+      stats: {
+        turns: 1,
+        steps: 1,
+        llm_ms: 0,
+        tool_ms: 200,
+        input_tokens: 0,
+        output_tokens: 0,
+        cached_input_tokens: 0,
+        cache_hit_pct: null,
+        tokens_per_sec: null,
+      },
+    };
+  });
+
+  const view = await openTrajectory(page);
+  const inspector = view.getByTestId("traj-inspector");
+  await inspector.getByTestId("traj-tab-preview").click();
+  await expect(inspector.getByTestId("traj-detail-output")).toContainText("web_scan result line 299");
+
+  // The overflow belongs to the inspector body: it stays inside the split
+  // instead of growing past it, and it scrolls all the way to the last line.
+  const splitBox = (await view.getByTestId("traj-split").boundingBox())!;
+  const body = inspector.locator(".traj-inspector-body");
+  const bodyBox = (await body.boundingBox())!;
+  expect(bodyBox.y + bodyBox.height).toBeLessThanOrEqual(splitBox.y + splitBox.height + 1);
+
+  const scrolled = await body.evaluate((el) => {
+    el.scrollTop = el.scrollHeight;
+    return { top: el.scrollTop, overflow: el.scrollHeight - el.clientHeight };
+  });
+  expect(scrolled.overflow).toBeGreaterThan(0);
+  expect(scrolled.top).toBe(scrolled.overflow);
 });

--- a/ui/src/styles/chat.css
+++ b/ui/src/styles/chat.css
@@ -1937,6 +1937,10 @@ button.stop:disabled { opacity: .6; cursor: default; }
 .traj-split {
   flex: 1 1 auto; min-height: 0;
   display: grid; grid-template-columns: 1fr;
+  /* minmax(0, 1fr) pins the row to the split's own height. With an implicit
+     auto row a long inspector grows the row past the modal and gets clipped
+     instead of scrolling. */
+  grid-template-rows: minmax(0, 1fr);
   border: 1px solid var(--border); border-radius: var(--radius-sm);
   overflow: hidden;
   background: var(--bg-elev);
@@ -1961,6 +1965,9 @@ button.stop:disabled { opacity: .6; cursor: default; }
 }
 .traj-inspector {
   min-width: 0;
+  min-height: 0;
+  height: 100%;
+  overflow: hidden;
   display: flex; flex-direction: column;
   border-left: 1px solid var(--border);
   background: var(--bg-app);

--- a/ui/src/trajectory.rs
+++ b/ui/src/trajectory.rs
@@ -588,6 +588,7 @@ pub(crate) fn TrajectoryView(
     let tab = create_rw_signal(InspectorTab::Summary);
     let jump_seq = create_rw_signal(0u32);
     let jump_target = create_rw_signal(None::<String>);
+    let search = move || query.get().trim().to_lowercase();
 
     create_effect(move |_| {
         let _tick = jump_seq.get();
@@ -602,10 +603,9 @@ pub(crate) fn TrajectoryView(
     });
 
     create_effect(move |_| {
-        let q = query.get().trim().to_lowercase();
         let snap = snapshot.get();
         let live_cells = live.get();
-        let keys: Vec<String> = visible_rows(&snap, &live_cells, &q)
+        let keys: Vec<String> = visible_rows(&snap, &live_cells, &search())
             .into_iter()
             .map(|(key, _, _)| key)
             .collect();
@@ -618,6 +618,226 @@ pub(crate) fn TrajectoryView(
         }
         selected.set(keys.first().cloned());
     });
+
+    // The list body, the Gantt, and the inspector each track their own inputs.
+    // Selection must never invalidate the list body: re-rendering it would
+    // recreate the scroll container and send the reader back to turn 1.
+    let is_empty = create_memo(move |_| {
+        snapshot.with(|snap| snap.as_ref().map_or(0, |s| s.turns.len())) == 0
+            && live.with(|cells| cells.is_empty())
+    });
+    let selected_cell = create_memo(move |_| {
+        let key = selected.get()?;
+        let snap = snapshot.get();
+        let live_cells = live.get();
+        visible_rows(&snap, &live_cells, &search())
+            .into_iter()
+            .find(|(candidate, _, _)| *candidate == key)
+            .map(|(_, turn, cell)| (turn, cell.clone()))
+    });
+
+    let gantt = move || {
+        let loc = locale.get();
+        let snap = snapshot.get();
+        let live_cells = live.get();
+        let rows = visible_rows(&snap, &live_cells, &search());
+        let segs = gantt_segments(axis.get(), &rows);
+        (!segs.is_empty()).then(|| {
+            let lanes = ["input", "model", "tools"];
+            view! {
+                <div class="traj-gantt" data-testid="traj-gantt">
+                    {lanes.into_iter().map(|lane| {
+                        let lane_segs: Vec<GanttSeg> = segs.iter().filter(|seg| seg.lane == lane).cloned().collect();
+                        let label_key = match lane {
+                            "input" => "trajectory.legend.input",
+                            "model" => "trajectory.legend.model",
+                            _ => "trajectory.legend.tools",
+                        };
+                        view! {
+                            <div class="traj-gantt-lane">
+                                <span class="traj-gantt-label">{t(loc, label_key)}</span>
+                                <div class="traj-gantt-track">
+                                    {lane_segs.into_iter().map(|seg| {
+                                        let key = seg.key.clone();
+                                        let select_key = key.clone();
+                                        let active_key = key.clone();
+                                        view! {
+                                            <button type="button" class=format!("traj-gantt-seg {}", seg.lane)
+                                                class:selected=move || selected.get().as_deref() == Some(active_key.as_str())
+                                                style=format!("left:{:.2}%;width:{:.2}%", seg.left_pct, seg.width_pct)
+                                                data-testid="traj-gantt-seg"
+                                                data-traj-key=key.clone()
+                                                aria-label=key.clone()
+                                                on:click=move |_| {
+                                                    selected.set(Some(select_key.clone()));
+                                                    inspector_open.set(true);
+                                                    jump_target.set(Some(select_key.clone()));
+                                                    jump_seq.update(|n| *n = n.saturating_add(1));
+                                                }>
+                                            </button>
+                                        }
+                                    }).collect_view()}
+                                </div>
+                            </div>
+                        }
+                    }).collect_view()}
+                </div>
+            }
+        })
+    };
+
+    let list_body = move || {
+        let loc = locale.get();
+        let q = search();
+        let snap = snapshot.get();
+        let live_cells = live.get();
+        let running = busy.get();
+        let turns = snap.as_ref().map(|s| s.turns.len()).unwrap_or(0);
+        let mut any_visible = false;
+        let turn_views = snap
+            .as_ref()
+            .map(|s| {
+                s.turns
+                    .iter()
+                    .filter_map(|turn| {
+                        let cells: Vec<(usize, &TrajectoryCellDto)> = turn
+                            .cells
+                            .iter()
+                            .enumerate()
+                            .filter(|(_, cell)| cell_matches(cell, &q))
+                            .collect();
+                        if cells.is_empty() {
+                            return None;
+                        }
+                        any_visible = true;
+                        let running_turn = running && turn.index as usize == turns;
+                        let timing = turn_timing(&turn.cells);
+                        Some(view! {
+                            <section class="traj-turn">
+                                <div class="traj-turn-head">
+                                    <span>{tf(loc, "trajectory.turn", &[("n", &turn.index.to_string())])}</span>
+                                    {running_turn.then(|| view! {
+                                        <span class="traj-running">{t(loc, "trajectory.running")}</span>
+                                    })}
+                                </div>
+                                {timing.map(|(input_ms, model_ms, tool_ms)| view! {
+                                    <div class="traj-bar">
+                                        {(input_ms > 0).then(|| view! {
+                                            <div class="traj-bar-seg input" style=format!("flex-grow:{input_ms}")></div>
+                                        })}
+                                        {(model_ms > 0).then(|| view! {
+                                            <div class="traj-bar-seg model" style=format!("flex-grow:{model_ms}")></div>
+                                        })}
+                                        {(tool_ms > 0).then(|| view! {
+                                            <div class="traj-bar-seg tools" style=format!("flex-grow:{tool_ms}")></div>
+                                        })}
+                                    </div>
+                                })}
+                                <div class="traj-rows">
+                                    {cells.into_iter().map(|(ci, cell)| {
+                                        let key = format!("{}:{ci}", turn.index);
+                                        view! {
+                                            <TrajectoryCellRow
+                                                cell=cell.clone()
+                                                cell_key=key
+                                                selected=selected
+                                                inspector_open=inspector_open />
+                                        }
+                                    }).collect_view()}
+                                </div>
+                            </section>
+                        })
+                    })
+                    .collect_view()
+            })
+            .unwrap_or_default();
+        let live_view = (!live_cells.is_empty()).then(|| {
+            let next_turn = turns as i64 + 1;
+            let visible: Vec<(usize, &TrajectoryCellDto)> = live_cells
+                .iter()
+                .enumerate()
+                .filter(|(_, cell)| cell_matches(cell, &q))
+                .collect();
+            view! {
+                <section class="traj-turn live" data-testid="traj-live-turn">
+                    <div class="traj-turn-head">
+                        <span>{tf(loc, "trajectory.turn", &[("n", &next_turn.to_string())])}</span>
+                        <span class="traj-running">{t(loc, "trajectory.running")}</span>
+                    </div>
+                    <div class="traj-rows">
+                        {visible.into_iter().map(|(ci, cell)| {
+                            let key = format!("live:{ci}");
+                            view! {
+                                <TrajectoryCellRow
+                                    cell=cell.clone()
+                                    cell_key=key
+                                    selected=selected
+                                    inspector_open=inspector_open />
+                            }
+                        }).collect_view()}
+                    </div>
+                </section>
+            }
+        });
+        let no_match = (!any_visible && !q.is_empty() && live_cells.is_empty())
+            .then(|| view! { <div class="trajectory-empty">{t(loc, "trajectory.no_match")}</div> });
+        view! {
+            {turn_views}
+            {live_view}
+            {no_match}
+        }
+    };
+
+    let inspector = move || {
+        if !inspector_open.get() {
+            return None;
+        }
+        let loc = locale.get();
+        let view = match selected_cell.get() {
+            Some((turn, cell)) => {
+                let live_selected = selected
+                    .get()
+                    .is_some_and(|key| key.starts_with("live:"));
+                view! {
+                    <TrajectoryInspector
+                        cell=cell
+                        turn=turn
+                        running=busy.get() && live_selected
+                        tab=tab
+                        inspector_open=inspector_open />
+                }
+                .into_view()
+            }
+            None => view! {
+                <div class="traj-inspector traj-inspector-empty" data-testid="traj-inspector">
+                    <div class="traj-inspector-head">
+                        <span class="traj-inspector-title">{t(loc, "trajectory.select_event")}</span>
+                        <button type="button" class="ps-close" data-testid="traj-inspector-close"
+                            title=t(loc, "trajectory.close_inspector")
+                            aria-label=t(loc, "trajectory.close_inspector")
+                            on:click=move |_| inspector_open.set(false)>
+                            {compose_icon("close")}
+                        </button>
+                    </div>
+                </div>
+            }
+            .into_view(),
+        };
+        Some(view)
+    };
+
+    let footer = move || {
+        let loc = locale.get();
+        snapshot.with(|snap| {
+            snap.as_ref().map(|s| {
+                view! {
+                    <div class="trajectory-footer" data-testid="trajectory-footer">
+                        {stats_line(loc, &s.stats)}
+                    </div>
+                }
+            })
+        })
+    };
 
     view! {
         <div class="trajectory" data-testid="trajectory-view">
@@ -657,196 +877,18 @@ pub(crate) fn TrajectoryView(
                 </div>
             </div>
             {move || {
-                let loc = locale.get();
-                let q = query.get().trim().to_lowercase();
-                let snap = snapshot.get();
-                let live_cells = live.get();
-                let running = busy.get();
-                let axis_now = axis.get();
-                let turns = snap.as_ref().map(|s| s.turns.len()).unwrap_or(0);
-                if turns == 0 && live_cells.is_empty() {
+                if is_empty.get() {
                     return view! {
-                        <div class="trajectory-empty">{t(loc, "trajectory.empty")}</div>
+                        <div class="trajectory-empty">
+                            {move || t(locale.get(), "trajectory.empty")}
+                        </div>
                     }.into_view();
                 }
-                let rows = visible_rows(&snap, &live_cells, &q);
-                let segs = gantt_segments(axis_now, &rows);
-                let selected_key = selected.get();
-                let selected_cell = selected_key.as_ref().and_then(|key| {
-                    rows.iter().find(|(k, _, _)| k == key).map(|(_, turn, cell)| (*turn, (*cell).clone()))
-                });
-                let lanes = ["input", "model", "tools"];
-                let gantt = (!segs.is_empty()).then(|| {
-                    view! {
-                        <div class="traj-gantt" data-testid="traj-gantt">
-                            {lanes.into_iter().map(|lane| {
-                                let lane_segs: Vec<GanttSeg> = segs.iter().filter(|seg| seg.lane == lane).cloned().collect();
-                                let label_key = match lane {
-                                    "input" => "trajectory.legend.input",
-                                    "model" => "trajectory.legend.model",
-                                    _ => "trajectory.legend.tools",
-                                };
-                                view! {
-                                    <div class="traj-gantt-lane">
-                                        <span class="traj-gantt-label">{t(loc, label_key)}</span>
-                                        <div class="traj-gantt-track">
-                                            {lane_segs.into_iter().map(|seg| {
-                                                let key = seg.key.clone();
-                                                let select_key = key.clone();
-                                                let active_key = key.clone();
-                                                view! {
-                                                    <button type="button" class=format!("traj-gantt-seg {}", seg.lane)
-                                                        class:selected=move || selected.get().as_deref() == Some(active_key.as_str())
-                                                        style=format!("left:{:.2}%;width:{:.2}%", seg.left_pct, seg.width_pct)
-                                                        data-testid="traj-gantt-seg"
-                                                        data-traj-key=key.clone()
-                                                        aria-label=key.clone()
-                                                        on:click=move |_| {
-                                                            selected.set(Some(select_key.clone()));
-                                                            inspector_open.set(true);
-                                                            jump_target.set(Some(select_key.clone()));
-                                                            jump_seq.update(|n| *n = n.saturating_add(1));
-                                                        }>
-                                                    </button>
-                                                }
-                                            }).collect_view()}
-                                        </div>
-                                    </div>
-                                }
-                            }).collect_view()}
-                        </div>
-                    }
-                });
-                let mut any_visible = false;
-                let turn_views = snap
-                    .as_ref()
-                    .map(|s| {
-                        s.turns
-                            .iter()
-                            .filter_map(|turn| {
-                                let cells: Vec<(usize, &TrajectoryCellDto)> = turn
-                                    .cells
-                                    .iter()
-                                    .enumerate()
-                                    .filter(|(_, cell)| cell_matches(cell, &q))
-                                    .collect();
-                                if cells.is_empty() {
-                                    return None;
-                                }
-                                any_visible = true;
-                                let running_turn = running && turn.index as usize == turns;
-                                let timing = turn_timing(&turn.cells);
-                                Some(view! {
-                                    <section class="traj-turn">
-                                        <div class="traj-turn-head">
-                                            <span>{tf(loc, "trajectory.turn", &[("n", &turn.index.to_string())])}</span>
-                                            {running_turn.then(|| view! {
-                                                <span class="traj-running">{t(loc, "trajectory.running")}</span>
-                                            })}
-                                        </div>
-                                        {timing.map(|(input_ms, model_ms, tool_ms)| view! {
-                                            <div class="traj-bar">
-                                                {(input_ms > 0).then(|| view! {
-                                                    <div class="traj-bar-seg input" style=format!("flex-grow:{input_ms}")></div>
-                                                })}
-                                                {(model_ms > 0).then(|| view! {
-                                                    <div class="traj-bar-seg model" style=format!("flex-grow:{model_ms}")></div>
-                                                })}
-                                                {(tool_ms > 0).then(|| view! {
-                                                    <div class="traj-bar-seg tools" style=format!("flex-grow:{tool_ms}")></div>
-                                                })}
-                                            </div>
-                                        })}
-                                        <div class="traj-rows">
-                                            {cells.into_iter().map(|(ci, cell)| {
-                                                let key = format!("{}:{ci}", turn.index);
-                                                view! {
-                                                    <TrajectoryCellRow
-                                                        cell=cell.clone()
-                                                        cell_key=key
-                                                        selected=selected
-                                                        inspector_open=inspector_open />
-                                                }
-                                            }).collect_view()}
-                                        </div>
-                                    </section>
-                                })
-                            })
-                            .collect_view()
-                    })
-                    .unwrap_or_default();
-                let live_view = (!live_cells.is_empty()).then(|| {
-                    let next_turn = turns as i64 + 1;
-                    let visible: Vec<(usize, &TrajectoryCellDto)> = live_cells
-                        .iter()
-                        .enumerate()
-                        .filter(|(_, cell)| cell_matches(cell, &q))
-                        .collect();
-                    view! {
-                        <section class="traj-turn live" data-testid="traj-live-turn">
-                            <div class="traj-turn-head">
-                                <span>{tf(loc, "trajectory.turn", &[("n", &next_turn.to_string())])}</span>
-                                <span class="traj-running">{t(loc, "trajectory.running")}</span>
-                            </div>
-                            <div class="traj-rows">
-                                {visible.into_iter().map(|(ci, cell)| {
-                                    let key = format!("live:{ci}");
-                                    view! {
-                                        <TrajectoryCellRow
-                                            cell=cell.clone()
-                                            cell_key=key
-                                            selected=selected
-                                            inspector_open=inspector_open />
-                                    }
-                                }).collect_view()}
-                            </div>
-                        </section>
-                    }
-                });
-                let inspector = inspector_open.get().then(|| match selected_cell {
-                    Some((turn, cell)) => {
-                        let live_selected = selected_key.as_deref().is_some_and(|k| k.starts_with("live:"));
-                        view! {
-                            <TrajectoryInspector
-                                cell=cell
-                                turn=turn
-                                running=running && live_selected
-                                tab=tab
-                                inspector_open=inspector_open />
-                        }.into_view()
-                    }
-                    None => view! {
-                        <div class="traj-inspector traj-inspector-empty" data-testid="traj-inspector">
-                            <div class="traj-inspector-head">
-                                <span class="traj-inspector-title">{t(loc, "trajectory.select_event")}</span>
-                                <button type="button" class="ps-close" data-testid="traj-inspector-close"
-                                    title=t(loc, "trajectory.close_inspector")
-                                    aria-label=t(loc, "trajectory.close_inspector")
-                                    on:click=move |_| inspector_open.set(false)>
-                                    {compose_icon("close")}
-                                </button>
-                            </div>
-                        </div>
-                    }.into_view(),
-                });
-                let footer = snap.as_ref().map(|s| {
-                    view! {
-                        <div class="trajectory-footer" data-testid="trajectory-footer">
-                            {stats_line(loc, &s.stats)}
-                        </div>
-                    }
-                });
-                let no_match = (!any_visible && !q.is_empty() && live_cells.is_empty()).then(|| {
-                    view! { <div class="trajectory-empty">{t(loc, "trajectory.no_match")}</div> }
-                });
                 view! {
                     {gantt}
-                    <div class="traj-split" class:is-open=inspector_open.get() data-testid="traj-split">
-                        <div class="traj-list" data-testid="traj-list">
-                            {turn_views}
-                            {live_view}
-                            {no_match}
-                        </div>
+                    <div class="traj-split" class:is-open=move || inspector_open.get()
+                        data-testid="traj-split">
+                        <div class="traj-list" data-testid="traj-list">{list_body}</div>
                         {inspector}
                     </div>
                     {footer}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #958.

## Problem

Two separate defects in the 轨迹 (trajectory) panel, both reported in #958:

1. **The timeline snapped back to the top on every click.** Scroll down to the newest turn, click one of its rows, and the list jumped straight back to 第 1 轮. The reader had to manually scroll to the bottom again to keep watching the running turn.
2. **The right-hand detail panel could not show long content.** When a call (e.g. `web_scan` / `web_open_tab`) produced more output than fits, the 摘要/预览/原始/来源 panel was simply cut off with no scrollbar and no way to reach the rest.

## Cause

**(1)** `TrajectoryView` rendered the Gantt, the event list, and the inspector from a single reactive closure, and that closure read `selected`. Because `<div class="traj-list">` lived *inside* the closure, every selection change tore down and recreated the scroll container itself, resetting `scrollTop` to 0. The existing `scroll_traj_row_to_top` double-`requestAnimationFrame` jump was a workaround for exactly this, and it only ran for Gantt-segment clicks — a plain row click got the reset with no compensation. The same closure also read `inspector_open`, so closing the inspector reset the scroll too.

**(2)** `.traj-split` is a grid with no `grid-template-rows`, so its row was implicitly `auto`. `.traj-list` opts out of that with `min-height: 0`, which drops its minimum contribution to 0 and lets the row settle at the container height — but `.traj-inspector` had no such rule. A long `<pre>` made the inspector's automatic minimum size grow the row past the modal, `.traj-split { overflow: hidden }` clipped the overflow, and `.traj-inspector-body` (which already has `overflow: auto`) never became the scroller because it always had room. The `@media (max-width: 800px)` stacked layout already set `minmax(0, 1fr)`; the default two-column layout did not.

## Changes

**`ui/src/trajectory.rs`** — split the one monolithic closure into four that each track only their own inputs:

| Closure | Re-renders on |
| --- | --- |
| `gantt` | snapshot, live cells, query, axis |
| `list_body` | snapshot, live cells, query, busy |
| `inspector` | `inspector_open`, `selected_cell`, busy |
| `footer` | snapshot |

`.traj-list` now lives outside any selection-dependent closure, so a row click only toggles `class:selected` on the rows and swaps the inspector; the scroll container is never recreated. `class:is-open` became a reactive binding rather than a value read during render. Two new memos back this: `is_empty` (so the empty-state branch only flips when emptiness actually changes) and `selected_cell` (`PartialEq`-deduped, so streaming live cells do not rebuild the inspector while the reader is scrolling through a long result).

No behavior was intentionally changed: the Gantt jump, auto-selection of the first visible row, search filtering, and the empty/no-match states all work as before.

**`ui/src/styles/chat.css`** — `grid-template-rows: minmax(0, 1fr)` on `.traj-split` pins the row to the split's own height, and `.traj-inspector` gets the `min-height: 0; height: 100%; overflow: hidden` treatment `.traj-list` already had, so `.traj-inspector-body` becomes the scroller.

**`docs/trajectory-view.md`** — documents that selecting a row leaves the list where it is, and that the inspector scrolls independently.

## Tests

`ui-tests/tests/trajectory.spec.ts` — two new Playwright tests, plus a `runOneTurn` / `seedTallTrajectory` helper extracted from the existing Gantt test (which now reuses it):

- **"selecting a row leaves the list scrolled where the reader left it"** — with a 20-turn snapshot, scrolls the list to a definite offset near the newest turns, hit-tests the live layout for whichever row the reader would see mid-viewport, and clicks it. Selecting a row changes no layout, so `scrollTop` is asserted to come back exactly unchanged. Closing the inspector *does* change row heights (badges are 2px taller than icons, ~120px over 60 rows, which Chrome's scroll anchoring legitimately absorbs), so that half asserts the weaker property that matters: the row stays inside the list viewport.
- **"the inspector scrolls when a call has more content than fits"** — a 300-line tool result, asserting the inspector body stays within the split's box and scrolls to its own end.

Both fail on `main` and pass with the fix. Without it `scrollTop` goes 2463 → 0 (the reported jump to the top) and the inspector body extends 5757px past a 610px split.

The first version of the scroll test drove the list with `scrollIntoView` and clicked via `locator.click`. Both perform their own scrolling — `locator.click` calls `scrollIntoViewIfNeeded`, which honours the row's `scroll-margin-top` — and near maximum scroll the last rows sit under the sticky turn header. That drift stayed under the assertion's tolerance locally but exceeded it on CI runners with different font metrics. The test now avoids every scrolling API, waits out the modal's 280ms entry animation before taking coordinates, and clicks with the raw mouse, so only the app can move the list. Verified 70/70 green at `--repeat-each=10` with both 2 and 4 workers.

Full verification: the whole Playwright suite passes, `cargo test --workspace` passes (1392 tests, 0 failures), `ui` unit tests (285) pass, `cargo check --target wasm32-unknown-unknown` clean, `cargo fmt --all -- --check` clean for the touched files.

## Manual smoke steps

1. Open a session with many turns, open 轨迹, switch to 调用.
2. Scroll to the bottom and click the newest tool row — the list must not move.
3. Close and reopen the inspector — the list must stay near the same rows.
4. Click a Gantt segment — it must still jump that row to the top of the list (unchanged behavior).
5. Select a call with a long result and check 预览 / 原始 — the right panel must scroll to the end.

## Known limitations / follow-ups

- The list still re-renders wholesale when the snapshot or live cells change. Leptos preserves `scrollTop` across that child swap (verified experimentally), so the reader keeps their position, but the list does not *follow* a running turn. Auto-follow-when-at-bottom would need keyed `<For>` rendering and is left as a separate change.
- At maximum scroll the last row sits underneath the sticky turn header (the `.traj-list::after` spacer is `calc(100% - 36px)`). Pre-existing and untouched here.
- The `ui` workspace has pre-existing `cargo fmt` drift in nine unrelated files; per AGENTS.md that belongs in its own formatting-only commit, so it is deliberately left out of this PR.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce02a206-2d4d-4df5-8784-641ddc4e9948?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce02a206-2d4d-4df5-8784-641ddc4e9948&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

