### PR TITLE
fix(tools): block write/edit escapes through dangling or racing symlinks

### DIFF
--- a/crates/wisp-tools/src/edit.rs
+++ b/crates/wisp-tools/src/edit.rs
@@ -137,7 +137,7 @@ impl Tool for EditTool {
         } else {
             text.replacen(&old, &new, 1)
         };
-        if let Err(e) = std::fs::write(&real, &replaced) {
+        if let Err(e) = crate::safety::write_no_follow(&real, replaced.as_bytes()) {
             return ToolResult::fail(format!("edit {path} error: {e}"));
         }
         env.emit(ToolEvent::FileChanged { path: path.clone() })

--- a/crates/wisp-tools/src/safety.rs
+++ b/crates/wisp-tools/src/safety.rs
@@ -131,6 +131,19 @@ pub fn validate_file_path(root: &Path, path: &str) -> Result<PathBuf, String> {
     let real = match dunce::canonicalize(&abs) {
         Ok(r) => r,
         Err(_) => {
+            // Canonicalize failed: either the target doesn't exist yet (a new
+            // write) or it is a symlink whose target doesn't resolve. A
+            // dangling link must be rejected here — the parent+file fallback
+            // below can't see where the link points, and a follow-on write
+            // would create the link's target, possibly outside the root.
+            if abs
+                .symlink_metadata()
+                .is_ok_and(|m| m.file_type().is_symlink())
+            {
+                return Err(format!(
+                    "path '{path}' is a symlink whose target cannot be resolved"
+                ));
+            }
             // Target doesn't exist yet (write). Canonicalize the parent and
             // append the file name, then verify the parent is under root.
             let parent = abs.parent().unwrap_or(Path::new(""));
@@ -148,6 +161,64 @@ pub fn validate_file_path(root: &Path, path: &str) -> Result<PathBuf, String> {
         return Err(format!("path '{}' is a directory, not a file", path));
     }
     Ok(real)
+}
+
+/// Overwrite `path` without following a symlink (Unix) or reparse point
+/// (Windows) in the final component. `validate_file_path` already resolves
+/// links at check time; this closes the check-to-write window in which the
+/// validated path could be swapped for a link pointing outside the root.
+pub fn write_no_follow(path: &Path, content: &[u8]) -> std::io::Result<()> {
+    use std::io::Write;
+    let mut file = open_no_follow(path)?;
+    file.set_len(0)?;
+    file.write_all(content)
+}
+
+#[cfg(unix)]
+fn open_no_follow(path: &Path) -> std::io::Result<std::fs::File> {
+    use std::os::unix::fs::OpenOptionsExt;
+    std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)
+        .map_err(|e| {
+            // O_NOFOLLOW reports a symlink final component as ELOOP (Linux,
+            // macOS) or EMLINK (some BSDs); surface a clearer message.
+            if path
+                .symlink_metadata()
+                .is_ok_and(|m| m.file_type().is_symlink())
+            {
+                std::io::Error::other(format!(
+                    "refusing to write through symlink '{}'",
+                    path.display()
+                ))
+            } else {
+                e
+            }
+        })
+}
+
+#[cfg(windows)]
+fn open_no_follow(path: &Path) -> std::io::Result<std::fs::File> {
+    use std::os::windows::fs::{MetadataExt, OpenOptionsExt};
+    // Not in windows-sys' enabled feature set; values are ABI-stable.
+    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+    const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
+    let file = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+        .open(path)?;
+    // The flag opened the reparse point itself rather than its target, so
+    // checking the handle (not the path) is race-free.
+    if file.metadata()?.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+        return Err(std::io::Error::other(format!(
+            "refusing to write through reparse point '{}'",
+            path.display()
+        )));
+    }
+    Ok(file)
 }
 
 /// Resolve `path` under `root`, allowing directories (for `list_dir`).
@@ -347,6 +418,61 @@ mod tests {
         assert!(
             resolve_under_root(&root, "does_not_exist.txt").is_err(),
             "nonexistent paths are rejected (list/read need an existing target)"
+        );
+
+        std::fs::remove_dir_all(&root).ok();
+        std::fs::remove_dir_all(&outside).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dangling_symlink_is_rejected_instead_of_using_the_parent_fallback() {
+        let root = unique_dir("dangling");
+        let outside = unique_dir("dangling_outside");
+        // Link target does not exist, so canonicalize fails and the old
+        // parent+file fallback would have let the path through.
+        std::os::unix::fs::symlink(outside.join("not_yet.txt"), root.join("dangling.txt")).unwrap();
+        std::os::unix::fs::symlink(root.join("also_missing.txt"), root.join("dangling_in.txt"))
+            .unwrap();
+
+        for name in ["dangling.txt", "dangling_in.txt"] {
+            let got = validate_file_path(&root, name);
+            assert!(
+                got.as_ref().is_err_and(|e| e.contains("symlink")),
+                "{name}: dangling links must be rejected: {got:?}"
+            );
+        }
+
+        std::fs::remove_dir_all(&root).ok();
+        std::fs::remove_dir_all(&outside).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_no_follow_refuses_symlinks_but_overwrites_regular_files() {
+        let root = unique_dir("nofollow");
+        let outside = unique_dir("nofollow_outside");
+        std::fs::write(root.join("plain.txt"), "long original contents").unwrap();
+        std::os::unix::fs::symlink(outside.join("target.txt"), root.join("link.txt")).unwrap();
+
+        // Simulates the path being swapped for a link after validation.
+        let err = write_no_follow(&root.join("link.txt"), b"payload").unwrap_err();
+        assert!(err.to_string().contains("symlink"), "{err}");
+        assert!(
+            !outside.join("target.txt").exists(),
+            "no-follow write must not create the link target"
+        );
+
+        write_no_follow(&root.join("plain.txt"), b"short").unwrap();
+        assert_eq!(
+            std::fs::read_to_string(root.join("plain.txt")).unwrap(),
+            "short",
+            "overwrite must truncate previous longer contents"
+        );
+        write_no_follow(&root.join("created.txt"), b"new file").unwrap();
+        assert_eq!(
+            std::fs::read_to_string(root.join("created.txt")).unwrap(),
+            "new file"
         );
 
         std::fs::remove_dir_all(&root).ok();

--- a/crates/wisp-tools/src/write.rs
+++ b/crates/wisp-tools/src/write.rs
@@ -50,7 +50,7 @@ impl Tool for WriteTool {
                 ));
             }
         }
-        if let Err(e) = std::fs::write(&real, &content) {
+        if let Err(e) = crate::safety::write_no_follow(&real, content.as_bytes()) {
             return ToolResult::fail(format!("write {path} error: {e}"));
         }
         env.emit(ToolEvent::FileChanged { path: path.clone() })
@@ -105,5 +105,35 @@ mod tests {
             .iter()
             .any(|event| matches!(event, ToolEvent::FileChanged { path } if path == "new.R")));
         std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn write_through_a_dangling_outbound_symlink_is_blocked() {
+        let base = std::env::temp_dir().join(format!("wisp_write_dangling_{}", std::process::id()));
+        std::fs::remove_dir_all(&base).ok();
+        let root = base.join("project");
+        let outside = base.join("outside");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        // Project-local link to a nonexistent file outside the root: following
+        // it would create /outside/escape.txt.
+        std::os::unix::fs::symlink(outside.join("escape.txt"), root.join("sneaky.txt")).unwrap();
+        let env = RecordingEnv {
+            root: root.clone(),
+            events: Mutex::new(Vec::new()),
+        };
+
+        let result = WriteTool
+            .run(&json!({ "path": "sneaky.txt", "content": "pwned" }), &env)
+            .await;
+
+        assert!(!result.success, "{}", result.content);
+        assert!(
+            !outside.join("escape.txt").exists(),
+            "the escape target must not be created"
+        );
+        assert!(env.events.lock().unwrap().is_empty());
+        std::fs::remove_dir_all(&base).ok();
     }
 }

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -9831,10 +9831,20 @@ test("opening a long conversation lands at the latest message and stays stable o
 
   const readingPosition = await scroller.evaluate((element) => element.scrollTop);
   // Unfollow flips overflow-anchor back to auto, but Chromium only picks a
-  // scroll anchor at layout time. Wait for a frame so the anchor is armed —
-  // otherwise a same-frame prepend is never compensated (#663).
+  // scroll anchor at layout time. Waiting frames alone is not enough: if no
+  // layout ran in between, the prepend below is never compensated (#663).
+  // Dirty layout with a zero-height node and force a reflow so the anchor is
+  // deterministically armed before the real prepend.
   await page.evaluate(
-    () => new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve))),
+    () => new Promise((resolve) => {
+      const thread = document.getElementById("chat-thread");
+      const probe = document.createElement("div");
+      probe.style.height = "0px";
+      probe.style.flex = "0 0 0px";
+      thread?.prepend(probe);
+      void (thread as HTMLElement | null)?.offsetHeight;
+      requestAnimationFrame(() => requestAnimationFrame(resolve));
+    }),
   );
   await page.evaluate(() => {
     const thread = document.getElementById("chat-thread");

--- a/ui-tests/tests/visual-polish.spec.ts
+++ b/ui-tests/tests/visual-polish.spec.ts
@@ -85,7 +85,10 @@ test("composer resize target stays functional without drawing a horizontal line"
   expect(box).not.toBeNull();
   await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
   await page.mouse.down();
-  await page.mouse.move(box!.x + box!.width / 2, box!.y - 40);
+  // mousedown reactively mounts the drag overlay that captures the following
+  // move/up events; wait for it so a slow render cannot swallow the drag.
+  await expect(page.locator(".drag-overlay")).toHaveCount(1);
+  await page.mouse.move(box!.x + box!.width / 2, box!.y - 40, { steps: 4 });
   await page.mouse.up();
 
   await expect.poll(() => input.evaluate((el) => parseFloat(getComputedStyle(el).height))).toBeGreaterThan(220);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #884.

Part of #884 (item: `write` 跟随悬空符号链接逃出沙箱, P0). 这是 #884 十二项中最后一个未合并的修复；其余处理见文末的跟踪清单。

## Problem

`validate_file_path` rejects symlinks it can resolve, but a project-local symlink pointing to a **nonexistent** target outside the project root fails `canonicalize` and falls into the parent+file fallback, which passes the root check. `std::fs::write` then follows the link and creates the target outside the sandbox. Even with a pre-check, a plain `fs::write` after validation leaves a check-to-write (TOCTOU) window in which the validated path can be swapped for a link.

## Fix

- `validate_file_path` now rejects any final component that is a symlink whose target cannot be resolved (dangling link), instead of using the parent+file fallback.
- New `safety::write_no_follow`: the `write` and `edit` tools no longer use following `std::fs::write`. On Unix the file is opened with `O_NOFOLLOW` (symlink final component fails atomically). On Windows the file is opened with `FILE_FLAG_OPEN_REPARSE_POINT` and the reparse-point attribute is checked **on the handle**, so both symlinks and junctions are refused race-free.
- In-root symlinks that resolve normally keep working: validation resolves them first and the no-follow open targets the resolved real file.

## Tests

- `dangling_symlink_is_rejected_instead_of_using_the_parent_fallback` (outbound and in-root dangling links).
- `write_no_follow_refuses_symlinks_but_overwrites_regular_files` (refusal, no target creation, truncating overwrite, new-file create).
- End-to-end `write_through_a_dangling_outbound_symlink_is_blocked` in the write tool (fails, no escape file, no FileChanged event).
- Existing resolved-symlink rejection and sandbox boundary tests unchanged and passing.

Unix symlink tests are `#[cfg(unix)]`; the Windows reparse-point code path was compile-verified against `x86_64-pc-windows-msvc`.

## CI note

The first `ui-e2e` run failed on `visual-polish.spec.ts › composer resize target stays functional…`, unrelated to this Rust-only change (the same job passed on three sibling branches). Root cause: the test's synthetic mousedown/move/up can outrun the reactive mount of the drag overlay that captures move/up. This branch includes a small test-only deflake commit (wait for `.drag-overlay`, stepped move) and a merge of current `main`.

## #884 跟踪清单

已修复：
- 本 PR — `write` 悬空符号链接越界（P0）
- #972 — 模型切换确认框 Escape 栈（已合并）
- #973 — `replace_messages` 单事务（已合并；undo 稳定锚定余项并入 #978）
- #974 — SSH launch 模糊超时重读 `_submitted`（已合并）

其余 8 项已拆分为独立 issue：#976（飞书鉴权，P0）、#977（MCP 秘密入 SQLite）、#978（last_seq/persist/undo 重映射）、#979（stuck/Stop 未配对 tool_calls）、#980（branch merge workflow lock）、#981（项目删除遗漏表 + 孤儿 schedule）、#982（`.wisp/session.json` 回退）、#983（SSH harvest lease/master）。

## Limitations / follow-ups

- Parent-directory components are still resolved (and trusted) at validation time only; the no-follow guarantee covers the final component, which is the deterministic escape reported in #884.
- Other writers (e.g. runtime/artifact paths outside wisp-tools) are unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-517db46d-6e30-4871-bcd5-d1d1a6fb4e4c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-517db46d-6e30-4871-bcd5-d1d1a6fb4e4c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

