### PR TITLE
feat: recover conversations from orphaned workspaces

### DIFF
--- a/crates/wisp-dto/src/lib.rs
+++ b/crates/wisp-dto/src/lib.rs
@@ -2618,6 +2618,33 @@ pub struct ProjectSummary {
     pub last_synced_at: Option<i64>,
 }
 
+/// Read-only scan result shown before an orphaned workspace is registered and
+/// its `.wisp/history` context archives are imported.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct WorkspaceSessionRecoveryPreview {
+    pub workspace_dir: String,
+    pub suggested_name: String,
+    pub archive_count: usize,
+    pub valid_archive_count: usize,
+    pub recoverable_session_count: usize,
+    pub message_count: usize,
+    pub invalid_archive_count: usize,
+    pub duplicate_archive_count: usize,
+    pub earliest_message_at: Option<i64>,
+    pub latest_message_at: Option<i64>,
+}
+
+/// Result of the transactional workspace-session recovery import.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct WorkspaceSessionRecoveryResult {
+    pub project_id: String,
+    pub project_name: String,
+    pub recovered_session_count: usize,
+    pub message_count: usize,
+    pub invalid_archive_count: usize,
+    pub duplicate_archive_count: usize,
+}
+
 /// Editable project settings (Project Settings modal). `agent_context` is the
 /// project's `.wisp/WISP.md`, injected into every seeded system prompt.
 #[derive(Clone, Deserialize, Default)]

--- a/crates/wisp-store/src/lib.rs
+++ b/crates/wisp-store/src/lib.rs
@@ -76,6 +76,7 @@ pub use projects::{is_scratch_project_id, SCRATCH_PROJECT_PREFIX};
 pub use provenance::{canonical_json, canonical_json_sha256};
 pub use remote_staging::RemoteStagingEntry;
 pub use schedules::{next_slot_after, ScheduleRecord, ScheduleRunRecord};
