### PR TITLE
fix(run): reattach SSH Runs after an ambiguous launch failure

### DIFF
--- a/src-tauri/src/run_context/remote.rs
+++ b/src-tauri/src/run_context/remote.rs
@@ -672,18 +672,22 @@ pub(super) async fn ensure_remote_started(
             }
             match launch_remote(runner, &remote.handle).await {
                 Ok(handle) => Ok(handle),
-                Err(launch_error) if remote.handle.is_local_detached() => {
-                    // The Windows launch host can time out after its detached
-                    // supervisor has already acknowledged the command. Re-read
-                    // the idempotent control directory before declaring the Run
-                    // failed; this observes an existing handle but never starts
-                    // the command a second time.
+                Err(launch_error) => {
+                    // The launch RPC can fail after the remote supervisor has
+                    // already acknowledged the command: the Windows launch
+                    // host can time out on its detached supervisor, and an
+                    // SSH response can be lost to a transport timeout or
+                    // disconnect after `_submitted` was written. Re-read the
+                    // idempotent control directory before declaring the Run
+                    // failed; this observes an existing handle but never
+                    // starts the command a second time. A genuine remote
+                    // script failure leaves no `_submitted`, so the original
+                    // launch error still surfaces.
                     match prepare_remote(runner, remote).await {
                         Ok(PrepareRemote::Existing(handle)) => Ok(handle),
                         _ => Err(launch_error),
                     }
                 }
-                Err(error) => Err(error),
             }
         }
     }

--- a/src-tauri/src/run_context/tests.rs
+++ b/src-tauri/src/run_context/tests.rs
@@ -1038,6 +1038,9 @@ async fn ssh_launch_failure_stops_after_the_first_attempt() {
         ok_output("__WISP_PREPARED__\n"),
         ok_output(""),
         Err("temporary SSH disconnect".into()),
+        // Post-failure reattach probe: nothing was submitted remotely, so the
+        // original launch error must surface and the Run must fail.
+        ok_output("__WISP_PREPARED__\n"),
     ]));
     runner
         .synthesize_launch_ack
@@ -1086,7 +1089,16 @@ async fn ssh_launch_failure_stops_after_the_first_attempt() {
             .iter()
             .filter(|command| command.script == "launch SSH Run")
             .count(),
-        1
+        1,
+        "the reattach probe must never resend the launch"
+    );
+    assert_eq!(
+        commands
+            .iter()
+            .filter(|command| command.script == "prepare SSH Run")
+            .count(),
+        2,
+        "one prepare before launch, one reattach probe after the failure"
     );
     let _ = std::fs::remove_dir_all(&tmp);
 }
@@ -1146,6 +1158,65 @@ async fn local_launch_timeout_reattaches_when_supervisor_acknowledged() {
     let commands = runner.commands.lock().unwrap();
     assert_eq!(commands.len(), 3);
     assert!(commands[2].script.starts_with("prepare local Run"));
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[tokio::test]
+async fn ssh_launch_timeout_reattaches_when_supervisor_acknowledged() {
+    let tmp =
+        std::env::temp_dir().join(format!("wisp_ssh_launch_reattach_{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&tmp).unwrap();
+    let store = wisp_store::Store::open(&tmp.join("wisp.sqlite"))
+        .await
+        .unwrap();
+    store
+        .create_project("p", "proj", &tmp.to_string_lossy())
+        .await
+        .unwrap();
+
+    let handle = test_handle("ssh-run", false);
+    let mut run = wisp_store::RunRecord::new("ssh-run", "p", "ssh:gpu", "Remote", "ssh_direct");
+    run.command = Some("long-analysis".into());
+    run.timeout_secs = Some(60);
+    run.remote_handle_json = Some(serde_json::to_string(&handle).unwrap());
+    store.create_run(&run).await.unwrap();
+    assert!(store
+        .activate_run_lifecycle("ssh-run", wisp_store::RunStatus::Submitted, "owner", 360)
+        .await
+        .unwrap());
+
+    // The remote supervisor wrote `_submitted`, but the launch RPC response
+    // was lost to a transport timeout. The reattach probe must observe the
+    // existing handle instead of failing the Run.
+    let runner = ScriptedRunRunner::new(vec![
+        ok_output("__WISP_PREPARED__\n"),
+        Err("launch SSH Run timed out after 20s".into()),
+        ok_output("__WISP_HANDLE__:test-token:4242:999\n"),
+    ]);
+    let mut remote = RemoteRun {
+        run_id: "ssh-run".into(),
+        project_id: "p".into(),
+        frame_id: None,
+        command: "long-analysis".into(),
+        timeout: Duration::from_secs(60),
+        input_refs: Vec::new(),
+        output_specs: Vec::new(),
+        harvest_root: Some(tmp.clone()),
+        handle,
+    };
+
+    let confirmed = ensure_remote_started(&store, "owner", &runner, &mut remote)
+        .await
+        .unwrap();
+
+    assert!(confirmed.is_confirmed());
+    let commands = runner.commands.lock().unwrap();
+    assert_eq!(commands.len(), 3);
+    assert_eq!(commands[1].script, "launch SSH Run");
+    assert_eq!(
+        commands[2].script, "prepare SSH Run",
+        "the probe re-reads the control directory and never relaunches"
+    );
     let _ = std::fs::remove_dir_all(&tmp);
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Part of #884 (item: SSH launch 发生模糊超时时不会重新读取 `_submitted`, P1 运行时完整性).

## Problem

In `ensure_remote_started`, only `local_detached` Runs re-ran `prepare_remote` after a launch failure. For SSH-direct Runs, a transport timeout or disconnect **after** the remote supervisor had already `nohup`'d the command and written `_submitted` marked the Run failed locally and stopped polling — orphaning the still-running remote job.

## Fix

The post-failure `prepare_remote` probe now applies to all remote handles. The prepare payload is idempotent: when `_submitted` exists it returns the existing handle (`PrepareRemote::Existing`), which is accepted and polling continues; it never resends the launch. When the remote script genuinely failed, no `_submitted` exists, the probe returns `Prepared` (or errors), and the original launch error still surfaces, so definite failures keep failing.

## Tests

- New `ssh_launch_timeout_reattaches_when_supervisor_acknowledged`: prepare → launch transport timeout → probe returns the handle ack → the Run is confirmed; asserts the probe is a `prepare SSH Run` and launch is sent exactly once.
- Updated `ssh_launch_failure_stops_after_the_first_attempt`: the probe now returns `__WISP_PREPARED__` (nothing submitted remotely) and the test asserts the Run still fails with the original error, launch count stays 1, and exactly one reattach probe was sent.
- `cargo test -p wisp-tauri run_context`: 114 passed.

## Limitations / follow-ups

- The probe fires on every SSH launch failure (one extra idempotent RPC even for definite script failures) rather than classifying error strings; this is the same policy the local-detached path already used and avoids fragile error-message matching.
- The harvest lease/SSH-master items from #884 are separate and untouched here.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-517db46d-6e30-4871-bcd5-d1d1a6fb4e4c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-517db46d-6e30-4871-bcd5-d1d1a6fb4e4c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

