### PR TITLE
perf(core): run parallel-safe read prefixes

### DIFF
--- a/crates/wisp-core/src/agent.rs
+++ b/crates/wisp-core/src/agent.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 use wisp_llm::{
     is_retriable, Completion, Content, LlmError, Message, Part, Provider, ToolCall, ToolSchema,
 };
-use wisp_tools::{ImageData, Registry, ToolControl, ToolEnv};
+use wisp_tools::{Approval, ImageData, Registry, ToolControl, ToolEnv, ToolResult};
 
 const RETRY_DELAYS: [u64; 5] = [2_000, 10_000, 30_000, 60_000, 120_000];
 const CANCEL_POLL_INTERVAL: Duration = Duration::from_millis(25);
@@ -489,7 +489,57 @@ async fn agent_loop_inner(
         }
 
         let mut batch_control = ToolControl::Continue;
-        for (index, tc) in comp.tool_calls.iter().enumerate() {
+        let mut sequential_start = 0usize;
+        if cancel.is_some_and(|flag| flag.load(Ordering::Relaxed)) {
+            append_interrupted_tool_results(ctx, tools, output, &comp.tool_calls);
+            anyhow::bail!(STOPPED_BY_USER);
+        }
+        if comp.tool_calls.len() > 1 {
+            if let Some((split, payloads)) =
+                run_parallel_safe_prefix(tools, &env, &comp.tool_calls).await
+            {
+                sequential_start = split;
+                let mut boundary: Option<(String, ToolControl)> = None;
+                for payload in payloads {
+                    if boundary.is_none() && payload.result.control != ToolControl::Continue {
+                        boundary = Some((payload.name.clone(), payload.result.control));
+                    }
+                    append_tool_outcome(
+                        ctx,
+                        vision_provider,
+                        tools,
+                        output,
+                        env.project_root(),
+                        payload,
+                    )
+                    .await;
+                }
+                // Parallel-safe tools must not report writes. Drain
+                // defensively so an incorrect implementation cannot leak a
+                // stale report into the next sequential producing call.
+                let _ = env.take_reported_writes();
+                if cancel.is_some_and(|flag| flag.load(Ordering::Relaxed)) {
+                    append_interrupted_tool_results(ctx, tools, output, &comp.tool_calls[split..]);
+                    anyhow::bail!(STOPPED_BY_USER);
+                }
+                if let Some((name, control)) = boundary {
+                    // Every call in the prefix already ran concurrently and
+                    // therefore keeps its actual result. Only the untouched
+                    // sequential suffix receives synthetic skipped results.
+                    append_skipped_tool_results(
+                        ctx,
+                        tools,
+                        output,
+                        &comp.tool_calls[split..],
+                        &name,
+                        control,
+                    );
+                    batch_control = control;
+                    sequential_start = comp.tool_calls.len();
+                }
+            }
+        }
+        for (index, tc) in comp.tool_calls.iter().enumerate().skip(sequential_start) {
             if cancel.is_some_and(|c| c.load(Ordering::Relaxed)) {
                 append_interrupted_tool_results(ctx, tools, output, &comp.tool_calls[index..]);
                 anyhow::bail!(STOPPED_BY_USER);
@@ -574,51 +624,21 @@ async fn agent_loop_inner(
                     });
                 }
             }
