### PR TITLE
fix(ui): slim R/Python source selection popup

### DIFF
--- a/docs/agent-delegation.md
+++ b/docs/agent-delegation.md
@@ -71,11 +71,13 @@ selections after reload. Removed or unavailable templates fail closed instead
 of silently falling back to an invented plan.
 
 The first built-in action is **Research literature**. Select text in a
-conversation or file preview, then choose the action from the floating
-selection toolbar or the right-click menu. Wisp attaches the selection and the
-`literature-review` Skill to the current composer, adds an editable prompt that
-asks for verified supporting and conflicting evidence, and focuses the
-composer. Review or extend the request, then send it normally. The Agent's
+conversation or a non-code file preview, then choose the action from the
+floating selection toolbar or the right-click menu. R and Python source
+selections keep Run / Ask AI / quote / explain instead. Wisp attaches the
+selection and the `literature-review` Skill to the current composer, adds an
+editable prompt that asks for verified supporting and conflicting evidence,
+and focuses the composer. Review or extend the request, then send it
+normally. The Agent's
 tool activity, progress, interruptions, and result now use the current
 conversation instead of a separate side-panel lifecycle, so switching away
 after sending and returning does not discard the research transcript.

--- a/src-tauri/src/run_context/tests.rs
+++ b/src-tauri/src/run_context/tests.rs
@@ -2989,12 +2989,17 @@ impl RunCommandRunner for RefuseCollectRunner {
 async fn ssh_harvest_collect_renews_parent_lease_past_expiry() {
     let tmp = std::env::temp_dir().join(format!("wisp_ssh_harvest_lease_{}", uuid::Uuid::new_v4()));
     std::fs::create_dir_all(&tmp).unwrap();
-    let store = seed_active_harvest_run(&tmp, "run-lease", "test-owner", 1).await;
+    // `lifecycle_lease_until` is a unix-second timestamp. A 1s lease can
+    // expire in 1ms if activation lands at the end of a second, so harvest
+    // startup on a loaded CI runner loses it before the renewer runs.
+    // Two seconds always covers startup; collect is held longer so the
+    // original lease would expire without renewal.
+    let store = seed_active_harvest_run(&tmp, "run-lease", "test-owner", 2).await;
     let runner = HarvestFakeRunner {
         manifest: remote_only_manifest("run-lease"),
         files: Vec::new(),
         commands: StdMutex::new(Vec::new()),
-        collect_hold: Some(Duration::from_millis(1500)),
+        collect_hold: Some(Duration::from_millis(2500)),
     };
     let remote = harvest_test_remote("run-lease", &tmp, remote_only_harvest_spec());
 

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -5243,7 +5243,16 @@ test("R scripts expose variables and console while only selected code can run", 
     selection.addRange(range);
     window.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, cancelable: true }));
   });
