### PR TITLE
fix(store): make replace_messages a single write transaction

### DIFF
--- a/crates/wisp-store/src/sessions.rs
+++ b/crates/wisp-store/src/sessions.rs
@@ -810,52 +810,20 @@ impl Store {
     }
 
     pub async fn append_message(&self, frame_id: &str, seq: i64, msg: &Message) -> Result<()> {
-        let id = uuid::Uuid::new_v4().to_string();
-        let role = if msg.role == wisp_llm::Role::User
-            && msg.tool_name.as_deref() == Some(super::AGENT_WORKFLOW_COMPLETION_TOOL)
-        {
-            "internal".into()
-        } else {
-            format!("{:?}", msg.role).to_ascii_lowercase()
-        };
-        let content = serde_json::to_string(&msg.content)?;
-        let tool_calls = if msg.tool_calls.is_empty() {
-            None
-        } else {
-            Some(serde_json::to_string(&msg.tool_calls)?)
-        };
-        sqlx::query("INSERT INTO messages(id,frame_id,seq,role,content,tool_calls,tool_call_id,tool_name,reasoning,ts,model_name) VALUES(?,?,?,?,?,?,?,?,?,?,?)")
-            .bind(id).bind(frame_id).bind(seq).bind(role).bind(content)
-            .bind(tool_calls)
-            .bind(msg.tool_call_id.as_deref())
-            .bind(msg.tool_name.as_deref())
-            .bind(msg.reasoning.as_deref())
-            .bind(msg.ts)
-            .bind(msg.model_name.as_deref())
-            .execute(&self.pool).await?;
-        Ok(())
+        insert_message_row(&self.pool, frame_id, seq, msg).await
     }
 
-    /// Replace a frame's model context wholesale (user-triggered /compact).
-    /// Only the `messages` rows are rewritten — the session_ui_events visual
-    /// transcript keeps the full history on purpose. Resource links anchor to
-    /// message seqs, which a rewrite invalidates, so they are dropped too.
+    /// Replace a frame's model context wholesale (user-triggered /compact and
+    /// automatic compaction). Only the `messages` rows are rewritten — the
+    /// session_ui_events visual transcript keeps the full history on purpose.
+    /// Resource links and turn undo anchor to message seqs, which a rewrite
+    /// invalidates, so they are dropped too. Deletes and inserts share one
+    /// write transaction: an interruption mid-replace leaves the previous
+    /// transcript fully intact instead of an emptied or half-written frame.
     pub async fn replace_messages(&self, frame_id: &str, msgs: &[Message]) -> Result<()> {
-        sqlx::query("DELETE FROM message_resource_links WHERE frame_id=?")
-            .bind(frame_id)
-            .execute(&self.pool)
-            .await?;
-        sqlx::query("DELETE FROM turn_file_undo WHERE frame_id=?")
-            .bind(frame_id)
-            .execute(&self.pool)
-            .await?;
-        sqlx::query("DELETE FROM messages WHERE frame_id=?")
-            .bind(frame_id)
-            .execute(&self.pool)
-            .await?;
-        for (i, msg) in msgs.iter().enumerate() {
-            self.append_message(frame_id, (i + 1) as i64, msg).await?;
-        }
+        let mut tx = self.begin_write().await?;
+        replace_message_rows(&mut tx, frame_id, msgs).await?;
+        tx.commit().await?;
         Ok(())
     }
 
@@ -932,6 +900,73 @@ impl Store {
     ) -> Result<()> {
         truncate_message_rows(tx, frame_id, keep).await
     }
