### PR TITLE
fix: collapse cumulative OpenAI-compatible SSE snapshots (#985)

### DIFF
--- a/crates/wisp-llm/src/openai.rs
+++ b/crates/wisp-llm/src/openai.rs
@@ -411,6 +411,34 @@ fn in_band_stream_error(val: &Value) -> Option<LlmError> {
     })
 }
 
+/// Merge one SSE `content` / `reasoning_content` value into the assembled
+/// string. Compatible relays disagree on whether the field is a fragment or
+/// the full snapshot so far; treating snapshots as fragments is O(n²) in both
+/// the assembled text and every live UI event (#985).
+///
+/// Returns the byte offset of the newly appended suffix, or `None` when the
+/// chunk is empty or a duplicate snapshot.
+fn apply_stream_delta(acc: &mut String, incoming: &str) -> Option<usize> {
+    if incoming.is_empty() || incoming == acc.as_str() {
+        return None;
+    }
+    if incoming.starts_with(acc.as_str()) {
+        let start = acc.len();
+        acc.push_str(&incoming[start..]);
+        return (start < acc.len()).then_some(start);
+    }
+    let start = acc.len();
+    acc.push_str(incoming);
+    Some(start)
+}
+
+fn stream_reasoning_delta(delta: &Value) -> Option<&str> {
+    delta
+        .get("reasoning_content")
+        .and_then(|v| v.as_str())
+        .or_else(|| delta.get("reasoning").and_then(|v| v.as_str()))
+}
+
 fn append_stream_content_delta(
     delta: &Value,
     content: &mut String,
@@ -420,22 +448,18 @@ fn append_stream_content_delta(
     // Some compatible endpoints (notably Alibaba/DashScope thinking streams)
     // include `content: ""` beside every non-empty `reasoning_content` delta.
     // Emitting that empty text event breaks an otherwise contiguous reasoning
-    // run into one UI disclosure per token fragment.
-    if let Some(t) = delta
-        .get("content")
-        .and_then(|v| v.as_str())
-        .filter(|t| !t.is_empty())
-    {
-        content.push_str(t);
-        sink.on_text(t);
+    // run into one UI disclosure per token fragment. `apply_stream_delta`
+    // already drops empty strings; keep using it so a snapshot replay of the
+    // same text also stays silent.
+    if let Some(t) = delta.get("content").and_then(|v| v.as_str()) {
+        if let Some(start) = apply_stream_delta(content, t) {
+            sink.on_text(&content[start..]);
+        }
     }
-    if let Some(r) = delta
-        .get("reasoning_content")
-        .and_then(|v| v.as_str())
-        .filter(|r| !r.is_empty())
-    {
-        reasoning.push_str(r);
-        sink.on_reasoning(r);
+    if let Some(r) = stream_reasoning_delta(delta) {
+        if let Some(start) = apply_stream_delta(reasoning, r) {
+            sink.on_reasoning(&reasoning[start..]);
+        }
     }
 }
 
@@ -878,6 +902,85 @@ mod tests {
         assert_eq!(reasoning, "column in test fixtures");
         assert_eq!(sink.text, ["Fixed."]);
         assert_eq!(sink.reasoning, ["column in", " test fixtures"]);
+    }
+
+    #[test]
+    fn apply_stream_delta_keeps_true_fragments() {
+        let mut acc = String::new();
+        assert_eq!(apply_stream_delta(&mut acc, "Hel"), Some(0));
+        assert_eq!(apply_stream_delta(&mut acc, "lo"), Some(3));
+        assert_eq!(apply_stream_delta(&mut acc, " world"), Some(5));
+        assert_eq!(acc, "Hello world");
+    }
+
+    #[test]
+    fn apply_stream_delta_collapses_growing_snapshots() {
+        let mut acc = String::new();
+        let mut emitted = String::new();
+        for snap in ["H", "He", "Hel", "Hell", "Hello", "Hello", "Hello!"] {
+            if let Some(start) = apply_stream_delta(&mut acc, snap) {
+                emitted.push_str(&acc[start..]);
+            }
+        }
+        assert_eq!(acc, "Hello!");
+        assert_eq!(emitted, "Hello!");
+    }
+
+    #[test]
+    fn apply_stream_delta_snapshot_replay_is_linear() {
+        let mut acc = String::new();
+        let mut emitted = 0usize;
+        for n in 1..=256 {
+            let snap = "x".repeat(n);
+            if let Some(start) = apply_stream_delta(&mut acc, &snap) {
+                emitted += acc.len() - start;
+            }
+        }
+        assert_eq!(acc.len(), 256);
+        assert_eq!(emitted, 256);
+    }
+
+    #[test]
+    fn append_stream_collapses_cumulative_content_and_reasoning() {
+        let mut content = String::new();
+        let mut reasoning = String::new();
+        let mut sink = RecordingSink::default();
+
+        for delta in [
+            json!({"content": "", "reasoning_content": "think"}),
+            json!({"content": "", "reasoning_content": "think more"}),
+            json!({"content": "Hi", "reasoning_content": "think more"}),
+            json!({"content": "Hi there", "reasoning_content": "think more"}),
+            json!({"content": "Hi there", "reasoning_content": "think more", "reasoning": "ignored"}),
+        ] {
+            append_stream_content_delta(&delta, &mut content, &mut reasoning, &mut sink);
+        }
+
+        assert_eq!(content, "Hi there");
+        assert_eq!(reasoning, "think more");
+        assert_eq!(sink.text, ["Hi", " there"]);
+        assert_eq!(sink.reasoning, ["think", " more"]);
+    }
+
+    #[test]
+    fn append_stream_accepts_qwen_reasoning_field() {
+        let mut content = String::new();
+        let mut reasoning = String::new();
+        let mut sink = RecordingSink::default();
+        append_stream_content_delta(
+            &json!({"reasoning": "step"}),
+            &mut content,
+            &mut reasoning,
+            &mut sink,
+        );
+        append_stream_content_delta(
+            &json!({"reasoning": "step 2"}),
+            &mut content,
+            &mut reasoning,
+            &mut sink,
+        );
+        assert_eq!(reasoning, "step 2");
+        assert_eq!(sink.reasoning, ["step", " 2"]);
     }
 
     #[test]

--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -163,7 +163,10 @@ entry selects the Anthropic protocol and sets its endpoint suffix to
 OpenAI-compatible reasoning streams are normalized into one reasoning channel.
 Empty `content` placeholders sent alongside Alibaba/DashScope
 `reasoning_content` chunks are ignored, so a continuous thought process remains
-one disclosure in the conversation.
+one disclosure in the conversation. If a compatible relay resends the full
+`content` or `reasoning_content` snapshot on every SSE chunk instead of a
+fragment, Wisp keeps only the new suffix so the assembled reply and live UI
+events stay linear.
 
 If a provider ends a turn after returning only reasoning tokens—without visible
 text or a tool call—Wisp reports a resumable error instead of showing the turn


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## User-facing problem

[#985](https://github.com/xuzhougeng/wisp-science/issues/985) reports `wisp-tauri` private memory growing ~1.2 GB/min during ordinary multi-turn chat on Windows (1.3 and 1.6, GLM and OpenAI via a custom OpenAI-compatible relay). Thread and handle counts stay flat, so this is data retention, not a handle leak.

The highest-probability cause is a compatible relay that resends the **full** `delta.content` / `delta.reasoning_content` so far on every SSE chunk. The stream parser treated every value as a fragment (`push_str` + live `on_text` / `on_reasoning`), which is O(n²) in assembled text and every cloned persist/live UI event.

This PR does **not** claim to close #985. It only removes that quadratic path. Unbounded live `AgentEvent` queues and uncapped Text/Reasoning fan-out remain follow-ups if memory still climbs against a true incremental stream.

## What changed

- `apply_stream_delta` in `crates/wisp-llm/src/openai.rs`: empty or exact-snapshot replay is ignored; a value that extends the assembled prefix emits only the new suffix; anything else stays a true fragment.
- Stream reasoning also accepts Qwen-style `delta.reasoning` when `reasoning_content` is absent.
- `docs/model-configuration.md` notes the snapshot-collapse behavior.

## Tests

Local:

- `cargo fmt --all -- --check`
- `cargo test -p wisp-llm` — 56 passed (includes the new snapshot/fragment tests)

`cargo test --workspace` cannot compile `wisp-tauri` in this environment (`gdk-3.0` missing). That crate was not changed.

## Manual smoke

1. Point an OpenAI-compatible profile at the same custom relay used in #985 (GLM thinking model).
2. Run a multi-turn session with reasoning + a few shell tools.
3. Sample `wisp-tauri` `PrivateMemorySize64` every 30s. Growth should stay in the tens-to-hundreds of MB, not ≥1 GB/min.
4. Confirm the visible reply/reasoning is not stuttering or repeating the full prefix each token.

## Known limitations / follow-up

- Heuristic can drop a true incremental token that is an exact replay of the text so far (e.g. `"ha"` + `"ha"`). Growing-prefix snapshots cannot be distinguished from that case.
- Does not bound live `AgentEvent` channels, persist Text/Reasoning volume, or kernel stdout.
- Does not change Anthropic / Responses stream parsers.
- Does not auto-close #985; confirm on the reporter's relay before closing.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe6090b2-1baa-4b2e-ae5a-30f1403f1b19?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe6090b2-1baa-4b2e-ae5a-30f1403f1b19&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

