### PR TITLE
fix(core): run leading read-only tool batches in parallel

### DIFF
--- a/crates/wisp-core/src/agent.rs
+++ b/crates/wisp-core/src/agent.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 use wisp_llm::{
     is_retriable, Completion, Content, LlmError, Message, Part, Provider, ToolCall, ToolSchema,
 };
-use wisp_tools::{ImageData, Registry, ToolControl, ToolEnv};
+use wisp_tools::{ImageData, Registry, ToolControl, ToolEnv, ToolResult};
 
 const RETRY_DELAYS: [u64; 5] = [2_000, 10_000, 30_000, 60_000, 120_000];
 const CANCEL_POLL_INTERVAL: Duration = Duration::from_millis(25);
@@ -489,137 +489,175 @@ async fn agent_loop_inner(
         }
 
         let mut batch_control = ToolControl::Continue;
-        for (index, tc) in comp.tool_calls.iter().enumerate() {
-            if cancel.is_some_and(|c| c.load(Ordering::Relaxed)) {
-                append_interrupted_tool_results(ctx, tools, output, &comp.tool_calls[index..]);
-                anyhow::bail!(STOPPED_BY_USER);
-            }
-            let name = tc.function.name.clone();
-            let args = tc.args_value();
-            let producing = provenance::is_producing(&name);
-            let root = producing.then(|| env.project_root().to_path_buf());
-            let source = provenance::source_of(&name, &args);
-            // Registered before the pre-snapshot so concurrent sessions of the
-            // same workspace can tell which of each other's writes are theirs.
-            let scope = output.provenance_scope();
-            let window = root
-                .as_deref()
-                .map(|root| provenance::begin_window(root, scope.as_deref()));
-            let before = if let Some(root) = root.clone() {
-                tokio::task::spawn_blocking(move || provenance::snapshot(&root))
-                    .await
-                    .unwrap_or_default()
-            } else {
-                Default::default()
-            };
-            let preimages = if let Some(root) = root.clone() {
-                let before = before.clone();
-                let source = source.clone();
-                tokio::task::spawn_blocking(move || {
-                    provenance::capture_text_preimages(&before, &root, &source)
-                })
-                .await
-                .unwrap_or_default()
-            } else {
-                Default::default()
-            };
-            let t0 = std::time::Instant::now();
-            let result = tools.run(&name, &args, &env).await;
-            // Drain even for non-producing calls so a stale kernel report
-            // cannot leak into the next call's provenance record.
-            let reported = env.take_reported_writes();
-            let control = result.control;
-            let duration_ms = t0.elapsed().as_millis() as u64;
-            if let Some(root) = &root {
-                let root2 = root.clone();
-                let after = tokio::task::spawn_blocking(move || provenance::snapshot(&root2))
-                    .await
-                    .unwrap_or_default();
-                let finished = window.map(provenance::ProducingWindow::finish);
-                let (mut written, mut read) = provenance::diff(&before, &after, root, &source);
-                if let Some(finished) = &finished {
-                    provenance::retain_unambiguous_writes(
-                        &mut written,
-                        &after,
-                        root,
-                        &source,
-                        finished,
-                    );
-                }
-                provenance::augment_written_paths(
-                    &name,
-                    root,
-                    &source,
-                    result.success,
-                    &preimages,
-                    &mut written,
-                );
-                // After retain: a kernel-reported path survives an ambiguity
-                // drop, and a report never widens what retain kept for
-                // unreported paths.
-                provenance::union_reported_writes(&mut written, &reported);
-                read.retain(|path| !written.contains(path));
-                if !written.is_empty() {
-                    let file_changes =
-                        provenance::undo_file_changes(&before, root, &written, &preimages);
-                    output.provenance(&provenance::ProvenanceRecord {
-                        tool: name.clone(),
-                        language: provenance::language_of(&name),
-                        source,
-                        output: result.content.clone(),
-                        success: result.success,
-                        files_written: written,
-                        files_read: read,
-                        file_changes,
-                    });
-                }
-            }
-            let (content, tool_text, ok) = if let Some(img) = &result.image {
-                match vision_provider {
-                    Some(vision) => match describe_image(vision, img, &name, &args).await {
-                        Ok(text) => (Content::text(text.clone()), text, true),
-                        Err(e) => {
-                            let text = format!("{name} error: vision model failed: {e}");
-                            (Content::text(text.clone()), text, false)
-                        }
-                    },
-                    None => {
-                        let text = format!("{name} error: no vision model is configured. Mark an API model as vision-capable in Settings -> Models and set it for image analysis.");
-                        (Content::text(text.clone()), text, false)
+        // Read-only fan-out: when the model issues several independent
+        // retrieval calls in one batch, run the leading run of them
+        // concurrently instead of paying N sequential round trips. The first
+        // call that can write, prompt, or is unknown ends the parallel run;
+        // it and everything after it stay sequential so provenance windows,
+        // approval prompts, and side effects keep their order.
+        let mut sequential_start = 0usize;
+        if cancel.is_some_and(|c| c.load(Ordering::Relaxed)) {
+            append_interrupted_tool_results(ctx, tools, output, &comp.tool_calls);
+            anyhow::bail!(STOPPED_BY_USER);
+        }
+        if comp.tool_calls.len() > 1 {
+            if let Some((split, payloads)) =
+                run_read_only_prefix(&tools, &env, &comp.tool_calls).await
+            {
+                sequential_start = split;
+                for (index, payload) in payloads.into_iter().enumerate() {
+                    let ToolPayload {
+                        id,
+                        name,
+                        args,
+                        result,
+                        duration_ms,
+                    } = payload;
+                    let control = result.control;
+                    append_tool_outcome(
+                        ctx,
+                        vision_provider,
+                        tools,
+                        output,
+                        env.project_root(),
+                        &id,
+                        &name,
+                        &args,
+                        result,
+                        duration_ms,
+                    )
+                    .await;
+                    if control != ToolControl::Continue {
+                        append_skipped_tool_results(
+                            ctx,
+                            tools,
+                            output,
+                            &comp.tool_calls[index + 1..],
+                            &name,
+                            control,
+                        );
+                        batch_control = control;
+                        break;
                     }
                 }
-            } else {
-                (
-                    Content::text(result.content.clone()),
-                    result.content.clone(),
-                    result.success,
-                )
-            };
-            output.tool_result(&tools.event_name(&name, &args), ok, &tool_text, duration_ms);
-            ctx.append_tool(
-                &tc.id,
-                &name,
-                budget_tool_result(env.project_root(), &name, content),
-            );
-            if let Some(m) = ctx.messages.last() {
-                output.on_message(m);
             }
-
-            if control != ToolControl::Continue {
-                // A user decision invalidates calls the model optimistically
-                // placed later in the same batch. Do not execute them, but do
-                // persist a synthetic result for each one: providers require
-                // every assistant tool call to have a matching tool message.
-                append_skipped_tool_results(
+        }
+        if batch_control == ToolControl::Continue {
+            for (index, tc) in comp.tool_calls.iter().enumerate().skip(sequential_start) {
+                if cancel.is_some_and(|c| c.load(Ordering::Relaxed)) {
+                    append_interrupted_tool_results(ctx, tools, output, &comp.tool_calls[index..]);
+                    anyhow::bail!(STOPPED_BY_USER);
+                }
+                let name = tc.function.name.clone();
+                let args = tc.args_value();
+                let producing = provenance::is_producing(&name);
+                let root = producing.then(|| env.project_root().to_path_buf());
+                let source = provenance::source_of(&name, &args);
+                // Registered before the pre-snapshot so concurrent sessions of the
+                // same workspace can tell which of each other's writes are theirs.
+                let scope = output.provenance_scope();
+                let window = root
+                    .as_deref()
+                    .map(|root| provenance::begin_window(root, scope.as_deref()));
+                let before = if let Some(root) = root.clone() {
+                    tokio::task::spawn_blocking(move || provenance::snapshot(&root))
+                        .await
+                        .unwrap_or_default()
+                } else {
+                    Default::default()
+                };
+                let preimages = if let Some(root) = root.clone() {
+                    let before = before.clone();
+                    let source = source.clone();
+                    tokio::task::spawn_blocking(move || {
+                        provenance::capture_text_preimages(&before, &root, &source)
+                    })
+                    .await
+                    .unwrap_or_default()
+                } else {
+                    Default::default()
+                };
+                let t0 = std::time::Instant::now();
+                let result = tools.run(&name, &args, &env).await;
+                // Drain even for non-producing calls so a stale kernel report
+                // cannot leak into the next call's provenance record.
+                let reported = env.take_reported_writes();
+                let control = result.control;
+                let duration_ms = t0.elapsed().as_millis() as u64;
+                if let Some(root) = &root {
+                    let root2 = root.clone();
+                    let after = tokio::task::spawn_blocking(move || provenance::snapshot(&root2))
+                        .await
+                        .unwrap_or_default();
+                    let finished = window.map(provenance::ProducingWindow::finish);
+                    let (mut written, mut read) = provenance::diff(&before, &after, root, &source);
+                    if let Some(finished) = &finished {
+                        provenance::retain_unambiguous_writes(
+                            &mut written,
+                            &after,
+                            root,
+                            &source,
+                            finished,
+                        );
+                    }
+                    provenance::augment_written_paths(
+                        &name,
+                        root,
+                        &source,
+                        result.success,
+                        &preimages,
+                        &mut written,
+                    );
+                    // After retain: a kernel-reported path survives an ambiguity
+                    // drop, and a report never widens what retain kept for
+                    // unreported paths.
+                    provenance::union_reported_writes(&mut written, &reported);
+                    read.retain(|path| !written.contains(path));
+                    if !written.is_empty() {
+                        let file_changes =
+                            provenance::undo_file_changes(&before, root, &written, &preimages);
+                        output.provenance(&provenance::ProvenanceRecord {
+                            tool: name.clone(),
+                            language: provenance::language_of(&name),
+                            source,
+                            output: result.content.clone(),
+                            success: result.success,
+                            files_written: written,
+                            files_read: read,
+                            file_changes,
+                        });
+                    }
+                }
+                append_tool_outcome(
                     ctx,
+                    vision_provider,
                     tools,
                     output,
-                    &comp.tool_calls[index + 1..],
+                    env.project_root(),
+                    &tc.id,
                     &name,
-                    control,
-                );
-                batch_control = control;
-                break;
+                    &args,
+                    result,
+                    duration_ms,
+                )
+                .await;
+
+                if control != ToolControl::Continue {
+                    // A user decision invalidates calls the model optimistically
+                    // placed later in the same batch. Do not execute them, but do
+                    // persist a synthetic result for each one: providers require
+                    // every assistant tool call to have a matching tool message.
+                    append_skipped_tool_results(
+                        ctx,
+                        tools,
+                        output,
+                        &comp.tool_calls[index + 1..],
+                        &name,
+                        control,
+                    );
+                    batch_control = control;
+                    break;
+                }
             }
         }
         if batch_control == ToolControl::StopTurn {
@@ -664,6 +702,104 @@ fn append_synthetic_tool_results(
         if let Some(message) = ctx.messages.last() {
             output.on_message(message);
         }
+    }
+}
+
+/// One finished tool call from a model batch, ready to be ingested into the
+/// context: identity, arguments, raw result, and wall-clock duration.
+struct ToolPayload {
+    id: String,
+    name: String,
+    args: serde_json::Value,
+    result: ToolResult,
+    duration_ms: u64,
+}
+
+/// The longest leading run of model-issued calls that are registered
+/// read-only tools requiring no approval, executed concurrently. `None` when
+/// there is nothing worth parallelizing (fewer than two eligible calls up
+/// front). Anything that can write, prompt, or is unknown breaks the run and
+/// stays on the sequential path.
+async fn run_read_only_prefix(
+    tools: &Registry,
+    env: &dyn ToolEnv,
+    calls: &[ToolCall],
+) -> Option<(usize, Vec<ToolPayload>)> {
+    let mut split = 0usize;
+    for tc in calls {
+        let name = tc.function.name.as_str();
+        let Some(tool) = tools.get(name) else { break };
+        if !tool.read_only()
+            || tool.minimum_approval() != wisp_tools::Approval::Allow
+            || env.approval_mode(name).await != wisp_tools::Approval::Allow
+        {
+            break;
+        }
+        split += 1;
+    }
+    if split < 2 {
+        return None;
+    }
+    let payloads = futures_util::future::join_all(calls[..split].iter().map(|tc| {
+        let name = tc.function.name.clone();
+        let args = tc.args_value();
+        async move {
+            let t0 = std::time::Instant::now();
+            let result = tools.run(&name, &args, env).await;
+            ToolPayload {
+                id: tc.id.clone(),
+                name,
+                args,
+                result,
+                duration_ms: t0.elapsed().as_millis() as u64,
+            }
+        }
+    }))
+    .await;
+    Some((split, payloads))
+}
+
+/// Ingest one finished tool call: image handling, the result event, and the
+/// context append. Shared by the parallel read-only fast path and the
+/// sequential loop.
+#[allow(clippy::too_many_arguments)]
+async fn append_tool_outcome(
+    ctx: &mut ContextManager,
+    vision_provider: Option<&dyn Provider>,
+    tools: &Registry,
+    output: &dyn Output,
+    root: &Path,
+    id: &str,
+    name: &str,
+    args: &serde_json::Value,
+    result: ToolResult,
+    duration_ms: u64,
+) {
+    let (content, tool_text, ok) = if let Some(img) = &result.image {
+        match vision_provider {
+            Some(vision) => match describe_image(vision, img, name, args).await {
+                Ok(text) => (Content::text(text.clone()), text, true),
+                Err(e) => {
+                    let text = format!("{name} error: vision model failed: {e}");
+                    (Content::text(text.clone()), text, false)
+                }
+            },
+            None => {
+                let text = format!("{name} error: no vision model is configured. Mark an API model as vision-capable in Settings -> Models and set it for image analysis.");
+                (Content::text(text.clone()), text, false)
+            }
+        }
+    } else {
+        (
+            Content::text(result.content.clone()),
+            result.content.clone(),
+            result.success,
+        )
+    };
+    output.tool_result(&tools.event_name(name, args), ok, &tool_text, duration_ms);
+    ctx.append_tool(id, name, budget_tool_result(root, name, content));
+    if let Some(m) = ctx.messages.last() {
+        output.on_message(m);
     }
 }
 
@@ -1494,6 +1630,211 @@ mod tests {
             .iter()
             .filter_map(|message| message.tool_call_id.as_deref())
             .collect()
+    }
+
+    /// Two read-only tools sharing ONE barrier (both must be in flight
+    /// before either proceeds) and a shared concurrency peak counter.
+    /// Sequential execution can never reach 2 in-flight runs.
+    struct BarrierReadPair;
+
+    impl BarrierReadPair {
+        fn tools(
+            name_a: &'static str,
+            name_b: &'static str,
+        ) -> (BarrierReadTool, BarrierReadTool, Arc<AtomicUsize>) {
+            let barrier = Arc::new(tokio::sync::Barrier::new(2));
+            let max_concurrent = Arc::new(AtomicUsize::new(0));
+            let in_flight = Arc::new(AtomicUsize::new(0));
+            let max = max_concurrent.clone();
+            let make = |name: &'static str| BarrierReadTool {
+                name,
+                barrier: barrier.clone(),
+                max_concurrent: max_concurrent.clone(),
+                in_flight: in_flight.clone(),
+            };
+            (make(name_a), make(name_b), max)
+        }
+    }
+
+    /// A read-only tool that waits on a shared barrier before finishing.
+    struct BarrierReadTool {
+        name: &'static str,
+        barrier: Arc<tokio::sync::Barrier>,
+        max_concurrent: Arc<AtomicUsize>,
+        in_flight: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl Tool for BarrierReadTool {
+        fn name(&self) -> &str {
+            self.name
+        }
+
+        fn schema(&self) -> ToolSchema {
+            ToolSchema::new(
+                self.name,
+                "barrier read tool",
+                serde_json::json!({"type": "object"}),
+            )
+        }
+
+        fn read_only(&self) -> bool {
+            true
+        }
+
+        async fn run(&self, _args: &serde_json::Value, _env: &dyn ToolEnv) -> ToolResult {
+            let now = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+            self.max_concurrent.fetch_max(now, Ordering::SeqCst);
+            self.barrier.wait().await;
+            self.in_flight.fetch_sub(1, Ordering::SeqCst);
+            ToolResult::ok("read done")
+        }
+    }
+
+    #[tokio::test]
+    async fn read_only_batch_prefix_runs_concurrently() {
+        // Both tools wait on the SAME 2-party barrier: the batch only
+        // finishes if the loop runs the two calls concurrently. Sequential
+        // execution deadlocks here and fails the test.
+        let (tool_a, tool_b, max) = BarrierReadPair::tools("probe_a", "probe_b");
+        let provider = SequenceProvider::new([
+            Completion {
+                tool_calls: vec![
+                    call("a-1", "probe_a", serde_json::json!({})),
+                    call("b-1", "probe_b", serde_json::json!({})),
+                ],
+                finish_reason: Some("tool_calls".into()),
+                ..Completion::default()
+            },
+            Completion {
+                content: "done".into(),
+                finish_reason: Some("stop".into()),
+                ..Completion::default()
+            },
+        ]);
+        let mut tools = Registry::builtins().filtered(&[]);
+        tools.add(Box::new(tool_a));
+        tools.add(Box::new(tool_b));
+        let mut ctx = ContextManager::new(100_000);
+
+        agent_loop(
+            &mut ctx,
+            &provider,
+            None,
+            &tools,
+            Path::new("."),
+            &NullOutput,
+            "probe both",
+            0,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(max.load(Ordering::SeqCst), 2);
+        assert_eq!(tool_result_ids(&ctx), vec!["a-1", "b-1"]);
+    }
+
+    #[tokio::test]
+    async fn read_only_prefix_stays_sequential_after_first_asking_tool() {
+        // Leading unknown tool breaks the parallel run: nothing runs ahead of
+        // it, and the whole batch executes sequentially (a 1-party barrier
+        // never blocks).
+        let barrier = Arc::new(tokio::sync::Barrier::new(1));
+        let probe = BarrierReadTool {
+            name: "probe_seq",
+            barrier,
+            max_concurrent: Arc::new(AtomicUsize::new(0)),
+            in_flight: Arc::new(AtomicUsize::new(0)),
+        };
+        let runs = Arc::new(AtomicUsize::new(0));
+        let provider = SequenceProvider::new([
+            Completion {
+                tool_calls: vec![
+                    call("w-1", "writer", serde_json::json!({})),
+                    call("r-1", "probe_seq", serde_json::json!({})),
+                ],
+                finish_reason: Some("tool_calls".into()),
+                ..Completion::default()
+            },
+            Completion {
+                content: "done".into(),
+                finish_reason: Some("stop".into()),
+                ..Completion::default()
+            },
+        ]);
+        let mut tools = Registry::builtins().filtered(&[]);
+        tools.add(Box::new(probe));
+        tools.add(Box::new(CountingTool {
+            name: "writer",
+            runs: runs.clone(),
+        }));
+        let mut ctx = ContextManager::new(100_000);
+
+        agent_loop(
+            &mut ctx,
+            &provider,
+            None,
+            &tools,
+            Path::new("."),
+            &NullOutput,
+            "mixed batch",
+            0,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(runs.load(Ordering::SeqCst), 1);
+        assert_eq!(tool_result_ids(&ctx), vec!["w-1", "r-1"]);
+    }
+
+    #[tokio::test]
+    async fn sequential_path_still_handles_a_single_read_only_call() {
+        // A lone read-only call is not worth a parallel run; it must still go
+        // through the ordinary sequential path and produce its result.
+        let probe = BarrierReadTool {
+            name: "probe_solo",
+            barrier: Arc::new(tokio::sync::Barrier::new(1)),
+            max_concurrent: Arc::new(AtomicUsize::new(0)),
+            in_flight: Arc::new(AtomicUsize::new(0)),
+        };
+        let provider = SequenceProvider::new([
+            Completion {
+                tool_calls: vec![call("solo-1", "probe_solo", serde_json::json!({}))],
+                finish_reason: Some("tool_calls".into()),
+                ..Completion::default()
+            },
+            Completion {
+                content: "done".into(),
+                finish_reason: Some("stop".into()),
+                ..Completion::default()
+            },
+        ]);
+        let mut tools = Registry::builtins().filtered(&[]);
+        tools.add(Box::new(probe));
+        let mut ctx = ContextManager::new(100_000);
+
+        agent_loop(
+            &mut ctx,
+            &provider,
+            None,
+            &tools,
+            Path::new("."),
+            &NullOutput,
+            "single probe",
+            0,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(tool_result_ids(&ctx), vec!["solo-1"]);
+        assert!(ctx
+            .messages
+            .iter()
+            .any(|m| m.tool_name.as_deref() == Some("probe_solo")
+                && m.content.as_text().contains("read done")));
     }
 
     #[tokio::test]

--- a/crates/wisp-core/src/provenance.rs
+++ b/crates/wisp-core/src/provenance.rs
@@ -42,7 +42,7 @@ pub struct TextPreimage {
     pub checksum: String,
 }
 
-const SKIP_DIRS: &[&str] = &[
+pub(crate) const SKIP_DIRS: &[&str] = &[
     ".git",
     ".venv",
     "node_modules",

--- a/crates/wisp-core/src/system_prompt.rs
+++ b/crates/wisp-core/src/system_prompt.rs
@@ -1,8 +1,9 @@
 //! Layered system-prompt assembly, ported from mangopi-cli's `SystemPrompt`.
 //!
 //! Sections: base intro, safety, built-in rules, tool guidance, skills
-//! guidance, user rules (memory), environment.
+//! guidance, user rules (memory), environment, workspace overview.
 
+use crate::provenance::SKIP_DIRS;
 use std::path::Path;
 use wisp_skills::SkillIndex;
 
@@ -89,6 +90,8 @@ never reduce the promised samples or scientific objective without the user's exp
     fn tool_guidance() -> String {
         "## Tool Selection\n\n\
 Use the dedicated tool when one exists (read/write/edit/search/grep/attempt_completion). Reach for **shell** only when no dedicated tool fits — it runs PowerShell on Windows and POSIX `sh` on macOS/Linux, with a 60s timeout.\n\
+Batch independent read-only calls: when you need several files, searches, or greps that do not depend on each other's results, issue them all in ONE batch — they run concurrently instead of turn by turn. Calls that need an earlier result, and any call that writes or prompts, belong in a later batch.\n\
+For multi-file comprehension questions (\"how does X work across this codebase\"), delegate to the **explore** subagent when it is available: it reads and searches in its own context and returns a compact conclusion, instead of you pulling many files into this conversation.\n\
 When the user asks what a configured Workflow is, what it does, or how it works, call **explain_workflow** when available and explain the returned task graph. Inspection is not execution: do not call **delegate_tasks** unless the user asks to run the Workflow.\n\
 When the user asks to change app appearance or preferences (font size, theme, language, compaction, notifications) or to inspect disk storage for this project, call **configure**. Do not send them to Settings for those allowlisted keys. Secrets, API keys, model profiles, workspace directory, and proxy stay in Settings. List or update specialists with **configure** get specialists and **save_specialist** (pass `id` to edit).\n\
 Use **edit** (not write) for small in-place changes; read the target first so `old` matches the current file exactly, and ensure `old` is unique or pass `all=true`.\n\
@@ -222,6 +225,112 @@ If a named workflow is disabled or unavailable, follow the same principles direc
         )
     }
 
+    /// A first-turn orientation block: a shallow project tree and the git
+    /// state, so the model starts with correct paths instead of spending its
+    /// first iterations listing directories. Cheap to build (depth-2, heavy
+    /// dirs skipped, listing capped) and written once at prompt assembly.
+    fn workspace_overview(root: &Path) -> String {
+        let mut out = String::from("## Workspace Overview\n\n");
+        out.push_str("Shallow project tree (depth 2, bulky/hidden dirs omitted):\n\n");
+        out.push_str(&Self::project_tree(root));
+        out.push('\n');
+        out.push_str(&Self::git_overview(root));
+        out.push_str(
+            "\nThe tree is a snapshot from session start and may be stale or truncated; verify a \
+             path with read/search before editing it. Do not list the root directory with shell \
+             just to rediscover what is here.\n",
+        );
+        out
+    }
+
+    /// Two-level directory listing. Each directory shows up to
+    /// [`TREE_ENTRIES_PER_DIR`] entries plus an `(+N more)` marker; the whole
+    /// render stops at [`TREE_MAX_BYTES`].
+    fn project_tree(root: &Path) -> String {
+        const TREE_ENTRIES_PER_DIR: usize = 12;
+        const TREE_MAX_DIRS: usize = 40;
+        const TREE_MAX_BYTES: usize = 4 * 1024;
+
+        fn skip_entry(name: &str) -> bool {
+            SKIP_DIRS.contains(&name)
+                || name.starts_with('.')
+                || matches!(name, "target" | "build" | "dist")
+        }
+
+        fn sorted_entries(dir: &Path) -> Vec<(String, bool)> {
+            let mut entries: Vec<(String, bool)> = std::fs::read_dir(dir)
+                .into_iter()
+                .flatten()
+                .flatten()
+                .filter_map(|entry| {
+                    let name = entry.file_name().to_string_lossy().into_owned();
+                    (!skip_entry(&name)).then(|| {
+                        let is_dir = entry.file_type().map(|t| t.is_dir()).unwrap_or(false);
+                        (name, is_dir)
+                    })
+                })
+                .collect();
+            entries.sort();
+            entries
+        }
+
+        fn render(dir: &Path, prefix: &str, out: &mut String, dirs_left: &mut usize) {
+            if *dirs_left == 0 || out.len() > TREE_MAX_BYTES {
+                return;
+            }
+            let entries = sorted_entries(dir);
+            let shown = entries.iter().take(TREE_ENTRIES_PER_DIR);
+            let hidden = entries.len().saturating_sub(TREE_ENTRIES_PER_DIR);
+            for (name, is_dir) in shown {
+                if out.len() > TREE_MAX_BYTES {
+                    return;
+                }
+                if *is_dir {
+                    *dirs_left -= 1;
+                    out.push_str(&format!("{prefix}{name}/\n"));
+                    render(&dir.join(name), &format!("{prefix}  "), out, dirs_left);
+                } else {
+                    out.push_str(&format!("{prefix}{name}\n"));
+                }
+            }
+            if hidden > 0 {
+                out.push_str(&format!("{prefix}(+{hidden} more)\n"));
+            }
+        }
+
+        let mut out = String::new();
+        let mut dirs_left = TREE_MAX_DIRS;
+        render(root, "", &mut out, &mut dirs_left);
+        out
+    }
+
+    /// `git branch` + a one-line dirty summary. Any git failure (not a repo,
+    /// git absent) degrades to a "not a repository" line, never an error.
+    fn git_overview(root: &Path) -> String {
+        let run = |args: &[&str]| -> Option<String> {
+            std::process::Command::new("git")
+                .arg("-C")
+                .arg(root)
+                .args(args)
+                .output()
+                .ok()
+                .filter(|o| o.status.success())
+                .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        };
+        let Some(branch) = run(&["rev-parse", "--abbrev-ref", "HEAD"]) else {
+            return "Git status: not a repository (or git unavailable).\n".into();
+        };
+        let dirty = run(&["status", "--porcelain"])
+            .map(|s| s.lines().count())
+            .unwrap_or(0);
+        let state = if dirty == 0 {
+            "clean".to_string()
+        } else {
+            format!("{dirty} changed file(s)")
+        };
+        format!("Git status: branch {branch}, {state}.\n")
+    }
+
     pub fn assemble(&self) -> String {
         let mut sections = vec![
             Self::base_intro(),
@@ -237,6 +346,7 @@ If a named workflow is disabled or unavailable, follow the same principles direc
         }
         sections.push(self.memory());
         sections.push(self.environment());
+        sections.push(Self::workspace_overview(self.project_root));
         sections.join("\n\n")
     }
 }
@@ -577,6 +687,50 @@ mod tests {
         assert!(!out.contains("SHOULD_NOT_BE_IN_SYSTEM_PROMPT"), "{out}");
 
         std::fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn workspace_overview_lists_project_files_and_skips_heavy_dirs() {
+        let root = std::env::temp_dir().join(format!(
+            "wisp-tree-{}-{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(root.join("crates/wisp-core/src")).unwrap();
+        std::fs::create_dir_all(root.join("node_modules/pkg")).unwrap();
+        std::fs::write(root.join("crates/wisp-core/src/lib.rs"), "pub mod x;").unwrap();
+        std::fs::write(root.join("README.md"), "readme").unwrap();
+
+        let tree = SystemPrompt::project_tree(&root);
+        assert!(tree.contains("crates/"), "{tree}");
+        assert!(tree.contains("wisp-core/"), "{tree}");
+        assert!(tree.contains("lib.rs"), "{tree}");
+        assert!(tree.contains("README.md"), "{tree}");
+        assert!(!tree.contains("node_modules"), "{tree}");
+        assert!(!tree.contains("pkg"), "{tree}");
+
+        let overview = SystemPrompt::workspace_overview(&root);
+        assert!(overview.contains("## Workspace Overview"), "{overview}");
+        assert!(
+            overview.contains("Git status:"),
+            "git line must exist even when degraded: {overview}"
+        );
+
+        std::fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn tool_guidance_teaches_batching_and_explore_delegation() {
+        let out = SystemPrompt::new(std::path::Path::new("/tmp"), &SkillIndex::default(), None)
+            .assemble();
+        assert!(
+            out.contains("Batch independent read-only calls"),
+            "batching guidance missing:\n{out}"
+        );
+        assert!(
+            out.contains("**explore** subagent"),
+            "explore delegation guidance missing:\n{out}"
+        );
     }
 
     #[test]

--- a/crates/wisp-tools/src/edit.rs
+++ b/crates/wisp-tools/src/edit.rs
@@ -9,6 +9,97 @@ use std::io::Read;
 use wisp_llm::ToolSchema;
 
 const MAX_EDIT_BYTES: u64 = 10 * 1024 * 1024;
+/// Files larger than this skip the closest-match scan: the Levenshtein pass
+/// over every line window gets too expensive to justify better error text.
+const MAX_CLOSEST_SCAN_BYTES: usize = 1024 * 1024;
+const CLOSEST_MATCH_MIN_SIMILARITY: f64 = 0.5;
+const CLOSEST_SNIPPET_MAX_LINES: usize = 20;
+
+fn char_levenshtein(a: &str, b: &str) -> usize {
+    let b: Vec<char> = b.chars().collect();
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    let mut curr: Vec<usize> = vec![0; b.len() + 1];
+    for (i, ca) in a.chars().enumerate() {
+        curr[0] = i + 1;
+        for (j, cb) in b.iter().enumerate() {
+            curr[j + 1] = (prev[j] + usize::from(ca != *cb))
+                .min(prev[j + 1] + 1)
+                .min(curr[j] + 1);
+        }
+        std::mem::swap(&mut prev, &mut curr);
+    }
+    prev[b.len()]
+}
+
+/// Best contiguous line window resembling `old`, as
+/// `(1-based start line, end line, similarity, snippet)` when the similarity
+/// reaches [`CLOSEST_MATCH_MIN_SIMILARITY`].
+fn find_closest_match(text: &str, old: &str) -> Option<(usize, usize, f64, String)> {
+    if text.len() > MAX_CLOSEST_SCAN_BYTES || old.is_empty() {
+        return None;
+    }
+    let old_lines: Vec<&str> = old.lines().collect();
+    let file_lines: Vec<&str> = text.lines().collect();
+    let window = old_lines.len();
+    if old_lines.is_empty() || window > file_lines.len() {
+        return None;
+    }
+    let old_joined = old_lines.join("\n");
+    let target_len = old_joined.chars().count();
+    let mut best: Option<(usize, f64)> = None;
+    for start in 0..=(file_lines.len() - window) {
+        let candidate = file_lines[start..start + window].join("\n");
+        let candidate_len = candidate.chars().count();
+        // A window this far off in length cannot reach the similarity floor.
+        if candidate_len.abs_diff(target_len) > target_len / 2 + 8 {
+            continue;
+        }
+        let distance = char_levenshtein(&candidate, &old_joined);
+        let similarity = 1.0 - distance as f64 / candidate_len.max(target_len).max(1) as f64;
+        if best.map_or(true, |(_, s)| similarity > s) {
+            best = Some((start, similarity));
+        }
+    }
+    let (start, similarity) = best?;
+    if similarity < CLOSEST_MATCH_MIN_SIMILARITY {
+        return None;
+    }
+    let lines = &file_lines[start..start + window];
+    let snippet = if lines.len() > CLOSEST_SNIPPET_MAX_LINES {
+        let mut s = lines[..CLOSEST_SNIPPET_MAX_LINES].join("\n");
+        s.push_str(&format!(
+            "\n... ({} more lines)",
+            lines.len() - CLOSEST_SNIPPET_MAX_LINES
+        ));
+        s
+    } else {
+        lines.join("\n")
+    };
+    Some((start + 1, start + window, similarity, snippet))
+}
+
+fn not_found_message(path: &str, text: &str, old: &str) -> String {
+    match find_closest_match(text, old) {
+        Some((start, end, similarity, snippet)) => format!(
+            "edit error: old string not found in {path}. Closest match at lines {start}-{end} \
+(similarity {}%):\n```\n{snippet}\n```\nThe file may have changed — re-read the exact region \
+and retry with the current text.",
+            (similarity * 100.0).round() as u32
+        ),
+        None => format!(
+            "edit error: old string not found in {path} ({} lines); re-read the file because it may have changed",
+            text.lines().count().max(1)
+        ),
+    }
+}
+
+/// 1-based line numbers of the first `limit` occurrences of `old` in `text`.
+fn match_line_numbers(text: &str, old: &str, limit: usize) -> Vec<usize> {
+    text.match_indices(old)
+        .take(limit)
+        .map(|(idx, _)| text[..idx].bytes().filter(|b| *b == b'\n').count() + 1)
+        .collect()
+}
 
 fn replaced_len(text: &str, old: &str, new: &str, all: bool) -> Option<usize> {
     let count = if all {
@@ -117,14 +208,19 @@ impl Tool for EditTool {
             Err(e) => return ToolResult::fail(format!("edit {path} error: {e}")),
         }
         if !text.contains(&old) {
-            return ToolResult::fail(
-                "edit error: old string not found; re-read the file because it may have changed",
-            );
+            return ToolResult::fail(not_found_message(&path, &text, &old));
         }
         let count = text.matches(&old).count();
         if !all && count > 1 {
+            let lines = match_line_numbers(&text, &old, 5);
             return ToolResult::fail(format!(
-                "edit error: old_string appears {count} times, must be unique (use all=true)"
+                "edit error: old_string appears {count} times, must be unique (use all=true); \
+matches at lines {}",
+                lines
+                    .iter()
+                    .map(|l| l.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
             ));
         }
         let Some(result_len) = replaced_len(&text, &old, &new, all) else {
@@ -350,5 +446,124 @@ mod tests {
             replaced_len("aaa", "a", &"x".repeat(MAX_EDIT_BYTES as usize), true)
                 .is_some_and(|len| len as u64 > MAX_EDIT_BYTES)
         );
+    }
+
+    #[tokio::test]
+    async fn not_found_error_reports_closest_near_miss_match() {
+        let tmp = std::env::temp_dir().join(format!("wisp_edit_closest_{}", std::process::id()));
+        std::fs::remove_dir_all(&tmp).ok();
+        std::fs::create_dir_all(&tmp).unwrap();
+        let content = "def compute_total(items):\n    total = 0\n    for item in items:\n        total += item.price\n    return total\n";
+        std::fs::write(tmp.join("cart.py"), content).unwrap();
+
+        // One character off (`cost` vs `price`) with identical indentation.
+        let result = EditTool
+            .run(
+                &json!({
+                    "path": "cart.py",
+                    "old": "        total += item.cost",
+                    "new": "        total += 0"
+                }),
+                &TestEnv(tmp.clone()),
+            )
+            .await;
+
+        assert!(!result.success);
+        assert!(
+            result.content.contains("Closest match at lines 4-4"),
+            "{}",
+            result.content
+        );
+        assert!(
+            result.content.contains("        total += item.price"),
+            "snippet must keep the original indentation: {}",
+            result.content
+        );
+        assert!(
+            result
+                .content
+                .contains("re-read the exact region and retry with the current text"),
+            "{}",
+            result.content
+        );
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[tokio::test]
+    async fn not_found_error_without_closest_match_keeps_re_read_hint() {
+        let tmp = std::env::temp_dir().join(format!("wisp_edit_unrelated_{}", std::process::id()));
+        std::fs::remove_dir_all(&tmp).ok();
+        std::fs::create_dir_all(&tmp).unwrap();
+        std::fs::write(tmp.join("notes.txt"), "alpha\nbeta\ngamma\n").unwrap();
+
+        let result = EditTool
+            .run(
+                &json!({
+                    "path": "notes.txt",
+                    "old": "zzz completely unrelated qqq",
+                    "new": "x"
+                }),
+                &TestEnv(tmp.clone()),
+            )
+            .await;
+
+        assert!(!result.success);
+        assert!(
+            !result.content.contains("Closest match"),
+            "{}",
+            result.content
+        );
+        assert!(
+            result
+                .content
+                .contains("re-read the file because it may have changed"),
+            "{}",
+            result.content
+        );
+        assert!(result.content.contains("(3 lines)"), "{}", result.content);
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[tokio::test]
+    async fn ambiguous_old_string_error_lists_match_line_numbers() {
+        let tmp = std::env::temp_dir().join(format!("wisp_edit_ambiguous_{}", std::process::id()));
+        std::fs::remove_dir_all(&tmp).ok();
+        std::fs::create_dir_all(&tmp).unwrap();
+        std::fs::write(
+            tmp.join("dup.txt"),
+            "dup here\nmiddle\ndup here\nx\ndup here\n",
+        )
+        .unwrap();
+
+        let result = EditTool
+            .run(
+                &json!({ "path": "dup.txt", "old": "dup here", "new": "unique" }),
+                &TestEnv(tmp.clone()),
+            )
+            .await;
+
+        assert!(!result.success);
+        assert!(
+            result.content.contains("appears 3 times"),
+            "{}",
+            result.content
+        );
+        assert!(
+            result.content.contains("matches at lines 1, 3, 5"),
+            "{}",
+            result.content
+        );
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn char_levenshtein_ratio_and_scan_guards() {
+        assert_eq!(char_levenshtein("kitten", "sitting"), 3);
+        assert_eq!(char_levenshtein("same", "same"), 0);
+        // Unrelated short window must fall below the similarity floor.
+        assert!(find_closest_match("alpha\nbeta\n", "zzz unrelated qqq").is_none());
+        // Oversized files skip the scan entirely.
+        let big = "x\n".repeat(MAX_CLOSEST_SCAN_BYTES / 2 + 2);
+        assert!(find_closest_match(&big, "x").is_none());
     }
 }


### PR DESCRIPTION
## Problem

Leading read-only tool calls in one model batch ran one after another. The first turn often spent iterations listing the workspace. Edit "not found" errors did not show a near-miss; duplicate matches did not include line numbers.

Split out of closed #1006 (absorb of #987 / #1004). Independent PR to `main` — not stacked with the other three.

## Change

- Parallel leading run of registered read-only, auto-allow tools. The first write, prompt, or unknown call ends the parallel run; it and everything after stay sequential so provenance windows, approval prompts, and side effects keep their order. User-cancel pairing and synthetic tool results from current `main` are preserved.
- System prompt: shallow workspace overview (depth 2, heavy dirs skipped) plus batching / explore guidance.
- Edit errors report the closest Levenshtein near-miss and duplicate-match line numbers.

Does **not** include provenance snapshot-cache (responsiveness PR) or native `view_image` attach (vision PR).

## Files

- `crates/wisp-core/src/agent.rs`
- `crates/wisp-core/src/system_prompt.rs`
- `crates/wisp-core/src/provenance.rs`
- `crates/wisp-tools/src/edit.rs`

## Tests

- `read_only_batch_prefix_runs_concurrently` (shared barrier; sequential would deadlock)
- `read_only_prefix_stays_sequential_after_first_asking_tool`
- `sequential_path_still_handles_a_single_read_only_call`
- `workspace_overview_lists_project_files_and_skips_heavy_dirs`
- `tool_guidance_teaches_batching_and_explore_delegation`
- edit near-miss / duplicate line-number tests

Overlaps `agent.rs` with the vision and responsiveness PRs; rebase if those land first.

Does not bump the version. Next release remains 1.7.0.