### PR TITLE
fix(ui): keep file-path clicks from opening the selection popup

### DIFF
--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -5269,6 +5269,24 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
               }, 30);
               return fid;
             }
+            if (String(arg("message") ?? "").includes("CLIPBOARDIMAGE")) {
+              setTimeout(() => {
+                emit("agent", { kind: "User", frame_id: fid, text: msg });
+                emit("agent", {
+                  kind: "Text",
+                  frame_id: fid,
+                  delta: [
+                    "Saved the screenshots as local files for this turn.",
+                    "",
+                    '<image name="clipboard-preview.png" path="C:\\Users\\Alice\\AppData\\Local\\Temp\\clipboard-preview.png"></image>',
+                    "",
+                    '<image name="clipboard-preview-2.png" path="C:\\Users\\Alice\\AppData\\Local\\Temp\\clipboard-preview-2.png"></image>',
+                  ].join("\n"),
+                });
+                emit("agent", { kind: "Done", frame_id: fid });
+              }, 30);
+              return fid;
+            }
             if (String(arg("message") ?? "").includes("ARTIFACTATTRIBUTION")) {
               setTimeout(() => {
                 emit("agent", { kind: "User", frame_id: fid, text: msg });

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -3856,6 +3856,39 @@ test("side chat stays at the latest message after sending and switching tabs", a
   await expect.poll(bottomGap).toBeLessThan(8);
 });
 
+test("clicking a PNG path opens the image preview without the selection popup", async ({ page }) => {
+  await enterApp(page);
+  await composer(page).fill("CLIPBOARDIMAGE");
+  await page.getByRole("button", { name: "Send" }).click();
+
+  const reply = page.locator(".msg.assistant", { hasText: "Saved the screenshots as local files" });
+  await expect(reply).toBeVisible({ timeout: 10_000 });
+  const pathLink = reply.locator("a", { hasText: "clipboard-preview.png" }).first();
+  await expect(pathLink).toBeVisible();
+
+  // Clicking a long Windows path often selects the link label. mouseup used to
+  // treat that leftover selection as a quote and stack the popup on the preview.
+  await pathLink.evaluate((el) => {
+    const range = document.createRange();
+    range.selectNodeContents(el);
+    const selection = window.getSelection()!;
+    selection.removeAllRanges();
+    selection.addRange(range);
+    el.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, cancelable: true, button: 0 }));
+  });
+  await expect(page.locator(".selection-popup")).toHaveCount(0);
+
+  await pathLink.click();
+  const modal = page.locator(".artifact-modal");
+  await expect(modal).toBeVisible();
+  await expect(modal.locator(".am-name")).toHaveText("clipboard-preview.png");
+  await expect(page.locator(".selection-popup")).toHaveCount(0);
+
+  await page.keyboard.press("Escape");
+  await expect(modal).toHaveCount(0);
+  await expect(reply).toBeVisible();
+});
+
 test("transcript selections add to the main composer without closing the right pane", async ({ page }) => {
   await enterApp(page);
   await composer(page).fill("STEPSDEMO");

--- a/ui/src/context_menu.rs
+++ b/ui/src/context_menu.rs
@@ -194,6 +194,24 @@ pub(crate) fn uses_native_text_menu(ev: &web_sys::MouseEvent) -> bool {
         .is_some()
 }
 
+/// True when this mouseup landed on a control that already has a click action
+/// (file/path link, artifact chip, attachment, copy button). A click that
+/// happens to select the control's own label must not also raise the quote
+/// popup on top of the preview or other action that click opens.
+pub(crate) fn selection_popup_blocked(ev: &web_sys::MouseEvent) -> bool {
+    event_element(ev)
+        .and_then(|target| closest(&target, "a, button"))
+        .is_some()
+}
+
+fn event_element(ev: &web_sys::MouseEvent) -> Option<web_sys::Element> {
+    let target = ev.target()?;
+    if let Ok(el) = target.clone().dyn_into::<web_sys::Element>() {
+        return Some(el);
+    }
+    target.dyn_into::<web_sys::Node>().ok()?.parent_element()
+}
+
 pub(crate) fn selection_text() -> Option<String> {
     let win = web_sys::window()?;
     let sel = win.get_selection().ok().flatten()?;

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -8421,6 +8421,15 @@ fn App() -> impl IntoView {
         if in_popup {
             return;
         }
+        // File links and buttons own the click (image preview, artifact chip).
+        // Do not also raise the quote bar from a leftover selection of the
+        // control's label — that stacks on top of the preview.
+        if context_menu::selection_popup_blocked(&ev) {
+            if matches!(selection_popup.get_untracked(), Some((_, Some(_), _, _))) {
+                selection_popup.set(None);
+            }
+            return;
+        }
         let json = preview_selection();
         if json.is_empty() {
             if matches!(selection_popup.get_untracked(), Some((_, Some(_), _, _))) {
@@ -10489,6 +10498,13 @@ fn App() -> impl IntoView {
                     // the popup on top of the context menu. Also honors the
                     // "selection quick actions" setting.
                     if ev.button() != 0 {
+                        return;
+                    }
+                    // Clicking a path/file link opens the preview on `click`.
+                    // mouseup runs first and must not treat the link text as a
+                    // quote selection, or both overlays appear together.
+                    if context_menu::selection_popup_blocked(&ev) {
+                        selection_popup.set(None);
                         return;
                     }
                     let popup = selection_popup_enabled

--- a/ui/src/text.rs
+++ b/ui/src/text.rs
@@ -1772,6 +1772,15 @@ mod md_catalog_tests {
     }
 
     #[test]
+    fn rewrites_windows_clipboard_image_tags_to_clickable_links() {
+        let src = r#"<image name="clipboard-preview.png" path="C:\Users\Alice\AppData\Local\Temp\clipboard-preview.png"></image>"#;
+        let html = md_to_html(src);
+        assert!(html.contains("clipboard-preview.png"), "{html}");
+        assert!(html.contains("<a href="), "{html}");
+        assert!(!html.contains("<image"), "{html}");
+    }
+
+    #[test]
     fn renders_dollar_math_as_math_spans() {
         let html = md_to_html("质能方程 $E = mc^2$ 成立。\n\n$$\\int_0^1 x^2 dx$$\n");
         assert!(


### PR DESCRIPTION
## Problem

Clicking a local image path in chat (for example a Windows temp PNG link) opened the image preview **and** the selection quick-actions bar at the same time.

`mouseup` on the transcript runs before `click`. A click on a long path often selects the link label; that leftover selection was treated as a quote, so the quote bar stacked on top of the preview (`z-index` 130 vs modal overlay 100).

## Changes

- `selection_popup_blocked`: skip the quote bar when `mouseup` lands on a control that already has a click action (`a` or `button` — file/path links, artifact chips, attachments, copy).
- Applied in the chat `mouseup` handler and the window-level file-preview selection handler.
- Ordinary prose selections still raise the quote bar.

## Tests

- Playwright: click a fixture PNG path with the link text selected; preview opens, selection popup stays closed; Escape closes only the modal.
- Playwright: transcript prose selection still adds to the composer.
- Unit: Windows `<image path="...">` tags still rewrite to clickable links.

`cargo fmt --all -- --check`, `cd ui && cargo check --target wasm32-unknown-unknown`, `cargo test --manifest-path ui/Cargo.toml rewrites_windows_clipboard`, and the two Playwright tests above passed.

## Manual smoke

1. Open a conversation whose reply contains a clickable local `.png` path.
2. Click the path once. The image preview should open; the selection quick-actions bar should not.
3. Select ordinary prose in the same reply. The quote bar should still appear.

## Limitations / follow-up

- Drag-selecting text and releasing on a link/button also suppresses the quote bar. Right-click still offers the same actions. Release next to the link to quote a passage that ends on a path.