### PR TITLE
fix(kernel): close scoped write and WSL attribution gaps

### DIFF
--- a/crates/wisp-core/src/provenance.rs
+++ b/crates/wisp-core/src/provenance.rs
@@ -42,7 +42,13 @@ pub struct TextPreimage {
     pub checksum: String,
 }
 
-const SKIP_DIRS: &[&str] = &[
+/// Directory names omitted by workspace snapshots at any depth.
+///
+/// Runtime launchers also send this exact policy to local Python workers so
+/// paths the host can never attribute do not consume the worker's report cap.
+/// Keep the policy here: snapshot traversal and reported-write folding remain
+/// the final source of truth.
+pub const SNAPSHOT_SKIP_DIRS: &[&str] = &[
     ".git",
     ".venv",
     "node_modules",
@@ -327,7 +333,9 @@ fn relative_identity(path: &str) -> String {
 /// drift.
 fn is_snapshot_skipped(relative: &str) -> bool {
     match relative.rsplit_once('/') {
-        Some((parents, _)) => parents.split('/').any(|dir| SKIP_DIRS.contains(&dir)),
+        Some((parents, _)) => parents
+            .split('/')
+            .any(|dir| SNAPSHOT_SKIP_DIRS.contains(&dir)),
         None => false,
     }
 }
@@ -713,7 +721,7 @@ fn snapshot_capped(root: &Path, max_entries: usize) -> BTreeMap<PathBuf, SystemT
             let p = entry.path();
             if ft.is_dir() {
                 let name = p.file_name().and_then(|n| n.to_str()).unwrap_or("");
-                if !SKIP_DIRS.contains(&name) {
+                if !SNAPSHOT_SKIP_DIRS.contains(&name) {
                     stack.push(p);
                 }
             } else if ft.is_file() {

--- a/crates/wisp-runtime/src/kernel.rs
+++ b/crates/wisp-runtime/src/kernel.rs
@@ -40,6 +40,16 @@ pub struct KernelResp {
     /// worker did not (or could not) observe; `Some([])` means it observed
     /// and the cell wrote nothing. Never conflate the two.
     pub files_written: Option<Vec<String>>,
+    /// `project` means `files_written` contains project-relative paths from a
+    /// host-configured write scope. Absent keeps the legacy absolute-path
+    /// contract for older bundled workers.
+    pub files_written_base: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KernelWriteScope {
+    pub root: String,
+    pub skip_dirs: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -80,6 +90,8 @@ struct RawResp {
     usage: RawUsage,
     #[serde(default)]
     files_written: Option<Vec<String>>,
+    #[serde(default)]
+    files_written_base: Option<String>,
 }
 
 #[derive(Deserialize, Debug, Default)]
@@ -209,6 +221,22 @@ impl KernelClient {
 
     pub fn ready(&self) -> &KernelReady {
         &self.ready
+    }
+
+    /// Configure the worker's project write boundary before its first cell.
+    /// Only Python workers currently implement this optional startup frame.
+    pub async fn configure_write_scope(&mut self, scope: &KernelWriteScope) -> Result<()> {
+        let id = uuid::Uuid::new_v4().to_string();
+        self.send(serde_json::json!({
+            "type": "configure",
+            "id": id,
+            "write_scope": {
+                "root": scope.root,
+                "skip_dirs": scope.skip_dirs,
+            }
+        }))
+        .await?;
+        read_configured(&mut self.stdout, &id, STARTUP_TIMEOUT).await
     }
 
     async fn execute_cell(
@@ -497,10 +525,47 @@ async fn read_response<R: AsyncBufRead + Unpin>(
                     cpu_s: response.usage.cpu_s,
                     rss_kb: response.usage.rss_kb,
                     files_written: response.files_written,
+                    files_written_base: response.files_written_base,
                 });
             }
             other => bail!("unexpected protocol frame '{other}' during execution"),
         }
+    }
+}
+
+async fn read_configured<R: AsyncBufRead + Unpin>(
+    reader: &mut R,
+    request_id: &str,
+    timeout: Duration,
+) -> Result<()> {
+    let frame = tokio::time::timeout(timeout, read_protocol_line(reader))
+        .await
+        .map_err(|_| anyhow!("timed out waiting for write-scope configuration"))??;
+    let kind = frame
+        .get("type")
+        .and_then(|value| value.as_str())
+        .ok_or_else(|| anyhow!("write-scope response is missing string field 'type'"))?;
+    let id = frame
+        .get("id")
+        .and_then(|value| value.as_str())
+        .unwrap_or("unknown");
+    if id != request_id {
+        bail!(
+            "write-scope response id '{}' does not match active request '{}'",
+            id,
+            request_id
+        );
+    }
+    match kind {
+        "configured" => Ok(()),
+        "configure_error" => bail!(
+            "kernel worker rejected write scope: {}",
+            frame
+                .get("error")
+                .and_then(|value| value.as_str())
+                .unwrap_or("unknown configuration error")
+        ),
+        other => bail!("unexpected protocol frame '{other}' during write-scope configuration"),
     }
 }
 
@@ -588,6 +653,38 @@ mod tests {
             .await
             .unwrap_err();
         assert!(error.to_string().contains("jsonlite"));
+    }
+
+    #[tokio::test]
+    async fn write_scope_configuration_accepts_ack_and_surfaces_rejection() {
+        let (reader, mut writer) = duplex(1024);
+        writer
+            .write_all(b"{\"type\":\"configured\",\"id\":\"scope-1\"}\n")
+            .await
+            .unwrap();
+        read_configured(
+            &mut BufReader::new(reader),
+            "scope-1",
+            Duration::from_secs(1),
+        )
+        .await
+        .unwrap();
+
+        let (reader, mut writer) = duplex(1024);
+        writer
+            .write_all(
+                b"{\"type\":\"configure_error\",\"id\":\"scope-2\",\"error\":\"bad root\"}\n",
+            )
+            .await
+            .unwrap();
+        let error = read_configured(
+            &mut BufReader::new(reader),
+            "scope-2",
+            Duration::from_secs(1),
+        )
+        .await
+        .unwrap_err();
+        assert!(error.to_string().contains("bad root"));
     }
 
     #[tokio::test]
@@ -776,7 +873,7 @@ mod tests {
         let (reader, mut writer) = duplex(2048);
         writer
             .write_all(
-                br#"{"type":"result","id":"cell-1","stdout":"","stderr":"","error":null,"files_written":["/p/a.txt","/p/b.txt"]}
+                br#"{"type":"result","id":"cell-1","stdout":"","stderr":"","error":null,"files_written":["a.txt","b.txt"],"files_written_base":"project"}
 "#,
             )
             .await
@@ -791,8 +888,9 @@ mod tests {
         .unwrap();
         assert_eq!(
             response.files_written,
-            Some(vec!["/p/a.txt".into(), "/p/b.txt".into()])
+            Some(vec!["a.txt".into(), "b.txt".into()])
         );
+        assert_eq!(response.files_written_base.as_deref(), Some("project"));
     }
 
     #[tokio::test]

--- a/crates/wisp-runtime/src/lib.rs
+++ b/crates/wisp-runtime/src/lib.rs
@@ -9,7 +9,9 @@ pub use env::{
     bundled_mock_mcp_path, bundled_r_worker_path, bundled_worker_path, conda_prefix_envs,
     direct_rscript, find_rscript, resolve_bundled_script, PythonEnv,
 };
-pub use kernel::{KernelClient, KernelReady, KernelResp, MAX_CODE_BYTES, PROTOCOL_VERSION};
+pub use kernel::{
+    KernelClient, KernelReady, KernelResp, KernelWriteScope, MAX_CODE_BYTES, PROTOCOL_VERSION,
+};
 pub use manager::{
     LaunchedRuntime, RuntimeEvent, RuntimeExecution, RuntimeInfo, RuntimeKernel, RuntimeKey,
     RuntimeLanguage, RuntimeLauncher, RuntimeManager, RuntimeMetadata, RuntimeObject,

--- a/crates/wisp-runtime/src/tool.rs
+++ b/crates/wisp-runtime/src/tool.rs
@@ -59,6 +59,38 @@ fn project_relative_writes(root: &Path, reported: &[String]) -> Vec<String> {
     out
 }
 
+/// Validate paths already reported relative to a host-configured project
+/// boundary. Joining and canonicalizing again keeps a compromised or stale
+/// worker from naming a symlink target outside the project.
+fn validated_project_writes(root: &Path, reported: &[String]) -> Vec<String> {
+    let root = dunce::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
+    let mut out = Vec::new();
+    for raw in reported {
+        let normalized = normalize_separators(raw);
+        let relative = Path::new(&normalized);
+        if relative.is_absolute()
+            || relative
+                .components()
+                .any(|component| !matches!(component, std::path::Component::Normal(_)))
+        {
+            continue;
+        }
+        let candidate = root.join(relative);
+        let Ok(candidate) = dunce::canonicalize(candidate) else {
+            continue;
+        };
+        if candidate.strip_prefix(&root).is_err() {
+            continue;
+        }
+        if !normalized.is_empty() {
+            out.push(normalized);
+        }
+    }
+    out.sort();
+    out.dedup();
+    out
+}
+
 /// Hand a finished cell's self-reported writes to the running tool
 /// environment. Only local kernels report: a remote or WSL worker's absolute
 /// paths describe another machine's filesystem. An absent report means the
@@ -70,7 +102,11 @@ fn report_local_writes(env: &dyn ToolEnv, context_id: &str, response: &KernelRes
     let Some(reported) = &response.files_written else {
         return;
     };
-    let paths = project_relative_writes(env.project_root(), reported);
+    let paths = match response.files_written_base.as_deref() {
+        None => project_relative_writes(env.project_root(), reported),
+        Some("project") => validated_project_writes(env.project_root(), reported),
+        Some(_) => Vec::new(),
+    };
     if !paths.is_empty() {
         env.report_written_paths(&paths);
     }
@@ -353,7 +389,7 @@ impl Tool for RTool {
 mod tests {
     use super::{
         code_arg, context_id, project_relative_writes, report_local_writes,
-        PYTHON_TOOL_DESCRIPTION, R_TOOL_DESCRIPTION,
+        validated_project_writes, PYTHON_TOOL_DESCRIPTION, R_TOOL_DESCRIPTION,
     };
     use crate::{KernelResp, LOCAL_CONTEXT_ID, MAX_CODE_BYTES};
     use std::path::{Path, PathBuf};
@@ -482,6 +518,27 @@ mod tests {
         std::fs::remove_dir_all(&root).ok();
     }
 
+    #[test]
+    fn configured_project_writes_reject_absolute_traversal_and_missing_paths() {
+        let root = unique_tmp("configured_writes");
+        std::fs::create_dir_all(root.join("out")).unwrap();
+        std::fs::write(root.join("out/a.txt"), b"a").unwrap();
+        let absolute = root.join("out/a.txt").to_string_lossy().into_owned();
+        assert_eq!(
+            validated_project_writes(
+                &root,
+                &[
+                    "out/a.txt".into(),
+                    "../escape.txt".into(),
+                    absolute,
+                    "out/missing.txt".into(),
+                ],
+            ),
+            vec!["out/a.txt".to_string()]
+        );
+        std::fs::remove_dir_all(&root).ok();
+    }
+
     /// Captures what the finished-cell branch of `run_runtime` hands to the
     /// agent loop.
     struct RecordingEnv {
@@ -525,6 +582,26 @@ mod tests {
         let reported = vec![root.join("fig_1.png").to_string_lossy().into_owned()];
 
         report_local_writes(&env, LOCAL_CONTEXT_ID, &response_with(Some(reported)));
+
+        assert_eq!(
+            *env.reported.lock().unwrap(),
+            vec![vec!["fig_1.png".to_string()]]
+        );
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn configured_local_report_reaches_the_tool_environment() {
+        let root = unique_tmp("report_configured_local");
+        std::fs::write(root.join("fig_1.png"), b"x").unwrap();
+        let env = recording_env(root.clone());
+        let response = KernelResp {
+            files_written: Some(vec!["fig_1.png".into()]),
+            files_written_base: Some("project".into()),
+            ..KernelResp::default()
+        };
+
+        report_local_writes(&env, LOCAL_CONTEXT_ID, &response);
 
         assert_eq!(
             *env.reported.lock().unwrap(),

--- a/crates/wisp-runtime/src/tool.rs
+++ b/crates/wisp-runtime/src/tool.rs
@@ -92,20 +92,24 @@ fn validated_project_writes(root: &Path, reported: &[String]) -> Vec<String> {
 }
 
 /// Hand a finished cell's self-reported writes to the running tool
-/// environment. Only local kernels report: a remote or WSL worker's absolute
-/// paths describe another machine's filesystem. An absent report means the
-/// worker could not observe, so the host keeps inferring from its snapshot.
-fn report_local_writes(env: &dyn ToolEnv, context_id: &str, response: &KernelResp) {
-    if context_id != LOCAL_CONTEXT_ID {
-        return;
-    }
+/// environment. Legacy absolute reports are local-only. A host-configured
+/// project-relative report is also safe for WSL because its REPL runs inside
+/// the translated Windows project root; SSH remains a different filesystem.
+/// An absent report means the worker could not observe, so the host keeps
+/// inferring from its snapshot.
+fn report_runtime_writes(env: &dyn ToolEnv, context_id: &str, response: &KernelResp) {
     let Some(reported) = &response.files_written else {
         return;
     };
-    let paths = match response.files_written_base.as_deref() {
-        None => project_relative_writes(env.project_root(), reported),
-        Some("project") => validated_project_writes(env.project_root(), reported),
-        Some(_) => Vec::new(),
+    let paths = match (context_id, response.files_written_base.as_deref()) {
+        (LOCAL_CONTEXT_ID, None) => project_relative_writes(env.project_root(), reported),
+        (LOCAL_CONTEXT_ID, Some("project")) => {
+            validated_project_writes(env.project_root(), reported)
+        }
+        (context, Some("project")) if context.starts_with("wsl:") => {
+            validated_project_writes(env.project_root(), reported)
+        }
+        _ => Vec::new(),
     };
     if !paths.is_empty() {
         env.report_written_paths(&paths);
@@ -126,8 +130,8 @@ pub struct RTool {
     session_id: String,
 }
 
-const PYTHON_TOOL_DESCRIPTION: &str = "Execute Python code in a persistent REPL. Variables, imports, and loaded data persist per conversation and execution context; parallel conversations never share interpreter state. Return values of expressions are printed. Paths are interpreted inside the selected context. Use this for analysis, data loading, plotting, and computation when required packages already exist. Do not use this as a package installer; if dependencies are missing, set up a project-local pixi environment or use local-env-setup first.";
-const R_TOOL_DESCRIPTION: &str = "Execute R code in a persistent REPL. Variables, libraries, and loaded data persist per conversation and execution context; parallel conversations never share interpreter state. The final visible value is printed. Paths are interpreted inside the selected context. Write plots explicitly with png(), pdf(), ggsave(), or another file device. Rscript and the jsonlite package must already exist in that context; this tool does not install packages.";
+const PYTHON_TOOL_DESCRIPTION: &str = "Execute Python code in a persistent REPL. Variables, imports, and loaded data persist per conversation and execution context; parallel conversations never share interpreter state. Return values of expressions are printed. Local and WSL REPLs start in the project root; SSH REPLs use the execution context workdir. Use this for analysis, data loading, plotting, and computation when required packages already exist. Do not use this as a package installer; if dependencies are missing, set up a project-local pixi environment or use local-env-setup first.";
+const R_TOOL_DESCRIPTION: &str = "Execute R code in a persistent REPL. Variables, libraries, and loaded data persist per conversation and execution context; parallel conversations never share interpreter state. The final visible value is printed. Local and WSL REPLs start in the project root; SSH REPLs use the execution context workdir. Write plots explicitly with png(), pdf(), ggsave(), or another file device. Rscript and the jsonlite package must already exist in that context; this tool does not install packages.";
 
 impl ReplTool {
     pub fn new(manager: RuntimeManager, project_id: impl Into<String>) -> Self {
@@ -254,7 +258,7 @@ async fn run_runtime(
                     env.emit(ToolEvent::Stdout { chunk }).await;
                 }
                 Some(RuntimeEvent::Finished(Ok(response))) => {
-                    report_local_writes(env, &key.context_id, &response);
+                    report_runtime_writes(env, &key.context_id, &response);
                     let success = response.error.is_none();
                     return ToolResult {
                         success,
@@ -388,7 +392,7 @@ impl Tool for RTool {
 #[cfg(test)]
 mod tests {
     use super::{
-        code_arg, context_id, project_relative_writes, report_local_writes,
+        code_arg, context_id, project_relative_writes, report_runtime_writes,
         validated_project_writes, PYTHON_TOOL_DESCRIPTION, R_TOOL_DESCRIPTION,
     };
     use crate::{KernelResp, LOCAL_CONTEXT_ID, MAX_CODE_BYTES};
@@ -408,6 +412,8 @@ mod tests {
         for description in [PYTHON_TOOL_DESCRIPTION, R_TOOL_DESCRIPTION] {
             assert!(description.contains("persist per conversation"));
             assert!(description.contains("parallel conversations never share interpreter state"));
+            assert!(description.contains("Local and WSL REPLs start in the project root"));
+            assert!(description.contains("SSH REPLs use the execution context workdir"));
         }
     }
 
@@ -581,7 +587,7 @@ mod tests {
         let env = recording_env(root.clone());
         let reported = vec![root.join("fig_1.png").to_string_lossy().into_owned()];
 
-        report_local_writes(&env, LOCAL_CONTEXT_ID, &response_with(Some(reported)));
+        report_runtime_writes(&env, LOCAL_CONTEXT_ID, &response_with(Some(reported)));
 
         assert_eq!(
             *env.reported.lock().unwrap(),
@@ -601,7 +607,7 @@ mod tests {
             ..KernelResp::default()
         };
 
-        report_local_writes(&env, LOCAL_CONTEXT_ID, &response);
+        report_runtime_writes(&env, LOCAL_CONTEXT_ID, &response);
 
         assert_eq!(
             *env.reported.lock().unwrap(),
@@ -610,20 +616,42 @@ mod tests {
         std::fs::remove_dir_all(&root).ok();
     }
 
-    /// A remote or WSL worker's absolute paths describe another filesystem,
-    /// and an absent report means "host, keep inferring". Neither may reach
-    /// the record.
     #[test]
-    fn only_local_kernels_with_an_actual_report_are_forwarded() {
+    fn configured_wsl_report_is_forwarded_but_ssh_stays_remote() {
+        let root = unique_tmp("report_configured_wsl");
+        std::fs::write(root.join("fig_1.png"), b"x").unwrap();
+        let response = KernelResp {
+            files_written: Some(vec!["fig_1.png".into()]),
+            files_written_base: Some("project".into()),
+            ..KernelResp::default()
+        };
+        let wsl = recording_env(root.clone());
+        report_runtime_writes(&wsl, "wsl:Ubuntu", &response);
+        assert_eq!(
+            *wsl.reported.lock().unwrap(),
+            vec![vec!["fig_1.png".to_string()]]
+        );
+
+        let ssh = recording_env(root.clone());
+        report_runtime_writes(&ssh, "ssh:gpu-box", &response);
+        assert!(ssh.reported.lock().unwrap().is_empty());
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    /// A remote or WSL worker's legacy absolute paths describe another
+    /// filesystem, and an absent report means "host, keep inferring". Neither
+    /// may reach the record.
+    #[test]
+    fn only_local_legacy_absolute_reports_are_forwarded() {
         let root = unique_tmp("report_gates");
         std::fs::write(root.join("fig_1.png"), b"x").unwrap();
         let inside = vec![root.join("fig_1.png").to_string_lossy().into_owned()];
         let env = recording_env(root.clone());
 
-        report_local_writes(&env, "ssh:gpu-box", &response_with(Some(inside.clone())));
-        report_local_writes(&env, "wsl:Ubuntu", &response_with(Some(inside)));
-        report_local_writes(&env, LOCAL_CONTEXT_ID, &response_with(None));
-        report_local_writes(&env, LOCAL_CONTEXT_ID, &response_with(Some(Vec::new())));
+        report_runtime_writes(&env, "ssh:gpu-box", &response_with(Some(inside.clone())));
+        report_runtime_writes(&env, "wsl:Ubuntu", &response_with(Some(inside)));
+        report_runtime_writes(&env, LOCAL_CONTEXT_ID, &response_with(None));
+        report_runtime_writes(&env, LOCAL_CONTEXT_ID, &response_with(Some(Vec::new())));
 
         assert!(env.reported.lock().unwrap().is_empty());
         std::fs::remove_dir_all(&root).ok();

--- a/docs/superpowers/plans/2026-08-20-kernel-reported-writes-implementation-notes.md
+++ b/docs/superpowers/plans/2026-08-20-kernel-reported-writes-implementation-notes.md
@@ -88,17 +88,21 @@ credit for rewrites the mtime-granularity snapshot cannot see.
   on 500 writes with every path under the cap: 0.024 s median baseline vs
   0.028 s with the hook, about 8 µs per file.
 
-**Not done: #947 gap 3 (WSL).** The gap as filed assumed WSL kernels run in the
-project directory and only needed a `/mnt/<drive>/…` prefix translation. They do
-not: `build_attached_command` runs `cd {runtime_workdir} && exec …` where
-`runtime_workdir` is the context's configured workdir, else the probed
-`pwd`/`home`, else `~` — and `project_root` is unused in that branch
-(`src-tauri/src/runtime_launcher.rs`). So a WSL cell's relative writes land
-outside the project entirely, which also means the host's workspace snapshot
-cannot see them either. Making reports work there requires first deciding
-whether WSL kernels should `cd` into the project (WSL *terminals* already do,
-via `wsl.exe --cd`); that is a user-visible behavior change, not a path-mapping
-fix.
+## WSL project-root runtimes (2026-08-27, #947 gap 3)
+
+- WSL Python and R REPLs now translate the registered Windows project root with
+  `wslpath -a -u` and enter it before starting the worker. Translation or `cd`
+  failure aborts startup with an actionable error instead of silently running
+  in the context home. This aligns WSL REPLs with local REPLs, WSL terminals,
+  and WSL Runs. SSH retains its configured/probed remote workdir.
+- WSL Python workers receive the same host-owned write scope as local workers,
+  using `.` after the launcher has entered the translated project. Their
+  project-relative reports are joined and canonicalized against the Windows
+  project root before reaching provenance. Legacy absolute WSL reports and all
+  SSH reports remain rejected.
+- Pure tests cover launch command quoting, WSL-vs-SSH working-directory
+  behavior, write-scope selection, WSL report forwarding, and the SSH gate; CI
+  does not require a real WSL distro.
 
 ## Host-configured report scope (2026-08-27, #947 gap 1)
 

--- a/docs/superpowers/plans/2026-08-20-kernel-reported-writes-implementation-notes.md
+++ b/docs/superpowers/plans/2026-08-20-kernel-reported-writes-implementation-notes.md
@@ -100,6 +100,26 @@ whether WSL kernels should `cd` into the project (WSL *terminals* already do,
 via `wsl.exe --cd`); that is a user-visible behavior change, not a path-mapping
 fix.
 
+## Host-configured report scope (2026-08-27, #947 gap 1)
+
+- The host now sends a write-scope configuration frame to each local Python
+  worker before its first cell. The scope contains the project root and the
+  exact `SNAPSHOT_SKIP_DIRS` policy owned by `wisp-core`; the Python worker no
+  longer maintains a second project-layout list.
+- Configured workers resolve symlinks, discard paths outside the project and
+  under every snapshot-skipped parent directory before storing a candidate,
+  and return normalized project-relative paths marked with
+  `files_written_base: "project"`. The Rust host joins and canonicalizes those
+  paths again before they reach `ToolEnv`.
+- Candidate memory safety and report completeness are separate limits. A
+  larger count/byte guard bounds raw write-intent candidates, while the 512
+  semantic cap is applied only after candidates are proven changed. Exceeding
+  either guard still omits the field so snapshot inference remains the safe
+  fallback.
+- Real-worker regressions cover all snapshot-skipped directories, outside-root
+  writes, unchanged intent-only opens, the true 513-output cap, and a leaf file
+  whose own name matches a skipped directory.
+
 ## Deviations
 
 - Windows CI invokes `python` instead of `python3` (sibling step on the same matrix job). `python3` is not on PATH on `windows-latest`; Unix steps keep the planned `python3` command so the worker tests still run on all three OSes.

--- a/docs/superpowers/specs/2026-07-14-wisp-runtime-design.md
+++ b/docs/superpowers/specs/2026-07-14-wisp-runtime-design.md
@@ -344,8 +344,9 @@ plugin registry.
 - A macOS GUI app may not inherit the user's interactive shell `PATH`. Runtime
   discovery must support an explicitly configured interpreter path and report an
   actionable error when discovery fails.
-- Native Windows and WSL are separate contexts. Do not silently translate Windows
-  paths into Linux paths or vice versa.
+- Native Windows and WSL are separate contexts. Do not heuristically translate
+  arbitrary paths. The one explicit bridge is the registered project root: WSL
+  terminals, Runs, and interactive runtimes translate it with `wslpath`.
 
 ### 9.2 WSL and SSH worker deployment
 
@@ -365,10 +366,13 @@ therefore marks the runtime `dead` and loses its in-memory state.
 ### 9.3 Working directory
 
 - Local runtimes start in the project root.
-- WSL/SSH runtimes use the context's configured default workdir when present,
+- WSL runtimes start in the same project root translated with `wslpath`, because
+  WSL shares the Windows filesystem and project-relative writes participate in
+  local provenance, undo, and publication records.
+- SSH runtimes use the context's configured default workdir when present,
   otherwise the probed context home/current directory.
-- v1 does not create or synchronize a remote mirror of the local project.
-- Remote data should be addressed with paths meaningful inside that context.
+- v1 does not create or synchronize an SSH mirror of the local project. Remote
+  data should be addressed with paths meaningful inside that context.
 
 A future project-to-context workspace binding may provide a stable remote project
 root without changing runtime identity.

--- a/python/kernel_worker.py
+++ b/python/kernel_worker.py
@@ -10,7 +10,8 @@ Response: {"type": "result", "id": "<uuid>", "stdout": "...", "stderr": "...",
            "error": null|"<traceback>", "interrupted": false,
            "trace": {"error_lineno": null, "error_call": null},
            "usage": {"wall_s": 0.0, "cpu_s": 0.0, "rss_kb": 0},
-           "files_written": ["<abs path>", ...]  # omitted if unobserved/truncated}
+           "files_written": ["<path>", ...],  # omitted if unobserved/truncated
+           "files_written_base": "project"}  # present for configured relative reports
 
 `files_written` lists the files this cell actually changed, not the ones it
 opened for writing; see `_WriteObserver`.
@@ -42,9 +43,13 @@ MAX_LINECACHE_BYTES = 8 * 1024 * 1024
 MAX_CODE_SIZE = 1024 * 1024
 MAX_CODE_LINES = 20_000
 MAX_REQUEST_SIZE = 8 * 1024 * 1024
-# Cap on distinct write paths reported per cell. Exceeding it omits the
-# field entirely: a truncated list would look authoritative while being wrong.
+# Cap on actual, project-eligible changes reported per cell. Exceeding it
+# omits the field entirely: a truncated list would look authoritative while
+# being wrong. Candidate intent has a separate, larger memory guard so paths
+# later proven unchanged do not consume this semantic cap.
 MAX_REPORTED_WRITES = 512
+MAX_OBSERVED_WRITE_CANDIDATES = 4096
+MAX_OBSERVED_WRITE_PATH_BYTES = 4 * 1024 * 1024
 _WRITE_FLAGS = (
     os.O_WRONLY | os.O_RDWR | os.O_APPEND | os.O_CREAT | os.O_TRUNC
 )
@@ -94,6 +99,12 @@ def _is_bytecode_cache(path) -> bool:
     return "__pycache__" in normalized.split("/")[:-1]
 
 
+def _path_components(path):
+    """Split an OS-native relative path without rewriting Unix backslashes."""
+    normalized = path.replace(os.altsep, os.sep) if os.altsep else path
+    return [part for part in normalized.split(os.sep) if part not in ("", ".")]
+
+
 class _WriteObserver:
     """Collect the paths this interpreter changed during one cell.
 
@@ -114,19 +125,53 @@ class _WriteObserver:
         self._active = False
         self._paths = []
         self._before = {}
+        self._relative = {}
+        self._path_bytes = 0
         self._truncated = False
+        self._project_root = None
+        self._skip_dirs = frozenset()
+
+    def configure(self, root, skip_dirs):
+        """Set the host-owned project boundary used by subsequent cells."""
+        if self._active:
+            raise ValueError("cannot configure write scope during a cell")
+        if not isinstance(root, str) or not root:
+            raise ValueError("write scope root must be a non-empty string")
+        if not isinstance(skip_dirs, list):
+            raise ValueError("write scope skip_dirs must be a list")
+        cleaned = []
+        for name in skip_dirs:
+            if (
+                not isinstance(name, str)
+                or not name
+                or name in (".", "..")
+                or "/" in name
+                or "\\" in name
+            ):
+                raise ValueError("write scope skip_dirs contains an invalid name")
+            cleaned.append(name)
+        project_root = os.path.realpath(os.path.abspath(root))
+        if not os.path.isdir(project_root):
+            raise ValueError("write scope root is not an existing directory")
+        self._project_root = project_root
+        self._skip_dirs = frozenset(cleaned)
+
+    @property
+    def report_base(self):
+        return "project" if self._project_root is not None else None
 
     def begin(self):
         self._active = True
         self._paths = []
         self._before = {}
+        self._relative = {}
+        self._path_bytes = 0
         self._truncated = False
 
     def finish(self):
         self._active = False
         if self._truncated:
-            self._paths = []
-            self._before = {}
+            self._reset_cell()
             return None
         out = []
         for path in self._paths:
@@ -136,12 +181,38 @@ class _WriteObserver:
                 # or byte-for-byte the file we saw before the open.
                 if after is None or after == self._before[path]:
                     continue
-                out.append(path)
+                out.append(self._relative.get(path, path))
+                if len(out) > MAX_REPORTED_WRITES:
+                    self._reset_cell()
+                    return None
             except Exception:
                 pass
+        self._reset_cell()
+        return out
+
+    def _reset_cell(self):
         self._paths = []
         self._before = {}
-        return out
+        self._relative = {}
+        self._path_bytes = 0
+
+    def _project_relative(self, resolved):
+        if self._project_root is None:
+            return None
+        candidate = os.path.realpath(resolved)
+        try:
+            common = os.path.commonpath([self._project_root, candidate])
+        except (OSError, ValueError):
+            return False
+        if os.path.normcase(common) != os.path.normcase(self._project_root):
+            return False
+        relative = os.path.relpath(candidate, self._project_root)
+        if relative in ("", "."):
+            return False
+        components = _path_components(relative)
+        if any(name in self._skip_dirs for name in components[:-1]):
+            return False
+        return "/".join(components)
 
     def _note(self, path):
         if not self._active or self._truncated:
@@ -158,17 +229,27 @@ class _WriteObserver:
             resolved.encode("utf-8", "strict")
         except Exception:
             return
+        if self._project_root is not None:
+            resolved = os.path.realpath(resolved)
+        relative = self._project_relative(resolved)
+        if relative is False:
+            return
+        if relative is None and _is_bytecode_cache(resolved):
+            return
         if resolved in self._before:
             return
-        # Filtered before the cap so paths that can never be reported do not
-        # evict the ones that can.
-        if _is_bytecode_cache(resolved):
-            return
-        if len(self._paths) >= MAX_REPORTED_WRITES:
+        encoded_bytes = len(resolved.encode("utf-8"))
+        if (
+            len(self._paths) >= MAX_OBSERVED_WRITE_CANDIDATES
+            or self._path_bytes + encoded_bytes > MAX_OBSERVED_WRITE_PATH_BYTES
+        ):
             self._truncated = True
             return
         self._before[resolved] = _file_state(resolved)
         self._paths.append(resolved)
+        self._path_bytes += encoded_bytes
+        if relative is not None:
+            self._relative[resolved] = relative
 
     def hook(self, event, args):
         try:
@@ -487,6 +568,25 @@ def main():
             continue
 
         rid = req.get("id", "unknown")
+        if req.get("type") == "configure":
+            try:
+                scope = req.get("write_scope")
+                if not isinstance(scope, dict):
+                    raise ValueError("write_scope must be an object")
+                _WRITE_OBSERVER.configure(
+                    scope.get("root"),
+                    scope.get("skip_dirs"),
+                )
+                configured = {"type": "configured", "id": rid}
+            except Exception as error:
+                configured = {
+                    "type": "configure_error",
+                    "id": rid,
+                    "error": str(error),
+                }
+            protocol_out.write(json.dumps(configured) + "\n")
+            protocol_out.flush()
+            continue
         if req.get("type") == "inspect":
             inspection = _inspect_objects(namespace)
             with protocol_lock:
@@ -572,6 +672,8 @@ def main():
         # complete list (cap exceeded). An explicit [] means "wrote nothing".
         if files_written is not None:
             resp["files_written"] = files_written
+            if _WRITE_OBSERVER.report_base is not None:
+                resp["files_written_base"] = _WRITE_OBSERVER.report_base
         with protocol_lock:
             protocol_out.write(json.dumps(resp) + "\n")
             protocol_out.flush()

--- a/python/test_kernel_worker.py
+++ b/python/test_kernel_worker.py
@@ -42,6 +42,21 @@ class KernelWorkerTests(unittest.TestCase):
             if response.get("type") == "result" and response.get("id") == rid:
                 return response
 
+    def _configure_write_scope(self, worker, root, skip_dirs=None):
+        request = {
+            "type": "configure",
+            "id": "configure-write-scope",
+            "write_scope": {
+                "root": str(root),
+                "skip_dirs": skip_dirs
+                or [".git", ".venv", "node_modules", ".wisp", "uploads", "__pycache__"],
+            },
+        }
+        worker.stdin.write(json.dumps(request) + "\n")
+        worker.stdin.flush()
+        response = json.loads(worker.stdout.readline())
+        self.assertEqual(response, {"type": "configured", "id": request["id"]})
+
     def _close(self, worker):
         if worker.poll() is None:
             try:
@@ -313,6 +328,7 @@ class KernelWorkerTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             worker = self._spawn(cwd=tmp)
             try:
+                self._configure_write_scope(worker, tmp)
                 response = self._exec(
                     worker,
                     "for i in range(513):\n    open(f'f{i}.txt', 'w').write('x')",
@@ -320,6 +336,7 @@ class KernelWorkerTests(unittest.TestCase):
                 )
                 self.assertIsNone(response.get("error"), response.get("error"))
                 self.assertNotIn("files_written", response)
+                self.assertNotIn("files_written_base", response)
             finally:
                 self._close(worker)
 
@@ -351,6 +368,7 @@ class KernelWorkerTests(unittest.TestCase):
                 Path(tmp, f"mod_{index}.py").write_text(f"V = {index}\n", encoding="utf-8")
             worker = self._spawn(cwd=tmp)
             try:
+                self._configure_write_scope(worker, tmp)
                 response = self._exec(
                     worker,
                     "\n".join(
@@ -370,6 +388,103 @@ class KernelWorkerTests(unittest.TestCase):
                 written = response.get("files_written")
                 self.assertIsNotNone(written, "300 discarded .pyc paths exhausted the cap")
                 self.assertEqual(len(written), 250, written)
+                self.assertEqual(response.get("files_written_base"), "project")
+                self.assertTrue(all(path.startswith("results/") for path in written), written)
+            finally:
+                self._close(worker)
+
+    def test_all_host_skipped_directories_are_filtered_before_the_cap(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            worker = self._spawn(cwd=tmp)
+            try:
+                self._configure_write_scope(worker, tmp)
+                response = self._exec(
+                    worker,
+                    "\n".join(
+                        [
+                            "import os",
+                            "for directory in ['.git', '.venv', 'node_modules', '.wisp', 'uploads']:",
+                            "    os.makedirs(directory, exist_ok=True)",
+                            "    for i in range(120):",
+                            "        open(os.path.join(directory, f'noise_{i}.txt'), 'w').write('x')",
+                            "os.makedirs('results', exist_ok=True)",
+                            "for i in range(250):",
+                            "    open(f'results/out_{i}.csv', 'w').write('x')",
+                        ]
+                    ),
+                    rid="all-skipped-cap",
+                )
+                self.assertIsNone(response.get("error"), response.get("error"))
+                written = response.get("files_written")
+                self.assertEqual(len(written or []), 250, written)
+                self.assertTrue(all(path.startswith("results/") for path in written), written)
+            finally:
+                self._close(worker)
+
+    def test_outside_project_writes_do_not_consume_the_cap(self):
+        with tempfile.TemporaryDirectory() as tmp, tempfile.TemporaryDirectory() as outside:
+            worker = self._spawn(cwd=tmp)
+            try:
+                self._configure_write_scope(worker, tmp)
+                response = self._exec(
+                    worker,
+                    "\n".join(
+                        [
+                            "import os",
+                            f"outside = {outside!r}",
+                            "for i in range(600):",
+                            "    open(os.path.join(outside, f'noise_{i}.txt'), 'w').write('x')",
+                            "os.makedirs('results', exist_ok=True)",
+                            "for i in range(250):",
+                            "    open(f'results/out_{i}.csv', 'w').write('x')",
+                        ]
+                    ),
+                    rid="outside-cap",
+                )
+                self.assertIsNone(response.get("error"), response.get("error"))
+                written = response.get("files_written")
+                self.assertEqual(len(written or []), 250, written)
+                self.assertTrue(all(path.startswith("results/") for path in written), written)
+            finally:
+                self._close(worker)
+
+    def test_unchanged_intent_candidates_do_not_consume_the_report_cap(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            for index in range(600):
+                Path(tmp, f"existing_{index}.txt").write_text("x", encoding="utf-8")
+            worker = self._spawn(cwd=tmp)
+            try:
+                self._configure_write_scope(worker, tmp)
+                response = self._exec(
+                    worker,
+                    "\n".join(
+                        [
+                            "import os",
+                            "for i in range(600):",
+                            "    open(f'existing_{i}.txt', 'a').close()",
+                            "os.makedirs('results', exist_ok=True)",
+                            "for i in range(250):",
+                            "    open(f'results/out_{i}.csv', 'w').write('x')",
+                        ]
+                    ),
+                    rid="unchanged-candidates",
+                )
+                self.assertIsNone(response.get("error"), response.get("error"))
+                written = response.get("files_written")
+                self.assertEqual(len(written or []), 250, written)
+                self.assertTrue(all(path.startswith("results/") for path in written), written)
+            finally:
+                self._close(worker)
+
+    def test_leaf_named_like_a_skipped_directory_is_reported(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            worker = self._spawn(cwd=tmp)
+            try:
+                self._configure_write_scope(worker, tmp)
+                response = self._exec(worker, "open('uploads', 'w').write('x')", rid="skip-leaf")
+                self.assertIsNone(response.get("error"), response.get("error"))
+                self.assertEqual(response.get("files_written"), ["uploads"])
+                self.assertEqual(response.get("files_written_base"), "project")
             finally:
                 self._close(worker)
 

--- a/src-tauri/src/runtime_launcher.rs
+++ b/src-tauri/src/runtime_launcher.rs
@@ -14,8 +14,8 @@ use std::{
 };
 use tauri::State;
 use wisp_runtime::{
-    find_rscript, KernelClient, LaunchedRuntime, PythonEnv, RuntimeKey, RuntimeLanguage,
-    RuntimeLauncher, RuntimeMetadata, PROTOCOL_VERSION,
+    find_rscript, KernelClient, KernelWriteScope, LaunchedRuntime, PythonEnv, RuntimeKey,
+    RuntimeLanguage, RuntimeLauncher, RuntimeMetadata, PROTOCOL_VERSION,
 };
 
 const DEPLOY_TIMEOUT: Duration = Duration::from_secs(30);
@@ -240,7 +240,7 @@ impl RuntimeLauncher for TauriRuntimeLauncher {
             Vec::new()
         };
         envs.extend(ssh_auth_envs.iter().cloned());
-        let client = match KernelClient::spawn_command(
+        let mut client = match KernelClient::spawn_command(
             &command.program,
             &command.args,
             envs.as_slice(),
@@ -267,6 +267,19 @@ impl RuntimeLauncher for TauriRuntimeLauncher {
                 return Err(error);
             }
         };
+        if key.language == RuntimeLanguage::Python
+            && context.kind == wisp_store::ExecutionContextKind::Local
+        {
+            client
+                .configure_write_scope(&KernelWriteScope {
+                    root: project_root.to_string_lossy().into_owned(),
+                    skip_dirs: wisp_core::provenance::SNAPSHOT_SKIP_DIRS
+                        .iter()
+                        .map(|name| (*name).to_string())
+                        .collect(),
+                })
+                .await?;
+        }
         let ready = client.ready().clone();
         Ok(LaunchedRuntime::new(
             Box::new(client),

--- a/src-tauri/src/runtime_launcher.rs
+++ b/src-tauri/src/runtime_launcher.rs
@@ -267,18 +267,8 @@ impl RuntimeLauncher for TauriRuntimeLauncher {
                 return Err(error);
             }
         };
-        if key.language == RuntimeLanguage::Python
-            && context.kind == wisp_store::ExecutionContextKind::Local
-        {
-            client
-                .configure_write_scope(&KernelWriteScope {
-                    root: project_root.to_string_lossy().into_owned(),
-                    skip_dirs: wisp_core::provenance::SNAPSHOT_SKIP_DIRS
-                        .iter()
-                        .map(|name| (*name).to_string())
-                        .collect(),
-                })
-                .await?;
+        if let Some(scope) = kernel_write_scope(&context, key.language, project_root) {
+            client.configure_write_scope(&scope).await?;
         }
         let ready = client.ready().clone();
         Ok(LaunchedRuntime::new(
@@ -290,6 +280,30 @@ impl RuntimeLauncher for TauriRuntimeLauncher {
             },
         ))
     }
+}
+
+fn kernel_write_scope(
+    context: &wisp_store::ExecutionContext,
+    language: RuntimeLanguage,
+    project_root: &Path,
+) -> Option<KernelWriteScope> {
+    if language != RuntimeLanguage::Python {
+        return None;
+    }
+    let root = match context.kind {
+        wisp_store::ExecutionContextKind::Local => project_root.to_string_lossy().into_owned(),
+        // The WSL launch command enters the translated project root before
+        // starting the worker, so `.` is already the correct in-distro path.
+        wisp_store::ExecutionContextKind::Wsl => ".".into(),
+        wisp_store::ExecutionContextKind::Ssh => return None,
+    };
+    Some(KernelWriteScope {
+        root,
+        skip_dirs: wisp_core::provenance::SNAPSHOT_SKIP_DIRS
+            .iter()
+            .map(|name| (*name).to_string())
+            .collect(),
+    })
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -438,7 +452,32 @@ fn build_attached_command(
             },
             cwd: Some(project_root.to_path_buf()),
         }),
-        wisp_store::ExecutionContextKind::Wsl | wisp_store::ExecutionContextKind::Ssh => {
+        wisp_store::ExecutionContextKind::Wsl => {
+            let worker =
+                remote_worker.ok_or_else(|| "remote worker path is required".to_string())?;
+            let interpreter = shell_single_quote(interpreter);
+            let worker = remote_path_expression(worker)?;
+            let execute = match language {
+                RuntimeLanguage::Python => format!("exec {interpreter} {worker}",),
+                RuntimeLanguage::R => format!("exec {interpreter} --vanilla {worker}"),
+            };
+            let project_root = project_root.to_string_lossy();
+            validate_context_value("project root", &project_root)?;
+            let project_root = shell_single_quote(&project_root);
+            let script = format!(
+                "project_root=$(wslpath -a -u {project_root}) || {{ echo 'Wisp could not translate the project root for WSL' >&2; exit 125; }}\ncd \"$project_root\" || {{ echo 'Wisp could not enter the project root in WSL' >&2; exit 125; }}\n{execute}"
+            );
+            let distro = wsl_distro(context)?;
+            Ok(AttachedCommand {
+                program: PathBuf::from("wsl.exe"),
+                args: ["-d", &distro, "--", "sh", "-lc", &script]
+                    .into_iter()
+                    .map(OsString::from)
+                    .collect(),
+                cwd: None,
+            })
+        }
+        wisp_store::ExecutionContextKind::Ssh => {
             let worker =
                 remote_worker.ok_or_else(|| "remote worker path is required".to_string())?;
             let workdir = runtime_workdir(context)?;
@@ -454,29 +493,13 @@ fn build_attached_command(
                     remote_path_expression(&workdir)?,
                 ),
             };
-            match context.kind {
-                wisp_store::ExecutionContextKind::Wsl => {
-                    let distro = wsl_distro(context)?;
-                    Ok(AttachedCommand {
-                        program: PathBuf::from("wsl.exe"),
-                        args: ["-d", &distro, "--", "sh", "-lc", &script]
-                            .into_iter()
-                            .map(OsString::from)
-                            .collect(),
-                        cwd: None,
-                    })
-                }
-                wisp_store::ExecutionContextKind::Ssh => {
-                    let mut args = SshConnection::from_execution_context(context)?.ssh_args()?;
-                    args.push(script);
-                    Ok(AttachedCommand {
-                        program: PathBuf::from("ssh"),
-                        args: args.into_iter().map(OsString::from).collect(),
-                        cwd: None,
-                    })
-                }
-                wisp_store::ExecutionContextKind::Local => unreachable!(),
-            }
+            let mut args = SshConnection::from_execution_context(context)?.ssh_args()?;
+            args.push(script);
+            Ok(AttachedCommand {
+                program: PathBuf::from("ssh"),
+                args: args.into_iter().map(OsString::from).collect(),
+                cwd: None,
+            })
         }
     }
 }
@@ -775,7 +798,30 @@ mod tests {
     }
 
     #[test]
-    fn wsl_and_ssh_launches_preserve_context_configuration() {
+    fn write_scope_is_project_local_for_local_and_wsl_but_disabled_for_ssh_and_r() {
+        let local = wisp_store::ExecutionContext::new("local", "Local").unwrap();
+        let wsl = wisp_store::ExecutionContext::new("wsl:Ubuntu", "WSL").unwrap();
+        let ssh = wisp_store::ExecutionContext::new("ssh:gpu", "SSH").unwrap();
+        let project = Path::new(r"C:\Users\me\project one");
+
+        let local_scope = kernel_write_scope(&local, RuntimeLanguage::Python, project).unwrap();
+        assert_eq!(local_scope.root, project.to_string_lossy());
+        assert_eq!(
+            local_scope.skip_dirs,
+            wisp_core::provenance::SNAPSHOT_SKIP_DIRS
+        );
+        assert_eq!(
+            kernel_write_scope(&wsl, RuntimeLanguage::Python, project)
+                .unwrap()
+                .root,
+            "."
+        );
+        assert!(kernel_write_scope(&ssh, RuntimeLanguage::Python, project).is_none());
+        assert!(kernel_write_scope(&wsl, RuntimeLanguage::R, project).is_none());
+    }
+
+    #[test]
+    fn wsl_uses_project_root_while_ssh_preserves_context_workdir() {
         let mut wsl = wisp_store::ExecutionContext::new("wsl:Ubuntu-24.04", "WSL").unwrap();
         wsl.config_json = serde_json::json!({
             "distro": "Ubuntu 24.04",
@@ -793,7 +839,7 @@ mod tests {
             &wsl_python,
             Path::new("unused"),
             Some("~/.wisp-science/runtime/python.py"),
-            Path::new("unused"),
+            Path::new(r"C:\Users\me\project one"),
         )
         .unwrap();
         let wsl_args = wsl_command
@@ -803,14 +849,21 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(wsl_command.program, PathBuf::from("wsl.exe"));
         assert_eq!(&wsl_args[..2], ["-d", "Ubuntu 24.04"]);
-        assert!(wsl_args.last().unwrap().contains("/scratch/project one"));
+        let wsl_script = wsl_args.last().unwrap();
+        assert!(
+            wsl_script.contains(r"wslpath -a -u 'C:\Users\me\project one'"),
+            "{wsl_script}"
+        );
+        assert!(wsl_script.contains("cd \"$project_root\""), "{wsl_script}");
+        assert!(!wsl_script.contains("/scratch/project one"), "{wsl_script}");
 
         let mut ssh = wisp_store::ExecutionContext::new("ssh:gpu-box", "GPU").unwrap();
         ssh.config_json = serde_json::json!({
             "user": "alice",
             "port": 2222,
             "identity_file": "/home/alice/.ssh/lab key",
-            "python_executable": "/opt/python/bin/python"
+            "python_executable": "/opt/python/bin/python",
+            "workdir": "/scratch/ssh project"
         })
         .to_string();
         let ssh_command = build_attached_command(
@@ -833,6 +886,7 @@ mod tests {
             .windows(2)
             .any(|args| args == ["-i", "/home/alice/.ssh/lab key"]));
         assert!(ssh_args.contains(&"alice@gpu-box".to_string()));
+        assert!(ssh_args.last().unwrap().contains("/scratch/ssh project"));
 
         wsl.capabilities_json = serde_json::json!({
             "rscript_executable": "/opt/R/bin/Rscript",
@@ -846,7 +900,7 @@ mod tests {
             &rscript,
             Path::new("unused"),
             Some("~/.wisp-science/runtime/r.R"),
-            Path::new("unused"),
+            Path::new(r"C:\Users\me\project one"),
         )
         .unwrap();
         assert!(r_command
@@ -855,6 +909,12 @@ mod tests {
             .unwrap()
             .to_string_lossy()
             .contains("--vanilla"));
+        assert!(r_command
+            .args
+            .last()
+            .unwrap()
+            .to_string_lossy()
+            .contains("wslpath -a -u"));
     }
 
     /// A pixi/conda interpreter cannot find its own shared libraries without


### PR DESCRIPTION
## Problem

Issue #947 still had two attribution gaps after the initial kernel-reported writes work:

- write candidates outside the project or inside snapshot-skipped directories could consume the 512-entry report cap before host filtering;
- WSL REPLs started in the context home/workdir instead of the active project, so relative outputs were outside local project provenance.

## Changes

This PR keeps the two fixes as separate logical commits:

1. Scope Python write reports before applying the cap
   - adds a host-to-worker configure handshake for the project root and shared skip-directory policy;
   - filters outside-root paths, symlink escapes, and skipped directories before the final 512 real-change cap;
   - emits project-relative reports and validates/canonicalizes them again on the Rust host.
2. Root WSL REPLs in the active project
   - translates the Windows project root with wslpath and enters it before starting Python or R workers;
   - fails startup with an actionable exit-125 error if translation or cd fails;
   - accepts configured project-relative reports from WSL Python while keeping SSH reports remote and rejected.

The runtime design and implementation notes document the resulting Local, WSL, and SSH behavior.

## Verification

Passed locally on Windows:

- cargo fmt --all -- --check
- git diff --check
- Python worker suite: 20 tests run, 1 optional C-extension test skipped because numpy/matplotlib are unavailable
- cargo test -p wisp-runtime: 54 passed
- cargo test -p wisp-core -p wisp-tools: 178 + 56 passed
- cargo test -p wisp-tauri runtime_launcher::tests -- --test-threads=1: 9 passed
- real Ubuntu WSL smoke with Python 3.10.12: worker configured from the translated repository root, wrote .codex-gap3-wsl-smoke/output.txt, reported the project-relative path, and the Windows host observed it immediately

The full cargo test --workspace run did not finish green on this Windows machine: wisp-tauri reported 881 passed and 10 failures outside the modified areas (temporary-root path rejection in Method Search, one path-case assertion, and two SQLite file-lock failures). The same Method Search path failures reproduce when run serially. CI remains the cross-platform authority for these unrelated failures.

## Known limitations

- R and shell execution still rely on host snapshots rather than kernel self-reporting.
- SSH runtimes retain their remote configured/probed workdir and do not forward remote write reports.
- Python writes performed entirely below unobserved subprocess or SQLite internals remain outside the worker hook; host snapshots are still the fallback where the filesystem is shared.

Fixes #947