### PR TITLE
fix(ui): keep pinned R/Python environment on screen after resize

### DIFF
--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -7118,6 +7118,36 @@ test("runtime inspector lists object metadata without loading object contents", 
   await expect(page.locator(".rightpane")).toBeVisible();
 });
 
+test("pinned runtime environment stays on screen after the window shrinks", async ({ page }) => {
+  await page.setViewportSize({ width: 1600, height: 900 });
+  await enterApp(page);
+  await page.getByTestId("session-runtime-strip")
+    .locator('[data-runtime-language="r"][data-runtime-context="local"]')
+    .click();
+  const environment = page.getByRole("region", { name: "R Environment" });
+  await expect(environment).toBeVisible();
+  await environment.getByRole("button", { name: "Pin environment to conversation" }).click();
+  await expect(environment).toHaveClass(/is-pinned/);
+  await expectInsideViewport(environment, 1600, 900);
+
+  // Restoring a maximized window used to leave the pin at the old right-edge
+  // coordinates, so it vanished until the window was maximized again.
+  await page.setViewportSize({ width: 900, height: 640 });
+  await expect(environment).toBeVisible();
+  await expect.poll(async () => {
+    const box = await environment.boundingBox();
+    if (!box) return false;
+    return box.x >= 0
+      && box.y >= 0
+      && box.x + box.width <= 900
+      && box.y + box.height <= 640;
+  }).toBe(true);
+
+  await page.setViewportSize({ width: 1600, height: 900 });
+  await expect(environment).toBeVisible();
+  await expectInsideViewport(environment, 1600, 900);
+});
+
 test("conversation runtime strip shows bound servers and opens R/Python environments", async ({ page }) => {
   await enterApp(page);
   const strip = page.getByTestId("session-runtime-strip");

--- a/ui/src/app_support/runtime.rs
+++ b/ui/src/app_support/runtime.rs
@@ -1205,22 +1205,91 @@ fn runtime_environment_viewport() -> (i32, i32) {
         .unwrap_or((1280, 720))
 }
 
-fn clamp_runtime_environment_position(x: i32, y: i32) -> (i32, i32) {
-    const MARGIN: i32 = 16;
-    const PANEL_WIDTH: i32 = 620;
-    const PANEL_HEIGHT: i32 = 560;
-    let (viewport_width, viewport_height) = runtime_environment_viewport();
-    let width = PANEL_WIDTH.min((viewport_width - MARGIN * 2).max(0));
-    let height = PANEL_HEIGHT.min((viewport_height - MARGIN * 2).max(0));
+const RUNTIME_ENVIRONMENT_MARGIN: i32 = 16;
+const RUNTIME_ENVIRONMENT_PANEL_WIDTH: i32 = 620;
+const RUNTIME_ENVIRONMENT_PANEL_HEIGHT: i32 = 560;
+
+pub(crate) fn clamp_runtime_environment_position_in(
+    x: i32,
+    y: i32,
+    viewport_width: i32,
+    viewport_height: i32,
+) -> (i32, i32) {
+    let width = RUNTIME_ENVIRONMENT_PANEL_WIDTH
+        .min((viewport_width - RUNTIME_ENVIRONMENT_MARGIN * 2).max(0));
+    let height = RUNTIME_ENVIRONMENT_PANEL_HEIGHT
+        .min((viewport_height - RUNTIME_ENVIRONMENT_MARGIN * 2).max(0));
     (
-        x.clamp(MARGIN, (viewport_width - width - MARGIN).max(MARGIN)),
-        y.clamp(MARGIN, (viewport_height - height - MARGIN).max(MARGIN)),
+        x.clamp(
+            RUNTIME_ENVIRONMENT_MARGIN,
+            (viewport_width - width - RUNTIME_ENVIRONMENT_MARGIN).max(RUNTIME_ENVIRONMENT_MARGIN),
+        ),
+        y.clamp(
+            RUNTIME_ENVIRONMENT_MARGIN,
+            (viewport_height - height - RUNTIME_ENVIRONMENT_MARGIN).max(RUNTIME_ENVIRONMENT_MARGIN),
+        ),
     )
+}
+
+pub(crate) fn clamp_runtime_environment_position(x: i32, y: i32) -> (i32, i32) {
+    let (viewport_width, viewport_height) = runtime_environment_viewport();
+    clamp_runtime_environment_position_in(x, y, viewport_width, viewport_height)
 }
 
 fn default_runtime_environment_position() -> (i32, i32) {
     let (viewport_width, viewport_height) = runtime_environment_viewport();
-    clamp_runtime_environment_position(viewport_width - 636, (viewport_height - 560) / 2)
+    clamp_runtime_environment_position(
+        viewport_width - RUNTIME_ENVIRONMENT_PANEL_WIDTH - RUNTIME_ENVIRONMENT_MARGIN,
+        (viewport_height - RUNTIME_ENVIRONMENT_PANEL_HEIGHT) / 2,
+    )
+}
+
+#[cfg(test)]
+mod runtime_environment_position_tests {
+    use super::{
+        clamp_runtime_environment_position_in, RUNTIME_ENVIRONMENT_MARGIN,
+        RUNTIME_ENVIRONMENT_PANEL_HEIGHT, RUNTIME_ENVIRONMENT_PANEL_WIDTH,
+    };
+
+    #[test]
+    fn shrinking_a_maximized_window_pulls_the_pin_back_on_screen() {
+        let maximized_x = 1920 - RUNTIME_ENVIRONMENT_PANEL_WIDTH - RUNTIME_ENVIRONMENT_MARGIN;
+        let maximized_y = (1080 - RUNTIME_ENVIRONMENT_PANEL_HEIGHT) / 2;
+        let restored_width = 1100;
+        let restored_height = 760;
+        let (x, y) = clamp_runtime_environment_position_in(
+            maximized_x,
+            maximized_y,
+            restored_width,
+            restored_height,
+        );
+        assert_eq!(
+            x,
+            restored_width - RUNTIME_ENVIRONMENT_PANEL_WIDTH - RUNTIME_ENVIRONMENT_MARGIN
+        );
+        assert_eq!(
+            y,
+            restored_height - RUNTIME_ENVIRONMENT_PANEL_HEIGHT - RUNTIME_ENVIRONMENT_MARGIN
+        );
+        assert!(x + RUNTIME_ENVIRONMENT_PANEL_WIDTH <= restored_width);
+        assert!(y + RUNTIME_ENVIRONMENT_PANEL_HEIGHT <= restored_height);
+    }
+
+    #[test]
+    fn a_left_aligned_pin_stays_put_when_the_window_grows() {
+        assert_eq!(
+            clamp_runtime_environment_position_in(16, 16, 1920, 1080),
+            (16, 16)
+        );
+    }
+
+    #[test]
+    fn a_tiny_window_keeps_the_margin() {
+        assert_eq!(
+            clamp_runtime_environment_position_in(400, 300, 400, 300),
+            (RUNTIME_ENVIRONMENT_MARGIN, RUNTIME_ENVIRONMENT_MARGIN)
+        );
+    }
 }
 
 #[component]

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -8426,14 +8426,25 @@ fn App() -> impl IntoView {
     });
 
     window_event_listener(ev::resize, move |_| {
-        let Some(geom) = context_usage_geom.get_untracked() else {
-            return;
-        };
         let (viewport_w, viewport_h) = viewport_size();
-        let clamped =
-            clamp_context_usage_geom(geom.x, geom.y, geom.w, geom.h, viewport_w, viewport_h);
-        if clamped != geom {
-            context_usage_geom.set(Some(clamped));
+        if let Some(geom) = context_usage_geom.get_untracked() {
+            let clamped =
+                clamp_context_usage_geom(geom.x, geom.y, geom.w, geom.h, viewport_w, viewport_h);
+            if clamped != geom {
+                context_usage_geom.set(Some(clamped));
+            }
+        }
+        // The pinned R/Python inspector stores pixel coordinates from the
+        // current window. Restoring from maximize leaves those coordinates
+        // past the new right/bottom edge, so the panel vanishes until the
+        // window is maximized again.
+        if runtime_environment_pinned.get_untracked() {
+            let (x, y) = runtime_environment_position.get_untracked();
+            let next =
+                clamp_runtime_environment_position_in(x, y, viewport_w as i32, viewport_h as i32);
+            if next != (x, y) {
+                runtime_environment_position.set(next);
+            }
         }
     });
 

--- a/ui/src/styles/right-pane.css
+++ b/ui/src/styles/right-pane.css
@@ -192,7 +192,17 @@ button.run-status:hover { filter:brightness(0.96); }
 .runtime-modal-body { display:flex; flex:1 1 auto; gap:12px; min-height:0; overflow:hidden; }
 .runtime-modal-body > .context-modal-section { flex:1 1 360px; min-width:280px; overflow-y:auto; padding:1px; }
 .runtime-environment-panel { position:static; z-index:2; display:flex; flex:1.35 1 520px; min-width:430px; flex-direction:column; overflow:hidden; border:1px solid var(--border-strong); border-radius: var(--radius-sm); background:var(--bg-elev); box-shadow:var(--shadow-sm); }
-.runtime-environment-panel.is-pinned { position:fixed; z-index:90; left:var(--runtime-environment-x); top:var(--runtime-environment-y); width:min(620px, calc(100vw - 32px)); height:min(560px, calc(100vh - 32px)); min-width:0; box-shadow:0 20px 56px rgba(0,0,0,.22); }
+.runtime-environment-panel.is-pinned {
+  position:fixed;
+  z-index:90;
+  /* Keep the pin on-screen when the window shrinks before JS reclamps. */
+  left:clamp(16px, var(--runtime-environment-x), calc(100vw - 16px - min(620px, calc(100vw - 32px))));
+  top:clamp(16px, var(--runtime-environment-y), calc(100vh - 16px - min(560px, calc(100vh - 32px))));
+  width:min(620px, calc(100vw - 32px));
+  height:min(560px, calc(100vh - 32px));
+  min-width:0;
+  box-shadow:0 20px 56px rgba(0,0,0,.22);
+}
 .runtime-environment-head { display:flex; align-items:center; gap:8px; min-height:58px; padding:9px 10px 9px 14px; border-bottom:1px solid var(--border); }
 .runtime-environment-langs { display:flex; flex:0 0 auto; align-items:center; gap:4px; padding:3px; border:1px solid var(--border); border-radius:999px; background:var(--bg-sunken); }
 .runtime-environment-lang { min-width:54px; padding:4px 9px; border:0; border-radius:999px; background:transparent; color:var(--text-muted); font:inherit; font-size:11.5px; font-weight:650; cursor:pointer; }


### PR DESCRIPTION
## Problem

Pinning the R/Python memory environment floats it at pixel coordinates from the current window. After maximizing, restoring the window left those coordinates past the new right/bottom edge, so the panel vanished. Maximizing again brought it back.

## Change

- Reclamp the pinned inspector on window resize, same as the context-usage panel.
- CSS-clamp `left`/`top` so the pin cannot paint off-screen before JS catches up.
- Keep a dragged pin on the left where it was; only pull it back when it would leave the viewport.

## Files

- `ui/src/app_support/runtime.rs` — viewport-aware clamp helper and unit tests
- `ui/src/main.rs` — resize listener reclamps a pinned inspector
- `ui/src/styles/right-pane.css` — CSS clamp on pinned `left`/`top`
- `ui-tests/tests/ui.spec.ts` — pin, shrink viewport, assert it stays on screen

## Tests

- `cargo test --manifest-path ui/Cargo.toml --bin wisp-ui runtime_environment_position`
- `cargo check --manifest-path ui/Cargo.toml --target wasm32-unknown-unknown`
- Playwright: `runtime inspector lists object metadata without loading object contents` and `pinned runtime environment stays on screen after the window shrinks`

## Smoke

1. Maximize the window, open Local R or Python, pin the memory environment.
2. Restore / shrink the window — the panel should stay fully visible, typically against the new right edge.
3. Maximize again — it should still be visible (now at the clamped position, not jumped off-screen).
4. Drag the pinned panel, then resize — dragging should not jump from a stale origin.

## Limitations

Resize keeps the last on-screen coordinates; it does not restore the original right-edge offset from the maximized window.