### PR TITLE
fix: share HTTP client and recheck browser connection

### DIFF
--- a/crates/wisp-llm/src/provider.rs
+++ b/crates/wisp-llm/src/provider.rs
@@ -298,7 +298,28 @@ pub struct ProviderConfig {
 }
 
 /// Shared reqwest client for all providers, honoring `cfg.proxy`.
+/// Process-wide connection pool for the default proxy configuration. Review /
+/// follow-up / memory side calls used to build a fresh `reqwest::Client` per
+/// call — every one of them paid a new TLS handshake before this cache. Explicit
+/// proxy configs stay per-client because they vary by profile.
+static SHARED_CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
+
 pub(crate) fn http_client(cfg: &ProviderConfig) -> reqwest::Client {
+    http_client_from_pool(cfg, &SHARED_CLIENT)
+}
+
+fn http_client_from_pool(
+    cfg: &ProviderConfig,
+    shared: &std::sync::OnceLock<reqwest::Client>,
+) -> reqwest::Client {
+    let proxy = cfg.proxy.as_deref().map(str::trim);
+    if matches!(proxy, None | Some("")) {
+        return shared.get_or_init(|| build_http_client(cfg)).clone();
+    }
+    build_http_client(cfg)
+}
+
+fn build_http_client(cfg: &ProviderConfig) -> reqwest::Client {
     let mut b = reqwest::Client::builder()
         .user_agent("wisp-science")
         // A total request timeout also caps a healthy, actively streaming SSE
@@ -508,6 +529,30 @@ mod tests {
             cfg.proxy = proxy.map(Into::into);
             let _ = http_client(&cfg);
         }
+    }
+
+    #[test]
+    fn default_proxy_configuration_reuses_one_client_pool() {
+        let shared = std::sync::OnceLock::new();
+        let cfg = ProviderConfig::openai("https://api.example.com", "k", "m");
+
+        let _first = http_client_from_pool(&cfg, &shared);
+        let initialized = shared
+            .get()
+            .expect("default client initializes shared pool") as *const _;
+        let _second = http_client_from_pool(&cfg, &shared);
+        let reused = shared.get().expect("shared pool remains initialized") as *const _;
+
+        assert_eq!(initialized, reused);
+
+        let direct_pool = std::sync::OnceLock::new();
+        let mut direct = cfg;
+        direct.proxy = Some("none".into());
+        let _ = http_client_from_pool(&direct, &direct_pool);
+        assert!(
+            direct_pool.get().is_none(),
+            "explicit proxy modes must not reuse the default connection pool"
+        );
     }
 
     // #437: a stream that closes without a terminal marker is a cut, EXCEPT

--- a/src-tauri/src/app_commands.rs
+++ b/src-tauri/src/app_commands.rs
@@ -584,6 +584,12 @@ pub(super) fn open_browser_extension_page(
     state.browser_bridge.open_extension_setup()
 }
 
+/// Live extension connection check for the offline banner's display gate.
+#[tauri::command]
+pub(super) async fn extension_connected(state: State<'_, AppState>) -> Result<bool, String> {
+    Ok(state.browser_bridge.extension_connected().await)
+}
+
 #[tauri::command]
 pub(super) fn reveal_in_file_manager(
     app: AppHandle,

--- a/src-tauri/src/browser_bridge/mod.rs
+++ b/src-tauri/src/browser_bridge/mod.rs
@@ -1403,6 +1403,15 @@ impl BrowserBridge {
             opened,
         }
     }
+
+    /// Live connection status for the offline banner's recheck: the per-turn
+    /// judgment is frozen into the transcript, so a banner from a transient
+    /// disconnect sticks forever even after the extension reconnects (and
+    /// resurrects on session reload). The UI rechecks through this before
+    /// showing the banner.
+    pub async fn extension_connected(&self) -> bool {
+        self.client_connected().await
+    }
 }
 
 #[derive(Serialize, Clone)]
@@ -3036,6 +3045,19 @@ mod tests {
             Approval::Ask
         );
         let _ = std::fs::remove_file(tmp);
+    }
+
+    #[tokio::test]
+    async fn extension_connection_status_tracks_live_clients() {
+        let bridge = BrowserBridge::new(PathBuf::from("extension"));
+        assert!(!bridge.extension_connected().await);
+
+        let (tx, _rx) = mpsc::unbounded_channel();
+        bridge.install_client(7, tx).await;
+        assert!(bridge.extension_connected().await);
+
+        bridge.disconnect_client(7).await;
+        assert!(!bridge.extension_connected().await);
     }
 
     #[tokio::test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7028,6 +7028,7 @@ pub fn run() {
             app_updates::install_update,
             app_commands::open_external_url,
             app_commands::open_browser_extension_page,
+            app_commands::extension_connected,
             ui_heartbeat,
             app_commands::reveal_in_file_manager,
             connector_commands::list_mcp_connections,

