### PR TITLE
fix: desktop turns fail closed instead of loading session.json (#982)

### DIFF
--- a/crates/wisp-core/src/lib.rs
+++ b/crates/wisp-core/src/lib.rs
@@ -96,6 +96,36 @@ impl Agent {
         memory_enabled: bool,
         vision_cfg: Option<ProviderConfig>,
     ) -> Self {
+        let mut agent = Self::new_without_session_file(
+            cfg,
+            skills,
+            memory,
+            root,
+            max_context,
+            max_iter,
+            memory_enabled,
+            vision_cfg,
+        );
+        agent.ctx.load(&agent.session_path);
+        agent
+    }
+
+    /// Desktop constructor: empty context, no `.wisp/session.json` load.
+    ///
+    /// CLI/headless should keep using [`Self::new`], which still hydrates the
+    /// project-level session file. Desktop turns load SQLite history afterward
+    /// and must fail closed if that load fails — leftover CLI or other-session
+    /// messages in the project file must never enter the model context.
+    pub fn new_without_session_file(
+        cfg: ProviderConfig,
+        skills: Arc<SkillIndex>,
+        memory: Arc<MemoryManager>,
+        root: PathBuf,
+        max_context: usize,
+        max_iter: usize,
+        memory_enabled: bool,
+        vision_cfg: Option<ProviderConfig>,
+    ) -> Self {
         let provider = wisp_llm::build(cfg.clone());
         let vision_provider = vision_cfg.map(wisp_llm::build);
         let mut tools = build_registry(skills, memory, memory_enabled);
@@ -107,13 +137,11 @@ impl Agent {
             max_context,
         )));
         let session_path = root.join(".wisp").join("session.json");
-        let mut ctx = ContextManager::new(max_context);
-        ctx.load(&session_path);
         Self {
             provider,
             vision_provider,
             tools,
-            ctx,
+            ctx: ContextManager::new(max_context),
             root,
             max_iter,
             session_path,
@@ -293,6 +321,17 @@ impl Agent {
     }
 }
 
+/// Map a desktop SQLite `load_messages` result into a fail-closed turn error.
+///
+/// Desktop agents are constructed with [`Agent::new_without_session_file`], so
+/// a leftover `.wisp/session.json` is never in context. Callers must not fall
+/// back to that file when this returns `Err`.
+pub fn require_sqlite_session_messages<E: std::fmt::Display>(
+    loaded: Result<Vec<wisp_llm::Message>, E>,
+) -> Result<Vec<wisp_llm::Message>, String> {
+    loaded.map_err(|error| format!("Failed to load session messages from SQLite: {error}"))
+}
+
 // --- memory tools ---
 
 pub struct SearchMemoryTool {
@@ -383,5 +422,97 @@ mod memory_tool_tests {
             "queries": [{ "text": "cohort", "kind": "exact", "extra": true }]
         }))
         .is_err());