-            let (content, tool_text, ok) = if let Some(img) = &result.image {
-                if ctx.supports_vision {
-                    // Fast path: the active model reads images natively, so
-                    // attach the picture directly to the tool result. The old
-                    // path round-tripped every view_image through a vision
-                    // describer first — one extra LLM call per image that, on
-                    // a reasoning vision model, averaged ~18s (p90 154s) per
-                    // look. The label text keeps the transcript readable and
-                    // `age_images` keeps old images bounded in context.
-                    (
-                        image_content(&img.label, &img.data_url),
-                        img.label.clone(),
-                        true,
-                    )
-                } else {
-                    match vision_provider {
-                        Some(vision) => match describe_image(vision, img, &name, &args).await {
-                            Ok(text) => (Content::text(text.clone()), text, true),
-                            Err(e) => {
-                                let text = format!("{name} error: vision model failed: {e}");
-                                (Content::text(text.clone()), text, false)
-                            }
-                        },
-                        None => {
-                            let text = format!("{name} error: no vision model is configured. Mark an API model as vision-capable in Settings -> Models and set it for image analysis.");
-                            (Content::text(text.clone()), text, false)
-                        }
-                    }
-                }
-            } else {
-                (
-                    Content::text(result.content.clone()),
-                    result.content.clone(),
-                    result.success,
-                )
-            };
-            output.tool_result(&tools.event_name(&name, &args), ok, &tool_text, duration_ms);
-            ctx.append_tool(
-                &tc.id,
-                &name,
-                budget_tool_result(env.project_root(), &name, content),
-            );
-            if let Some(m) = ctx.messages.last() {
-                output.on_message(m);
-            }
+            append_tool_outcome(
+                ctx,
+                vision_provider,
+                tools,
+                output,
+                env.project_root(),
+                ToolPayload {
+                    id: tc.id.clone(),
+                    name: name.clone(),
+                    args: args.clone(),
+                    result,
+                    duration_ms,
+                },
+            )
+            .await;
 
             if control != ToolControl::Continue {
                 // A user decision invalidates calls the model optimistically
@@ -679,6 +699,117 @@ fn append_synthetic_tool_results(
         if let Some(message) = ctx.messages.last() {
             output.on_message(message);
         }
+    }
+}
+
+struct ToolPayload {
+    id: String,
+    name: String,
+    args: serde_json::Value,
+    result: ToolResult,
+    duration_ms: u64,
+}
+
+/// Run the longest leading prefix whose tools explicitly opt into concurrent
+/// execution. Approval is checked before starting any future; an unknown,
+/// interactive, denied, or merely read-only tool ends the prefix.
+async fn run_parallel_safe_prefix(
+    tools: &Registry,
+    env: &dyn ToolEnv,
+    calls: &[ToolCall],
+) -> Option<(usize, Vec<ToolPayload>)> {
+    let mut split = 0usize;
+    for call in calls {
+        let name = call.function.name.as_str();
+        let Some(tool) = tools.get(name) else { break };
+        if !tool.parallel_safe() {
+            break;
+        }
+        let host_approval = env.approval_mode(name).await;
+        if host_approval == Approval::Deny
+            || (!env.approval_bypass()
+                && (host_approval == Approval::Ask || tool.minimum_approval() == Approval::Ask))
+        {
+            break;
+        }
+        split += 1;
+    }
+    if split < 2 {
+        return None;
+    }
+
+    let payloads = futures_util::future::join_all(calls[..split].iter().map(|call| {
+        let name = call.function.name.clone();
+        let args = call.args_value();
+        async move {
+            let started = std::time::Instant::now();
+            let result = tools.run(&name, &args, env).await;
+            ToolPayload {
+                id: call.id.clone(),
+                name,
+                args,
+                result,
+                duration_ms: started.elapsed().as_millis() as u64,
+            }
+        }
+    }))
+    .await;
+    Some((split, payloads))
+}
+
+/// Append one completed tool result in model-call order. Both the concurrent
+/// retrieval path and the ordinary sequential path use this function so image
+/// routing cannot diverge between them.
+async fn append_tool_outcome(
+    ctx: &mut ContextManager,
+    vision_provider: Option<&dyn Provider>,
+    tools: &Registry,
+    output: &dyn Output,
+    root: &Path,
+    payload: ToolPayload,
+) {
+    let ToolPayload {
+        id,
+        name,
+        args,
+        result,
+        duration_ms,
+    } = payload;
+    let (content, tool_text, ok) = if let Some(image) = &result.image {
+        if ctx.supports_vision {
+            // Preserve the native-image fast path from #1009 for both
+            // sequential and parallel-safe read calls.
+            (
+                image_content(&image.label, &image.data_url),
+                image.label.clone(),
+                true,
+            )
+        } else {
+            match vision_provider {
+                Some(vision) => match describe_image(vision, image, &name, &args).await {
+                    Ok(text) => (Content::text(text.clone()), text, true),
+                    Err(error) => {
+                        let text = format!("{name} error: vision model failed: {error}");
+                        (Content::text(text.clone()), text, false)
+                    }
+                },
+                None => {
+                    let text = format!("{name} error: no vision model is configured. Mark an API model as vision-capable in Settings -> Models and set it for image analysis.");
+                    (Content::text(text.clone()), text, false)
+                }
+            }
+        }
+    } else {
+        (
+            Content::text(result.content.clone()),
+            result.content.clone(),
+            result.success,
+        )
+    };
+    output.tool_result(&tools.event_name(&name, &args), ok, &tool_text, duration_ms);
+    ctx.append_tool(&id, &name, budget_tool_result(root, &name, content));
+    if let Some(message) = ctx.messages.last() {
+        output.on_message(message);
     }
 }
 
