### PR TITLE
Keep the runtime script tool contract portable and honest

### DIFF
--- a/crates/wisp-runtime/src/manager.rs
+++ b/crates/wisp-runtime/src/manager.rs
@@ -409,7 +409,8 @@ impl RuntimeManager {
         let requires_existing =
             options.expected_generation.is_some() || !options.required_objects.is_empty();
         let session = if requires_existing {
-            self.registry()
+            let session = self
+                .registry()
                 .sessions
                 .get(key)
                 .cloned()
@@ -417,18 +418,14 @@ impl RuntimeManager {
                     anyhow!(
                         "runtime is not started; load the required objects before executing this source"
                     )
-                })?
+                })?;
+            // The registry lookup bypasses `session`, so this branch is the only
+            // place that still has to reject a runtime started elsewhere.
+            ensure_session_cwd(key, &session, cwd)?;
+            session
         } else {
             self.session(key.clone(), cwd.to_path_buf())?
         };
-        if session.cwd != cwd {
-            return Err(anyhow!(
-                "runtime for project '{}' was started in '{}', not '{}'",
-                key.project_id,
-                session.cwd.display(),
-                cwd.display()
-            ));
-        }
         let info = session.wait_started().await?;
         if let Some(expected) = options.expected_generation {
             if info.generation != expected {
@@ -583,14 +580,7 @@ impl RuntimeManager {
     fn session(&self, key: RuntimeKey, cwd: PathBuf) -> Result<Arc<RuntimeSession>> {
         let mut registry = self.registry();
         if let Some(session) = registry.sessions.get(&key) {
-            if session.cwd != cwd {
-                return Err(anyhow!(
-                    "runtime for project '{}' was started in '{}', not '{}'",
-                    key.project_id,
-                    session.cwd.display(),
-                    cwd.display()
-                ));
-            }
+            ensure_session_cwd(&key, session, &cwd)?;
             return Ok(session.clone());
         }
 
@@ -905,6 +895,20 @@ async fn runtime_driver(
         info.last_error = Some(error);
     }
     info_tx.send_replace(info);
+}
+
+/// A live runtime is bound to the directory it was launched in; reusing it from
+/// another root would silently resolve relative paths against the wrong project.
+fn ensure_session_cwd(key: &RuntimeKey, session: &RuntimeSession, cwd: &Path) -> Result<()> {
+    if session.cwd == cwd {
+        return Ok(());
+    }
+    Err(anyhow!(
+        "runtime for project '{}' was started in '{}', not '{}'",
+        key.project_id,
+        session.cwd.display(),
+        cwd.display()
+    ))
 }
 
 fn fail_pending(requests: &mut mpsc::UnboundedReceiver<RuntimeRequest>, message: &str) {
@@ -1288,6 +1292,37 @@ mod tests {
             .unwrap_err();
         assert!(error.to_string().contains("runtime is not started"));
         assert_eq!(launcher.launches.load(Ordering::SeqCst), 0);
+    }
+
+    /// The guarded path looks the session up straight out of the registry, which
+    /// skips the directory check that `session` applies on the lazy path.
+    #[tokio::test]
+    async fn a_guarded_execution_still_rejects_a_runtime_from_another_root() {
+        let launcher = FakeLauncher::default();
+        let manager = manager(&launcher);
+        let key = RuntimeKey::local_python("project-a");
+        manager
+            .start(key.clone(), PathBuf::from("project-a"))
+            .await
+            .unwrap();
+
+        let error = manager
+            .execute_with_options(
+                &key,
+                Path::new("project-b"),
+                "get",
+                RuntimeExecutionOptions {
+                    required_objects: vec!["value".into()],
+                    ..RuntimeExecutionOptions::default()
+                },
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            error.to_string().contains("was started in"),
+            "{error}, expected the started-elsewhere rejection"
+        );
+        manager.shutdown_all().await;
     }
 
     #[tokio::test]

--- a/crates/wisp-runtime/src/tool.rs
+++ b/crates/wisp-runtime/src/tool.rs
@@ -482,16 +482,12 @@ impl Tool for ReplTool {
             json!({
                 "type": "object",
                 "properties": {
-                    "code": { "type": "string", "description": "Python code to execute (statements or a single expression)" },
-                    "script_path": { "type": "string", "description": "Project-relative .py file whose exact UTF-8 content is executed in this persistent runtime; mutually exclusive with code" },
-                    "required_objects": { "type": "array", "items": { "type": "string" }, "maxItems": 64, "description": "Bindings that must already exist in this runtime before execution; a missing/dead/restarted runtime fails instead of lazy-starting empty" },
+                    "code": { "type": "string", "description": "Python code to execute (statements or a single expression). Provide exactly one of code or script_path" },
+                    "script_path": { "type": "string", "description": "Project-relative .py file whose exact UTF-8 content is executed in this persistent runtime. Provide exactly one of code or script_path. The path is always resolved in the local project root, so an ssh: context needs the script present locally; only its content crosses the connection" },
+                    "required_objects": { "type": "array", "items": { "type": "string" }, "maxItems": 64, "description": "Top-level binding names (not attribute paths such as adata.X) that must already exist in this runtime before execution; a missing/dead/restarted runtime fails instead of lazy-starting empty" },
                     "expected_runtime_generation": { "type": "integer", "minimum": 1, "description": "Optional generation guard from a previous runtime-script result" },
                     "context_id": { "type": "string", "description": "Execution context id; defaults to local (for example local, ssh:gpu, or wsl:Ubuntu)" }
-                },
-                "oneOf": [
-                    { "required": ["code"] },
-                    { "required": ["script_path"] }
-                ]
+                }
             }),
         )
     }
@@ -555,16 +551,12 @@ impl Tool for RTool {
             json!({
                 "type": "object",
                 "properties": {
-                    "code": { "type": "string", "description": "R code to execute (one or more expressions)" },
-                    "script_path": { "type": "string", "description": "Project-relative .R file whose exact UTF-8 content is executed in this persistent runtime; mutually exclusive with code" },
-                    "required_objects": { "type": "array", "items": { "type": "string" }, "maxItems": 64, "description": "Bindings that must already exist in this runtime before execution; a missing/dead/restarted runtime fails instead of lazy-starting empty" },
+                    "code": { "type": "string", "description": "R code to execute (one or more expressions). Provide exactly one of code or script_path" },
+                    "script_path": { "type": "string", "description": "Project-relative .R file whose exact UTF-8 content is executed in this persistent runtime. Provide exactly one of code or script_path. The path is always resolved in the local project root, so an ssh: context needs the script present locally; only its content crosses the connection" },
+                    "required_objects": { "type": "array", "items": { "type": "string" }, "maxItems": 64, "description": "Top-level binding names (not attribute paths such as obj$slot) that must already exist in this runtime before execution; a missing/dead/restarted runtime fails instead of lazy-starting empty" },
                     "expected_runtime_generation": { "type": "integer", "minimum": 1, "description": "Optional generation guard from a previous runtime-script result" },
                     "context_id": { "type": "string", "description": "Execution context id; defaults to local (for example local, ssh:gpu, or wsl:Ubuntu)" }
-                },
-                "oneOf": [
-                    { "required": ["code"] },
-                    { "required": ["script_path"] }
-                ]
+                }
             }),
         )
     }
