### PR TITLE
fix(tools): report ambiguous edit line numbers

### DIFF
--- a/crates/wisp-tools/src/edit.rs
+++ b/crates/wisp-tools/src/edit.rs
@@ -9,6 +9,26 @@ use std::io::Read;
 use wisp_llm::ToolSchema;
 
 const MAX_EDIT_BYTES: u64 = 10 * 1024 * 1024;
+const MAX_AMBIGUOUS_MATCH_LINES: usize = 5;
+
+/// Return the 1-based start line of the first `limit` non-overlapping matches.
+/// The cursor advances through the file once instead of rescanning the whole
+/// prefix for every occurrence.
+fn match_line_numbers(text: &str, old: &str, limit: usize) -> Vec<usize> {
+    let mut line = 1usize;
+    let mut cursor = 0usize;
+    text.match_indices(old)
+        .take(limit)
+        .map(|(index, _)| {
+            line += text[cursor..index]
+                .bytes()
+                .filter(|byte| *byte == b'\n')
+                .count();
+            cursor = index;
+            line
+        })
+        .collect()
+}
 
 fn replaced_len(text: &str, old: &str, new: &str, all: bool) -> Option<usize> {
     let count = if all {
@@ -123,8 +143,20 @@ impl Tool for EditTool {
         }
         let count = text.matches(&old).count();
         if !all && count > 1 {
+            let lines = match_line_numbers(&text, &old, MAX_AMBIGUOUS_MATCH_LINES);
+            let line_label = if count > lines.len() {
+                "first match lines"
+            } else {
+                "match lines"
+            };
             return ToolResult::fail(format!(
-                "edit error: old_string appears {count} times, must be unique (use all=true)"
+                "edit error: old_string appears {count} times, must be unique (use all=true); \
+{line_label}: {}",
+                lines
+                    .iter()
+                    .map(usize::to_string)
+                    .collect::<Vec<_>>()
+                    .join(", ")
             ));
         }
         let Some(result_len) = replaced_len(&text, &old, &new, all) else {
@@ -350,5 +382,42 @@ mod tests {
             replaced_len("aaa", "a", &"x".repeat(MAX_EDIT_BYTES as usize), true)
                 .is_some_and(|len| len as u64 > MAX_EDIT_BYTES)
         );
+    }
+
+    #[tokio::test]
+    async fn ambiguous_edit_reports_bounded_match_line_numbers() {
+        let tmp =
+            std::env::temp_dir().join(format!("wisp_edit_ambiguous_lines_{}", std::process::id()));
+        std::fs::remove_dir_all(&tmp).ok();
+        std::fs::create_dir_all(&tmp).unwrap();
+        std::fs::write(
+            tmp.join("dup.txt"),
+            "dup\nkeep\ndup\nkeep\ndup\nkeep\ndup\nkeep\ndup\nkeep\ndup\n",
+        )
+        .unwrap();
+
+        let result = EditTool
+            .run(
+                &json!({ "path": "dup.txt", "old": "dup", "new": "unique" }),
+                &TestEnv(tmp.clone()),
+            )
+            .await;
+
+        assert!(!result.success);
+        assert!(
+            result.content.contains("appears 6 times"),
+            "{}",
+            result.content
+        );
+        assert!(
+            result.content.contains("first match lines: 1, 3, 5, 7, 9"),
+            "{}",
+            result.content
+        );
+        assert_eq!(
+            std::fs::read_to_string(tmp.join("dup.txt")).unwrap(),
+            "dup\nkeep\ndup\nkeep\ndup\nkeep\ndup\nkeep\ndup\nkeep\ndup\n"
+        );
+        std::fs::remove_dir_all(tmp).ok();
     }
 }


### PR DESCRIPTION
## Problem

When an edit target appeared more than once, the tool only reported the count. The Agent had to re-read or search the file to locate each duplicate before making the target unique.

## Changes

- Report the 1-based start lines of ambiguous exact matches.
- Bound diagnostics to the first five match lines.
- Scan line positions incrementally instead of rescanning the file prefix for every occurrence.

## Tests

- Added a six-match regression test covering the five-line output cap and unchanged-file guarantee.
- Passed all wisp-tools edit tests.
- Passed cargo fmt and diff checks.

## Limitations

This PR intentionally does not add fuzzy or Levenshtein matching. The tool still requires an exact old string and asks the Agent to re-read when no exact match exists.