### PR TITLE
fix(channels): bind Feishu owner and force IM mutating-tool Ask

### DIFF
--- a/crates/wisp-core/src/output.rs
+++ b/crates/wisp-core/src/output.rs
@@ -90,6 +90,12 @@ pub trait Output: Send + Sync {
     fn approval_bypass(&self) -> bool {
         false
     }
+    /// When true, mutating tools require Ask even if the host policy is Allow
+    /// and even if [`Self::approval_bypass`] is set. Used for unattended IM
+    /// turns that share the desktop approval UI.
+    fn force_ask_mutations(&self) -> bool {
+        false
+    }
     fn restrict_read_paths_to_project(&self) -> bool {
         false
     }
@@ -233,6 +239,9 @@ impl<'a> wisp_tools::ToolEnv for ToolEnvAdapter<'a> {
     }
     fn approval_bypass(&self) -> bool {
         self.out.approval_bypass()
+    }
+    fn force_ask_mutations(&self) -> bool {
+        self.out.force_ask_mutations()
     }
     fn danger_auto_approve(&self) -> bool {
         self.out.danger_auto_approve()

--- a/crates/wisp-dto/src/lib.rs
+++ b/crates/wisp-dto/src/lib.rs
@@ -1751,6 +1751,10 @@ pub struct ChannelsStatus {
     #[serde(default)]
     pub feishu_detail: String,
     #[serde(default)]
+    pub feishu_owner_open_id: String,
+    #[serde(default)]
+    pub feishu_pending_owner_open_id: String,
+    #[serde(default)]
     pub weixin_enabled: bool,
     #[serde(default)]
     pub weixin_bound: bool,

--- a/crates/wisp-tools/src/env.rs
+++ b/crates/wisp-tools/src/env.rs
@@ -242,6 +242,12 @@ pub trait ToolEnv: Send + Sync {
     fn approval_bypass(&self) -> bool {
         false
     }
+    /// When true, mutating tools (`plan_mode_blocks && !read_only`) require Ask
+    /// even if the host policy is Allow and even if [`Self::approval_bypass`]
+    /// is set. Used for unattended IM turns.
+    fn force_ask_mutations(&self) -> bool {
+        false
+    }
     /// Whether this session is in plan mode: the agent researches and drafts a
     /// plan, so `Registry::run` refuses every tool outside
     /// [`crate::PLAN_MODE_READ_ONLY`]. Default `false`.

--- a/crates/wisp-tools/src/lib.rs
+++ b/crates/wisp-tools/src/lib.rs
@@ -395,9 +395,14 @@ async fn run_registered_tool(tool: &dyn Tool, args: &Value, env: &dyn ToolEnv) -
     // Per-tool approval gate. `Deny` blocks before the call card even shows;
     // `Ask` shows the card then routes through `confirm`; `Allow` runs as before.
     let host_approval = env.approval_mode(name).await;
+    let mutating = plan_mode_blocks(name) && !tool.read_only();
     let approval = if host_approval == env::Approval::Deny {
         // An explicit block remains a hard policy even in Full Permission.
         env::Approval::Deny
+    } else if env.force_ask_mutations() && mutating {
+        // IM turns must not inherit an unattended Allow default, including
+        // Full Permission / skip-connector bypass.
+        env::Approval::Ask
     } else if env.approval_bypass() {
         // Full Permission suppresses both host prompts and a tool's built-in
         // minimum approval requirement. Plan mode already gated mutations
@@ -629,6 +634,7 @@ mod approval_tests {
         mode: Approval,
         confirm_ok: bool,
         bypass: bool,
+        force_ask: bool,
     }
     #[async_trait::async_trait]
     impl ToolEnv for PolicyEnv {
@@ -643,6 +649,9 @@ mod approval_tests {
         }
         fn approval_bypass(&self) -> bool {
             self.bypass
+        }
+        fn force_ask_mutations(&self) -> bool {
+            self.force_ask
         }
         async fn emit(&self, _event: ToolEvent) {}
     }
@@ -729,6 +738,7 @@ mod approval_tests {
             mode,
             confirm_ok,
             bypass: false,
+            force_ask: false,
         };
         let res = reg.run("spy", &serde_json::json!({}), &env).await;
         (RAN.load(Ordering::SeqCst), res)
@@ -745,6 +755,7 @@ mod approval_tests {
             mode: Approval::Allow,
             confirm_ok: false,
             bypass: false,
+            force_ask: false,
         };
         let result = registry
             .run("third_party", &serde_json::json!({}), &env)
@@ -766,6 +777,7 @@ mod approval_tests {
             mode: Approval::Allow,
             confirm_ok: false,
             bypass: true,
+            force_ask: false,
         };
         let allowed = registry
             .run("third_party", &serde_json::json!({}), &bypass)
@@ -779,12 +791,76 @@ mod approval_tests {
             mode: Approval::Deny,
             confirm_ok: true,
             bypass: true,
+            force_ask: false,
         };
         let blocked = registry
             .run("third_party", &serde_json::json!({}), &denied)
             .await;
         assert!(!blocked.success);
         assert!(!RAN.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn im_force_ask_mutations_upgrades_allow_and_bypass() {
+        static RAN: AtomicBool = AtomicBool::new(false);
+        RAN.store(false, Ordering::SeqCst);
+        let mut registry = Registry { tools: vec![] };
+        registry.add(Box::new(SpyTool(&RAN)));
+        let env = PolicyEnv {
+            root: PathBuf::from("."),
+            mode: Approval::Allow,
+            confirm_ok: false,
+            bypass: true,
+            force_ask: true,
+        };
+        let result = registry.run("spy", &serde_json::json!({}), &env).await;
+        assert!(!result.success);
+        assert_eq!(result.control, ToolControl::StopBatch);
+        assert!(!RAN.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn im_force_ask_preserves_explicit_deny() {
+        static RAN: AtomicBool = AtomicBool::new(false);
+        RAN.store(false, Ordering::SeqCst);
+        let mut registry = Registry { tools: vec![] };
+        registry.add(Box::new(SpyTool(&RAN)));
+        let env = PolicyEnv {
+            root: PathBuf::from("."),
+            mode: Approval::Deny,
+            confirm_ok: true,
+            bypass: true,
+            force_ask: true,
+        };
+        let result = registry.run("spy", &serde_json::json!({}), &env).await;
+        assert!(!result.success);
+        assert!(!RAN.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn im_force_ask_lets_read_only_allow_through() {
+        let dir = std::env::temp_dir().join(format!(
+            "wisp-im-read-allow-{}-{}",
+            std::process::id(),
+            line!()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("note.txt"), "hello").unwrap();
+        let registry = Registry::builtins();
+        let env = PolicyEnv {
+            root: dir.clone(),
+            mode: Approval::Allow,
+            confirm_ok: false,
+            bypass: false,
+            force_ask: true,
+        };
+        let read = serde_json::json!({ "path": dir.join("note.txt").to_string_lossy() });
+        let write = serde_json::json!({ "path": "gated.txt", "content": "no" });
+        assert!(registry.run("read", &read, &env).await.success);
+        let blocked = registry.run("write", &write, &env).await;
+        assert!(!blocked.success);
+        assert!(!dir.join("gated.txt").exists());
+        let _ = std::fs::remove_dir_all(dir);
     }
 
     #[tokio::test]

--- a/docs/basic-configuration.md
+++ b/docs/basic-configuration.md
@@ -381,7 +381,7 @@ Wisp 插件可以把 Skill、本地 stdio MCP 服务和 MCP App 打包为一个�
 
 ![飞书机器人配置](assets/basic-configuration/07-feishu-setup.png)
 
-App Secret 只保存在操作系统凭据库中。私聊消息直接处理；群聊中需要 @ 机器人。若 CardKit 权限不足，Wisp 会退化为普通文本回复。
+App Secret 只保存在操作系统凭据库中。扫码创建应用时，若飞书返回扫码账号的 `open_id`，该账号会成为所有者；也可以在设置里确认待配对请求，或手动填写 `open_id`。第一个给机器人发消息的人不会被自动设为所有者。只有所有者的私聊和群聊 @ 会进入 Agent；其他人会被拒绝。飞书/微信轮次里的写入、编辑、执行类工具即使桌面默认允许，仍会在桌面端弹出审批。若 CardKit 权限不足，Wisp 会退化为普通文本回复。
 
 ### 微信 iLink
 

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -32,7 +32,9 @@ sends directly going forward.
 
 Only plain text is supported in v1 (WeChat voice messages arrive as transcripts
 and work too). Tool-approval prompts still appear in the desktop app —
-unattended turns that need approval wait until you click there.
+unattended turns that need approval wait until you click there. IM turns
+additionally force Ask on write/edit/shell and other mutating tools even when
+the desktop policy defaults to Allow, including Full Permission.
 
 ## Feishu bot
 
@@ -55,12 +57,18 @@ An existing app can still be configured manually on
 4. Paste App ID / App Secret in Settings → Remote Access, select the matching
    region, save, then toggle on. The secret is stored in the OS keyring.
 
-Direct (p2p) messages are handled as-is; in group chats the bot only reacts
-when @-mentioned. Duplicate event delivery is deduped by `event_id`. Normal
-agent turns appear as a single CardKit card: the card shows a safe, coarse
-view of tool progress and partial answer text, then becomes the final answer.
-Raw model reasoning, tool output, and command output are never copied into the
-external progress card. Slash-command replies remain plain text.
+Only the **bound owner** can drive agent turns. Scanning to create the app
+binds that Feishu account when the registration response includes an
+`open_id`. Otherwise bind an owner in Settings by confirming a pending pairing
+request or pasting their `open_id`. The first person to message the bot is
+never made owner automatically. Direct (p2p) and group @-mentions from anyone
+else are rejected before they enter the agent.
+
+Duplicate event delivery is deduped by `event_id`. Normal agent turns appear
+as a single CardKit card: the card shows a safe, coarse view of tool progress
+and partial answer text, then becomes the final answer. Raw model reasoning,
+tool output, and command output are never copied into the external progress
+card. Slash-command replies remain plain text.
 
 If CardKit creation or delivery is unavailable (for example because the app is
 missing CardKit permissions), Wisp falls back to one plain-text final reply.
@@ -91,10 +99,10 @@ pbbp2 frames → ACK ≤3s → events; REST token cache + CardKit stream),
 protobuf frame codec, round-trip tested), `weixin.rs` (QR bind, `getupdates`
 long-poll with cursor, send), and `mod.rs` (ChannelManager, live progress
 observer, shared last-message route in the `channel_last_message_route` setting,
-Tauri commands). The route contains `project_id` and an optional `session_id`;
-an empty session is the intentional pending state created by `/project` or
-`/new`. Inbound text reuses the same `send_message` path as the UI, so desktop
-and both channels update the same route and history/tools/approvals behave
-identically.
+Feishu owner pairing, Tauri commands). The route contains `project_id` and an
+optional `session_id`; an empty session is the intentional pending state created
+by `/project` or `/new`. Inbound text reuses the same `send_message` path as the
+UI with `TurnOrigin::Im`, so desktop and both channels update the same route
+and history, while mutating-tool approval is stricter for IM.
 Protocol shapes follow phantty's tested implementations and the official
 `larksuite/oapi-sdk-go`.

--- a/src-tauri/src/agent_turn.rs
+++ b/src-tauri/src/agent_turn.rs
@@ -9,6 +9,21 @@
 
 use super::*;
 
+/// Where a user-visible turn originated. IM turns share the desktop approval
+/// UI but must not inherit an unattended Allow default for mutating tools.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) enum TurnOrigin {
+    #[default]
+    Desktop,
+    Im,
+}
+
+impl TurnOrigin {
+    fn force_ask_mutations(self) -> bool {
+        matches!(self, Self::Im)
+    }
+}
+
 #[tauri::command]
 pub(crate) async fn send_message(
     state: State<'_, AppState>,
@@ -38,6 +53,7 @@ pub(crate) async fn send_message(
         guide,
         replace,
         None,
+        TurnOrigin::Desktop,
     )
     .await
 }
@@ -61,6 +77,7 @@ pub(crate) async fn send_message_inner(
     // started before running this message ("replace the current task").
     replace: Option<bool>,
     mut workflow_guard: Option<tokio::sync::OwnedMutexGuard<()>>,
+    origin: TurnOrigin,
 ) -> Result<String, String> {
     let resume = resume.unwrap_or(false);
     // Automatic delegation resume carries an owned workflow guard and uses the
@@ -1087,6 +1104,7 @@ pub(crate) async fn send_message_inner(
         prov: Some(prov_tx),
         provenance_scope,
         turn_id: browser_turn_id.clone(),
+        force_ask_mutations: origin.force_ask_mutations(),
     };
 
     let turn_start = agent.ctx.messages.len();
@@ -1299,6 +1317,7 @@ pub(crate) fn spawn_queue_driver(
                 None,
                 None,
                 Some(guard),
+                TurnOrigin::Desktop,
             )
             .await
             {

--- a/src-tauri/src/channels/feishu.rs
+++ b/src-tauri/src/channels/feishu.rs
@@ -10,7 +10,7 @@
 use super::{feishu_card, pbbp2, set_status, ChannelStatus};
 use anyhow::{anyhow, bail, Context, Result};
 use futures_util::{SinkExt, StreamExt};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::collections::{HashSet, VecDeque};
 use std::sync::atomic::{AtomicI64, Ordering};
@@ -350,6 +350,41 @@ pub struct InboundMessage {
     pub text: Option<String>,
 }
 
+/// Persisted owner identity. The first inbound sender is never written here.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
+pub struct OwnerBinding {
+    pub open_id: String,
+    #[serde(default)]
+    pub bound_at: String,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SenderDecision {
+    Allow,
+    Reject,
+    /// No owner is bound yet. Record a pending pairing request; do not accept.
+    Unbound,
+}
+
+pub const NON_OWNER_REPLY: &str = "此机器人只响应已绑定的所有者。";
+pub const UNBOUND_REPLY: &str =
+    "尚未绑定所有者。请在桌面端「设置 → 远程接入 → 飞书」确认配对后，再发送消息。";
+
+/// Compare an inbound sender with the desktop-confirmed owner.
+///
+/// An empty owner is never treated as "anyone": the first messenger stays
+/// pending until the desktop confirms or an open_id is entered explicitly.
+pub fn sender_decision(sender_open_id: &str, owner_open_id: Option<&str>) -> SenderDecision {
+    if sender_open_id.is_empty() {
+        return SenderDecision::Reject;
+    }
+    match owner_open_id.map(str::trim).filter(|id| !id.is_empty()) {
+        None => SenderDecision::Unbound,
+        Some(owner) if owner == sender_open_id => SenderDecision::Allow,
+        Some(_) => SenderDecision::Reject,
+    }
+}
+
 /// Normalize an `im.message.receive_v1` event payload. Returns None for other
 /// event types, non-user senders, and group messages that do not @ the bot.
 pub fn parse_message_event(payload: &[u8], bot_open_id: &str) -> Option<InboundMessage> {
@@ -480,6 +515,13 @@ async fn connect_once(
         let rest = rest.clone();
         tokio::spawn(async move {
             while let Some(msg) = event_rx.recv().await {
+                if let Some(reply) = super::authorize_feishu_sender(&app, &msg.sender_open_id).await
+                {
+                    if let Err(e) = rest.send_text(&msg.chat_id, &reply).await {
+                        tracing::warn!(target: "wisp", channel = "feishu", error = %e, "send owner-auth reply failed");
+                    }
+                    continue;
+                }
                 let Some(text) = msg.text.as_deref().filter(|text| !text.is_empty()) else {
                     if let Err(e) = rest
                         .send_text(&msg.chat_id, "暂不支持该消息类型,请发送文本消息。")
@@ -782,6 +824,53 @@ mod tests {
         }))
         .unwrap();
         assert!(parse_message_event(&echo, "ou_bot").is_none());
+    }
+
+    #[test]
+    fn sender_decision_never_auto_binds_the_first_messenger() {
+        assert_eq!(sender_decision("ou_user", None), SenderDecision::Unbound);
+        assert_eq!(
+            sender_decision("ou_user", Some("")),
+            SenderDecision::Unbound
+        );
+        assert_eq!(
+            sender_decision("ou_user", Some("  ")),
+            SenderDecision::Unbound
+        );
+    }
+
+    #[test]
+    fn sender_decision_allows_only_the_bound_owner() {
+        assert_eq!(
+            sender_decision("ou_owner", Some("ou_owner")),
+            SenderDecision::Allow
+        );
+        assert_eq!(
+            sender_decision("ou_stranger", Some("ou_owner")),
+            SenderDecision::Reject
+        );
+        assert_eq!(
+            sender_decision("", Some("ou_owner")),
+            SenderDecision::Reject
+        );
+    }
+
+    #[test]
+    fn parse_keeps_non_owner_payloads_for_the_auth_gate() {
+        // Auth is a separate step so group @-bot from a stranger still
+        // produces an InboundMessage, then sender_decision rejects it.
+        let mentions = json!([{"key": "@_user_1", "id": {"open_id": "ou_bot"}}]);
+        let payload = event_json("group", "text", "{\"text\":\"@_user_1 hi\"}", mentions);
+        let msg = parse_message_event(&payload, "ou_bot").unwrap();
+        assert_eq!(msg.sender_open_id, "ou_user");
+        assert_eq!(
+            sender_decision(&msg.sender_open_id, Some("ou_owner")),
+            SenderDecision::Reject
+        );
+        assert_eq!(
+            sender_decision(&msg.sender_open_id, Some("ou_user")),
+            SenderDecision::Allow
+        );
     }
 
     #[test]

--- a/src-tauri/src/channels/feishu_registration.rs
+++ b/src-tauri/src/channels/feishu_registration.rs
@@ -36,6 +36,8 @@ struct BeginResponse {
 #[derive(Debug, Default, Deserialize, PartialEq, Eq)]
 struct UserInfo {
     #[serde(default)]
+    open_id: String,
+    #[serde(default)]
     tenant_brand: String,
 }
 
@@ -218,6 +220,7 @@ impl RegistrationFlow {
                         app_id: response.client_id,
                         app_secret: response.client_secret,
                         international: self.international,
+                        owner_open_id: response.user_info.open_id,
                     });
                 }
                 Decision::SwitchToLark => {
@@ -260,6 +263,7 @@ pub enum RegistrationPoll {
         app_id: String,
         app_secret: String,
         international: bool,
+        owner_open_id: String,
     },
     Denied,
     Expired,
@@ -345,6 +349,7 @@ mod tests {
         let response = PollResponse {
             user_info: UserInfo {
                 tenant_brand: "lark".into(),
+                ..Default::default()
             },
             ..Default::default()
         };
@@ -360,6 +365,7 @@ mod tests {
         .unwrap();
         assert_eq!(response.client_id, "cli_9");
         assert_eq!(response.user_info.tenant_brand, "feishu");
+        assert_eq!(response.user_info.open_id, "ou_1");
         assert_eq!(decide(&response, false), Decision::Success);
     }
 }

--- a/src-tauri/src/channels/mod.rs
+++ b/src-tauri/src/channels/mod.rs
@@ -1,10 +1,12 @@
 //! External IM channels (Feishu bot, WeChat iLink bot).
 //!
 //! Inbound text from a channel drives a normal agent session — the turn runs
-//! through the same `send_message` path the UI uses, so history, tools,
-//! approvals, and persistence all behave identically and the conversation is
-//! visible in the desktop app. The final assistant message is sent back to
-//! the IM chat when the turn completes.
+//! through the same `send_message` path the UI uses, so history, tools, and
+//! persistence behave the same way and the conversation is visible in the
+//! desktop app. The final assistant message is sent back to the IM chat when
+//! the turn completes. Feishu additionally requires a desktop-confirmed owner
+//! before any inbound message may enter that path, and IM turns force Ask on
+//! mutating tools even when the desktop policy defaults to Allow.
 //!
 //! Desktop, Feishu, and WeChat share one durable last-message route. An ordinary
 //! IM message always continues the session that most recently accepted a user
@@ -23,12 +25,14 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex as StdMutex, OnceLock};
-use tauri::{AppHandle, Manager, State};
+use tauri::{AppHandle, Emitter, Manager, State};
 use tokio::sync::watch;
 use wisp_store::secrets::Secret;
 use wisp_store::Store;
 
 const FEISHU_SECRET: &str = "feishu_app_secret";
+const FEISHU_OWNER_KEY: &str = "feishu_owner_binding";
+const FEISHU_PENDING_OWNER_KEY: &str = "feishu_pending_owner";
 const WEIXIN_TOKEN_SECRET: &str = "weixin_bot_token";
 /// ponytail: single reply cap for both channels; per-channel limits if an API
 /// ever rejects shorter messages.
@@ -162,6 +166,96 @@ async fn load_secret(name: &'static str) -> String {
 
 async fn load_weixin_binding(store: &Store) -> Option<weixin::Binding> {
     serde_json::from_str(&get_setting(store, "weixin_binding").await).ok()
+}
+
+fn emit_channels_updated(app: &AppHandle) {
+    let _ = app.emit("channels-updated", ());
+}
+
+async fn load_feishu_owner(store: &Store) -> Option<String> {
+    let raw = get_setting(store, FEISHU_OWNER_KEY).await;
+    let binding: feishu::OwnerBinding = serde_json::from_str(&raw).ok()?;
+    let open_id = binding.open_id.trim();
+    (!open_id.is_empty()).then(|| open_id.to_string())
+}
+
+async fn load_feishu_pending_owner(store: &Store) -> Option<String> {
+    let open_id = get_setting(store, FEISHU_PENDING_OWNER_KEY).await;
+    let open_id = open_id.trim();
+    (!open_id.is_empty()).then(|| open_id.to_string())
+}
+
+async fn save_feishu_owner(store: &Store, open_id: &str) -> Result<(), String> {
+    let open_id = open_id.trim();
+    if open_id.is_empty() {
+        return Err("所有者 open_id 不能为空。".into());
+    }
+    let binding = feishu::OwnerBinding {
+        open_id: open_id.to_string(),
+        bound_at: chrono::Utc::now().to_rfc3339(),
+    };
+    let json = serde_json::to_string(&binding).map_err(|error| error.to_string())?;
+    store
+        .set_setting(FEISHU_OWNER_KEY, &json)
+        .await
+        .map_err(|error| error.to_string())?;
+    store
+        .set_setting(FEISHU_PENDING_OWNER_KEY, "")
+        .await
+        .map_err(|error| error.to_string())?;
+    Ok(())
+}
+
+async fn clear_feishu_owner(store: &Store) -> Result<(), String> {
+    store
+        .set_setting(FEISHU_OWNER_KEY, "")
+        .await
+        .map_err(|error| error.to_string())?;
+    store
+        .set_setting(FEISHU_PENDING_OWNER_KEY, "")
+        .await
+        .map_err(|error| error.to_string())?;
+    Ok(())
+}
+
+async fn save_feishu_pending_owner(store: &Store, open_id: &str) -> Result<(), String> {
+    let open_id = open_id.trim();
+    if open_id.is_empty() {
+        return Ok(());
+    }
+    if load_feishu_pending_owner(store).await.as_deref() == Some(open_id) {
+        return Ok(());
+    }
+    store
+        .set_setting(FEISHU_PENDING_OWNER_KEY, open_id)
+        .await
+        .map_err(|error| error.to_string())
+}
+
+/// Gate one inbound Feishu sender. `None` means the message may enter the
+/// agent path; `Some(reply)` is sent back and the turn is not started.
+pub(crate) async fn authorize_feishu_sender(
+    app: &AppHandle,
+    sender_open_id: &str,
+) -> Option<String> {
+    let state = app.state::<AppState>();
+    let owner = load_feishu_owner(&state.store).await;
+    match feishu::sender_decision(sender_open_id, owner.as_deref()) {
+        feishu::SenderDecision::Allow => None,
+        feishu::SenderDecision::Reject => Some(feishu::NON_OWNER_REPLY.to_string()),
+        feishu::SenderDecision::Unbound => {
+            if let Err(error) = save_feishu_pending_owner(&state.store, sender_open_id).await {
+                tracing::warn!(
+                    target: "wisp",
+                    channel = "feishu",
+                    %error,
+                    "failed to record pending Feishu owner"
+                );
+            }
+            emit_channels_updated(app);
+            Some(feishu::UNBOUND_REPLY.to_string())
+        }
+    }
 }
 
 // --------------------------------------------- live agent progress observers
@@ -847,10 +941,10 @@ pub(crate) async fn handle_inbound_observed(
     // before the long agent turn so a later `/stop` can interrupt it. The
     // destination runtime serializes subsequent turns in this same session.
     drop(_turn_guard);
-    let result = crate::send_message(
-        app.state(),
+    let result = crate::send_message_inner(
+        state.inner(),
         app.clone(),
-        window,
+        window.label(),
         Some(session_id.clone()),
         text.to_string(),
         None,
@@ -860,6 +954,8 @@ pub(crate) async fn handle_inbound_observed(
         progress.as_ref().map(PendingProgress::id),
         None,
         None,
+        None,
+        crate::TurnOrigin::Im,
     )
     .await;
     match result {
@@ -884,6 +980,8 @@ pub struct ChannelsStatus {
     pub feishu_has_secret: bool,
     pub feishu_state: String,
     pub feishu_detail: String,
+    pub feishu_owner_open_id: String,
+    pub feishu_pending_owner_open_id: String,
     pub weixin_enabled: bool,
     pub weixin_bound: bool,
     pub weixin_state: String,
@@ -908,6 +1006,10 @@ pub(crate) async fn channels_status(
         feishu_has_secret,
         feishu_state: feishu.state,
         feishu_detail: feishu.detail,
+        feishu_owner_open_id: load_feishu_owner(&state.store).await.unwrap_or_default(),
+        feishu_pending_owner_open_id: load_feishu_pending_owner(&state.store)
+            .await
+            .unwrap_or_default(),
         weixin_enabled: get_setting(&state.store, "weixin_enabled").await == "true",
         weixin_bound: load_weixin_binding(&state.store).await.is_some(),
         weixin_state: weixin.state,
@@ -1043,6 +1145,7 @@ pub(crate) async fn feishu_bind_poll(
             app_id,
             app_secret,
             international,
+            owner_open_id,
         } => {
             let stored_secret = app_secret;
             tokio::task::spawn_blocking(move || Secret::set(FEISHU_SECRET, &stored_secret))
@@ -1062,6 +1165,10 @@ pub(crate) async fn feishu_bind_poll(
                 )
                 .await
                 .map_err(|e| e.to_string())?;
+            if !owner_open_id.trim().is_empty() {
+                save_feishu_owner(&state.store, &owner_open_id).await?;
+            }
+            emit_channels_updated(&app);
             if get_setting(&state.store, "feishu_enabled").await == "true" {
                 mgr.start_feishu(&app).await;
             }
@@ -1087,6 +1194,7 @@ pub(crate) async fn feishu_bind_cancel(
 pub(crate) async fn feishu_unbind(
     state: State<'_, AppState>,
     mgr: State<'_, ChannelManager>,
+    app: AppHandle,
 ) -> Result<(), String> {
     mgr.stop_feishu();
     mgr.feishu_registrations.lock().await.clear();
@@ -1101,6 +1209,51 @@ pub(crate) async fn feishu_unbind(
         .set_setting("feishu_enabled", "false")
         .await
         .map_err(|e| e.to_string())?;
+    clear_feishu_owner(&state.store).await?;
+    emit_channels_updated(&app);
+    Ok(())
+}
+
+#[tauri::command]
+pub(crate) async fn set_feishu_owner(
+    state: State<'_, AppState>,
+    app: AppHandle,
+    open_id: String,
+) -> Result<(), String> {
+    let open_id = open_id.trim();
+    if open_id.is_empty() {
+        clear_feishu_owner(&state.store).await?;
+    } else {
+        save_feishu_owner(&state.store, open_id).await?;
+    }
+    emit_channels_updated(&app);
+    Ok(())
+}
+
+#[tauri::command]
+pub(crate) async fn confirm_feishu_pending_owner(
+    state: State<'_, AppState>,
+    app: AppHandle,
+) -> Result<(), String> {
+    let Some(open_id) = load_feishu_pending_owner(&state.store).await else {
+        return Err("没有待确认的飞书发送者。".into());
+    };
+    save_feishu_owner(&state.store, &open_id).await?;
+    emit_channels_updated(&app);
+    Ok(())
+}
+
+#[tauri::command]
+pub(crate) async fn reject_feishu_pending_owner(
+    state: State<'_, AppState>,
+    app: AppHandle,
+) -> Result<(), String> {
+    state
+        .store
+        .set_setting(FEISHU_PENDING_OWNER_KEY, "")
+        .await
+        .map_err(|e| e.to_string())?;
+    emit_channels_updated(&app);
     Ok(())
 }
 
@@ -1551,5 +1704,31 @@ mod tests {
         )
         .unwrap();
         assert!(svg.contains("<svg"));
+    }
+
+    #[tokio::test]
+    async fn feishu_owner_is_never_the_first_pending_sender() {
+        let path =
+            std::env::temp_dir().join(format!("wisp_feishu_owner_{}.sqlite", uuid::Uuid::new_v4()));
+        let store = Store::open(&path).await.unwrap();
+        assert!(load_feishu_owner(&store).await.is_none());
+
+        save_feishu_pending_owner(&store, "ou_stranger")
+            .await
+            .unwrap();
+        assert!(load_feishu_owner(&store).await.is_none());
+        assert_eq!(
+            load_feishu_pending_owner(&store).await.as_deref(),
+            Some("ou_stranger")
+        );
+
+        save_feishu_owner(&store, "ou_owner").await.unwrap();
+        assert_eq!(load_feishu_owner(&store).await.as_deref(), Some("ou_owner"));
+        assert!(load_feishu_pending_owner(&store).await.is_none());
+
+        clear_feishu_owner(&store).await.unwrap();
+        assert!(load_feishu_owner(&store).await.is_none());
+        drop(store);
+        let _ = std::fs::remove_file(path);
     }
 }

--- a/src-tauri/src/delegation_completion.rs
+++ b/src-tauri/src/delegation_completion.rs
@@ -457,6 +457,7 @@ async fn dispatch_frame(app: AppHandle, frame_id: String) {
         None,
         None,
         Some(workflow_guard),
+        crate::TurnOrigin::Desktop,
     )
     .await;
     let (success, error) = match &result {

--- a/src-tauri/src/dto_contract_tests.rs
+++ b/src-tauri/src/dto_contract_tests.rs
@@ -380,3 +380,32 @@ fn mcp_connection_list_contract_redacts_secrets() {
         _ => panic!("expected http"),
     }
 }
+
+#[test]
+fn channels_status_contract_includes_feishu_owner() {
+    let backend = crate::channels::ChannelsStatus {
+        feishu_enabled: true,
+        feishu_bound: true,
+        feishu_international: false,
+        feishu_app_id: "cli_1".into(),
+        feishu_has_secret: true,
+        feishu_state: "running".into(),
+        feishu_detail: String::new(),
+        feishu_owner_open_id: "ou_owner".into(),
+        feishu_pending_owner_open_id: "ou_pending".into(),
+        weixin_enabled: false,
+        weixin_bound: false,
+        weixin_state: "stopped".into(),
+        weixin_detail: String::new(),
+        device: crate::device_bridge::DeviceBridgeSettingsStatus {
+            enabled: false,
+            mode: crate::device_bridge::DeviceBridgeMode::Lan,
+            has_token: false,
+            runtime: crate::device_bridge::DeviceBridgeRuntimeStatus::default(),
+        },
+    };
+    let dto: wisp_dto::ChannelsStatus = roundtrip(&backend);
+    assert_eq!(dto.feishu_owner_open_id, "ou_owner");
+    assert_eq!(dto.feishu_pending_owner_open_id, "ou_pending");
+    assert_eq!(dto.feishu_app_id, "cli_1");
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2645,6 +2645,9 @@ struct TauriOutput {
     provenance_scope: String,
     /// Per-send_message id used to attribute real-browser tabs to this turn.
     turn_id: String,
+    /// IM turns force Ask on mutating tools and skip Full Permission
+    /// auto-approval so an unattended Feishu/WeChat message cannot write/shell.
+    force_ask_mutations: bool,
 }
 
 impl TauriOutput {
@@ -2678,7 +2681,7 @@ impl TauriOutput {
         message: &str,
         allow_full_permission: bool,
     ) -> wisp_tools::ConfirmDecision {
-        if allow_full_permission && self.full_permission() {
+        if allow_full_permission && self.full_permission() && !self.force_ask_mutations {
             return wisp_tools::ConfirmDecision::Approved;
         }
         let (tool, preview) = parse_confirm_payload(message);
@@ -3019,10 +3022,16 @@ impl Output for TauriOutput {
         })
     }
     fn approval_bypass(&self) -> bool {
-        self.full_permission()
+        self.full_permission() && !self.force_ask_mutations
     }
     fn danger_auto_approve(&self) -> bool {
+        if self.force_ask_mutations {
+            return false;
+        }
         self.full_permission() || self.approvals.read().map(|p| p.full()).unwrap_or(false)
+    }
+    fn force_ask_mutations(&self) -> bool {
+        self.force_ask_mutations
     }
     fn plan_mode(&self) -> bool {
         self.plan_mode
@@ -6735,6 +6744,9 @@ pub fn run() {
             channels::feishu_bind_poll,
             channels::feishu_bind_cancel,
             channels::feishu_unbind,
+            channels::set_feishu_owner,
+            channels::confirm_feishu_pending_owner,
+            channels::reject_feishu_pending_owner,
             channels::set_weixin_channel,
             channels::weixin_bind_start,
             channels::weixin_bind_poll,

--- a/src-tauri/src/scheduler.rs
+++ b/src-tauri/src/scheduler.rs
@@ -129,6 +129,7 @@ async fn run_scheduled_turn(
         None,
         None,
         None,
+        crate::TurnOrigin::Desktop,
     )
     .await
     .map(Some)

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -1097,6 +1097,8 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
     feishu_has_secret: false,
     feishu_state: "stopped",
     feishu_detail: "",
+    feishu_owner_open_id: "",
+    feishu_pending_owner_open_id: "ou_pending",
     weixin_enabled: false,
     weixin_bound: false,
     weixin_state: "stopped",
@@ -3030,6 +3032,8 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
             mockChannels.feishu_bound = true;
             mockChannels.feishu_has_secret = true;
             mockChannels.feishu_app_id = "cli_scan_created";
+            mockChannels.feishu_owner_open_id = "ou_scan_owner";
+            mockChannels.feishu_pending_owner_open_id = "";
             mockChannels.feishu_international = Boolean(arg("international") ?? mockChannels.feishu_international);
             return { state: "confirmed", retry_after_ms: 0, app_id: mockChannels.feishu_app_id };
           case "feishu_bind_cancel":
@@ -3039,7 +3043,20 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
             mockChannels.feishu_enabled = false;
             mockChannels.feishu_has_secret = false;
             mockChannels.feishu_app_id = "";
+            mockChannels.feishu_owner_open_id = "";
+            mockChannels.feishu_pending_owner_open_id = "";
             mockChannels.feishu_state = "stopped";
+            return null;
+          case "set_feishu_owner":
+            mockChannels.feishu_owner_open_id = String(arg("openId") ?? "").trim();
+            mockChannels.feishu_pending_owner_open_id = "";
+            return null;
+          case "confirm_feishu_pending_owner":
+            mockChannels.feishu_owner_open_id = mockChannels.feishu_pending_owner_open_id;
+            mockChannels.feishu_pending_owner_open_id = "";
+            return null;
+          case "reject_feishu_pending_owner":
+            mockChannels.feishu_pending_owner_open_id = "";
             return null;
           case "set_weixin_channel":
             mockChannels.weixin_enabled = Boolean(arg("enabled"));

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -13077,6 +13077,12 @@ test("remote access settings: Feishu, WeChat, and StickS3 setup", async ({ page 
   // setup path.
   await page.getByTestId("feishu-channel-row").click();
   await expect(page.getByTestId("feishu-channel-card")).toBeVisible();
+  await expect(page.getByTestId("feishu-pending-owner")).toBeVisible();
+  await expect(page.getByTestId("feishu-pending-owner")).toContainText("ou_pending");
+  await page.getByTestId("feishu-pending-reject").click();
+  await expect.poll(() => lastInvokeArgs(page, "reject_feishu_pending_owner")).not.toBeNull();
+  await expect(page.getByTestId("feishu-pending-owner")).toHaveCount(0);
+  await expect(page.getByTestId("feishu-owner-status")).toContainText("No owner bound");
   await page.getByTestId("feishu-international").check();
   await page.getByTestId("feishu-app-id").fill("cli_test123");
   await page.getByTestId("feishu-app-secret").fill("secret-xyz");
@@ -13097,6 +13103,13 @@ test("remote access settings: Feishu, WeChat, and StickS3 setup", async ({ page 
   await expect(page.getByTestId("feishu-qr")).toBeVisible();
   await expect(page.getByTestId("feishu-unbind")).toBeVisible({ timeout: 10_000 });
   await expect(page.getByTestId("feishu-app-id")).toHaveValue("cli_scan_created");
+  await expect(page.getByTestId("feishu-owner-status")).toContainText("ou_scan_owner");
+  await page.getByTestId("feishu-owner-id").fill("ou_manual");
+  await page.getByTestId("feishu-owner-save").click();
+  await expect.poll(() => lastInvokeArgs(page, "set_feishu_owner")).toMatchObject({
+    openId: "ou_manual",
+  });
+  await expect(page.getByTestId("feishu-owner-status")).toContainText("ou_manual");
 
   // Back on the list the bound bot's toggle is now enabled.
   await page.locator(".settings-head-back").click();

--- a/ui/src/channels_view.rs
+++ b/ui/src/channels_view.rs
@@ -4,13 +4,15 @@
 //! everything else is self-contained and fetched on mount.
 
 use crate::app_support::{copy_text, js_error_text};
-use crate::bindings::invoke_checked;
+use crate::bindings::{invoke_checked, listen};
 use crate::dto::{ChannelsStatus, FeishuBindPoll, FeishuBindStart, WeixinBindStart};
 use crate::i18n::{localize_backend, t, Locale};
 use crate::text::{event_target_checked, event_target_input};
 use leptos::*;
 use serde_wasm_bindgen::to_value;
 use std::net::Ipv4Addr;
+use wasm_bindgen::closure::Closure;
+use wasm_bindgen::JsCast;
 use wasm_bindgen::JsValue;
 
 const DEFAULT_DEVICE_BRIDGE_PORT: u16 = 18_766;
@@ -70,6 +72,7 @@ pub(super) fn ChannelsPane(
     let status = create_rw_signal(None::<ChannelsStatus>);
     let feishu_app_id = create_rw_signal(String::new());
     let feishu_secret = create_rw_signal(String::new());
+    let feishu_owner_id = create_rw_signal(String::new());
     let feishu_international = create_rw_signal(false);
     let feishu_qr = create_rw_signal(None::<FeishuBindStart>);
     let feishu_bind_state = create_rw_signal(String::new());
@@ -95,6 +98,16 @@ pub(super) fn ChannelsPane(
         });
     });
     refresh.call(());
+    {
+        let refresh = refresh;
+        spawn_local(async move {
+            let callback = Closure::wrap(Box::new(move |_event: JsValue| {
+                refresh.call(());
+            }) as Box<dyn FnMut(JsValue)>);
+            let _ = listen("channels-updated", callback.as_ref().unchecked_ref()).await;
+            callback.forget();
+        });
+    }
 
     let save_feishu = Callback::new(move |enabled: bool| {
         let arg = to_value(&serde_json::json!({
@@ -244,6 +257,7 @@ pub(super) fn ChannelsPane(
                 Ok(_) => {
                     let _ = feishu_app_id.try_set(String::new());
                     let _ = feishu_secret.try_set(String::new());
+                    let _ = feishu_owner_id.try_set(String::new());
                     let _ = msg.try_set(Some((
                         true,
                         t(locale.get_untracked(), "channels.feishu.unbound").into(),
@@ -255,6 +269,86 @@ pub(super) fn ChannelsPane(
                         localize_backend(locale.get_untracked(), &js_error_text(error)),
                     )));
                 }
+            }
+            refresh.call(());
+        });
+    });
+
+    let save_feishu_owner = Callback::new(move |_: ()| {
+        let arg = to_value(&serde_json::json!({
+            "openId": feishu_owner_id.get_untracked().trim(),
+        }))
+        .unwrap();
+        spawn_local(async move {
+            match invoke_checked("set_feishu_owner", arg).await {
+                Ok(_) => {
+                    let _ = msg.try_set(Some((
+                        true,
+                        t(locale.get_untracked(), "channels.feishu.owner_saved").into(),
+                    )));
+                }
+                Err(error) => {
+                    let _ = msg.try_set(Some((
+                        false,
+                        localize_backend(locale.get_untracked(), &js_error_text(error)),
+                    )));
+                }
+            }
+            refresh.call(());
+        });
+    });
+
+    let clear_feishu_owner = Callback::new(move |_: ()| {
+        let arg = to_value(&serde_json::json!({ "openId": "" })).unwrap();
+        spawn_local(async move {
+            match invoke_checked("set_feishu_owner", arg).await {
+                Ok(_) => {
+                    let _ = feishu_owner_id.try_set(String::new());
+                    let _ = msg.try_set(Some((
+                        true,
+                        t(locale.get_untracked(), "channels.feishu.owner_cleared").into(),
+                    )));
+                }
+                Err(error) => {
+                    let _ = msg.try_set(Some((
+                        false,
+                        localize_backend(locale.get_untracked(), &js_error_text(error)),
+                    )));
+                }
+            }
+            refresh.call(());
+        });
+    });
+
+    let confirm_feishu_pending = Callback::new(move |_: ()| {
+        spawn_local(async move {
+            match invoke_checked("confirm_feishu_pending_owner", JsValue::UNDEFINED).await {
+                Ok(_) => {
+                    let _ = msg.try_set(Some((
+                        true,
+                        t(locale.get_untracked(), "channels.feishu.owner_saved").into(),
+                    )));
+                }
+                Err(error) => {
+                    let _ = msg.try_set(Some((
+                        false,
+                        localize_backend(locale.get_untracked(), &js_error_text(error)),
+                    )));
+                }
+            }
+            refresh.call(());
+        });
+    });
+
+    let reject_feishu_pending = Callback::new(move |_: ()| {
+        spawn_local(async move {
+            if let Err(error) =
+                invoke_checked("reject_feishu_pending_owner", JsValue::UNDEFINED).await
+            {
+                let _ = msg.try_set(Some((
+                    false,
+                    localize_backend(locale.get_untracked(), &js_error_text(error)),
+                )));
             }
             refresh.call(());
         });
@@ -657,6 +751,68 @@ pub(super) fn ChannelsPane(
                             on:input=move |ev| feishu_secret.set(event_target_input(&ev).value()) />
                     </label>
                 </div>
+                <div class="channel-divider">
+                    <span>{move || t(locale.get(), "channels.feishu.owner_title")}</span>
+                </div>
+                {move || {
+                    let pending = status.get().unwrap_or_default().feishu_pending_owner_open_id;
+                    let loc = locale.get();
+                    (!pending.is_empty()).then(move || {
+                        let pending_label = pending.clone();
+                        view! {
+                            <div class="channel-bind-row" data-testid="feishu-pending-owner">
+                                <div>
+                                    <strong>{t(loc, "channels.feishu.pending_title")}</strong>
+                                    <p>{format!("{} ({pending_label})", t(loc, "channels.feishu.pending_hint"))}</p>
+                                </div>
+                                <div class="row channel-bind-actions">
+                                    <button type="button" class="primary" data-testid="feishu-pending-confirm"
+                                        on:click=move |_| confirm_feishu_pending.call(())>
+                                        {t(loc, "channels.feishu.pending_confirm")}
+                                    </button>
+                                    <button type="button" data-testid="feishu-pending-reject"
+                                        on:click=move |_| reject_feishu_pending.call(())>
+                                        {t(loc, "channels.feishu.pending_reject")}
+                                    </button>
+                                </div>
+                            </div>
+                        }
+                    })
+                }}
+                <div class="channel-bind-row">
+                    <div>
+                        <strong data-testid="feishu-owner-status">{move || {
+                            let owner = status.get().unwrap_or_default().feishu_owner_open_id;
+                            if owner.is_empty() {
+                                t(locale.get(), "channels.feishu.owner_not_bound").to_string()
+                            } else {
+                                format!("{} · {owner}", t(locale.get(), "channels.feishu.owner_bound"))
+                            }
+                        }}</strong>
+                        <p>{move || t(locale.get(), "channels.feishu.owner_hint")}</p>
+                    </div>
+                    {move || status.get().map(|s| !s.feishu_owner_open_id.is_empty()).unwrap_or(false).then(|| view! {
+                        <button type="button" data-testid="feishu-owner-clear"
+                            on:click=move |_| clear_feishu_owner.call(())>
+                            {move || t(locale.get(), "channels.feishu.owner_clear")}
+                        </button>
+                    })}
+                </div>
+                <div class="settings-form-grid">
+                    <label class="span-2">
+                        <span>{move || t(locale.get(), "channels.feishu.owner_open_id")}</span>
+                        <input type="text" data-testid="feishu-owner-id"
+                            placeholder="ou_xxxxxxxx"
+                            prop:value=move || feishu_owner_id.get()
+                            on:input=move |ev| feishu_owner_id.set(event_target_input(&ev).value()) />
+                    </label>
+                </div>
+                <div class="row" style="justify-content:flex-start;">
+                    <button type="button" data-testid="feishu-owner-save"
+                        on:click=move |_| save_feishu_owner.call(())>
+                        {move || t(locale.get(), "channels.feishu.owner_save")}
+                    </button>
+                </div>
                 {move || {
                     let detail = status.get().unwrap_or_default().feishu_detail;
                     (!detail.is_empty()).then(|| view! { <p class="settings-field-hint">{detail}</p> })
@@ -871,7 +1027,12 @@ pub(super) fn ChannelsPane(
                                 {feishu_badge}
                             </span>
                             <span class="settings-list-sub">{move || {
-                                if status.get().map(|s| s.feishu_bound).unwrap_or(false) {
+                                let s = status.get().unwrap_or_default();
+                                if !s.feishu_pending_owner_open_id.is_empty() {
+                                    t(locale.get(), "channels.feishu.pending_title").to_string()
+                                } else if s.feishu_bound && s.feishu_owner_open_id.is_empty() {
+                                    t(locale.get(), "channels.feishu.owner_missing").to_string()
+                                } else if s.feishu_bound {
                                     feishu_region()
                                 } else {
                                     t(locale.get(), "channels.feishu.subtitle").to_string()

--- a/ui/src/i18n.rs
+++ b/ui/src/i18n.rs
@@ -1319,7 +1319,21 @@ fn lookup(locale: Locale, key: &str) -> Option<&'static str> {
         (Locale::En, "channels.feishu.region_lark") => Some("Lark International"),
         (Locale::En, "channels.feishu.app_id") => Some("App ID"),
         (Locale::En, "channels.feishu.app_secret") => Some("App Secret"),
-        (Locale::En, "channels.feishu.hint") => Some("The app must expose a bot, use long-connection event subscription for im.message.receive_v1, and have message send/receive plus bot-info permissions. Agent turns are returned as live CardKit progress cards."),
+        (Locale::En, "channels.feishu.hint") => Some("The app must expose a bot, use long-connection event subscription for im.message.receive_v1, and have message send/receive plus bot-info permissions. Agent turns are returned as live CardKit progress cards. Only the bound owner can drive turns; mutating tools from Feishu still ask for desktop approval."),
+        (Locale::En, "channels.feishu.owner_title") => Some("Bound owner"),
+        (Locale::En, "channels.feishu.owner_hint") => Some("The owner must be confirmed here or entered explicitly. The first person to message the bot is never bound automatically."),
+        (Locale::En, "channels.feishu.owner_not_bound") => Some("No owner bound"),
+        (Locale::En, "channels.feishu.owner_bound") => Some("Owner"),
+        (Locale::En, "channels.feishu.owner_missing") => Some("App connected · owner not bound"),
+        (Locale::En, "channels.feishu.owner_open_id") => Some("Owner open_id"),
+        (Locale::En, "channels.feishu.owner_save") => Some("Bind owner"),
+        (Locale::En, "channels.feishu.owner_clear") => Some("Clear owner"),
+        (Locale::En, "channels.feishu.owner_saved") => Some("Feishu owner saved."),
+        (Locale::En, "channels.feishu.owner_cleared") => Some("Feishu owner cleared."),
+        (Locale::En, "channels.feishu.pending_title") => Some("Pending owner pairing"),
+        (Locale::En, "channels.feishu.pending_hint") => Some("A Feishu user messaged the bot. Confirm on this computer to bind them as owner."),
+        (Locale::En, "channels.feishu.pending_confirm") => Some("Confirm owner"),
+        (Locale::En, "channels.feishu.pending_reject") => Some("Reject"),
         (Locale::En, "channels.weixin.title") => Some("WeChat bot (iLink)"),
         (Locale::En, "channels.weixin.subtitle") => Some("Personal 1:1 messages · QR code binding"),
         (Locale::En, "channels.weixin.toggle") => Some("Enable WeChat bot"),
@@ -3764,7 +3778,21 @@ Do not leave generated files in the project root.",
         (Locale::Zh, "channels.feishu.region_lark") => Some("Lark 国际版"),
         (Locale::Zh, "channels.feishu.app_id") => Some("App ID"),
         (Locale::Zh, "channels.feishu.app_secret") => Some("App Secret"),
-        (Locale::Zh, "channels.feishu.hint") => Some("应用需启用机器人能力，事件订阅选择「长连接」并订阅 im.message.receive_v1，同时开通消息收发与获取机器人信息权限。AI 处理过程会通过 CardKit 卡片持续更新。"),
+        (Locale::Zh, "channels.feishu.hint") => Some("应用需启用机器人能力，事件订阅选择「长连接」并订阅 im.message.receive_v1，同时开通消息收发与获取机器人信息权限。AI 处理过程会通过 CardKit 卡片持续更新。只有已绑定的所有者可以发起任务；飞书侧的写入/执行类工具仍会在桌面端请求审批。"),
+        (Locale::Zh, "channels.feishu.owner_title") => Some("绑定所有者"),
+        (Locale::Zh, "channels.feishu.owner_hint") => Some("所有者必须在本机确认配对或手动填写 open_id。第一个给机器人发消息的人不会被自动设为所有者。"),
+        (Locale::Zh, "channels.feishu.owner_not_bound") => Some("尚未绑定所有者"),
+        (Locale::Zh, "channels.feishu.owner_bound") => Some("所有者"),
+        (Locale::Zh, "channels.feishu.owner_missing") => Some("应用已连接 · 尚未绑定所有者"),
+        (Locale::Zh, "channels.feishu.owner_open_id") => Some("所有者 open_id"),
+        (Locale::Zh, "channels.feishu.owner_save") => Some("绑定所有者"),
+        (Locale::Zh, "channels.feishu.owner_clear") => Some("清除所有者"),
+        (Locale::Zh, "channels.feishu.owner_saved") => Some("已保存飞书所有者。"),
+        (Locale::Zh, "channels.feishu.owner_cleared") => Some("已清除飞书所有者。"),
+        (Locale::Zh, "channels.feishu.pending_title") => Some("待确认所有者配对"),
+        (Locale::Zh, "channels.feishu.pending_hint") => Some("有飞书用户向机器人发了消息。请在本机确认后才会将其绑定为所有者。"),
+        (Locale::Zh, "channels.feishu.pending_confirm") => Some("确认所有者"),
+        (Locale::Zh, "channels.feishu.pending_reject") => Some("拒绝"),
         (Locale::Zh, "channels.weixin.title") => Some("微信机器人(iLink)"),
         (Locale::Zh, "channels.weixin.subtitle") => Some("个人一对一消息 · 扫码绑定"),
         (Locale::Zh, "channels.weixin.toggle") => Some("启用微信机器人"),
@@ -5569,7 +5597,10 @@ mod queue_label_tests {
             t(Locale::En, "browser.auto_close_tabs"),
             "Automatically close browser tabs"
         );
-        assert_eq!(t(Locale::Zh, "browser.auto_close_tabs"), "自动关闭浏览器标签页");
+        assert_eq!(
+            t(Locale::Zh, "browser.auto_close_tabs"),
+            "自动关闭浏览器标签页"
+        );
         assert_eq!(
             tf(Locale::En, "browser.cleanup.body", &[("n", "18")]),
             "This turn opened 18 tabs. Selected tabs will be closed. Uncheck any you want to keep."
@@ -5585,11 +5616,19 @@ mod queue_label_tests {
         assert_eq!(t(Locale::En, "trajectory.export"), "Export HTML");
         assert_eq!(t(Locale::Zh, "trajectory.export"), "导出 HTML");
         assert_eq!(
-            tf(Locale::En, "trajectory.export_saved", &[("path", "/tmp/a.html")]),
+            tf(
+                Locale::En,
+                "trajectory.export_saved",
+                &[("path", "/tmp/a.html")]
+            ),
             "Trajectory saved to /tmp/a.html"
         );
         assert_eq!(
-            tf(Locale::Zh, "trajectory.export_saved", &[("path", "/tmp/a.html")]),
+            tf(
+                Locale::Zh,
+                "trajectory.export_saved",
+                &[("path", "/tmp/a.html")]
+            ),
             "轨迹已保存到 /tmp/a.html"
         );
     }


### PR DESCRIPTION
## Problem

Feishu inbound messages did not check a bound owner. `parse_message_event` only dropped bot echo and required a group @mention, then `handle_inbound` reused the desktop `send_message` path. Tool approval defaults to Allow, so a stranger in p2p or a group @ could silently trigger write/shell.

Fixes #976 (split from #884).

## Changes

- **Feishu owner pairing:** owner is set only by a trusted desktop flow — QR registration `open_id`, explicit `open_id` in Settings, or confirming a pending pairing request. The first messenger is never auto-bound.
- **Auth gate:** non-owner p2p and group @ messages are rejected before they enter the agent. Unbound senders get a pairing reply; the pending `open_id` shows in Settings → Remote Access → Feishu.
- **Turn origin:** desktop vs IM. IM mutating tools (`write` / `edit` / `shell` and anything else plan-mode would block) force Ask even when the host policy is Allow, including Full Permission. Read-only tools and `attempt_completion` stay Allow.
- Docs for channels and basic configuration.

## Tests

- Sender policy: owner/non-owner, unbound first messenger, group @ payloads still parsed then rejected.
- Owner persistence never promotes pending → owner automatically.
- Registry: IM force-Ask upgrades Allow/bypass, preserves Deny, lets `read` through.
- DTO contract for `feishu_owner_open_id` / pending fields.
- Playwright remote-access flow: reject pending pairing, QR bind sets owner, explicit owner save.

`cargo fmt --all -- --check`, `cargo test --workspace`, `cd ui && cargo check --target wasm32-unknown-unknown`, and the Playwright remote-access test all passed.

## Manual smoke

1. Settings → Remote Access → Feishu: connect the app, leave owner empty, message the bot from Feishu. Confirm the pending pairing on the desktop; a second account should be rejected.
2. From the bound owner, ask the agent to write a file. The desktop should prompt even if tool approval is Allow / Full Permission.

## Limitations / follow-up

- ACP-bound sessions still use ACP's own permission UI, not this built-in IM force-Ask.
- Only one pending Feishu owner is kept (last sender wins) until confirmed or rejected.