### PR TITLE
Files: sort by size or modified time

### DIFF
--- a/crates/wisp-dto/src/lib.rs
+++ b/crates/wisp-dto/src/lib.rs
@@ -2500,6 +2500,8 @@ pub struct DirEntry {
     pub name: String,
     pub is_dir: bool,
     pub size: u64,
+    #[serde(default)]
+    pub modified_unix_millis: Option<u64>,
 }
 
 #[derive(Deserialize, Clone)]

--- a/docs/remote-file-browser.md
+++ b/docs/remote-file-browser.md
@@ -2,7 +2,9 @@
 
 The Files panel can switch between the current local project and registered
 SSH execution contexts. In the local project, its toolbar can create an empty
-file, create a folder, and refresh the current directory. Right-click a local
+file, create a folder, refresh the current directory, and sort entries by
+name, size, or modification time. Sorting by size shows file sizes on the
+right; sorting by time shows each entry's update time there instead. Right-click a local
 file or folder to rename or delete it. These operations are constrained to the
 project root, reject path separators in names, and never overwrite an existing
 entry; deleting a non-empty folder requires an explicit confirmation.
@@ -14,7 +16,8 @@ Selecting an SSH context opens the remote user's home directory and supports:
 - entering an absolute path (or `~` / `~/...`) and pressing Enter;
 - moving to the parent directory;
 - opening child directories;
-- viewing non-hidden file names and sizes;
+- viewing non-hidden file names, sizes, and modification times;
+- sorting the current directory by name, size, or modification time;
 - uploading local files into the current remote folder with the **Upload**
   button or by dropping them onto the Files panel;
 - downloading a remote file through its right-click menu and a native save

--- a/src-tauri/src/file_browser.rs
+++ b/src-tauri/src/file_browser.rs
@@ -29,6 +29,8 @@ pub(super) struct DirEntry {
     name: String,
     is_dir: bool,
     size: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    modified_unix_millis: Option<u64>,
 }
 
 #[derive(Serialize, Clone, Debug, PartialEq, Eq)]