-  await page.locator(".selection-popup").getByRole("button", { name: "Run in runtime" }).click();
+  const popup = page.locator(".selection-popup");
+  await expect(popup.getByRole("button")).toHaveText([
+    "Run in runtime",
+    "Ask AI in the conversation",
+    "Quote in side chat",
+    "Explain in side chat",
+  ]);
+  await expect(popup.getByRole("button", { name: "Research literature" })).toHaveCount(0);
+  await expect(popup.getByRole("button", { name: "Add to review" })).toHaveCount(0);
+  await popup.getByRole("button", { name: "Run in runtime" }).click();
   await expect.poll(() => lastInvokeArgs(page, "execute_runtime")).toMatchObject({
     contextId: "ssh:gpu-server",
     language: "r",

--- a/ui/src/context_menu.rs
+++ b/ui/src/context_menu.rs
@@ -4,6 +4,7 @@ use crate::app_support::{
 };
 use crate::dto::QuickAction;
 use crate::i18n::{self, Locale};
+use crate::text::is_runtime_code_selection;
 use crate::window_capture_escape;
 use leptos::*;
 use wasm_bindgen::prelude::*;
@@ -549,8 +550,9 @@ pub fn build(
         closest(&target, ".fb-row, .rp-tile, .side-item.ses, .side-folder").is_some();
     if text_entry.is_none() && !on_structural_row {
         if let Some(text) = selection_text() {
-            // Mirror the selection popup's quote/explain actions so right-click
-            // offers everything in one menu instead of stacking popups.
+            // Mirror the selection popup so right-click offers the same
+            // destinations instead of stacking overlays. R/Python source
+            // keeps quote/explain and skips literature/review actions.
             let source = closest(&target, "[data-file-path]")
                 .and_then(|el| el.get_attribute("data-file-path"))
                 .filter(|source| !source.is_empty());
@@ -569,22 +571,24 @@ pub fn build(
                     quote_payload,
                 ),
             ];
-            items.extend(
-                quick_actions
-                    .iter()
-                    .filter(|action| action.enabled && action.context == "selection")
-                    .map(|action| {
-                        item(
-                            "runQuickAction",
-                            crate::app_support::quick_action_label(locale, action),
-                            format!(
-                                "{}\u{1e}{}\u{1e}{text}",
-                                action.id,
-                                source.as_deref().unwrap_or_default()
-                            ),
-                        )
-                    }),
-            );
+            if !is_runtime_code_selection(source.as_deref()) {
+                items.extend(
+                    quick_actions
+                        .iter()
+                        .filter(|action| action.enabled && action.context == "selection")
+                        .map(|action| {
+                            item(
+                                "runQuickAction",
+                                crate::app_support::quick_action_label(locale, action),
+                                format!(
+                                    "{}\u{1e}{}\u{1e}{text}",
+                                    action.id,
+                                    source.as_deref().unwrap_or_default()
+                                ),
+                            )
+                        }),
+                );
+            }
             items.push(item(
                 "explainSelection",
                 i18n::t(locale, "selection.explain"),

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -75,9 +75,9 @@ use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 use text::{
     dom_value, event_target_checked, event_target_value, file_kind, format_bytes,
-    group_artifact_indices, ime_composing, join_path, md_to_html, note_composition_end,
-    opens_in_system_browser, parent_path, provider_defaults, runtime_language,
-    user_message_presentation, DEEPSEEK_FLASH_MODEL, DEEPSEEK_PRO_MODEL,
+    group_artifact_indices, ime_composing, is_runtime_code_selection, join_path, md_to_html,
+    note_composition_end, opens_in_system_browser, parent_path, provider_defaults,
+    runtime_language, user_message_presentation, DEEPSEEK_FLASH_MODEL, DEEPSEEK_PRO_MODEL,
 };
 use trajectory::TrajectoryOverlay;
 use wasm_bindgen::prelude::*;
@@ -8408,7 +8408,8 @@ fn App() -> impl IntoView {
     });
 
     // Selecting text inside any file preview (tagged `data-file-path`) raises the
-    // same quote popup the chat uses, plus an "annotate" action. Runs on window
+    // same quote popup the chat uses. Papers also get annotate / literature;
+    // R/Python source gets Run instead. Runs on window
     // so it covers the center preview, the artifact modal, and the right pane
     // uniformly. Fires after the chat's own element handler during bubbling, so
     // it only clears/replaces a *preview* popup (source == Some) and never stomps
@@ -10322,11 +10323,17 @@ fn App() -> impl IntoView {
                 let star_text = source.is_none().then(|| text.clone());
                 // Run the selection in the file's bound runtime — the RStudio
                 // reflex. Only for R/Python sources, where a runtime exists.
+                let runtime_source = is_runtime_code_selection(source.as_deref());
                 let run_selection = source.as_deref()
                     .and_then(runtime_language)
                     .map(|language| (source.clone().unwrap_or_default(), language, text));
+                let popup_class = if runtime_source {
+                    "selection-popup selection-popup-code"
+                } else {
+                    "selection-popup"
+                };
                 view! {
-                    <div class="selection-popup" style=format!("left:{x}px;top:{y}px")>
+                    <div class=popup_class style=format!("left:{x}px;top:{y}px")>
                         {star_text.map(|text| view! {
                             <button type="button" class="selection-popup-btn"
                                 on:click=move |_| {
@@ -10385,7 +10392,10 @@ fn App() -> impl IntoView {
                                 </button>
                             }
                         })}
-                        {quick_actions.get().into_iter()
+                        {runtime_source.then(|| view! {
+                            <span class="selection-popup-sep" aria-hidden="true"></span>
+                        })}
+                        {(!runtime_source).then(|| quick_actions.get().into_iter()
                             .filter(|action| action.enabled && action.context == "selection")
                             .map(|action| {
                             let action_id = action.id.clone();
@@ -10407,7 +10417,7 @@ fn App() -> impl IntoView {
                                     <span>{label}</span>
                                 </button>
                             }
-                            }).collect_view()}
+                            }).collect_view())}
                         <button type="button" class="selection-popup-btn"
                             on:click=move |_| {
                                 composer_quotes.update(|items| items.push(
@@ -10468,13 +10478,13 @@ fn App() -> impl IntoView {
                                     false,
                                 ));
                             }>
-                            {compose_icon("chat")}
+                            {compose_icon("sparkles")}
                             <span>{t(locale.get(), "selection.explain")}</span>
                         </button>
                         // Annotate → append the passage to reviews/<file>.md, which the
-                        // agent reads back with its ordinary tools. Only offered when the
-                        // selection came from a file preview (source path known).
-                        {annotate_source.map(|src| {
+                        // agent reads back with its ordinary tools. Offered on papers
+                        // and other previews, not on R/Python source (run/ask/quote).
+                        {annotate_source.filter(|_| !runtime_source).map(|src| {
                             let quote = annotate_text.clone();
                             view! {
                                 <button type="button" class="selection-popup-btn"

--- a/ui/src/styles/chat.css
+++ b/ui/src/styles/chat.css
@@ -1255,6 +1255,10 @@ details.tool:not([open]) > summary.head .run-dot { animation: tool-pulse 1.1s ea
   box-shadow: var(--shadow); transform: translate(-50%, calc(-100% - 10px));
   animation: selection-popup-in var(--motion-duration-fast) var(--motion-ease-decelerate) both;
 }
+.selection-popup-code { flex-wrap: nowrap; }
+.selection-popup-sep {
+  flex: 0 0 1px; align-self: stretch; margin: 3px 4px; background: var(--border-strong);
+}
 .selection-popup-btn {
   display: inline-flex; align-items: center; gap: 6px; padding: 5px 10px; border: none; border-radius: var(--radius-xs);
   background: transparent; color: var(--text); font: inherit; font-size: 12.5px; font-weight: 500;

--- a/ui/src/text.rs
+++ b/ui/src/text.rs
@@ -1421,6 +1421,13 @@ pub(crate) fn runtime_language(path: &str) -> Option<&'static str> {
     }
 }
 
+/// R/Python source selections keep the runtime-centric popup (run, ask AI,
+/// quote, explain). Literature research and review notes belong on papers
+/// and chat, not on executable source.
+pub(crate) fn is_runtime_code_selection(source: Option<&str>) -> bool {
+    source.and_then(runtime_language).is_some()
+}
+
 pub(crate) fn file_kind(path: &str) -> Option<&'static str> {
     let (_, ext) = path.rsplit_once('.')?;
     if ext.is_empty() {
@@ -1537,8 +1544,8 @@ pub(crate) fn fasta_seq_count(text: &str) -> usize {
 mod md_catalog_tests {
     use super::{
         code_lang, decode_href, fence_identifier_line_runs, file_kind, format_bytes,
-        md_document_to_html, md_inline_to_html, md_to_html, parent_path, parse_notebook,
-        pretty_json, push_nb_output, runtime_language, strip_ansi, tool_card_label,
+        is_runtime_code_selection, md_document_to_html, md_inline_to_html, md_to_html, parent_path,
+        parse_notebook, pretty_json, push_nb_output, runtime_language, strip_ansi, tool_card_label,
         user_message_presentation, NbOutput, MAX_NB_OUTPUT_BYTES, MAX_NB_TOTAL_OUTPUT_BYTES,
     };
 
@@ -2016,6 +2023,18 @@ mod md_catalog_tests {
         assert_eq!(runtime_language("main.rs"), None);
         assert_eq!(runtime_language("notes.md"), None);
         assert_eq!(runtime_language("Makefile"), None);
+    }
+
+    #[test]
+    fn runtime_code_selections_skip_literature_and_review_actions() {
+        assert!(is_runtime_code_selection(Some(
+            "analysis/scripts/mathys2019_umap.R"
+        )));
+        assert!(is_runtime_code_selection(Some("qc.py")));
+        assert!(!is_runtime_code_selection(Some("notes.md")));
+        assert!(!is_runtime_code_selection(Some("paper.pdf")));
+        assert!(!is_runtime_code_selection(Some("artifact:art-markdown")));
+        assert!(!is_runtime_code_selection(None));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Selecting R or Python source opened a two-row floating menu that mixed runtime actions with literature research and Add to review. Those review actions belong on papers and chat, not on executable source.

## Change

For R/Python source selections, the popup and matching right-click menu keep:

- Run in runtime
- Ask AI in the conversation
- Quote in side chat
- Explain in side chat

Literature research and Add to review remain on conversation text, Markdown, PDFs, and other non-runtime previews.

The R/Python popup stays on one row, with a divider after Run and a distinct icon for Explain.

## Files

- `ui/src/text.rs` — `is_runtime_code_selection` helper
- `ui/src/main.rs` — selection popup actions
- `ui/src/context_menu.rs` — right-click menu
- `ui/src/styles/chat.css` — compact code popup
- `ui-tests/tests/ui.spec.ts` — R selection shows exactly those four buttons
- `docs/agent-delegation.md` — Research literature no longer claimed on R/Python source

## Tests

- `cargo test --manifest-path ui/Cargo.toml runtime_code_selections_skip_literature`
- `cargo check --manifest-path ui/Cargo.toml --target wasm32-unknown-unknown`
- Playwright: R runtime selection, Python rebind, literature research (chat), Markdown add-to-review, workspace-code Ask AI

## Smoke

1. Open an `.R` or `.py` file in the center preview.
2. Select a statement — the popup should be a single row: Run | Ask AI / Quote / Explain. No Research literature or Add to review.
3. Right-click the same selection — the context menu should omit Research literature.
4. Select text in chat or a Markdown/PDF preview — Research literature and Add to review still appear.

## Limitations

Custom Quick Actions with `context: selection` are also hidden on R/Python source, same as the built-in literature action.
