### PR TITLE
fix(ui): cut idle CPU from streaming markdown, transfer tray, and follow scroll

### DIFF
--- a/src-tauri/src/delegation_completion.rs
+++ b/src-tauri/src/delegation_completion.rs
@@ -19,6 +19,12 @@ use wisp_store::{
 };
 
 const COMPLETION_POLL_INTERVAL: Duration = Duration::from_millis(250);
+/// Idle backoff for the dispatcher loop: consecutive polls that find nothing
+/// to dispatch stretch the interval up to this cap, so a fully idle app stops
+/// hammering SQLite ~8x/second. Any dispatch resets the backoff to the fast
+/// interval — a workflow finishing mid-backoff is picked up within one slow
+/// tick, which is fine for a background completion path.
+const COMPLETION_POLL_IDLE: Duration = Duration::from_secs(5);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
@@ -465,7 +471,13 @@ async fn dispatch_frame(app: AppHandle, frame_id: String) {
 pub(crate) fn start_dispatcher(app: &AppHandle) {
     let app = app.clone();
     tauri::async_runtime::spawn(async move {
+        let mut idle_polls: u32 = 0;
         loop {
+            let interval = if idle_polls >= 4 {
+                COMPLETION_POLL_IDLE
+            } else {
+                COMPLETION_POLL_INTERVAL
+            };
             let state = app.state::<AppState>();
             repair_incomplete_deliveries(&state.store).await;
             let frames = match state
@@ -476,9 +488,14 @@ pub(crate) fn start_dispatcher(app: &AppHandle) {
                 Ok(frames) => frames,
                 Err(error) => {
                     tracing::warn!(target: "wisp", %error, "failed to poll Agent completions");
-                    tokio::time::sleep(COMPLETION_POLL_INTERVAL).await;
+                    tokio::time::sleep(interval).await;
                     continue;
                 }
+            };
+            idle_polls = if frames.is_empty() {
+                idle_polls.saturating_add(1)
+            } else {
+                0
             };
             for frame_id in frames {
                 let mut active = state.completion_dispatches.lock().await;
@@ -497,7 +514,7 @@ pub(crate) fn start_dispatcher(app: &AppHandle) {
                         .remove(&frame_id);
                 });
             }
-            tokio::time::sleep(COMPLETION_POLL_INTERVAL).await;
+            tokio::time::sleep(interval).await;
         }
     });
 }

--- a/ui/src/app_support/messages.rs
+++ b/ui/src/app_support/messages.rs
@@ -1,6 +1,9 @@
 use super::*;
 use leptos::leptos_dom::helpers::TimeoutHandle;
-use std::{cell::Cell, rc::Rc};
+use std::{
+    cell::{Cell, RefCell},
+    rc::Rc,
+};
 
 const STREAMING_MARKDOWN_TAIL_THRESHOLD_BYTES: usize = 8_000;
 
@@ -25,6 +28,28 @@ pub(crate) fn streaming_markdown_commit_interval_ms(
     } else {
         50
     }
+}
+
+/// Append rendered HTML into the streaming prefix container. Done via DOM
+/// text because `inner_html=` would replace (and re-layout) the whole prefix.
+fn append_html_block(dom_id: &str, html: &str) {
+    if html.is_empty() {
+        return;
+    }
+    let Some(el) = web_sys::window()
+        .and_then(|window| window.document())
+        .and_then(|document| document.get_element_by_id(dom_id))
+    else {
+        return;
+    };
+    let _ = el.insert_adjacent_html("beforeend", html);
+}
+
+/// True when `text` extends `previous` past a Markdown block boundary, so the
+/// new suffix can be parsed on its own and appended without re-rendering the
+/// already-painted prefix.
+fn streaming_markdown_can_append_prefix(previous: &str, text: &str) -> bool {
+    !previous.is_empty() && text.starts_with(previous) && previous.ends_with("\n\n")
 }
 
 fn assistant_text_at(items: RwSignal<Vec<ChatItem>>, source_item: usize) -> String {
@@ -102,19 +127,49 @@ pub(crate) fn StreamingAssistantMessage(
         }
     });
 
