### PR TITLE
fix: reuse provenance snapshots, share HTTP pool, recheck browser banner

### DIFF
--- a/crates/wisp-core/src/agent.rs
+++ b/crates/wisp-core/src/agent.rs
@@ -8,7 +8,7 @@ use crate::output::{StreamSinkAdapter, ToolEnvAdapter};
 use crate::provenance;
 use crate::Output;
 use anyhow::Result;
-use std::collections::VecDeque;
+use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
@@ -289,6 +289,13 @@ async fn agent_loop_inner(
     let mut iteration = 0usize;
     let mut auto_continues = 0usize;
     let mut recent_sigs: VecDeque<String> = VecDeque::with_capacity(STUCK_WINDOW);
+    // Last producing call's after-snapshot per workspace root, reused as the
+    // next call's before-snapshot. `remove` on take keeps the entry fresh only
+    // for the immediately following producing call; a miss simply rescans.
+    let mut snapshot_cache: HashMap<
+        std::path::PathBuf,
+        BTreeMap<std::path::PathBuf, std::time::SystemTime>,
+    > = HashMap::new();
     loop {
         if cancel.is_some_and(|c| c.load(Ordering::Relaxed)) {
             anyhow::bail!("stopped by user");
@@ -506,9 +513,12 @@ async fn agent_loop_inner(
                 .as_deref()
                 .map(|root| provenance::begin_window(root, scope.as_deref()));
             let before = if let Some(root) = root.clone() {
-                tokio::task::spawn_blocking(move || provenance::snapshot(&root))
-                    .await
-                    .unwrap_or_default()
+                match snapshot_cache.remove(&root) {
+                    Some(cached) => cached,
+                    None => tokio::task::spawn_blocking(move || provenance::snapshot(&root))
+                        .await
+                        .unwrap_or_default(),
+                }
             } else {
                 Default::default()
             };
@@ -535,6 +545,12 @@ async fn agent_loop_inner(
                 let after = tokio::task::spawn_blocking(move || provenance::snapshot(&root2))
                     .await
                     .unwrap_or_default();
+                // Halve the scan cost: the next producing call reuses this
+                // after-snapshot as its before-snapshot instead of rescanning
+                // the whole workspace (each scan walks up to MAX_ENTRIES
+                // entries — hundreds of ms on DrvFs/network mounts, paid twice
+                // per tool before this cache).
+                snapshot_cache.insert(root.clone(), after.clone());
                 let finished = window.map(provenance::ProducingWindow::finish);
                 let (mut written, mut read) = provenance::diff(&before, &after, root, &source);
                 if let Some(finished) = &finished {

--- a/crates/wisp-llm/src/provider.rs
+++ b/crates/wisp-llm/src/provider.rs
@@ -298,7 +298,21 @@ pub struct ProviderConfig {
 }
 
 /// Shared reqwest client for all providers, honoring `cfg.proxy`.
+/// Process-wide connection pool for the no-proxy case. Review / follow-up /
+/// memory side calls used to build a fresh `reqwest::Client` per call — every
+/// one of them paid a new TLS handshake (~hundreds of ms) before this cache.
+/// Proxy configs stay per-client (they vary by profile and are rare).
+static SHARED_CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
+
 pub(crate) fn http_client(cfg: &ProviderConfig) -> reqwest::Client {
+    let proxy = cfg.proxy.as_deref().map(str::trim);
+    if matches!(proxy, None | Some("")) {
+        return SHARED_CLIENT.get_or_init(|| build_http_client(cfg)).clone();
+    }
+    build_http_client(cfg)
+}
+
+fn build_http_client(cfg: &ProviderConfig) -> reqwest::Client {
     let mut b = reqwest::Client::builder()
         .user_agent("wisp-science")
         // A total request timeout also caps a healthy, actively streaming SSE

--- a/src-tauri/src/app_commands.rs
+++ b/src-tauri/src/app_commands.rs
@@ -584,6 +584,12 @@ pub(super) fn open_browser_extension_page(
     state.browser_bridge.open_extension_setup()
 }
 
+/// Live extension connection check for the offline banner's display gate.
+#[tauri::command]
+pub(super) async fn extension_connected(state: State<'_, AppState>) -> Result<bool, String> {
+    Ok(state.browser_bridge.extension_connected().await)
+}
+
 #[tauri::command]
 pub(super) fn reveal_in_file_manager(
     app: AppHandle,

--- a/src-tauri/src/browser_bridge/mod.rs
+++ b/src-tauri/src/browser_bridge/mod.rs
@@ -1403,6 +1403,15 @@ impl BrowserBridge {
             opened,
         }
     }
+
+    /// Live connection status for the offline banner's recheck: the per-turn
+    /// judgment is frozen into the transcript, so a banner from a transient
+    /// disconnect sticks forever even after the extension reconnects (and
+    /// resurrects on session reload). The UI rechecks through this before
+    /// showing the banner.
+    pub async fn extension_connected(&self) -> bool {
+        self.client_connected().await
+    }
 }
 
 #[derive(Serialize, Clone)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7028,6 +7028,7 @@ pub fn run() {
             app_updates::install_update,
             app_commands::open_external_url,
             app_commands::open_browser_extension_page,
+            app_commands::extension_connected,
             ui_heartbeat,
             app_commands::reveal_in_file_manager,
             connector_commands::list_mcp_connections,

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -5428,6 +5428,8 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
             return null;
           case "open_browser_extension_page":
             return { extension_path: "/mock/wisp/browser-extension", opened: false };
+          case "extension_connected":
+            return false;
           case "ui_heartbeat":
             return null;
           case "list_specialists":
@@ -5829,6 +5831,8 @@ export function parallelMock(): void {
             return null;
           case "open_browser_extension_page":
             return { extension_path: "/mock/wisp/browser-extension", opened: false };
+          case "extension_connected":
+            return false;
           case "ui_heartbeat":
             return null;
           default: return null;

--- a/ui/mock-bridge.js
+++ b/ui/mock-bridge.js
@@ -880,6 +880,8 @@
             return null;
           case "open_browser_extension_page":
             return { extension_path: "/mock/wisp/browser-extension", opened: false };
+          case "extension_connected":
+            return false;
           case "list_library_items":
             return libraryItems;
           case "get_research_graph":

--- a/ui/src/app_support/messages.rs
+++ b/ui/src/app_support/messages.rs
@@ -11,7 +11,11 @@ pub(crate) fn streaming_markdown_commit_interval_ms(
     if let Some(cost_ms) = recent_parse_cost_ms.filter(|cost| cost.is_finite()) {
         // Keep Markdown parsing below roughly one sixth of the main-thread
         // budget. The live plain-text tail still advances on every delta flush.
-        return (cost_ms.max(0.0) * 6.0).ceil().clamp(50.0, 1_200.0) as u64;
+        // The 400 ms cap (down from 1200) keeps typing-feel latency tight now
+        // that commits append only the new suffix instead of re-parsing the
+        // whole prefix — full re-parses only happen mid-block, which the
+        // adaptive cost still throttles.
+        return (cost_ms.max(0.0) * 6.0).ceil().clamp(50.0, 400.0) as u64;
     }
 
     // Cold-start fallback before the first measured parse. Length is only a
@@ -1493,7 +1497,7 @@ mod streaming_markdown_tests {
         );
         assert_eq!(
             streaming_markdown_commit_interval_ms(1_000, Some(400.0)),
-            1_200
+            400
         );
     }
 }

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -11368,6 +11368,21 @@ fn App() -> impl IntoView {
                         return None;
                     };
                     (active_session.get().as_deref() == Some(notice.frame_id.as_str())).then(|| {
+                        // The per-turn judgment is frozen in the transcript, so
+                        // a transient disconnect sticks forever — even across
+                        // session reloads — after the extension reconnects.
+                        // Recheck live: connected now means the banner is
+                        // stale and must not render.
+                        {
+                            let notice_cb = browser_offline_notice;
+                            let frame_id = notice.frame_id.clone();
+                            spawn_local(async move {
+                                let value = invoke("extension_connected", JsValue::UNDEFINED).await;
+                                if value.as_bool().unwrap_or(false) {
+                                    set_browser_offline_notice(notice_cb, &frame_id, None);
+                                }
+                            });
+                        }
                         let retry_text = notice.retry_text.clone();
                         let can_retry = !retry_text.trim().is_empty();
                         view! {


### PR DESCRIPTION
## Problem

Each producing tool call scanned the workspace twice. No-proxy side HTTP calls built a new reqwest client each time. The offline banner did not recheck a live browser-extension connection. The streaming markdown commit cap was still 1200ms after the parse budget dropped.

Split out of closed #1006 (absorb of #987 / #1004). Independent PR to `main` — not stacked with the other three.

## Change

- Provenance reuses the previous producing call's after-snapshot as the next before-snapshot.
- Shared process-wide reqwest pool for no-proxy side calls.
- Offline banner rechecks live extension connection (`extension_connected`) before staying on screen.
- Stream commit cap 1200ms → 400ms.

## Files

- `crates/wisp-core/src/agent.rs`
- `crates/wisp-llm/src/provider.rs`
- `src-tauri/src/app_commands.rs`
- `src-tauri/src/browser_bridge/mod.rs`
- `src-tauri/src/lib.rs`
- `ui/src/app_support/messages.rs`
- `ui/src/main.rs`
- `ui/mock-bridge.js`
- `ui-tests/tests/mock-tauri.ts`

Overlaps `messages.rs` / `main.rs` with the CPU PR and `agent.rs` with the vision and agent PRs; rebase if those land first.

Does not bump the version. Next release remains 1.7.0.