@@ -1509,6 +1640,256 @@ mod tests {
             .iter()
             .filter_map(|message| message.tool_call_id.as_deref())
             .collect()
+    }
+
+    struct ParallelProbe {
+        name: &'static str,
+        barrier: Arc<tokio::sync::Barrier>,
+        in_flight: Arc<AtomicUsize>,
+        max_in_flight: Arc<AtomicUsize>,
+        runs: Arc<AtomicUsize>,
+        delay: Duration,
+        cancel: Option<Arc<AtomicBool>>,
+        result: ToolResult,
+    }
+
+    #[async_trait]
+    impl Tool for ParallelProbe {
+        fn name(&self) -> &str {
+            self.name
+        }
+
+        fn schema(&self) -> ToolSchema {
+            ToolSchema::new(
+                self.name,
+                "parallel-safe test retrieval",
+                serde_json::json!({"type": "object"}),
+            )
+        }
+
+        fn parallel_safe(&self) -> bool {
+            true
+        }
+
+        async fn run(&self, _args: &serde_json::Value, _env: &dyn ToolEnv) -> ToolResult {
+            self.runs.fetch_add(1, Ordering::SeqCst);
+            let current = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+            self.max_in_flight.fetch_max(current, Ordering::SeqCst);
+            self.barrier.wait().await;
+            if let Some(cancel) = &self.cancel {
+                cancel.store(true, Ordering::SeqCst);
+            }
+            tokio::time::sleep(self.delay).await;
+            self.in_flight.fetch_sub(1, Ordering::SeqCst);
+            self.result.clone()
+        }
+    }
+
+    fn parallel_probe_pair(
+        first_result: ToolResult,
+        second_result: ToolResult,
+    ) -> (
+        ParallelProbe,
+        ParallelProbe,
+        Arc<AtomicUsize>,
+        Arc<AtomicUsize>,
+    ) {
+        let barrier = Arc::new(tokio::sync::Barrier::new(2));
+        let in_flight = Arc::new(AtomicUsize::new(0));
+        let max_in_flight = Arc::new(AtomicUsize::new(0));
+        let runs = Arc::new(AtomicUsize::new(0));
+        let build = |name, delay, result| ParallelProbe {
+            name,
+            barrier: barrier.clone(),
+            in_flight: in_flight.clone(),
+            max_in_flight: max_in_flight.clone(),
+            runs: runs.clone(),
+            delay,
+            cancel: None,
+            result,
+        };
+        (
+            build("parallel_a", Duration::from_millis(20), first_result),
+            build("parallel_b", Duration::ZERO, second_result),
+            max_in_flight,
+            runs,
+        )
+    }
+
+    #[tokio::test]
+    async fn parallel_safe_prefix_runs_concurrently_and_keeps_model_order() {
+        let (first, second, max_in_flight, runs) = parallel_probe_pair(
+            ToolResult::ok("first actual"),
+            ToolResult::ok("second actual"),
+        );
+        let writer_runs = Arc::new(AtomicUsize::new(0));
+        let provider = SequenceProvider::new([
+            Completion {
+                tool_calls: vec![
+                    call("a-1", "parallel_a", serde_json::json!({})),
+                    call("b-1", "parallel_b", serde_json::json!({})),
+                    call("w-1", "writer", serde_json::json!({})),
+                ],
+                finish_reason: Some("tool_calls".into()),
+                ..Completion::default()
+            },
+            Completion {
+                content: "done".into(),
+                finish_reason: Some("stop".into()),
+                ..Completion::default()
+            },
+        ]);
+        let mut tools = Registry::builtins().filtered(&[]);
+        tools.add(Box::new(first));
+        tools.add(Box::new(second));
+        tools.add(Box::new(CountingTool {
+            name: "writer",
+            runs: writer_runs.clone(),
+        }));
+        let mut ctx = ContextManager::new(100_000);
+
+        agent_loop(
+            &mut ctx,
+            &provider,
+            None,
+            &tools,
+            Path::new("."),
+            &NullOutput,
+            "inspect then write",
+            0,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(max_in_flight.load(Ordering::SeqCst), 2);
+        assert_eq!(runs.load(Ordering::SeqCst), 2);
+        assert_eq!(writer_runs.load(Ordering::SeqCst), 1);
+        assert_eq!(tool_result_ids(&ctx), vec!["a-1", "b-1", "w-1"]);
+        let texts = ctx
+            .messages
+            .iter()
+            .filter(|message| message.tool_call_id.is_some())
+            .map(|message| message.content.as_text())
+            .collect::<Vec<_>>();
+        assert_eq!(texts, vec!["first actual", "second actual", "ran"]);
+    }
+
+    #[tokio::test]
+    async fn parallel_prefix_keeps_actual_results_before_skipping_the_suffix() {
+        let (first, second, _max_in_flight, runs) = parallel_probe_pair(
+            ToolResult::fail("boundary actual").stop_batch(),
+            ToolResult::ok("second actual"),
+        );
+        let writer_runs = Arc::new(AtomicUsize::new(0));
+        let provider = SequenceProvider::new([
+            Completion {
+                tool_calls: vec![
+                    call("a-1", "parallel_a", serde_json::json!({})),
+                    call("b-1", "parallel_b", serde_json::json!({})),
+                    call("w-1", "writer", serde_json::json!({})),
+                ],
+                finish_reason: Some("tool_calls".into()),
+                ..Completion::default()
+            },
+            Completion {
+                content: "done".into(),
+                finish_reason: Some("stop".into()),
+                ..Completion::default()
+            },
+        ]);
+        let mut tools = Registry::builtins().filtered(&[]);
+        tools.add(Box::new(first));
+        tools.add(Box::new(second));
+        tools.add(Box::new(CountingTool {
+            name: "writer",
+            runs: writer_runs.clone(),
+        }));
+        let mut ctx = ContextManager::new(100_000);
+
+        agent_loop(
+            &mut ctx,
+            &provider,
+            None,
+            &tools,
+            Path::new("."),
+            &NullOutput,
+            "inspect with boundary",
+            0,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(runs.load(Ordering::SeqCst), 2);
+        assert_eq!(writer_runs.load(Ordering::SeqCst), 0);
+        assert_eq!(tool_result_ids(&ctx), vec!["a-1", "b-1", "w-1"]);
+        let texts = ctx
+            .messages
+            .iter()
+            .filter(|message| message.tool_call_id.is_some())
+            .map(|message| message.content.as_text())
+            .collect::<Vec<_>>();
+        assert_eq!(texts[0], "boundary actual");
+        assert_eq!(texts[1], "second actual");
+        assert!(texts[2].contains("Skipped because"), "{}", texts[2]);
+    }
+
+    #[tokio::test]
+    async fn cancellation_keeps_finished_parallel_results_and_interrupts_the_suffix() {
+        let cancel = Arc::new(AtomicBool::new(false));
+        let (mut first, second, _max_in_flight, runs) = parallel_probe_pair(
+            ToolResult::ok("first actual"),
+            ToolResult::ok("second actual"),
+        );
+        first.cancel = Some(cancel.clone());
+        let writer_runs = Arc::new(AtomicUsize::new(0));
+        let provider = SequenceProvider::new([Completion {
+            tool_calls: vec![
+                call("a-1", "parallel_a", serde_json::json!({})),
+                call("b-1", "parallel_b", serde_json::json!({})),
+                call("w-1", "writer", serde_json::json!({})),
+            ],
+            finish_reason: Some("tool_calls".into()),
+            ..Completion::default()
+        }]);
+        let mut tools = Registry::builtins().filtered(&[]);
+        tools.add(Box::new(first));
+        tools.add(Box::new(second));
+        tools.add(Box::new(CountingTool {
+            name: "writer",
+            runs: writer_runs.clone(),
+        }));
+        let mut ctx = ContextManager::new(100_000);
+
+        let error = agent_loop(
+            &mut ctx,
+            &provider,
+            None,
+            &tools,
+            Path::new("."),
+            &NullOutput,
+            "inspect then cancel",
+            0,
+            Some(cancel.as_ref()),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(error.to_string().contains(STOPPED_BY_USER));
+        assert_eq!(runs.load(Ordering::SeqCst), 2);
+        assert_eq!(writer_runs.load(Ordering::SeqCst), 0);
+        assert_eq!(tool_result_ids(&ctx), vec!["a-1", "b-1", "w-1"]);
+        let texts = ctx
+            .messages
+            .iter()
+            .filter(|message| message.tool_call_id.is_some())
+            .map(|message| message.content.as_text())
+            .collect::<Vec<_>>();
+        assert_eq!(texts[0], "first actual");
+        assert_eq!(texts[1], "second actual");
+        assert_eq!(texts[2], INTERRUPTED_BY_USER);
+        assert!(crate::unpaired_tool_call_ids(&ctx.messages).is_empty());
     }
 
     #[tokio::test]

--- a/crates/wisp-core/src/output.rs
+++ b/crates/wisp-core/src/output.rs
@@ -157,10 +157,11 @@ pub struct ToolEnvAdapter<'a> {
     guidance: Option<&'a std::sync::Mutex<Vec<(u64, String)>>>,
     /// Kernel-reported writes for the in-flight tool call.
     ///
-    /// Tool calls within one agent loop run strictly sequentially, so
-    /// drain-per-call is race-free; parallel subagent loops each construct
-    /// their own adapter, so reports cannot cross loops. The buffer must be
-    /// drained unconditionally after every tool call so a stale report can
+    /// Producing tool calls within one agent loop run strictly sequentially;
+    /// the only overlapping calls are explicitly parallel-safe retrievals,
+    /// which must never report writes. Parallel subagent loops each construct
+    /// their own adapter, so reports cannot cross loops. The buffer is drained
+    /// after every sequential call and parallel prefix so a stale report can
     /// never leak into the next call's record.
     reported_writes: std::sync::Mutex<Vec<String>>,
 }

--- a/crates/wisp-core/src/system_prompt.rs
+++ b/crates/wisp-core/src/system_prompt.rs
@@ -89,6 +89,8 @@ never reduce the promised samples or scientific objective without the user's exp
     fn tool_guidance() -> String {
         "## Tool Selection\n\n\
 Use the dedicated tool when one exists (read/write/edit/search/grep/attempt_completion). Reach for **shell** only when no dedicated tool fits — it runs PowerShell on Windows and POSIX `sh` on macOS/Linux, with a 60s timeout.\n\
+Batch independent read/search/grep calls: when several retrievals do not depend on each other's results, issue them in ONE model batch so the host can run the parallel-safe prefix concurrently. Calls that need an earlier result, and every call that writes or prompts, belong in a later batch.\n\
+For multi-file comprehension questions, use the **explore** subagent when it is available so its compact conclusion, rather than every intermediate file, enters this conversation.\n\
 When the user asks what a configured Workflow is, what it does, or how it works, call **explain_workflow** when available and explain the returned task graph. Inspection is not execution: do not call **delegate_tasks** unless the user asks to run the Workflow.\n\
 When the user asks to change app appearance or preferences (font size, theme, language, compaction, notifications) or to inspect disk storage for this project, call **configure**. Do not send them to Settings for those allowlisted keys. Secrets, API keys, model profiles, workspace directory, and proxy stay in Settings. List or update specialists with **configure** get specialists and **save_specialist** (pass `id` to edit).\n\
 Use **edit** (not write) for small in-place changes; read the target first so `old` matches the current file exactly, and ensure `old` is unique or pass `all=true`.\n\
@@ -577,6 +579,15 @@ mod tests {
         assert!(!out.contains("SHOULD_NOT_BE_IN_SYSTEM_PROMPT"), "{out}");
 
         std::fs::remove_dir_all(root).ok();
+    }
+
+    #[test]
+    fn tool_guidance_names_parallel_safe_batches_and_explore() {
+        let prompt = SystemPrompt::new(std::path::Path::new("/tmp"), &SkillIndex::default(), None)
+            .assemble();
+        assert!(prompt.contains("Batch independent read/search/grep calls"));
+        assert!(prompt.contains("parallel-safe prefix concurrently"));
+        assert!(prompt.contains("**explore** subagent"));
     }
 
     #[test]

--- a/crates/wisp-tools/src/grep.rs
+++ b/crates/wisp-tools/src/grep.rs
@@ -37,6 +37,9 @@ impl Tool for GrepTool {
     fn preview(&self, args: &serde_json::Value) -> String {
         arg_str(args, "pat").unwrap_or_default()
     }
+    fn parallel_safe(&self) -> bool {
+        true
+    }
     async fn run(&self, args: &serde_json::Value, env: &dyn ToolEnv) -> ToolResult {
         let pat = match arg_str(args, "pat") {
             Ok(p) => p,

--- a/crates/wisp-tools/src/lib.rs
+++ b/crates/wisp-tools/src/lib.rs
@@ -541,6 +541,23 @@ mod approval_tests {
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::{Arc, Mutex};
 
+    #[test]
+    fn only_audited_builtin_retrievals_opt_into_parallel_batches() {
+        let tools = Registry::builtins();
+        for name in ["read", "search", "grep"] {
+            assert!(
+                tools.get(name).is_some_and(|tool| tool.parallel_safe()),
+                "{name} should be parallel-safe"
+            );
+        }
+        for name in ["write", "edit", "shell", "view_image"] {
+            assert!(
+                !tools.get(name).is_some_and(|tool| tool.parallel_safe()),
+                "{name} must stay sequential"
+            );
+        }
+    }
+
     /// A tool that flips a flag when it actually runs, so we can assert whether
     /// the approval gate let it through.
     struct SpyTool(&'static AtomicBool);

--- a/crates/wisp-tools/src/read.rs
+++ b/crates/wisp-tools/src/read.rs
@@ -79,6 +79,9 @@ impl Tool for ReadTool {
     fn preview(&self, args: &serde_json::Value) -> String {
         arg_str(args, "path").unwrap_or_default()
     }
+    fn parallel_safe(&self) -> bool {
+        true
+    }
     async fn run(&self, args: &serde_json::Value, env: &dyn ToolEnv) -> ToolResult {
         let requested_path = match arg_str(args, "path") {
             Ok(p) => p,

--- a/crates/wisp-tools/src/search.rs
+++ b/crates/wisp-tools/src/search.rs
@@ -45,6 +45,9 @@ impl Tool for SearchTool {
     fn preview(&self, args: &serde_json::Value) -> String {
         arg_str(args, "pat").unwrap_or_default()
     }
+    fn parallel_safe(&self) -> bool {
+        true
+    }
     async fn run(&self, args: &serde_json::Value, env: &dyn ToolEnv) -> ToolResult {
         let pat = match arg_str(args, "pat") {
             Ok(p) => p,

--- a/crates/wisp-tools/src/tool.rs
+++ b/crates/wisp-tools/src/tool.rs
@@ -28,6 +28,14 @@ pub trait Tool: Send + Sync {
     fn read_only(&self) -> bool {
         false
     }
+    /// Whether independent calls may overlap inside one model-issued batch.
+    /// This is stricter than [`Self::read_only`]: implementations must not
+    /// prompt, mutate host state, materialize artifacts, or depend on another
+    /// call in the same batch. Default false keeps dynamic tools sequential
+    /// until their complete behavior is explicitly audited.
+    fn parallel_safe(&self) -> bool {
+        false
+    }
     /// One-line preview shown in the tool-call card (e.g. the file path).
     fn preview(&self, _args: &Value) -> String {
         String::new()


### PR DESCRIPTION
## Problem

Independent read, search, and grep calls emitted in one model batch were executed sequentially. The previous broad attempt also treated generic read-only tools as parallel-safe, even though some MCP retrieval tools materialize local artifacts.

## Changes

- Add an explicit parallel_safe tool capability with a fail-closed default.
- Opt in only the audited read, search, and grep built-ins.
- Run only the leading eligible prefix concurrently; writers, prompts, unknown tools, view_image, and dynamic tools stay sequential.
- Append completed results in the original model-call order.
- Preserve every actual prefix result when one call returns StopBatch; synthesize skipped results only for the untouched suffix.
- Preserve #1009 native image routing when read returns an image.
- Teach the Agent to batch independent retrievals and use explore for larger multi-file comprehension.

## Tests

- Concurrent barrier test with reverse completion timing and ordered model context.
- StopBatch test proving already-executed results are retained and the writer suffix is skipped.
- Cancellation test proving completed prefix results stay paired and the suffix is interrupted.
- Built-in opt-in inventory test and prompt guidance test.
- Existing native vision view_image regression test.
- Passed the complete wisp-core and wisp-tools test suites, cargo fmt, and diff checks.

## Limitations

Only read, search, and grep opt in. MCP tools and other dynamic read-only tools remain sequential until their local side effects and control behavior are independently audited. A cancellation waits for already-started tool futures to observe cancellation or finish.