@@ -515,8 +517,20 @@ pub(super) fn list_dir(
     if !dir.is_dir() {
         return Err(format!("'{}' is not a directory", rel));
     }
+    list_dir_entries(&dir)
+}
+
+fn modified_unix_millis(metadata: &std::fs::Metadata) -> Option<u64> {
+    metadata
+        .modified()
+        .ok()
+        .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|duration| duration.as_millis() as u64)
+}
+
+fn list_dir_entries(dir: &Path) -> Result<Vec<DirEntry>, String> {
     let mut entries = vec![];
-    for ent in std::fs::read_dir(&dir).map_err(|e| format!("{e}"))? {
+    for ent in std::fs::read_dir(dir).map_err(|e| format!("{e}"))? {
         let ent = ent.map_err(|e| format!("{e}"))?;
         let meta = ent.metadata().map_err(|e| format!("{e}"))?;
         let name = ent.file_name().to_string_lossy().into_owned();
@@ -527,6 +541,7 @@ pub(super) fn list_dir(
             name,
             is_dir: meta.is_dir(),
             size: meta.len(),
+            modified_unix_millis: modified_unix_millis(&meta),
         });
     }
     entries.sort_by(|a, b| {
@@ -751,6 +766,9 @@ for entry in ./*; do
     continue
   fi
   name=${{entry#./}}
+  mtime=$(stat -c '%Y' "$entry" 2>/dev/null) ||
+    mtime=$(stat -f '%m' "$entry" 2>/dev/null) ||
+    mtime=0
   if [ -d "$entry" ]; then
     kind=d
     size=0
@@ -760,7 +778,7 @@ for entry in ./*; do
       size=$(stat -f '%z' "$entry" 2>/dev/null) ||
       size=0
   fi
-  printf '%s\000%s\000%s\000' "$kind" "$size" "$name"
+  printf '%s\000%s\000%s\000%s\000' "$kind" "$size" "$mtime" "$name"
 done"#
     ))
 }
@@ -803,11 +821,11 @@ fn parse_remote_directory(stdout: &[u8]) -> Result<DirectoryListing, String> {
     } else {
         records
     };
-    if records.len() % 3 != 0 {
+    if records.len() % 4 != 0 {
         return Err("Remote directory response contained an incomplete entry".into());
     }
-    let mut entries = Vec::with_capacity(records.len() / 3);
-    for record in records.chunks_exact(3) {
+    let mut entries = Vec::with_capacity(records.len() / 4);
+    for record in records.chunks_exact(4) {
         let is_dir = match record[0] {
             b"d" => true,
             b"f" => false,
@@ -817,10 +835,17 @@ fn parse_remote_directory(stdout: &[u8]) -> Result<DirectoryListing, String> {
             .trim()
             .parse::<u64>()
             .map_err(|_| "Remote directory response contained an invalid file size".to_string())?;
+        let mtime_secs = String::from_utf8_lossy(record[2])
+            .trim()
+            .parse::<u64>()
+            .map_err(|_| {
+                "Remote directory response contained an invalid modified time".to_string()
+            })?;
         entries.push(DirEntry {
-            name: String::from_utf8_lossy(record[2]).into_owned(),
+            name: String::from_utf8_lossy(record[3]).into_owned(),
             is_dir,
             size,
+            modified_unix_millis: (mtime_secs > 0).then_some(mtime_secs.saturating_mul(1000)),
         });
     }
     entries.sort_by(|a, b| {
@@ -1468,6 +1493,8 @@ mod tests {
         assert!(script.contains("WISP_REMOTE_DIR_V1\\000"));
         assert!(script.contains("stat -c '%s'"));
         assert!(script.contains("stat -f '%z'"));
+        assert!(script.contains("stat -c '%Y'"));
+        assert!(script.contains("stat -f '%m'"));
         assert!(!script.contains("wc -c"));
     }
 
@@ -1480,7 +1507,7 @@ mod tests {
     #[test]
     fn remote_directory_runner_parses_banner_and_sorts_directories_first() {
         let identity = test_identity_file();
-        let stdout = b"login banner\nWISP_REMOTE_DIR_V1\0/home/research\0f\012\0notes.txt\0d\00\0projects\0f\03\0a.csv\0".to_vec();
+        let stdout = b"login banner\nWISP_REMOTE_DIR_V1\0/home/research\0f\012\01700000000\0notes.txt\0d\00\01700001000\0projects\0f\03\01700002000\0a.csv\0".to_vec();
         let mut runner = FakeRemoteRunner::returning(RemoteOutput {
             status: 0,
             stdout,
@@ -1496,16 +1523,19 @@ mod tests {
                     name: "projects".into(),
                     is_dir: true,
                     size: 0,
+                    modified_unix_millis: Some(1_700_001_000_000),
                 },
                 DirEntry {
                     name: "a.csv".into(),
                     is_dir: false,
                     size: 3,
+                    modified_unix_millis: Some(1_700_002_000_000),
                 },
                 DirEntry {
                     name: "notes.txt".into(),
                     is_dir: false,
                     size: 12,
+                    modified_unix_millis: Some(1_700_000_000_000),
                 },
             ]
         );
@@ -1880,6 +1910,45 @@ mod tests {
         collect_file_search_hits(&base, ".", "notes", 50, &mut hits).unwrap();
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].path, "notes.txt");
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn list_dir_entries_include_size_and_modified_time() {
+        let base = std::env::temp_dir().join(format!(
+            "wisp_list_dir_mtime_{}_{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&base).unwrap();
+        std::fs::write(base.join("notes.md"), b"hello").unwrap();
+        std::fs::create_dir(base.join("analysis")).unwrap();
+
+        let entries = list_dir_entries(&base).unwrap();
+        assert_eq!(entries[0].name, "analysis");
+        assert!(entries[0].is_dir);
+        assert!(entries[0].modified_unix_millis.is_some());
+        assert_eq!(entries[1].name, "notes.md");
+        assert!(!entries[1].is_dir);
+        assert_eq!(entries[1].size, 5);
+        let modified = entries[1].modified_unix_millis.expect("mtime");
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64;
+        assert!(
+            now.saturating_sub(modified) < 60_000,
+            "listed mtime {modified} should be recent relative to {now}"
+        );
+
+        let json = serde_json::to_value(&entries[1]).unwrap();
+        assert_eq!(json["size"], 5);
+        assert_eq!(json["modified_unix_millis"], modified);
+        let dto: wisp_dto::DirEntry = serde_json::from_value(json).unwrap();
+        assert_eq!(dto.name, "notes.md");
+        assert_eq!(dto.size, 5);
+        assert_eq!(dto.modified_unix_millis, Some(modified));
 
         let _ = std::fs::remove_dir_all(&base);
     }

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -449,6 +449,13 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
   // previews re-read content written by an agent tool.
   let workspaceR = 'library(Seurat)\nin_dir <- "data"\nplot(1:3)\n';
   (window as any).__setMockWorkspaceR = (value: string) => { workspaceR = String(value); };
+  const FILE_NOW = Date.now();
+  const workspaceMtimes: Record<string, number> = {
+    data: FILE_NOW - 5 * 86_400_000,
+    DEG: FILE_NOW - 1 * 86_400_000,
+    "report.csv": FILE_NOW - 90_000,
+    "manuscript.docx": FILE_NOW - 2 * 86_400_000,
+  };
   let workspaceEntries = [
     { path: "data", is_dir: true, size: 0 },
     { path: "DEG", is_dir: true, size: 0 },
@@ -472,7 +479,10 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
     { path: "manuscript.docx", is_dir: false, size: 11351 },
     { path: "office-preview.xlsx", is_dir: false, size: 3600 },
     { path: "office-preview.pptx", is_dir: false, size: 8600 },
-  ];
+  ].map((entry) => ({
+    ...entry,
+    modified_unix_millis: workspaceMtimes[entry.path] ?? FILE_NOW - 30 * 86_400_000,
+  }));
   type MemoryFile = { name: string; preview: string; bytes: number };
   const memoryByProject: Record<string, MemoryFile[]> = {
     default: [{ name: "2026-07-01.md", preview: "User prefers DeepSeek.", bytes: 128 }],
@@ -3886,19 +3896,20 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
                 name: entry.path.slice(entry.path.lastIndexOf("/") + 1),
                 is_dir: entry.is_dir,
                 size: entry.size,
+                modified_unix_millis: entry.modified_unix_millis,
               }))
               .sort((a, b) => Number(b.is_dir) - Number(a.is_dir) || a.name.localeCompare(b.name));
           }
           case "create_file": {
             const path = String(arg("path") ?? "");
             if (workspaceEntries.some((entry) => entry.path === path)) throw new Error(`workspace entry '${path}' already exists`);
-            workspaceEntries.push({ path, is_dir: false, size: 0 });
+            workspaceEntries.push({ path, is_dir: false, size: 0, modified_unix_millis: Date.now() });
             return null;
           }
           case "create_directory": {
             const path = String(arg("path") ?? "");
             if (workspaceEntries.some((entry) => entry.path === path)) throw new Error(`workspace entry '${path}' already exists`);
-            workspaceEntries.push({ path, is_dir: true, size: 0 });
+            workspaceEntries.push({ path, is_dir: true, size: 0, modified_unix_millis: Date.now() });
             return null;
           }
           case "rename_entry": {
@@ -3931,16 +3942,16 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
               return {
                 path,
                 entries: [
-                  { name: "rna-seq", is_dir: true, size: 0 },
-                  { name: "README.md", is_dir: false, size: 512 },
+                  { name: "rna-seq", is_dir: true, size: 0, modified_unix_millis: FILE_NOW - 86_400_000 },
+                  { name: "README.md", is_dir: false, size: 512, modified_unix_millis: FILE_NOW - 2 * 86_400_000 },
                 ],
               };
             }
             return {
               path: "/home/research",
-              entries: [
-                { name: "projects", is_dir: true, size: 0 },
-                { name: "notes.txt", is_dir: false, size: 128 },
+                entries: [
+                { name: "projects", is_dir: true, size: 0, modified_unix_millis: FILE_NOW - 86_400_000 },
+                { name: "notes.txt", is_dir: false, size: 128, modified_unix_millis: FILE_NOW - 90_000 },
               ],
             };
           }

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -4960,18 +4960,19 @@ test("Files sorts by size and modified time and Escape closes only the sort menu
   await expect(files.locator('.fb-row[data-workspace-path="report.csv"] .fb-size')).toHaveText("4.0 KB");
 
   await files.getByTestId("files-sort").click();
-  await expect(files.locator(".fb-sort-menu")).toBeVisible();
+  const sortMenu = files.locator(".fb-sort-menu");
+  await expect(sortMenu).toBeVisible();
   await page.keyboard.press("Escape");
-  await expect(files.locator(".fb-sort-menu")).toHaveCount(0);
+  await expect(sortMenu).toHaveCount(0);
   await expect(files).toBeVisible();
 
   await files.getByTestId("files-sort").click();
-  await page.getByRole("menuitem", { name: "Size" }).click();
+  await sortMenu.getByRole("menuitem", { name: "Size" }).click();
   await expect(fileRows.first()).toHaveAttribute("data-workspace-path", "manuscript.docx");
   await expect(fileRows.first().locator(".fb-size")).toHaveText("11.1 KB");
 
   await files.getByTestId("files-sort").click();
-  await page.getByRole("menuitem", { name: "Modified" }).click();
+  await sortMenu.getByRole("menuitem", { name: "Modified" }).click();
   await expect(fileRows.first()).toHaveAttribute("data-workspace-path", "report.csv");
   await expect(fileRows.first().locator(".fb-size")).toHaveText(/^\d{2}:\d{2}$/);
   await expect(files.locator('.fb-row.dir[data-workspace-path="DEG"] .fb-size')).toHaveText(/\d/);

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -4951,6 +4951,32 @@ test("Files creates, renames, deletes, and refreshes local entries", async ({ pa
   await expect.poll(() => lastInvokeArgs(page, "list_dir")).toMatchObject({ path: "." });
 });
 
+test("Files sorts by size and modified time and Escape closes only the sort menu", async ({ page }) => {
+  await enterApp(page);
+  await page.getByRole("button", { name: "Files" }).click();
+  const files = page.locator(".rp-files");
+  const fileRows = files.locator(".fb-row:not(.dir)");
+
+  await expect(files.locator('.fb-row[data-workspace-path="report.csv"] .fb-size')).toHaveText("4.0 KB");
+
+  await files.getByTestId("files-sort").click();
+  await expect(files.locator(".fb-sort-menu")).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(files.locator(".fb-sort-menu")).toHaveCount(0);
+  await expect(files).toBeVisible();
+
+  await files.getByTestId("files-sort").click();
+  await page.getByRole("menuitem", { name: "Size" }).click();
+  await expect(fileRows.first()).toHaveAttribute("data-workspace-path", "manuscript.docx");
+  await expect(fileRows.first().locator(".fb-size")).toHaveText("11.1 KB");
+
+  await files.getByTestId("files-sort").click();
+  await page.getByRole("menuitem", { name: "Modified" }).click();
+  await expect(fileRows.first()).toHaveAttribute("data-workspace-path", "report.csv");
+  await expect(fileRows.first().locator(".fb-size")).toHaveText(/^\d{2}:\d{2}$/);
+  await expect(files.locator('.fb-row.dir[data-workspace-path="DEG"] .fb-size')).toHaveText(/\d/);
+});
+
 test("text entries keep the native context menu", async ({ page }) => {
   await enterApp(page);
   await page.locator(".proj-switch").click();

--- a/ui/src/app_support/files.rs
+++ b/ui/src/app_support/files.rs
@@ -525,6 +525,7 @@ pub(crate) fn file_row_meta_view(entry: &DirEntry, sort: &str) -> impl IntoView 
     }
 }
 
+#[component]
 pub(crate) fn FileSortControl(
     sort_by: RwSignal<String>,
     menu_open: RwSignal<bool>,

--- a/ui/src/app_support/files.rs
+++ b/ui/src/app_support/files.rs
@@ -475,6 +475,118 @@ pub(crate) fn workspace_relative_path(root: &str, path: &str) -> Option<String> 
         .map(|relative| relative.trim_start_matches('/').to_string())
 }
 
+pub(crate) const FILE_SORT_NAME: &str = "name";
+pub(crate) const FILE_SORT_SIZE: &str = "size";
+pub(crate) const FILE_SORT_MODIFIED: &str = "modified";
+pub(crate) const FILE_SORT_PREF: &str = "wisp-file-sort";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FileRowMeta {
+    Size(u64),
+    Modified(u64),
+}
+
+pub(crate) fn sort_dir_entries(entries: &mut [DirEntry], sort: &str) {
+    entries.sort_by(|a, b| {
+        b.is_dir.cmp(&a.is_dir).then_with(|| match sort {
+            FILE_SORT_SIZE => b
+                .size
+                .cmp(&a.size)
+                .then_with(|| a.name.to_lowercase().cmp(&b.name.to_lowercase())),
+            FILE_SORT_MODIFIED => b
+                .modified_unix_millis
+                .unwrap_or(0)
+                .cmp(&a.modified_unix_millis.unwrap_or(0))
+                .then_with(|| a.name.to_lowercase().cmp(&b.name.to_lowercase())),
+            _ => a.name.to_lowercase().cmp(&b.name.to_lowercase()),
+        })
+    });
+}
+
+pub(crate) fn file_row_meta(entry: &DirEntry, sort: &str) -> Option<FileRowMeta> {
+    if sort == FILE_SORT_MODIFIED {
+        return entry
+            .modified_unix_millis
+            .filter(|ms| *ms > 0)
+            .map(FileRowMeta::Modified);
+    }
+    (!entry.is_dir).then_some(FileRowMeta::Size(entry.size))
+}
+
+pub(crate) fn file_row_meta_view(entry: &DirEntry, sort: &str) -> impl IntoView {
+    match file_row_meta(entry, sort) {
+        Some(FileRowMeta::Size(n)) => {
+            view! { <span class="fb-size">{format_bytes(n)}</span> }.into_view()
+        }
+        Some(FileRowMeta::Modified(ms)) => {
+            view! { <span class="fb-size">{format_message_time(ms as i64)}</span> }.into_view()
+        }
+        None => ().into_view(),
+    }
+}
+
+pub(crate) fn FileSortControl(
+    sort_by: RwSignal<String>,
+    menu_open: RwSignal<bool>,
+) -> impl IntoView {
+    let locale = use_locale();
+    window_capture_escape(move || {
+        if !menu_open.get_untracked() {
+            return false;
+        }
+        menu_open.set(false);
+        true
+    });
+    view! {
+        <div class="fb-sort">
+            <button type="button"
+                data-testid="files-sort"
+                class:active=move || menu_open.get()
+                aria-expanded=move || menu_open.get().to_string()
+                aria-haspopup="menu"
+                title=move || t(locale.get(), "files.sort")
+                aria-label=move || t(locale.get(), "files.sort")
+                on:click=move |ev: web_sys::MouseEvent| {
+                    ev.stop_propagation();
+                    menu_open.update(|open| *open = !*open);
+                }>
+                {compose_icon("sort")}
+                <span>{move || t(locale.get(), "files.sort")}</span>
+            </button>
+            {move || menu_open.get().then(|| {
+                let loc = locale.get();
+                let opts = [
+                    (FILE_SORT_NAME, "files.sort_name"),
+                    (FILE_SORT_SIZE, "files.sort_size"),
+                    (FILE_SORT_MODIFIED, "files.sort_modified"),
+                ];
+                view! {
+                    <div class="fb-sort-backdrop" on:click=move |_| menu_open.set(false)></div>
+                    <div class="fb-sort-menu" role="menu" on:click=|ev: web_sys::MouseEvent| ev.stop_propagation()>
+                        <div class="fb-sort-label">{t(loc, "files.sort_by")}</div>
+                        <div class="fb-sort-opts">
+                            {opts.into_iter().map(|(val, key)| view! {
+                                <button type="button" class="fb-sort-opt" role="menuitem"
+                                    class:active=move || sort_by.get().as_str() == val
+                                    on:click=move |_| {
+                                        sort_by.set(val.into());
+                                        save_view_pref(FILE_SORT_PREF, val);
+                                        menu_open.set(false);
+                                    }>
+                                    <span>{t(loc, key)}</span>
+                                    <span class="fb-sort-check" class:on=move || sort_by.get().as_str() == val>
+                                        {compose_icon("check")}
+                                    </span>
+                                </button>
+                            }).collect_view()}
+                        </div>
+                    </div>
+                }
+            })}
+        </div>
+    }
+}
+
 pub(crate) fn workspace_absolute_path(root: &str, path: &str) -> Option<String> {
     if root.is_empty() {
         return None;
@@ -539,6 +651,70 @@ mod workspace_copy_path_tests {
                 r"\\server\share\project\results\table.csv"
             ),
             Some("results/table.csv".into())
+        );
+    }
+}
+
+#[cfg(test)]
+mod file_sort_tests {
+    use super::{
+        file_row_meta, sort_dir_entries, DirEntry, FileRowMeta, FILE_SORT_MODIFIED, FILE_SORT_NAME,
+        FILE_SORT_SIZE,
+    };
+
+    fn entry(name: &str, is_dir: bool, size: u64, modified: Option<u64>) -> DirEntry {
+        DirEntry {
+            name: name.into(),
+            is_dir,
+            size,
+            modified_unix_millis: modified,
+        }
+    }
+
+    fn names(entries: &[DirEntry]) -> Vec<&str> {
+        entries.iter().map(|entry| entry.name.as_str()).collect()
+    }
+
+    #[test]
+    fn sorts_directories_first_then_by_size_or_modified_time() {
+        let mut entries = vec![
+            entry("notes.md", false, 12, Some(10)),
+            entry("data", true, 0, Some(5)),
+            entry("big.bin", false, 100, Some(1)),
+            entry("results", true, 0, Some(20)),
+        ];
+
+        sort_dir_entries(&mut entries, FILE_SORT_NAME);
+        assert_eq!(names(&entries), ["data", "results", "big.bin", "notes.md"]);
+
+        sort_dir_entries(&mut entries, FILE_SORT_SIZE);
+        assert_eq!(names(&entries), ["data", "results", "big.bin", "notes.md"]);
+
+        sort_dir_entries(&mut entries, FILE_SORT_MODIFIED);
+        assert_eq!(names(&entries), ["results", "data", "notes.md", "big.bin"]);
+    }
+
+    #[test]
+    fn right_column_follows_the_active_sort() {
+        let file = entry("notes.md", false, 12, Some(1_700_000_000_000));
+        let dir = entry("data", true, 4096, Some(1_700_000_000_000));
+        assert_eq!(
+            file_row_meta(&file, FILE_SORT_NAME),
+            Some(FileRowMeta::Size(12))
+        );
+        assert_eq!(
+            file_row_meta(&file, FILE_SORT_SIZE),
+            Some(FileRowMeta::Size(12))
+        );
+        assert_eq!(
+            file_row_meta(&file, FILE_SORT_MODIFIED),
+            Some(FileRowMeta::Modified(1_700_000_000_000))
+        );
+        assert_eq!(file_row_meta(&dir, FILE_SORT_NAME), None);
+        assert_eq!(file_row_meta(&dir, FILE_SORT_SIZE), None);
+        assert_eq!(
+            file_row_meta(&dir, FILE_SORT_MODIFIED),
+            Some(FileRowMeta::Modified(1_700_000_000_000))
         );
     }
 }

--- a/ui/src/app_support/messages.rs
+++ b/ui/src/app_support/messages.rs
@@ -250,6 +250,7 @@ pub(crate) fn compose_icon(kind: &str) -> impl IntoView {
         "user" => view! { <path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/> }.into_view(),
         "wrench" => view! { <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/> }.into_view(),
         "clock" => view! { <circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/> }.into_view(),
+        "sort" => view! { <path d="m21 16-4 4-4-4"/><path d="M17 20V4"/><path d="m3 8 4-4 4 4"/><path d="M7 4v16"/> }.into_view(),
         "search" => view! { <circle cx="11" cy="11" r="7"/><path d="m20 20-3.5-3.5"/> }.into_view(),
         "eye-off" => view! { <path d="m3 3 18 18"/><path d="M10.6 10.6a2 2 0 0 0 2.8 2.8"/><path d="M9.9 4.2A10.8 10.8 0 0 1 12 4c5 0 9 5 9 8a12.4 12.4 0 0 1-2 3.7"/><path d="M6.6 6.6C4.4 8 3 10.2 3 12c0 3 4 8 9 8a10.4 10.4 0 0 0 4.2-.9"/> }.into_view(),
         "terminal" => view! { <path d="m4 17 6-5-6-5"/><path d="M12 19h8"/> }.into_view(),

--- a/ui/src/i18n.rs
+++ b/ui/src/i18n.rs
@@ -2256,6 +2256,11 @@ fn lookup(locale: Locale, key: &str) -> Option<&'static str> {
         (Locale::En, "files.new_directory") => Some("New folder"),
         (Locale::En, "files.refresh") => Some("Refresh"),
         (Locale::En, "files.select_entries") => Some("Select"),
+        (Locale::En, "files.sort") => Some("Sort"),
+        (Locale::En, "files.sort_by") => Some("Sort by"),
+        (Locale::En, "files.sort_name") => Some("Name"),
+        (Locale::En, "files.sort_size") => Some("Size"),
+        (Locale::En, "files.sort_modified") => Some("Modified"),
         (Locale::En, "files.copy_absolute_path") => Some("Copy absolute path"),
         (Locale::En, "files.copy_relative_path") => Some("Copy relative path"),
         (Locale::En, "files.rename_file") => Some("Rename file"),
@@ -4720,6 +4725,11 @@ Do not leave generated files in the project root.",
         (Locale::Zh, "files.new_directory") => Some("新建文件夹"),
         (Locale::Zh, "files.refresh") => Some("刷新"),
         (Locale::Zh, "files.select_entries") => Some("选择"),
+        (Locale::Zh, "files.sort") => Some("排序"),
+        (Locale::Zh, "files.sort_by") => Some("排序方式"),
+        (Locale::Zh, "files.sort_name") => Some("名称"),
+        (Locale::Zh, "files.sort_size") => Some("大小"),
+        (Locale::Zh, "files.sort_modified") => Some("更新时间"),
         (Locale::Zh, "files.copy_absolute_path") => Some("复制绝对路径"),
         (Locale::Zh, "files.copy_relative_path") => Some("复制相对路径"),
         (Locale::Zh, "files.rename_file") => Some("重命名文件"),
@@ -5601,6 +5611,20 @@ mod queue_label_tests {
         // Sent-message rewind keeps its own label.
         assert_eq!(t(Locale::Zh, "msg.edit"), "回溯");
         assert_eq!(t(Locale::En, "msg.edit"), "Rewind");
+    }
+
+    #[test]
+    fn file_sort_labels_exist_in_both_locales() {
+        assert_eq!(t(Locale::En, "files.sort"), "Sort");
+        assert_eq!(t(Locale::Zh, "files.sort"), "排序");
+        assert_eq!(t(Locale::En, "files.sort_by"), "Sort by");
+        assert_eq!(t(Locale::Zh, "files.sort_by"), "排序方式");
+        assert_eq!(t(Locale::En, "files.sort_name"), "Name");
+        assert_eq!(t(Locale::Zh, "files.sort_name"), "名称");
+        assert_eq!(t(Locale::En, "files.sort_size"), "Size");
+        assert_eq!(t(Locale::Zh, "files.sort_size"), "大小");
+        assert_eq!(t(Locale::En, "files.sort_modified"), "Modified");
+        assert_eq!(t(Locale::Zh, "files.sort_modified"), "更新时间");
     }
 
     #[test]

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -1333,6 +1333,12 @@ fn App() -> impl IntoView {
     let file_source = create_rw_signal("local".to_string());
     let file_query = create_rw_signal(String::new());
     let file_cwd = create_rw_signal(".".to_string());
+    let file_sort = create_rw_signal(load_view_pref(
+        FILE_SORT_PREF,
+        FILE_SORT_NAME,
+        &[FILE_SORT_NAME, FILE_SORT_SIZE, FILE_SORT_MODIFIED],
+    ));
+    let file_sort_menu_open = create_rw_signal(false);
     let file_entries = create_rw_signal::<Vec<DirEntry>>(vec![]);
     let file_search_hits = create_rw_signal::<Vec<FileSearchHit>>(vec![]);
     let selecting_workspace_entries = create_rw_signal(false);
@@ -13602,6 +13608,7 @@ fn App() -> impl IntoView {
                                                 let next = dom_value(&event);
                                                 selecting_workspace_entries.set(false);
                                                 selected_workspace_paths.set(HashSet::new());
+                                                file_sort_menu_open.set(false);
                                                 file_source.set(next.clone());
                                                 file_query.set(String::new());
                                                 if next == "local" {
@@ -13688,6 +13695,7 @@ fn App() -> impl IntoView {
                                                         "files.select_entries"
                                                     })}</span>
                                                 </button>
+                                                <FileSortControl sort_by=file_sort menu_open=file_sort_menu_open />
                                             </div>
                                             <input class="fb-search" type="text"
                                                 placeholder=move || t(locale.get(), "files.search")
@@ -13762,7 +13770,9 @@ fn App() -> impl IntoView {
                                                             }
                                                         }).collect_view()
                                                     } else {
-                                                        let entries = file_entries.get();
+                                                        let sort = file_sort.get();
+                                                        let mut entries = file_entries.get();
+                                                        sort_dir_entries(&mut entries, &sort);
                                                         if entries.is_empty() {
                                                             // Nothing listed also covers "the tab
                                                             // was opened before a project was", so
@@ -13804,6 +13814,7 @@ fn App() -> impl IntoView {
                                                                     }>
                                                                         <span class="fb-icon">{compose_icon("folder")}</span>
                                                                         <span class="fb-name">{name}</span>
+                                                                        {file_row_meta_view(&e, &sort)}
                                                                     </button>
                                                                 }.into_view()
                                                             } else {
@@ -13825,7 +13836,7 @@ fn App() -> impl IntoView {
                                                                     }>
                                                                         <span class="fb-icon">{compose_icon("doc")}</span>
                                                                         <span class="fb-name">{name}</span>
-                                                                        <span class="fb-size">{format_bytes(e.size)}</span>
+                                                                        {file_row_meta_view(&e, &sort)}
                                                                     </button>
                                                                 }.into_view()
                                                             }
@@ -13918,6 +13929,7 @@ fn App() -> impl IntoView {
                                                     {compose_icon("sync")}
                                                     <span>{t(loc, "files.refresh")}</span>
                                                 </button>
+                                                <FileSortControl sort_by=file_sort menu_open=file_sort_menu_open />
                                             </div>
                                             <div class="fb-list" class:grid=move || rp_grid.get()>
                                                 {if remote_file_loading.get() {
@@ -13980,7 +13992,10 @@ fn App() -> impl IntoView {
                                                 } else if remote_file_entries.get().is_empty() {
                                                     view! { <div class="rp-empty rp-files-empty"><p>{t(loc, "files.empty_remote")}</p></div> }.into_view()
                                                 } else {
-                                                    remote_file_entries.get().into_iter().map(|entry| {
+                                                    let sort = file_sort.get();
+                                                    let mut entries = remote_file_entries.get();
+                                                    sort_dir_entries(&mut entries, &sort);
+                                                    entries.into_iter().map(|entry| {
                                                         let name = entry.name.clone();
                                                         let full = join_path(&remote_file_cwd.get(), &name);
                                                         if entry.is_dir {
@@ -14000,6 +14015,7 @@ fn App() -> impl IntoView {
                                                                 }>
                                                                     <span class="fb-icon">{compose_icon("folder")}</span>
                                                                     <span class="fb-name">{name}</span>
+                                                                    {file_row_meta_view(&entry, &sort)}
                                                                 </button>
                                                             }.into_view()
                                                         } else {
@@ -14024,7 +14040,7 @@ fn App() -> impl IntoView {
                                                                     }>
                                                                     <span class="fb-icon">{compose_icon("doc")}</span>
                                                                     <span class="fb-name">{name}</span>
-                                                                    <span class="fb-size">{format_bytes(entry.size)}</span>
+                                                                    {file_row_meta_view(&entry, &sort)}
                                                                     {download_uri.map(|uri| {
                                                                         let download = uri.clone();
                                                                         view! {

--- a/ui/src/styles/explorer.css
+++ b/ui/src/styles/explorer.css
@@ -28,7 +28,28 @@
 .fb-row-action svg { width: 15px; height: 15px; }
 .fb-icon { flex: 0 0 auto; font-size: 14px; }
 .fb-name { flex: 1 1 auto; font-size: 13.5px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.fb-size { flex: 0 0 auto; font-size: 11px; color: var(--text-faint); }
+.fb-size { flex: 0 0 auto; font-size: 11px; color: var(--text-faint); font-variant-numeric: tabular-nums; }
+.fb-sort { position: relative; }
+.fb-sort-backdrop { position: fixed; inset: 0; z-index: 40; }
+.fb-sort-menu {
+  position: absolute; z-index: 41; top: calc(100% + 4px); right: 0; min-width: 168px;
+  background: var(--bg-elev); border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm); box-shadow: 0 8px 28px rgba(0,0,0,.14); padding: 8px;
+  transform-origin: top right;
+  animation: motion-surface-in-soft var(--motion-duration-fast) var(--motion-ease-decelerate) both;
+}
+.fb-sort-label { font-size: 10.5px; color: var(--text-faint); padding: 2px 6px 5px; }
+.fb-sort-opts { display: flex; flex-direction: column; gap: 1px; }
+.fb-sort-opt {
+  display: flex; align-items: center; justify-content: space-between; gap: 8px; width: 100%;
+  background: transparent; border: none; border-radius: var(--radius-xs); padding: 6px 8px;
+  font: inherit; font-size: 13px; color: var(--text); cursor: pointer; text-align: left;
+}
+.fb-sort-opt:hover { background: var(--bg-sunken); }
+.fb-sort-opt.active { color: var(--clay); }
+.fb-sort-check { display: inline-flex; opacity: 0; color: var(--clay); }
+.fb-sort-check.on { opacity: 1; }
+.fb-sort-check svg { width: 15px; height: 15px; }
 .fb-root { margin-top: 4px; font-family: var(--font-mono); font-size: 11px; }
 .fb-path-rel { flex: 0 0 auto; font-size: 11px; color: var(--text-faint); font-family: var(--font-mono); max-width: 42%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .file-entry-location { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-family: var(--font-mono); }

--- a/ui/src/styles/explorer.css
+++ b/ui/src/styles/explorer.css
@@ -30,12 +30,12 @@
 .fb-name { flex: 1 1 auto; font-size: 13.5px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .fb-size { flex: 0 0 auto; font-size: 11px; color: var(--text-faint); font-variant-numeric: tabular-nums; }
 .fb-sort { position: relative; }
-.fb-sort-backdrop { position: fixed; inset: 0; z-index: 40; }
+.fb-sort-backdrop { position: fixed; inset: 0; z-index: 71; }
 .fb-sort-menu {
-  position: absolute; z-index: 41; top: calc(100% + 4px); right: 0; min-width: 168px;
+  position: absolute; z-index: 72; top: calc(100% + 4px); left: 0; min-width: 168px;
   background: var(--bg-elev); border: 1px solid var(--border-strong);
   border-radius: var(--radius-sm); box-shadow: 0 8px 28px rgba(0,0,0,.14); padding: 8px;
-  transform-origin: top right;
+  transform-origin: top left;
   animation: motion-surface-in-soft var(--motion-duration-fast) var(--motion-ease-decelerate) both;
 }
 .fb-sort-label { font-size: 10.5px; color: var(--text-faint); padding: 2px 6px 5px; }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The Files panel always listed folders first, then files alphabetically, and always showed size on the right. There was no way to sort by size or update time, and modification times were not in the listing payload.

## Change

- `list_dir` and the remote directory protocol now include `modified_unix_millis`.
- Files toolbar adds a **Sort** menu: Name, Size (largest first), Modified (newest first). Folders stay first.
- Right-hand column follows the sort: size when sorting by name or size; update time when sorting by modified time.
- Sort choice is persisted in `localStorage` (`wisp-file-sort`). Escape closes only the sort menu.

## Tests

- Backend: local listing includes mtime; remote parser reads the 4-field record; DTO round-trip.
- UI unit tests for sort order and which meta the right column shows.
- Playwright: size sort puts `manuscript.docx` first among files with `11.1 KB`; time sort puts `report.csv` first and shows `HH:mm`; Escape closes the menu. Related Files panel tests still pass (navigate, copy paths, create/rename/delete, SSH browse).

## Manual smoke

1. Open Files on a project with mixed file sizes and ages.
2. Sort → Size: files reorder largest-first and still show sizes.
3. Sort → Modified: files reorder newest-first and the right column shows times.
4. Press Escape immediately after opening Sort: menu closes, Files stays open.
5. Switch to an SSH host and confirm the same sort/meta behavior.

## Follow-up

- Global filename search is still name-ordered and always shows size (hits have no mtime).
- Directory sizes are still the inode size, not a recursive total, so size-sort among folders is not meaningful.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-49db4e30-3ab7-486d-ab6d-3294a7d4a8a9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49db4e30-3ab7-486d-ab6d-3294a7d4a8a9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

