### PR TITLE
perf(ui): idle the settled transfer tray clock

### DIFF
--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -6330,6 +6330,10 @@ test("completed SSH transfer cards leave the composer tray promptly", async ({ p
   });
   await expect(card).toContainText("Download complete");
   await expect(card).toBeHidden({ timeout: 5_000 });
+  // Crossing another shared-clock tick must not remount an expired card after
+  // the transfer tray has dropped its clock dependency.
+  await page.waitForTimeout(1_200);
+  await expect(card).toBeHidden();
 });
 
 test("monitor_run renders a live Run card from summary polls and on-demand detail", async ({ page }) => {

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -6849,6 +6849,35 @@ fn App() -> impl IntoView {
     let runtime_object_states =
         create_rw_signal::<HashMap<String, RuntimeObjectState>>(HashMap::new());
     let run_clock = create_rw_signal(now_secs());
+    // The transfer tray needs the shared clock only while the active session
+    // has an active or briefly lingering transfer. Once the last card expires,
+    // this effect reruns with `clock_active = false` and drops its run_clock
+    // dependency; historical progress records then stay idle between run-list
+    // updates instead of rebuilding the tray every second.
+    let transfer_tray_clock_active = create_rw_signal(false);
+    let transfer_tray_now = create_rw_signal(run_clock.get_untracked());
+    create_effect(move |_| {
+        let clock_active = transfer_tray_clock_active.get();
+        let now = if clock_active {
+            run_clock.get()
+        } else {
+            run_clock.get_untracked()
+        };
+        let has_visible_transfer = active_session.get().is_some_and(|session_id| {
+            run_records.with(|records| {
+                records.iter().any(|run| {
+                    run.frame_id.as_deref() == Some(session_id.as_str())
+                        && run_progress(run).is_some_and(|progress| {
+                            transfer_progress_visible(&progress, &run.status, now)
+                        })
+                })
+            })
+        });
+        transfer_tray_now.set(now);
+        if clock_active != has_visible_transfer {
+            transfer_tray_clock_active.set(has_visible_transfer);
+        }
+    });
     let show_add_host = create_rw_signal(false);
     let host_alias = create_rw_signal(String::new());
     let host_hostname = create_rw_signal(String::new());
@@ -11309,10 +11338,10 @@ fn App() -> impl IntoView {
             </div>
 
             {move || active_session.get().and_then(|session_id| {
-                // Finished transfers linger briefly for confirmation. Reading
-                // the shared clock makes this tray recompute after run polling
-                // stops, so settled cards cannot remain over the conversation.
-                let now = run_clock.get();
+                // Finished transfers linger briefly for confirmation. The
+                // clock-driving effect above stops updating this signal after
+                // the final card expires.
+                let now = transfer_tray_now.get();
                 let transfers = run_records.with(|records| {
                     records
                         .iter()


### PR DESCRIPTION
## Problem

The composer transfer tray read the shared one-second run clock unconditionally whenever a session was open. Historical transfer progress therefore kept rescanning and rebuilding the tray every second long after all transfer cards had expired.

## Changes

- Add a conditional clock-driving effect for the active session transfer tray.
- Subscribe to the shared clock only while an active or briefly lingering transfer is visible.
- Drop the clock dependency after the last card expires; run-list or session changes can reactivate it.
- Keep the existing three-second completion confirmation window.

## Tests

- Active SSH transfer progress and cancellation Playwright scenario passes.
- Completed transfer card disappears and remains absent across a later shared-clock tick.
- `cd ui && cargo check --target wasm32-unknown-unknown`
- `cargo fmt --all -- --check`

## Manual smoke

1. Start an SSH upload or download and verify its progress card updates.
2. Complete it and verify the completion card disappears after the confirmation window.
3. Leave the conversation open and confirm the expired card does not reappear.

## Scope

This PR only changes transfer tray clock subscription. It does not include scrolling or incremental Markdown rendering changes from #1010.