### PR TITLE
Fix download of pinned artifact-version previews in branch/exploration views

### DIFF
--- a/src-tauri/src/app_commands.rs
+++ b/src-tauri/src/app_commands.rs
@@ -245,7 +245,11 @@ pub(super) async fn download_file(
     path: String,
 ) -> Result<Option<String>, String> {
     use tauri_plugin_dialog::DialogExt;
-    let ap = state.active(window.label());
+    // Resolve against the active frame's working project so downloads inside
+    // an exploration branch read that branch's workspace, not the mainline.
+    let (ap, _scope) =
+        crate::exploration_commands::working_project_for_active_frame(&state, window.label())
+            .await?;
     let remote = parse_ssh_artifact_uri(&path);
     let local = if remote.is_none() {
         let real = wisp_tools::safety::validate_file_path(&ap.root, &path)?;

--- a/src-tauri/src/artifact_commands.rs
+++ b/src-tauri/src/artifact_commands.rs
@@ -703,3 +703,71 @@ pub(super) async fn read_artifact_version_bytes(
     .map_err(|e| format!("{e}"))??;
     Ok(Response::new(bytes))
 }
+
+/// Save the immutable artifact version behind an `artifact-version:` preview
+/// path. This is the download counterpart of `read_artifact_version`: it must
+/// never follow the artifact's mutable latest-version pointer, so previews
+/// pinned by branch/exploration views download the exact bytes they display.
+#[tauri::command]
+pub(super) async fn download_artifact_version(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    window: tauri::WebviewWindow,
+    version_id: String,
+) -> Result<Option<String>, String> {
+    use tauri_plugin_dialog::DialogExt;
+
+    let version = state
+        .store
+        .get_artifact_version(&version_id)
+        .await
+        .map_err(|e| format!("{e}"))?
+        .ok_or_else(|| format!("artifact version '{version_id}' not found"))?;
+    let (working_project, scope) =
+        crate::exploration_commands::working_project_for_active_frame(&state, window.label())
+            .await?;
+    if !state
+        .store
+        .artifact_visible_in_scope(&version.artifact_id, &scope)
+        .await
+        .map_err(|error| error.to_string())?
+    {
+        return Err(format!(
+            "artifact version '{version_id}' not found in the active state"
+        ));
+    }
+    let artifact = state
+        .store
+        .get_artifact_detail(&version.artifact_id)
+        .await
+        .map_err(|e| format!("{e}"))?
+        .ok_or_else(|| format!("artifact '{}' not found", version.artifact_id))?;
+    let root = if matches!(&scope, wisp_store::StateScope::Exploration { .. }) {
+        working_project.root
+    } else {
+        PathBuf::from(artifact.project_root)
+    };
+    let source = wisp_tools::safety::validate_file_path(&root, &version.storage_path)?;
+    if !source.is_file() {
+        return Err(format!(
+            "artifact '{}' is no longer readable",
+            artifact.name
+        ));
+    }
+
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    app.dialog()
+        .file()
+        .set_file_name(&artifact.name)
+        .save_file(move |path| {
+            let _ = tx.send(path);
+        });
+    let Some(destination) = rx.await.map_err(|error| error.to_string())? else {
+        return Ok(None);
+    };
+    let destination = PathBuf::from(destination.to_string());
+    tokio::fs::copy(source, &destination)
+        .await
+        .map_err(|error| format!("copy failed: {error}"))?;
+    Ok(Some(destination.display().to_string()))
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7001,6 +7001,7 @@ pub fn run() {
             artifact_commands::read_artifact,
             artifact_commands::read_artifact_bytes,
             artifact_commands::download_artifact,
+            artifact_commands::download_artifact_version,
             artifact_commands::read_artifact_version,
             artifact_commands::read_artifact_version_bytes,
             artifact_commands::missing_files,

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -4564,6 +4564,7 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
           case "list_artifacts":
             return mockPublication ? [artifacts[1]] : [];
           case "download_artifact":
+          case "download_artifact_version":
             return null;
           case "side_chat": {
             const question = String(arg("question") ?? "");

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -10868,6 +10868,13 @@ test("bound Markdown resources use immutable versions and a scrollable center pr
   const modal = page.locator(".artifact-modal");
   await expect(modal).toBeVisible();
   await expect(modal.locator(".am-name")).toHaveText("report.md");
+  // Downloading a pinned version must go through the version command — the
+  // workspace-path download would fail on branch/exploration views where the
+  // file only exists as a stored artifact version.
+  await modal.getByRole("button", { name: "Download" }).click();
+  await expect.poll(() => lastInvokeArgs(page, "download_artifact_version"))
+    .toMatchObject({ versionId: "resource-version-markdown" });
+  expect(await lastInvokeArgs(page, "download_file")).toBeNull();
   await modal.getByRole("button", { name: "Open in center" }).click();
   const tab = page.locator('.center-tab[data-center-path="artifact-version:resource-version-markdown"]');
   await expect(tab).toContainText("report.md");

--- a/ui/src/app_support/extensions.rs
+++ b/ui/src/app_support/extensions.rs
@@ -209,7 +209,9 @@ impl ExtensionsState {
 
     pub(crate) fn set_plugin_enabled(self, id: String, version: String, enabled: bool) {
         let Self {
-            plugins_msg, locale, ..
+            plugins_msg,
+            locale,
+            ..
         } = self;
         spawn_local(async move {
             let args = to_value(&serde_json::json!({
@@ -237,7 +239,9 @@ impl ExtensionsState {
 
     pub(crate) fn remove_plugin(self, id: String, version: String) {
         let Self {
-            plugins_msg, locale, ..
+            plugins_msg,
+            locale,
+            ..
         } = self;
         spawn_local(async move {
             let args =

--- a/ui/src/app_support/mod.rs
+++ b/ui/src/app_support/mod.rs
@@ -13,11 +13,12 @@ use crate::publication::PublicationEvidenceSource;
 use crate::text::{
     code_lang, decode_href, dom_value, event_target_value, extract_href_from_tag, fasta_seq_count,
     fenced_blocks, file_kind, format_bytes, format_duration_ms, html_escape, ime_composing,
-    is_external_href, is_separator, is_table_row, md_document_to_html, md_inline_to_html,
-    md_to_html, next_artifact_id, normalize_path, opens_in_system_browser, parent_path,
-    parse_csv_line, parse_notebook, pretty_json, provider_defaults, provider_value, split_row,
-    join_api_url, normalize_endpoint, same_endpoint, DEEPSEEK_FLASH_MODEL, DEEPSEEK_PRO_MODEL,
-    tool_card_label, tool_lang, unique_dom_id, user_message_presentation, NbOutput, Notebook,
+    is_external_href, is_separator, is_table_row, join_api_url, md_document_to_html,
+    md_inline_to_html, md_to_html, next_artifact_id, normalize_endpoint, normalize_path,
+    opens_in_system_browser, parent_path, parse_csv_line, parse_notebook, pretty_json,
+    provider_defaults, provider_value, same_endpoint, split_row, tool_card_label, tool_lang,
+    unique_dom_id, user_message_presentation, NbOutput, Notebook, DEEPSEEK_FLASH_MODEL,
+    DEEPSEEK_PRO_MODEL,
 };
 use leptos::{ev, window_event_listener, *};
 use serde_wasm_bindgen::to_value;

--- a/ui/src/app_support/model_settings.rs
+++ b/ui/src/app_support/model_settings.rs
@@ -348,12 +348,9 @@ impl ModelSettingsState {
                 let provider = provider_value(&entry.provider).to_string();
                 let endpoint_suffix = entry.endpoint_suffix.trim().to_string();
                 let effective_api_url = join_api_url(&api_url, &endpoint_suffix);
-                let (max_tokens, context_window) = catalog_limits_or_default(
-                    &provider,
-                    &effective_api_url,
-                    entry.model.trim(),
-                )
-                .await;
+                let (max_tokens, context_window) =
+                    catalog_limits_or_default(&provider, &effective_api_url, entry.model.trim())
+                        .await;
                 let image = entry.is_image_model();
                 let video = entry.is_video_model();
                 let media = image || video;

--- a/ui/src/app_support/previews.rs
+++ b/ui/src/app_support/previews.rs
@@ -1346,10 +1346,7 @@ mod download_invocation_tests {
     fn routes_each_preview_path_spelling_to_its_command() {
         assert_eq!(
             download_invocation("artifact:art-1"),
-            Some((
-                "download_artifact",
-                serde_json::json!({ "id": "art-1" })
-            ))
+            Some(("download_artifact", serde_json::json!({ "id": "art-1" })))
         );
         // Pinned versions (branch/exploration previews) must download the
         // exact displayed bytes, never a workspace path that may not exist.

--- a/ui/src/app_support/previews.rs
+++ b/ui/src/app_support/previews.rs
@@ -1298,40 +1298,83 @@ pub(crate) fn opens_in_modal(kind: &str) -> bool {
     matches!(kind, "image" | "pdf" | "csv")
 }
 
-/// Fire the native save dialog to download a workspace file (backend copies it).
-/// Remote-preview paths go out as the ssh:// spelling `download_file` already
-/// understands, so the modal's download button works for remote files too.
-pub(crate) fn download_artifact(path: String) {
-    if let Some(id) = artifact_id_path(&path).map(str::to_owned) {
-        spawn_local(async move {
-            let arg = to_value(&serde_json::json!({ "id": id })).unwrap();
-            if let Err(error) = invoke_checked("download_artifact", arg).await {
-                show_toast(&localize_backend(
-                    Locale::detect_browser(),
-                    &js_error_text(error),
-                ));
-            }
-        });
-        return;
+/// Map each preview-path spelling onto the backend command that can save it:
+/// `artifact:` ids and pinned `artifact-version:` ids have no workspace path,
+/// so they go to their dedicated commands; remote previews go out as the
+/// ssh:// spelling `download_file` already understands; everything else is a
+/// workspace path for `download_file`.
+pub(crate) fn download_invocation(path: &str) -> Option<(&'static str, serde_json::Value)> {
+    if let Some(id) = artifact_id_path(path) {
+        return Some(("download_artifact", serde_json::json!({ "id": id })));
     }
-    let path = match remote_file_path(&path) {
+    if let Some(id) = artifact_version_id_path(path) {
+        return Some((
+            "download_artifact_version",
+            serde_json::json!({ "versionId": id }),
+        ));
+    }
+    let path = match remote_file_path(path) {
         Some((context_id, remote_path)) => {
-            match crate::context_menu::remote_file_download_uri(context_id, remote_path) {
-                Some(uri) => uri,
-                None => return,
-            }
+            crate::context_menu::remote_file_download_uri(context_id, remote_path)?
         }
-        None => path,
+        None => path.to_string(),
+    };
+    Some(("download_file", serde_json::json!({ "path": path })))
+}
+
+/// Fire the native save dialog to download the file behind a preview path
+/// (backend copies it).
+pub(crate) fn download_artifact(path: String) {
+    let Some((command, args)) = download_invocation(&path) else {
+        return;
     };
     spawn_local(async move {
-        let arg = to_value(&serde_json::json!({ "path": path })).unwrap();
-        if let Err(error) = invoke_checked("download_file", arg).await {
+        if let Err(error) = invoke_checked(command, to_value(&args).unwrap()).await {
             show_toast(&localize_backend(
                 Locale::detect_browser(),
                 &js_error_text(error),
             ));
         }
     });
+}
+
+#[cfg(test)]
+mod download_invocation_tests {
+    use super::download_invocation;
+
+    #[test]
+    fn routes_each_preview_path_spelling_to_its_command() {
+        assert_eq!(
+            download_invocation("artifact:art-1"),
+            Some((
+                "download_artifact",
+                serde_json::json!({ "id": "art-1" })
+            ))
+        );
+        // Pinned versions (branch/exploration previews) must download the
+        // exact displayed bytes, never a workspace path that may not exist.
+        assert_eq!(
+            download_invocation("artifact-version:ver-1"),
+            Some((
+                "download_artifact_version",
+                serde_json::json!({ "versionId": "ver-1" })
+            ))
+        );
+        assert_eq!(
+            download_invocation("remote:ssh:gpu:/data/run.csv"),
+            Some((
+                "download_file",
+                serde_json::json!({ "path": "ssh://gpu/data/run.csv" })
+            ))
+        );
+        assert_eq!(
+            download_invocation("results/report.md"),
+            Some((
+                "download_file",
+                serde_json::json!({ "path": "results/report.md" })
+            ))
+        );
+    }
 }
 
 pub(crate) fn reveal_in_file_manager(path: String) {

--- a/ui/src/app_support/settings.rs
+++ b/ui/src/app_support/settings.rs
@@ -819,12 +819,9 @@ pub(crate) fn model_form_entry(
 pub(crate) fn suggested_base_url_models(api_url: &str) -> Vec<ModelFormEntry> {
     let host = normalize_endpoint(api_url).to_ascii_lowercase();
     match host.as_str() {
-        host if host.contains("api.anthropic.com") => vec![model_form_entry(
-            "anthropic",
-            "claude-sonnet-5",
-            "",
-            false,
-        )],
+        host if host.contains("api.anthropic.com") => {
+            vec![model_form_entry("anthropic", "claude-sonnet-5", "", false)]
+        }
         host if host.contains("api.openai.com") => vec![
             model_form_entry("openai_responses", "gpt-5.5", "", false),
             model_form_entry("openai_responses", "gpt-image-2", "", true),
@@ -898,10 +895,7 @@ pub(crate) fn endpoint_has_stored_key(models: &[ModelProfile], api_url: &str) ->
         .any(|profile| profile.has_api_key && same_endpoint(&profile.api_url, api_url))
 }
 
-pub(crate) fn sibling_profile_id<'a>(
-    models: &'a [ModelProfile],
-    api_url: &str,
-) -> Option<&'a str> {
+pub(crate) fn sibling_profile_id<'a>(models: &'a [ModelProfile], api_url: &str) -> Option<&'a str> {
     models
         .iter()
         .find(|profile| profile.has_api_key && same_endpoint(&profile.api_url, api_url))
@@ -1164,7 +1158,8 @@ fn secret_fields_json(fields: &[ConnSecretField]) -> Vec<serde_json::Value> {
 }
 
 fn secret_fields_from_entries(entries: &[McpSecretEntry]) -> Vec<ConnSecretField> {
-    let mut fields: Vec<ConnSecretField> = entries.iter().map(ConnSecretField::from_entry).collect();
+    let mut fields: Vec<ConnSecretField> =
+        entries.iter().map(ConnSecretField::from_entry).collect();
     if fields.is_empty() {
         fields.push(ConnSecretField::default());
     }
@@ -1203,10 +1198,7 @@ pub(crate) fn build_conn_json(f: &ConnForm, assign_id: bool) -> serde_json::Valu
 pub(crate) fn conn_form_from_row(row: &ConnRow) -> ConnForm {
     match &row.transport {
         ConnTransport::Stdio {
-            command,
-            args,
-            env,
-            ..
+            command, args, env, ..
         } => ConnForm {
             id: Some(row.id.clone()),
             name: row.name.clone(),
@@ -1241,9 +1233,7 @@ pub(crate) fn conn_form_from_row(row: &ConnRow) -> ConnForm {
 #[cfg(test)]
 mod mcp_secret_form_tests {
     use super::{build_conn_json, conn_form_from_row};
-    use crate::dto::{
-        ConnForm, ConnRow, ConnSecretField, ConnTransport, McpSecretEntry,
-    };
+    use crate::dto::{ConnForm, ConnRow, ConnSecretField, ConnTransport, McpSecretEntry};
 
     #[test]
     fn build_conn_json_omits_empty_secret_values() {

--- a/ui/src/app_support/share.rs
+++ b/ui/src/app_support/share.rs
@@ -1006,7 +1006,9 @@ mod share_tests {
             "助手",
             "| 项目 | 数值 |\n| --- | --- |\n| A | 1 |\n| B | 2 |\n\n质能 $E = mc^2$\n\n$$\\int_0^1 x^2 dx$$\n",
         );
-        let html = row["html"].as_str().expect("assistant row should carry chat HTML");
+        let html = row["html"]
+            .as_str()
+            .expect("assistant row should carry chat HTML");
         assert!(html.contains("<table>"), "{html}");
         assert!(html.contains("<th>"), "{html}");
         assert!(html.contains("项目"), "{html}");

--- a/ui/src/context_menu.rs
+++ b/ui/src/context_menu.rs
@@ -69,8 +69,7 @@ fn item(action: &str, label: String, payload: String) -> CtxItem {
 pub(crate) fn motif_sequence_path(path: &str) -> bool {
     let lower = path.to_ascii_lowercase();
     [
-        ".dna", ".fa", ".fasta", ".fna", ".ffn", ".faa", ".frn", ".gb", ".gbk",
-        ".genbank", ".seq",
+        ".dna", ".fa", ".fasta", ".fna", ".ffn", ".faa", ".frn", ".gb", ".gbk", ".genbank", ".seq",
     ]
     .iter()
     .any(|extension| lower.ends_with(extension))

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -7208,8 +7208,10 @@ fn App() -> impl IntoView {
             );
             let _ = window.add_event_listener_with_callback("focus", beat.as_ref().unchecked_ref());
             if let Some(document) = window.document() {
-                let _ = document
-                    .add_event_listener_with_callback("visibilitychange", beat.as_ref().unchecked_ref());
+                let _ = document.add_event_listener_with_callback(
+                    "visibilitychange",
+                    beat.as_ref().unchecked_ref(),
+                );
             }
         }
         beat.forget();
@@ -7460,7 +7462,10 @@ fn App() -> impl IntoView {
                             Ok(_) => show_toast(&tf(
                                 locale.get_untracked(),
                                 "motif.added_file",
-                                &[("name", payload.rsplit(['/', '\\']).next().unwrap_or(&payload))],
+                                &[(
+                                    "name",
+                                    payload.rsplit(['/', '\\']).next().unwrap_or(&payload),
+                                )],
                             )),
                             Err(error) => show_warning_toast(&js_error_text(error)),
                         }

--- a/ui/src/mcp_app.rs
+++ b/ui/src/mcp_app.rs
@@ -54,7 +54,9 @@ fn supports_host_dna_import(payload: &serde_json::Value) -> bool {
         == Some("motif_open_workbench")
 }
 
-pub(crate) fn active_motif_instance(apps: &std::collections::HashMap<String, String>) -> Option<String> {
+pub(crate) fn active_motif_instance(
+    apps: &std::collections::HashMap<String, String>,
+) -> Option<String> {
     apps.iter().find_map(|(instance_id, payload_json)| {
         serde_json::from_str::<serde_json::Value>(payload_json)
             .ok()
@@ -218,7 +220,10 @@ mod tests {
     #[test]
     fn mcp_app_instance_id_falls_back_to_tool_name() {
         assert_eq!(
-            mcp_app_instance_id("sess-1", &serde_json::json!({ "tool": { "name": "open_app" } })),
+            mcp_app_instance_id(
+                "sess-1",
+                &serde_json::json!({ "tool": { "name": "open_app" } })
+            ),
             "mcp-app:sess-1:open_app"
         );
         assert_eq!(

--- a/ui/src/text.rs
+++ b/ui/src/text.rs
@@ -182,7 +182,10 @@ mod endpoint_tests {
             "https://api.deepseek.com",
             "https://api.openai.com"
         ));
-        assert_eq!(endpoint_host("https://api.deepseek.com/v1"), "api.deepseek.com");
+        assert_eq!(
+            endpoint_host("https://api.deepseek.com/v1"),
+            "api.deepseek.com"
+        );
     }
 
     #[test]

--- a/ui/src/trajectory.rs
+++ b/ui/src/trajectory.rs
@@ -1,6 +1,4 @@
-use crate::app_support::{
-    compose_icon, js_error_text, show_toast, show_warning_toast,
-};
+use crate::app_support::{compose_icon, js_error_text, show_toast, show_warning_toast};
 use crate::bindings::invoke_checked;
 use crate::chat_render::fmt_tokens;
 use crate::dto::{


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Clicking Download on a preview opened from a branch/exploration view failed with a toast like `file not found: artifact-version:79033eee-…`. Those previews (resource links, inline images, method-search outputs) are pinned to immutable artifact versions via the `artifact-version:<version_id>` path spelling. Reading works because `ui/src/api.js` routes that spelling to `read_artifact_version_bytes`, but the download button sent the raw string to `download_file`, which only understands workspace-relative paths and `ssh://` URIs.

Related gap: `download_file` always resolved against the mainline project root, so workspace files that only exist in an exploration branch workspace also failed to download.

## Changes

- `src-tauri/src/artifact_commands.rs`: new `download_artifact_version` command — the download counterpart of `read_artifact_version`. Same scope visibility check and root resolution (exploration working project root vs mainline project root), then the native save dialog and copy, mirroring `download_artifact`.
- `src-tauri/src/lib.rs`: register the command.
- `src-tauri/src/app_commands.rs`: `download_file` now resolves the local root through `working_project_for_active_frame`, so downloads inside an exploration branch read that branch's workspace.
- `ui/src/app_support/previews.rs`: extracted the pure `download_invocation()` routing (path spelling → command + args) and routed `artifact-version:` to the new command; `download_artifact()` now just fires the chosen invoke. All download buttons (artifact modal, artifact tiles, file browser, MCP `downloadFile`) funnel through this one function.
- `ui-tests/tests/mock-tauri.ts`: mock `download_artifact_version`.

## Tests

- New `download_invocation_tests` unit test covering all four path spellings (`artifact:`, `artifact-version:`, `remote:ssh:…`, workspace path).
- Extended the "bound Markdown resources" Playwright test: clicking Download in the version-pinned modal invokes `download_artifact_version` with the version id and never calls `download_file`.

## Manual smoke

1. In a session, click a bound resource link (e.g. a generated README) to open the preview modal; click Download → save dialog appears and the file saves.
2. Start an exploration / open a branch view, open a file produced there, click Download → saves instead of "file not found".

## Limitations / follow-ups

- `reveal_in_file_manager` still resolves against the mainline root only; revealing exploration-branch files is untouched by this PR.
- `download_artifact_version` saves under the artifact's current filename (versions do not store their own filename).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8de3b6d6-1f54-47e8-b6e2-07cd133af5fa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8de3b6d6-1f54-47e8-b6e2-07cd133af5fa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