+    }
+}
+
+#[cfg(test)]
+mod session_ctor_tests {
+    use super::*;
+    use wisp_llm::ProviderConfig;
+
+    fn leftover_root(label: &str) -> PathBuf {
+        let root = std::env::temp_dir().join(format!(
+            "wisp-session-ctor-{label}-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(root.join(".wisp")).unwrap();
+        root
+    }
+
+    fn leftover_cfg() -> ProviderConfig {
+        ProviderConfig::openai("http://127.0.0.1:9/v1", "sk-test", "test-model")
+    }
+
+    fn write_leftover_session(root: &std::path::Path) {
+        let mut ctx = ContextManager::new(1_000);
+        ctx.append_user("leftover from another session");
+        ctx.save(&root.join(".wisp").join("session.json"));
+    }
+
+    fn construct(root: PathBuf, without_session_file: bool) -> Agent {
+        let skills = Arc::new(SkillIndex::load(&[]));
+        let memory = Arc::new(MemoryManager::new(&root));
+        if without_session_file {
+            Agent::new_without_session_file(
+                leftover_cfg(),
+                skills,
+                memory,
+                root,
+                8_000,
+                4,
+                false,
+                None,
+            )
+        } else {
+            Agent::new(leftover_cfg(), skills, memory, root, 8_000, 4, false, None)
+        }
+    }
+
+    #[test]
+    fn new_loads_project_session_json() {
+        let root = leftover_root("cli");
+        write_leftover_session(&root);
+        let agent = construct(root.clone(), false);
+        assert_eq!(agent.ctx.messages.len(), 1);
+        assert!(
+            agent.ctx.messages[0]
+                .content
+                .as_text()
+                .contains("leftover from another session"),
+            "CLI/headless Agent::new must still hydrate .wisp/session.json"
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn new_without_session_file_ignores_leftover_session_json() {
+        let root = leftover_root("desktop");
+        write_leftover_session(&root);
+        let agent = construct(root.clone(), true);
+        assert!(
+            agent.ctx.is_empty(),
+            "desktop constructor must not read leftover .wisp/session.json"
+        );
+        assert_eq!(
+            agent.session_path,
+            root.join(".wisp").join("session.json"),
+            "session_path stays available for an explicit later save"
+        );
+        assert!(agent.session_path.exists());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn require_sqlite_session_messages_fails_closed() {
+        let ok = require_sqlite_session_messages(Ok(vec![wisp_llm::Message::user("from store")]));
+        assert_eq!(ok.unwrap().len(), 1);
+
+        let err = require_sqlite_session_messages::<&str>(Err("disk full")).unwrap_err();
+        assert!(
+            err.contains("Failed to load session messages from SQLite"),
+            "desktop turns must surface a clear SQLite failure: {err}"
+        );
+        assert!(err.contains("disk full"), "{err}");
     }
 }

--- a/crates/wisp-core/src/lib.rs
+++ b/crates/wisp-core/src/lib.rs
@@ -505,7 +505,9 @@ mod session_ctor_tests {
 
     #[test]
     fn require_sqlite_session_messages_fails_closed() {
-        let ok = require_sqlite_session_messages(Ok(vec![wisp_llm::Message::user("from store")]));
+        let loaded: Result<Vec<wisp_llm::Message>, &str> =
+            Ok(vec![wisp_llm::Message::user("from store")]);
+        let ok = require_sqlite_session_messages(loaded);
         assert_eq!(ok.unwrap().len(), 1);
 
         let err = require_sqlite_session_messages::<&str>(Err("disk full")).unwrap_err();

--- a/src-tauri/src/agent_turn.rs
+++ b/src-tauri/src/agent_turn.rs
@@ -493,7 +493,9 @@ pub(crate) async fn send_message_inner(
             }
             None => skills,
         };
-        let mut agent = Agent::new(
+        // Desktop history lives in SQLite. Do not hydrate the project-shared
+        // `.wisp/session.json` (CLI leftover / other session) into model context.
+        let mut agent = Agent::new_without_session_file(
             cfg.clone(),
             skills.clone(),
             ap.memory.clone(),
@@ -659,16 +661,13 @@ pub(crate) async fn send_message_inner(
                 frame_id.clone(),
             )));
         }
-        match state.store.load_messages(&frame_id).await {
-            Ok(msgs) => {
-                agent.ctx.messages = msgs;
-                if let Some(message) = agent.ctx.messages.first_mut() {
-                    if let wisp_llm::Content::Text(prompt) = &mut message.content {
-                        ssh_hosts::strip_legacy_compute_section(prompt);
-                    }
-                }
+        let msgs =
+            wisp_core::require_sqlite_session_messages(state.store.load_messages(&frame_id).await)?;
+        agent.ctx.messages = msgs;
+        if let Some(message) = agent.ctx.messages.first_mut() {
+            if let wisp_llm::Content::Text(prompt) = &mut message.content {
+                ssh_hosts::strip_legacy_compute_section(prompt);
             }
-            Err(e) => tracing::warn!("load session from sqlite failed: {e}"),
         }
         rt.set_last_seq(agent.ctx.messages.len() as i64);
         agent.seed_system_prompt(&skills, None);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## User-facing problem

[#982](https://github.com/xuzhougeng/wisp-science/issues/982): `Agent::new` always loaded the project-shared `.wisp/session.json`. Desktop turns then overwrote context from SQLite, but a load failure only logged a warning — leftover CLI / other-session messages stayed in the model context and later compaction could write them into SQLite.

## What changed

- `Agent::new_without_session_file` builds an empty context and does **not** read `session.json`.
- Desktop turn rebuild uses that constructor.
- SQLite `load_messages` failure now fails the turn (`Failed to load session messages from SQLite: …`).
- `Agent::new` / `with_provider` still load `session.json` for CLI/headless.

## Tests

- `cargo test -p wisp-core` — empty constructor ignores leftover `session.json`; `new` still loads it; store errors fail closed
- CI: rust, ui-e2e, and headless evals passed

## Manual smoke

1. Put a stale `.wisp/session.json` in a project (other-session messages). Open a desktop session whose SQLite history is empty/different. The model must not see the file contents.
2. If SQLite load fails, the turn must error instead of chatting against the file.

## Known limitations

- Desktop still *writes* `session.json` via `Agent::save` if that path is invoked; this PR only stops reading it on the desktop rebuild path.
- Other Tauri test helpers still call `Agent::new` (not the desktop turn path).

Closes #982
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-67e65a2c-0219-4cbe-8b2e-9c00881a42a6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-67e65a2c-0219-4cbe-8b2e-9c00881a42a6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

