### PR TITLE
fix(ui): preserve browser scroll anchoring

### DIFF
--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -9863,6 +9863,7 @@ test("opening a long conversation lands at the latest message and stays stable o
   await expect.poll(() => scroller.evaluate((element) => element.scrollTop)).toBeGreaterThan(before - 240);
 
   const readingPosition = await scroller.evaluate((element) => element.scrollTop);
+  await expect(scroller).toHaveCSS("overflow-anchor", "auto");
   // Unfollow flips overflow-anchor back to auto, but Chromium only picks a
   // scroll anchor at layout time. Waiting frames alone is not enough: if no
   // layout ran in between, the prepend below is never compensated (#663).
@@ -9887,6 +9888,14 @@ test("opening a long conversation lands at the latest message and stays stable o
     thread?.prepend(spacer);
   });
   await expect.poll(() => scroller.evaluate((element) => element.scrollTop))
+    .toBeGreaterThan(readingPosition + 400);
+  // ResizeObserver runs after layout. Verify the scroll helper keeps the
+  // browser's prepend compensation instead of briefly accepting it and then
+  // restoring the stale pre-prepend bookmark.
+  await page.evaluate(
+    () => new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve))),
+  );
+  expect(await scroller.evaluate((element) => element.scrollTop))
     .toBeGreaterThan(readingPosition + 400);
 });
 

--- a/ui/src/scroll.js
+++ b/ui/src/scroll.js
@@ -54,10 +54,18 @@ export function attach_chat_scroll(scrollerId, contentId) {
   const rememberProgrammatic = () => {
     programmaticTop = scroller.scrollTop;
   };
-  const snapFollow = () => {
-    snapBottom(scroller);
-    rememberProgrammatic();
-    readingTop = scroller.scrollTop;
+  const snapFollow = (force = false) => {
+    // Write-only follow snap: skip the assignment when we already wrote this
+    // max. Repeated programmatic scrollTop writes suppress Chromium overflow
+    // anchoring, which #663 needs after the user scrolls away. `force` is for
+    // jump-to-latest / rebuild clamps, where scrollTop moved without max
+    // changing.
+    const max = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
+    if (force || max - programmaticTop > 2) {
+      scroller.scrollTop = max;
+    }
+    programmaticTop = max;
+    readingTop = max;
   };
   const restoreBookmark = () => {
     const max = Math.max(0, scroller.scrollHeight - scroller.clientHeight);
@@ -114,7 +122,7 @@ export function attach_chat_scroll(scrollerId, contentId) {
         && scroller.scrollTop < 8
         && readingTop > Math.max(scroller.clientHeight, 200)
       ) {
-        snapFollow();
+        snapFollow(true);
         syncPill();
         return;
       }
@@ -126,11 +134,15 @@ export function attach_chat_scroll(scrollerId, contentId) {
     // Reflow-driven clamp. Scroll events fire before paint, so an instant
     // snap here means the clamped position is never painted — without it the
     // view visibly bounces on every thinking delta. When parked, restore the
-    // bookmark instead of adopting the collapse's scrollTop=0 (#927).
+    // bookmark if the thread collapsed toward 0 (#927); if scrollTop moved
+    // down, that is overflow-anchor compensating a prepend (#663) — keep it.
     if (follow) {
-      snapFollow();
-    } else {
+      snapFollow(true);
+    } else if (scroller.scrollTop + 2 < readingTop) {
       restoreBookmark();
+    } else {
+      readingTop = scroller.scrollTop;
+      programmaticTop = scroller.scrollTop;
     }
     syncPill();
   };
@@ -148,7 +160,7 @@ export function attach_chat_scroll(scrollerId, contentId) {
       hidden = false;
       lastHeight = h;
       if (follow) {
-        snapFollow();
+        snapFollow(true);
       } else {
         restoreBookmark();
       }
@@ -160,13 +172,18 @@ export function attach_chat_scroll(scrollerId, contentId) {
     if (follow) {
       // ResizeObserver already coalesces streaming DOM changes. Keep the hot
       // path to one bottom snap and skip the row/viewport geometry used only
-      // by the scroll-away pill.
+      // by the scroll-away pill — reading gap geometry here forces a layout
+      // on every streaming frame, so the pill is only synced when it could
+      // actually be visible (not following).
       snapFollow();
-      syncPill();
       return;
     }
     if (grew) {
-      restoreBookmark();
+      // Parked: overflow-anchor keeps the visible rows stable on prepend.
+      // Do not restoreBookmark here — that writes the pre-prepend scrollTop
+      // and undoes the compensation (#663).
+      syncPill();
+      return;
     }
     syncFollow();
   };
@@ -214,14 +231,14 @@ export function attach_chat_scroll(scrollerId, contentId) {
     snap: () => {
       const requested = performance.now();
       setFollow(true);
-      snapFollow();
+      snapFollow(true);
       lastHeight = content.scrollHeight;
       syncPill();
       requestAnimationFrame(() => {
         requestAnimationFrame(() => {
           if (lastUserScroll < requested) {
             setFollow(true);
-            snapFollow();
+            snapFollow(true);
             lastHeight = content.scrollHeight;
             syncPill();
           }


### PR DESCRIPTION
## Problem

When a reader scrolls away from the bottom, Chromium compensates prepended content through overflow anchoring. The chat scroll helper then wrote the stale pre-prepend scrollTop back, undoing that compensation. Repeated follow-mode writes also performed unnecessary layout work.

## Changes

- Keep downward non-user scroll movement as browser overflow-anchor compensation while still restoring genuine rebuild clamps toward the top.
- Skip redundant follow-bottom assignments unless a forced rebuild or jump requires one.
- Avoid pill geometry work on the streaming follow path.
- Preserve forced snaps for rebuild clamps, hidden-view reveals, and jump-to-latest.

## Tests

- Strengthened the #663 Playwright regression to require overflow anchoring and verify its compensated position survives ResizeObserver processing.
- Targeted seven follow, rebuild, reading-position, and jump-pill Playwright scenarios pass.
- `cd ui && cargo check --target wasm32-unknown-unknown`
- `cargo fmt --all -- --check`

## Manual smoke

1. Open a long conversation and scroll upward.
2. Load or prepend older content; the visible reading position should remain stable.
3. Return to the bottom and stream a long response; the view should remain followed.

## Scope

This PR contains only scroll-follow and scroll-anchor behavior. The incremental Markdown append experiment from #1010 is intentionally excluded.