### PR TITLE
fix(ui): auto-refresh R/Python runtime status and memory environment after agent cells

### DIFF
--- a/crates/wisp-dto/src/lib.rs
+++ b/crates/wisp-dto/src/lib.rs
@@ -4135,7 +4135,7 @@ pub struct RuntimeKeyDto {
     pub language: String,
 }
 
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct RuntimeInfo {
     pub runtime_id: String,

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -5260,6 +5260,32 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
                 }, 12_000);
               });
             }
+            if (String(arg("message") ?? "").includes("RAUTOREFRESH")) {
+              // An agent `r` cell lazily revives the dead local R runtime and
+              // finishes; the open memory environment must follow without a
+              // manual sync click.
+              setTimeout(() => {
+                emit("agent", { kind: "User", frame_id: fid, text: msg });
+                emit("agent", { kind: "ToolCall", frame_id: fid, name: "r", preview: "[r @ local] x <- rnorm(10)" });
+                const local = runtimeInfos.find((item) =>
+                  item.key.projectId === "default"
+                  && item.key.contextId === "local"
+                  && item.key.language === "r"
+                );
+                if (local) {
+                  local.runtimeId = `runtime-r-local-${Date.now()}`;
+                  local.generation += 1;
+                  local.status = "ready";
+                  local.processId = 5501;
+                  local.lastActivityAtMs = Date.now();
+                  local.lastError = null;
+                }
+                emit("agent", { kind: "ToolResult", frame_id: fid, name: "r", ok: true, content: "(no output)" });
+                emit("agent", { kind: "Text", frame_id: fid, delta: "Created x in the R session." });
+                emit("agent", { kind: "Done", frame_id: fid });
+              }, 30);
+              return fid;
+            }
             if (String(arg("message") ?? "").includes("RNOTEBOOK")) {
               setTimeout(() => {
                 emit("agent", { kind: "User", frame_id: fid, text: msg });

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -7110,6 +7110,36 @@ test("conversation runtime strip shows bound servers and opens R/Python environm
   await expect(page.getByRole("region", { name: "R Environment" })).toBeVisible();
 });
 
+test("an agent r cell refreshes the open R memory environment without manual sync", async ({ page }) => {
+  await enterApp(page);
+  const strip = page.getByTestId("session-runtime-strip");
+  const rChip = strip.locator('[data-runtime-language="r"][data-runtime-context="local"]');
+  await expect(rChip).toContainText("Dead");
+  await rChip.click();
+  const environment = page.getByRole("region", { name: "R Environment" });
+  await expect(environment).toBeVisible();
+  // Dead runtime: nothing to inspect yet, so the table stays empty.
+  await expect(environment.locator(".runtime-environment-row")).toHaveCount(0);
+  const inspectsBeforeTurn = await invokeCount(page, "inspect_runtime");
+
+  // Pin the panel so it floats next to the conversation, then let the agent
+  // run an R cell that lazily restarts the runtime.
+  await environment.getByRole("button", { name: "Pin environment to conversation" }).click();
+  await composer(page).fill("RAUTOREFRESH seed the session");
+  await page.getByRole("button", { name: "Send" }).click();
+
+  // The finished tool call alone must refresh the status chip and re-inspect
+  // the open panel — no manual sync click.
+  await expect(rChip).toContainText("Ready");
+  await expect(environment.locator(".runtime-environment-row", { hasText: "counts" })).toBeVisible();
+  expect(await invokeCount(page, "inspect_runtime")).toBeGreaterThan(inspectsBeforeTurn);
+  await expect.poll(() => lastInvokeArgs(page, "inspect_runtime")).toMatchObject({
+    projectId: "default",
+    contextId: "local",
+    language: "r",
+  });
+});
+
 test("runtime environment switches language and filters objects", async ({ page }) => {
   await enterApp(page);
   await page.getByTestId("session-runtime-strip")

--- a/ui/src/app_support/runtime.rs
+++ b/ui/src/app_support/runtime.rs
@@ -69,11 +69,64 @@ fn run_lists_render_eq(current: &[RunSummary], next: &[RunSummary]) -> bool {
         })
 }
 
+async fn fetch_runtimes(into: RwSignal<Vec<RuntimeInfo>>) -> Option<Vec<RuntimeInfo>> {
+    let value = invoke("list_runtimes", JsValue::UNDEFINED).await;
+    let list = serde_wasm_bindgen::from_value::<Vec<RuntimeInfo>>(value).ok()?;
+    // This is polled every second while the agent runs. A no-op republish
+    // rebuilds the memory environment panel, which recreates its filter input
+    // mid-keystroke; only real changes may publish.
+    if into.with_untracked(|current| current != &list) {
+        into.set(list.clone());
+    }
+    Some(list)
+}
+
 pub(crate) fn refresh_runtimes(into: RwSignal<Vec<RuntimeInfo>>) {
     spawn_local(async move {
-        let value = invoke("list_runtimes", JsValue::UNDEFINED).await;
-        if let Ok(list) = serde_wasm_bindgen::from_value::<Vec<RuntimeInfo>>(value) {
-            into.set(list);
+        let _ = fetch_runtimes(into).await;
+    });
+}
+
+/// After an agent `python`/`r` cell finishes: pull the runtime list (the cell
+/// may have lazily started or killed a process) and, when the open memory
+/// environment shows that language, re-inspect it so its variable table
+/// follows the agent without a manual sync click. The inspect is gated on the
+/// *fresh* status — the signal the panel had could still say `missing` for a
+/// runtime the cell just created, and inspecting a truly absent runtime would
+/// replace the panel's content with a "not started" error.
+pub(crate) fn refresh_runtime_environment_after_tool(
+    language: String,
+    runtime_environment: RwSignal<Option<RuntimeSlot>>,
+    states: RwSignal<HashMap<String, RuntimeObjectState>>,
+    runtimes: RwSignal<Vec<RuntimeInfo>>,
+    locale: RwSignal<Locale>,
+) {
+    spawn_local(async move {
+        let Some(list) = fetch_runtimes(runtimes).await else {
+            return;
+        };
+        let Some(slot) = runtime_environment.get_untracked() else {
+            return;
+        };
+        if slot.language != language {
+            return;
+        }
+        let inspectable = list.iter().any(|info| {
+            info.key.project_id == slot.project_id
+                && info.key.context_id == slot.context_id
+                && info.key.language == slot.language
+                && matches!(info.status.as_str(), "ready" | "busy")
+        });
+        if inspectable {
+            inspect_runtime_objects(
+                runtime_binding_state_key(&slot.project_id, &slot.context_id, &slot.language),
+                slot.project_id,
+                slot.context_id,
+                slot.language,
+                locale,
+                states,
+                runtimes,
+            );
         }
     });
 }
@@ -888,18 +941,17 @@ pub(crate) fn open_runtime_environment(
         .info
         .as_ref()
         .is_some_and(|info| matches!(info.status.as_str(), "ready" | "busy"));
-    let inspect_runtime_id = slot
-        .info
-        .as_ref()
-        .map(|info| info.runtime_id.clone())
-        .unwrap_or_default();
+    // Key object snapshots by the stable binding, not the process runtime id:
+    // the panel then keeps showing data across lazy starts and restarts, and
+    // agent-driven refreshes land where the panel reads.
+    let inspect_key = runtime_binding_state_key(&slot.project_id, &slot.context_id, &slot.language);
     let inspect_project = slot.project_id.clone();
     let inspect_context = slot.context_id.clone();
     let inspect_language = slot.language.clone();
     runtime_environment.set(Some(slot));
     if can_inspect {
         inspect_runtime_objects(
-            inspect_runtime_id,
+            inspect_key,
             inspect_project,
             inspect_context,
             inspect_language,
@@ -1207,11 +1259,15 @@ pub(crate) fn RuntimeEnvironmentPanel(
         let language_label = if slot.language == "r" { "R" } else { "Python" };
         let status = slot_status(&slot);
         let status_class = format!("runtime-status {status}");
-        let runtime_id = slot.info.as_ref().map(|info| info.runtime_id.clone()).unwrap_or_default();
+        // The binding key survives the process: a runtime the agent lazily
+        // started (or restarted) mid-conversation publishes its inspection
+        // under the same key this panel reads.
+        let state_key = runtime_binding_state_key(&slot.project_id, &slot.context_id, &slot.language);
+        let has_runtime = slot.info.is_some();
         let can_refresh = status == "ready";
-        let refresh_runtime_id = runtime_id.clone();
-        let loading_runtime_id = runtime_id.clone();
-        let content_runtime_id = runtime_id;
+        let refresh_state_key = state_key.clone();
+        let loading_state_key = state_key.clone();
+        let content_state_key = state_key;
         let refresh_project = slot.project_id.clone();
         let refresh_context = slot.context_id.clone();
         let refresh_language = slot.language.clone();
@@ -1356,10 +1412,10 @@ pub(crate) fn RuntimeEnvironmentPanel(
                         title=t(locale.get(), "runtime.inspect_objects")
                         aria-label=t(locale.get(), "runtime.inspect_objects")
                         disabled=move || !can_refresh || states.with(|states| {
-                            states.get(&loading_runtime_id).is_some_and(|state| state.loading)
+                            states.get(&loading_state_key).is_some_and(|state| state.loading)
                         })
                         on:click=move |_| inspect_runtime_objects(
-                            refresh_runtime_id.clone(),
+                            refresh_state_key.clone(),
                             refresh_project.clone(),
                             refresh_context.clone(),
                             refresh_language.clone(),
@@ -1392,14 +1448,17 @@ pub(crate) fn RuntimeEnvironmentPanel(
                 </div>
                 <div class="runtime-environment-body">
                     {move || {
-                        if content_runtime_id.is_empty() {
+                        let state = states.with(|states| {
+                            states.get(&content_state_key).cloned().unwrap_or_default()
+                        });
+                        // No process and nothing inspected yet: a last-known
+                        // snapshot (from before a stop or crash) stays visible
+                        // next to the status chip instead of vanishing.
+                        if !has_runtime && state.snapshot.is_none() && state.error.is_none() {
                             return view! {
                                 <div class="runtime-environment-empty">{t(locale.get(), "runtime.environment_unavailable")}</div>
                             }.into_view();
                         }
-                        let state = states.with(|states| {
-                            states.get(&content_runtime_id).cloned().unwrap_or_default()
-                        });
                         if state.loading && state.snapshot.is_none() {
                             return view! {
                                 <div class="runtime-environment-empty">{t(locale.get(), "runtime.objects_loading")}</div>

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -1726,6 +1726,12 @@ fn App() -> impl IntoView {
     // Declared up here (not with the other context-view signals) so the
     // composer @ menu can offer servers and runtimes alongside artifacts.
     let execution_contexts = create_rw_signal::<Vec<ExecutionContext>>(vec![]);
+    // Also up here: the agent event handler below refreshes runtime status and
+    // the open memory environment after each finished python/r tool call.
+    let runtime_infos = create_rw_signal::<Vec<RuntimeInfo>>(vec![]);
+    let runtime_environment = create_rw_signal(None::<RuntimeSlot>);
+    let runtime_object_states =
+        create_rw_signal::<HashMap<String, RuntimeObjectState>>(HashMap::new());
     create_effect(move |_| {
         let Some(mode) = picker_mode.get() else {
             return;
@@ -2612,6 +2618,21 @@ fn App() -> impl IntoView {
                 refresh_transcript_projections(&frame_id);
                 if active_cb.get_untracked().as_deref() == Some(frame_id.as_str()) {
                     schedule_chat_follow();
+                }
+                // A finished python/r cell changed interpreter state. Refresh
+                // the runtime status chips and, when the memory environment
+                // for that language is open, re-inspect it so the variable
+                // table follows the agent without a manual sync click.
+                if matches!(name.as_str(), "python" | "r")
+                    && active_cb.get_untracked().as_deref() == Some(frame_id.as_str())
+                {
+                    refresh_runtime_environment_after_tool(
+                        name.clone(),
+                        runtime_environment,
+                        runtime_object_states,
+                        runtime_infos,
+                        locale,
+                    );
                 }
             }
             AgentEvent::ToolPresentation {
@@ -6845,12 +6866,8 @@ fn App() -> impl IntoView {
         }
         current
     });
-    let runtime_environment = create_rw_signal(None::<RuntimeSlot>);
     let runtime_environment_pinned = create_rw_signal(false);
     let runtime_environment_position = create_rw_signal((16, 16));
-    let runtime_infos = create_rw_signal::<Vec<RuntimeInfo>>(vec![]);
-    let runtime_object_states =
-        create_rw_signal::<HashMap<String, RuntimeObjectState>>(HashMap::new());
     let run_clock = create_rw_signal(now_secs());
     // The transfer tray needs the shared clock only while the active session
     // has an active or briefly lingering transfer. Once the last card expires,
@@ -7247,7 +7264,14 @@ fn App() -> impl IntoView {
     }
     {
         let refresh = Closure::wrap(Box::new(move || {
-            if show_right.get_untracked() && right_tab.get_untracked() == RightTab::Hosts {
+            // While a turn runs, agent python/r cells move runtimes between
+            // starting/busy/ready outside any UI action; poll so the composer
+            // strip and memory environment status stay current. The equality
+            // guard in refresh_runtimes keeps unchanged polls from
+            // republishing (and re-rendering) anything.
+            if busy.get_untracked()
+                || (show_right.get_untracked() && right_tab.get_untracked() == RightTab::Hosts)
+            {
                 refresh_runtimes(runtime_infos);
             }
         }) as Box<dyn FnMut()>);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Follow-up to #1027: the R runtime's state was not refreshed in time. After the agent ran R code, the composer strip kept showing a stale status and the memory environment stayed empty until the user clicked the manual sync button.

Two gaps caused this:

- `list_runtimes` was only polled while the right-pane Hosts tab was open, and nothing refreshed after an agent `python`/`r` tool call finished.
- The memory environment keyed its object snapshots by the process runtime id. A runtime the agent lazily started mid-conversation had no id when the panel opened, so even a fresh inspection landed under a key the panel never read.

## Changes

- After each finished `python`/`r` tool call on the active conversation, fetch the runtime list and re-inspect the open memory environment for that language (`refresh_runtime_environment_after_tool`). The inspect is gated on the freshly fetched ready/busy status so a truly absent runtime never replaces the panel with a "not started" error.
- Poll `list_runtimes` once a second while a turn is running, not only while the Hosts tab is open, so starting/busy/ready transitions show live in the strip.
- `refresh_runtimes` skips no-op republishes (`RuntimeInfo` now derives `PartialEq` in `wisp-dto`), so the per-second polling cannot rebuild the panel and drop the filter input mid-keystroke.
- The memory environment keys snapshots by the stable `binding:{project}:{context}:{language}` key, the same one the center-file inspector already uses. Inspections of lazily started or restarted processes land where the panel reads, and a last-known snapshot stays visible next to the status chip if the process dies.

## Tests

- New Playwright regression: `an agent r cell refreshes the open R memory environment without manual sync` — opens the dead local R environment, lets a mock agent `r` cell revive the runtime, and asserts the status chip flips to Ready and the variable table fills with no sync click.
- `cargo fmt --all -- --check` (both workspaces), `cd ui && cargo check --target wasm32-unknown-unknown`, `cargo test --bin wisp-ui` (298 passed), `cargo check --workspace`, and the full runtime Playwright suite (11 tests) passed.

## Manual smoke

1. Open a conversation and click the R chip in the composer strip while the R runtime has never started.
2. Ask the agent to run R code that creates a variable.
3. The chip should move through Busy to Ready and the memory environment should list the new variable without clicking sync.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8e581fc1-9b46-43ef-87a2-b6d8f188ad05?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e581fc1-9b46-43ef-87a2-b6d8f188ad05&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

