### PR TITLE
fix: persist last_seq from MAX(seq) and abort failed workers (#978)

### DIFF
--- a/crates/wisp-store/src/lib.rs
+++ b/crates/wisp-store/src/lib.rs
@@ -19,6 +19,7 @@ mod library;
 mod lineage;
 mod method_search;
 mod models;
+mod persist_seq;
 mod plugins;
 mod project_state_revisions;
 mod project_sync;
@@ -66,6 +67,7 @@ pub use method_search::{
     MethodStrategyStat,
 };
 pub use models::*;
+pub use persist_seq::{join_or_abort_persist, persist_seq_loop, PersistJoinError};
 pub use project_state_revisions::{ProjectStateRevision, ProjectStateRevisionSummary};
 pub use project_sync::ProjectSyncState;
 pub use project_transfer::ProjectTransferStats;

--- a/crates/wisp-store/src/persist_seq.rs
+++ b/crates/wisp-store/src/persist_seq.rs
@@ -1,0 +1,194 @@
+//! Incremental message persistence: seq policy and worker teardown.
+//!
+//! `last_seq` is the durable `COALESCE(MAX(seq), 0)` of persisted rows, not an
+//! in-memory message count. The worker stops at the first append failure so
+//! later messages cannot be written after a hole. On timeout the JoinHandle
+//! must be aborted and joined before replace/compaction can run.
+
+use std::fmt;
+use std::future::Future;
+use std::time::Duration;
+use tokio::sync::mpsc::UnboundedReceiver;
+use tokio::task::JoinHandle;
+
+/// Persist items with monotonically increasing seqs starting after `start_seq`.
+///
+/// Stops at the first append error and returns it. Later items stay in the
+/// channel and are dropped with the receiver — they are not written.
+pub async fn persist_seq_loop<T, E, F, Fut>(
+    mut seq: i64,
+    mut rx: UnboundedReceiver<T>,
+    mut append: F,
+) -> Result<i64, E>
+where
+    F: FnMut(i64, T) -> Fut,
+    Fut: Future<Output = Result<(), E>>,
+{
+    while let Some(item) = rx.recv().await {
+        seq += 1;
+        append(seq, item).await?;
+    }
+    Ok(seq)
+}
+
+/// Why [`join_or_abort_persist`] could not return the task's output.
+#[derive(Debug)]
+pub enum PersistJoinError {
+    /// The task was aborted and has exited.
+    Aborted,
+    /// The task panicked.
+    Join(tokio::task::JoinError),
+    /// `abort()` was called but the task did not exit within `wait`.
+    AbortWaitTimeout,
+}
+
+impl fmt::Display for PersistJoinError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Aborted => write!(f, "persist task was aborted"),
+            Self::Join(error) => write!(f, "persist task panicked: {error}"),
+            Self::AbortWaitTimeout => {
+                write!(f, "persist task did not exit after abort")
+            }
+        }
+    }
+}
+
+impl std::error::Error for PersistJoinError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Join(error) => Some(error),
+            Self::Aborted | Self::AbortWaitTimeout => None,
+        }
+    }
+}
+
+/// Wait for a persist task. On timeout, abort it and wait for the task to exit
+/// so a late INSERT cannot race with replace/compaction.
+pub async fn join_or_abort_persist<T>(
+    mut handle: JoinHandle<T>,
+    wait: Duration,
+) -> Result<T, PersistJoinError> {
+    match tokio::time::timeout(wait, &mut handle).await {
+        Ok(Ok(value)) => Ok(value),
+        Ok(Err(error)) if error.is_cancelled() => Err(PersistJoinError::Aborted),
+        Ok(Err(error)) => Err(PersistJoinError::Join(error)),
+        Err(_elapsed) => {
+            handle.abort();
+            match tokio::time::timeout(wait, handle).await {
+                Ok(Ok(value)) => Ok(value),
+                Ok(Err(error)) if error.is_cancelled() => Err(PersistJoinError::Aborted),
+                Ok(Err(error)) => Err(PersistJoinError::Join(error)),
+                Err(_elapsed) => Err(PersistJoinError::AbortWaitTimeout),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    #[tokio::test]
+    async fn first_append_failure_stops_worker() {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let attempts = Arc::new(Mutex::new(Vec::new()));
+        let recorded = attempts.clone();
+        let task = tokio::spawn(persist_seq_loop(0, rx, move |seq, item: &'static str| {
+            let recorded = recorded.clone();
+            async move {
+                recorded.lock().unwrap().push((seq, item));
+                if seq == 1 {
+                    Err("first append failed")
+                } else {
+                    Ok(())
+                }
+            }
+        }));
+        tx.send("first").unwrap();
+        tx.send("second").unwrap();
+        drop(tx);
+        let result = task.await.unwrap();
+        assert_eq!(result, Err("first append failed"));
+        assert_eq!(*attempts.lock().unwrap(), vec![(1, "first")]);
+    }
+
+    #[tokio::test]
+    async fn successful_loop_returns_final_seq() {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let handle = tokio::spawn(persist_seq_loop(5, rx, |_seq, _item: u8| async {
+            Ok::<(), ()>(())
+        }));
+        tx.send(1).unwrap();
+        tx.send(2).unwrap();
+        drop(tx);
+        let seq = join_or_abort_persist(handle, Duration::from_secs(1))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(seq, 7);
+    }
+
+    struct ExitFlag(Arc<AtomicBool>);
+
+    impl Drop for ExitFlag {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    #[tokio::test]
+    async fn abort_prevents_late_append_and_waits_for_exit() {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<()>();
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (gate_tx, gate_rx) = tokio::sync::oneshot::channel();
+        let appended = Arc::new(AtomicBool::new(false));
+        let exited = Arc::new(AtomicBool::new(false));
+        let append_count = Arc::new(AtomicUsize::new(0));
+        let mut started_tx = Some(started_tx);
+        let mut gate_rx = Some(gate_rx);
+        let handle = tokio::spawn({
+            let appended = appended.clone();
+            let exited = exited.clone();
+            let append_count = append_count.clone();
+            async move {
+                let _exit = ExitFlag(exited);
+                persist_seq_loop(0, rx, move |_seq, _item| {
+                    let started_tx = started_tx.take();
+                    let gate_rx = gate_rx.take();
+                    let appended = appended.clone();
+                    let append_count = append_count.clone();
+                    async move {
+                        append_count.fetch_add(1, Ordering::SeqCst);
+                        if let Some(started_tx) = started_tx {
+                            let _ = started_tx.send(());
+                        }
+                        if let Some(gate_rx) = gate_rx {
+                            let _ = gate_rx.await;
+                        }
+                        appended.store(true, Ordering::SeqCst);
+                        Ok::<(), ()>(())
+                    }
+                })
+                .await
+            }
+        });
+        tx.send(()).unwrap();
+        started_rx.await.unwrap();
+        let outcome = join_or_abort_persist(handle, Duration::from_millis(20)).await;
+        assert!(matches!(outcome, Err(PersistJoinError::Aborted)));
+        assert!(
+            exited.load(Ordering::SeqCst),
+            "teardown must wait until the persist task has exited"
+        );
+        // Releasing the gate would complete a late write if the task were still
+        // running after we returned (the previous timeout-only JoinHandle drop).
+        let _ = gate_tx.send(());
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        assert!(!appended.load(Ordering::SeqCst));
+        assert_eq!(append_count.load(Ordering::SeqCst), 1);
+        drop(tx);
+    }
+}

--- a/crates/wisp-store/src/sessions.rs
+++ b/crates/wisp-store/src/sessions.rs
@@ -817,7 +817,9 @@ impl Store {
     /// automatic compaction). Only the `messages` rows are rewritten — the
     /// session_ui_events visual transcript keeps the full history on purpose.
     /// Resource links and turn undo anchor to message seqs, which a rewrite
-    /// invalidates, so they are dropped too. Deletes and inserts share one
+    /// invalidates, so they are dropped too. Remapping `turn_file_undo` onto
+    /// the rewritten seqs would need a stable turn/message id (known #973
+    /// limitation); do not expand that here. Deletes and inserts share one
     /// write transaction: an interruption mid-replace leaves the previous
     /// transcript fully intact instead of an emptied or half-written frame.
     pub async fn replace_messages(&self, frame_id: &str, msgs: &[Message]) -> Result<()> {
@@ -878,6 +880,19 @@ impl Store {
     pub async fn message_count(&self, frame_id: &str) -> Result<i64> {
         Ok(
             sqlx::query_scalar("SELECT COUNT(*) FROM messages WHERE frame_id=?")
+                .bind(frame_id)
+                .fetch_one(&self.pool)
+                .await?,
+        )
+    }
+
+    /// Durable seq cursor for a frame: `COALESCE(MAX(seq), 0)`.
+    ///
+    /// This is the source of truth for `last_seq` recovery. Do not use
+    /// `messages.len()` or `COUNT(*)` — gaps make those diverge from `MAX(seq)`.
+    pub async fn max_message_seq(&self, frame_id: &str) -> Result<i64> {
+        Ok(
+            sqlx::query_scalar("SELECT COALESCE(MAX(seq),0) FROM messages WHERE frame_id=?")
                 .bind(frame_id)
                 .fetch_one(&self.pool)
                 .await?,
@@ -955,6 +970,8 @@ async fn replace_message_rows(
         .bind(frame_id)
         .execute(&mut **tx)
         .await?;
+    // #973/#978: undo rows key off pre-compaction seqs. Mapping them onto the
+    // rewritten 1..n seqs needs a stable turn/message id; wipe instead.
     sqlx::query("DELETE FROM turn_file_undo WHERE frame_id=?")
         .bind(frame_id)
         .execute(&mut **tx)
@@ -1323,11 +1340,7 @@ impl Store {
         .bind(start_seq)
         .fetch_one(&self.pool)
         .await?;
-        let latest_seq: i64 =
-            sqlx::query_scalar("SELECT COALESCE(MAX(seq),0) FROM messages WHERE frame_id=?")
-                .bind(frame_id)
-                .fetch_one(&self.pool)
-                .await?;
+        let latest_seq = self.max_message_seq(frame_id).await?;
 
         let start_event_seq: i64 = sqlx::query_scalar(
             "SELECT COALESCE(MAX(seq),0) FROM session_ui_events WHERE frame_id=? \

--- a/crates/wisp-store/src/store_tests.rs
+++ b/crates/wisp-store/src/store_tests.rs
@@ -2439,6 +2439,34 @@ async fn transcript_pages_keep_complete_user_turns_and_matching_events() {
 }
 
 #[tokio::test]
+async fn max_message_seq_uses_max_not_count_when_seqs_have_gaps() {
+    let tmp = std::env::temp_dir().join(format!(
+        "wisp_store_max_seq_gap_{}.sqlite",
+        uuid::Uuid::new_v4()
+    ));
+    let store = Store::open(&tmp).await.unwrap();
+    store.create_project("p", "proj", "").await.unwrap();
+    store.create_frame("f", "p", "OPERON", "m").await.unwrap();
+    assert_eq!(store.max_message_seq("f").await.unwrap(), 0);
+    store
+        .append_message("f", 1, &Message::user("first"))
+        .await
+        .unwrap();
+    store
+        .append_message("f", 3, &Message::assistant("third"))
+        .await
+        .unwrap();
+    assert_eq!(store.message_count("f").await.unwrap(), 2);
+    assert_eq!(store.max_message_seq("f").await.unwrap(), 3);
+    let page = store
+        .load_session_transcript_page("f", None, 20)
+        .await
+        .unwrap();
+    assert_eq!(page.latest_seq, 3);
+    let _ = std::fs::remove_file(tmp);
+}
+
+#[tokio::test]
 async fn recent_turn_preview_messages_are_turn_and_content_bounded() {
     let tmp = std::env::temp_dir().join(format!(
         "wisp_store_recent_turns_{}.sqlite",

--- a/src-tauri/src/agent_turn.rs
+++ b/src-tauri/src/agent_turn.rs
@@ -937,7 +937,7 @@ pub(crate) async fn send_message_inner(
                             );
                         }
                     }
-                    Ok(())
+                    Ok::<(), anyhow::Error>(())
                 }
             })
             .await

--- a/src-tauri/src/agent_turn.rs
+++ b/src-tauri/src/agent_turn.rs
@@ -459,7 +459,7 @@ pub(crate) async fn send_message_inner(
     if guard.is_some()
         && state
             .store
-            .message_count(&frame_id)
+            .max_message_seq(&frame_id)
             .await
             .map_err(|error| error.to_string())?
             > rt.last_seq()
@@ -670,7 +670,7 @@ pub(crate) async fn send_message_inner(
             }
             Err(e) => tracing::warn!("load session from sqlite failed: {e}"),
         }
-        rt.set_last_seq(agent.ctx.messages.len() as i64);
+        rt.sync_last_seq_from_store(&state.store, &frame_id).await?;
         agent.seed_system_prompt(&skills, None);
         if let Some(message) = agent.ctx.messages.first_mut() {
             if let wisp_llm::Content::Text(prompt) = &mut message.content {
@@ -747,7 +747,7 @@ pub(crate) async fn send_message_inner(
                     .replace_messages(&frame_id, &agent.ctx.messages)
                     .await
                     .map_err(|e| format!("replace: rolling back the context failed: {e}"))?;
-                rt.set_last_seq(agent.ctx.messages.len() as i64);
+                rt.sync_last_seq_from_store(&state.store, &frame_id).await?;
             }
         }
     }
@@ -768,7 +768,7 @@ pub(crate) async fn send_message_inner(
                     .map_err(|e| {
                         format!("compact: persisting the rewritten context failed: {e}")
                     })?;
-                rt.set_last_seq(agent.ctx.messages.len() as i64);
+                rt.sync_last_seq_from_store(&state.store, &frame_id).await?;
                 let event = AgentEvent::Compaction {
                     frame_id: frame_id.clone(),
                     before,
@@ -877,62 +877,70 @@ pub(crate) async fn send_message_inner(
     //
     // First flush any messages already in the context but not yet persisted
     // (e.g. a system prompt seeded here), so the incremental seq lines up with
-    // what a later reload expects.
+    // what a later reload expects. Stop at the first append failure so later
+    // rows cannot be written after a hole.
     let start_seq = {
         let start = rt.last_seq() as usize;
         if start < agent.ctx.messages.len() {
             let mut seq = rt.last_seq();
             for m in &agent.ctx.messages[start..] {
                 seq += 1;
-                let _ = state.store.append_message(&frame_id, seq, m).await;
+                if let Err(error) = state.store.append_message(&frame_id, seq, m).await {
+                    let _ = rt.sync_last_seq_from_store(&state.store, &frame_id).await;
+                    return Err(format!("incremental persist failed: {error}"));
+                }
             }
-            rt.set_last_seq(agent.ctx.messages.len() as i64);
+            rt.sync_last_seq_from_store(&state.store, &frame_id).await?;
         }
         rt.last_seq()
     };
 
     let (persist_handle, persist_tx) = {
-        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Message>();
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<Message>();
         let store = state.store.clone();
         let fid = frame_id.clone();
         let resource_root = ap.root.clone();
         let resource_project_id = ap.id.clone();
         let resource_app = app.clone();
         let stamp = model_label.clone();
-        let mut seq = start_seq;
         let handle = tokio::spawn(async move {
-            while let Some(mut msg) = rx.recv().await {
-                if msg.role == wisp_llm::Role::Assistant && msg.model_name.is_none() {
-                    msg.model_name = Some(stamp.clone());
-                }
-                seq += 1;
-                if let Err(e) = store.append_message(&fid, seq, &msg).await {
-                    tracing::warn!("incremental persist seq {seq} failed: {e}");
-                    continue;
-                }
-                if message_uses_resource_bindings(&msg) {
-                    let resources = resource_refs::bind_new_message_resources(
-                        &store,
-                        &resource_root,
-                        &resource_project_id,
-                        &fid,
-                        seq,
-                        &msg.content.as_text(),
-                    )
-                    .await;
-                    if !resources.is_empty() {
-                        emit_agent_event(
-                            &resource_app,
-                            AgentEvent::Resources {
-                                frame_id: fid.clone(),
-                                seq,
-                                resources: resources.iter().map(Into::into).collect(),
-                            },
-                        );
+            wisp_store::persist_seq_loop(start_seq, rx, move |seq, mut msg| {
+                let store = store.clone();
+                let fid = fid.clone();
+                let stamp = stamp.clone();
+                let resource_root = resource_root.clone();
+                let resource_project_id = resource_project_id.clone();
+                let resource_app = resource_app.clone();
+                async move {
+                    if msg.role == wisp_llm::Role::Assistant && msg.model_name.is_none() {
+                        msg.model_name = Some(stamp);
                     }
+                    store.append_message(&fid, seq, &msg).await?;
+                    if message_uses_resource_bindings(&msg) {
+                        let resources = resource_refs::bind_new_message_resources(
+                            &store,
+                            &resource_root,
+                            &resource_project_id,
+                            &fid,
+                            seq,
+                            &msg.content.as_text(),
+                        )
+                        .await;
+                        if !resources.is_empty() {
+                            emit_agent_event(
+                                &resource_app,
+                                AgentEvent::Resources {
+                                    frame_id: fid,
+                                    seq,
+                                    resources: resources.iter().map(Into::into).collect(),
+                                },
+                            );
+                        }
+                    }
+                    Ok(())
                 }
-            }
-            seq
+            })
+            .await
         });
         (handle, tx)
     };
@@ -1134,8 +1142,9 @@ pub(crate) async fn send_message_inner(
     agent.ctx.clear_runtime_injections();
     state.running_turns.lock().await.remove(&frame_id);
 
-    // Close the persist channel and wait for the task to flush; its final seq is
-    // the authoritative persisted count.
+    // Close the persist channel and wait for the task to flush (abort + join on
+    // timeout so a late INSERT cannot race replace/compaction). last_seq then
+    // comes from durable MAX(seq), never from the in-memory message count.
     drop(output);
     // Drain the live coalescer before the direct Done/Error emit below so the
     // final buffered deltas cannot arrive after the turn boundary.
@@ -1151,14 +1160,18 @@ pub(crate) async fn send_message_inner(
     {
         tracing::warn!("UI event persistence did not finish cleanly");
     }
-    match tokio::time::timeout(std::time::Duration::from_secs(5), persist_handle).await {
-        Ok(Ok(final_seq)) => rt.set_last_seq(final_seq),
-        other => {
-            tracing::warn!("persist task did not finish cleanly: {other:?}");
-            rt.set_last_seq(agent.ctx.messages.len() as i64);
-        }
+    match wisp_store::join_or_abort_persist(persist_handle, std::time::Duration::from_secs(5)).await
+    {
+        Ok(Ok(_)) => {}
+        Ok(Err(error)) => tracing::warn!("incremental persist failed: {error}"),
+        Err(error) => tracing::warn!("persist task did not finish cleanly: {error}"),
+    }
+    if let Err(error) = rt.sync_last_seq_from_store(&state.store, &frame_id).await {
+        tracing::warn!("{error}");
     }
     let _ = tokio::time::timeout(std::time::Duration::from_secs(10), prov_handle).await;
+    // replace/compaction must not start until the persist task has finished
+    // or been aborted and joined — a late INSERT would race the rewrite.
     if agent.ctx.compaction_revision() != compaction_revision {
         if let Err(error) = state
             .store
@@ -1168,8 +1181,8 @@ pub(crate) async fn send_message_inner(
             result = Err(anyhow::anyhow!(
                 "automatic compact: persisting the rewritten context failed: {error}"
             ));
-        } else {
-            rt.set_last_seq(agent.ctx.messages.len() as i64);
+        } else if let Err(error) = rt.sync_last_seq_from_store(&state.store, &frame_id).await {
+            tracing::warn!("{error}");
         }
     }
     // Resume is already mid-turn. A normal send is mid-turn once the loop

--- a/src-tauri/src/app_state.rs
+++ b/src-tauri/src/app_state.rs
@@ -29,6 +29,7 @@ pub(crate) struct SessionRuntime {
     pub(crate) workflow: Arc<tokio::sync::Mutex<()>>,
     pub(crate) cancel: Arc<AtomicBool>,
     pub(crate) deleted: AtomicBool,
+    /// Last persisted message seq (`COALESCE(MAX(seq),0)`), not a message count.
     pub(crate) last_seq: StdMutex<i64>,
     /// Guide (#410): mid-turn messages the running loop drains into user
     /// messages at its next iteration; ids let queued senders detect that.
@@ -111,6 +112,21 @@ impl SessionRuntime {
     }
     pub(crate) fn set_last_seq(&self, v: i64) {
         *self.last_seq.lock().unwrap() = v;
+    }
+
+    /// Refresh `last_seq` from the durable `MAX(seq)` cursor. Recovery paths
+    /// must not use `messages.len()`.
+    pub(crate) async fn sync_last_seq_from_store(
+        &self,
+        store: &Store,
+        frame_id: &str,
+    ) -> Result<i64, String> {
+        let seq = store
+            .max_message_seq(frame_id)
+            .await
+            .map_err(|error| format!("reading MAX(seq) failed: {error}"))?;
+        self.set_last_seq(seq);
+        Ok(seq)
     }
     pub(crate) fn set_mcp_app_context(&self, instance_id: String, context: Option<McpAppContext>) {
         let mut contexts = self.mcp_app_contexts.lock().unwrap();

--- a/src-tauri/src/session_commands.rs
+++ b/src-tauri/src/session_commands.rs
@@ -918,7 +918,7 @@ pub(super) async fn rewind_session(
         .await
         .map_err(|e| format!("{e}"))?;
     if let Some(rt) = state.sessions.lock().await.get(&frame_id) {
-        rt.set_last_seq(keep as i64);
+        rt.sync_last_seq_from_store(&state.store, &frame_id).await?;
     }
     Ok(())
 }
@@ -1244,6 +1244,7 @@ pub(super) async fn load_session(
         state.set_active_frame(window.label(), Some(id.clone()));
         let _ = state.store.mark_frame_seen(&id).await;
         if let Some(rt) = state.sessions.lock().await.get(&id).cloned() {
+            // latest_seq is COALESCE(MAX(seq),0) from this page load.
             rt.set_last_seq(page.latest_seq);
         }
     }

--- a/src-tauri/src/turn_undo.rs
+++ b/src-tauri/src/turn_undo.rs
@@ -460,7 +460,9 @@ pub(super) async fn undo_turn(
     }
     if let Some(runtime) = runtime {
         *runtime.agent.lock().await = None;
-        runtime.set_last_seq(target.keep_seq);
+        runtime
+            .sync_last_seq_from_store(&state.store, &frame_id)
+            .await?;
     }
     for change in applied {
         crate::emit_agent_event(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## User-facing problem

[#978](https://github.com/xuzhougeng/wisp-science/issues/978): turn runtime treated `messages.len()` as the seq baseline while `load_session` used `COALESCE(MAX(seq),0)`. After a seq gap those disagreed. The persist worker advanced seq before append and `continue`d on failure (silent drop). A 5s timeout dropped the `JoinHandle` while the Tokio task kept running, so a late INSERT could race `replace_messages` / compaction.

## What changed

- `Store::max_message_seq` is the single recovery source. Rebuild, rewind, undo, and persist teardown sync `last_seq` from it — never from the in-memory count.
- Persist worker (`persist_seq_loop`) stops at the first append error and does not write later messages.
- Teardown uses `join_or_abort_persist`: wait, then abort + join before replace/compaction.
- Incremental catch-up also stops on the first failed append.

## Tests

- `cargo test -p wisp-store` — includes gap `MAX(seq)`, first-append-fails, abort-prevents-late-write

## Manual smoke

1. Send a multi-tool turn, Stop mid-flight, then send again. Seq should stay monotonic; no duplicate/missing rows.
2. Trigger `/compact` after a long turn. Transcript should rewrite only after persist has finished.

## Known limitations

- `turn_file_undo` after compaction is still the #973 whole-table wipe (comment left; no remap in this PR).
- Persist failure at end-of-turn is logged and last_seq is resynced from the DB; the in-memory transcript may still be ahead until the next rebuild.

Closes #978
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-67e65a2c-0219-4cbe-8b2e-9c00881a42a6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-67e65a2c-0219-4cbe-8b2e-9c00881a42a6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