--- a/ui-tests/tests/browser-offline.spec.ts
+++ b/ui-tests/tests/browser-offline.spec.ts
@@ -33,6 +33,12 @@ async function lastInvokeArgs(page: Page, cmd: string) {
   }, cmd);
 }
 
+async function invokeCount(page: Page, cmd: string) {
+  return page.evaluate((name) =>
+    ((window as any).__skillInvokeLog ?? []).filter((call: any) => call.cmd === name).length,
+  cmd);
+}
+
 async function startLiveRetrievalTurn(page: Page) {
   await page.locator("#composer-input").fill("latest rustc version");
   await page.getByRole("button", { name: "Send" }).click();
@@ -121,6 +127,19 @@ test("a later connected browser_setup clears the offline banner", async ({ page 
     content: JSON.stringify({ status: "connected", live_retrieval: true, connected_tabs: 1 }),
   });
   await expect(banner).toHaveCount(0);
+});
+
+test("a live extension recheck clears a stale offline verdict", async ({ page }) => {
+  await enterApp(page);
+  const sessionId = await startLiveRetrievalTurn(page);
+  await page.evaluate(() => {
+    (window as any).__extensionConnected = true;
+  });
+
+  await emitTauriEvent(page, "agent", disconnectedSetup(sessionId));
+
+  await expect.poll(() => invokeCount(page, "extension_connected")).toBe(1);
+  await expect(page.getByTestId("browser-offline-banner")).toHaveCount(0);
 });
 
 test("successful live retrieval survives a stream disconnect error", async ({ page }) => {

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -5428,6 +5428,8 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
             return null;
           case "open_browser_extension_page":
             return { extension_path: "/mock/wisp/browser-extension", opened: false };
+          case "extension_connected":
+            return Boolean((window as any).__extensionConnected);
           case "ui_heartbeat":
             return null;
           case "list_specialists":
@@ -5829,6 +5831,8 @@ export function parallelMock(): void {
             return null;
           case "open_browser_extension_page":
             return { extension_path: "/mock/wisp/browser-extension", opened: false };
+          case "extension_connected":
+            return Boolean((window as any).__extensionConnected);
           case "ui_heartbeat":
             return null;
           default: return null;

--- a/ui/mock-bridge.js
+++ b/ui/mock-bridge.js
@@ -880,6 +880,8 @@
             return null;
           case "open_browser_extension_page":
             return { extension_path: "/mock/wisp/browser-extension", opened: false };
+          case "extension_connected":
+            return Boolean(window.__extensionConnected);
           case "list_library_items":
             return libraryItems;
           case "get_research_graph":

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -832,6 +832,20 @@ fn App() -> impl IntoView {
     // Live web retrieval failed because the Chrome extension is disconnected.
     // Root-owned so Escape can dismiss it without first focusing the banner.
     let browser_offline_notice = create_rw_signal::<Option<BrowserOfflineNotice>>(None);
+    // A transcript records the connection state at tool-call time. Recheck the
+    // live bridge once whenever a notice appears so a reconnect does not leave
+    // a stale banner on screen or revive one after a session reload.
+    create_effect(move |_| {
+        let Some(notice) = browser_offline_notice.get() else {
+            return;
+        };
+        spawn_local(async move {
+            let value = invoke("extension_connected", JsValue::UNDEFINED).await;
+            if value.as_bool().unwrap_or(false) {
+                set_browser_offline_notice(browser_offline_notice, &notice.frame_id, None);
+            }
+        });
+    });
     let browser_tab_cleanup = create_rw_signal(None::<BrowserTabCleanupPrompt>);
     let browser_tab_cleanup_queue = create_rw_signal(Vec::<BrowserTabCleanupPrompt>::new());
     let browser_tab_cleanup_selected = create_rw_signal(HashSet::<(String, i64)>::new());


### PR DESCRIPTION
## Problem

- Short-lived LLM requests created fresh default reqwest clients, preventing connection-pool and TLS-session reuse.
- A stale browser-offline verdict could keep the banner visible after the extension had reconnected.

## Changes

- Reuse one process-wide HTTP client for the default proxy configuration while keeping explicit proxy configurations isolated.
- Expose the browser extension live connection state through a Tauri command.
- Recheck that live state once when an offline notice appears and clear stale notices after reconnection.

## Tests

- Added a unit test for default HTTP client pool reuse.
- Added a browser bridge connection lifecycle test.
- Added a Playwright regression test for clearing a stale offline verdict.
- Passed cargo fmt, targeted Rust tests, wasm32 UI check, and the complete Playwright suite (457 passed, 2 skipped).
- The Tauri suite passed 900/901 tests; the unrelated lease-timing failure passed on an immediate isolated rerun.

## Manual smoke

1. Disconnect the browser extension and trigger a browser retrieval offline notice.
2. Reconnect the extension.
3. Return to or reload the conversation and confirm the stale notice clears.

## Limitations / follow-up

- Explicit proxy profiles still create their own clients so distinct proxy settings cannot leak across profiles.
- This PR intentionally excludes provenance snapshot caching and streaming Markdown scheduling changes from the closed #1007.