### PR TITLE
Preview bound .py and .R scripts

### DIFF
--- a/src-tauri/src/resource_refs.rs
+++ b/src-tauri/src/resource_refs.rs
@@ -265,6 +265,8 @@ fn kind_and_mime(path: &Path, requested_kind: &str) -> Option<(String, String)> 
         "ipynb" => ("notebook", "application/x-ipynb+json"),
         "html" | "htm" => ("html", "text/html"),
         "txt" | "log" => ("text", "text/plain"),
+        "py" | "pyw" => ("code", "text/x-python"),
+        "r" => ("code", "text/x-r"),
         _ => return None,
     };
     let kind = if requested_kind == "image" && kind == "image" {
@@ -591,6 +593,18 @@ mod tests {
             kind_and_mime(Path::new("references.bib"), "file"),
             Some(("text".to_string(), "text/x-bibtex".to_string()))
         );
+        assert_eq!(
+            kind_and_mime(Path::new("analysis/scripts/random_walk_demo.py"), "file"),
+            Some(("code".to_string(), "text/x-python".to_string()))
+        );
+        assert_eq!(
+            kind_and_mime(Path::new("gui.pyw"), "file"),
+            Some(("code".to_string(), "text/x-python".to_string()))
+        );
+        assert_eq!(
+            kind_and_mime(Path::new("analysis/plot.R"), "file"),
+            Some(("code".to_string(), "text/x-r".to_string()))
+        );
     }
 
     #[test]