@@ -623,7 +615,7 @@ mod tests {
         source_arg, validated_project_writes, PYTHON_TOOL_DESCRIPTION, R_TOOL_DESCRIPTION,
     };
     use crate::{
-        KernelResp, LaunchedRuntime, RTool, RuntimeKernel, RuntimeKey, RuntimeLauncher,
+        KernelResp, LaunchedRuntime, RTool, ReplTool, RuntimeKernel, RuntimeKey, RuntimeLauncher,
         RuntimeManager, RuntimeMetadata, RuntimeObjectList, RuntimeOutput, LOCAL_CONTEXT_ID,
         MAX_CODE_BYTES,
     };
@@ -676,6 +668,66 @@ mod tests {
     fn code_size_is_rejected_before_runtime_dispatch() {
         let args = serde_json::json!({"code": "x".repeat(MAX_CODE_BYTES + 1)});
         assert!(code_arg(&args).unwrap_err().contains("byte limit"));
+    }
+
+    /// `api_url` is user-configurable, so tool schemas reach OpenAI-compatible
+    /// gateways verbatim — nothing in `wisp-llm` rewrites them. Keep the schema
+    /// to the plain object/properties subset every provider accepts and enforce
+    /// the code/script_path exclusivity in Rust instead of a `oneOf` branch.
+    #[test]
+    fn runtime_tool_schemas_stay_in_the_portable_json_schema_subset() {
+        let manager = RuntimeManager::new(Arc::new(EchoLauncher::default()));
+        let python = ReplTool::new(manager.clone(), "project-a").schema();
+        let r = RTool::new(manager, "project-a").schema();
+        for schema in [&python, &r] {
+            let parameters = &schema.function.parameters;
+            assert_eq!(parameters["type"], "object");
+            assert!(
+                parameters.get("oneOf").is_none()
+                    && parameters.get("anyOf").is_none()
+                    && parameters.get("allOf").is_none(),
+                "{parameters}"
+            );
+            let properties = parameters["properties"].as_object().unwrap();
+            for name in [
+                "code",
+                "script_path",
+                "required_objects",
+                "expected_runtime_generation",
+                "context_id",
+            ] {
+                assert!(properties.contains_key(name), "missing {name}");
+            }
+            for name in ["code", "script_path"] {
+                let description = properties[name]["description"].as_str().unwrap();
+                assert!(
+                    description.contains("exactly one of code or script_path"),
+                    "{name}: {description}"
+                );
+            }
+            let script_path = properties["script_path"]["description"]
+                .as_str()
+                .unwrap()
+                .to_string();
+            assert!(script_path.contains("resolved in the local project root"));
+            assert!(properties["required_objects"]["description"]
+                .as_str()
+                .unwrap()
+                .contains("Top-level binding names"));
+        }
+    }
+
+    #[test]
+    fn a_source_argument_is_still_mandatory_without_a_schema_branch() {
+        let root = unique_tmp("runtime_source_missing");
+        let env = recording_env(root.clone());
+        let error =
+            source_arg(&serde_json::json!({"context_id": "local"}), &env, "py").unwrap_err();
+        assert!(
+            error.contains("provide exactly one of 'code' or 'script_path'"),
+            "{error}"
+        );
+        std::fs::remove_dir_all(&root).ok();
     }
 
     #[test]

--- a/docs/superpowers/specs/2026-07-14-wisp-runtime-design.md
+++ b/docs/superpowers/specs/2026-07-14-wisp-runtime-design.md
@@ -534,16 +534,23 @@ saved project script without leaving the runtime:
 python(code? | script_path?, required_objects?, expected_runtime_generation?, context_id?)
 ```
 
-- Exactly one of `code` or `script_path` is required. `script_path` is a
-  project-relative UTF-8 `.py` file; the host reads and hashes its exact content,
-  then sends the content to the selected runtime. The file need not be copied to
-  an SSH host.
+- Exactly one of `code` or `script_path` is required. The schema keeps both
+  optional and the host rejects a call that supplies neither or both, because
+  tool schemas reach user-configured OpenAI-compatible gateways verbatim and a
+  `oneOf` branch is not portable across them.
+- `script_path` is a project-relative UTF-8 `.py` file; the host reads and hashes
+  its exact content, then sends the content to the selected runtime. The file
+  need not be copied to an SSH host — but the path is always resolved in the
+  *local* project root, so a script that exists only on the remote host cannot be
+  named this way. Read it into `code`, or fetch it into the project first.
 - `context_id` is optional and defaults to `local`, preserving existing model calls.
 - A non-local value must resolve to a registered ExecutionContext.
 - The tool lazily ensures and reuses the runtime for its key.
-- `required_objects` declares bindings that must already exist. When non-empty,
-  the tool never lazily starts an empty runtime; the worker checks the bindings
-  before evaluating any source.
+- `required_objects` declares top-level binding names that must already exist;
+  attribute or slot paths such as `adata.X` or `obj$slot` are not resolved. When
+  non-empty, the tool never lazily starts an empty runtime, and it rejects a
+  runtime started in another directory instead of falling back to a new one; the
+  worker checks the bindings before evaluating any source.
 - `expected_runtime_generation` optionally rejects a restarted/replaced runtime.
 
 The new R tool mirrors it:


### PR DESCRIPTION
## Problem

Follow-up to #1042. That PR gave `python`/`r` a `script_path` so a reproducible script executes inside the already-loaded persistent runtime instead of a fresh `Rscript`/`python file.py` process. Three things it left behind are cheaper to fix now than after the tool contract is in front of models:

1. **The schema used a top-level `oneOf`.** Tool schemas reach providers verbatim — `wisp-llm` does not rewrite them, `api_url` is user-configurable, and wisp's own MCP validator explicitly documents that it does not evaluate combinators (`crates/wisp-mcp/src/tool.rs`). So the branch enforced nothing locally while risking a 400 on a strict OpenAI-compatible gateway, and as a side effect neither `code` nor `script_path` was `required` any more.
2. **`script_path` resolution was documented as half the truth.** The spec said the file "need not be copied to an SSH host", which is true, but omitted that the path is always resolved in the *local* project root — a script that exists only on the remote host cannot be named this way.
3. **`required_objects` was described as "bindings"** without saying it matches top-level names only; `adata.X` or `obj$slot` is treated as one literal name and reported missing.

Plus one duplication: `execute_with_options` re-checked the working directory after both branches even though `session()` already checks the lazy path, and the guarded (registry-lookup) path — the only one that actually needed the check — had no test.

## Changes

- `crates/wisp-runtime/src/tool.rs`: drop `oneOf` from both schemas, keep the object/properties subset every provider accepts, and state the exclusivity, the local-root resolution, and the top-level-name restriction in the argument descriptions. Enforcement stays where it already was, in `source_arg()`.
- `crates/wisp-runtime/src/manager.rs`: extract `ensure_session_cwd()` and call it from `session()` and from the guarded branch of `execute_with_options()` only, instead of once per branch plus once after.
- `docs/superpowers/specs/2026-07-14-wisp-runtime-design.md`: record why the schema stays combinator-free, the local-root constraint with the two workarounds, and the binding-name scope.

No behavior change for callers that already pass valid arguments; this is contract clarity plus one guard that moves rather than disappears.

## Tests

`cargo test -p wisp-runtime --lib` — 65 passed (62 before #1042, 3 new here):

- `runtime_tool_schemas_stay_in_the_portable_json_schema_subset` — both schemas are `type: object`, carry no `oneOf`/`anyOf`/`allOf`, expose all five properties, and their descriptions state the exclusivity, the local-root resolution, and the top-level-name rule.
- `a_source_argument_is_still_mandatory_without_a_schema_branch` — a call with neither `code` nor `script_path` is rejected by the host, so removing the schema branch does not make the argument optional in practice.
- `a_guarded_execution_still_rejects_a_runtime_from_another_root` — covers the path whose check had no test: a `required_objects` execution against a runtime started in a different directory is rejected rather than silently reused.

Also run: `cargo test -p wisp-core -p wisp-cli -p wisp-mcp` (all green), `cargo fmt --all -- --check`, `git diff --check`.

## Manual smoke

Not needed — no user-visible surface changes. The observable difference is the JSON sent in the tool definition; `runtime_tool_schemas_stay_in_the_portable_json_schema_subset` asserts its shape.

## Merge order

Branched off #1042, so merge that first. Until it lands this PR's diff shows #1042's commit too; the merge-base moves once #1042 is in `main` and only the three files above remain.

## Known limitations / follow-up

- The editor UI still has no whole-script Runtime action (unchanged from #1042). That remains the one genuine feature follow-up.
- `required_objects` still checks names only, not types or shapes. Sufficient for "did the expensive object survive", not a schema contract for the data.
