### PR TITLE
fix(agent): avoid abort on stale models

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7290,6 +7290,7 @@ dependencies = [
  "sha2",
  "sqlx",
  "tokio",
+ "tracing",
  "uuid",
  "wisp-llm",
 ]

--- a/crates/wisp-core/src/agent.rs
+++ b/crates/wisp-core/src/agent.rs
@@ -103,6 +103,20 @@ fn budget_tool_result_with_limit(
     Content::text(ContextManager::truncate_middle(text, half, half, &marker))
 }
 
+/// Cap tool results restored from SQLite. Ingestion already budgets live
+/// results; leftover LM Studio / local transcripts can still be huge and
+/// must not blow the next send (#1070).
+pub fn bound_tool_results_in_history(root: &Path, messages: &mut [Message]) {
+    for message in messages {
+        if message.role != wisp_llm::Role::Tool {
+            continue;
+        }
+        let name = message.tool_name.clone().unwrap_or_else(|| "tool".into());
+        let content = std::mem::replace(&mut message.content, Content::text(""));
+        message.content = budget_tool_result(root, &name, content);
+    }
+}
+
 /// Mid-turn guidance queue: `(id, text)` pairs pushed by the host while a turn
 /// is running and drained into real user messages at the loop's next
 /// iteration. The id lets the queued sender detect whether the loop consumed
@@ -902,7 +916,7 @@ async fn stream_with_retry(
             }
         }
     }