+
+    #[cfg(test)]
+    pub(crate) async fn replace_message_rows_for_test(
+        tx: &mut Transaction<'_, Sqlite>,
+        frame_id: &str,
+        msgs: &[Message],
+    ) -> Result<()> {
+        replace_message_rows(tx, frame_id, msgs).await
+    }
+}
+
+async fn insert_message_row<'e, E>(
+    executor: E,
+    frame_id: &str,
+    seq: i64,
+    msg: &Message,
+) -> Result<()>
+where
+    E: sqlx::Executor<'e, Database = Sqlite>,
+{
+    let id = uuid::Uuid::new_v4().to_string();
+    let role = if msg.role == wisp_llm::Role::User
+        && msg.tool_name.as_deref() == Some(super::AGENT_WORKFLOW_COMPLETION_TOOL)
+    {
+        "internal".into()
+    } else {
+        format!("{:?}", msg.role).to_ascii_lowercase()
+    };
+    let content = serde_json::to_string(&msg.content)?;
+    let tool_calls = if msg.tool_calls.is_empty() {
+        None
+    } else {
+        Some(serde_json::to_string(&msg.tool_calls)?)
+    };
+    sqlx::query("INSERT INTO messages(id,frame_id,seq,role,content,tool_calls,tool_call_id,tool_name,reasoning,ts,model_name) VALUES(?,?,?,?,?,?,?,?,?,?,?)")
+        .bind(id).bind(frame_id).bind(seq).bind(role).bind(content)
+        .bind(tool_calls)
+        .bind(msg.tool_call_id.as_deref())
+        .bind(msg.tool_name.as_deref())
+        .bind(msg.reasoning.as_deref())
+        .bind(msg.ts)
+        .bind(msg.model_name.as_deref())
+        .execute(executor).await?;
+    Ok(())
+}
+
+async fn replace_message_rows(
+    tx: &mut Transaction<'_, Sqlite>,
+    frame_id: &str,
+    msgs: &[Message],
+) -> Result<()> {
+    sqlx::query("DELETE FROM message_resource_links WHERE frame_id=?")
+        .bind(frame_id)
+        .execute(&mut **tx)
+        .await?;
+    sqlx::query("DELETE FROM turn_file_undo WHERE frame_id=?")
+        .bind(frame_id)
+        .execute(&mut **tx)
+        .await?;
+    sqlx::query("DELETE FROM messages WHERE frame_id=?")
+        .bind(frame_id)
+        .execute(&mut **tx)
+        .await?;
+    for (i, msg) in msgs.iter().enumerate() {
+        insert_message_row(&mut **tx, frame_id, (i + 1) as i64, msg).await?;
+    }
+    Ok(())
 }
 
 /// Reconcile branch provenance before removing a mainline suffix.

--- a/crates/wisp-store/src/store_tests.rs
+++ b/crates/wisp-store/src/store_tests.rs
@@ -2900,6 +2900,102 @@ async fn session_ui_events_created_at_backfill_is_idempotent() {
 }
 
 #[tokio::test]