+    let hid = unique_dom_id("stream-md");
+    // (source text, container DOM id, last inner_html). Returning the previous
+    // inner_html on the append path keeps the Leptos binding unchanged so it
+    // cannot wipe the nodes just inserted via insert_adjacent_html.
+    let rendered_prefix: Rc<RefCell<Option<(String, String, String)>>> =
+        Rc::new(RefCell::new(None));
+    let hid_for_memo = hid.clone();
     let html = create_memo({
         let recent_parse_cost_ms = Rc::clone(&recent_parse_cost_ms);
         move |_| {
             let started_at = js_sys::Date::now();
             let project_root =
                 project.and_then(|project| project.get().map(|project| project.root));
-            let html = enrich_md_html(
-                md_to_html(&rendered_text.get()),
-                &[],
-                &[],
-                locale.get(),
-                project_root.as_deref(),
+            let text = rendered_text.get();
+            let appendable = rendered_prefix.borrow().as_ref().is_some_and(
+                |(prefix, _, _)| streaming_markdown_can_append_prefix(prefix, &text),
             );
+            let html = if appendable {
+                let (prefix, dom_id, keep_html) =
+                    rendered_prefix.borrow().as_ref().cloned().unwrap();
+                let suffix = text[prefix.len()..].to_string();
+                let parsed = enrich_md_html(
+                    md_to_html(&suffix),
+                    &[],
+                    &[],
+                    locale.get(),
+                    project_root.as_deref(),
+                );
+                append_html_block(&dom_id, &parsed);
+                *rendered_prefix.borrow_mut() = Some((text, dom_id, keep_html.clone()));
+                keep_html
+            } else {
+                let fresh = enrich_md_html(
+                    md_to_html(&text),
+                    &[],
+                    &[],
+                    locale.get(),
+                    project_root.as_deref(),
+                );
+                *rendered_prefix.borrow_mut() =
+                    Some((text, hid_for_memo.clone(), fresh.clone()));
+                fresh
+            };
             let elapsed = (js_sys::Date::now() - started_at).max(0.0);
             let smoothed = recent_parse_cost_ms
                 .get()
@@ -136,7 +191,6 @@ pub(crate) fn StreamingAssistantMessage(
             _ => String::new(),
         })
     });
-    let hid = unique_dom_id("stream-md");
     // `inner_html` replaces the whole parsed prefix on every commit. Running
     // highlight.js and KaTeX here would therefore rescan and mutate an
     // increasingly large, short-lived DOM tree each time. The settled
@@ -153,7 +207,7 @@ pub(crate) fn StreamingAssistantMessage(
             >
                 <div
                     class="streaming-markdown-prefix md"
-                    id=hid
+                    id=hid.clone()
                     inner_html=move || html.get()
                     on:click=move |ev: web_sys::MouseEvent| {
                         handle_md_click(&ev, &[], &[], &on_artifact, &on_file)
@@ -1495,6 +1549,24 @@ mod streaming_markdown_tests {
             streaming_markdown_commit_interval_ms(1_000, Some(400.0)),
             1_200
         );
+    }
+
+    #[test]
+    fn append_path_requires_a_finished_block_boundary() {
+        use super::streaming_markdown_can_append_prefix;
+        assert!(streaming_markdown_can_append_prefix(
+            "Hello.\n\n",
+            "Hello.\n\nWorld.\n\n"
+        ));
+        assert!(!streaming_markdown_can_append_prefix(
+            "Hello.\n",
+            "Hello.\nWorld."
+        ));
+        assert!(!streaming_markdown_can_append_prefix(
+            "Hello.\n\n",
+            "Other.\n\n"
+        ));
+        assert!(!streaming_markdown_can_append_prefix("", "Hello.\n\n"));
     }
 }
 

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -11295,24 +11295,34 @@ fn App() -> impl IntoView {
             </div>
 
             {move || active_session.get().and_then(|session_id| {
-                // Finished transfers linger briefly for confirmation. Reading
-                // the shared clock makes this tray recompute after run polling
-                // stops, so settled cards cannot remain over the conversation.
-                let now = run_clock.get();
-                let transfers = run_records.with(|records| {
+                // Finished transfers linger briefly for confirmation, so the
+                // tray must recompute after run polling stops. Outer closure
+                // subscribes only to the run list; the inner one owns the
+                // every-second clock. With no transfer-worthy runs the clock
+                // is never subscribed.
+                let session_for_inner = session_id.clone();
+                run_records.with(|records| {
                     records
                         .iter()
                     .filter(|run| run.frame_id.as_deref() == Some(session_id.as_str()))
-                    .filter_map(|run| {
-                            let progress = run_progress(run)?;
-                        transfer_progress_visible(&progress, &run.status, now)
-                                .then_some((run.clone(), progress))
-                    })
-                        .collect::<Vec<_>>()
-                });
-                (!transfers.is_empty()).then(|| view! {
-                    <div class="transfer-tray" aria-live="polite">
-                        {transfers.into_iter().map(|(run, progress)| {
+                    .any(|run| run_progress(run).is_some())
+                })
+                .then(move || {
+                    let now = run_clock.get();
+                    let transfers = run_records.with(|records| {
+                        records
+                            .iter()
+                        .filter(|run| run.frame_id.as_deref() == Some(session_for_inner.as_str()))
+                        .filter_map(|run| {
+                                let progress = run_progress(run)?;
+                            transfer_progress_visible(&progress, &run.status, now)
+                                    .then_some((run.clone(), progress))
+                        })
+                            .collect::<Vec<_>>()
+                    });
+                    (!transfers.is_empty()).then(|| view! {
+                        <div class="transfer-tray" aria-live="polite">
+                            {transfers.into_iter().map(|(run, progress)| {
                             let run_id = run.id.clone();
                             let cancellable = matches!(
                                 run.status.as_str(),
@@ -11355,8 +11365,9 @@ fn App() -> impl IntoView {
                                     {run_progress_meter(progress, locale.get())}
                                 </section>
                             }
-                        }).collect_view()}
-                    </div>
+                            }).collect_view()}
+                        </div>
+                    })
                 })
             })}
 

--- a/ui/src/pet.rs
+++ b/ui/src/pet.rs
@@ -164,8 +164,11 @@ impl DesktopPetActivity {
 }
 
 fn install_runtime_poll(status: RwSignal<PetStatus>, activity: RwSignal<DesktopPetActivity>) {
-    let callback =
-        Closure::wrap(Box::new(move || refresh_desktop_pet(status, activity)) as Box<dyn FnMut()>);
+    // Interval stays 2 s so turning the pet back on is noticed quickly.
+    // Disabled ticks still call get_pet; they skip the SQLite run snapshot.
+    let callback = Closure::wrap(Box::new(move || {
+        refresh_desktop_pet_fast(status.get_untracked().enabled, status, activity);
+    }) as Box<dyn FnMut()>);
     let _ = window().set_interval_with_callback_and_timeout_and_arguments_0(
         callback.as_ref().unchecked_ref(),
         2_000,
@@ -184,7 +187,11 @@ fn install_listener(event: &'static str, callback: Closure<dyn FnMut(JsValue)>) 
     });
 }
 
-fn refresh_desktop_pet(status: RwSignal<PetStatus>, activity: RwSignal<DesktopPetActivity>) {
+fn refresh_desktop_pet_fast(
+    full: bool,
+    status: RwSignal<PetStatus>,
+    activity: RwSignal<DesktopPetActivity>,
+) {
     spawn_local(async move {
         let value = invoke("get_pet", JsValue::UNDEFINED).await;
         let visible = serde_wasm_bindgen::from_value::<PetStatus>(value)
@@ -198,9 +205,14 @@ fn refresh_desktop_pet(status: RwSignal<PetStatus>, activity: RwSignal<DesktopPe
             .unwrap_or(JsValue::UNDEFINED);
         let _ = invoke("set_pet_window_visible", args).await;
 
-        let snapshot = invoke("get_pet_runtime_status", JsValue::UNDEFINED).await;
-        if let Ok(snapshot) = serde_wasm_bindgen::from_value::<PetRuntimeSnapshot>(snapshot) {
-            activity.update(|current| current.replace_from_snapshot(snapshot));
+        // The runtime snapshot (a SQLite run query) and the pet window sync
+        // only matter while the pet is actually shown; skip them on idle
+        // probes so a disabled pet costs one cheap settings read per tick.
+        if full && visible {
+            let snapshot = invoke("get_pet_runtime_status", JsValue::UNDEFINED).await;
+            if let Ok(snapshot) = serde_wasm_bindgen::from_value::<PetRuntimeSnapshot>(snapshot) {
+                activity.update(|current| current.replace_from_snapshot(snapshot));
+            }
         }
     });
 }
@@ -228,12 +240,12 @@ pub(crate) fn PetDesktop() -> impl IntoView {
         body.set_class_name("pet-window-shell");
     }
 
-    refresh_desktop_pet(status, activity);
+    refresh_desktop_pet_fast(true, status, activity);
     install_runtime_poll(status, activity);
     install_listener(
         "pet-config-changed",
         Closure::wrap(Box::new(move |_: JsValue| {
-            refresh_desktop_pet(status, activity);
+            refresh_desktop_pet_fast(true, status, activity);
         }) as Box<dyn FnMut(JsValue)>),
     );
     install_listener(

--- a/ui/src/scroll.js
+++ b/ui/src/scroll.js
@@ -54,10 +54,18 @@ export function attach_chat_scroll(scrollerId, contentId) {
   const rememberProgrammatic = () => {
     programmaticTop = scroller.scrollTop;
   };
-  const snapFollow = () => {
-    snapBottom(scroller);
-    rememberProgrammatic();
-    readingTop = scroller.scrollTop;
+  const snapFollow = (force = false) => {
+    // Write-only follow snap: skip the assignment when we already wrote this
+    // max. Repeated programmatic scrollTop writes suppress Chromium overflow
+    // anchoring, which #663 needs after the user scrolls away. `force` is for
+    // jump-to-latest / rebuild clamps, where scrollTop moved without max
+    // changing.
+    const max = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
+    if (force || max - programmaticTop > 2) {
+      scroller.scrollTop = max;
+    }
+    programmaticTop = max;
+    readingTop = max;
   };
   const restoreBookmark = () => {
     const max = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
@@ -114,7 +122,7 @@ export function attach_chat_scroll(scrollerId, contentId) {
         && scroller.scrollTop < 8
         && readingTop > Math.max(scroller.clientHeight, 200)
       ) {
-        snapFollow();
+        snapFollow(true);
         syncPill();
         return;
       }
@@ -126,11 +134,15 @@ export function attach_chat_scroll(scrollerId, contentId) {
     // Reflow-driven clamp. Scroll events fire before paint, so an instant
     // snap here means the clamped position is never painted — without it the
     // view visibly bounces on every thinking delta. When parked, restore the
-    // bookmark instead of adopting the collapse's scrollTop=0 (#927).
+    // bookmark if the thread collapsed toward 0 (#927); if scrollTop moved
+    // down, that is overflow-anchor compensating a prepend (#663) — keep it.
     if (follow) {
-      snapFollow();
-    } else {
+      snapFollow(true);
+    } else if (scroller.scrollTop + 2 < readingTop) {
       restoreBookmark();
+    } else {
+      readingTop = scroller.scrollTop;
+      programmaticTop = scroller.scrollTop;
     }
     syncPill();
   };
@@ -148,7 +160,7 @@ export function attach_chat_scroll(scrollerId, contentId) {
       hidden = false;
       lastHeight = h;
       if (follow) {
-        snapFollow();
+        snapFollow(true);
       } else {
         restoreBookmark();
       }
@@ -160,13 +172,18 @@ export function attach_chat_scroll(scrollerId, contentId) {
     if (follow) {
       // ResizeObserver already coalesces streaming DOM changes. Keep the hot
       // path to one bottom snap and skip the row/viewport geometry used only
-      // by the scroll-away pill.
+      // by the scroll-away pill — reading gap geometry here forces a layout
+      // on every streaming frame, so the pill is only synced when it could
+      // actually be visible (not following).
       snapFollow();
-      syncPill();
       return;
     }
     if (grew) {
-      restoreBookmark();
+      // Parked: overflow-anchor keeps the visible rows stable on prepend.
+      // Do not restoreBookmark here — that writes the pre-prepend scrollTop
+      // and undoes the compensation (#663).
+      syncPill();
+      return;
     }
     syncFollow();
   };
@@ -214,14 +231,14 @@ export function attach_chat_scroll(scrollerId, contentId) {
     snap: () => {
       const requested = performance.now();
       setFollow(true);
-      snapFollow();
+      snapFollow(true);
       lastHeight = content.scrollHeight;
       syncPill();
       requestAnimationFrame(() => {
         requestAnimationFrame(() => {
           if (lastUserScroll < requested) {
             setFollow(true);
-            snapFollow();
+            snapFollow(true);
             lastHeight = content.scrollHeight;
             syncPill();
           }


### PR DESCRIPTION
## Problem

Streaming markdown re-parsed the entire prefix on every commit (O(n²) CPU). The transfer tray stayed subscribed to a 1s clock while idle. Completion dispatch polled every 250ms. Pet poll queried runs while the pet was disabled. Follow-mode `scrollTop` writes suppressed `overflow-anchor` after the user scrolled away.

Split out of closed #1006 (absorb of #987 / #1004). Independent PR to `main` — not stacked with the other three.

## Change

- Streaming commits that continue past a block boundary parse only the new suffix and append it. The Leptos `inner_html` binding returns the previous HTML on the append path so it cannot wipe the inserted nodes.
- Transfer tray unsubscribes from the 1s clock when idle (records effect, then clock effect).
- Completion dispatcher backs off 250ms → 5s when idle.
- Pet poll still checks settings every 2s but skips the run query while disabled (`status.get_untracked().enabled`).
- Follow snaps skip redundant `scrollTop` writes; jump/clamp still force a write.

## Files

- `ui/src/app_support/messages.rs`
- `ui/src/main.rs`
- `ui/src/pet.rs`
- `ui/src/scroll.js`
- `src-tauri/src/delegation_completion.rs`

## Tests

- `streaming_markdown_can_append_prefix` unit tests
- Existing scroll follow tests (jump / clamp / overflow-anchor)

Does not bump the version. Next release remains 1.7.0.