-    Err(last.expect("retry loop always returns or breaks"))
+    Err(last.unwrap_or_else(|| LlmError::Config("LLM stream retry exhausted".into())))
 }
 
 fn cancelled_stream_error() -> LlmError {
@@ -1018,6 +1032,7 @@ fn has_repeated_suffix_cycle<T: Eq>(observations: &VecDeque<T>, repeat_limit: us
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::context::repair_unpaired_tool_calls;
     use crate::output::NullOutput;
     use async_trait::async_trait;
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -1098,6 +1113,48 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(std::fs::read_to_string(spill.path()).unwrap(), raw);
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[test]
+    fn loaded_history_bounds_leftover_tool_results_without_panicking() {
+        let root = std::env::temp_dir().join(format!(
+            "wisp-bound-history-{}",
+            uuid::Uuid::new_v4().simple()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let mut asst = Message::assistant("");
+        asst.tool_calls = vec![
+            ToolCall {
+                id: "call-1".into(),
+                kind: "function".into(),
+                function: FunctionCall {
+                    name: "read".into(),
+                    arguments: "not-json".into(),
+                },
+            },
+            ToolCall {
+                id: String::new(),
+                kind: "function".into(),
+                function: FunctionCall {
+                    name: "shell".into(),
+                    arguments: String::new(),
+                },
+            },
+        ];
+        let mut messages = vec![
+            Message::user("hello"),
+            asst,
+            Message::tool("call-1", "read", "x".repeat(80_000)),
+            Message::assistant(""),
+        ];
+        assert_eq!(repair_unpaired_tool_calls(&mut messages), 1);
+        bound_tool_results_in_history(&root, &mut messages);
+        assert!(messages[2].content.as_text().len() < 80_000);
+        let mut ctx = ContextManager::new(128_000);
+        ctx.messages = messages;
+        let prepared = ctx.prepare_for_api(&NullOutput);
+        assert!(!prepared.is_empty());
         std::fs::remove_dir_all(&root).ok();
     }
 

--- a/crates/wisp-core/src/lib.rs
+++ b/crates/wisp-core/src/lib.rs
@@ -16,7 +16,9 @@ pub mod session_locks;
 pub mod subagent;
 pub mod system_prompt;
 
-pub use agent::{agent_loop, agent_loop_continue, AgentLoopOutcome, GuidanceQueue};
+pub use agent::{
+    agent_loop, agent_loop_continue, bound_tool_results_in_history, AgentLoopOutcome, GuidanceQueue,
+};
 pub use context::{
     repair_unpaired_tool_calls, tool_call_pairing, unpaired_tool_call_ids, ContextManager,
     ContextToolDetail, ContextUsage, ContextUsageDetails, UNPAIRED_ON_LOAD_RESULT,

--- a/crates/wisp-llm/src/openai.rs
+++ b/crates/wisp-llm/src/openai.rs
@@ -1267,6 +1267,43 @@ mod tests {
         assert_eq!(out[0]["role"], "user");
     }
 
+    #[test]
+    fn sanitize_survives_empty_ids_invalid_args_and_empty_assistant() {
+        let mut asst = Message::assistant("");
+        asst.tool_calls = vec![
+            call(""),
+            ToolCall {
+                id: "ok".into(),
+                kind: "function".into(),
+                function: FunctionCall {
+                    name: "read".into(),
+                    arguments: "not-json {".into(),
+                },
+            },
+        ];
+        let msgs = vec![
+            Message::user("hi"),
+            asst,
+            Message::tool("ok", "read", "x".repeat(8_000)),
+            Message::assistant(""),
+        ];
+        let out = OpenAiProvider::sanitize(&msgs);
+        assert_eq!(out[0]["role"], "user");
+        assert_eq!(out[1]["role"], "assistant");
+        let kept = out[1]["tool_calls"].as_array().unwrap();
+        assert_eq!(kept.len(), 1);
+        assert_eq!(kept[0]["id"], "ok");
+        assert_eq!(out[2]["role"], "tool");
+        assert!(
+            !out.iter().any(|row| {
+                row["role"] == "assistant"
+                    && row.get("tool_calls").is_none()
+                    && row["content"] == ""
+            }),
+            "empty assistant turns without tool_calls must be dropped"
+        );
+    }
+
     // A well-formed pair passes through untouched.
     #[test]
     fn keeps_matched_pair() {

--- a/crates/wisp-llm/src/provider.rs
+++ b/crates/wisp-llm/src/provider.rs
@@ -343,7 +343,10 @@ fn build_http_client(cfg: &ProviderConfig) -> reqwest::Client {
             }
         }
     }
-    b.build().expect("reqwest client")
+    b.build().unwrap_or_else(|error| {
+        tracing::error!(%error, "reqwest client build failed; using default client");
+        reqwest::Client::new()
+    })
 }
 
 impl ProviderConfig {

--- a/crates/wisp-store/Cargo.toml
+++ b/crates/wisp-store/Cargo.toml
@@ -17,6 +17,7 @@ hex = { workspace = true }
 sha2 = { workspace = true }
 uuid = { workspace = true }
 wisp-llm = { workspace = true }
+tracing = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 keyring = { workspace = true, features = ["windows-native"] }

--- a/crates/wisp-store/src/sessions.rs
+++ b/crates/wisp-store/src/sessions.rs
@@ -986,6 +986,36 @@ impl Store {
     }
 }
 
+fn message_from_row(row: &sqlx::sqlite::SqliteRow) -> Result<(i64, Message)> {
+    let seq: i64 = row.try_get("seq")?;
+    let role: String = row.try_get("role")?;
+    let content_json: String = row.try_get("content")?;
+    let content: wisp_llm::Content =
+        serde_json::from_str(&content_json).unwrap_or(wisp_llm::Content::text(""));
+    let tool_calls_json: Option<String> = row.try_get("tool_calls")?;
+    let tool_calls: Vec<wisp_llm::ToolCall> = tool_calls_json
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default();
+    let tool_call_id: Option<String> = row.try_get("tool_call_id")?;
+    let tool_name: Option<String> = row.try_get("tool_name")?;
+    let reasoning: Option<String> = row.try_get("reasoning")?;
+    let ts: i64 = row.try_get("ts")?;
+    let model_name: Option<String> = row.try_get("model_name")?;
+    Ok((
+        seq,
+        Message {
+            role: parse_role(&role),
+            content,
+            tool_calls,
+            tool_call_id,
+            tool_name,
+            reasoning,
+            ts,
+            model_name,
+        },
+    ))
+}
+
 pub(crate) async fn insert_message_row<'e, E>(
     executor: E,
     frame_id: &str,
@@ -1282,34 +1312,12 @@ impl Store {
             .fetch_all(&self.pool).await?;
         let mut out = vec![];
         for row in rows {
-            let seq: i64 = row.try_get("seq")?;
-            let role: String = row.try_get("role")?;
-            let content_json: String = row.try_get("content")?;
-            let content: wisp_llm::Content =
-                serde_json::from_str(&content_json).unwrap_or(wisp_llm::Content::text(""));
-            let tool_calls_json: Option<String> = row.try_get("tool_calls")?;
-            let tool_calls: Vec<wisp_llm::ToolCall> = tool_calls_json
-                .and_then(|s| serde_json::from_str(&s).ok())
-                .unwrap_or_default();
-            let tool_call_id: Option<String> = row.try_get("tool_call_id")?;
-            let tool_name: Option<String> = row.try_get("tool_name")?;
-            let reasoning: Option<String> = row.try_get("reasoning")?;
-            let ts: i64 = row.try_get("ts")?;
-            let model_name: Option<String> = row.try_get("model_name")?;
-            let role = parse_role(&role);
-            out.push((
-                seq,
-                Message {
-                    role,
-                    content,
-                    tool_calls,
-                    tool_call_id,
-                    tool_name,
-                    reasoning,
-                    ts,
-                    model_name,
-                },
-            ));
+            match message_from_row(&row) {
+                Ok(item) => out.push(item),
+                Err(error) => {
+                    tracing::warn!(frame_id, %error, "skipping unreadable message row");
+                }
+            }
         }
         Ok(out)
     }

--- a/crates/wisp-store/src/store_tests.rs
+++ b/crates/wisp-store/src/store_tests.rs
@@ -145,6 +145,63 @@ async fn roundtrip() {
 }
 
 #[tokio::test]
+async fn load_messages_keeps_readable_rows_when_history_is_damaged() {
+    let tmp = std::env::temp_dir().join(format!(
+        "wisp_store_bad_history_{}.sqlite",
+        uuid::Uuid::new_v4()
+    ));
+    let store = Store::open(&tmp).await.unwrap();
+    store.create_project("p1", "proj", "").await.unwrap();
+    store
+        .create_frame("f1", "p1", "OPERON", "m3")
+        .await
+        .unwrap();
+    store
+        .append_message("f1", 0, &Message::user("hello"))
+        .await
+        .unwrap();
+    sqlx::query(
+        "INSERT INTO messages(id,frame_id,seq,role,content,tool_calls,ts) VALUES(?,?,?,?,?,?,?)",
+    )
+    .bind("bad-json")
+    .bind("f1")
+    .bind(1i64)
+    .bind("assistant")
+    .bind("not-json")
+    .bind("{")
+    .bind(1i64)
+    .execute(&store.pool)
+    .await
+    .unwrap();
+    sqlx::query("INSERT INTO messages(id,frame_id,seq,role,content,ts) VALUES(?,?,?,?,?,?)")
+        .bind("bad-seq")
+        .bind("f1")
+        .bind("oops")
+        .bind("user")
+        .bind("\"skipped\"")
+        .bind(1i64)
+        .execute(&store.pool)
+        .await
+        .unwrap();
+    store
+        .append_message("f1", 3, &Message::user("still here"))
+        .await
+        .unwrap();
+
+    let msgs = store.load_messages("f1").await.unwrap();
+    assert_eq!(
+        msgs.iter()
+            .map(|message| message.content.as_text())
+            .collect::<Vec<_>>(),
+        ["hello", "", "still here"]
+    );
+    assert_eq!(msgs[1].role, wisp_llm::Role::Assistant);
+    assert!(msgs[1].tool_calls.is_empty());
+
+    let _ = std::fs::remove_file(&tmp);
+}
+
+#[tokio::test]
 async fn named_draft_is_listable_but_not_resumable() {
     let tmp = std::env::temp_dir().join(format!(
         "wisp_store_named_draft_{}.sqlite",

--- a/src-tauri/src/agent_turn.rs
+++ b/src-tauri/src/agent_turn.rs
@@ -423,7 +423,11 @@ pub(crate) async fn send_message_inner(
         .flatten()
         .and_then(|s| s.parse::<usize>().ok())
         .unwrap_or(DEFAULT_MAX_ITER);
-    let session_profile_id = models::session_profile_id(&state.store, &frame_id).await;
+    let (session_profile_id, rebound_model) =
+        models::resolve_session_profile(&state.store, &frame_id).await;
+    if rebound_model {
+        *guard = None;
+    }
     let model_label = models::session_label(&state.store, &frame_id).await;
     let specialist = specialists::session_specialist(&state.store, &frame_id).await;
     let max_context = match &specialist {
@@ -680,8 +684,9 @@ pub(crate) async fn send_message_inner(
                 frame_id.clone(),
             )));
         }
-        let msgs =
+        let mut msgs =
             wisp_core::require_sqlite_session_messages(state.store.load_messages(&frame_id).await)?;
+        wisp_core::bound_tool_results_in_history(&ap.root, &mut msgs);
         agent.ctx.messages = msgs;
         if let Some(message) = agent.ctx.messages.first_mut() {
             if let wisp_llm::Content::Text(prompt) = &mut message.content {
@@ -746,7 +751,9 @@ pub(crate) async fn send_message_inner(
         }
         *guard = Some(agent);
     }
-    let agent = guard.as_mut().unwrap();
+    let agent = guard
+        .as_mut()
+        .ok_or_else(|| "Failed to prepare the session agent.".to_string())?;
     let (auto_continue, auto_continue_limit) = load_auto_continue_settings(&state.store).await;
     apply_live_agent_settings(
         agent,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -725,6 +725,13 @@ pub async fn active_profile_id(store: &wisp_store::Store) -> String {
 }
 
 pub async fn session_profile_id(store: &wisp_store::Store, frame_id: &str) -> String {
+    resolve_session_profile(store, frame_id).await.0
+}
+
+/// Chat profile for `frame_id`. A leftover id (deleted LM Studio profile, etc.)
+/// falls back to the active chat model and is rewritten on the frame so later
+/// turns do not keep resolving a dead binding (#1070).
+pub async fn resolve_session_profile(store: &wisp_store::Store, frame_id: &str) -> (String, bool) {
     let profiles = ensure(store).await;
     let bound = store
         .frame_model(frame_id)
@@ -736,10 +743,33 @@ pub async fn session_profile_id(store: &wisp_store::Store, frame_id: &str) -> St
         .iter()
         .any(|profile| profile.id == bound && is_chat_model(profile))
     {
-        bound
-    } else {
-        active_id(store, &profiles).await
+        return (bound, false);
     }
+    let fallback = active_id(store, &profiles).await;
+    let rebound = !bound.is_empty() && !fallback.is_empty() && bound != fallback;
+    if rebound {
+        if let Ok(Some(project_id)) = store.frame_project_id(frame_id).await {
+            if let Err(error) = store
+                .set_frame_model(frame_id, &project_id, &fallback)
+                .await
+            {
+                tracing::warn!(
+                    frame_id,
+                    bound,
+                    fallback,
+                    "session model {bound} is gone; could not persist fallback {fallback}: {error}"
+                );
+            } else {
+                tracing::warn!(
+                    frame_id,
+                    bound,
+                    fallback,
+                    "session model {bound} is gone; rebound to {fallback}"
+                );
+            }
+        }
+    }
+    (fallback, rebound)
 }
 
 pub async fn session_label(store: &wisp_store::Store, frame_id: &str) -> String {
@@ -804,11 +834,14 @@ fn key_for(id: &str) -> String {
 pub async fn active_config(store: &wisp_store::Store) -> (String, String, String, String) {
     let profiles = ensure(store).await;
     let id = active_id(store, &profiles).await;
-    let p = profiles
+    let Some(p) = profiles
         .iter()
         .find(|p| p.id == id)
         .cloned()
-        .unwrap_or_else(|| profiles[0].clone());
+        .or_else(|| profiles.first().cloned())
+    else {
+        return ("openai".into(), String::new(), String::new(), String::new());
+    };
     let api_url = effective_api_url(&p);
     (p.provider, api_url, p.model, key_for(&p.id))
 }
@@ -1801,6 +1834,46 @@ mod tests {
 
         assert_eq!(session_profile_id(&store, "a").await, "m2");
         assert_eq!(session_profile_id(&store, "b").await, "m1");
+        drop(store);
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    #[tokio::test]
+    async fn dangling_session_model_rebinds_to_active_chat_profile() {
+        let tmp = std::env::temp_dir().join(format!(
+            "wisp_session_model_rebind_{}.sqlite",
+            uuid::Uuid::new_v4()
+        ));
+        let store = wisp_store::Store::open(&tmp).await.unwrap();
+        store.create_project("p", "project", "").await.unwrap();
+        save_raw(
+            &store,
+            &[
+                test_profile("m1", "first", "model-1"),
+                test_profile("m2", "second", "model-2"),
+            ],
+        )
+        .await
+        .unwrap();
+        store.set_setting(ACTIVE_KEY, "m2").await.unwrap();
+        store
+            .create_frame("lmstudio", "p", "OPERON", "m3")
+            .await
+            .unwrap();
+        store.create_frame("ok", "p", "OPERON", "m1").await.unwrap();
+
+        let (id, rebound) = resolve_session_profile(&store, "lmstudio").await;
+        assert_eq!(id, "m2");
+        assert!(rebound);
+        assert_eq!(
+            store.frame_model("lmstudio").await.unwrap().as_deref(),
+            Some("m2")
+        );
+        assert_eq!(session_profile_id(&store, "ok").await, "m1");
+        assert_eq!(
+            store.frame_model("ok").await.unwrap().as_deref(),
+            Some("m1")
+        );
         drop(store);
         let _ = std::fs::remove_file(&tmp);
     }

--- a/src-tauri/src/session_commands.rs
+++ b/src-tauri/src/session_commands.rs
@@ -864,11 +864,24 @@ pub(super) async fn latest_used_session(
     window: tauri::WebviewWindow,
 ) -> Result<Option<String>, String> {
     let ap = state.active(window.label());
-    state
+    let Some(id) = state
         .store
         .latest_used_session_id(&ap.id)
         .await
-        .map_err(|e| format!("{e}"))
+        .map_err(|e| format!("{e}"))?
+    else {
+        return Ok(None);
+    };
+    let _ = crate::models::session_profile_id(&state.store, &id).await;
+    if let Err(error) = state.store.load_messages(&id).await {
+        tracing::warn!(
+            session_id = %id,
+            %error,
+            "skipping last-session resume because the transcript could not be loaded"
+        );
+        return Ok(None);
+    }
+    Ok(Some(id))
 }
 
 #[tauri::command]


### PR DESCRIPTION
## Problem

Restoring an older Wisp database and sending a message can abort the whole macOS app. The crash is `SIGABRT` on a Tokio worker (`panic = abort`). Typical shape: LM Studio / deleted profiles left `frames.model` pointing at gone ids such as `m3`, last-session resume reopens that conversation, and send hydrates a damaged or oversized transcript.

Fixes #1070.

## What changed

- `resolve_session_profile` falls back to the active chat model and **writes that id back** onto the frame. Send drops the cached agent after a rebind.
- Last-session resume rebinds first; if the transcript cannot be loaded at all, it does not auto-open that conversation.
- Unreadable SQLite message rows are skipped instead of failing the whole load.
- Tool results restored from SQLite are bounded with the existing 16 KiB budget before they enter model context.
- Send-path panics that can follow bad imported state now return errors: empty model list, reqwest client build, missing agent, exhausted LLM retries.

## Tests

- Dangling `m3` session rebinds to the active chat profile and persists `m2`.
- Load keeps readable rows when content JSON / tool_calls / seq are damaged.
- Loaded LM Studio-like history (unpaired empty tool id, invalid args, huge tool output, empty assistant) bounds and `prepare_for_api` without panicking.
- OpenAI `sanitize` keeps a matched call, drops empty assistant turns, and does not panic on empty ids / invalid arguments.

Local verification on Windows:

- `cargo fmt --all -- --check` — passed
- `cargo test -p wisp-store load_messages_keeps_readable` — passed
- `cargo test -p wisp-store named_draft_is_listable` — passed
- `cargo test -p wisp-core loaded_history_bounds` — passed
- `cargo test -p wisp-llm sanitize_survives` — passed
- `cargo test -p wisp-tauri dangling_session_model` — passed
- `cargo test -p wisp-tauri session_profile_binding` — passed

## Manual smoke

1. Restore or copy an old database that still has sessions bound to deleted model ids.
2. Open the project (last-session resume should not crash).
3. Send a short message in that conversation.
4. Confirm the app stays up, the session model is a currently listed chat profile, and the turn either streams or shows a normal error instead of quitting.

## Known limitations

- Workspace `panic = abort` is unchanged. Other `unwrap` / `expect` sites outside this send/resume path can still kill the process.
- Rebind is silent in the UI (log warning only); there is no toast yet.
- Oversized tool results are truncated for the model; full text is spilled under `.wisp/tool-output/` when the write succeeds.