### PR TITLE
Stack R/Python selection popup vertically

### DIFF
--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -5345,6 +5345,8 @@ test("R scripts expose variables and console while only selected code can run", 
     window.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, cancelable: true }));
   });
   const popup = page.locator(".selection-popup");
+  await expect(popup).toHaveClass(/selection-popup-code/);
+  await expect(popup).toHaveCSS("flex-direction", "column");
   await expect(popup.getByRole("button")).toHaveText([
     "Run in runtime",
     "Ask AI in the conversation",

--- a/ui/src/app_support/palettes.rs
+++ b/ui/src/app_support/palettes.rs
@@ -95,6 +95,10 @@ mod quick_action_routing_tests {
 }
 
 pub(crate) fn selection_popup_x(x: i32) -> i32 {
+    selection_popup_x_with_max_width(x, 720)
+}
+
+pub(crate) fn selection_popup_x_with_max_width(x: i32, max_width: i32) -> i32 {
     let Some(viewport) = web_sys::window()
         .and_then(|window| window.inner_width().ok())
         .and_then(|value| value.as_f64())
@@ -103,11 +107,18 @@ pub(crate) fn selection_popup_x(x: i32) -> i32 {
         return x;
     };
     let usable = (viewport - 24).max(0);
-    let half_width = usable.min(720) / 2;
+    let half_width = usable.min(max_width.max(0)) / 2;
     x.clamp(half_width, viewport - half_width)
 }
 
+/// Keep enough room above the anchor for the popup. Code selections use a
+/// vertical menu (~4 stacked actions), so they need a taller clearance than
+/// the compact horizontal chat/preview popup.
 pub(crate) fn selection_popup_y(y: i32) -> i32 {
+    selection_popup_y_with_clearance(y, 120)
+}
+
+pub(crate) fn selection_popup_y_with_clearance(y: i32, min_clearance: i32) -> i32 {
     let Some(viewport) = web_sys::window()
         .and_then(|window| window.inner_height().ok())
         .and_then(|value| value.as_f64())
@@ -116,7 +127,7 @@ pub(crate) fn selection_popup_y(y: i32) -> i32 {
         return y;
     };
     let max_y = (viewport - 12).max(0);
-    y.clamp(120.min(max_y), max_y)
+    y.clamp(min_clearance.min(max_y), max_y)
 }
 
 /// Bounding box of the open runtime workbench, for divider-drag geometry.

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -10665,7 +10665,11 @@ fn App() -> impl IntoView {
                 } else {
                     selection_popup_x(x)
                 };
-                let y = selection_popup_y_with_clearance(y, if runtime_source { 200 } else { 120 });
+                let y = if runtime_source {
+                    selection_popup_y_with_clearance(y, 200)
+                } else {
+                    selection_popup_y(y)
+                };
                 let quote = text.clone();
                 let quote_source = source.clone();
                 let quote_source_for_click = quote_source.clone();

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -10657,8 +10657,15 @@ fn App() -> impl IntoView {
                 }
             })}
             {move || selection_popup.get().filter(|_| !demo_mode.get()).map(|(text, source, x, y)| {
-                let x = selection_popup_x(x);
-                let y = selection_popup_y(y);
+                // Run the selection in the file's bound runtime — the RStudio
+                // reflex. Only for R/Python sources, where a runtime exists.
+                let runtime_source = is_runtime_code_selection(source.as_deref());
+                let x = if runtime_source {
+                    selection_popup_x_with_max_width(x, 320)
+                } else {
+                    selection_popup_x(x)
+                };
+                let y = selection_popup_y_with_clearance(y, if runtime_source { 200 } else { 120 });
                 let quote = text.clone();
                 let quote_source = source.clone();
                 let quote_source_for_click = quote_source.clone();
@@ -10672,9 +10679,6 @@ fn App() -> impl IntoView {
                 // Only chat-transcript selections (no source path) can be saved
                 // as a highlight; file-preview selections have their own actions.
                 let star_text = source.is_none().then(|| text.clone());
-                // Run the selection in the file's bound runtime — the RStudio
-                // reflex. Only for R/Python sources, where a runtime exists.
-                let runtime_source = is_runtime_code_selection(source.as_deref());
                 let run_selection = source.as_deref()
                     .and_then(runtime_language)
                     .map(|language| (source.clone().unwrap_or_default(), language, text));

--- a/ui/src/styles/chat.css
+++ b/ui/src/styles/chat.css
@@ -1316,15 +1316,24 @@ details.tool:not([open]) > summary.head .run-dot { animation: tool-pulse 1.1s ea
   box-shadow: var(--shadow); transform: translate(-50%, calc(-100% - 10px));
   animation: selection-popup-in var(--motion-duration-fast) var(--motion-ease-decelerate) both;
 }
-.selection-popup-code { flex-wrap: nowrap; }
+/* R/Python source selections: stack actions vertically so long zh labels
+   stay readable instead of stretching into a wide horizontal bar. */
+.selection-popup-code {
+  flex-direction: column; align-items: stretch; flex-wrap: nowrap;
+  max-width: min(320px, calc(100vw - 24px));
+}
 .selection-popup-sep {
   flex: 0 0 1px; align-self: stretch; margin: 3px 4px; background: var(--border-strong);
+}
+.selection-popup-code .selection-popup-sep {
+  flex: 0 0 1px; width: auto; height: 1px; margin: 4px 3px;
 }
 .selection-popup-btn {
   display: inline-flex; align-items: center; gap: 6px; padding: 5px 10px; border: none; border-radius: var(--radius-xs);
   background: transparent; color: var(--text); font: inherit; font-size: 12.5px; font-weight: 500;
   cursor: pointer; white-space: nowrap;
 }
+.selection-popup-code .selection-popup-btn { justify-content: flex-start; width: 100%; }
 .selection-popup-btn:hover { background: var(--bg-sunken); }
 .selection-popup-btn svg { width: 14px; height: 14px; color: var(--text-muted); }
 .composer textarea {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Selecting code in R/Python scripts showed a **horizontal** floating action bar. With Chinese labels (`在 runtime 运行`, `在右侧对话中交给 AI`, …) the bar stretched very wide and was hard to scan.

## Change

- `.selection-popup-code` (R/Python runtime sources only) now uses `flex-direction: column` with full-width action buttons.
- The run/AI divider becomes a horizontal rule in that layout.
- Positioning clearance matches the taller/narrower menu (320px max width, 200px top clearance).
- Chat/preview selection popups stay horizontal.

## Tests

- Playwright: assert `.selection-popup-code` and `flex-direction: column` on R script selection.
- Local: `cargo fmt --check`, `ui` wasm check, targeted Playwright test passed.

## Smoke

1. Open an `.R` or `.py` file in the center pane.
2. Select a few lines → the popup should stack Run / Ask AI / Quote / Explain **vertically**.
3. Select text in chat or a markdown preview → popup remains horizontal.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0abed5b1-58e3-4d08-8a74-4e2e5065ef99?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0abed5b1-58e3-4d08-8a74-4e2e5065ef99&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

