### PR TITLE
fix(ui): stop full-width underlines on png/pdf path links

### DIFF
--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -4581,6 +4581,18 @@ test("Generated artifacts survive follow-up tool commentary and ignore mentioned
   await expect(reply.locator('.message-artifact-card[data-artifact-name="old-report.md"]')).toHaveCount(0);
   const pathLink = reply.locator('a.workspace-path-link[href="notes/FIGURE_LEGEND.md"]');
   await expect(pathLink).toHaveText("notes/FIGURE_LEGEND.md");
+  await expect.poll(async () => pathLink.evaluate((el) => {
+    const style = getComputedStyle(el);
+    return {
+      decoration: style.textDecorationLine,
+      shadow: style.boxShadow,
+      display: style.display,
+    };
+  })).toEqual({
+    decoration: "none",
+    shadow: "none",
+    display: "inline",
+  });
   await pathLink.click();
   const linkedModal = page.locator('.artifact-modal:has(.am-figure[data-file-path="notes/FIGURE_LEGEND.md"])');
   await expect(linkedModal).toBeVisible();

--- a/ui/src/styles/chat.css
+++ b/ui/src/styles/chat.css
@@ -1058,13 +1058,43 @@ details.tool:not([open]) > summary.head .run-dot { animation: tool-pulse 1.1s ea
 .md a {
   color: var(--clay-strong);
   font-weight: 500;
-  text-decoration: none;
-  box-shadow: inset 0 -1px 0 color-mix(in srgb, var(--clay) 34%, transparent);
-  transition: color .12s ease, box-shadow .12s ease;
+  text-decoration-line: underline;
+  text-decoration-color: color-mix(in srgb, var(--clay) 34%, transparent);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.16em;
+  box-shadow: none;
+  transition: color .12s ease, text-decoration-color .12s ease;
 }
 .md a:hover {
   color: var(--clay);
-  box-shadow: inset 0 -1.5px 0 color-mix(in srgb, var(--clay) 70%, transparent);
+  box-shadow: none;
+  text-decoration-color: color-mix(in srgb, var(--clay) 76%, transparent);
+}
+/* Inline-code project paths already sit in a chip. An inset box-shadow
+   underline follows the paragraph box when the path is the only child,
+   drawing a full-width line under png/pdf links. */
+.md a.workspace-path-link {
+  display: inline;
+  width: auto;
+  max-width: 100%;
+  box-shadow: none;
+  text-decoration: none;
+  font-weight: inherit;
+  vertical-align: baseline;
+}
+.md a.workspace-path-link code {
+  color: var(--clay-strong);
+  border-color: color-mix(in srgb, var(--clay) 28%, var(--border));
+  background: color-mix(in srgb, var(--clay-soft) 55%, transparent);
+}
+.md a.workspace-path-link:hover {
+  color: var(--clay);
+  box-shadow: none;
+  text-decoration: none;
+}
+.md a.workspace-path-link:hover code {
+  border-color: color-mix(in srgb, var(--clay) 48%, var(--border));
+  background: color-mix(in srgb, var(--clay-soft) 88%, transparent);
 }
 .md li > p:first-child:not(:only-child) a {
   font-weight: 600;

--- a/ui/src/styles/share-export.css
+++ b/ui/src/styles/share-export.css
@@ -164,8 +164,19 @@ html, body {
 .md a {
   color: var(--clay-strong);
   font-weight: 500;
+  text-decoration-line: underline;
+  text-decoration-color: color-mix(in srgb, var(--clay) 34%, transparent);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.16em;
+  box-shadow: none;
+}
+.md a.workspace-path-link {
   text-decoration: none;
-  box-shadow: inset 0 -1px 0 color-mix(in srgb, var(--clay) 34%, transparent);
+}
+.md a.workspace-path-link code {
+  color: var(--clay-strong);
+  border-color: color-mix(in srgb, var(--clay) 28%, var(--border));
+  background: color-mix(in srgb, var(--clay-soft) 55%, transparent);
 }
 .md strong { font-weight: 600; color: var(--text); }
 .md code { font-family: var(--font-mono); font-size: 0.86em; background: var(--bg-sunken); border: 1px solid var(--border); border-radius: 5px; padding: 0.1em 0.35em; }


### PR DESCRIPTION
## Problem

Inline-code project paths (`figures/foo.png`, `.pdf`, …) rendered as `workspace-path-link`. `.md a` used `box-shadow: inset 0 -1px` as an underline. When the path was the only child of a paragraph, that shadow followed the paragraph box and drew a teal line across the whole reply. Nested `code` already has a chip border, so the extra line looked worse.

## Changes

- Ordinary Markdown links use `text-decoration` so the line stays under the text.
- `.workspace-path-link` drops the shadow/underline and keeps a compact clay code chip (chat + share/export CSS).
- Playwright checks the path link is `inline` with no decoration or box-shadow.

## Tests

- Extended `Generated artifacts survive follow-up tool commentary and ignore mentioned paths`.

`npx playwright test tests/ui.spec.ts --grep "Generated artifacts survive follow-up"` passed.

## Manual smoke

1. Open a conversation whose reply cites `figures/….png` on its own line and a `.pdf` inline.
2. Confirm there is no full-width underline; the path is a short chip. Hover only darkens the chip border.
3. Click still opens the artifact.

## Limitations / follow-up

- Unresolved resource links still use their own warning inset shadow; that is separate from path chips.