### PR TITLE
fix(ui): keep quote popup alive through follow-scroll

### DIFF
--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -147,10 +147,14 @@ async function selectAssistantReplyText(
     const selection = window.getSelection()!;
     selection.removeAllRanges();
     selection.addRange(range);
-    body.dispatchEvent(new MouseEvent(type, {
+    const rect = range.getBoundingClientRect();
+    const target = document.querySelector(".chat") ?? body;
+    target.dispatchEvent(new MouseEvent(type, {
       bubbles: true,
       cancelable: true,
       button: type === "contextmenu" ? 2 : 0,
+      clientX: rect.left + rect.width / 2,
+      clientY: rect.top + Math.min(rect.height / 2, 12),
     }));
     return node.data.trim();
   }, eventType);
@@ -4321,8 +4325,15 @@ test("selected text can be staged as a removable side-chat quote", async ({ page
   await page.getByRole("button", { name: "Send" }).click();
   await expect(page.getByText(/60,675 genes/)).toBeVisible({ timeout: 10_000 });
 
+  await expect(page.getByRole("button", { name: "Hide follow-up questions" })).toBeVisible();
   const selected = await selectAssistantReplyText(page);
   const popup = page.locator(".selection-popup");
+  await expect(popup.getByRole("button", { name: "Quote in side chat" })).toBeVisible();
+  // Follow-scroll / composer resize must not steal the popup while the
+  // selection is still live — that is what failed ui-e2e on #1027.
+  await page.locator(".chat").evaluate((el) => {
+    el.scrollTop = Math.max(0, el.scrollTop - 8);
+  });
   await expect(popup.getByRole("button", { name: "Quote in side chat" })).toBeVisible();
   await popup.getByRole("button", { name: "Quote in side chat" }).click();
 

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -8482,6 +8482,14 @@ fn App() -> impl IntoView {
         focus_composer();
     });
 
+    // User-initiated scroll (wheel/trackpad) — not follow-scroll — should
+    // hide the fixed quote popup, whose client coordinates are now stale.
+    window_event_listener(ev::wheel, move |_| {
+        if selection_popup.get_untracked().is_some() {
+            selection_popup.set(None);
+        }
+    });
+
     // Dismiss the selection popup on any press outside it: starting a new
     // selection, clicking the composer, or clicking elsewhere in the app.
     window_event_listener(ev::mousedown, move |ev| {
@@ -10508,7 +10516,12 @@ fn App() -> impl IntoView {
                     selection_popup.set(popup);
                 }
                 on:scroll=move |_| {
-                    if selection_popup.get_untracked().is_some() {
+                    // Follow-scroll (follow-ups, the runtime strip remounting)
+                    // used to dismiss the quote popup while the selection was
+                    // still live. Only clear it when the selection is gone.
+                    if selection_popup.get_untracked().is_some()
+                        && context_menu::selection_text().is_none()
+                    {
                         selection_popup.set(None);
                     }
                 }>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

#1030 stopped the runtime strip from remounting on no-op context refreshes, but follow-up chips and other chat follow-scroll still dismissed the selection popup while the highlight was live. That is the same `element was detached` failure as #1027.

This commit landed on `cursor/fix-chat-runtime-e2e-46a0` after #1030 merged, so it still needs to land on `main`.

## Changes

- Dismiss the quote popup on user wheel, not on follow-scroll, while a selection remains.
- Pin the Playwright selection to the text’s client coordinates and wait for follow-ups before quoting.
- Assert a programmatic chat scroll does not hide Quote.

## Tests

- Playwright: `selected text can be staged as a removable side-chat quote` (3×), other STEPSDEMO selection tests, highlight popup Escape

## Manual smoke

1. Send a turn, wait for follow-ups, select assistant text. Quote should stay if the thread follow-scrolls.
2. Wheel the transcript: popup closes. Click Quote: side chat gets the excerpt.

## Limitations / follow-up

- Scrollbar-drag without a wheel event still leaves the popup in place (coordinates may be stale).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ee2f4b1-9e75-421f-a94e-1ed9fce046a0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ee2f4b1-9e75-421f-a94e-1ed9fce046a0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