@@ -740,6 +754,38 @@ mod tests {
         for document in documents {
             let version = store
                 .get_artifact_version(document.artifact_version_id.as_deref().unwrap())
+                .await
+                .unwrap()
+                .unwrap();
+            assert!(root.join(version.storage_path).is_file());
+        }
+
+        std::fs::create_dir_all(root.join("analysis/scripts")).unwrap();
+        std::fs::write(
+            root.join("analysis/scripts/random_walk_demo.py"),
+            b"SEED = 42\n",
+        )
+        .unwrap();
+        std::fs::write(root.join("analysis/plot.R"), b"plot(1:3)\n").unwrap();
+        let scripts = bind_new_message_resources(
+            &store,
+            &root,
+            "project",
+            "frame",
+            7,
+            "[script](analysis/scripts/random_walk_demo.py) [r](analysis/plot.R)",
+        )
+        .await;
+        assert_eq!(scripts.len(), 2);
+        assert_eq!(scripts[0].status, "ready");
+        assert_eq!(scripts[0].resource_kind, "code");
+        assert_eq!(scripts[0].mime_type, "text/x-python");
+        assert_eq!(scripts[1].status, "ready");
+        assert_eq!(scripts[1].resource_kind, "code");
+        assert_eq!(scripts[1].mime_type, "text/x-r");
+        for script in scripts {
+            let version = store
+                .get_artifact_version(script.artifact_version_id.as_deref().unwrap())
                 .await
                 .unwrap()
                 .unwrap();

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -2141,7 +2141,7 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
               return {
                 items: [{
                   role: "assistant",
-                  text: "[Open bound report](D:/ZZM/03.%20figures/report.md')\n\n[Open bound manuscript](/abs/path/D:/ZZM/paper/manuscript.docx)\n\n[Open bound references](references.bib)",
+                  text: "[Open bound report](D:/ZZM/03.%20figures/report.md')\n\n[Open bound manuscript](/abs/path/D:/ZZM/paper/manuscript.docx)\n\n[Open bound references](references.bib)\n\n[Open bound Python script](analysis/scripts/random_walk_demo.py)\n\n[Open bound R script](analysis/plot.R)",
                   tool_name: null,
                   ok: null,
                   resources: [
@@ -2178,6 +2178,30 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
                       displayName: "references.bib",
                       kind: "text",
                       mimeType: "text/x-bibtex",
+                      status: "ready",
+                      error: null,
+                    },
+                    {
+                      id: "resource-link-python",
+                      ordinal: 3,
+                      originalReference: "analysis/scripts/random_walk_demo.py",
+                      artifactId: "resource-artifact-python",
+                      artifactVersionId: "resource-version-python",
+                      displayName: "random_walk_demo.py",
+                      kind: "code",
+                      mimeType: "text/x-python",
+                      status: "ready",
+                      error: null,
+                    },
+                    {
+                      id: "resource-link-r",
+                      ordinal: 4,
+                      originalReference: "analysis/plot.R",
+                      artifactId: "resource-artifact-r",
+                      artifactVersionId: "resource-version-r",
+                      displayName: "plot.R",
+                      kind: "code",
+                      mimeType: "text/x-r",
                       status: "ready",
                       error: null,
                     },
@@ -4149,6 +4173,22 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
                 path: "artifact-version:resource-version-bib",
                 mime: "text/x-bibtex",
                 text: "@article{wisp,\n  title = {Wisp Science}\n}",
+                base64: null,
+              };
+            }
+            if (arg("versionId") === "resource-version-python") {
+              return {
+                path: "artifact-version:resource-version-python",
+                mime: "text/x-python",
+                text: "SEED = 42\nprint('random walk')\n",
+                base64: null,
+              };
+            }
+            if (arg("versionId") === "resource-version-r") {
+              return {
+                path: "artifact-version:resource-version-r",
+                mime: "text/x-r",
+                text: 'in_dir <- "data"\nplot(1:3)\n',
                 base64: null,
               };
             }

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -11088,12 +11088,15 @@ test("bound Python resources open their immutable code preview", async ({ page }
   await search.fill("Enumerate");
   await search.press("Enter");
 
-  await page.getByRole("link", { name: "Open bound Python script" }).click();
+  const pythonLink = page.getByRole("link", { name: "Open bound Python script" });
+  await expect(pythonLink).toHaveAttribute("title", "random_walk_demo.py");
+  await pythonLink.click();
   const modal = page.locator(".artifact-modal");
   await expect(modal).toBeVisible();
   await expect(modal.locator(".am-name")).toHaveText("random_walk_demo.py");
-  await expect(modal.locator(".rp-code-body code")).toHaveClass(/language-python/);
-  await expect(modal.locator(".rp-code-body code")).toContainText("SEED = 42");
+  const figure = modal.locator(".am-figure .rp-code-body code");
+  await expect(figure).toHaveClass(/language-python/);
+  await expect(figure).toContainText("SEED = 42");
   await modal.getByRole("button", { name: "Open in center" }).click();
   await expect(page.locator('.center-tab[data-center-path="artifact-version:resource-version-python"]'))
     .toContainText("random_walk_demo.py");
@@ -11111,12 +11114,15 @@ test("bound R resources open their immutable code preview", async ({ page }) => 
   await search.fill("Enumerate");
   await search.press("Enter");
 
-  await page.getByRole("link", { name: "Open bound R script" }).click();
+  const rLink = page.getByRole("link", { name: "Open bound R script" });
+  await expect(rLink).toHaveAttribute("title", "plot.R");
+  await rLink.click();
   const modal = page.locator(".artifact-modal");
   await expect(modal).toBeVisible();
   await expect(modal.locator(".am-name")).toHaveText("plot.R");
-  await expect(modal.locator(".rp-code-body code")).toHaveClass(/language-r/);
-  await expect(modal.locator(".rp-code-body code")).toContainText("plot(1:3)");
+  const figure = modal.locator(".am-figure .rp-code-body code");
+  await expect(figure).toHaveClass(/language-r/);
+  await expect(figure).toContainText("plot(1:3)");
   await modal.getByRole("button", { name: "Open in center" }).click();
   await expect(page.locator('.center-tab[data-center-path="artifact-version:resource-version-r"]'))
     .toContainText("plot.R");

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -11081,6 +11081,52 @@ test("bound DOCX resources open their immutable preview", async ({ page }) => {
     .toMatchObject({ versionId: "resource-version-docx" });
 });
 
+test("bound Python resources open their immutable code preview", async ({ page }) => {
+  await page.goto("/?mockResourceSession=1");
+  await page.getByRole("button", { name: "Search" }).click();
+  const search = commandPalette(page);
+  await search.fill("Enumerate");
+  await search.press("Enter");
+
+  await page.getByRole("link", { name: "Open bound Python script" }).click();
+  const modal = page.locator(".artifact-modal");
+  await expect(modal).toBeVisible();
+  await expect(modal.locator(".am-name")).toHaveText("random_walk_demo.py");
+  await expect(modal.locator(".rp-code-body code")).toHaveClass(/language-python/);
+  await expect(modal.locator(".rp-code-body code")).toContainText("SEED = 42");
+  await modal.getByRole("button", { name: "Open in center" }).click();
+  await expect(page.locator('.center-tab[data-center-path="artifact-version:resource-version-python"]'))
+    .toContainText("random_walk_demo.py");
+  const preview = page.locator(".center-file-preview");
+  await expect(preview.locator(".rp-code-body code")).toHaveClass(/language-python/);
+  await expect(preview).toContainText("SEED = 42");
+  await expect.poll(() => lastInvokeArgs(page, "read_artifact_version"))
+    .toMatchObject({ versionId: "resource-version-python" });
+});
+
+test("bound R resources open their immutable code preview", async ({ page }) => {
+  await page.goto("/?mockResourceSession=1");
+  await page.getByRole("button", { name: "Search" }).click();
+  const search = commandPalette(page);
+  await search.fill("Enumerate");
+  await search.press("Enter");
+
+  await page.getByRole("link", { name: "Open bound R script" }).click();
+  const modal = page.locator(".artifact-modal");
+  await expect(modal).toBeVisible();
+  await expect(modal.locator(".am-name")).toHaveText("plot.R");
+  await expect(modal.locator(".rp-code-body code")).toHaveClass(/language-r/);
+  await expect(modal.locator(".rp-code-body code")).toContainText("plot(1:3)");
+  await modal.getByRole("button", { name: "Open in center" }).click();
+  await expect(page.locator('.center-tab[data-center-path="artifact-version:resource-version-r"]'))
+    .toContainText("plot.R");
+  const preview = page.locator(".center-file-preview");
+  await expect(preview.locator(".rp-code-body code")).toHaveClass(/language-r/);
+  await expect(preview).toContainText("plot(1:3)");
+  await expect.poll(() => lastInvokeArgs(page, "read_artifact_version"))
+    .toMatchObject({ versionId: "resource-version-r" });
+});
+
 test("bound BibTeX resources open their immutable text preview", async ({ page }) => {
   await page.goto("/?mockResourceSession=1");
   await page.getByRole("button", { name: "Search" }).click();

--- a/ui/src/app_support/mod.rs
+++ b/ui/src/app_support/mod.rs
@@ -11,11 +11,12 @@ use crate::dto::*;
 use crate::i18n::{localize_backend, t, tf, use_locale, Locale};
 use crate::publication::PublicationEvidenceSource;
 use crate::text::{
-    code_lang, decode_href, dom_value, event_target_value, extract_href_from_tag, fasta_seq_count,
+    decode_href, dom_value, event_target_value, extract_href_from_tag, fasta_seq_count,
     fenced_blocks, file_kind, format_bytes, format_duration_ms, html_escape, ime_composing,
     is_external_href, is_separator, is_table_row, join_api_url, md_document_to_html,
     md_inline_to_html, md_to_html, next_artifact_id, normalize_endpoint, normalize_path,
     opens_in_system_browser, parent_path, parse_csv_line, parse_notebook, pretty_json,
+    preview_code_lang,
     provider_defaults, provider_value, same_endpoint, split_row, tool_card_label, tool_lang,
     unique_dom_id, user_message_presentation, NbOutput, Notebook, DEEPSEEK_FLASH_MODEL,
     DEEPSEEK_PRO_MODEL,

--- a/ui/src/app_support/previews.rs
+++ b/ui/src/app_support/previews.rs
@@ -500,14 +500,19 @@ pub(crate) fn NotebookFilePreview(path: String) -> impl IntoView {
 }
 
 #[component]
-pub(crate) fn WorkspaceFilePreview(dom_id: String, path: String, kind: String) -> impl IntoView {
+pub(crate) fn WorkspaceFilePreview(
+    dom_id: String,
+    path: String,
+    kind: String,
+    #[prop(optional)] filename: Option<String>,
+) -> impl IntoView {
     match kind.as_str() {
         "csv" => view! { <CsvFilePreview path=path /> }.into_view(),
         // Artifact/version tabs aren't real paths, so the extension can't be read
         // back off them — the kind is the only language signal here.
         "json" => view! { <CodeFilePreview path=path lang="json".to_string() /> }.into_view(),
         "code" | "text" => {
-            let lang = code_lang(&path).unwrap_or("plaintext").to_string();
+            let lang = preview_code_lang(&path, filename.as_deref()).to_string();
             view! { <CodeFilePreview path=path lang=lang /> }.into_view()
         }
         "notebook" => view! { <NotebookFilePreview path=path /> }.into_view(),
@@ -1254,7 +1259,12 @@ pub(crate) fn artifact_preview(a: &Artifact, dom_id: String, locale: Locale) -> 
         PreviewData::File { path, kind } => view! {
             <p class="rp-path hint">{a.location.clone().unwrap_or_else(|| path.clone())}</p>
             <div class="rp-file-preview" data-file-path=path.clone()>
-                <WorkspaceFilePreview dom_id=dom_id path=path.clone() kind=kind.clone() />
+                <WorkspaceFilePreview
+                    dom_id=dom_id
+                    path=path.clone()
+                    kind=kind.clone()
+                    filename=Some(a.name.clone())
+                />
             </div>
         }
         .into_view(),
@@ -1541,7 +1551,12 @@ pub(crate) fn ArtifactModal(
                 <div class="am-figure" class:zoomable-preview=is_zoomable
                     class:docx-preview=is_docx class:office-preview=is_office
                     data-file-path=path_head.clone()>
-                    <WorkspaceFilePreview dom_id=dom_id path=path_head.clone() kind=kind.clone() />
+                    <WorkspaceFilePreview
+                        dom_id=dom_id
+                        path=path_head.clone()
+                        kind=kind.clone()
+                        filename=Some(name.clone())
+                    />
                 </div>
                 <div class="am-tabs">
                     {["code","log","inputs","env"].iter().map(|k| {

--- a/ui/src/app_support/previews.rs
+++ b/ui/src/app_support/previews.rs
@@ -1263,7 +1263,7 @@ pub(crate) fn artifact_preview(a: &Artifact, dom_id: String, locale: Locale) -> 
                     dom_id=dom_id
                     path=path.clone()
                     kind=kind.clone()
-                    filename=Some(a.name.clone())
+                    filename=a.name.clone()
                 />
             </div>
         }
@@ -1555,7 +1555,7 @@ pub(crate) fn ArtifactModal(
                         dom_id=dom_id
                         path=path_head.clone()
                         kind=kind.clone()
-                        filename=Some(name.clone())
+                        filename=name.clone()
                     />
                 </div>
                 <div class="am-tabs">

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -10292,7 +10292,12 @@ fn App() -> impl IntoView {
                             }).into_view()
                         } else {
                             view! {
-                                <WorkspaceFilePreview dom_id=dom_id.clone() path=path.clone() kind=kind.clone() />
+                                <WorkspaceFilePreview
+                                    dom_id=dom_id.clone()
+                                    path=path.clone()
+                                    kind=kind.clone()
+                                    filename=Some(file.name.clone())
+                                />
                             }.into_view()
                         }}
                         {run_language.map(|language| {

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -10296,7 +10296,7 @@ fn App() -> impl IntoView {
                                     dom_id=dom_id.clone()
                                     path=path.clone()
                                     kind=kind.clone()
-                                    filename=Some(file.name.clone())
+                                    filename=file.name.clone()
                                 />
                             }.into_view()
                         }}

--- a/ui/src/text.rs
+++ b/ui/src/text.rs
@@ -1411,6 +1411,14 @@ pub(crate) fn code_lang(path: &str) -> Option<&'static str> {
     })
 }
 
+/// Highlight language for a preview path. Durable resource tabs use
+/// `artifact-version:<id>` (no extension), so fall back to the display filename.
+pub(crate) fn preview_code_lang(path: &str, filename: Option<&str>) -> &'static str {
+    code_lang(path)
+        .or_else(|| filename.and_then(code_lang))
+        .unwrap_or("plaintext")
+}
+
 /// The persistent-runtime language a source file can be bound to, or `None` for
 /// files with no runtime. The returned ids are the `RuntimeLanguage` wire
 /// spelling, so they pass straight to the runtime commands.
@@ -1545,8 +1553,9 @@ mod md_catalog_tests {
     use super::{
         code_lang, decode_href, fence_identifier_line_runs, file_kind, format_bytes,
         is_runtime_code_selection, md_document_to_html, md_inline_to_html, md_to_html, parent_path,
-        parse_notebook, pretty_json, push_nb_output, runtime_language, strip_ansi, tool_card_label,
-        user_message_presentation, NbOutput, MAX_NB_OUTPUT_BYTES, MAX_NB_TOTAL_OUTPUT_BYTES,
+        parse_notebook, pretty_json, preview_code_lang, push_nb_output, runtime_language,
+        strip_ansi, tool_card_label, user_message_presentation, NbOutput, MAX_NB_OUTPUT_BYTES,
+        MAX_NB_TOTAL_OUTPUT_BYTES,
     };
 
     #[test]
@@ -1870,6 +1879,25 @@ mod md_catalog_tests {
         assert_eq!(code_lang("a.py"), Some("python"));
         assert_eq!(code_lang("pixi.toml"), Some("ini"));
         assert_eq!(code_lang("notes.txt"), None);
+        assert_eq!(
+            preview_code_lang(
+                "artifact-version:resource-version-python",
+                Some("random_walk_demo.py")
+            ),
+            "python"
+        );
+        assert_eq!(
+            preview_code_lang("artifact-version:resource-version-r", Some("plot.R")),
+            "r"
+        );
+        assert_eq!(
+            preview_code_lang("scripts/regulon2gmt.py", None),
+            "python"
+        );
+        assert_eq!(
+            preview_code_lang("artifact-version:resource-version-txt", Some("notes.txt")),
+            "plaintext"
+        );
         // Rmd/qmd are Markdown with chunks — the Markdown preview already
         // highlights fenced code, so they must not fall into the code branch.
         assert_eq!(file_kind("analysis.Rmd"), Some("markdown"));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Markdown links to Python and R scripts currently fail durable resource binding with `unsupported preview resource type`. Hovering a deliverable like `analysis/scripts/random_walk_demo.py` only shows that error, and click-to-preview never opens.

This change:

- Treats `.py`, `.pyw`, and `.R`/`.r` as previewable `code` resources (`text/x-python` / `text/x-r`)
- Snapshots them like other bound files so the link opens the immutable version
- Resolves highlight language from the display filename when the preview path is `artifact-version:<id>`

**Tests**
- `kind_and_mime` + bind coverage for `.py` / `.R`
- `preview_code_lang` unit tests
- Playwright: bound Python and R resources open a highlighted code preview

**Smoke**
1. Have the agent emit `[script](analysis/scripts/foo.py)` and `[plot](analysis/plot.R)`
2. Hover the link — title should be the filename, not `unsupported preview resource type`
3. Click — modal and center preview should show highlighted source

**Limits**
- Already-persisted unresolved bindings are not rewritten; new messages bind correctly
- Other source extensions (`.sh`, `.rs`, …) remain on the previous allowlist
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f8e2c27-969a-4149-9032-9182a4176ec1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f8e2c27-969a-4149-9032-9182a4176ec1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

