### PR TITLE
fix: renew harvest leases and keep collect off the SSH master (#983)

### DIFF
--- a/crates/wisp-store/src/models.rs
+++ b/crates/wisp-store/src/models.rs
@@ -1264,6 +1264,21 @@ pub struct ResearchGraph {
     pub edges: Vec<ResearchEdge>,
 }
 
+/// Automatic harvest should skip collect/transfer once outputs are registered.
+pub fn skip_auto_harvest(harvested_at: Option<i64>) -> bool {
+    harvested_at.is_some()
+}
+
+/// `renew_run_lifecycle` / `finish_active_run_owned` return false when the
+/// caller no longer holds a live lease. `message` is the hard-error text.
+pub fn require_lifecycle_hold(held: bool, message: &str) -> Result<(), String> {
+    if held {
+        Ok(())
+    } else {
+        Err(message.to_string())
+    }
+}
+
 impl RunRecord {
     pub fn new(
         id: impl Into<String>,
@@ -1303,6 +1318,10 @@ impl RunRecord {
             cleanup_error: None,
             logs_path: None,
         }
+    }
+
+    pub fn is_harvested(&self) -> bool {
+        skip_auto_harvest(self.harvested_at)
     }
 
     pub(crate) fn validate(&self) -> Result<()> {

--- a/crates/wisp-store/src/store_tests.rs
+++ b/crates/wisp-store/src/store_tests.rs
@@ -3985,6 +3985,17 @@ async fn remote_staging_ledger_round_trips_and_counts_external_references() {
     let _ = std::fs::remove_file(&tmp);
 }
 
+#[test]
+fn auto_harvest_skip_and_lease_hold_are_pure_helpers() {
+    assert!(!skip_auto_harvest(None));
+    assert!(skip_auto_harvest(Some(1)));
+    assert!(require_lifecycle_hold(true, "ok").is_ok());
+    assert_eq!(
+        require_lifecycle_hold(false, "Run lifecycle lease was lost").unwrap_err(),
+        "Run lifecycle lease was lost"
+    );
+}
+
 #[tokio::test]
 async fn run_harvest_state_is_recorded_once_and_survives_reopen() {
     let tmp = std::env::temp_dir().join(format!(
@@ -4005,6 +4016,7 @@ async fn run_harvest_state_is_recorded_once_and_survives_reopen() {
         .harvested_at
         .is_none());
     assert!(store.mark_run_harvested("r").await.unwrap());
+    assert!(store.get_run("r").await.unwrap().unwrap().is_harvested());
     let harvested_at = store
         .get_run("r")
         .await

--- a/src-tauri/src/run_context.rs
+++ b/src-tauri/src/run_context.rs
@@ -20,6 +20,7 @@ mod transfer;
 pub(crate) use harvest_remote::WorkspaceListing;
 #[cfg(all(test, windows))]
 use remote::scp_local_path;
+pub(super) use remote::ssh_dedicated_script_command;
 #[cfg(test)]
 use remote::{cancel_payload, launch_payload, poll_payload, prepare_payload};
 use remote::{
@@ -2715,35 +2716,41 @@ async fn finish_remote_run(
     status: wisp_store::RunStatus,
     exit_code: Option<i64>,
 ) -> Result<(), String> {
-    if status == wisp_store::RunStatus::Succeeded && !remote.output_specs.is_empty() {
-        if let Some(frame_id) = remote.frame_id.as_deref() {
-            match harvest_finished_remote(store, runner, owner_id, remote, frame_id).await {
-                Ok(()) => {
-                    store
-                        .mark_run_harvested(&remote.run_id)
-                        .await
-                        .map_err(|e| e.to_string())?;
-                }
-                Err(error) => {
-                    store
-                        .record_run_poll_owned(
-                            &remote.run_id,
-                            owner_id,
-                            None,
-                            None,
-                            Some(&format!("remote artifact registration failed: {error}")),
-                        )
-                        .await
-                        .map_err(|e| e.to_string())?;
+    with_run_lifecycle_lease(store, &remote.run_id, owner_id, async {
+        if status == wisp_store::RunStatus::Succeeded && !remote.output_specs.is_empty() {
+            if let Some(frame_id) = remote.frame_id.as_deref() {
+                match harvest_finished_remote(store, runner, owner_id, remote, frame_id).await {
+                    Ok(()) => {
+                        store
+                            .mark_run_harvested(&remote.run_id)
+                            .await
+                            .map_err(|e| e.to_string())?;
+                    }
+                    Err(error) => {
+                        store
+                            .record_run_poll_owned(
+                                &remote.run_id,
+                                owner_id,
+                                None,
+                                None,
+                                Some(&format!("remote artifact registration failed: {error}")),
+                            )
+                            .await
+                            .map_err(|e| e.to_string())?;
+                    }
                 }
             }
         }
-    }
-    let _ = store
-        .finish_active_run_owned(&remote.run_id, owner_id, status, exit_code)
-        .await
-        .map_err(|e| e.to_string())?;
-    Ok(())
+        harvest_remote::require_owned_finish(
+            store
+                .finish_active_run_owned(&remote.run_id, owner_id, status, exit_code)
+                .await
+                .map_err(|e| e.to_string())?,
+            "Run",
+        )?;
+        Ok(())
+    })
+    .await
 }
 
 /// Register a succeeded detached Run's declared outputs: local globs for
@@ -2756,6 +2763,14 @@ async fn harvest_finished_remote(
     remote: &RemoteRun,
     frame_id: &str,
 ) -> Result<(), String> {
+    let harvested_at = store
+        .get_run(&remote.run_id)
+        .await
+        .map_err(|e| e.to_string())?
+        .and_then(|run| run.harvested_at);
+    if harvest_remote::skip_auto_harvest(harvested_at) {
+        return Ok(());
+    }
     let fallback = PathBuf::from(".");
     if remote.handle.is_local_detached() {
         let references: Vec<_> = remote
@@ -3367,6 +3382,33 @@ async fn record_run_outcome(
                 stderr_tail: Some(stderr_tail),
                 remote_workdir: None,
             })
+        }
+    }
+}
+
+/// Keep `run_id`'s lifecycle lease alive until `operation` completes.
+/// Renew failure is a hard error so a long harvest cannot outlive its owner.
+async fn with_run_lifecycle_lease<T>(
+    store: &wisp_store::Store,
+    run_id: &str,
+    owner_id: &str,
+    operation: impl std::future::Future<Output = Result<T, String>>,
+) -> Result<T, String> {
+    tokio::pin!(operation);
+    let mut interval = tokio::time::interval(harvest_remote::harvest_lease_interval());
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    interval.tick().await;
+    loop {
+        tokio::select! {
+            result = &mut operation => return result,
+            _ = interval.tick() => {
+                harvest_remote::require_lease_renewed(
+                    store
+                        .renew_run_lifecycle(run_id, owner_id, ACTIVE_LEASE_SECS)
+                        .await
+                        .map_err(|e| e.to_string())?,
+                )?;
+            }
         }
     }
 }

--- a/src-tauri/src/run_context.rs
+++ b/src-tauri/src/run_context.rs
@@ -20,14 +20,13 @@ mod transfer;
 pub(crate) use harvest_remote::WorkspaceListing;
 #[cfg(all(test, windows))]
 use remote::scp_local_path;
-pub(super) use remote::ssh_dedicated_script_command;
 #[cfg(test)]
 use remote::{cancel_payload, launch_payload, poll_payload, prepare_payload};
 use remote::{
     cancel_remote, checked_output, ensure_remote_started, permanent_remote_start_error,
     poll_remote, prepare_remote, remote_poll_interval, remote_poll_interval_for,
-    remote_terminal_status, resolve_input_paths, ssh_script_command, PrepareRemote, RemoteCancel,
-    RemotePollState,
+    remote_terminal_status, resolve_input_paths, ssh_dedicated_script_command, ssh_script_command,
+    PrepareRemote, RemoteCancel, RemotePollState,
 };
 #[cfg(test)]
 use remote::{parse_input_progress, remote_poll_delay_secs};

--- a/src-tauri/src/run_context.rs
+++ b/src-tauri/src/run_context.rs
@@ -3386,6 +3386,8 @@ async fn record_run_outcome(
 }
 
 /// Keep `run_id`'s lifecycle lease alive until `operation` completes.
+/// Renew runs on its own task so a store write inside `operation` is not
+/// paused while another connection tries to renew (that deadlocks SQLite).
 /// Renew failure is a hard error so a long harvest cannot outlive its owner.
 async fn with_run_lifecycle_lease<T>(
     store: &wisp_store::Store,
@@ -3393,20 +3395,40 @@ async fn with_run_lifecycle_lease<T>(
     owner_id: &str,
     operation: impl std::future::Future<Output = Result<T, String>>,
 ) -> Result<T, String> {
+    let store = store.clone();
+    let run_id = run_id.to_string();
+    let owner_id = owner_id.to_string();
+    let mut renew = tokio::spawn(async move {
+        let mut interval = tokio::time::interval(harvest_remote::harvest_lease_interval());
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        interval.tick().await;
+        loop {
+            interval.tick().await;
+            harvest_remote::require_lease_renewed(
+                store
+                    .renew_run_lifecycle(&run_id, &owner_id, ACTIVE_LEASE_SECS)
+                    .await
+                    .map_err(|e| e.to_string())?,
+            )?;
+        }
+        #[allow(unreachable_code)]
+        Ok::<(), String>(())
+    });
     tokio::pin!(operation);
-    let mut interval = tokio::time::interval(harvest_remote::harvest_lease_interval());
-    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-    interval.tick().await;
-    loop {
-        tokio::select! {
-            result = &mut operation => return result,
-            _ = interval.tick() => {
-                harvest_remote::require_lease_renewed(
-                    store
-                        .renew_run_lifecycle(run_id, owner_id, ACTIVE_LEASE_SECS)
-                        .await
-                        .map_err(|e| e.to_string())?,
-                )?;
+    tokio::select! {
+        result = &mut operation => {
+            renew.abort();
+            let _ = renew.await;
+            result
+        }
+        renew_result = &mut renew => {
+            match renew_result {
+                Ok(Err(error)) => Err(error),
+                Ok(Ok(())) => Err("Run lifecycle lease renewer exited".into()),
+                Err(join) if join.is_cancelled() => {
+                    Err("Run lifecycle lease renewer cancelled".into())
+                }
+                Err(join) => Err(join.to_string()),
             }
         }
     }

--- a/src-tauri/src/run_context/harvest_remote.rs
+++ b/src-tauri/src/run_context/harvest_remote.rs
@@ -4,8 +4,8 @@
 //! outputs are transferred and recorded, never the full remote file inventory.
 
 use super::{
-    checked_output, ssh_script_command, transfer_progress, RemoteRun, RemoteRunHandle,
-    RunCommandRunner, REMOTE_RPC_TIMEOUT,
+    checked_output, ssh_dedicated_script_command, ssh_script_command, transfer_progress,
+    with_run_lifecycle_lease, RemoteRun, RemoteRunHandle, RunCommandRunner, REMOTE_RPC_TIMEOUT,
 };
 use crate::harvest::{HarvestedArtifact, OutputResidency, OutputSpec};
 use sha2::{Digest, Sha256};
@@ -35,6 +35,32 @@ fn persist_assignment(remote_data_root: &str, run_id: &str) -> String {
 
 const COLLECT_TIMEOUT: Duration = Duration::from_secs(30 * 60);
 const PULL_TIMEOUT: Duration = Duration::from_secs(4 * 60 * 60);
+
+/// Automatic harvest must not collect/transfer again once outputs are registered.
+pub(super) fn skip_auto_harvest(harvested_at: Option<i64>) -> bool {
+    wisp_store::skip_auto_harvest(harvested_at)
+}
+
+/// `renew_run_lifecycle` returning false is a hard error for long harvest work.
+pub(super) fn require_lease_renewed(renewed: bool) -> Result<(), String> {
+    wisp_store::require_lifecycle_hold(renewed, "Run lifecycle lease was lost")
+}
+
+/// `finish_active_run_owned` returning false means the owner/lease did not take.
+pub(super) fn require_owned_finish(finished: bool, subject: &str) -> Result<(), String> {
+    wisp_store::require_lifecycle_hold(
+        finished,
+        &format!("{subject} lifecycle lease was lost before finish"),
+    )
+}
+
+pub(super) fn harvest_lease_interval() -> Duration {
+    if cfg!(test) {
+        Duration::from_millis(10)
+    } else {
+        Duration::from_secs(1)
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum RemoteOutputKind {
@@ -582,125 +608,134 @@ async fn collect_pull_register(
     )
     .await?;
 
-    let collect = checked_output(
-        "SSH harvest collection",
-        runner
-            .run(
-                ssh_script_command(
-                    connection,
-                    "collect SSH run outputs",
-                    collect_payload(
-                        workdir,
-                        token,
-                        &remote.run_id,
-                        &prefs.remote_data_root,
-                        specs,
-                    ),
-                )?,
-                COLLECT_TIMEOUT,
+    let harvest = async {
+        let collect = checked_output(
+            "SSH harvest collection",
+            runner
+                .run(
+                    ssh_dedicated_script_command(
+                        connection,
+                        "collect SSH run outputs",
+                        collect_payload(
+                            workdir,
+                            token,
+                            &remote.run_id,
+                            &prefs.remote_data_root,
+                            specs,
+                        ),
+                    )?,
+                    COLLECT_TIMEOUT,
+                )
+                .await,
+        )?;
+        let plan = plan_from_manifest(specs, parse_collect_manifest(&collect.stdout)?)?;
+
+        let landing = landing_dir(harvest_root, &prefs.local_results_dir, &remote.run_id);
+        if plan.download_files > 0 {
+            pull_harvest_dir(
+                store,
+                runner,
+                owner_id,
+                remote,
+                connection,
+                workdir,
+                &plan,
+                &landing,
+                renew_parent,
             )
-            .await,
-    )?;
-    let plan = plan_from_manifest(specs, parse_collect_manifest(&collect.stdout)?)?;
+            .await?;
+        }
 
-    let landing = landing_dir(harvest_root, &prefs.local_results_dir, &remote.run_id);
-    if plan.download_files > 0 {
-        pull_harvest_dir(
-            store,
-            runner,
-            owner_id,
-            remote,
-            connection,
-            workdir,
-            &plan,
-            &landing,
-            renew_parent,
-        )
-        .await?;
+        let mut harvested = Vec::new();
+        for entry in &plan.entries {
+            let spec = &remote.output_specs[entry.spec_idx];
+            let artifact = match &entry.kind {
+                RemoteOutputKind::Remote => {
+                    let relative = entry
+                        .path
+                        .split_once(&format!("/artifacts/{}/", remote.run_id))
+                        .map(|(_, rel)| rel)
+                        .unwrap_or(&entry.path);
+                    let logical_key = spec
+                        .logical_key
+                        .clone()
+                        .unwrap_or_else(|| format!("path:{relative}"));
+                    let uri = super::remote_files::ssh_uri_for_remote_path(
+                        &connection.alias,
+                        &entry.path,
+                    );
+                    let artifact = crate::harvest::register_reference_artifact(
+                        store,
+                        &remote.project_id,
+                        frame_id,
+                        &remote.run_id,
+                        &spec.kind,
+                        &uri,
+                        Some(entry.size),
+                        Some(entry.checksum.clone()),
+                        &logical_key,
+                    )
+                    .await?;
+                    ledger_harvest_persist(
+                        store,
+                        &remote.project_id,
+                        &format!("ssh:{}", connection.alias),
+                        &remote.run_id,
+                        &entry.path,
+                        Some(entry.checksum.clone()),
+                        i64::try_from(entry.size).ok(),
+                    )
+                    .await?;
+                    artifact
+                }
+                RemoteOutputKind::File => {
+                    let logical_key = spec
+                        .logical_key
+                        .clone()
+                        .unwrap_or_else(|| format!("path:{}", entry.path));
+                    crate::harvest::register_local_artifact(
+                        store,
+                        &remote.project_id,
+                        frame_id,
+                        &remote.run_id,
+                        &spec.kind,
+                        harvest_root,
+                        &landing.join(&entry.path),
+                        &logical_key,
+                        &entry.path,
+                        entry.size > crate::snapshot_store::DEFAULT_SNAPSHOT_LIMIT,
+                    )
+                    .await?
+                }
+                RemoteOutputKind::Bundle { .. } => {
+                    let logical_key = spec
+                        .logical_key
+                        .clone()
+                        .unwrap_or_else(|| format!("bundle:{}", spec.glob));
+                    crate::harvest::register_local_artifact(
+                        store,
+                        &remote.project_id,
+                        frame_id,
+                        &remote.run_id,
+                        &spec.kind,
+                        harvest_root,
+                        &landing.join("bundles").join(&entry.path),
+                        &logical_key,
+                        &spec.glob,
+                        entry.size > crate::snapshot_store::DEFAULT_SNAPSHOT_LIMIT,
+                    )
+                    .await?
+                }
+            };
+            harvested.push(artifact);
+        }
+        Ok(harvested)
+    };
+    if renew_parent {
+        with_run_lifecycle_lease(store, &remote.run_id, owner_id, harvest).await
+    } else {
+        harvest.await
     }
-
-    let mut harvested = Vec::new();
-    for entry in &plan.entries {
-        let spec = &remote.output_specs[entry.spec_idx];
-        let artifact = match &entry.kind {
-            RemoteOutputKind::Remote => {
-                let relative = entry
-                    .path
-                    .split_once(&format!("/artifacts/{}/", remote.run_id))
-                    .map(|(_, rel)| rel)
-                    .unwrap_or(&entry.path);
-                let logical_key = spec
-                    .logical_key
-                    .clone()
-                    .unwrap_or_else(|| format!("path:{relative}"));
-                let uri =
-                    super::remote_files::ssh_uri_for_remote_path(&connection.alias, &entry.path);
-                let artifact = crate::harvest::register_reference_artifact(
-                    store,
-                    &remote.project_id,
-                    frame_id,
-                    &remote.run_id,
-                    &spec.kind,
-                    &uri,
-                    Some(entry.size),
-                    Some(entry.checksum.clone()),
-                    &logical_key,
-                )
-                .await?;
-                ledger_harvest_persist(
-                    store,
-                    &remote.project_id,
-                    &format!("ssh:{}", connection.alias),
-                    &remote.run_id,
-                    &entry.path,
-                    Some(entry.checksum.clone()),
-                    i64::try_from(entry.size).ok(),
-                )
-                .await?;
-                artifact
-            }
-            RemoteOutputKind::File => {
-                let logical_key = spec
-                    .logical_key
-                    .clone()
-                    .unwrap_or_else(|| format!("path:{}", entry.path));
-                crate::harvest::register_local_artifact(
-                    store,
-                    &remote.project_id,
-                    frame_id,
-                    &remote.run_id,
-                    &spec.kind,
-                    harvest_root,
-                    &landing.join(&entry.path),
-                    &logical_key,
-                    &entry.path,
-                    entry.size > crate::snapshot_store::DEFAULT_SNAPSHOT_LIMIT,
-                )
-                .await?
-            }
-            RemoteOutputKind::Bundle { .. } => {
-                let logical_key = spec
-                    .logical_key
-                    .clone()
-                    .unwrap_or_else(|| format!("bundle:{}", spec.glob));
-                crate::harvest::register_local_artifact(
-                    store,
-                    &remote.project_id,
-                    frame_id,
-                    &remote.run_id,
-                    &spec.kind,
-                    harvest_root,
-                    &landing.join("bundles").join(&entry.path),
-                    &logical_key,
-                    &spec.glob,
-                    entry.size > crate::snapshot_store::DEFAULT_SNAPSHOT_LIMIT,
-                )
-                .await?
-            }
-        };
-        harvested.push(artifact);
-    }
-    Ok(harvested)
 }
 
 async fn ledger_harvest_persist(
@@ -833,9 +868,12 @@ async fn pull_harvest_dir(
         None,
         started,
     );
-    let _ = store
-        .renew_run_lifecycle(&transfer_id, owner_id, super::ACTIVE_LEASE_SECS)
-        .await;
+    require_lease_renewed(
+        store
+            .renew_run_lifecycle(&transfer_id, owner_id, super::ACTIVE_LEASE_SECS)
+            .await
+            .map_err(|e| e.to_string())?,
+    )?;
     let _ = store
         .update_run_progress_owned(&transfer_id, owner_id, &final_progress)
         .await;
@@ -844,9 +882,13 @@ async fn pull_harvest_dir(
             .update_run_output_owned(&transfer_id, owner_id, None, Some(error))
             .await;
     }
-    let _ = store
-        .finish_active_run_owned(&transfer_id, owner_id, status, exit_code)
-        .await;
+    require_owned_finish(
+        store
+            .finish_active_run_owned(&transfer_id, owner_id, status, exit_code)
+            .await
+            .map_err(|e| e.to_string())?,
+        "harvest transfer",
+    )?;
     result
 }
 
@@ -881,27 +923,29 @@ async fn pull_and_verify(
     };
     let pull = runner.run(command, PULL_TIMEOUT);
     tokio::pin!(pull);
-    let mut interval = tokio::time::interval(if cfg!(test) {
-        Duration::from_millis(10)
-    } else {
-        Duration::from_secs(1)
-    });
+    let mut interval = tokio::time::interval(harvest_lease_interval());
     interval.tick().await;
     let output = loop {
         tokio::select! {
             output = &mut pull => break output,
             _ = interval.tick() => {
-                if !store
-                    .renew_run_lifecycle(transfer_id, owner_id, super::ACTIVE_LEASE_SECS)
-                    .await
-                    .map_err(|e| e.to_string())?
-                {
-                    return Err("harvest transfer lifecycle lease expired".into());
-                }
+                require_lease_renewed(
+                    store
+                        .renew_run_lifecycle(transfer_id, owner_id, super::ACTIVE_LEASE_SECS)
+                        .await
+                        .map_err(|e| e.to_string())?,
+                )?;
                 if renew_parent {
-                    let _ = store
-                        .renew_run_lifecycle(&remote.run_id, owner_id, super::ACTIVE_LEASE_SECS)
-                        .await;
+                    require_lease_renewed(
+                        store
+                            .renew_run_lifecycle(
+                                &remote.run_id,
+                                owner_id,
+                                super::ACTIVE_LEASE_SECS,
+                            )
+                            .await
+                            .map_err(|e| e.to_string())?,
+                    )?;
                 }
                 let progress = transfer_progress(
                     "download",
@@ -1483,5 +1527,26 @@ mod tests {
         assert_eq!(dir, Path::new("/proj/remote/gpu/run-1"));
         let dir = landing_dir(Path::new("/proj"), "results/../../etc", "run 1");
         assert_eq!(dir, Path::new("/proj/results/etc/run_1"));
+    }
+
+    #[test]
+    fn skip_auto_harvest_when_already_registered() {
+        assert!(!skip_auto_harvest(None));
+        assert!(skip_auto_harvest(Some(1)));
+    }
+
+    #[test]
+    fn lease_and_finish_helpers_are_hard_errors() {
+        assert!(require_lease_renewed(true).is_ok());
+        assert!(require_lease_renewed(false)
+            .unwrap_err()
+            .contains("lease was lost"));
+        assert!(require_owned_finish(true, "Run").is_ok());
+        assert!(require_owned_finish(false, "Run")
+            .unwrap_err()
+            .contains("lost before finish"));
+        assert!(require_owned_finish(false, "harvest transfer")
+            .unwrap_err()
+            .contains("harvest transfer"));
     }
 }

--- a/src-tauri/src/run_context/remote.rs
+++ b/src-tauri/src/run_context/remote.rs
@@ -59,8 +59,33 @@ pub(super) fn ssh_script_command(
     label: &str,
     payload: String,
 ) -> Result<RunCommand, String> {
+    ssh_script_command_inner(connection, label, payload, false)
+}
+
+/// Long harvest RPCs (collect) must not occupy the shared per-host master slot.
+/// `sh -s --` is the existing dedicated-session shape in `eligible_payload`:
+/// stdin is present and the trailing remote command is not exactly `sh -s`, so
+/// ProcessRunRunner spawns a private ssh process.
+pub(super) fn ssh_dedicated_script_command(
+    connection: &crate::ssh_hosts::SshConnection,
+    label: &str,
+    payload: String,
+) -> Result<RunCommand, String> {
+    ssh_script_command_inner(connection, label, payload, true)
+}
+
+fn ssh_script_command_inner(
+    connection: &crate::ssh_hosts::SshConnection,
+    label: &str,
+    payload: String,
+    dedicated: bool,
+) -> Result<RunCommand, String> {
     let mut args = connection.ssh_args()?;
-    args.push("sh -s".into());
+    args.push(if dedicated {
+        "sh -s --".into()
+    } else {
+        "sh -s".into()
+    });
     Ok(RunCommand {
         context_id: format!("ssh:{}", connection.alias),
         program: "ssh".into(),

--- a/src-tauri/src/run_context/tests.rs
+++ b/src-tauri/src/run_context/tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use std::collections::VecDeque;
 #[cfg(unix)]
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex as StdMutex;
 use std::time::Duration;
 
@@ -2541,6 +2541,7 @@ struct HarvestFakeRunner {
     manifest: String,
     files: Vec<(String, Vec<u8>)>,
     commands: StdMutex<Vec<RunCommand>>,
+    collect_hold: Option<Duration>,
 }
 
 #[async_trait::async_trait]
@@ -2554,11 +2555,16 @@ impl RunCommandRunner for HarvestFakeRunner {
         let destination = command.args.last().cloned().unwrap_or_default();
         self.commands.lock().unwrap().push(command);
         match program.as_str() {
-            "ssh" => Ok(RunCommandOutput {
-                exit_code: 0,
-                stdout: self.manifest.clone(),
-                stderr: String::new(),
-            }),
+            "ssh" => {
+                if let Some(hold) = self.collect_hold {
+                    tokio::time::sleep(hold).await;
+                }
+                Ok(RunCommandOutput {
+                    exit_code: 0,
+                    stdout: self.manifest.clone(),
+                    stderr: String::new(),
+                })
+            }
             "scp" => {
                 let root = PathBuf::from(destination).join("harvest");
                 for (relative, bytes) in &self.files {
@@ -2636,6 +2642,7 @@ async fn ssh_harvest_downloads_verifies_and_registers_selected_outputs() {
             ("bundles/bundle_1.tar.gz".into(), archive.clone()),
         ],
         commands: StdMutex::new(Vec::new()),
+        collect_hold: None,
     };
     let remote = harvest_test_remote("run-h", &tmp, harvest_specs());
 
@@ -2719,6 +2726,20 @@ async fn ssh_harvest_downloads_verifies_and_registers_selected_outputs() {
         assert!(payload.contains("tar -czf"));
         // Default remote data root derives from the project name ("proj").
         assert!(payload.contains("persist=\"$HOME/wisp/proj/data/artifacts/run-h\""));
+        assert_eq!(
+            collect.args.last().map(String::as_str),
+            Some("sh -s --"),
+            "collect must use a dedicated SSH session"
+        );
+        assert!(
+            crate::ssh_master::eligible_payload(
+                &collect.program,
+                &collect.args,
+                collect.stdin.as_deref(),
+            )
+            .is_none(),
+            "collect must not occupy the shared SSH master slot"
+        );
     }
 
     // A retried harvest re-registers nothing: same versions, same lineage rows.
@@ -2764,6 +2785,7 @@ async fn ssh_harvest_checksum_mismatch_registers_nothing() {
         manifest,
         files: vec![("files/results/out.tsv".into(), table)],
         commands: StdMutex::new(Vec::new()),
+        collect_hold: None,
     };
     let remote = harvest_test_remote(
         "run-bad",
@@ -2815,6 +2837,7 @@ async fn ssh_harvest_collect_error_reports_bundle_guidance() {
         manifest: "__WISP_HARVEST_ERROR__:output glob matched more than 500 files; set bundle:true or narrow the glob to final products\n".into(),
         files: Vec::new(),
         commands: StdMutex::new(Vec::new()),
+        collect_hold: None,
     };
     let remote = harvest_test_remote(
         "run-cap",
@@ -2842,6 +2865,349 @@ async fn ssh_harvest_collect_error_reports_bundle_guidance() {
         .unwrap()
         .harvested_at
         .is_none());
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+fn remote_only_harvest_spec() -> Vec<crate::harvest::OutputSpec> {
+    vec![crate::harvest::OutputSpec {
+        glob: "big/*.bam".into(),
+        kind: "data".into(),
+        residency: crate::harvest::OutputResidency::Remote,
+        logical_key: None,
+        max_file_mb: None,
+        max_total_mb: None,
+        bundle: false,
+    }]
+}
+
+fn remote_only_manifest(run_id: &str) -> String {
+    format!(
+        "__WISP_HARVEST__:remote:0:12345:{}:/home/alice/.wisp-science/artifacts/{run_id}/big/x.bam\n\
+         __WISP_HARVEST_DONE__\n",
+        "ab".repeat(32),
+    )
+}
+
+async fn seed_active_harvest_run(
+    tmp: &Path,
+    run_id: &str,
+    owner: &str,
+    lease_secs: i64,
+) -> wisp_store::Store {
+    let store = wisp_store::Store::open(&tmp.join("wisp.sqlite"))
+        .await
+        .unwrap();
+    store
+        .create_project("p", "proj", &tmp.to_string_lossy())
+        .await
+        .unwrap();
+    store.create_frame("f", "p", "OPERON", "m").await.unwrap();
+    store
+        .upsert_execution_context(&harvest_test_context())
+        .await
+        .unwrap();
+    let mut run = wisp_store::RunRecord::new(run_id, "p", "ssh:gpu", "Remote", "ssh_direct");
+    run.frame_id = Some("f".into());
+    store.create_run(&run).await.unwrap();
+    assert!(store
+        .activate_run_lifecycle(run_id, wisp_store::RunStatus::Running, owner, lease_secs)
+        .await
+        .unwrap());
+    store
+}
+
+/// Models the shared SSH master slot: non-dedicated RPCs serialize, dedicated
+/// collect does not take the lock so poll/cancel can proceed concurrently.
+struct SlotAwareHarvestRunner {
+    manifest: String,
+    slot: tokio::sync::Mutex<()>,
+    collect_started: Arc<tokio::sync::Semaphore>,
+    collect_release: Arc<tokio::sync::Semaphore>,
+    commands: StdMutex<Vec<RunCommand>>,
+}
+
+#[async_trait::async_trait]
+impl RunCommandRunner for SlotAwareHarvestRunner {
+    async fn run(
+        &self,
+        command: RunCommand,
+        _timeout: Duration,
+    ) -> Result<RunCommandOutput, String> {
+        let uses_master = crate::ssh_master::eligible_payload(
+            &command.program,
+            &command.args,
+            command.stdin.as_deref(),
+        )
+        .is_some();
+        let script = command.script.clone();
+        self.commands.lock().unwrap().push(command);
+        if script.contains("collect SSH") {
+            assert!(
+                !uses_master,
+                "collect must bypass the shared SSH master slot"
+            );
+            self.collect_started.add_permits(1);
+            let _permit = self.collect_release.acquire().await.unwrap();
+            return Ok(RunCommandOutput {
+                exit_code: 0,
+                stdout: self.manifest.clone(),
+                stderr: String::new(),
+            });
+        }
+        let _slot = self
+            .slot
+            .try_lock()
+            .map_err(|_| "shared SSH master slot is occupied".to_string())?;
+        if script.contains("poll") {
+            return ok_output(&poll_response("running", "still going", ""));
+        }
+        if script.contains("cancel") {
+            return ok_output("__WISP_CANCEL__:cancelled\n");
+        }
+        Err(format!("unexpected command: {script}"))
+    }
+}
+
+struct RefuseCollectRunner {
+    commands: StdMutex<Vec<RunCommand>>,
+}
+
+#[async_trait::async_trait]
+impl RunCommandRunner for RefuseCollectRunner {
+    async fn run(
+        &self,
+        command: RunCommand,
+        _timeout: Duration,
+    ) -> Result<RunCommandOutput, String> {
+        self.commands.lock().unwrap().push(command);
+        Err("should not collect".into())
+    }
+}
+
+#[tokio::test]
+async fn ssh_harvest_collect_renews_parent_lease_past_expiry() {
+    let tmp = std::env::temp_dir().join(format!("wisp_ssh_harvest_lease_{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&tmp).unwrap();
+    let store = seed_active_harvest_run(&tmp, "run-lease", "test-owner", 1).await;
+    let runner = HarvestFakeRunner {
+        manifest: remote_only_manifest("run-lease"),
+        files: Vec::new(),
+        commands: StdMutex::new(Vec::new()),
+        collect_hold: Some(Duration::from_millis(1500)),
+    };
+    let remote = harvest_test_remote("run-lease", &tmp, remote_only_harvest_spec());
+
+    harvest_remote::harvest_ssh_run(&store, &runner, "test-owner", &remote, true)
+        .await
+        .unwrap();
+
+    assert!(store
+        .finish_active_run_owned(
+            "run-lease",
+            "test-owner",
+            wisp_store::RunStatus::Succeeded,
+            Some(0),
+        )
+        .await
+        .unwrap());
+    let collect = runner
+        .commands
+        .lock()
+        .unwrap()
+        .iter()
+        .find(|command| command.program == "ssh")
+        .cloned()
+        .unwrap();
+    assert_eq!(collect.args.last().map(String::as_str), Some("sh -s --"));
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[tokio::test]
+async fn ssh_harvest_collect_renew_failure_aborts() {
+    let tmp = std::env::temp_dir().join(format!(
+        "wisp_ssh_harvest_renew_fail_{}",
+        uuid::Uuid::new_v4()
+    ));
+    std::fs::create_dir_all(&tmp).unwrap();
+    let store = seed_active_harvest_run(&tmp, "run-steal", "test-owner", 30).await;
+    let runner = HarvestFakeRunner {
+        manifest: remote_only_manifest("run-steal"),
+        files: Vec::new(),
+        commands: StdMutex::new(Vec::new()),
+        collect_hold: Some(Duration::from_millis(80)),
+    };
+    let remote = harvest_test_remote("run-steal", &tmp, remote_only_harvest_spec());
+
+    let error = harvest_remote::harvest_ssh_run(&store, &runner, "other-owner", &remote, true)
+        .await
+        .unwrap_err();
+
+    assert!(error.contains("lease was lost"), "{error}");
+    assert!(store
+        .get_run("run-steal")
+        .await
+        .unwrap()
+        .unwrap()
+        .harvested_at
+        .is_none());
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[tokio::test]
+async fn ssh_harvest_collect_does_not_block_same_host_poll_or_cancel() {
+    let tmp = std::env::temp_dir().join(format!("wisp_ssh_harvest_slot_{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&tmp).unwrap();
+    let store = seed_active_harvest_run(&tmp, "run-slot", "test-owner", 30).await;
+    let collect_started = Arc::new(tokio::sync::Semaphore::new(0));
+    let collect_release = Arc::new(tokio::sync::Semaphore::new(0));
+    let runner = Arc::new(SlotAwareHarvestRunner {
+        manifest: remote_only_manifest("run-slot"),
+        slot: tokio::sync::Mutex::new(()),
+        collect_started: collect_started.clone(),
+        collect_release: collect_release.clone(),
+        commands: StdMutex::new(Vec::new()),
+    });
+    let remote = harvest_test_remote("run-slot", &tmp, remote_only_harvest_spec());
+    let harvest_remote_run = remote.clone();
+    let harvest = tokio::spawn({
+        let store = store.clone();
+        let runner = runner.clone();
+        async move {
+            harvest_remote::harvest_ssh_run(
+                &store,
+                runner.as_ref(),
+                "test-owner",
+                &harvest_remote_run,
+                true,
+            )
+            .await
+        }
+    });
+
+    tokio::time::timeout(Duration::from_secs(2), collect_started.acquire())
+        .await
+        .expect("collect never started")
+        .expect("collect start permit");
+    let poll = tokio::time::timeout(
+        Duration::from_secs(1),
+        poll_remote(runner.as_ref(), &remote.handle),
+    )
+    .await
+    .expect("poll blocked by harvest collect")
+    .unwrap();
+    assert_eq!(poll.state, RemotePollState::Running);
+    let cancel = tokio::time::timeout(
+        Duration::from_secs(1),
+        cancel_remote(runner.as_ref(), &remote.handle),
+    )
+    .await
+    .expect("cancel blocked by harvest collect")
+    .unwrap();
+    assert_eq!(cancel, RemoteCancel::Cancelled);
+
+    collect_release.add_permits(1);
+    harvest.await.unwrap().unwrap();
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[tokio::test]
+async fn finish_remote_run_errors_when_lease_is_lost() {
+    let tmp = std::env::temp_dir().join(format!("wisp_ssh_finish_lease_{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&tmp).unwrap();
+    let store = seed_active_harvest_run(&tmp, "run-fin", "owner-a", 30).await;
+    let runner = RefuseCollectRunner {
+        commands: StdMutex::new(Vec::new()),
+    };
+    let remote = harvest_test_remote("run-fin", &tmp, Vec::new());
+
+    let error = finish_remote_run(
+        &store,
+        &runner,
+        "owner-b",
+        &remote,
+        wisp_store::RunStatus::Succeeded,
+        Some(0),
+    )
+    .await
+    .unwrap_err();
+
+    assert!(error.contains("lease was lost"), "{error}");
+    assert_eq!(
+        store.get_run("run-fin").await.unwrap().unwrap().status,
+        wisp_store::RunStatus::Running
+    );
+    assert!(runner.commands.lock().unwrap().is_empty());
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[tokio::test]
+async fn auto_harvest_skips_collect_when_already_harvested() {
+    let tmp = std::env::temp_dir().join(format!("wisp_ssh_harvest_skip_{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&tmp).unwrap();
+    let store = seed_active_harvest_run(&tmp, "run-skip", "test-owner", 30).await;
+    let runner = HarvestFakeRunner {
+        manifest: remote_only_manifest("run-skip"),
+        files: Vec::new(),
+        commands: StdMutex::new(Vec::new()),
+        collect_hold: None,
+    };
+    let remote = harvest_test_remote("run-skip", &tmp, remote_only_harvest_spec());
+
+    harvest_finished_remote(&store, &runner, "test-owner", &remote, "f")
+        .await
+        .unwrap();
+    assert_eq!(
+        runner
+            .commands
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|command| command.program == "ssh")
+            .count(),
+        1
+    );
+
+    harvest_finished_remote(&store, &runner, "test-owner", &remote, "f")
+        .await
+        .unwrap();
+    assert_eq!(
+        runner
+            .commands
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|command| command.program == "ssh")
+            .count(),
+        1,
+        "second auto harvest must not collect again"
+    );
+
+    let refuse = RefuseCollectRunner {
+        commands: StdMutex::new(Vec::new()),
+    };
+    finish_remote_run(
+        &store,
+        &refuse,
+        "test-owner",
+        &remote,
+        wisp_store::RunStatus::Succeeded,
+        Some(0),
+    )
+    .await
+    .unwrap();
+    assert!(
+        refuse.commands.lock().unwrap().is_empty(),
+        "finish after harvested_at must skip collect"
+    );
+    assert_eq!(
+        store.get_run("run-skip").await.unwrap().unwrap().status,
+        wisp_store::RunStatus::Succeeded
+    );
 
     let _ = std::fs::remove_dir_all(&tmp);
 }
@@ -2997,6 +3363,7 @@ async fn ssh_harvest_uses_stored_local_results_dir_and_data_root() {
         manifest,
         files: vec![("files/results/out.tsv".into(), table.clone())],
         commands: StdMutex::new(Vec::new()),
+        collect_hold: None,
     };
     let remote = harvest_test_remote(
         "run-p",
@@ -4196,6 +4563,7 @@ async fn download_run_files_registers_one_row_per_selection() {
             ("bundles/bundle_1.tar.gz".into(), archive.clone()),
         ],
         commands: StdMutex::new(Vec::new()),
+        collect_hold: None,
     };
     let remote = harvest_test_remote("run-sel", &tmp, Vec::new());
 

--- a/src-tauri/src/run_context/tests.rs
+++ b/src-tauri/src/run_context/tests.rs
@@ -3060,7 +3060,7 @@ async fn ssh_harvest_collect_renew_failure_aborts() {
 async fn ssh_harvest_collect_does_not_block_same_host_poll_or_cancel() {
     let tmp = std::env::temp_dir().join(format!("wisp_ssh_harvest_slot_{}", uuid::Uuid::new_v4()));
     std::fs::create_dir_all(&tmp).unwrap();
-    let store = seed_active_harvest_run(&tmp, "run-slot", "test-owner", 30).await;
+    let store = seed_harvest_run(&tmp, "run-slot").await;
     let collect_started = Arc::new(tokio::sync::Semaphore::new(0));
     let collect_release = Arc::new(tokio::sync::Semaphore::new(0));
     let runner = Arc::new(SlotAwareHarvestRunner {
@@ -3081,13 +3081,13 @@ async fn ssh_harvest_collect_does_not_block_same_host_poll_or_cancel() {
                 runner.as_ref(),
                 "test-owner",
                 &harvest_remote_run,
-                true,
+                false,
             )
             .await
         }
     });
 
-    tokio::time::timeout(Duration::from_secs(2), collect_started.acquire())
+    let _started = tokio::time::timeout(Duration::from_secs(2), collect_started.acquire())
         .await
         .expect("collect never started")
         .expect("collect start permit");

--- a/src-tauri/src/ssh_master.rs
+++ b/src-tauri/src/ssh_master.rs
@@ -344,6 +344,10 @@ mod tests {
         ));
         // stdin as data for the remote command needs a dedicated session
         assert!(eligible_payload("ssh", &args(&["-T", "host", "cat > f"]), Some("data")).is_none());
+        // Harvest collect uses `sh -s --` so it does not take the shared slot.
+        assert!(
+            eligible_payload("ssh", &args(&["-T", "host", "sh -s --"]), Some("collect")).is_none()
+        );
         assert!(eligible_payload("scp", &args(&["a", "b"]), None).is_none());
         assert!(eligible_payload("ssh", &args(&["host"]), None).is_none());
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## User-facing problem

[#983](https://github.com/xuzhougeng/wisp-science/issues/983): SSH harvest **collect** is a single blocking RPC (up to 30 minutes) with no parent Run lease renew (lease ~30s). Auto harvest (`finish_remote_run`) depends on that lease. Collect also occupied the shared per-host SSH master slot, blocking same-host poll/cancel/list. `finish_active_run_owned` results were ignored. Auto harvest did not check `harvested_at`, so it could collect twice.

## What changed

- Collect uses `ssh_dedicated_script_command` (`sh -s --`), the existing dedicated-session shape, so it does not take the short-RPC master slot. scp pull already bypassed master.
- `with_run_lifecycle_lease` covers collect + pull + register + finish. Renew runs on a separate task (avoids SQLite deadlock). Renew failure is a hard error.
- `finish_active_run_owned` is checked for the parent Run and the harvest transfer Run.
- Auto harvest skips collect when `harvested_at` is set.

## Tests

- `cargo test -p wisp-store` — skip/lease helpers
- Tauri harvest tests (CI): collect past lease expiry, renew failure aborts, same-host poll/cancel during collect, finish lost-lease errors, auto re-entry skip

## Manual smoke

1. Finish a long SSH run with several output specs. Harvest should complete even if collect exceeds 30s.
2. While collect is running, poll/cancel another run on the same host — it must not stall behind collect.
3. Trigger finish twice on an already-harvested run — the second pass must not collect again.

## Known limitations

- Other long SSH RPCs still use the shared master unless they opt into the dedicated command.
- Tests do not talk to a real SSH host (fake runner).

Closes #983
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-67e65a2c-0219-4cbe-8b2e-9c00881a42a6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-67e65a2c-0219-4cbe-8b2e-9c00881a42a6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

