### PR TITLE
fix: hold workflow locks before session branch merge (#980)

### DIFF
--- a/crates/wisp-core/src/lib.rs
+++ b/crates/wisp-core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod method_search;
 pub mod orchestration;
 pub mod output;
 pub mod provenance;
+pub mod session_locks;
 pub mod subagent;
 pub mod system_prompt;
 

--- a/crates/wisp-core/src/session_locks.rs
+++ b/crates/wisp-core/src/session_locks.rs
@@ -1,0 +1,212 @@
+//! Stable lock order for multi-session workflow guards.
+//!
+//! Branch merge must acquire existing runtimes (never insert) so a finishing
+//! turn that still holds `workflow` after leaving `running_turns` cannot be
+//! detached and replaced by a second runtime.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+/// Lexicographic id order for acquiring more than one session lock.
+pub fn session_lock_order<I, S>(ids: I) -> Vec<String>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let mut ids: Vec<String> = ids.into_iter().map(|s| s.as_ref().to_string()).collect();
+    ids.sort();
+    ids.dedup();
+    ids
+}
+
+/// Look up `ids` without inserting. Missing entries are skipped.
+pub fn existing_in_lock_order<T: Clone>(
+    map: &HashMap<String, T>,
+    ids: &[String],
+) -> Vec<(String, T)> {
+    session_lock_order(ids.iter())
+        .into_iter()
+        .filter_map(|id| map.get(&id).cloned().map(|value| (id, value)))
+        .collect()
+}
+
+/// Lock existing mutexes in [`session_lock_order`]. A holder (persist /
+/// compaction teardown) blocks the caller until it releases — merge must not
+/// detach until that wait finishes.
+pub async fn lock_existing_in_order<T: Send>(
+    locks: &HashMap<String, Arc<tokio::sync::Mutex<T>>>,
+    ids: &[String],
+) -> Vec<tokio::sync::OwnedMutexGuard<T>> {
+    let mut guards = Vec::new();
+    for (_, lock) in existing_in_lock_order(locks, ids) {
+        guards.push(lock.lock_owned().await);
+    }
+    guards
+}
+
+/// True when any target is in a live turn, approval wait, or review.
+pub fn session_targets_busy(
+    running: &HashSet<String>,
+    awaiting: &HashSet<String>,
+    reviewing: &HashSet<String>,
+    ids: &[String],
+) -> bool {
+    ids.iter()
+        .any(|id| running.contains(id) || awaiting.contains(id) || reviewing.contains(id))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn lock_order_is_lexicographic_regardless_of_input_order() {
+        assert_eq!(
+            session_lock_order(["z-main", "a-branch"]),
+            vec!["a-branch".to_string(), "z-main".to_string()]
+        );
+        assert_eq!(
+            session_lock_order(["a-branch", "z-main"]),
+            session_lock_order(["z-main", "a-branch"])
+        );
+        assert_eq!(
+            session_lock_order(["b", "a", "b"]),
+            vec!["a".to_string(), "b".to_string()]
+        );
+    }
+
+    #[test]
+    fn existing_lookup_never_inserts_a_second_runtime() {
+        let mut map = HashMap::new();
+        map.insert("main".into(), 1u8);
+        let found = existing_in_lock_order(&map, &["main".into(), "branch".into()]);
+        assert_eq!(found, vec![("main".into(), 1)]);
+        assert_eq!(map.len(), 1);
+        assert!(!map.contains_key("branch"));
+    }
+
+    #[test]
+    fn merge_refuses_while_busy() {
+        let ids = vec!["main".into(), "branch".into()];
+        let mut running = HashSet::new();
+        running.insert("main".into());
+        assert!(session_targets_busy(
+            &running,
+            &HashSet::new(),
+            &HashSet::new(),
+            &ids
+        ));
+
+        let mut awaiting = HashSet::new();
+        awaiting.insert("branch".into());
+        assert!(session_targets_busy(
+            &HashSet::new(),
+            &awaiting,
+            &HashSet::new(),
+            &ids
+        ));
+
+        let mut reviewing = HashSet::new();
+        reviewing.insert("main".into());
+        assert!(session_targets_busy(
+            &HashSet::new(),
+            &HashSet::new(),
+            &reviewing,
+            &ids
+        ));
+
+        assert!(!session_targets_busy(
+            &HashSet::new(),
+            &HashSet::new(),
+            &HashSet::new(),
+            &ids
+        ));
+    }
+
+    #[tokio::test]
+    async fn held_workflow_lock_blocks_merge_detach() {
+        let main = "frame-m".to_string();
+        let branch = "frame-b".to_string();
+        let main_rt = Arc::new(tokio::sync::Mutex::new(()));
+        let branch_rt = Arc::new(tokio::sync::Mutex::new(()));
+        let mut sessions = HashMap::new();
+        sessions.insert(main.clone(), main_rt.clone());
+        sessions.insert(branch.clone(), branch_rt.clone());
+        let ids = vec![main.clone(), branch.clone()];
+
+        // Persist/compaction still holds workflow after leaving running_turns.
+        let persist = main_rt.clone().lock_owned().await;
+
+        let merge_map = sessions.clone();
+        let merge = tokio::spawn({
+            let ids = ids.clone();
+            let main = main.clone();
+            async move {
+                let found = existing_in_lock_order(&merge_map, &ids);
+                assert_eq!(found.len(), 2);
+                let _locks = lock_existing_in_order(&merge_map, &ids).await;
+                let mut merge_map = merge_map;
+                merge_map.remove(&main).expect("main runtime")
+            }
+        });
+
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        assert!(
+            !merge.is_finished(),
+            "merge must wait for the finishing turn's workflow lock"
+        );
+
+        let turn_rt = sessions
+            .entry(main.clone())
+            .or_insert_with(|| {
+                panic!("created a second runtime for a frame still finishing persist")
+            })
+            .clone();
+        assert!(
+            Arc::ptr_eq(&turn_rt, &main_rt),
+            "same frame_id must reuse the existing runtime until merge detaches it"
+        );
+
+        drop(persist);
+        let detached = tokio::time::timeout(Duration::from_secs(1), merge)
+            .await
+            .expect("merge should finish once the workflow lock is released")
+            .unwrap();
+        assert!(Arc::ptr_eq(&detached, &main_rt));
+    }
+
+    #[tokio::test]
+    async fn opposite_input_order_does_not_deadlock() {
+        let locks: HashMap<_, _> = [
+            ("z".into(), Arc::new(tokio::sync::Mutex::new(()))),
+            ("a".into(), Arc::new(tokio::sync::Mutex::new(()))),
+        ]
+        .into_iter()
+        .collect();
+
+        let left = {
+            let locks = locks.clone();
+            tokio::spawn(async move {
+                for _ in 0..100 {
+                    let _g = lock_existing_in_order(&locks, &["z".into(), "a".into()]).await;
+                }
+            })
+        };
+        let right = {
+            let locks = locks.clone();
+            tokio::spawn(async move {
+                for _ in 0..100 {
+                    let _g = lock_existing_in_order(&locks, &["a".into(), "z".into()]).await;
+                }
+            })
+        };
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            left.await.unwrap();
+            right.await.unwrap();
+        })
+        .await
+        .expect("lexicographic lock order must not deadlock");
+    }
+}

