### PR TITLE
fix(ui): put the model switch confirm on the window Escape stack

### DIFF
--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -934,6 +934,35 @@ test("switching HTTP models confirms cache invalidation", async ({ page }) => {
   await expect(page.locator(".model-picker-label")).toHaveText("opus-4.8");
 });
 
+test("model switch confirm consumes Escape before the right pane", async ({ page }) => {
+  await enterApp(page);
+  await composer(page).fill("bind this conversation model");
+  await page.getByRole("button", { name: "Send" }).click();
+  await expect(page.getByText("Hello from mock wisp-science.")).toBeVisible();
+  await page.getByRole("button", { name: "Toggle panel" }).click();
+  await expect(page.locator(".rightpane")).toBeVisible();
+
+  await page.locator(".model-picker-btn").click();
+  const opusOption = page.getByRole("button", { name: /opus-4\.8/ });
+  await expect(opusOption).toBeVisible();
+  await opusOption.evaluate((element: HTMLElement) => element.click());
+  const modal = page.getByTestId("model-switch-confirm");
+  await expect(modal).toBeVisible();
+
+  // Root-owned confirm participates in the window Escape stack without focus:
+  // one press cancels only the switch, leaving the right pane open and the
+  // session model untouched.
+  await page.keyboard.press("Escape");
+  await expect(modal).toHaveCount(0);
+  await expect(page.locator(".rightpane")).toBeVisible();
+  await expect.poll(() => lastInvokeArgs(page, "set_active_model")).toBeNull();
+  await expect(page.locator(".model-picker-label")).toHaveText("deepseek-v4-pro");
+
+  // The next press reaches the parent layer.
+  await page.keyboard.press("Escape");
+  await expect(page.locator(".rightpane")).toBeHidden();
+});
+
 test("switching to a text-only model confirms historical images will be ignored", async ({ page }) => {
   await enterApp(page, "/?mockTextOnlyModel=1");
 

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -7891,6 +7891,13 @@ fn App() -> impl IntoView {
             }
             return;
         }
+        // The model switch confirm renders above the export/link/memory
+        // dialogs and everything below; Escape cancels the switch only.
+        if model_switch_confirm.get().is_some() {
+            ev.prevent_default();
+            model_switch_confirm.set(None);
+            return;
+        }
         if project_export_prompt.get().is_some() {
             ev.prevent_default();
             project_export_prompt.set(None);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Part of #884 (item: 模型切换确认框不在 window-level Escape 栈上, P2).

## Problem

`ModelSwitchConfirmOverlay` was rendered but never participated in the root window-level Escape stack. Pressing Escape immediately after the confirm opened fell through to lower layers — closing the right pane or rejecting a pending approval — while the confirm dialog stayed open.

## Fix

Added a `model_switch_confirm` branch to the root Escape handler in `ui/src/main.rs`, placed directly below `context_recovery_dialog` and above `project_export_prompt`, matching the overlay's DOM/visual stacking order. One press cancels only the model switch; nothing else changes.

## Tests

New Playwright test `model switch confirm consumes Escape before the right pane`: opens the right pane, raises the confirm from the model picker, presses Escape immediately **without moving focus into the dialog**, and asserts the confirm closes while the right pane stays open, the session model is unchanged, and `set_active_model` was never invoked; a second press then closes the right pane. Verified the test fails without the fix and passes with it.

- `cd ui && cargo check --target wasm32-unknown-unknown`: clean.
- `npx playwright test -g "model switch confirm consumes Escape"`: passing.

## Manual smoke

Open a non-empty conversation, toggle the right panel, pick a different model so the switch confirmation appears, press Escape once: only the confirmation closes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-517db46d-6e30-4871-bcd5-d1d1a6fb4e4c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-517db46d-6e30-4871-bcd5-d1d1a6fb4e4c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