+pub use session_imports::RecoveredWorkspaceSession;
 pub use sessions::{
     ModelTokenUsage, ProjectTokenUsage, SessionBranchDeltaMessage, SessionBranchLink,
     SessionBranchMerge, SessionBranchMergeCard, SessionBranchMergePreview, SessionTokenUsage,

--- a/crates/wisp-store/src/session_imports.rs
+++ b/crates/wisp-store/src/session_imports.rs
@@ -5,8 +5,136 @@
 
 use super::Store;
 use anyhow::Result;
+use std::collections::HashSet;
+use wisp_llm::{Message, Role};
+
+/// One validated conversation recovered from a workspace context archive.
+/// The caller owns archive parsing and deduplication; the store owns the
+/// all-or-nothing project/frame/message insertion.
+#[derive(Clone)]
+pub struct RecoveredWorkspaceSession {
+    pub source_session_id: String,
+    pub source_path: String,
+    pub messages: Vec<Message>,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
 
 impl Store {
+    /// Register an existing workspace and import all recovered conversations
+    /// in one transaction. A failed frame/message/provenance insert leaves no
+    /// half-created project in the live database.
+    pub async fn create_recovered_workspace_project(
+        &self,
+        project_id: &str,
+        name: &str,
+        workspace_dir: &str,
+        model_id: &str,
+        sessions: &[RecoveredWorkspaceSession],
+    ) -> Result<Vec<String>> {
+        if project_id.trim().is_empty() || name.trim().is_empty() || workspace_dir.trim().is_empty()
+        {
+            anyhow::bail!("recovered project identity is incomplete");
+        }
+        if sessions.is_empty() {
+            anyhow::bail!("no recoverable sessions were provided");
+        }
+        let mut source_ids = HashSet::new();
+        for session in sessions {
+            if session.source_session_id.trim().is_empty()
+                || session.messages.is_empty()
+                || !session
+                    .messages
+                    .iter()
+                    .any(|message| message.role == Role::User)
+            {
+                anyhow::bail!("recovered session is incomplete");
+            }
+            if !source_ids.insert(session.source_session_id.as_str()) {
+                anyhow::bail!("recovered session ids are not unique");
+            }
+        }
+
+        let now = chrono::Utc::now().timestamp();
+        let folder_id = uuid::Uuid::new_v4().to_string();
+        let mut tx = self.begin_write().await?;
+        sqlx::query(
+            "INSERT INTO projects(id,name,description,workspace_dir,created_at,updated_at) \
+             VALUES(?,?,'',?,?,?)",
+        )
+        .bind(project_id)
+        .bind(name.trim())
+        .bind(workspace_dir)
+        .bind(now)
+        .bind(now)
+        .execute(&mut *tx)
+        .await?;
+        sqlx::query(
+            "INSERT INTO folders(id,project_id,name,created_at,updated_at) VALUES(?,?,?,?,?)",
+        )
+        .bind(&folder_id)
+        .bind(project_id)
+        .bind("Recovered")
+        .bind(now)
+        .bind(now)
+        .execute(&mut *tx)
+        .await?;
+
+        let mut frame_ids = Vec::with_capacity(sessions.len());
+        for session in sessions {
+            let frame_id = uuid::Uuid::new_v4().to_string();
+            let created_at = if session.created_at > 0 {
+                session.created_at
+            } else {
+                now
+            };
+            let updated_at = if session.updated_at >= created_at {
+                session.updated_at
+            } else {
+                created_at
+            };
+            sqlx::query(
+                "INSERT INTO frames(\
+                   id,parent_frame_id,root_frame_id,agent_name,status,project_id,folder_id,model,\
+                   input_tokens,output_tokens,created_at,updated_at,completed_at\
+                 ) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,NULL)",
+            )
+            .bind(&frame_id)
+            .bind(&frame_id)
+            .bind(&frame_id)
+            .bind("OPERON")
+            .bind("running")
+            .bind(project_id)
+            .bind(&folder_id)
+            .bind(model_id)
+            .bind(0i64)
+            .bind(0i64)
+            .bind(created_at)
+            .bind(updated_at)
+            .execute(&mut *tx)
+            .await?;
+            for (index, message) in session.messages.iter().enumerate() {
+                super::sessions::insert_message_row(&mut *tx, &frame_id, index as i64 + 1, message)
+                    .await?;
+            }
+            sqlx::query(
+                "INSERT INTO session_imports(\
+                   source_session_id,frame_id,source_path,created_at,updated_at\
+                 ) VALUES(?,?,?,?,?)",
+            )
+            .bind(&session.source_session_id)
+            .bind(&frame_id)
+            .bind(&session.source_path)
+            .bind(now)
+            .bind(now)
+            .execute(&mut *tx)
+            .await?;
+            frame_ids.push(frame_id);
+        }
+        tx.commit().await?;
+        Ok(frame_ids)
+    }
+
     /// The frame a session archive was already imported into, if any.
     pub async fn find_session_import(&self, source_session_id: &str) -> Result<Option<String>> {
         Ok(
@@ -116,6 +244,75 @@ mod tests {
             .unwrap()
             .contains(&SESSION_IMPORTS_MIGRATION.to_string()));
         drop(reopened);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[tokio::test]
+    async fn recovered_workspace_project_is_inserted_atomically() {
+        let path = std::env::temp_dir().join(format!(
+            "wisp_store_workspace_recovery_{}.sqlite",
+            uuid::Uuid::new_v4()
+        ));
+        let store = Store::open(&path).await.unwrap();
+        let sessions = vec![
+            RecoveredWorkspaceSession {
+                source_session_id: "workspace:p:source-1".into(),
+                source_path: ".wisp/history/one.json".into(),
+                messages: vec![
+                    Message::user("first question"),
+                    Message::assistant("answer"),
+                ],
+                created_at: 10,
+                updated_at: 20,
+            },
+            RecoveredWorkspaceSession {
+                source_session_id: "workspace:p:source-2".into(),
+                source_path: ".wisp/history/two.json".into(),
+                messages: vec![Message::user("second question")],
+                created_at: 30,
+                updated_at: 30,
+            },
+        ];
+
+        let frames = store
+            .create_recovered_workspace_project(
+                "p",
+                "Recovered study",
+                "/workspace",
+                "model",
+                &sessions,
+            )
+            .await
+            .unwrap();
+        assert_eq!(frames.len(), 2);
+        assert_eq!(store.list_sessions("p").await.unwrap().len(), 2);
+        assert_eq!(store.message_count(&frames[0]).await.unwrap(), 2);
+        assert_eq!(
+            store
+                .find_session_import("workspace:p:source-1")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some(frames[0].as_str())
+        );
+
+        // This conflict happens after the transaction has inserted the new
+        // project, folder, frame, and messages. The unique provenance failure
+        // must roll the entire transaction back.
+        let error = store
+            .create_recovered_workspace_project(
+                "other",
+                "Broken",
+                "/other",
+                "model",
+                &[sessions[0].clone()],
+            )
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("UNIQUE"));
+        assert!(store.get_project("other").await.unwrap().is_none());
+
+        drop(store);
         let _ = std::fs::remove_file(path);
     }
 }

--- a/crates/wisp-store/src/sessions.rs
+++ b/crates/wisp-store/src/sessions.rs
@@ -986,7 +986,7 @@ impl Store {
     }
 }
 
-async fn insert_message_row<'e, E>(
+pub(crate) async fn insert_message_row<'e, E>(
     executor: E,
     frame_id: &str,
     seq: i64,

--- a/docs/project-transfer.md
+++ b/docs/project-transfer.md
@@ -1,6 +1,6 @@
 # Project transfer
 
-Wisp supports two deliberately different ways to bring a project onto a device:
+Wisp supports three deliberately different ways to bring a project onto a device:
 
 - **Open a folder in place** registers an existing local folder as a project. The
   folder remains where it is and Wisp does not copy its files. Use this after
@@ -9,11 +9,16 @@ Wisp supports two deliberately different ways to bring a project onto a device:
 - **Import a ZIP archive** restores a complete Wisp transfer into a new folder.
   The ZIP contains the workspace's regular files plus project-owned conversations,
   artifacts, runs, plans, provenance, and research-graph records.
+- **Recover conversations from a workspace** scans `.wisp/history` in an
+  orphaned folder whose application database and Wisp project ZIP are no longer
+  available. It registers the folder in place and imports the recoverable message
+  timelines into a `Recovered` conversation folder.
 
 Opening a folder in place creates a new local Wisp project record. Conversation
 history and other records that exist only in another device's Wisp database are
 not recovered from a plain folder copy; use ZIP export/import when those records
-must move too.
+must move too. Workspace conversation recovery is a best-effort disaster fallback,
+not an equivalent replacement for a complete project ZIP.
 
 To move a project from Windows to macOS:
 
@@ -38,6 +43,33 @@ copy.
 For a folder you copied yourself, choose **Import project → Open a folder in
 place** instead. Confirm its local name and path; Wisp registers that exact path
 without creating a duplicate workspace.
+
+## Recovering conversations from an orphaned workspace
+
+Choose **Import project → Recover conversations from a workspace** only when the
+original Wisp application database, project ZIP, and sync revision are unavailable.
+After a folder is selected, Wisp scans regular JSON files under `.wisp/history`,
+accepts both plain message-array compaction snapshots and structured Exploration
+checkpoints, deduplicates exact message arrays by content hash, and keeps the
+greatest `message_head` for checkpoints with the same source frame. The preview
+shows the recoverable conversation count, message count, valid archive count,
+time range, and skipped damaged/duplicate archives before making any database
+change.
+
+Confirming the preview registers the existing folder and inserts the project,
+`Recovered` folder, conversations, messages, and import provenance in one SQLite
+transaction. A failed insert leaves no half-recovered project, and Wisp never
+rewrites or deletes the source history archives.
+
+The history files are snapshots rather than a complete portable project database.
+Recovery can restore their stored message timelines, including tool calls and
+reasoning fields, but cannot reconstruct database-only UI events, reviews,
+resource bindings, runs, undo indexes, branch relationships, or other project
+records. Plain message arrays do not identify their original frame, so exact
+copies can be deduplicated but distinct snapshots from one conversation may be
+recovered separately. Ordinary conversations that never produced a compaction or
+Exploration checkpoint may not appear in `.wisp/history` at all. Use project ZIP
+export/import or manual project sync for complete, planned backup and migration.
 
 ## Path rules
 

--- a/src-tauri/src/dto_contract_tests.rs
+++ b/src-tauri/src/dto_contract_tests.rs
@@ -236,6 +236,35 @@ fn project_transfer_progress_contract() {
 }
 
 #[test]
+fn workspace_session_recovery_contract() {
+    let preview = wisp_dto::WorkspaceSessionRecoveryPreview {
+        workspace_dir: "/study".into(),
+        suggested_name: "Study".into(),
+        archive_count: 4,
+        valid_archive_count: 3,
+        recoverable_session_count: 2,
+        message_count: 648,
+        invalid_archive_count: 1,
+        duplicate_archive_count: 1,
+        earliest_message_at: Some(10),
+        latest_message_at: Some(20),
+    };
+    let decoded: wisp_dto::WorkspaceSessionRecoveryPreview = roundtrip(&preview);
+    assert_eq!(decoded, preview);
+
+    let result = wisp_dto::WorkspaceSessionRecoveryResult {
+        project_id: "project".into(),
+        project_name: "Study".into(),
+        recovered_session_count: 2,
+        message_count: 648,
+        invalid_archive_count: 1,
+        duplicate_archive_count: 1,
+    };
+    let decoded: wisp_dto::WorkspaceSessionRecoveryResult = roundtrip(&result);
+    assert_eq!(decoded, result);
+}
+
+#[test]
 fn trajectory_snapshot_contract() {
     let backend = crate::trajectory::TrajectorySnapshot {
         frame_id: "frame-1".into(),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -112,6 +112,7 @@ mod video_generation_tool;
 mod windows_snap;
 mod workspace_manifest;
 mod workspace_scan;
+mod workspace_session_recovery;
 mod wsl_contexts;
 
 pub(crate) use agent_turn::*;
@@ -6935,6 +6936,8 @@ pub fn run() {
             debug_request::get_context_usage_details,
             project_transfer::export_project,
             project_transfer::import_project,
+            workspace_session_recovery::preview_workspace_session_recovery,
+            workspace_session_recovery::recover_workspace_sessions,
             codex_import::list_codex_sessions,
             codex_import::list_claude_sessions,
             codex_import::preview_codex_session,

--- a/src-tauri/src/project_commands.rs
+++ b/src-tauri/src/project_commands.rs
@@ -3,7 +3,7 @@
 use super::*;
 use tauri::Manager;
 
-fn same_workspace_path(left: &Path, right: &Path) -> bool {
+pub(crate) fn same_workspace_path(left: &Path, right: &Path) -> bool {
     if left == right {
         return true;
     }

--- a/src-tauri/src/workspace_session_recovery.rs
+++ b/src-tauri/src/workspace_session_recovery.rs
@@ -1,0 +1,679 @@
+//! Best-effort recovery of conversations from an orphaned workspace.
+//!
+//! `.wisp/history/*.json` files are compaction snapshots or Exploration context
+//! checkpoints, not a complete project database. Recovery therefore imports
+//! only their message timelines into newly generated frames and keeps the source
+//! files untouched.
+
+use super::{models, project_commands, AppState};
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use tauri::State;
+use wisp_dto::{WorkspaceSessionRecoveryPreview, WorkspaceSessionRecoveryResult};
+use wisp_llm::{Message, Role};
+use wisp_store::{RecoveredWorkspaceSession, Store};
+
+const HISTORY_RELATIVE: &str = ".wisp/history";
+const MAX_ARCHIVE_FILES: usize = 1_000;
+const MAX_ARCHIVE_BYTES: u64 = 50 * 1024 * 1024;
+const MAX_TOTAL_ARCHIVE_BYTES: u64 = 200 * 1024 * 1024;
+const MAX_RECOVERED_MESSAGES: usize = 100_000;
+
+#[derive(Deserialize)]
+struct ContextArchive {
+    schema_version: u32,
+    frame_id: String,
+    message_head: i64,
+    messages: Vec<Message>,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum HistoryArchive {
+    Versioned(ContextArchive),
+    MessageArray(Vec<Message>),
+}
+
+struct RecoveryCandidate {
+    source_frame_id: String,
+    source_path: String,
+    message_head: i64,
+    messages: Vec<Message>,
+    created_at: i64,
+    updated_at: i64,
+}
+
+struct RecoveryScan {
+    preview: WorkspaceSessionRecoveryPreview,
+    manifest_project_id: Option<String>,
+    sessions: Vec<RecoveryCandidate>,
+}
+
+fn coded(code: &str, message: impl AsRef<str>) -> String {
+    format!("{code}: {}", message.as_ref())
+}
+
+fn manifest_string(root: &Path, key: &str) -> Option<String> {
+    let bytes = std::fs::read(root.join(".wisp/project.toml")).ok()?;
+    if bytes.len() > 64 * 1024 {
+        return None;
+    }
+    let text = std::str::from_utf8(&bytes).ok()?;
+    text.lines().find_map(|line| {
+        let (candidate, value) = line.split_once('=')?;
+        if candidate.trim() != key {
+            return None;
+        }
+        serde_json::from_str::<String>(value.trim())
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+    })
+}
+
+fn workspace_name(root: &Path) -> String {
+    manifest_string(root, "name")
+        .or_else(|| {
+            root.file_name()
+                .and_then(|name| name.to_str())
+                .map(str::to_owned)
+        })
+        .filter(|name| !name.trim().is_empty())
+        .unwrap_or_else(|| "Recovered project".into())
+}
+
+fn message_times(messages: &[Message], fallback: i64) -> (i64, i64) {
+    let earliest = messages
+        .iter()
+        .map(|message| message.ts)
+        .filter(|timestamp| *timestamp > 0)
+        .min()
+        .unwrap_or(fallback);
+    let latest = messages
+        .iter()
+        .map(|message| message.ts)
+        .filter(|timestamp| *timestamp > 0)
+        .max()
+        .unwrap_or(earliest);
+    (earliest, latest)
+}
+
+fn modified_at(metadata: &std::fs::Metadata) -> i64 {
+    metadata
+        .modified()
+        .ok()
+        .and_then(|modified| modified.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|duration| duration.as_secs().min(i64::MAX as u64) as i64)
+        .unwrap_or_else(|| chrono::Utc::now().timestamp())
+}
+
+fn scan_workspace(root: &Path) -> Result<RecoveryScan, String> {
+    let root = dunce::canonicalize(root).map_err(|error| {
+        coded(
+            "workspace_recovery_invalid_workspace",
+            format!("Cannot open the selected workspace: {error}"),
+        )
+    })?;
+    if !root.is_dir() {
+        return Err(coded(
+            "workspace_recovery_invalid_workspace",
+            "The selected workspace is not a directory.",
+        ));
+    }
+    let history = root.join(HISTORY_RELATIVE);
+    let history_metadata = std::fs::symlink_metadata(&history).map_err(|error| {
+        coded(
+            "workspace_recovery_no_history",
+            format!("No readable {HISTORY_RELATIVE} directory was found: {error}"),
+        )
+    })?;
+    if history_metadata.file_type().is_symlink() || !history_metadata.is_dir() {
+        return Err(coded(
+            "workspace_recovery_no_history",
+            format!("{HISTORY_RELATIVE} must be a real directory."),
+        ));
+    }
+
+    let mut paths = std::fs::read_dir(&history)
+        .map_err(|error| {
+            coded(
+                "workspace_recovery_no_history",
+                format!("Cannot read {HISTORY_RELATIVE}: {error}"),
+            )
+        })?
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().and_then(|value| value.to_str()) == Some("json"))
+        .collect::<Vec<_>>();
+    paths.sort();
+    if paths.len() > MAX_ARCHIVE_FILES {
+        return Err(coded(
+            "workspace_recovery_too_large",
+            format!("The workspace has more than {MAX_ARCHIVE_FILES} history archives."),
+        ));
+    }
+
+    let archive_count = paths.len();
+    let mut valid_archive_count = 0usize;
+    let mut invalid_archive_count = 0usize;
+    let mut duplicate_archive_count = 0usize;
+    let mut total_bytes = 0u64;
+    let mut candidates = BTreeMap::<String, RecoveryCandidate>::new();
+
+    for path in paths {
+        let metadata = match std::fs::symlink_metadata(&path) {
+            Ok(metadata)
+                if metadata.is_file()
+                    && !metadata.file_type().is_symlink()
+                    && metadata.len() > 0
+                    && metadata.len() <= MAX_ARCHIVE_BYTES =>
+            {
+                metadata
+            }
+            _ => {
+                invalid_archive_count += 1;
+                continue;
+            }
+        };
+        total_bytes = total_bytes.saturating_add(metadata.len());
+        if total_bytes > MAX_TOTAL_ARCHIVE_BYTES {
+            return Err(coded(
+                "workspace_recovery_too_large",
+                "The history archives exceed the 200 MiB recovery limit.",
+            ));
+        }
+        let archive = std::fs::read(&path)
+            .ok()
+            .and_then(|bytes| serde_json::from_slice::<HistoryArchive>(&bytes).ok());
+        let Some(archive) = archive else {
+            invalid_archive_count += 1;
+            continue;
+        };
+        let (dedupe_key, source_frame_id, message_head, messages) = match archive {
+            HistoryArchive::Versioned(archive)
+                if archive.schema_version == 1
+                    && archive.message_head > 0
+                    && !archive.frame_id.trim().is_empty()
+                    && archive.frame_id.len() <= 256 =>
+            {
+                (
+                    format!("frame:{}", archive.frame_id),
+                    archive.frame_id,
+                    archive.message_head,
+                    archive.messages,
+                )
+            }
+            HistoryArchive::Versioned(_) => {
+                invalid_archive_count += 1;
+                continue;
+            }
+            HistoryArchive::MessageArray(messages) => {
+                let encoded = match serde_json::to_vec(&messages) {
+                    Ok(encoded) => encoded,
+                    Err(_) => {
+                        invalid_archive_count += 1;
+                        continue;
+                    }
+                };
+                let digest = hex::encode(Sha256::digest(encoded));
+                (
+                    format!("messages:{digest}"),
+                    format!("message-sha256:{digest}"),
+                    i64::try_from(messages.len()).unwrap_or(i64::MAX),
+                    messages,
+                )
+            }
+        };
+        if messages.is_empty() || !messages.iter().any(|message| message.role == Role::User) {
+            invalid_archive_count += 1;
+            continue;
+        }
+        valid_archive_count += 1;
+        let fallback = modified_at(&metadata);
+        let (created_at, updated_at) = message_times(&messages, fallback);
+        let source_path = path
+            .strip_prefix(&root)
+            .unwrap_or(&path)
+            .to_string_lossy()
+            .replace('\\', "/");
+        let candidate = RecoveryCandidate {
+            source_frame_id,
+            source_path,
+            message_head,
+            messages,
+            created_at,
+            updated_at,
+        };
+        match candidates.entry(dedupe_key) {
+            std::collections::btree_map::Entry::Vacant(entry) => {
+                entry.insert(candidate);
+            }
+            std::collections::btree_map::Entry::Occupied(mut entry) => {
+                duplicate_archive_count += 1;
+                let current = entry.get();
+                if (candidate.message_head, candidate.messages.len())
+                    > (current.message_head, current.messages.len())
+                {
+                    entry.insert(candidate);
+                }
+            }
+        }
+    }
+
+    let sessions = candidates.into_values().collect::<Vec<_>>();
+    let message_count = sessions
+        .iter()
+        .map(|session| session.messages.len())
+        .sum::<usize>();
+    if message_count > MAX_RECOVERED_MESSAGES {
+        return Err(coded(
+            "workspace_recovery_too_large",
+            format!("The recovery contains more than {MAX_RECOVERED_MESSAGES} messages."),
+        ));
+    }
+    let earliest_message_at = sessions.iter().map(|session| session.created_at).min();
+    let latest_message_at = sessions.iter().map(|session| session.updated_at).max();
+    let preview = WorkspaceSessionRecoveryPreview {
+        workspace_dir: root.to_string_lossy().into_owned(),
+        suggested_name: workspace_name(&root),
+        archive_count,
+        valid_archive_count,
+        recoverable_session_count: sessions.len(),
+        message_count,
+        invalid_archive_count,
+        duplicate_archive_count,
+        earliest_message_at,
+        latest_message_at,
+    };
+    Ok(RecoveryScan {
+        preview,
+        manifest_project_id: manifest_string(&root, "project_id"),
+        sessions,
+    })
+}
+
+async fn ensure_workspace_is_unregistered(store: &Store, workspace: &Path) -> Result<(), String> {
+    let registered = store
+        .list_projects()
+        .await
+        .map_err(|error| error.to_string())?
+        .iter()
+        .any(|project| {
+            project_commands::same_workspace_path(workspace, Path::new(project.2.as_str()))
+        });
+    if registered {
+        return Err(coded(
+            "workspace_recovery_registered",
+            "This folder is already registered as a project.",
+        ));
+    }
+    Ok(())
+}
+
+fn probe_workspace_writable(root: &Path) -> Result<(), String> {
+    let marker = root.join(format!(
+        ".wisp-recovery-write-test-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&marker)
+        .map_err(|error| {
+            coded(
+                "workspace_recovery_not_writable",
+                format!("The selected workspace is not writable: {error}"),
+            )
+        })?;
+    drop(file);
+    std::fs::remove_file(&marker).map_err(|error| {
+        coded(
+            "workspace_recovery_not_writable",
+            format!("Could not remove the workspace write probe: {error}"),
+        )
+    })
+}
+
+async fn persist_scan(
+    store: &Store,
+    scan: RecoveryScan,
+    project_name: &str,
+    model_id: &str,
+) -> Result<WorkspaceSessionRecoveryResult, String> {
+    let project_name = project_name.trim();
+    if project_name.is_empty() {
+        return Err(coded(
+            "workspace_recovery_name_required",
+            "Project name is required.",
+        ));
+    }
+    if scan.sessions.is_empty() {
+        return Err(coded(
+            "workspace_recovery_no_sessions",
+            "No valid conversation archives were found.",
+        ));
+    }
+    let project_id = match scan
+        .manifest_project_id
+        .filter(|project_id| !project_id.trim().is_empty())
+    {
+        Some(project_id)
+            if store
+                .get_project(&project_id)
+                .await
+                .map_err(|e| e.to_string())?
+                .is_none() =>
+        {
+            project_id
+        }
+        _ => uuid::Uuid::new_v4().to_string(),
+    };
+    let recovered = scan
+        .sessions
+        .into_iter()
+        .map(|session| RecoveredWorkspaceSession {
+            source_session_id: format!(
+                "workspace-history:{project_id}:{}",
+                session.source_frame_id
+            ),
+            source_path: session.source_path,
+            messages: session.messages,
+            created_at: session.created_at,
+            updated_at: session.updated_at,
+        })
+        .collect::<Vec<_>>();
+    store
+        .create_recovered_workspace_project(
+            &project_id,
+            project_name,
+            &scan.preview.workspace_dir,
+            model_id,
+            &recovered,
+        )
+        .await
+        .map_err(|error| {
+            coded(
+                "workspace_recovery_import_failed",
+                format!("Could not import the recovered conversations: {error}"),
+            )
+        })?;
+    Ok(WorkspaceSessionRecoveryResult {
+        project_id,
+        project_name: project_name.into(),
+        recovered_session_count: recovered.len(),
+        message_count: scan.preview.message_count,
+        invalid_archive_count: scan.preview.invalid_archive_count,
+        duplicate_archive_count: scan.preview.duplicate_archive_count,
+    })
+}
+
+#[tauri::command]
+pub(super) async fn preview_workspace_session_recovery(
+    state: State<'_, AppState>,
+    workspace_dir: String,
+) -> Result<WorkspaceSessionRecoveryPreview, String> {
+    let path = PathBuf::from(workspace_dir.trim());
+    let scan = tokio::task::spawn_blocking(move || scan_workspace(&path))
+        .await
+        .map_err(|error| error.to_string())??;
+    ensure_workspace_is_unregistered(&state.store, Path::new(&scan.preview.workspace_dir)).await?;
+    Ok(scan.preview)
+}
+
+#[tauri::command]
+pub(super) async fn recover_workspace_sessions(
+    state: State<'_, AppState>,
+    workspace_dir: String,
+    name: String,
+) -> Result<WorkspaceSessionRecoveryResult, String> {
+    let path = PathBuf::from(workspace_dir.trim());
+    let scan = tokio::task::spawn_blocking(move || scan_workspace(&path))
+        .await
+        .map_err(|error| error.to_string())??;
+    let root = PathBuf::from(&scan.preview.workspace_dir);
+    ensure_workspace_is_unregistered(&state.store, &root).await?;
+    probe_workspace_writable(&root)?;
+    let model_id = models::active_profile_id(&state.store).await;
+    persist_scan(&state.store, scan, &name, &model_id).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_workspace(label: &str) -> PathBuf {
+        let root = std::env::temp_dir().join(format!(
+            "wisp_workspace_recovery_{label}_{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(root.join(HISTORY_RELATIVE)).unwrap();
+        root
+    }
+
+    fn message(role: Role, text: &str, ts: i64) -> Message {
+        let mut message = match role {
+            Role::User => Message::user(text),
+            Role::Assistant => Message::assistant(text),
+            Role::System => Message::system(text),
+            Role::Tool => Message::tool("call", "read", text),
+        };
+        message.ts = ts;
+        message
+    }
+
+    fn write_archive(
+        root: &Path,
+        name: &str,
+        frame_id: &str,
+        message_head: i64,
+        messages: Vec<Message>,
+    ) {
+        let body = serde_json::json!({
+            "schema_version": 1,
+            "frame_id": frame_id,
+            "message_head": message_head,
+            "messages": messages,
+        });
+        std::fs::write(
+            root.join(HISTORY_RELATIVE).join(name),
+            serde_json::to_vec_pretty(&body).unwrap(),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn scan_deduplicates_frames_and_reports_damaged_archives() {
+        let root = test_workspace("scan");
+        std::fs::create_dir_all(root.join(".wisp")).unwrap();
+        std::fs::write(
+            root.join(".wisp/project.toml"),
+            "layout_version = 1\nproject_id = \"original\"\nname = \"Recovered Study\"\n",
+        )
+        .unwrap();
+        write_archive(
+            &root,
+            "old.json",
+            "frame-1",
+            2,
+            vec![message(Role::User, "old", 10)],
+        );
+        write_archive(
+            &root,
+            "new.json",
+            "frame-1",
+            4,
+            vec![
+                message(Role::User, "question", 20),
+                message(Role::Assistant, "answer", 30),
+            ],
+        );
+        write_archive(
+            &root,
+            "other.json",
+            "frame-2",
+            1,
+            vec![message(Role::User, "other", 40)],
+        );
+        std::fs::write(root.join(HISTORY_RELATIVE).join("broken.json"), b"{").unwrap();
+
+        let scan = scan_workspace(&root).unwrap();
+        assert_eq!(scan.preview.suggested_name, "Recovered Study");
+        assert_eq!(scan.preview.archive_count, 4);
+        assert_eq!(scan.preview.valid_archive_count, 3);
+        assert_eq!(scan.preview.recoverable_session_count, 2);
+        assert_eq!(scan.preview.message_count, 3);
+        assert_eq!(scan.preview.invalid_archive_count, 1);
+        assert_eq!(scan.preview.duplicate_archive_count, 1);
+        assert_eq!(scan.preview.earliest_message_at, Some(20));
+        assert_eq!(scan.preview.latest_message_at, Some(40));
+        assert_eq!(scan.manifest_project_id.as_deref(), Some("original"));
+        assert_eq!(scan.sessions[0].message_head, 4);
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn scan_recovers_plain_message_arrays_and_deduplicates_exact_snapshots() {
+        let root = test_workspace("message_arrays");
+        let first = vec![
+            message(Role::System, "rules", 0),
+            message(Role::User, "question", 10),
+            message(Role::Assistant, "answer", 20),
+        ];
+        let second = vec![message(Role::User, "another question", 30)];
+        for (name, messages) in [
+            ("session-100.json", first.clone()),
+            ("session-101.json", first),
+            ("session-200.json", second),
+        ] {
+            std::fs::write(
+                root.join(HISTORY_RELATIVE).join(name),
+                serde_json::to_vec_pretty(&messages).unwrap(),
+            )
+            .unwrap();
+        }
+
+        let scan = scan_workspace(&root).unwrap();
+        assert_eq!(scan.preview.archive_count, 3);
+        assert_eq!(scan.preview.valid_archive_count, 3);
+        assert_eq!(scan.preview.recoverable_session_count, 2);
+        assert_eq!(scan.preview.message_count, 4);
+        assert_eq!(scan.preview.duplicate_archive_count, 1);
+        assert_eq!(scan.preview.earliest_message_at, Some(10));
+        assert_eq!(scan.preview.latest_message_at, Some(30));
+        assert!(scan
+            .sessions
+            .iter()
+            .all(|session| session.source_frame_id.starts_with("message-sha256:")));
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn writable_probe_closes_and_removes_its_windows_marker() {
+        let root = test_workspace("writable");
+        probe_workspace_writable(&root).unwrap();
+        assert!(std::fs::read_dir(&root).unwrap().all(|entry| {
+            !entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .starts_with(".wisp-recovery-write-test-")
+        }));
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn empty_history_is_previewed_without_creating_a_recovery_candidate() {
+        let root = test_workspace("empty");
+        let scan = scan_workspace(&root).unwrap();
+        assert_eq!(scan.preview.archive_count, 0);
+        assert_eq!(scan.preview.recoverable_session_count, 0);
+        assert_eq!(scan.preview.message_count, 0);
+        assert_eq!(scan.preview.earliest_message_at, None);
+        assert_eq!(scan.preview.latest_message_at, None);
+        assert!(scan.sessions.is_empty());
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn persist_scan_registers_project_and_recovered_sessions() {
+        let root = test_workspace("persist");
+        write_archive(
+            &root,
+            "one.json",
+            "source-frame",
+            2,
+            vec![
+                message(Role::User, "question", 10),
+                message(Role::Assistant, "answer", 20),
+            ],
+        );
+        let scan = scan_workspace(&root).unwrap();
+        let database = std::env::temp_dir().join(format!(
+            "wisp_workspace_recovery_{}.sqlite",
+            uuid::Uuid::new_v4()
+        ));
+        let store = Store::open(&database).await.unwrap();
+
+        let result = persist_scan(&store, scan, "Recovered", "model")
+            .await
+            .unwrap();
+        assert_eq!(result.recovered_session_count, 1);
+        assert_eq!(result.message_count, 2);
+        assert_eq!(
+            store.list_sessions(&result.project_id).await.unwrap().len(),
+            1
+        );
+
+        drop(store);
+        let _ = std::fs::remove_file(database);
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn persist_scan_generates_a_new_id_when_the_manifest_id_is_registered() {
+        let root = test_workspace("project_id_conflict");
+        std::fs::create_dir_all(root.join(".wisp")).unwrap();
+        std::fs::write(
+            root.join(".wisp/project.toml"),
+            "layout_version = 1\nproject_id = \"original\"\nname = \"Recovered Study\"\n",
+        )
+        .unwrap();
+        write_archive(
+            &root,
+            "one.json",
+            "source-frame",
+            1,
+            vec![message(Role::User, "question", 10)],
+        );
+        let scan = scan_workspace(&root).unwrap();
+        let database = std::env::temp_dir().join(format!(
+            "wisp_workspace_recovery_{}.sqlite",
+            uuid::Uuid::new_v4()
+        ));
+        let store = Store::open(&database).await.unwrap();
+        store
+            .create_project("original", "Existing", "/different/workspace")
+            .await
+            .unwrap();
+
+        let result = persist_scan(&store, scan, "Recovered", "model")
+            .await
+            .unwrap();
+        assert_ne!(result.project_id, "original");
+        assert_eq!(
+            store.list_sessions(&result.project_id).await.unwrap().len(),
+            1
+        );
+        assert_eq!(
+            store.get_project("original").await.unwrap().unwrap().0,
+            "Existing"
+        );
+
+        drop(store);
+        let _ = std::fs::remove_file(database);
+        let _ = std::fs::remove_dir_all(root);
+    }
+}

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -2468,6 +2468,29 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
             ];
           case "pick_directory":
             return "/mock/root/new-project";
+          case "preview_workspace_session_recovery":
+            return {
+              workspace_dir: String(arg("workspaceDir") ?? "/mock/root/new-project"),
+              suggested_name: "Recovered study",
+              archive_count: 4,
+              valid_archive_count: 3,
+              recoverable_session_count: 2,
+              message_count: 648,
+              invalid_archive_count: 1,
+              duplicate_archive_count: 1,
+              earliest_message_at: 1_725_000_000,
+              latest_message_at: 1_725_003_600,
+            };
+          case "recover_workspace_sessions":
+            projectNames.recovered = String(arg("name") ?? "Recovered study");
+            return {
+              project_id: "recovered",
+              project_name: projectNames.recovered,
+              recovered_session_count: 2,
+              message_count: 648,
+              invalid_archive_count: 1,
+              duplicate_archive_count: 1,
+            };
           case "pick_executable_file":
             return "/mock/picked/Rscript";
           case "open_project": {

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -12338,6 +12338,39 @@ test("import can open an existing folder in place without copying it", async ({ 
   await expect.poll(() => lastInvokeArgs(page, "import_project")).toBeNull();
 });
 
+test("workspace recovery previews archived conversations before transactional import", async ({ page }) => {
+  await page.goto("/");
+  await page.getByRole("button", { name: "Import project" }).click();
+  const options = page.getByTestId("project-import-options");
+  await expect(options.getByRole("button", { name: "Recover conversations from a workspace" })).toBeVisible();
+  await options.getByRole("button", { name: "Recover conversations from a workspace" }).click();
+
+  const recovery = page.getByTestId("workspace-session-recovery");
+  await expect(recovery).toBeVisible();
+  await expect(recovery.getByRole("heading", { name: "Recover workspace conversations" })).toBeVisible();
+  await expect(recovery.locator("#workspace-recovery-name")).toHaveValue("Recovered study");
+  await expect(recovery.locator(".workspace-recovery-stats")).toContainText("2conversations");
+  await expect(recovery.locator(".workspace-recovery-stats")).toContainText("648messages");
+  await expect(recovery).toContainText("1 damaged archive(s) and 1 duplicate archive(s) will be skipped");
+
+  // The preview owns the top Escape layer and closes immediately without a
+  // prior focus move or any import side effect.
+  await page.keyboard.press("Escape");
+  await expect(recovery).toBeHidden();
+  await expect.poll(() => lastInvokeArgs(page, "recover_workspace_sessions")).toBeNull();
+
+  await page.getByRole("button", { name: "Import project" }).click();
+  await page.getByTestId("project-import-options")
+    .getByRole("button", { name: "Recover conversations from a workspace" }).click();
+  await expect(recovery).toBeVisible();
+  await recovery.getByRole("button", { name: "Recover and open" }).click();
+  await expect.poll(() => lastInvokeArgs(page, "recover_workspace_sessions")).toMatchObject({
+    workspaceDir: "/mock/root/new-project",
+    name: "Recovered study",
+  });
+  await expect.poll(() => lastInvokeArgs(page, "open_project")).toMatchObject({ id: "recovered" });
+});
+
 test("project transfers stay in a lower-right progress card without blocking other projects", async ({ page }) => {
   await page.goto("/");
   await expect.poll(async () => page.evaluate(() =>

--- a/ui/src/app_support/projects.rs
+++ b/ui/src/app_support/projects.rs
@@ -41,6 +41,10 @@ pub(crate) fn ProjectsScreen(
     let new_ctx = create_rw_signal(String::new());
     let import_options_open = create_rw_signal(false);
     let opening_in_place = create_rw_signal(false);
+    let recovery_preview = create_rw_signal(None::<WorkspaceSessionRecoveryPreview>);
+    let recovery_name = create_rw_signal(String::new());
+    let recovery_busy = create_rw_signal(false);
+    let recovery_error = create_rw_signal(None::<String>);
     // Off by default: pointing at an existing repo must not litter it. Checking
     // the box reveals the convention text, which doubles as a worked example of
     // what Agent Context is for.
@@ -145,6 +149,11 @@ pub(crate) fn ProjectsScreen(
     create_effect(move |_| {
         if settings_project_id.get().is_some() && !settings_confirm_context.get() {
             focus_and_select_soon("project-home-settings-name");
+        }
+    });
+    create_effect(move |_| {
+        if recovery_preview.get().is_some() {
+            focus_and_select_soon("workspace-recovery-name");
         }
     });
 
@@ -447,6 +456,79 @@ pub(crate) fn ProjectsScreen(
         });
     });
 
+    let recover_from_workspace = Callback::new(move |_: ()| {
+        import_options_open.set(false);
+        open_error.set(None);
+        recovery_error.set(None);
+        spawn_local(async move {
+            let value = invoke("pick_directory", JsValue::UNDEFINED).await;
+            let Ok(Some(path)) = serde_wasm_bindgen::from_value::<Option<String>>(value) else {
+                return;
+            };
+            let args = to_value(&serde_json::json!({ "workspaceDir": path })).unwrap();
+            match invoke_checked("preview_workspace_session_recovery", args).await {
+                Ok(value) => {
+                    if let Ok(preview) =
+                        serde_wasm_bindgen::from_value::<WorkspaceSessionRecoveryPreview>(value)
+                    {
+                        recovery_name.set(preview.suggested_name.clone());
+                        recovery_preview.set(Some(preview));
+                    }
+                }
+                Err(error) => {
+                    open_error.set(Some(localize_backend(
+                        locale.get_untracked(),
+                        &js_error_text(error),
+                    )));
+                }
+            }
+        });
+    });
+
+    let confirm_workspace_recovery = Callback::new(move |_: ()| {
+        if recovery_busy.get_untracked() {
+            return;
+        }
+        let Some(preview) = recovery_preview.get_untracked() else {
+            return;
+        };
+        let name = recovery_name.get_untracked();
+        if name.trim().is_empty() || preview.recoverable_session_count == 0 {
+            return;
+        }
+        recovery_busy.set(true);
+        recovery_error.set(None);
+        spawn_local(async move {
+            let args = to_value(&serde_json::json!({
+                "workspaceDir": preview.workspace_dir,
+                "name": name,
+            }))
+            .unwrap();
+            match invoke_checked("recover_workspace_sessions", args).await {
+                Ok(value) => {
+                    if let Ok(result) =
+                        serde_wasm_bindgen::from_value::<WorkspaceSessionRecoveryResult>(value)
+                    {
+                        recovery_preview.set(None);
+                        recovery_name.set(String::new());
+                        recovery_busy.set(false);
+                        recovery_error.set(None);
+                        on_open.call(result.project_id);
+                    } else {
+                        recovery_busy.set(false);
+                    }
+                }
+                Err(error) => {
+                    recovery_busy.set(false);
+                    recovery_error.set(Some(localize_backend(
+                        locale.get_untracked(),
+                        &js_error_text(error),
+                    )));
+                }
+            }
+        });
+    });
+
     let resolve_sync_conflict = Callback::new(move |strategy: String| {
         let Some(id) = sync_conflict_project.get_untracked() else {
             return;
@@ -526,6 +608,15 @@ pub(crate) fn ProjectsScreen(
             ev.prevent_default();
             settings_confirm_context.set(false);
             settings_project_id.set(None);
+            return;
+        }
+        if recovery_preview.get().is_some() {
+            ev.prevent_default();
+            if !recovery_busy.get() {
+                recovery_preview.set(None);
+                recovery_name.set(String::new());
+                recovery_error.set(None);
+            }
             return;
         }
         if import_options_open.get() {
@@ -789,6 +880,11 @@ pub(crate) fn ProjectsScreen(
                                 <strong>{move || t(locale.get(), "projects.import_zip")}</strong>
                                 <span>{move || t(locale.get(), "projects.import_zip_hint")}</span>
                             </button>
+                            <button type="button" class="project-import-option"
+                                on:click=move |_| recover_from_workspace.call(())>
+                                <strong>{move || t(locale.get(), "projects.recover_workspace")}</strong>
+                                <span>{move || t(locale.get(), "projects.recover_workspace_hint")}</span>
+                            </button>
                         </div>
                         <div class="row">
                             <button type="button" on:click=move |_| import_options_open.set(false)>
@@ -797,6 +893,99 @@ pub(crate) fn ProjectsScreen(
                         </div>
                     </div>
                 </div>
+            })}
+            {move || recovery_preview.get().map(|preview| {
+                let range = match (preview.earliest_message_at, preview.latest_message_at) {
+                    (Some(start), Some(end)) => tf(
+                        locale.get(),
+                        "projects.recover_range",
+                        &[
+                            ("start", &format_message_datetime(start, locale.get())),
+                            ("end", &format_message_datetime(end, locale.get())),
+                        ],
+                    ),
+                    _ => t(locale.get(), "projects.recover_range_unknown").into(),
+                };
+                view! {
+                    <div class="overlay" data-testid="workspace-session-recovery">
+                        <div class="modal proj-settings-modal workspace-recovery-modal"
+                            role="dialog" aria-modal="true"
+                            aria-label=move || t(locale.get(), "projects.recover_title")>
+                            <div class="ps-head">
+                                <h2>{move || t(locale.get(), "projects.recover_title")}</h2>
+                                <button type="button" class="ps-close"
+                                    title=move || t(locale.get(), "projects.cancel")
+                                    disabled=move || recovery_busy.get()
+                                    on:click=move |_| {
+                                        recovery_preview.set(None);
+                                        recovery_name.set(String::new());
+                                        recovery_error.set(None);
+                                    }>{compose_icon("close")}</button>
+                            </div>
+                            <p class="project-in-place-hint">
+                                {move || t(locale.get(), "projects.recover_notice")}
+                            </p>
+                            <label>
+                                {move || t(locale.get(), "proj_settings.name")}
+                                <input id="workspace-recovery-name"
+                                    prop:value=move || recovery_name.get()
+                                    on:input=move |event| recovery_name.set(event_target_value(&event)) />
+                            </label>
+                            <div class="workspace-recovery-path" title=preview.workspace_dir.clone()>
+                                {preview.workspace_dir.clone()}
+                            </div>
+                            <div class="workspace-recovery-stats">
+                                <div><strong>{preview.recoverable_session_count}</strong><span>{move || t(locale.get(), "projects.recover_sessions")}</span></div>
+                                <div><strong>{preview.message_count}</strong><span>{move || t(locale.get(), "projects.recover_messages")}</span></div>
+                                <div><strong>{preview.valid_archive_count}</strong><span>{move || t(locale.get(), "projects.recover_archives")}</span></div>
+                            </div>
+                            <p class="workspace-recovery-range">{range}</p>
+                            {(preview.invalid_archive_count > 0 || preview.duplicate_archive_count > 0).then(|| view! {
+                                <p class="workspace-recovery-warning">
+                                    {tf(
+                                        locale.get(),
+                                        "projects.recover_skipped",
+                                        &[
+                                            ("invalid", &preview.invalid_archive_count.to_string()),
+                                            ("duplicate", &preview.duplicate_archive_count.to_string()),
+                                        ],
+                                    )}
+                                </p>
+                            })}
+                            {(preview.recoverable_session_count == 0).then(|| view! {
+                                <div class="workspace-recovery-error" role="alert">
+                                    {move || t(locale.get(), "projects.recover_empty")}
+                                </div>
+                            })}
+                            {move || recovery_error.get().map(|message| view! {
+                                <div class="workspace-recovery-error" role="alert">{message}</div>
+                            })}
+                            <div class="row">
+                                <button type="button"
+                                    disabled=move || recovery_busy.get()
+                                    on:click=move |_| {
+                                        recovery_preview.set(None);
+                                        recovery_name.set(String::new());
+                                        recovery_error.set(None);
+                                    }>{move || t(locale.get(), "projects.cancel")}</button>
+                                <button type="button" class="primary"
+                                    disabled=move || recovery_busy.get()
+                                        || recovery_name.get().trim().is_empty()
+                                        || preview.recoverable_session_count == 0
+                                    on:click=move |_| confirm_workspace_recovery.call(())>
+                                    {move || t(
+                                        locale.get(),
+                                        if recovery_busy.get() {
+                                            "projects.recovering"
+                                        } else {
+                                            "projects.recover_action"
+                                        },
+                                    )}
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                }
             })}
             {move || creating.get().then(|| view! {
                 <div class="overlay">

--- a/ui/src/i18n.rs
+++ b/ui/src/i18n.rs
@@ -2440,11 +2440,24 @@ fn lookup(locale: Locale, key: &str) -> Option<&'static str> {
         (Locale::En, "projects.search_close") => Some(" close"),
         (Locale::En, "projects.new") => Some("New project"),
         (Locale::En, "projects.import") => Some("Import project"),
-        (Locale::En, "projects.import_options_hint") => Some("Choose whether to use an existing folder in place or restore a complete Wisp archive."),
+        (Locale::En, "projects.import_options_hint") => Some("Open an existing folder, restore a complete Wisp archive, or recover conversations from workspace history."),
         (Locale::En, "projects.import_in_place") => Some("Open a folder in place"),
         (Locale::En, "projects.import_in_place_hint") => Some("Keep every file where it is. Wisp registers the folder without copying it."),
         (Locale::En, "projects.import_zip") => Some("Import a ZIP archive"),
         (Locale::En, "projects.import_zip_hint") => Some("Restore workspace files, conversations, and Wisp project records into a new folder."),
+        (Locale::En, "projects.recover_workspace") => Some("Recover conversations from a workspace"),
+        (Locale::En, "projects.recover_workspace_hint") => Some("Scan .wisp/history in an orphaned workspace and rebuild the recoverable conversation timelines in place."),
+        (Locale::En, "projects.recover_title") => Some("Recover workspace conversations"),
+        (Locale::En, "projects.recover_notice") => Some("This is a best-effort recovery of message timelines from .wisp/history. It does not restore UI-only events, runs, reviews, or other database-only records, and the source archives are not changed."),
+        (Locale::En, "projects.recover_sessions") => Some("conversations"),
+        (Locale::En, "projects.recover_messages") => Some("messages"),
+        (Locale::En, "projects.recover_archives") => Some("valid archives"),
+        (Locale::En, "projects.recover_range") => Some("Message range: {start} – {end}"),
+        (Locale::En, "projects.recover_range_unknown") => Some("The archives do not contain usable message timestamps."),
+        (Locale::En, "projects.recover_skipped") => Some("{invalid} damaged archive(s) and {duplicate} duplicate archive(s) will be skipped."),
+        (Locale::En, "projects.recover_empty") => Some("No recoverable conversations were found in this workspace."),
+        (Locale::En, "projects.recover_action") => Some("Recover and open"),
+        (Locale::En, "projects.recovering") => Some("Recovering…"),
         (Locale::En, "projects.open_folder_title") => Some("Open project folder"),
         (Locale::En, "projects.open_folder_hint") => Some("Wisp will use this folder in place. No project files are copied."),
         (Locale::En, "projects.open_folder_action") => Some("Open project"),
@@ -4971,11 +4984,24 @@ Do not leave generated files in the project root.",
         (Locale::Zh, "projects.search_close") => Some(" 关闭"),
         (Locale::Zh, "projects.new") => Some("新建项目"),
         (Locale::Zh, "projects.import") => Some("导入项目"),
-        (Locale::Zh, "projects.import_options_hint") => Some("请选择原地使用已有文件夹，或恢复一份完整的 Wisp 压缩包。"),
+        (Locale::Zh, "projects.import_options_hint") => Some("请选择原地使用已有文件夹、恢复完整的 Wisp 压缩包，或从工作区历史中恢复会话。"),
         (Locale::Zh, "projects.import_in_place") => Some("原地打开文件夹"),
         (Locale::Zh, "projects.import_in_place_hint") => Some("文件保持在当前位置；Wisp 只登记此文件夹，不复制任何项目文件。"),
         (Locale::Zh, "projects.import_zip") => Some("导入 ZIP 压缩包"),
         (Locale::Zh, "projects.import_zip_hint") => Some("把工作区文件、会话和 Wisp 项目记录完整恢复到一个新文件夹。"),
+        (Locale::Zh, "projects.recover_workspace") => Some("从工作区恢复会话"),
+        (Locale::Zh, "projects.recover_workspace_hint") => Some("扫描孤立工作区中的 .wisp/history，并在原位置重建可恢复的会话时间线。"),
+        (Locale::Zh, "projects.recover_title") => Some("恢复工作区会话"),
+        (Locale::Zh, "projects.recover_notice") => Some("这是基于 .wisp/history 的尽力恢复，只恢复消息时间线，不恢复仅存在于数据库中的 UI 事件、运行、审阅等记录；原始存档不会被修改。"),
+        (Locale::Zh, "projects.recover_sessions") => Some("个会话"),
+        (Locale::Zh, "projects.recover_messages") => Some("条消息"),
+        (Locale::Zh, "projects.recover_archives") => Some("个有效存档"),
+        (Locale::Zh, "projects.recover_range") => Some("消息时间范围：{start} – {end}"),
+        (Locale::Zh, "projects.recover_range_unknown") => Some("存档中没有可用的消息时间戳。"),
+        (Locale::Zh, "projects.recover_skipped") => Some("将跳过 {invalid} 个损坏存档和 {duplicate} 个重复存档。"),
+        (Locale::Zh, "projects.recover_empty") => Some("这个工作区中没有找到可恢复的会话。"),
+        (Locale::Zh, "projects.recover_action") => Some("恢复并打开"),
+        (Locale::Zh, "projects.recovering") => Some("正在恢复…"),
         (Locale::Zh, "projects.open_folder_title") => Some("打开项目文件夹"),
         (Locale::Zh, "projects.open_folder_hint") => Some("Wisp 会原地使用此文件夹，不会复制项目文件。"),
         (Locale::Zh, "projects.open_folder_action") => Some("打开项目"),
@@ -5184,6 +5210,64 @@ pub fn localize_backend(locale: Locale, msg: &str) -> String {
             t(locale, "err.cred_env_invalid")
         }
         "Credential value is required." => t(locale, "err.cred_value_required"),
+        m if m.starts_with("workspace_recovery_no_history:") => {
+            if locale == Locale::Zh {
+                "所选文件夹中没有可读取的 .wisp/history 会话存档目录。".into()
+            } else {
+                m.trim_start_matches("workspace_recovery_no_history:")
+                    .trim()
+                    .into()
+            }
+        }
+        m if m.starts_with("workspace_recovery_registered:") => {
+            t(locale, "projects.folder_registered")
+        }
+        m if m.starts_with("workspace_recovery_no_sessions:") => {
+            t(locale, "projects.recover_empty")
+        }
+        m if m.starts_with("workspace_recovery_name_required:") => {
+            if locale == Locale::Zh {
+                "项目名称不能为空。".into()
+            } else {
+                "Project name is required.".into()
+            }
+        }
+        m if m.starts_with("workspace_recovery_invalid_workspace:") => {
+            if locale == Locale::Zh {
+                "无法打开所选工作区，请确认该路径仍然存在且是文件夹。".into()
+            } else {
+                m.trim_start_matches("workspace_recovery_invalid_workspace:")
+                    .trim()
+                    .into()
+            }
+        }
+        m if m.starts_with("workspace_recovery_not_writable:") => {
+            if locale == Locale::Zh {
+                "所选工作区不可写，无法登记为可继续使用的恢复项目。".into()
+            } else {
+                m.trim_start_matches("workspace_recovery_not_writable:")
+                    .trim()
+                    .into()
+            }
+        }
+        m if m.starts_with("workspace_recovery_too_large:") => {
+            if locale == Locale::Zh {
+                "工作区历史超过安全恢复上限，请减少存档数量或大小后重试。".into()
+            } else {
+                m.trim_start_matches("workspace_recovery_too_large:")
+                    .trim()
+                    .into()
+            }
+        }
+        m if m.starts_with("workspace_recovery_import_failed:") => {
+            if locale == Locale::Zh {
+                "恢复会话写入失败，未创建半恢复项目；原始工作区未被修改。".into()
+            } else {
+                m.trim_start_matches("workspace_recovery_import_failed:")
+                    .trim()
+                    .into()
+            }
+        }
         m if m.starts_with("exploration_round_active:") => {
             if locale == Locale::Zh {
                 "另一个主线会话已有当前探索轮；请先结束该轮探索。".to_string()

--- a/ui/src/styles/modals.css
+++ b/ui/src/styles/modals.css
@@ -618,6 +618,25 @@
   background: color-mix(in srgb, var(--clay) 8%, var(--bg-elev));
   color: var(--text-muted); font-size: 12.5px; line-height: 1.5;
 }
+.workspace-recovery-modal { max-width: 600px; }
+.workspace-recovery-path {
+  overflow: hidden; padding: 8px 10px; border: 1px solid var(--border); border-radius: var(--radius-xs);
+  background: var(--bg-sunken); color: var(--text-faint); font: 11.5px/1.45 var(--font-mono);
+  text-overflow: ellipsis; white-space: nowrap; user-select: text;
+}
+.workspace-recovery-stats { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 8px; }
+.workspace-recovery-stats > div {
+  display: grid; gap: 2px; padding: 10px; border: 1px solid var(--border); border-radius: var(--radius-xs);
+  background: var(--bg-sunken);
+}
+.workspace-recovery-stats strong { font-size: 18px; font-weight: 650; }
+.workspace-recovery-stats span { color: var(--text-muted); font-size: 11.5px; }
+.workspace-recovery-range, .workspace-recovery-warning { margin: 0; color: var(--text-muted); font-size: 12px; line-height: 1.45; }
+.workspace-recovery-warning { color: var(--warn, #a16207); }
+.workspace-recovery-error {
+  padding: 8px 10px; border-radius: var(--radius-xs); background: color-mix(in srgb, var(--err) 10%, transparent);
+  color: var(--err); font-size: 12.5px; line-height: 1.45;
+}
 .host-modal { max-width: 460px; }
 .ssh-check-modal { max-width: 520px; }
 .ssh-check-modal .ssh-check-scroll { display: flex; flex-direction: column; gap: 10px; }


### PR DESCRIPTION
## Problem

When the application database, project ZIP, and sync revision are unavailable, copying an existing workspace back into Wisp does not rebuild its conversation list. The remaining .wisp/history archives are readable but had no supported recovery entry in the desktop UI.

Addresses #1068. This PR implements the agreed best-effort workspace recovery MVP; it intentionally does not claim full-fidelity project restoration.

## Summary

- Add Import project → Recover conversations from a workspace with a read-only preview before any write.
- Support both history formats found in current and older workspaces:
  - structured Exploration checkpoints with schema_version, frame_id, message_head, and messages;
  - plain Message[] snapshots written by context compaction.
- Deduplicate structured checkpoints by frame_id while retaining the greatest message_head, and deduplicate exact message-array snapshots by normalized SHA-256 content.
- Preview archive, conversation, message, damaged/duplicate, and timestamp-range counts.
- Reject already registered workspaces and enforce file-count, per-file size, total-size, and message-count limits.
- Register the workspace and insert Project, Recovered folder, Frames, Messages, and session_imports provenance in one SQLite transaction.
- Preserve the original history archives and generate a new project UUID when the manifest ID conflicts locally.
- Add shared DTOs, bilingual strings, UI styling, backend contract coverage, Playwright coverage, and project-transfer documentation.

A read-only scan of an actual local workspace found 4 valid message-array archives. Two 623-message archives were byte-identical; the recovery preview therefore resolves them to 3 conversations, 1481 messages, and 1 duplicate archive.

## Validation

Passed:

- cargo fmt --all -- --check
- git diff --check
- cargo test -p wisp-store session_imports::tests — 3 passed
- cargo test -p wisp-tauri workspace_session_recovery — 7 passed
- ui: cargo check --target wasm32-unknown-unknown
- focused workspace-recovery Playwright — 1 passed
- complete Playwright suite — 484 passed, 2 skipped, 0 failed

The complete cargo test --workspace run is not fully green on this Windows checkout. One unrelated existing test is reproducibly failing: wisp-runtime env::tests::install_deps_short_circuits_on_marker. In this checkout the packaged MCP requirements path is absent, so install_deps returns Ok before reaching the deliberately invalid executable. Recovery-focused Rust tests are green.

## Manual smoke steps

1. Keep an orphaned workspace containing .wisp/history outside the current project registry.
2. Open Import project → Recover conversations from a workspace and select the folder.
3. Verify the preview counts, editable project name, time range, and damaged/duplicate warning.
4. Press Escape immediately and confirm only the preview closes and no project is created.
5. Reopen the preview, confirm recovery, and verify the project opens with conversations grouped under Recovered.
6. Open a recovered conversation, review its timeline, and send a follow-up message.

## Known limitations and follow-up

- Plain Message[] snapshots do not contain the original frame ID. Exact copies can be deduplicated, but different compaction generations from one conversation may recover as separate conversations.
- UI events, reviews, resource bindings, runs, undo indexes, branch relationships, and other database-only records are not reconstructed.
- Conversations that never produced a compaction or Exploration checkpoint cannot be recovered from .wisp/history.
- Complete project ZIP export/import or project sync remains the supported full-fidelity migration path.