--- a/crates/wisp-core/src/session_locks.rs
+++ b/crates/wisp-core/src/session_locks.rs
@@ -146,8 +146,8 @@ mod tests {
                 let found = existing_in_lock_order(&merge_map, &ids);
                 assert_eq!(found.len(), 2);
                 let _locks = lock_existing_in_order(&merge_map, &ids).await;
-                let mut merge_map = merge_map;
-                merge_map.remove(&main).expect("main runtime")
+                // Production merge keeps the Arc and only drops the cached agent.
+                merge_map.get(&main).cloned()
             }
         });
 
@@ -165,15 +165,20 @@ mod tests {
             .clone();
         assert!(
             Arc::ptr_eq(&turn_rt, &main_rt),
-            "same frame_id must reuse the existing runtime until merge detaches it"
+            "same frame_id must reuse the existing runtime"
         );
 
         drop(persist);
-        let detached = tokio::time::timeout(Duration::from_secs(1), merge)
+        let kept = tokio::time::timeout(Duration::from_secs(1), merge)
             .await
             .expect("merge should finish once the workflow lock is released")
-            .unwrap();
-        assert!(Arc::ptr_eq(&detached, &main_rt));
+            .unwrap()
+            .expect("main runtime stays in the map");
+        assert!(Arc::ptr_eq(&kept, &main_rt));
+        assert!(
+            Arc::ptr_eq(sessions.get(&main).expect("main runtime"), &main_rt),
+            "merge must not replace the runtime Arc"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/session_commands.rs
+++ b/src-tauri/src/session_commands.rs
@@ -264,7 +264,21 @@ pub(super) async fn merge_session_branch_summary(
         .map_err(|error| error.to_string())?;
     let ids = [preview.main_session_id.clone(), id.clone()];
     if session_branch_is_busy(&state, &ids).await {
-        return Err("Wait for the branch and main conversation to finish before merging.".into());
+        return Err(BRANCH_MERGE_BUSY.into());
+    }
+
+    // A finishing turn drops `running_turns` before persist/compaction, but
+    // still holds `rt.workflow`. Collect existing runtimes (never insert) and
+    // wait for those locks so merge cannot detach a frame the old Arc still
+    // owns — that would let a new turn `or_insert_with` a second runtime.
+    let runtimes = {
+        let sessions = state.sessions.lock().await;
+        wisp_core::session_locks::existing_in_lock_order(&sessions, &ids)
+    };
+    let _merge_locks = lock_session_branch_merge_runtimes(&runtimes).await;
+
+    if session_branch_is_busy(&state, &ids).await {
+        return Err(BRANCH_MERGE_BUSY.into());
     }
     if state
         .store
@@ -280,6 +294,7 @@ pub(super) async fn merge_session_branch_summary(
         .merge_session_branch_summary(&id, &project.id, &expected_guard_hash, &summary)
         .await
         .map_err(|error| error.to_string())?;
+    // Main history changed; drop its cached agent. Branch messages are unchanged.
     state.sessions.lock().await.remove(&merged.main_session_id);
     state.set_active_frame(window.label(), Some(merged.main_session_id.clone()));
     Ok(merged)
@@ -287,22 +302,38 @@ pub(super) async fn merge_session_branch_summary(
 
 const BRANCH_SUMMARY_OUTPUT_TOKENS: u64 = 4_096;
 const BRANCH_SUMMARY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+const BRANCH_MERGE_BUSY: &str =
+    "Wait for the branch and main conversation to finish before merging.";
 
-fn session_branch_is_waiting(state: &AppState, ids: &[String]) -> bool {
-    let awaiting = state.awaiting_confirm.lock().unwrap();
-    let reviewing = state.reviewing.lock().unwrap();
-    ids.iter()
-        .any(|id| awaiting.contains(id) || reviewing.contains(id))
+/// Workflow then agent, in the already-sorted runtime list (lexicographic ids).
+/// Matches transfer/delete lock order per session; missing runtimes were skipped.
+async fn lock_session_branch_merge_runtimes(
+    runtimes: &[(String, Arc<SessionRuntime>)],
+) -> (
+    Vec<tokio::sync::OwnedMutexGuard<()>>,
+    Vec<tokio::sync::MutexGuard<'_, Option<Agent>>>,
+) {
+    let ids: Vec<String> = runtimes.iter().map(|(id, _)| id.clone()).collect();
+    let workflows = runtimes
+        .iter()
+        .map(|(id, rt)| (id.clone(), rt.workflow.clone()))
+        .collect();
+    let workflow = wisp_core::session_locks::lock_existing_in_order(&workflows, &ids).await;
+    let mut agent = Vec::with_capacity(runtimes.len());
+    for (_, rt) in runtimes {
+        agent.push(rt.agent.lock().await);
+    }
+    (workflow, agent)
 }
 
 async fn session_branch_is_busy(state: &AppState, ids: &[String]) -> bool {
-    state
-        .running_turns
-        .lock()
-        .await
-        .iter()
-        .any(|running| ids.contains(running))
-        || session_branch_is_waiting(state, ids)
+    let running = state.running_turns.lock().await.clone();
+    wisp_core::session_locks::session_targets_busy(
+        &running,
+        &state.awaiting_confirm.lock().unwrap(),
+        &state.reviewing.lock().unwrap(),
+        ids,
+    )
 }
 
 #[tauri::command]

--- a/src-tauri/src/session_commands.rs
+++ b/src-tauri/src/session_commands.rs
@@ -275,7 +275,7 @@ pub(super) async fn merge_session_branch_summary(
         let sessions = state.sessions.lock().await;
         wisp_core::session_locks::existing_in_lock_order(&sessions, &ids)
     };
-    let _merge_locks = lock_session_branch_merge_runtimes(&runtimes).await;
+    let (_workflow_locks, mut agent_guards) = lock_session_branch_merge_runtimes(&runtimes).await;
 
     if session_branch_is_busy(&state, &ids).await {
         return Err(BRANCH_MERGE_BUSY.into());
@@ -294,8 +294,20 @@ pub(super) async fn merge_session_branch_summary(
         .merge_session_branch_summary(&id, &project.id, &expected_guard_hash, &summary)
         .await
         .map_err(|error| error.to_string())?;
-    // Main history changed; drop its cached agent. Branch messages are unchanged.
-    state.sessions.lock().await.remove(&merged.main_session_id);
+    // Main history changed. Drop the cached agent but keep the Arc so a turn
+    // that already cloned it cannot `or_insert_with` a second runtime.
+    for ((session_id, runtime), agent) in runtimes.iter().zip(agent_guards.iter_mut()) {
+        if session_id == &merged.main_session_id {
+            agent.take();
+            let generation = runtime
+                .agent_config_generation
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+                .saturating_add(1);
+            runtime
+                .cached_agent_generation
+                .store(generation, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
     state.set_active_frame(window.label(), Some(merged.main_session_id.clone()));
     Ok(merged)
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## User-facing problem

[#980](https://github.com/xuzhougeng/wisp-science/issues/980): `merge_session_branch_summary` only did an instant busy check (`running_turns` + awaiting/review). A finishing turn drops `running_turns` before persist/compaction ends but still holds `workflow`. Merge then detached the runtime, so a new turn could `or_insert_with` a second `SessionRuntime` for the same frame.

## What changed

- Merge collects **existing** main/branch runtimes (never inserts) and locks `workflow` then `agent` in lexicographic id order.
- Busy/state is re-checked under those locks, then the DB merge runs.
- The cached main agent is cleared under the held locks. The Arc **stays** in `state.sessions` so a turn that already cloned it cannot create a second runtime.

Delete, transfer, and project-delete paths already held workflow locks and were not changed.

## Tests

- `cargo test -p wisp-core --lib session_locks` — lock order, busy refusal, workflow-held merge waits, no second Arc, no deadlock

## Manual smoke

1. Run a turn on main. While it is finishing (tools/persist), merge a branch into main. Merge should wait or refuse, not interleave with persist.
2. After merge, the next main turn should show the merged summary and only one runtime.

## Known limitations

- `running_turns` is still cleared before persist (#978 teardown ordering). This PR relies on the workflow lock, not on moving that remove.

Closes #980
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-67e65a2c-0219-4cbe-8b2e-9c00881a42a6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-67e65a2c-0219-4cbe-8b2e-9c00881a42a6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

