### PR TITLE
Fix project-relative read paths

### DIFF
--- a/crates/wisp-tools/src/env.rs
+++ b/crates/wisp-tools/src/env.rs
@@ -202,7 +202,12 @@ pub trait ToolEnv: Send + Sync {
                 .join(filename));
         }
         if !self.restrict_read_paths_to_project() {
-            return Ok(PathBuf::from(path));
+            let path = Path::new(path);
+            return Ok(if path.is_absolute() {
+                path.to_path_buf()
+            } else {
+                self.project_root().join(path)
+            });
         }
         if allow_directory {
             crate::safety::resolve_under_root(self.project_root(), path)

--- a/crates/wisp-tools/src/read.rs
+++ b/crates/wisp-tools/src/read.rs
@@ -68,7 +68,7 @@ impl Tool for ReadTool {
             json!({
                 "type": "object",
                 "properties": {
-                    "path": { "type": "string", "description": "Path to a text, document, or image file" },
+                    "path": { "type": "string", "description": "Path to a text, document, or image file; relative paths resolve from the active project root" },
                     "offset": { "type": "integer", "description": "Line number to start reading from (0-indexed, default 0)" },
                     "limit": { "type": "integer", "description": "Maximum number of lines to read (default: all lines)" }
                 },
@@ -270,6 +270,35 @@ mod tests {
                 .success
         );
         assert!(!ReadTool.run(&json!({"path":outside}), &env).await.success);
+        std::fs::remove_dir_all(container).ok();
+    }
+
+    #[tokio::test]
+    async fn ordinary_reads_resolve_relative_paths_from_the_project_root() {
+        let container = std::env::temp_dir().join(format!(
+            "wisp_read_relative_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let root = container.join("project");
+        let relative = PathBuf::from("analysis/scripts/example.R");
+        std::fs::create_dir_all(root.join(relative.parent().unwrap())).unwrap();
+        std::fs::write(root.join(&relative), "project relative").unwrap();
+        let outside = container.join("outside.txt");
+        std::fs::write(&outside, "absolute outside").unwrap();
+        let env = TestEnv(root);
+
+        let relative_result = ReadTool.run(&json!({"path": relative}), &env).await;
+        assert!(relative_result.success, "{}", relative_result.content);
+        assert!(relative_result.content.contains("project relative"));
+
+        let absolute_result = ReadTool.run(&json!({"path": outside}), &env).await;
+        assert!(absolute_result.success, "{}", absolute_result.content);
+        assert!(absolute_result.content.contains("absolute outside"));
+
         std::fs::remove_dir_all(container).ok();
     }
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -150,7 +150,9 @@ wisp-science/
   `/chat/completions` and Anthropic `/v1/messages`), both with SSE streaming.
   `RoutedProvider` picks a low/medium/high tier per turn.
 - **Tools** (`wisp-tools`): filesystem + shell tools with Windows-aware
-  dangerous-command gating and a path sandbox rooted at the project directory.
+  dangerous-command gating. Relative filesystem paths resolve from the active
+  project root; isolated exploration and delegated sessions additionally keep
+  reads and searches inside that root.
 - **Python/R REPLs** (`wisp-runtime`): one manager-owned process per
   project/context/language keeps its namespace across cells and conversations;
   local, WSL, and SSH contexts share one versioned protocol.


### PR DESCRIPTION
## Problem

A valid project-relative `read` path in an ordinary mainline conversation was resolved against the Wisp process working directory instead of the active project root. This made `read analysis/scripts/mathys2019_umap.R` fail with `os error 3` even though `search` found the file and an absolute-path read succeeded.

Closes #1051.

## Changes

- Resolve unrestricted relative read/search/grep paths from `ToolEnv::project_root()` while preserving explicit absolute paths.
- Keep delegated and exploration containment checks unchanged.
- Document the path contract in the `read` schema and development guide.
- Add regression coverage for a mainline project-relative read and the existing absolute outside-project behavior.

`edit` and `write` already resolve relative paths through `validate_file_path(project_root, path)` and are intentionally unchanged.

## Validation

- `cargo test -p wisp-tools` — 60 passed.
- `cargo fmt --all -- --check` — passed.
- `git diff --check` — passed.
- `cargo test --workspace` — 905 passed, 11 failed in Windows/shared-state areas unrelated to this change. The SSH staging failure passed on an exact rerun; the remaining 10 failures match the established Windows baseline groups (`method_search`, `resource_leases`, and `publication_commands`).

## Manual smoke steps

1. Open a project containing `analysis/scripts/mathys2019_umap.R`.
2. Ask the main agent to read `analysis/scripts/mathys2019_umap.R` and confirm it succeeds without searching for an absolute path first.
3. Confirm an explicitly supplied absolute path still reads successfully.

## Known limitations

- Ordinary mainline sessions retain their existing ability to read an explicitly supplied absolute path outside the active project. This PR changes only the base used for relative paths.
- Existing Windows full-workspace baseline failures are not addressed here.