### PR TITLE
perf: reduce idle background polling

### DIFF
--- a/src-tauri/src/delegation_completion.rs
+++ b/src-tauri/src/delegation_completion.rs
@@ -19,6 +19,16 @@ use wisp_store::{
 };
 
 const COMPLETION_POLL_INTERVAL: Duration = Duration::from_millis(250);
+const COMPLETION_POLL_IDLE_INTERVAL: Duration = Duration::from_secs(5);
+const COMPLETION_POLL_IDLE_THRESHOLD: u32 = 4;
+
+fn completion_poll_delay(idle_polls: u32, found_work: bool) -> Duration {
+    if found_work || idle_polls < COMPLETION_POLL_IDLE_THRESHOLD {
+        COMPLETION_POLL_INTERVAL
+    } else {
+        COMPLETION_POLL_IDLE_INTERVAL
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
@@ -465,6 +475,7 @@ async fn dispatch_frame(app: AppHandle, frame_id: String) {
 pub(crate) fn start_dispatcher(app: &AppHandle) {
     let app = app.clone();
     tauri::async_runtime::spawn(async move {
+        let mut idle_polls = 0u32;
         loop {
             let state = app.state::<AppState>();
             repair_incomplete_deliveries(&state.store).await;
@@ -476,9 +487,16 @@ pub(crate) fn start_dispatcher(app: &AppHandle) {
                 Ok(frames) => frames,
                 Err(error) => {
                     tracing::warn!(target: "wisp", %error, "failed to poll Agent completions");
-                    tokio::time::sleep(COMPLETION_POLL_INTERVAL).await;
+                    idle_polls = idle_polls.saturating_add(1);
+                    tokio::time::sleep(completion_poll_delay(idle_polls, false)).await;
                     continue;
                 }
+            };
+            let found_work = !frames.is_empty();
+            idle_polls = if found_work {
+                0
+            } else {
+                idle_polls.saturating_add(1)
             };
             for frame_id in frames {
                 let mut active = state.completion_dispatches.lock().await;
@@ -497,7 +515,7 @@ pub(crate) fn start_dispatcher(app: &AppHandle) {
                         .remove(&frame_id);
                 });
             }
-            tokio::time::sleep(COMPLETION_POLL_INTERVAL).await;
+            tokio::time::sleep(completion_poll_delay(idle_polls, found_work)).await;
         }
     });
 }
@@ -505,6 +523,20 @@ pub(crate) fn start_dispatcher(app: &AppHandle) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn completion_poll_backoff_resets_on_ready_work() {
+        assert_eq!(completion_poll_delay(0, false), COMPLETION_POLL_INTERVAL);
+        assert_eq!(completion_poll_delay(3, false), COMPLETION_POLL_INTERVAL);
+        assert_eq!(
+            completion_poll_delay(COMPLETION_POLL_IDLE_THRESHOLD, false),
+            COMPLETION_POLL_IDLE_INTERVAL
+        );
+        assert_eq!(
+            completion_poll_delay(u32::MAX, true),
+            COMPLETION_POLL_INTERVAL
+        );
+    }
 
     #[test]
     fn completion_policy_defaults_inline_and_disables_irrelevant_resume() {

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -209,6 +209,12 @@ async function lastInvokeArgs(page: Page, cmd: string) {
   }, cmd);
 }
 
+async function invokeCount(page: Page, cmd: string) {
+  return page.evaluate((name) =>
+    ((window as any).__skillInvokeLog ?? []).filter((call: any) => call.cmd === name).length,
+  cmd);
+}
+
 // How many run-list refreshes the UI has performed. The app polls `list_runs`
 // on a ticker (every second while a turn is busy or a transfer is active),
 // so "wait until N more polls happened" replaces fixed sleeps in tests that
@@ -11775,6 +11781,16 @@ test("pet stays off until the user explicitly configures its directory", async (
   await expect.poll(() => pet.getAttribute("data-state")).toMatch(/^(idle|looking)$/);
   await pet.click();
   await expect(pet).toHaveAttribute("data-state", "waving");
+});
+
+test("disabled desktop pet skips runtime run polling", async ({ page }) => {
+  await page.goto("/?pet=desktop");
+
+  // Wait for both the initial settings read and one interval tick. Neither
+  // should query the run snapshot while the pet is disabled.
+  await expect.poll(() => invokeCount(page, "get_pet")).toBeGreaterThanOrEqual(2);
+  expect(await invokeCount(page, "get_pet_runtime_status")).toBe(0);
+  await expect.poll(() => page.evaluate(() => (window as any).__petWindowVisible)).toBe(false);
 });
 
 test("desktop pet remains independent and reflects global agent state", async ({ page }) => {

--- a/ui/src/pet.rs
+++ b/ui/src/pet.rs
@@ -198,9 +198,14 @@ fn refresh_desktop_pet(status: RwSignal<PetStatus>, activity: RwSignal<DesktopPe
             .unwrap_or(JsValue::UNDEFINED);
         let _ = invoke("set_pet_window_visible", args).await;
 
-        let snapshot = invoke("get_pet_runtime_status", JsValue::UNDEFINED).await;
-        if let Ok(snapshot) = serde_wasm_bindgen::from_value::<PetRuntimeSnapshot>(snapshot) {
-            activity.update(|current| current.replace_from_snapshot(snapshot));
+        // A disabled or unconfigured pet has no visible runtime state. Keep
+        // the cheap settings probe so external changes are noticed, but do
+        // not query SQLite for active runs until the pet can be shown.
+        if visible {
+            let snapshot = invoke("get_pet_runtime_status", JsValue::UNDEFINED).await;
+            if let Ok(snapshot) = serde_wasm_bindgen::from_value::<PetRuntimeSnapshot>(snapshot) {
+                activity.update(|current| current.replace_from_snapshot(snapshot));
+            }
         }
     });
 }


### PR DESCRIPTION
## Problem

The background Agent completion dispatcher queried SQLite every 250 ms while idle, and a disabled desktop pet queried the active-run snapshot every two seconds even though no pet state was visible.

## Changes

- Back off completion polling to five seconds after four idle polls.
- Reset the current delay to 250 ms immediately when ready work is found.
- Back off repeated polling errors instead of spinning at the fast interval.
- Keep the pet settings probe, but skip the runtime run snapshot until the pet is visible.

## Tests

- Added a pure dispatcher backoff/reset unit test.
- Added a Playwright invoke-count regression test for a disabled desktop pet.
- Passed targeted Tauri and pet Playwright tests.
- Passed wasm32 UI check and cargo fmt.

## Manual smoke

1. Leave Agent workflows idle and confirm background completions are still delivered after work appears.
2. Open the desktop pet while disabled and confirm it stays hidden.
3. Enable a configured pet and confirm active Run state still appears.

## Limitations

Completion delivery may take up to five seconds when work becomes ready during a fully idle interval. Transfer-tray scheduling and scroll behavior are intentionally handled in separate PRs.