+async fn interrupted_replace_keeps_the_previous_transcript_and_seq_anchored_rows() {
+    let tmp = std::env::temp_dir().join(format!(
+        "wisp_replace_atomic_{}.sqlite",
+        uuid::Uuid::new_v4()
+    ));
+    let store = Store::open(&tmp).await.unwrap();
+    store.create_project("p", "P", "").await.unwrap();
+    store.create_frame("f", "p", "OPERON", "m").await.unwrap();
+    store
+        .append_message("f", 1, &Message::user("keep me"))
+        .await
+        .unwrap();
+    store
+        .append_message("f", 2, &Message::assistant("kept answer"))
+        .await
+        .unwrap();
+    store
+        .save_turn_file_undo(
+            "f",
+            1,
+            "src/main.rs",
+            true,
+            None,
+            Some("before"),
+            Some("after"),
+            true,
+            None,
+        )
+        .await
+        .unwrap();
+    sqlx::query(
+        "INSERT INTO message_resource_links(\
+         id,frame_id,message_seq,ordinal,original_reference,display_name,\
+         resource_kind,mime_type,status,created_at) \
+         VALUES('l1','f',1,0,'@r.csv','r.csv','file','text/csv','linked',1)",
+    )
+    .execute(&store.pool)
+    .await
+    .unwrap();
+
+    // Simulate a crash mid-replace: the deletes and half the inserts ran, but
+    // the transaction is dropped without commit.
+    {
+        let mut tx = store.begin_write().await.unwrap();
+        Store::replace_message_rows_for_test(
+            &mut tx,
+            "f",
+            &[Message::system("half-written checkpoint")],
+        )
+        .await
+        .unwrap();
+    }
+
+    let msgs = store.load_messages("f").await.unwrap();
+    assert_eq!(msgs.len(), 2, "old transcript must survive an interruption");
+    assert_eq!(msgs[0].content.as_text(), "keep me");
+    assert_eq!(msgs[1].content.as_text(), "kept answer");
+    assert_eq!(
+        store.list_turn_file_undo("f", 1).await.unwrap().len(),
+        1,
+        "undo rows must survive an interrupted replace"
+    );
+    assert_eq!(
+        store
+            .list_message_resource_links("f", 1, None)
+            .await
+            .unwrap()
+            .len(),
+        1,
+        "resource links must survive an interrupted replace"
+    );
+
+    // A committed replace applies wholesale and drops the seq-anchored rows,
+    // whose anchors the renumbering invalidated.
+    store
+        .replace_messages(
+            "f",
+            &[Message::system("checkpoint"), Message::user("recent tail")],
+        )
+        .await
+        .unwrap();
+    let msgs = store.load_messages("f").await.unwrap();
+    assert_eq!(msgs.len(), 2);
+    assert_eq!(msgs[0].content.as_text(), "checkpoint");
+    assert_eq!(msgs[1].content.as_text(), "recent tail");
+    assert!(store.list_turn_file_undo("f", 1).await.unwrap().is_empty());
+    assert!(store
+        .list_message_resource_links("f", 1, None)
+        .await
+        .unwrap()
+        .is_empty());
+    store.pool.close().await;
+    let _ = std::fs::remove_file(&tmp);
+}
+
+#[tokio::test]
 async fn side_chat_snapshot_survives_compaction_and_stops_at_completed_boundary() {
     let tmp = std::env::temp_dir().join(format!(
         "wisp_side_snapshot_{}.sqlite",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Part of #884 (item: `replace_messages` 非事务整表重写, P1 数据完整性).

## Problem

`Store::replace_messages` (used by `/compact`, automatic compaction, interrupt-replace, and exploration clones) ran three bare `DELETE`s (`message_resource_links`, `turn_file_undo`, `messages`) followed by row-by-row `INSERT`s directly on the pool. Any failure or crash mid-replace left the frame emptied or half-written, with the undo rows and resource links already gone — unrecoverable transcript loss.

## Fix

- The deletes and inserts now run inside one `BEGIN IMMEDIATE` write transaction (`replace_message_rows`), matching the existing `truncate_messages` style. An interruption rolls back to the previous transcript, undo rows, and resource links.
- The message INSERT is factored into `insert_message_row`, generic over the executor, so `append_message` and the transactional path share one statement.
- No signature or caller changes.

## Tests

New `interrupted_replace_keeps_the_previous_transcript_and_seq_anchored_rows`: seeds messages + a `turn_file_undo` row + a `message_resource_links` row, runs the replace inside a transaction that is dropped **without commit** (simulated crash), and asserts the old transcript, undo, and links are fully intact; then asserts a committed replace applies wholesale and drops the seq-anchored rows. Full `wisp-store` suite: 136 passed.

## Known limitations / follow-ups

- Undo rows are still dropped on a committed compaction because they anchor to `user_message_seq`, which the rewrite renumbers. Remapping undo across compaction (or re-keying undo to stable turn IDs) is the larger follow-up called out in #884's acceptance criteria; this PR fixes the atomicity/durability half.
- The persist-worker seq handling (also in #884) is a separate item and untouched here.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-517db46d-6e30-4871-bcd5-d1d1a6fb4e4c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-517db46d-6e30-4871-bcd5-d1d1a6fb4e4c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

