### PR TITLE
feat: 新增独立窗口并按项目隔离实时流、浏览器、IM、审批

### DIFF
--- a/crates/wisp-core/src/output.rs
+++ b/crates/wisp-core/src/output.rs
@@ -136,6 +136,10 @@ pub trait Output: Send + Sync {
     fn frame_id(&self) -> Option<&str> {
         None
     }
+    /// Host-owned project this loop belongs to. Default `None`.
+    fn project_id(&self) -> Option<&str> {
+        None
+    }
     /// Hard host-owned boundary checked before free-form source reaches a
     /// local shell or language runtime.
     fn preflight_local_execution(&self, _source: &str) -> Result<(), String> {
@@ -220,6 +224,9 @@ impl<'a> wisp_tools::ToolEnv for ToolEnvAdapter<'a> {
     }
     fn restrict_read_paths_to_project(&self) -> bool {
         self.out.restrict_read_paths_to_project()
+    }
+    fn project_id(&self) -> Option<&str> {
+        self.out.project_id()
     }
     async fn confirm(&self, message: &str) -> bool {
         self.out.confirm_async(message).await

--- a/crates/wisp-store/src/secrets.rs
+++ b/crates/wisp-store/src/secrets.rs
@@ -1,13 +1,19 @@
 //! OS keyring-backed secret storage for API keys.
 //!
-//! In **debug** builds we bypass the OS keyring and persist to a plaintext JSON
-//! file in the user's home dir. macOS binds each keychain item to the calling
-//! app's code signature, which `tauri dev` regenerates on every rebuild — so the
-//! real keyring pops the login-keychain password prompt on every dev run. Dev
-//! keys aren't worth that friction. Release builds use the OS keyring unchanged.
+//! In **debug** builds we persist new secrets to a plaintext JSON file in the
+//! user's home dir. macOS binds each keychain item to the calling app's code
+//! signature, which `tauri dev` regenerates on every rebuild — so the real
+//! keyring pops the login-keychain password prompt on every dev run. Dev keys
+//! aren't worth that friction. Release builds use the OS keyring unchanged.
+//!
+//! On Windows, a debug read still falls back to that same OS keyring when the
+//! file has no entry, so `cargo tauri dev` can reuse keys already saved in an
+//! installed Wisp. macOS stays file-only to avoid the prompt storm.
 
 /// A named secret (e.g. an API key) stored in the OS credential manager.
 pub struct Secret;
+
+const SERVICE: &str = "wisp";
 
 impl Secret {
     pub fn set(name: &str, value: &str) -> anyhow::Result<()> {
@@ -27,19 +33,17 @@ impl Secret {
 mod backend {
     use keyring::Entry;
 
-    const SERVICE: &str = "wisp";
-
     pub fn set(name: &str, value: &str) -> anyhow::Result<()> {
-        Entry::new(SERVICE, name)?.set_password(value)?;
+        Entry::new(super::SERVICE, name)?.set_password(value)?;
         Ok(())
     }
 
     pub fn get(name: &str) -> anyhow::Result<String> {
-        Ok(Entry::new(SERVICE, name)?.get_password()?)
+        Ok(Entry::new(super::SERVICE, name)?.get_password()?)
     }
 
     pub fn delete(name: &str) -> anyhow::Result<()> {
-        Entry::new(SERVICE, name)?.delete_credential()?;
+        Entry::new(super::SERVICE, name)?.delete_credential()?;
         Ok(())
     }
 }
@@ -87,10 +91,33 @@ mod backend {
     }
 
     pub fn get(name: &str) -> anyhow::Result<String> {
-        let _guard = lock();
-        load()
-            .remove(name)
-            .ok_or_else(|| anyhow::anyhow!("no secret named {name}"))
+        let file_value = {
+            let _guard = lock();
+            load().remove(name)
+        };
+        if let Some(value) = file_value.filter(|value| !value.is_empty()) {
+            return Ok(value);
+        }
+        os_keyring_fallback(name).ok_or_else(|| anyhow::anyhow!("no secret named {name}"))
+    }
+
+    /// Reuse keys saved by a release install. Windows only: unsigned `tauri
+    /// dev` on macOS prompts for the login keychain on every miss, and Linux
+    /// CI should not touch the session Secret Service.
+    fn os_keyring_fallback(name: &str) -> Option<String> {
+        #[cfg(windows)]
+        {
+            keyring::Entry::new(super::SERVICE, name)
+                .ok()?
+                .get_password()
+                .ok()
+                .filter(|value| !value.is_empty())
+        }
+        #[cfg(not(windows))]
+        {
+            let _ = name;
+            None
+        }
     }
 
     pub fn delete(name: &str) -> anyhow::Result<()> {

--- a/crates/wisp-tools/src/env.rs
+++ b/crates/wisp-tools/src/env.rs
@@ -320,6 +320,12 @@ pub trait ToolEnv: Send + Sync {
     fn frame_id(&self) -> Option<&str> {
         None
     }
+    /// Host-owned project this tool call belongs to. Browser tools use it to
+    /// serialize access to the one shared Chrome session across windows.
+    /// CLI and tests leave this unset so occupancy is skipped.
+    fn project_id(&self) -> Option<&str> {
+        None
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/docs/channels.md
+++ b/docs/channels.md
@@ -4,20 +4,20 @@ Settings → Remote Access connects IM bots to the workspace agent: messages you
 from Feishu or WeChat drive normal agent sessions (visible in the desktop app),
 and the final answer of each turn is sent back to the chat.
 
-Desktop, Feishu, and WeChat share one durable **last-message session**. Every
-ordinary IM message is sent to the session that most recently accepted a user
-message on any of those three surfaces. This makes it possible to start work in
-the desktop app and continue it from either bot without rebuilding context.
-Merely viewing or navigating to a session does not change the route.
+Desktop, Feishu, and WeChat share one durable **IM target project**. Ordinary
+IM messages continue that project's current IM session. Starting work on the
+desktop in another project does **not** move Feishu or WeChat to that project —
+it only records that project's last session. Use `/project` from either bot to
+choose the IM destination.
 
-The shared target can be inspected and changed from either Feishu or WeChat:
+The IM target can be inspected and changed from either Feishu or WeChat:
 
-- `/status` shows the shared project and last-message session.
-- `/project` lists projects; `/project <number|name|id>` switches project and
-  prepares the shared route for a new session there.
-- `/session` lists recent sessions in the selected project;
-  `/session <number|title|id>` makes one the shared target.
-- `/new` prepares a fresh shared session in the selected project.
+- `/status` shows the IM project and last IM session.
+- `/project` lists projects; `/project <number|name|id>` switches the IM
+  project and prepares a new session there.
+- `/session` lists recent sessions in the IM project;
+  `/session <number|title|id>` makes one the IM target.
+- `/new` prepares a fresh IM session in the selected project.
 - `/stop` cancels the shared target's running turn; `/help` shows the command
   list.
 - WeChat additionally supports `/approval`, `/approve <code>`, and
@@ -118,10 +118,10 @@ protobuf frame codec, round-trip tested), `weixin.rs` (QR bind, non-blocking
 control tasks, send), and `mod.rs` (ChannelManager, turn-scoped progress and
 approval observer, shared last-message route in the
 `channel_last_message_route` setting, Tauri commands). The route contains
-`project_id` and an optional `session_id`; an empty session is the intentional
-pending state created by `/project` or `/new`. Inbound text reuses the same
-`send_message` path as the UI with `TurnOrigin::Im`, so desktop and both channels
-update the same route and history, while mutating-tool approval is stricter for
-IM.
+the IM `project_id`, an optional IM `session_id`, and `last_session_by_project`.
+An empty IM session is the intentional pending state created by `/project` or
+`/new`. Desktop `send_message` only updates that project's last session. Inbound
+text reuses the same `send_message` path as the UI with `TurnOrigin::Im`, so
+history is shared, while mutating-tool approval is stricter for IM.
 Protocol shapes follow phantty's tested implementations and the official
 `larksuite/oapi-sdk-go`.

--- a/docs/development.md
+++ b/docs/development.md
@@ -85,7 +85,11 @@ Eval and the long-lived JSONL RPC protocol:
 | `WISP_MCP_PKG`       | Launch a bundled bio-tools server, e.g. `mcp_pubmed`          |
 
 Desktop stores API keys in the OS keyring and model profiles in
-`.wisp/wisp.sqlite`. Custom credentials map a display name to an environment
+`.wisp/wisp.sqlite`. `cargo tauri dev` writes new keys to
+`~/.wisp-science-dev-secrets.json` so unsigned rebuilds do not prompt for the
+macOS login keychain; on Windows a debug read still falls back to the OS
+keyring, so a File → New Window in a dev build can reuse keys already saved in
+an installed Wisp. Custom credentials map a display name to an environment
 variable and are injected only into newly launched local Python and bundled MCP
 processes — never copied to SSH/WSL hosts.
 

--- a/docs/workspace-navigation.md
+++ b/docs/workspace-navigation.md
@@ -6,8 +6,21 @@ in the sidebar, but it is not treated as the last conversation. Opening a
 specific conversation from Recent sessions or search still takes priority.
 
 Choose another workspace from the sidebar workspace menu to switch the current
-window in place. A separate window is opened only by an action explicitly
-labelled **Open in new window**.
+window in place. **File → New Window** opens a second GUI on the Projects home
+screen so you can run another project beside the first — the two windows keep
+separate workspaces, conversations, and runtimes. Each window remembers its own
+last project; opening a workspace in a second window does not change what the
+first window restores after a restart. Live agent streams, approval cards, and
+browser-tab cleanup prompts go only to windows bound to that conversation's
+project, so one workspace does not refresh previews or show approvals belonging
+to another. The real Chrome session is process-wide: if another project's agent
+is already driving it, browser tools fail closed until that turn finishes.
+Settings, API keys, and theme stay shared for the whole app. Approval scope
+and per-tool allow/ask/deny follow the window's project: changing them in
+one workspace does not rewrite another. Enabling a plugin or reloading skills
+only invalidates conversations in that project; installing or removing a
+plugin package still applies app-wide. A dedicated project window is also
+opened by any action labelled **Open in new window**.
 
 Each window title includes the open workspace name
 (`wisp science — my-project`) so the taskbar, Alt-Tab, and macOS title bar can

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -2,7 +2,7 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "Main window IPC: core APIs and agent event stream",
-  "windows": ["main", "proj-*"],
+  "windows": ["main", "proj-*", "home-*"],
   "remote": {
     "urls": ["http://localhost:1421", "http://127.0.0.1:1421"]
   },

--- a/src-tauri/src/acp.rs
+++ b/src-tauri/src/acp.rs
@@ -10,7 +10,7 @@ use std::{
     },
     time::Duration,
 };
-use tauri::{AppHandle, Emitter, State};
+use tauri::{AppHandle, State};
 use tokio::sync::Mutex;
 use uuid::Uuid;
 use wisp_acp::{
@@ -992,22 +992,17 @@ pub(crate) async fn run_acp_internal_turn(
     .await
 }
 
-/// `emit_to` the turn's own window when it has one; internal turns (review
-/// correction, channels) have no window and fall back to a broadcast.
+/// Route ACP UI to windows of this conversation's project. Internal turns
+/// (review, channels) have no originating window, but same-project peers
+/// still need the cards; other projects must not see them.
 fn emit_ask_event(
     app: &AppHandle,
-    window_label: Option<&str>,
+    frame_id: &str,
+    project_id: Option<&str>,
     event: &str,
     payload: serde_json::Value,
 ) {
-    match window_label {
-        Some(label) => {
-            let _ = app.emit_to(label, event, payload);
-        }
-        None => {
-            let _ = app.emit(event, payload);
-        }
-    }
+    crate::emit_to_session_surfaces(app, frame_id, project_id, event, &payload);
 }
 
 /// Surface new pending bridge `ask_user` rows to the UI. `acp_asks` doubles as
@@ -1016,7 +1011,7 @@ fn emit_ask_event(
 async fn surface_pending_asks(
     state: &AppState,
     app: &AppHandle,
-    window_label: Option<&str>,
+    project_id: Option<&str>,
     frame_id: &str,
 ) {
     let pending = state
@@ -1036,11 +1031,12 @@ async fn surface_pending_asks(
             .lock()
             .unwrap()
             .insert(frame_id.to_string());
-        state.device_hub.mark_needs_user(frame_id, None);
+        state.device_hub.mark_needs_user(frame_id, project_id);
         let payload: serde_json::Value = serde_json::from_str(&payload_json).unwrap_or_default();
         emit_ask_event(
             app,
-            window_label,
+            frame_id,
+            project_id,
             "ask-user-request",
             serde_json::json!({
                 "frameId": frame_id,
@@ -1056,7 +1052,7 @@ async fn surface_pending_asks(
 async fn settle_expired_asks(
     state: &AppState,
     app: &AppHandle,
-    window_label: Option<&str>,
+    project_id: Option<&str>,
     frame_id: &str,
 ) {
     let expired = state
@@ -1082,7 +1078,8 @@ async fn settle_expired_asks(
     for (request_id, _) in expired {
         emit_ask_event(
             app,
-            window_label,
+            frame_id,
+            project_id,
             "ask-user-resolved",
             serde_json::json!({
                 "frameId": frame_id,
@@ -1123,7 +1120,7 @@ async fn run_acp_turn_with_kind(
     .await;
     // Runs on every exit path, success or error — asks must never outlive
     // their turn as live cards.
-    settle_expired_asks(state, app, window_label, frame_id).await;
+    settle_expired_asks(state, app, Some(project.id.as_str()), frame_id).await;
     result
 }
 
@@ -1131,7 +1128,7 @@ async fn run_acp_turn_with_kind(
 async fn run_acp_turn_inner(
     state: &AppState,
     app: &AppHandle,
-    window_label: Option<&str>,
+    _window_label: Option<&str>,
     project: &ActiveProject,
     frame_id: &str,
     profile_id: Option<&str>,
@@ -1143,9 +1140,12 @@ async fn run_acp_turn_inner(
 ) -> Result<String, String> {
     let runtime = runtime_for(state, project, frame_id, profile_id).await?;
     if let Some(session_state) = runtime.session_state.lock().await.take() {
-        let _ = app.emit(
+        crate::emit_to_session_surfaces(
+            app,
+            frame_id,
+            Some(project.id.as_str()),
             "acp-session-state",
-            serde_json::json!({
+            &serde_json::json!({
                 "frameId": frame_id,
                 "modes": session_state.modes,
                 "configOptions": session_state.config_options,
@@ -1173,19 +1173,21 @@ async fn run_acp_turn_inner(
     }
     let mut next_seq = begin_acp_turn(&state.store, frame_id, message, turn_kind).await?;
     if turn_kind == AcpTurnKind::User {
-        crate::emit_agent_event(
+        crate::emit_agent_event_in(
             app,
             AgentEvent::User {
                 frame_id: frame_id.to_string(),
                 text: message.to_string(),
             },
+            Some(project.id.as_str()),
         );
-        crate::emit_agent_event(
+        crate::emit_agent_event_in(
             app,
             AgentEvent::MessageBoundary {
                 frame_id: frame_id.to_string(),
                 seq: next_seq - 1,
             },
+            Some(project.id.as_str()),
         );
     }
     let prompt = runtime.handle.prompt(runtime.session_id.clone(), content);
@@ -1202,7 +1204,7 @@ async fn run_acp_turn_inner(
         tokio::select! {
             result = &mut prompt => break result.map_err(|error| error.to_string())?,
             _ = ask_tick.tick() => {
-                surface_pending_asks(state, app, window_label, frame_id).await;
+                surface_pending_asks(state, app, Some(project.id.as_str()), frame_id).await;
             }
             event = runtime.handle.next_event() => match event {
                 Some(AcpSessionEvent::Update { kind, payload, .. }) => {
@@ -1215,7 +1217,7 @@ async fn run_acp_turn_inner(
                             } else {
                                 AgentEvent::Reasoning { frame_id: frame_id.to_string(), delta: text.to_string() }
                             };
-                            crate::emit_agent_event(app, event);
+                            crate::emit_agent_event_in(app, event, Some(project.id.as_str()));
                         }
                     } else {
                         if matches!(kind, AcpUpdateKind::ToolCall | AcpUpdateKind::ToolCallUpdate) {
@@ -1224,11 +1226,17 @@ async fn run_acp_turn_inner(
                         if kind == AcpUpdateKind::Plan {
                             plan = Some(payload.clone());
                         }
-                        let _ = app.emit("acp-session-update", serde_json::json!({
-                            "frameId": frame_id,
-                            "kind": format!("{kind:?}"),
-                            "payload": payload,
-                        }));
+                        crate::emit_to_session_surfaces(
+                            app,
+                            frame_id,
+                            Some(project.id.as_str()),
+                            "acp-session-update",
+                            &serde_json::json!({
+                                "frameId": frame_id,
+                                "kind": format!("{kind:?}"),
+                                "payload": payload,
+                            }),
+                        );
                     }
                 }
                 Some(AcpSessionEvent::Permission(request)) => {
@@ -1252,7 +1260,13 @@ async fn run_acp_turn_inner(
                     state.awaiting_confirm.lock().unwrap().insert(frame_id.to_string());
                     state.device_hub.mark_needs_user(frame_id, Some(&project.id));
                     crate::channels::publish_approval_request(&pending.remote_request);
-                    let _ = app.emit("permission-request", permission_event(frame_id, &request));
+                    crate::emit_to_session_surfaces(
+                        app,
+                        frame_id,
+                        Some(project.id.as_str()),
+                        "permission-request",
+                        &permission_event(frame_id, &request),
+                    );
                 }
                 Some(AcpSessionEvent::Exited { error }) => return Err(error.unwrap_or_else(|| "ACP Agent exited.".into())),
                 None => return Err("ACP Agent event stream closed.".into()),
@@ -1277,21 +1291,23 @@ async fn run_acp_turn_inner(
                 if let Some(text) = text_from_payload(&payload) {
                     if kind == AcpUpdateKind::AgentMessage {
                         assistant.push_str(text);
-                        crate::emit_agent_event(
+                        crate::emit_agent_event_in(
                             app,
                             AgentEvent::Text {
                                 frame_id: frame_id.to_string(),
                                 delta: text.to_string(),
                             },
+                            Some(project.id.as_str()),
                         );
                     } else if kind == AcpUpdateKind::AgentThought {
                         reasoning.push_str(text);
-                        crate::emit_agent_event(
+                        crate::emit_agent_event_in(
                             app,
                             AgentEvent::Reasoning {
                                 frame_id: frame_id.to_string(),
                                 delta: text.to_string(),
                             },
+                            Some(project.id.as_str()),
                         );
                     }
                 }
@@ -1308,9 +1324,12 @@ async fn run_acp_turn_inner(
                     if kind == AcpUpdateKind::Plan {
                         plan = Some(payload.clone());
                     }
-                    let _ = app.emit(
+                    crate::emit_to_session_surfaces(
+                        app,
+                        frame_id,
+                        Some(project.id.as_str()),
                         "acp-session-update",
-                        serde_json::json!({
+                        &serde_json::json!({
                             "frameId": frame_id,
                             "kind": format!("{kind:?}"),
                             "payload": payload,
@@ -1366,13 +1385,14 @@ async fn run_acp_turn_inner(
     )
     .await;
     if !resources.is_empty() {
-        crate::emit_agent_event(
+        crate::emit_agent_event_in(
             app,
             AgentEvent::Resources {
                 frame_id: frame_id.to_string(),
                 seq: next_seq,
                 resources: resources.iter().map(Into::into).collect(),
             },
+            Some(project.id.as_str()),
         );
     }
     cancel_pending_permissions(state, frame_id, &runtime).await;
@@ -1479,9 +1499,13 @@ async fn respond_acp_permission_inner(
         state.awaiting_confirm.lock().unwrap().remove(&frame_id);
         state.device_hub.resolve_needs_user(&frame_id);
     }
-    let _ = app.emit(
+    let project_id = state.store.frame_project_id(&frame_id).await.ok().flatten();
+    crate::emit_to_session_surfaces(
+        app,
+        &frame_id,
+        project_id.as_deref(),
         "permission-resolved",
-        serde_json::json!({
+        &serde_json::json!({
             "frameId": frame_id,
             "requestId": request_id,
         }),
@@ -1579,10 +1603,16 @@ pub(crate) async fn respond_ask_user(
         state.awaiting_confirm.lock().unwrap().remove(&frame_id);
         state.device_hub.resolve_needs_user(&frame_id);
     }
-    let _ = app.emit_to(
-        window.label(),
+    let project_id = state
+        .require_active(window.label())
+        .ok()
+        .map(|project| project.id);
+    crate::emit_to_session_surfaces(
+        &app,
+        &frame_id,
+        project_id.as_deref(),
         "ask-user-resolved",
-        serde_json::json!({
+        &serde_json::json!({
             "frameId": frame_id,
             "requestId": request_id,
             "expired": false,
@@ -1625,9 +1655,12 @@ pub(crate) async fn set_acp_session_config(
         .await
         .map_err(|error| error.to_string())?;
     let value = serde_json::to_value(&options).map_err(|error| error.to_string())?;
-    let _ = app.emit(
+    crate::emit_to_session_surfaces(
+        &app,
+        &frame_id,
+        Some(project.id.as_str()),
         "acp-session-state",
-        serde_json::json!({
+        &serde_json::json!({
             "frameId": frame_id,
             "configOptions": value,
         }),

--- a/src-tauri/src/agent_turn.rs
+++ b/src-tauri/src/agent_turn.rs
@@ -87,7 +87,7 @@ pub(crate) async fn send_message_inner(
     if !resume && message.trim().is_empty() {
         return Err("message is empty".into());
     }
-    let mut ap = state.active(window_label);
+    let mut ap = state.require_active(window_label)?;
     let mut explicit_scope = None;
     // A session belongs to one project for life, but the per-window active slot
     // can drift while it keeps running (another project opened in this window,
@@ -226,9 +226,8 @@ pub(crate) async fn send_message_inner(
             .map(|delivery| delivery.id.clone())
             .collect::<Vec<_>>();
         let artifact_references = resolve_acp_artifact_references(&state.store, refs).await?;
-        // Record the destination before waiting for a busy session. A user can
-        // therefore send a queued desktop follow-up and immediately continue
-        // that same conversation from Feishu or WeChat.
+        // Record this project's last session. Desktop sends never move the IM
+        // target project; Feishu/WeChat keep their own `/project` destination.
         channels::record_last_message_session(&state.store, &frame_id)
             .await
             .map_err(|error| format!("Failed to update the shared last-message route: {error}"))?;
@@ -345,8 +344,8 @@ pub(crate) async fn send_message_inner(
             .await?;
     }
 
-    // Route on accepted send, not on eventual execution. In particular, a
-    // follow-up queued behind a long turn must become the target immediately.
+    // Record this project's last session on accepted send. Desktop traffic
+    // must not steal the Feishu/WeChat IM project.
     channels::record_last_message_session(&state.store, &frame_id)
         .await
         .map_err(|error| format!("Failed to update the shared last-message route: {error}"))?;
@@ -1069,10 +1068,13 @@ pub(crate) async fn send_message_inner(
     let (live_event_handle, live_event_tx) = {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<AgentEvent>();
         let app = app.clone();
+        let live_project_id = ap.id.clone();
         let handle = tokio::spawn(coalesce_live_agent_events(
             rx,
             LIVE_EVENT_FLUSH_INTERVAL,
-            move |event| emit_agent_event_to_surfaces(&app, event),
+            move |event| {
+                emit_agent_event_to_surfaces_in(&app, event, Some(live_project_id.as_str()))
+            },
         ));
         (handle, tx)
     };
@@ -1080,6 +1082,7 @@ pub(crate) async fn send_message_inner(
     let provenance_scope =
         crate::native_delegation::conversation_scope(&state.store, &frame_id).await;
     let browser_turn_id = Uuid::new_v4().to_string();
+    crate::ensure_project_live_approvals(state, &ap.id).await;
     let output = TauriOutput {
         app: app.clone(),
         frame_id: frame_id.clone(),
@@ -1234,7 +1237,7 @@ pub(crate) async fn send_message_inner(
                 },
             )
             .await;
-            emit_browser_tab_cleanup(state, &app, &browser_turn_id).await;
+            emit_browser_tab_cleanup(state, &app, &browser_turn_id, &ap.id).await;
             Ok(frame_id)
         }
         Err(e) => {
@@ -1254,17 +1257,29 @@ pub(crate) async fn send_message_inner(
                 },
             )
             .await;
-            emit_browser_tab_cleanup(state, &app, &browser_turn_id).await;
+            emit_browser_tab_cleanup(state, &app, &browser_turn_id, &ap.id).await;
             Err(client_turn_error(turn_started, &message))
         }
     }
 }
 
-async fn emit_browser_tab_cleanup(state: &AppState, app: &AppHandle, turn_id: &str) {
+async fn emit_browser_tab_cleanup(
+    state: &AppState,
+    app: &AppHandle,
+    turn_id: &str,
+    project_id: &str,
+) {
     if let browser_bridge::TabCleanupAction::Prompt(prompt) =
         state.browser_bridge.complete_turn(turn_id).await
     {
-        let _ = app.emit("browser-tab-cleanup", prompt);
+        emit_to_session_surfaces_filtered(
+            app,
+            &prompt.frame_id,
+            Some(project_id),
+            "browser-tab-cleanup",
+            &prompt,
+            false,
+        );
     }
 }
 

--- a/src-tauri/src/app_commands.rs
+++ b/src-tauri/src/app_commands.rs
@@ -424,7 +424,7 @@ pub(super) async fn get_capabilities(
     state: State<'_, AppState>,
     window: tauri::WebviewWindow,
 ) -> Result<Capabilities, String> {
-    let ap = state.active(window.label());
+    let ap = state.require_active(window.label())?;
     let tags = load_skill_tags(&state.store).await;
     let (catalog, enabled) = project_skill_catalog(&state.store, &ap).await;
     let skills = skill_infos(&catalog, &tags, enabled.as_ref());

--- a/src-tauri/src/app_state.rs
+++ b/src-tauri/src/app_state.rs
@@ -470,16 +470,17 @@ pub(crate) struct AppState {
     /// frame id explicitly (`TauriOutput.frame_id`).
     pub(crate) active_frame: std::sync::RwLock<HashMap<String, String>>,
     /// Window that most recently submitted a user-routed turn for each session.
-    /// Agent events are process-wide, so every frontend window asks for the
-    /// same desktop notification. This origin lets the backend choose exactly
-    /// one window without conflating two conversations in the same project.
+    /// Live agent/approval UI is scoped to windows of the session's project;
+    /// this origin still picks which window owns the desktop notification.
     pub(crate) notification_window: std::sync::RwLock<HashMap<String, String>>,
     /// Per-session confirm channels, keyed by frame id.
     pub(crate) confirms: ConfirmMap,
     /// Sessions blocked on an inline approval card (Projects dashboard → Needs you).
     pub(crate) awaiting_confirm: Arc<StdMutex<HashSet<String>>>,
     /// Live per-tool approval policy, read on every tool call by `TauriOutput`.
-    pub(crate) approvals: Arc<StdRwLock<ApprovalPolicy>>,
+    /// Project overlays sit beside the process-wide default so two windows can
+    /// keep different scopes.
+    pub(crate) approvals: Arc<StdRwLock<LiveApprovals>>,
     /// Scoped approvals granted from the inline confirmation card.
     pub(crate) approval_grants: Arc<StdMutex<ApprovalGrants>>,
     /// Conversations whose approval prompts are bypassed for this app run.
@@ -531,12 +532,16 @@ impl AppState {
     }
     /// Snapshot a window's active project. Falls back to the "main" window's
     /// project (always initialized at startup) for un-scoped or early calls.
+    /// File → New Window views (`home-*`) never inherit another window's
+    /// workspace — they must open a project first.
     pub(crate) fn active(&self, label: &str) -> ActiveProject {
-        let map = self.active.read().unwrap();
-        map.get(label)
-            .or_else(|| map.get("main"))
-            .cloned()
-            .expect("main window active project is initialized at startup")
+        self.require_active(label)
+            .unwrap_or_else(|err| panic!("{err}"))
+    }
+    /// Like [`Self::active`], but blank File → New Window views without a bound
+    /// project return an error instead of leaking the main window's workspace.
+    pub(crate) fn require_active(&self, label: &str) -> Result<ActiveProject, String> {
+        lookup_window_binding(&self.active.read().unwrap(), label).cloned()
     }
     pub(crate) fn set_active(&self, label: &str, ap: ActiveProject) {
         self.active.write().unwrap().insert(label.to_string(), ap);
@@ -599,5 +604,103 @@ impl AppState {
             &active_projects,
             &active_frames,
         )
+    }
+
+    /// Windows currently bound to this session's project. Live agent, approval,
+    /// and browser-cleanup events use this set so a second project window never
+    /// receives another workspace's stream.
+    pub(crate) fn session_surface_labels(
+        &self,
+        frame_id: &str,
+        project_id: Option<&str>,
+    ) -> Vec<String> {
+        let active = self.active.read().unwrap();
+        let active_projects = active
+            .iter()
+            .map(|(label, project)| (label.clone(), project.id.clone()))
+            .collect::<HashMap<_, _>>();
+        let active_frames = self.active_frame.read().unwrap();
+        let inferred = project_id.map(str::to_string).or_else(|| {
+            active_frames.iter().find_map(|(label, viewed)| {
+                (viewed.as_str() == frame_id)
+                    .then(|| active.get(label).map(|project| project.id.clone()))
+                    .flatten()
+            })
+        });
+        let origin = self.notification_window.read().unwrap();
+        session_surface_window_labels(
+            origin.get(frame_id).map(String::as_str),
+            frame_id,
+            inferred.as_deref(),
+            &active_projects,
+            &active_frames,
+        )
+    }
+}
+
+pub(crate) const BLANK_WINDOW_NO_PROJECT: &str =
+    "Open a project in this window before running that action.";
+
+/// Labels minted by File → New Window. Dedicated `proj-*` windows and `main`
+/// keep their existing restore and close-to-tray behavior.
+pub(crate) fn is_blank_window_label(label: &str) -> bool {
+    label.starts_with("home-") && label.len() > "home-".len()
+}
+
+/// Resolve which project a window command may touch.
+///
+/// A File → New Window view has its own label and no binding until the user
+/// opens a project in that GUI. Falling back to `main` would let that window
+/// read or mutate another project's workspace, sessions, and runtimes.
+pub(crate) fn lookup_window_binding<'a, T>(
+    bound: &'a HashMap<String, T>,
+    label: &str,
+) -> Result<&'a T, String> {
+    if let Some(value) = bound.get(label) {
+        return Ok(value);
+    }
+    if is_blank_window_label(label) {
+        return Err(BLANK_WINDOW_NO_PROJECT.into());
+    }
+    bound
+        .get("main")
+        .ok_or_else(|| "main window active project is initialized at startup".into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_blank_window_label, lookup_window_binding, BLANK_WINDOW_NO_PROJECT};
+    use std::collections::HashMap;
+
+    #[test]
+    fn blank_window_labels_are_home_prefixed() {
+        assert!(is_blank_window_label(
+            "home-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        ));
+        assert!(!is_blank_window_label("home-"));
+        assert!(!is_blank_window_label("home"));
+        assert!(!is_blank_window_label("main"));
+        assert!(!is_blank_window_label("proj-default"));
+        assert!(!is_blank_window_label("pet"));
+    }
+
+    #[test]
+    fn blank_windows_do_not_inherit_the_main_project() {
+        let mut bound = HashMap::new();
+        bound.insert("main".to_string(), "project-a");
+        assert_eq!(
+            lookup_window_binding(&bound, "home-1").unwrap_err(),
+            BLANK_WINDOW_NO_PROJECT
+        );
+        assert_eq!(
+            *lookup_window_binding(&bound, "proj-default").unwrap(),
+            "project-a"
+        );
+        bound.insert("home-1".to_string(), "project-b");
+        assert_eq!(
+            *lookup_window_binding(&bound, "home-1").unwrap(),
+            "project-b"
+        );
+        assert_eq!(*lookup_window_binding(&bound, "main").unwrap(), "project-a");
     }
 }

--- a/src-tauri/src/browser_bridge/mod.rs
+++ b/src-tauri/src/browser_bridge/mod.rs
@@ -19,7 +19,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::{mpsc, oneshot, Mutex};
@@ -178,6 +178,37 @@ pub struct BrowserBridge {
     /// Tabs `web_open_tab` / tab-create commands opened, keyed by turn id.
     turn_ledgers: Mutex<HashMap<String, TurnTabLedger>>,
     pending_cleanups: Mutex<HashMap<String, PendingCleanup>>,
+    /// One real Chrome session for the whole process. Same-project tools may
+    /// reenter; a foreign project fails until the holders drop.
+    occupancy: Arc<StdMutex<Option<BrowserOccupancy>>>,
+}
+
+#[derive(Clone, Debug)]
+struct BrowserOccupancy {
+    project_id: String,
+    holders: usize,
+}
+
+#[derive(Debug)]
+struct BrowserOccupancyGuard {
+    occupancy: Arc<StdMutex<Option<BrowserOccupancy>>>,
+    project_id: String,
+}
+
+impl Drop for BrowserOccupancyGuard {
+    fn drop(&mut self) {
+        let mut occupancy = self.occupancy.lock().unwrap_or_else(|p| p.into_inner());
+        let Some(current) = occupancy.as_mut() else {
+            return;
+        };
+        if current.project_id != self.project_id {
+            return;
+        }
+        current.holders = current.holders.saturating_sub(1);
+        if current.holders == 0 {
+            *occupancy = None;
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -329,6 +360,39 @@ impl BrowserBridge {
             extension_update_lock: Mutex::new(()),
             turn_ledgers: Mutex::new(HashMap::new()),
             pending_cleanups: Mutex::new(HashMap::new()),
+            occupancy: Arc::new(StdMutex::new(None)),
+        }
+    }
+
+    fn occupy_project(&self, project_id: &str) -> Result<BrowserOccupancyGuard, String> {
+        let mut occupancy = self.occupancy.lock().unwrap_or_else(|p| p.into_inner());
+        match occupancy.as_mut() {
+            Some(current) if current.project_id == project_id => {
+                current.holders += 1;
+            }
+            Some(current) => {
+                return Err(format!(
+                    "browser is currently in use by another project ({}). Only one project's agent can drive the shared Chrome session at a time; wait until that turn finishes or stop it.",
+                    current.project_id
+                ));
+            }
+            None => {
+                *occupancy = Some(BrowserOccupancy {
+                    project_id: project_id.to_string(),
+                    holders: 1,
+                });
+            }
+        }
+        Ok(BrowserOccupancyGuard {
+            occupancy: self.occupancy.clone(),
+            project_id: project_id.to_string(),
+        })
+    }
+
+    fn occupy_for_env(&self, env: &dyn ToolEnv) -> Result<Option<BrowserOccupancyGuard>, String> {
+        match env.project_id() {
+            Some(project_id) if !project_id.is_empty() => self.occupy_project(project_id).map(Some),
+            _ => Ok(None),
         }
     }
 
@@ -362,6 +426,7 @@ impl BrowserBridge {
             extension_update_lock: Mutex::new(()),
             turn_ledgers: Mutex::new(HashMap::new()),
             pending_cleanups: Mutex::new(HashMap::new()),
+            occupancy: Arc::new(StdMutex::new(None)),
         });
         bridge.load_pending_cleanups().await;
         match TcpListener::bind(BRIDGE_ADDR).await {
@@ -2144,6 +2209,13 @@ const TEXT_SCAN_SCRIPT: &str = r#"(() => ({
   text: (document.body?.innerText || '').slice(0, 50000)
 }))()"#;
 
+fn occupy_or_fail(
+    bridge: &BrowserBridge,
+    env: &dyn ToolEnv,
+) -> Result<Option<BrowserOccupancyGuard>, ToolResult> {
+    bridge.occupy_for_env(env).map_err(ToolResult::fail)
+}
+
 pub struct BrowserSetupTool {
     bridge: Arc<BrowserBridge>,
     store: Store,
@@ -2179,7 +2251,11 @@ impl Tool for BrowserSetupTool {
         "show real-browser setup status and extension path".into()
     }
 
-    async fn run(&self, args: &Value, _env: &dyn ToolEnv) -> ToolResult {
+    async fn run(&self, args: &Value, env: &dyn ToolEnv) -> ToolResult {
+        let _occupancy = match occupy_or_fail(&self.bridge, env) {
+            Ok(guard) => guard,
+            Err(fail) => return fail,
+        };
         if let Some(action) = args.get("action").and_then(Value::as_str) {
             let result = match action {
                 "update_extension" => {
@@ -2265,7 +2341,11 @@ impl Tool for WebScanTool {
         }
     }
 
-    async fn run(&self, args: &Value, _env: &dyn ToolEnv) -> ToolResult {
+    async fn run(&self, args: &Value, env: &dyn ToolEnv) -> ToolResult {
+        let _occupancy = match occupy_or_fail(&self.bridge, env) {
+            Ok(guard) => guard,
+            Err(fail) => return fail,
+        };
         let session = match session_arg(args) {
             Ok(session) => session,
             Err(error) => return ToolResult::fail(error),
@@ -2383,6 +2463,10 @@ impl Tool for WebExecuteJsTool {
     }
 
     async fn run(&self, args: &Value, env: &dyn ToolEnv) -> ToolResult {
+        let _occupancy = match occupy_or_fail(&self.bridge, env) {
+            Ok(guard) => guard,
+            Err(fail) => return fail,
+        };
         let Some(script) = args
             .get("script")
             .and_then(Value::as_str)
@@ -2502,6 +2586,10 @@ impl Tool for WebOpenTabTool {
     }
 
     async fn run(&self, args: &Value, env: &dyn ToolEnv) -> ToolResult {
+        let _occupancy = match occupy_or_fail(&self.bridge, env) {
+            Ok(guard) => guard,
+            Err(fail) => return fail,
+        };
         let Some(url) = args
             .get("url")
             .and_then(Value::as_str)
@@ -2590,6 +2678,10 @@ impl Tool for WebScreenshotTool {
     }
 
     async fn run(&self, args: &Value, env: &dyn ToolEnv) -> ToolResult {
+        let _occupancy = match occupy_or_fail(&self.bridge, env) {
+            Ok(guard) => guard,
+            Err(fail) => return fail,
+        };
         let tab_id = match tab_id_arg(args) {
             Ok(tab_id) => tab_id,
             Err(error) => return ToolResult::fail(error),
@@ -2757,6 +2849,10 @@ impl Tool for WebSaveAssetsTool {
     }
 
     async fn run(&self, args: &Value, env: &dyn ToolEnv) -> ToolResult {
+        let _occupancy = match occupy_or_fail(&self.bridge, env) {
+            Ok(guard) => guard,
+            Err(fail) => return fail,
+        };
         let session = match session_arg(args) {
             Ok(session) => session,
             Err(error) => return ToolResult::fail(error),
@@ -2918,7 +3014,11 @@ impl Tool for WebAgentSendTool {
                 .collect::<String>()
         )
     }
-    async fn run(&self, args: &Value, _env: &dyn ToolEnv) -> ToolResult {
+    async fn run(&self, args: &Value, env: &dyn ToolEnv) -> ToolResult {
+        let _occupancy = match occupy_or_fail(&self.bridge, env) {
+            Ok(guard) => guard,
+            Err(fail) => return fail,
+        };
         let turn = match begin_chat_turn(&self.bridge, args).await {
             Ok(turn) => turn,
             Err(error) => return ToolResult::fail(error),
@@ -3016,7 +3116,11 @@ impl Tool for WebAgentWaitTool {
     fn preview(&self, _args: &Value) -> String {
         "wait for in-browser chat reply".into()
     }
-    async fn run(&self, args: &Value, _env: &dyn ToolEnv) -> ToolResult {
+    async fn run(&self, args: &Value, env: &dyn ToolEnv) -> ToolResult {
+        let _occupancy = match occupy_or_fail(&self.bridge, env) {
+            Ok(guard) => guard,
+            Err(fail) => return fail,
+        };
         let turn = match begin_chat_turn(&self.bridge, args).await {
             Ok(turn) => turn,
             Err(error) => return ToolResult::fail(error),
@@ -3093,7 +3197,11 @@ impl Tool for WebAgentReadTool {
     fn preview(&self, _args: &Value) -> String {
         "read last in-browser chat answer".into()
     }
-    async fn run(&self, args: &Value, _env: &dyn ToolEnv) -> ToolResult {
+    async fn run(&self, args: &Value, env: &dyn ToolEnv) -> ToolResult {
+        let _occupancy = match occupy_or_fail(&self.bridge, env) {
+            Ok(guard) => guard,
+            Err(fail) => return fail,
+        };
         let turn = match begin_chat_turn(&self.bridge, args).await {
             Ok(turn) => turn,
             Err(error) => return ToolResult::fail(error),
@@ -3124,8 +3232,21 @@ impl Tool for WebAgentReadTool {
 #[tauri::command]
 pub async fn list_pending_browser_tab_cleanups(
     state: tauri::State<'_, crate::AppState>,
+    window: tauri::WebviewWindow,
 ) -> Result<Vec<BrowserTabCleanupPrompt>, String> {
-    Ok(state.browser_bridge.list_pending_cleanups().await)
+    let project_id = match state.require_active(window.label()) {
+        Ok(project) => project.id.clone(),
+        Err(_) => return Ok(Vec::new()),
+    };
+    let prompts = state.browser_bridge.list_pending_cleanups().await;
+    let mut kept = Vec::new();
+    for prompt in prompts {
+        match state.store.frame_project_id(&prompt.frame_id).await {
+            Ok(Some(owner)) if owner == project_id => kept.push(prompt),
+            _ => {}
+        }
+    }
+    Ok(kept)
 }
 
 #[tauri::command]
@@ -3169,6 +3290,34 @@ mod tests {
         }
 
         async fn emit(&self, _event: wisp_tools::ToolEvent) {}
+    }
+
+    #[test]
+    fn occupancy_blocks_a_foreign_project_and_reenters_the_same_one() {
+        let bridge = BrowserBridge::new(PathBuf::from("extension"));
+        let first = bridge.occupy_project("proj-a").unwrap();
+        let nested = bridge.occupy_project("proj-a").unwrap();
+        let error = bridge.occupy_project("proj-b").unwrap_err();
+        assert!(
+            error.contains("another project"),
+            "foreign project should see occupancy: {error}"
+        );
+        assert!(error.contains("proj-a"), "{error}");
+        drop(first);
+        drop(nested);
+        let _other = bridge.occupy_project("proj-b").unwrap();
+    }
+
+    #[test]
+    fn occupancy_skips_envs_without_a_project() {
+        let bridge = BrowserBridge::new(PathBuf::from("extension"));
+        let env = NoEnv(PathBuf::from("."));
+        assert!(bridge.occupy_for_env(&env).unwrap().is_none());
+        let _held = bridge.occupy_project("proj-a").unwrap();
+        assert!(
+            bridge.occupy_for_env(&env).unwrap().is_none(),
+            "tests and CLI calls without a project id must not take or block the lock"
+        );
     }
 
     async fn empty_store() -> (Store, PathBuf) {

--- a/src-tauri/src/channels/mod.rs
+++ b/src-tauri/src/channels/mod.rs
@@ -8,11 +8,12 @@
 //! before any inbound message may enter that path, and IM turns force Ask on
 //! mutating tools even when the desktop policy defaults to Allow.
 //!
-//! Desktop, Feishu, and WeChat share one durable last-message route. An ordinary
-//! IM message always continues the session that most recently accepted a user
-//! message on any of those surfaces; `/project`, `/session`, and `/new` can
-//! explicitly move that shared target. Non-secret config lives in SQLite
-//! settings; the Feishu app secret and WeChat bot token live in the keyring.
+//! Desktop, Feishu, and WeChat share one durable **IM target project**. An
+//! ordinary IM message continues that project's current IM session; `/project`,
+//! `/session`, and `/new` move the IM target. A desktop send only updates that
+//! project's last session — it never steals the IM project. Non-secret config
+//! lives in SQLite settings; the Feishu app secret and WeChat bot token live
+//! in the keyring.
 
 pub mod feishu;
 pub mod feishu_card;
@@ -533,14 +534,18 @@ const LAST_MESSAGE_ROUTE_KEY: &str = "channel_last_message_route";
 /// accepted-send updates across the desktop, Feishu, and WeChat.
 static ROUTE_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
-/// The shared routing target. `session_id=None` is an explicit `/project` or
-/// `/new` selection: the next ordinary message creates a session there.
+/// The IM routing target plus the last accepted send per project. `project_id`
+/// / `session_id` are the Feishu/WeChat destination; desktop sends only write
+/// `last_session_by_project`. `session_id=None` is an explicit `/project` or
+/// `/new` selection: the next ordinary IM message creates a session there.
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
 struct SharedRoute {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     project_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    last_session_by_project: HashMap<String, String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -567,9 +572,9 @@ async fn route_set_unlocked(store: &Store, route: &SharedRoute) -> Result<(), St
         .map_err(|error| error.to_string())
 }
 
-/// Validate the persisted target. On first run after upgrading, recover the
-/// most recently inserted user message from the transcript store. This is only
-/// a cold-start fallback; every subsequent accepted send writes the exact route.
+/// Validate the persisted IM target. Legacy `{project_id, session_id}` JSON is
+/// kept as the IM destination and copied into `last_session_by_project`. A
+/// desktop send never becomes the IM project.
 async fn validated_route_unlocked(store: &Store) -> Result<SharedRoute, String> {
     let original = route_get_unlocked(store).await;
     let mut route = original.clone();
@@ -579,10 +584,30 @@ async fn validated_route_unlocked(store: &Store) -> Result<SharedRoute, String> 
             .await
             .map_err(|error| error.to_string())?
         {
-            Some(owner) => route.project_id = Some(owner),
+            Some(owner) => {
+                route.project_id = Some(owner.clone());
+                route
+                    .last_session_by_project
+                    .entry(owner)
+                    .or_insert_with(|| session_id.to_string());
+            }
             None => {
-                route.project_id = None;
                 route.session_id = None;
+                if let Some(project_id) = route.project_id.as_deref() {
+                    if let Some(fallback) = route.last_session_by_project.get(project_id).cloned() {
+                        if store
+                            .frame_project_id(&fallback)
+                            .await
+                            .map_err(|error| error.to_string())?
+                            .as_deref()
+                            == Some(project_id)
+                        {
+                            route.session_id = Some(fallback);
+                        } else {
+                            route.last_session_by_project.remove(project_id);
+                        }
+                    }
+                }
             }
         }
     }
@@ -596,18 +621,6 @@ async fn validated_route_unlocked(store: &Store) -> Result<SharedRoute, String> 
             {
                 route.project_id = None;
             }
-        }
-    }
-    if route.project_id.is_none() && route.session_id.is_none() {
-        if let Some((session_id, project_id)) = store
-            .last_user_message_session()
-            .await
-            .map_err(|error| error.to_string())?
-        {
-            route = SharedRoute {
-                project_id: Some(project_id),
-                session_id: Some(session_id),
-            };
         }
     }
     if route != original {
@@ -627,9 +640,9 @@ async fn set_route(store: &Store, route: &SharedRoute) -> Result<(), String> {
 }
 
 /// Called by the shared desktop/channel `send_message` path after validation,
-/// but before waiting for the destination session's turn lock. A queued user
-/// message therefore changes the route immediately, matching send order rather
-/// than eventual execution order.
+/// but before waiting for the destination session's turn lock. Desktop and IM
+/// both record that project's last session; only IM slash commands change the
+/// IM target project.
 pub(crate) async fn record_last_message_session(
     store: &Store,
     frame_id: &str,
@@ -640,33 +653,30 @@ pub(crate) async fn record_last_message_session(
         .await
         .map_err(|error| error.to_string())?
         .ok_or_else(|| format!("Session '{frame_id}' no longer exists."))?;
-    route_set_unlocked(
-        store,
-        &SharedRoute {
-            project_id: Some(project_id),
-            session_id: Some(frame_id.to_string()),
-        },
-    )
-    .await
+    let mut route = validated_route_unlocked(store).await?;
+    route
+        .last_session_by_project
+        .insert(project_id, frame_id.to_string());
+    route_set_unlocked(store, &route).await
 }
 
-/// Resolve an ordinary IM message to the shared target. Holding `ROUTE_LOCK`
+/// Resolve an ordinary IM message to the IM target. Holding `ROUTE_LOCK`
 /// across validation and creation makes the no-history case linearizable: a
 /// Feishu message and a WeChat message arriving together reuse one new frame.
-async fn resolve_message_session(
-    store: &Store,
-    default_project_id: &str,
-) -> Result<String, String> {
+async fn resolve_message_session(store: &Store) -> Result<String, String> {
     let _route_guard = ROUTE_LOCK.lock().await;
     let mut route = validated_route_unlocked(store).await?;
     if route.project_id.is_none() {
-        route.project_id = Some(default_project_id.to_string());
+        return Err("还没有 IM 目标项目。请先发送 /project 选择。".into());
     }
     if route.session_id.is_none() {
-        let project_id = route.project_id.as_deref().unwrap_or_default();
-        let frame_id = crate::create_session_frame(store, project_id)
+        let project_id = route.project_id.clone().unwrap_or_default();
+        let frame_id = crate::create_session_frame(store, &project_id)
             .await
             .map_err(|error| format!("创建会话失败: {error}"))?;
+        route
+            .last_session_by_project
+            .insert(project_id, frame_id.clone());
         route.session_id = Some(frame_id);
         // Persist before running the turn so a provider error does not make a
         // retry fan out into another empty session.
@@ -837,7 +847,7 @@ async fn project_name(store: &Store, project_id: &str) -> String {
 
 async fn route_status_text(store: &Store, route: &SharedRoute) -> String {
     let Some(project_id) = route.project_id.as_deref() else {
-        return "还没有最近发言会话。下一条普通消息会使用桌面端当前项目，也可以先发送 /project 选择。".into();
+        return "还没有 IM 目标项目。下一条普通消息前请先发送 /project 选择。".into();
     };
     let project = project_name(store, project_id).await;
     let session = match route.session_id.as_deref() {
@@ -853,7 +863,7 @@ async fn route_status_text(store: &Store, route: &SharedRoute) -> String {
         }
         None => "新会话（下一条普通消息创建）".into(),
     };
-    format!("共享目标项目: {project}\n最近发言会话: {session}")
+    format!("IM 目标项目: {project}\n最近 IM 会话: {session}")
 }
 
 /// The turn's answer for IM delivery. Agent turns normally finish via the
@@ -873,7 +883,7 @@ async fn last_assistant_text(store: &Store, frame_id: &str) -> Option<String> {
         .find(|t| !t.trim().is_empty())
 }
 
-const HELP_TEXT: &str = "可用命令:\n/status — 查看共享的最近发言会话\n/project — 列出项目\n/project <序号|名称|ID> — 切换项目\n/session — 列出当前项目的最近会话\n/session <序号|标题|ID> — 切换会话\n/new — 在当前项目开启新会话\n/approval — 查看待审批请求（微信）\n/approve <编号> — 批准一次（微信）\n/reject <编号> [原因] — 拒绝（微信）\n/stop — 停止当前任务\n/help — 显示本帮助\n\n桌面端、微信和飞书共用同一个路由目标：普通消息始终继续最近一次实际发送过用户消息的 session。/project、/session 和 /new 会显式切换这个共享目标。";
+const HELP_TEXT: &str = "可用命令:\n/status — 查看 IM 目标项目和会话\n/project — 列出项目\n/project <序号|名称|ID> — 切换 IM 目标项目\n/session — 列出当前 IM 项目的最近会话\n/session <序号|标题|ID> — 切换 IM 会话\n/new — 在当前 IM 项目开启新会话\n/approval — 查看待审批请求（微信）\n/approve <编号> — 批准一次（微信）\n/reject <编号> [原因] — 拒绝（微信）\n/stop — 停止当前任务\n/help — 显示本帮助\n\n微信和飞书共用同一个 IM 目标项目。桌面端在某个项目里发言只会更新该项目的最近会话，不会把 IM 目标抢走。/project、/session 和 /new 会显式切换这个 IM 目标。";
 
 /// Route one inbound IM text: chat commands are handled locally, everything
 /// else drives an agent turn. Returns the reply to send back (may be empty).
@@ -1003,7 +1013,7 @@ pub(crate) async fn handle_inbound_observed(
                 return format!("切换共享路由失败: {error}");
             }
             return format!(
-                "共享目标已切换到项目“{}”。下一条微信或飞书普通消息会在这里创建新会话；也可发送 /session 选择已有会话。",
+                "IM 目标已切换到项目“{}”。下一条微信或飞书普通消息会在这里创建新会话；也可发送 /session 选择已有会话。",
                 selected.name
             );
         }
@@ -1013,7 +1023,7 @@ pub(crate) async fn handle_inbound_observed(
                 Err(error) => return format!("读取共享路由失败: {error}"),
             };
             if route.project_id.is_none() {
-                route.project_id = Some(state.active("main").id);
+                return "还没有 IM 目标项目。请先发送 /project 选择。".into();
             }
             if argument.eq_ignore_ascii_case("new") {
                 route.session_id = None;
@@ -1056,7 +1066,7 @@ pub(crate) async fn handle_inbound_observed(
                 return format!("切换共享路由失败: {error}");
             }
             return format!(
-                "共享目标已切换到会话“{}” · {}。后续微信和飞书消息都会继续这个会话。",
+                "IM 目标已切换到会话“{}” · {}。后续微信和飞书消息都会继续这个会话。",
                 selected.title,
                 short_id(&selected.id)
             );
@@ -1067,7 +1077,7 @@ pub(crate) async fn handle_inbound_observed(
                 Err(error) => return format!("读取共享路由失败: {error}"),
             };
             if route.project_id.is_none() {
-                route.project_id = Some(state.active("main").id);
+                return "还没有 IM 目标项目。请先发送 /project 选择。".into();
             }
             route.session_id = None;
             let project = project_name(
@@ -1106,7 +1116,7 @@ pub(crate) async fn handle_inbound_observed(
         return "桌面端主窗口不可用,无法处理消息。".to_string();
     };
     // Resolve and, when needed, create the shared target atomically.
-    let session_id = match resolve_message_session(&state.store, &state.active("main").id).await {
+    let session_id = match resolve_message_session(&state.store).await {
         Ok(session_id) => session_id,
         Err(error) => return format!("路由消息失败: {error}"),
     };
@@ -1574,6 +1584,7 @@ mod tests {
         let route = SharedRoute {
             project_id: Some("project-1".into()),
             session_id: Some("session-1".into()),
+            ..Default::default()
         };
         let json = serde_json::to_string(&route).unwrap();
         assert_eq!(serde_json::from_str::<SharedRoute>(&json).unwrap(), route);
@@ -1616,7 +1627,7 @@ mod tests {
         assert!(HELP_TEXT.contains("/approval"));
         assert!(HELP_TEXT.contains("/approve <编号>"));
         assert!(HELP_TEXT.contains("/reject <编号>"));
-        assert!(HELP_TEXT.contains("微信和飞书共用同一个路由目标"));
+        assert!(HELP_TEXT.contains("微信和飞书共用同一个 IM 目标项目"));
         let projects = vec![ProjectChoice {
             id: "project-123456".into(),
             name: "Alpha".into(),
@@ -1630,9 +1641,68 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn shared_route_follows_the_last_sent_session_and_recovers_after_delete() {
+    async fn desktop_send_does_not_steal_the_im_project() {
         let path = std::env::temp_dir().join(format!(
-            "wisp_channels_last_route_{}.sqlite",
+            "wisp_channels_im_project_{}.sqlite",
+            uuid::Uuid::new_v4()
+        ));
+        let store = Store::open(&path).await.unwrap();
+        store
+            .create_project("project-1", "Alpha", "/workspace/alpha")
+            .await
+            .unwrap();
+        store
+            .create_project("project-2", "Beta", "/workspace/beta")
+            .await
+            .unwrap();
+        store
+            .create_frame("session-1", "project-1", "OPERON", "wisp")
+            .await
+            .unwrap();
+        store
+            .create_frame("session-2", "project-2", "OPERON", "wisp")
+            .await
+            .unwrap();
+        set_route(
+            &store,
+            &SharedRoute {
+                project_id: Some("project-1".into()),
+                session_id: Some("session-1".into()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        record_last_message_session(&store, "session-2")
+            .await
+            .unwrap();
+        let route = validated_route(&store).await.unwrap();
+        assert_eq!(route.project_id.as_deref(), Some("project-1"));
+        assert_eq!(route.session_id.as_deref(), Some("session-1"));
+        assert_eq!(
+            route
+                .last_session_by_project
+                .get("project-2")
+                .map(String::as_str),
+            Some("session-2")
+        );
+
+        store
+            .delete_session("session-1", "project-1")
+            .await
+            .unwrap();
+        let route = validated_route(&store).await.unwrap();
+        assert_eq!(route.project_id.as_deref(), Some("project-1"));
+        assert_eq!(route.session_id, None);
+        drop(store);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[tokio::test]
+    async fn legacy_route_json_becomes_the_im_target() {
+        let path = std::env::temp_dir().join(format!(
+            "wisp_channels_legacy_route_{}.sqlite",
             uuid::Uuid::new_v4()
         ));
         let store = Store::open(&path).await.unwrap();
@@ -1645,37 +1715,22 @@ mod tests {
             .await
             .unwrap();
         store
-            .create_frame("session-2", "project-1", "OPERON", "wisp")
-            .await
-            .unwrap();
-        store
-            .append_message("session-1", 1, &wisp_llm::Message::user("first"))
-            .await
-            .unwrap();
-        store
-            .append_message("session-2", 1, &wisp_llm::Message::user("second"))
-            .await
-            .unwrap();
-
-        // Cold-start migration discovers the latest actual user message.
-        let route = validated_route(&store).await.unwrap();
-        assert_eq!(route.session_id.as_deref(), Some("session-2"));
-
-        // The same writer is called by desktop, Feishu, and WeChat turn starts;
-        // there is intentionally no channel/chat key in the persisted value.
-        record_last_message_session(&store, "session-1")
+            .set_setting(
+                LAST_MESSAGE_ROUTE_KEY,
+                r#"{"project_id":"project-1","session_id":"session-1"}"#,
+            )
             .await
             .unwrap();
         let route = validated_route(&store).await.unwrap();
         assert_eq!(route.project_id.as_deref(), Some("project-1"));
         assert_eq!(route.session_id.as_deref(), Some("session-1"));
-
-        store
-            .delete_session("session-1", "project-1")
-            .await
-            .unwrap();
-        let route = validated_route(&store).await.unwrap();
-        assert_eq!(route.session_id.as_deref(), Some("session-2"));
+        assert_eq!(
+            route
+                .last_session_by_project
+                .get("project-1")
+                .map(String::as_str),
+            Some("session-1")
+        );
         drop(store);
         let _ = std::fs::remove_file(path);
     }
@@ -1704,6 +1759,7 @@ mod tests {
             &SharedRoute {
                 project_id: Some("project-1".into()),
                 session_id: None,
+                ..Default::default()
             },
         )
         .await
@@ -1727,10 +1783,20 @@ mod tests {
             .create_project("project-1", "Alpha", "/workspace/alpha")
             .await
             .unwrap();
+        set_route(
+            &store,
+            &SharedRoute {
+                project_id: Some("project-1".into()),
+                session_id: None,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
 
         let (feishu, wechat) = tokio::join!(
-            resolve_message_session(&store, "project-1"),
-            resolve_message_session(&store, "project-1")
+            resolve_message_session(&store),
+            resolve_message_session(&store)
         );
         let feishu = feishu.unwrap();
         let wechat = wechat.unwrap();

--- a/src-tauri/src/connector_commands.rs
+++ b/src-tauri/src/connector_commands.rs
@@ -1,11 +1,11 @@
 use super::{
-    bio_domains, clear_idle_agents, connect_mcp, load_approval_scope, load_disabled_connectors,
-    load_mcp_connections, load_skip_connectors, load_tool_approvals, refresh_approval_policy,
-    save_json_setting, save_mcp_connections, AppState, ApprovalMode, McpConnection, McpHttpAuth,
-    McpTransport, Scope,
+    bio_domains, clear_idle_agents, connect_mcp, load_approval_scope_for, load_disabled_connectors,
+    load_mcp_connections, load_skip_connectors_for, load_tool_approvals_for, project_setting_key,
+    refresh_approval_policy_for, save_json_setting, save_mcp_connections, AppState, ApprovalMode,
+    McpConnection, McpHttpAuth, McpTransport, Scope,
 };
 use serde::Serialize;
-use tauri::State;
+use tauri::{State, WebviewWindow};
 
 #[derive(Serialize, Clone)]
 pub(super) struct McpConnectionsView {
@@ -134,12 +134,20 @@ pub(super) struct ConnectorsView {
     scope: String,
 }
 
+fn window_project_id(state: &AppState, window: &WebviewWindow) -> Option<String> {
+    state.require_active(window.label()).ok().map(|ap| ap.id)
+}
+
 #[tauri::command]
-pub(super) async fn list_connectors(state: State<'_, AppState>) -> Result<ConnectorsView, String> {
+pub(super) async fn list_connectors(
+    state: State<'_, AppState>,
+    window: WebviewWindow,
+) -> Result<ConnectorsView, String> {
     let store = &state.store;
+    let project_id = window_project_id(&state, &window);
     let disabled = load_disabled_connectors(store).await;
-    let approvals = load_tool_approvals(store).await;
-    let skip = load_skip_connectors(store).await;
+    let approvals = load_tool_approvals_for(store, project_id.as_deref()).await;
+    let skip = load_skip_connectors_for(store, project_id.as_deref()).await;
 
     let mut connectors = vec![];
     for d in bio_domains() {
@@ -185,7 +193,10 @@ pub(super) async fn list_connectors(state: State<'_, AppState>) -> Result<Connec
             tools: vec![],
         });
     }
-    let scope = load_approval_scope(store).await.as_str().to_string();
+    let scope = load_approval_scope_for(store, project_id.as_deref())
+        .await
+        .as_str()
+        .to_string();
     Ok(ConnectorsView { connectors, scope })
 }
 
@@ -210,40 +221,48 @@ pub(super) async fn set_connector_enabled(
 }
 
 /// Set the approval mode ("allow" | "ask" | "deny") for a single tool. Enforced
-/// live on the next tool call — no session rebuild needed.
+/// live on the next tool call — no session rebuild needed. Writes the overlay
+/// for this window's project so a sibling window keeps its own policy.
 #[tauri::command]
 pub(super) async fn set_tool_approval(
     state: State<'_, AppState>,
+    window: WebviewWindow,
     tool: String,
     mode: String,
 ) -> Result<(), String> {
-    let mut approvals = load_tool_approvals(&state.store).await;
+    let project_id = window_project_id(&state, &window);
+    let mut approvals = load_tool_approvals_for(&state.store, project_id.as_deref()).await;
     // Store only overrides; "allow" is the default, so drop it to stay compact.
     if ApprovalMode::parse(&mode) == ApprovalMode::Allow {
         approvals.remove(&tool);
     } else {
         approvals.insert(tool, ApprovalMode::parse(&mode).as_str().into());
     }
-    save_json_setting(&state.store, "tool_approvals", &approvals).await?;
-    refresh_approval_policy(&state).await;
+    save_json_setting(
+        &state.store,
+        &project_setting_key("tool_approvals", project_id.as_deref()),
+        &approvals,
+    )
+    .await?;
+    refresh_approval_policy_for(&state, project_id.as_deref()).await;
     Ok(())
 }
 
-/// Set the global approval scope ("full" | "auto" | "ask"). Enforced live on
-/// the next tool call — no session rebuild needed.
+/// Set the approval scope ("full" | "auto" | "ask") for this window's project.
 #[tauri::command]
 pub(super) async fn set_approval_scope(
     state: State<'_, AppState>,
+    window: WebviewWindow,
     scope: String,
 ) -> Result<(), String> {
-    // Normalize through `Scope` so only the three valid values ever persist.
+    let project_id = window_project_id(&state, &window);
     save_json_setting(
         &state.store,
-        "approval_scope",
+        &project_setting_key("approval_scope", project_id.as_deref()),
         &Scope::parse(&scope).as_str(),
     )
     .await?;
-    refresh_approval_policy(&state).await;
+    refresh_approval_policy_for(&state, project_id.as_deref()).await;
     Ok(())
 }
 
@@ -251,18 +270,25 @@ pub(super) async fn set_approval_scope(
 #[tauri::command]
 pub(super) async fn set_connector_skip_approvals(
     state: State<'_, AppState>,
+    window: WebviewWindow,
     key: String,
     enabled: bool,
 ) -> Result<(), String> {
-    let mut skip = load_skip_connectors(&state.store).await;
+    let project_id = window_project_id(&state, &window);
+    let mut skip = load_skip_connectors_for(&state.store, project_id.as_deref()).await;
     if enabled {
         skip.insert(key);
     } else {
         skip.remove(&key);
     }
     let list: Vec<String> = skip.into_iter().collect();
-    save_json_setting(&state.store, "skip_approval_connectors", &list).await?;
-    refresh_approval_policy(&state).await;
+    save_json_setting(
+        &state.store,
+        &project_setting_key("skip_approval_connectors", project_id.as_deref()),
+        &list,
+    )
+    .await?;
+    refresh_approval_policy_for(&state, project_id.as_deref()).await;
     Ok(())
 }
 

--- a/src-tauri/src/desktop_lifecycle.rs
+++ b/src-tauri/src/desktop_lifecycle.rs
@@ -6,7 +6,6 @@ use tauri::{
 };
 use tauri::{AppHandle, Emitter, Manager};
 
-#[cfg(target_os = "windows")]
 pub(crate) const PET_WINDOW_LABEL: &str = "pet";
 
 #[cfg(target_os = "windows")]

--- a/src-tauri/src/exploration_commands.rs
+++ b/src-tauri/src/exploration_commands.rs
@@ -782,7 +782,7 @@ pub(crate) async fn working_project_for_active_frame(
     match state.active_frame(window_label) {
         Some(frame_id) => working_project_for_frame(state, &frame_id).await,
         None => {
-            let project = state.active(window_label);
+            let project = state.require_active(window_label)?;
             Ok((project.clone(), StateScope::mainline(project.id.clone())))
         }
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -267,6 +267,35 @@ enum AgentEvent {
     },
 }
 
+impl AgentEvent {
+    fn frame_id(&self) -> &str {
+        match self {
+            Self::User { frame_id, .. }
+            | Self::MessageBoundary { frame_id, .. }
+            | Self::Resources { frame_id, .. }
+            | Self::Text { frame_id, .. }
+            | Self::Reasoning { frame_id, .. }
+            | Self::ToolCall { frame_id, .. }
+            | Self::ToolResult { frame_id, .. }
+            | Self::ToolPresentation { frame_id, .. }
+            | Self::Usage { frame_id, .. }
+            | Self::Compaction { frame_id, .. }
+            | Self::CompactionStarted { frame_id, .. }
+            | Self::ContextWarning { frame_id, .. }
+            | Self::Diff { frame_id, .. }
+            | Self::FileChanged { frame_id, .. }
+            | Self::Stdout { frame_id, .. }
+            | Self::Done { frame_id, .. }
+            | Self::Error { frame_id, .. }
+            | Self::DelegationCompleted { frame_id, .. }
+            | Self::ReviewStarted { frame_id, .. }
+            | Self::ReviewFailed { frame_id, .. }
+            | Self::Review { frame_id, .. }
+            | Self::CorrectionStarted { frame_id, .. } => frame_id,
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Clone, PartialEq, Eq)]
 pub(crate) struct ConfirmRequest {
     /// Opaque, one-shot capability used by text-only remote approval surfaces.
@@ -294,8 +323,14 @@ impl ConfirmRequest {
     }
 }
 
-fn emit_confirm_request(app: &AppHandle, request: &ConfirmRequest) {
-    let _ = app.emit("confirm-request", request.clone());
+fn emit_confirm_request(app: &AppHandle, request: &ConfirmRequest, project_id: Option<&str>) {
+    emit_to_session_surfaces(
+        app,
+        &request.frame_id,
+        project_id,
+        "confirm-request",
+        request,
+    );
     channels::publish_approval_request(request);
 }
 
@@ -332,7 +367,7 @@ async fn request_image_resize_confirmation(
         .unwrap()
         .insert(frame_id.to_string());
     state.device_hub.mark_needs_user(frame_id, Some(project_id));
-    emit_confirm_request(app, &request);
+    emit_confirm_request(app, &request, Some(project_id));
     let approved = receive_confirm_decision(rx).await.approved();
     state.confirms.lock().unwrap().remove(frame_id);
     state.awaiting_confirm.lock().unwrap().remove(frame_id);
@@ -745,7 +780,7 @@ impl Scope {
 /// `tool_connector` is static (built once from `domains.json`); `tools`/`skip`/
 /// `scope` mirror the persisted settings and are refreshed by the approval
 /// commands.
-#[derive(Default)]
+#[derive(Clone, Default)]
 struct ApprovalPolicy {
     /// Global scope layered over the per-tool modes below.
     scope: Scope,
@@ -755,6 +790,21 @@ struct ApprovalPolicy {
     skip: HashSet<String>,
     /// Tool name -> bundled connector (domain slug), for resolving `skip`.
     tool_connector: HashMap<String, String>,
+}
+
+/// Process-wide defaults plus per-project overlays written from a window that
+/// already has a workspace open. Running turns read the overlay for their
+/// `project_id`, so changing approvals in project A does not rewrite project B.
+#[derive(Clone, Default)]
+struct LiveApprovals {
+    default: ApprovalPolicy,
+    by_project: HashMap<String, ApprovalPolicy>,
+}
+
+impl LiveApprovals {
+    fn for_project(&self, project_id: &str) -> &ApprovalPolicy {
+        self.by_project.get(project_id).unwrap_or(&self.default)
+    }
 }
 
 impl ApprovalPolicy {
@@ -1787,7 +1837,8 @@ async fn persist_and_emit_terminal_event(
         Ok(mut seq) => append_ui_event(&state.store, frame_id, &mut seq, event.clone()).await,
         Err(error) => tracing::warn!("load terminal UI event sequence failed: {error}"),
     }
-    emit_agent_event(app, event);
+    let project_id = state.store.frame_project_id(frame_id).await.ok().flatten();
+    emit_agent_event_in(app, event, project_id.as_deref());
 }
 
 /// Keep the raw terminal records intact for support bundles. Historical
@@ -2003,6 +2054,24 @@ async fn clear_idle_agents(state: &AppState) {
     }
 }
 
+async fn clear_idle_agents_for_project(state: &AppState, project_id: &str) {
+    let owned: HashSet<String> = match state.store.list_sessions(project_id).await {
+        Ok(rows) => rows.into_iter().map(|(id, ..)| id).collect(),
+        Err(_) => return,
+    };
+    let runtimes = state
+        .sessions
+        .lock()
+        .await
+        .iter()
+        .filter(|(frame_id, _)| owned.contains(*frame_id))
+        .map(|(_, rt)| rt.clone())
+        .collect::<Vec<_>>();
+    for rt in runtimes {
+        rt.invalidate_cached_agent();
+    }
+}
+
 async fn clear_session_agent(state: &AppState, frame_id: &str) {
     let runtime = state.sessions.lock().await.get(frame_id).cloned();
     if let Some(runtime) = runtime {
@@ -2194,6 +2263,79 @@ fn select_notification_window(
         .map(|label| selection(label, false))
 }
 
+/// Windows that should receive live session UI (agent stream, approvals).
+///
+/// Every window currently bound to the session's project sees the stream, so two
+/// views of the same workspace stay in sync. A window bound to a different
+/// project never does — unlike desktop notifications, live UI must not fall
+/// back onto a foreign workspace. Unbound File → New Window views and `pet`
+/// are excluded here; the pet overlay is added at emit time.
+fn session_surface_window_labels(
+    _origin: Option<&str>,
+    frame_id: &str,
+    project_id: Option<&str>,
+    active_projects: &HashMap<String, String>,
+    active_frames: &HashMap<String, String>,
+) -> Vec<String> {
+    let mut labels = if let Some(project_id) = project_id {
+        active_projects
+            .iter()
+            .filter(|(label, active_project)| {
+                label.as_str() != "pet" && active_project.as_str() == project_id
+            })
+            .map(|(label, _)| label.clone())
+            .collect::<Vec<_>>()
+    } else {
+        // Unknown owner: only windows already viewing this conversation.
+        // Never broadcast to `main` or to the origin's current (possibly
+        // foreign) project.
+        active_frames
+            .iter()
+            .filter(|(label, viewed)| viewed.as_str() == frame_id && label.as_str() != "pet")
+            .map(|(label, _)| label.clone())
+            .collect::<Vec<_>>()
+    };
+    labels.sort();
+    labels.dedup();
+    labels
+}
+
+/// Emit a live session event only to windows of that conversation's project.
+///
+/// `channels` / device-hub publishers stay process-wide; this helper is the
+/// GUI fan-out. The desktop pet listens for agent/approval activity, so it is
+/// included unless the caller is a window-local overlay such as browser-tab
+/// cleanup.
+pub(crate) fn emit_to_session_surfaces<T: Clone + Serialize>(
+    app: &AppHandle,
+    frame_id: &str,
+    project_id: Option<&str>,
+    event: &str,
+    payload: &T,
+) {
+    emit_to_session_surfaces_filtered(app, frame_id, project_id, event, payload, true);
+}
+
+fn emit_to_session_surfaces_filtered<T: Clone + Serialize>(
+    app: &AppHandle,
+    frame_id: &str,
+    project_id: Option<&str>,
+    event: &str,
+    payload: &T,
+    include_pet: bool,
+) {
+    let state = app.state::<AppState>();
+    let mut labels = state.session_surface_labels(frame_id, project_id);
+    if include_pet {
+        labels.push(desktop_lifecycle::PET_WINDOW_LABEL.to_string());
+    }
+    labels.sort();
+    labels.dedup();
+    for label in labels {
+        let _ = app.emit_to(&label, event, payload.clone());
+    }
+}
+
 #[tauri::command]
 async fn update_mcp_app_context(
     state: State<'_, AppState>,
@@ -2309,7 +2451,7 @@ async fn request_mcp_app_tool_confirmation(
         .unwrap()
         .insert(frame_id.to_string());
     state.device_hub.mark_needs_user(frame_id, Some(project_id));
-    emit_confirm_request(app, &request);
+    emit_confirm_request(app, &request, Some(project_id));
     let decision = receive_confirm_decision(rx).await;
     state.confirms.lock().unwrap().remove(frame_id);
     state.awaiting_confirm.lock().unwrap().remove(frame_id);
@@ -2376,6 +2518,7 @@ async fn call_mcp_app_tool(
         .await
         .map_err(|error| error.to_string())?
         .ok_or_else(|| MCP_APP_STALE_INSTANCE_ERROR.to_string())?;
+    ensure_project_live_approvals(&state, &project_id).await;
     // Plan mode and frozen-project gates match agent tool calls: read-only
     // tools stay available, everything else refuses.
     if plan_mode::session_plan_mode(&state.store, &frame_id).await
@@ -2388,7 +2531,7 @@ async fn call_mcp_app_tool(
     let host_approval = state
         .approvals
         .read()
-        .map(|policy| policy.mode_for(&name))
+        .map(|live| live.for_project(&project_id).mode_for(&name))
         .unwrap_or(wisp_tools::Approval::Allow);
     let full_permission = state
         .full_permission_sessions
@@ -2626,7 +2769,7 @@ struct TauriOutput {
     confirms: ConfirmMap,
     awaiting_confirm: Arc<StdMutex<HashSet<String>>>,
     /// Shared live approval policy (see `AppState::approvals`).
-    approvals: Arc<StdRwLock<ApprovalPolicy>>,
+    approvals: Arc<StdRwLock<LiveApprovals>>,
     /// Built-in plan mode for this session, read once per turn. ACP-bound
     /// frames never set it — their plan mode lives on the agent side.
     plan_mode: bool,
@@ -2682,10 +2825,14 @@ impl TauriOutput {
         match &self.live_events {
             Some(tx) => {
                 if let Err(send_error) = tx.send(event) {
-                    emit_agent_event_to_surfaces(&self.app, send_error.0);
+                    emit_agent_event_to_surfaces_in(
+                        &self.app,
+                        send_error.0,
+                        Some(&self.project_id),
+                    );
                 }
             }
-            None => emit_agent_event_to_surfaces(&self.app, event),
+            None => emit_agent_event_to_surfaces_in(&self.app, event, Some(&self.project_id)),
         }
     }
 
@@ -2726,7 +2873,7 @@ impl TauriOutput {
             .insert(self.frame_id.clone());
         self.device_hub
             .mark_needs_user(&self.frame_id, Some(&self.project_id));
-        emit_confirm_request(&self.app, &request);
+        emit_confirm_request(&self.app, &request, Some(&self.project_id));
 
         // There is deliberately no timeout: lack of approval must never be
         // converted into a denial that lets the same agent turn continue.
@@ -2775,18 +2922,23 @@ impl TauriOutput {
     }
 }
 
-fn emit_agent_event_to_surfaces(app: &AppHandle, event: AgentEvent) {
+fn emit_agent_event_to_surfaces_in(app: &AppHandle, event: AgentEvent, project_id: Option<&str>) {
     if !matches!(event, AgentEvent::ToolPresentation { .. }) {
         channels::publish_agent_event(&event);
     }
-    let _ = app.emit("agent", event);
+    let frame_id = event.frame_id().to_string();
+    emit_to_session_surfaces(app, &frame_id, project_id, "agent", &event);
 }
 
 fn emit_agent_event(app: &AppHandle, event: AgentEvent) {
+    emit_agent_event_in(app, event, None);
+}
+
+pub(crate) fn emit_agent_event_in(app: &AppHandle, event: AgentEvent, project_id: Option<&str>) {
     app.state::<AppState>()
         .device_hub
-        .apply_agent_event(&event, None);
-    emit_agent_event_to_surfaces(app, event);
+        .apply_agent_event(&event, project_id);
+    emit_agent_event_to_surfaces_in(app, event, project_id);
 }
 
 fn should_persist_ui_event(event: &AgentEvent) -> bool {
@@ -2969,7 +3121,7 @@ impl Output for TauriOutput {
     fn approval_mode(&self, tool: &str) -> wisp_tools::Approval {
         self.approvals
             .read()
-            .map(|p| p.mode_for(tool))
+            .map(|live| live.for_project(&self.project_id).mode_for(tool))
             .unwrap_or(wisp_tools::Approval::Allow)
     }
     fn restrict_read_paths_to_project(&self) -> bool {
@@ -3035,7 +3187,12 @@ impl Output for TauriOutput {
         if self.force_ask_mutations {
             return false;
         }
-        self.full_permission() || self.approvals.read().map(|p| p.full()).unwrap_or(false)
+        self.full_permission()
+            || self
+                .approvals
+                .read()
+                .map(|live| live.for_project(&self.project_id).full())
+                .unwrap_or(false)
     }
     fn force_ask_mutations(&self) -> bool {
         self.force_ask_mutations
@@ -3078,6 +3235,9 @@ impl Output for TauriOutput {
     }
     fn frame_id(&self) -> Option<&str> {
         Some(self.frame_id.as_str())
+    }
+    fn project_id(&self) -> Option<&str> {
+        Some(self.project_id.as_str())
     }
     fn preflight_local_execution(&self, source: &str) -> Result<(), String> {
         match &self.exploration_isolation {
@@ -3175,6 +3335,7 @@ struct MacMenuLabels {
     help: &'static str,
     theme: &'static str,
     new_session: &'static str,
+    new_window: &'static str,
     projects: &'static str,
     files: &'static str,
     export_current_project: &'static str,
@@ -3218,6 +3379,7 @@ fn mac_menu_labels(locale: AppMenuLocale) -> MacMenuLabels {
             help: "帮助",
             theme: "主题",
             new_session: "新建会话",
+            new_window: "新建窗口",
             projects: "项目",
             files: "文件",
             export_current_project: "导出当前项目",
@@ -3257,6 +3419,7 @@ fn mac_menu_labels(locale: AppMenuLocale) -> MacMenuLabels {
             help: "Help",
             theme: "Theme",
             new_session: "New Session",
+            new_window: "New Window",
             projects: "Projects",
             files: "Files",
             export_current_project: "Export Current Project",
@@ -3303,6 +3466,7 @@ fn build_menu_item(
 fn mac_menu_action(id: &str) -> Option<&'static str> {
     match id {
         "action.new" => Some("new"),
+        "action.new-window" => Some("new-window"),
         "action.projects" => Some("projects"),
         "action.files" => Some("files"),
         "action.export-current-project" => Some("export-current-project"),
@@ -3381,6 +3545,10 @@ fn install_macos_app_menu(app: &AppHandle, locale_tag: &str) -> Result<(), Strin
     let file_menu = SubmenuBuilder::new(app, labels.file)
         .item(
             &build_menu_item(app, "action.new", labels.new_session, Some("CmdOrCtrl+N"))
+                .map_err(|error| error.to_string())?,
+        )
+        .item(
+            &build_menu_item(app, "action.new-window", labels.new_window, None)
                 .map_err(|error| error.to_string())?,
         )
         .item(
@@ -3975,6 +4143,29 @@ async fn load_json_setting<T: serde::de::DeserializeOwned + Default>(
         .unwrap_or_default()
 }
 
+async fn load_json_setting_for_project<T: serde::de::DeserializeOwned + Default>(
+    store: &Store,
+    key: &str,
+    project_id: Option<&str>,
+) -> T {
+    if let Some(id) = project_id.filter(|id| !id.is_empty()) {
+        let specific = format!("{key}:{id}");
+        if let Some(raw) = store.get_setting(&specific).await.ok().flatten() {
+            if let Ok(value) = serde_json::from_str(&raw) {
+                return value;
+            }
+        }
+    }
+    load_json_setting(store, key).await
+}
+
+fn project_setting_key(key: &str, project_id: Option<&str>) -> String {
+    match project_id.filter(|id| !id.is_empty()) {
+        Some(id) => format!("{key}:{id}"),
+        None => key.to_string(),
+    }
+}
+
 async fn save_json_setting<T: Serialize>(store: &Store, key: &str, val: &T) -> Result<(), String> {
     let json = serde_json::to_string(val).map_err(|e| format!("{e}"))?;
     store
@@ -3993,13 +4184,18 @@ async fn load_disabled_connectors(store: &Store) -> HashSet<String> {
 }
 
 /// Persisted per-tool approvals (tool name -> "ask"/"deny"; "allow" omitted).
-async fn load_tool_approvals(store: &Store) -> HashMap<String, String> {
-    load_json_setting(store, "tool_approvals").await
+async fn load_tool_approvals_for(
+    store: &Store,
+    project_id: Option<&str>,
+) -> HashMap<String, String> {
+    load_json_setting_for_project(store, "tool_approvals", project_id).await
 }
 
-/// Persisted global approval scope ("full" | "auto" | "ask"; default "ask").
-async fn load_approval_scope(store: &Store) -> Scope {
-    Scope::parse(&load_json_setting::<String>(store, "approval_scope").await)
+/// Persisted approval scope ("full" | "auto" | "ask"; default "ask").
+async fn load_approval_scope_for(store: &Store, project_id: Option<&str>) -> Scope {
+    Scope::parse(
+        &load_json_setting_for_project::<String>(store, "approval_scope", project_id).await,
+    )
 }
 
 async fn load_approval_grants(store: &Store) -> ApprovalGrants {
@@ -4011,8 +4207,8 @@ async fn save_approval_grants(store: &Store, grants: &ApprovalGrants) -> Result<
 }
 
 /// Connector keys with "Skip approvals" on.
-async fn load_skip_connectors(store: &Store) -> HashSet<String> {
-    load_json_setting::<Vec<String>>(store, "skip_approval_connectors")
+async fn load_skip_connectors_for(store: &Store, project_id: Option<&str>) -> HashSet<String> {
+    load_json_setting_for_project::<Vec<String>>(store, "skip_approval_connectors", project_id)
         .await
         .into_iter()
         .collect()
@@ -4031,25 +4227,65 @@ fn build_tool_connector_map() -> HashMap<String, String> {
 
 /// Snapshot the persisted approval state into a fresh `ApprovalPolicy`.
 async fn build_approval_policy(store: &Store) -> ApprovalPolicy {
+    build_approval_policy_for(store, None).await
+}
+
+async fn build_approval_policy_for(store: &Store, project_id: Option<&str>) -> ApprovalPolicy {
     ApprovalPolicy {
-        scope: load_approval_scope(store).await,
-        tools: load_tool_approvals(store)
+        scope: load_approval_scope_for(store, project_id).await,
+        tools: load_tool_approvals_for(store, project_id)
             .await
             .into_iter()
             .map(|(k, v)| (k, ApprovalMode::parse(&v)))
             .collect(),
-        skip: load_skip_connectors(store).await,
+        skip: load_skip_connectors_for(store, project_id).await,
         tool_connector: build_tool_connector_map(),
     }
 }
 
+async fn project_has_approval_overlay(store: &Store, project_id: &str) -> bool {
+    for key in [
+        "approval_scope",
+        "tool_approvals",
+        "skip_approval_connectors",
+    ] {
+        if store
+            .get_setting(&format!("{key}:{project_id}"))
+            .await
+            .ok()
+            .flatten()
+            .is_some()
+        {
+            return true;
+        }
+    }
+    false
+}
+
 /// Reload the live approval policy after a settings change so running sessions
 /// see it on their next tool call (approval is enforced live, not per session).
-async fn refresh_approval_policy(state: &AppState) {
-    let policy = build_approval_policy(&state.store).await;
-    if let Ok(mut guard) = state.approvals.write() {
-        *guard = policy;
+async fn refresh_approval_policy_for(state: &AppState, project_id: Option<&str>) {
+    let policy = build_approval_policy_for(&state.store, project_id).await;
+    if let Ok(mut live) = state.approvals.write() {
+        match project_id {
+            Some(id) => {
+                live.by_project.insert(id.to_string(), policy);
+            }
+            None => live.default = policy,
+        }
     }
+}
+
+async fn ensure_project_live_approvals(state: &AppState, project_id: &str) {
+    let already = state
+        .approvals
+        .read()
+        .map(|live| live.by_project.contains_key(project_id))
+        .unwrap_or(false);
+    if already || !project_has_approval_overlay(&state.store, project_id).await {
+        return;
+    }
+    refresh_approval_policy_for(state, Some(project_id)).await;
 }
 
 async fn load_memory_enabled(store: &Store) -> bool {
@@ -6617,10 +6853,7 @@ pub fn run() {
                     .create_project("default", "Workspace", &legacy_ws)
                     .await
                     .ok();
-                let active_id = match store.get_setting("active_project_id").await.ok().flatten() {
-                    Some(id) if store.get_project(&id).await.ok().flatten().is_some() => id,
-                    _ => "default".to_string(),
-                };
+                let active_id = project_commands::startup_main_project_id(&store).await;
                 let (_, dir) = store
                     .get_project(&active_id)
                     .await
@@ -6655,9 +6888,12 @@ pub fn run() {
             let bootstrap = StdMutex::new(startup.record("tool_probe", || {
                 app_commands::initial_bootstrap(&root, skills.all().len())
             }));
-            let approvals = Arc::new(StdRwLock::new(startup.record("approvals", || {
-                tauri::async_runtime::block_on(build_approval_policy(&store))
-            })));
+            let approvals = Arc::new(StdRwLock::new(LiveApprovals {
+                default: startup.record("approvals", || {
+                    tauri::async_runtime::block_on(build_approval_policy(&store))
+                }),
+                by_project: HashMap::new(),
+            }));
             let approval_grants = Arc::new(StdMutex::new(startup.record("approval_grants", || {
                 tauri::async_runtime::block_on(load_approval_grants(&store))
             })));
@@ -6951,6 +7187,7 @@ pub fn run() {
             project_commands::create_project,
             project_commands::open_project,
             project_commands::open_project_window,
+            project_commands::open_new_window,
             project_commands::delete_project,
             project_commands::get_project_settings,
             project_commands::update_project,

--- a/src-tauri/src/lib_tests.rs
+++ b/src-tauri/src/lib_tests.rs
@@ -621,6 +621,10 @@ fn mac_menu_action_maps_update_and_settings_ids() {
     );
     assert_eq!(super::mac_menu_action("action.star-us"), Some("star-us"));
     assert_eq!(super::mac_menu_action("action.settings"), Some("settings"));
+    assert_eq!(
+        super::mac_menu_action("action.new-window"),
+        Some("new-window")
+    );
     assert_eq!(super::mac_menu_action("action.unknown"), None);
 }
 
@@ -1996,6 +2000,7 @@ fn capability_skill_counts_use_enabled_bundled_vs_project_added_inventory() {
 fn macos_close_hides_only_main_window_when_not_quitting() {
     assert!(should_hide_app_on_macos_close("main", false));
     assert!(!should_hide_app_on_macos_close("proj-default", false));
+    assert!(!should_hide_app_on_macos_close("home-1", false));
     assert!(!should_hide_app_on_macos_close("main", true));
 }
 
@@ -2003,6 +2008,7 @@ fn macos_close_hides_only_main_window_when_not_quitting() {
 fn windows_close_to_tray_applies_only_to_the_main_window() {
     assert!(should_hide_workspace_on_close("main"));
     assert!(!should_hide_workspace_on_close("proj-default"));
+    assert!(!should_hide_workspace_on_close("home-1"));
     assert!(!should_hide_workspace_on_close("pet"));
 }
 
@@ -2027,6 +2033,34 @@ fn project_window_url_carries_the_target_session() {
         super::project_commands::project_window_url("abc", Some("s1")),
         "index.html?project=abc&session=s1"
     );
+    assert_eq!(super::project_commands::blank_window_url(), "index.html");
+}
+
+#[test]
+fn default_capability_grants_ipc_to_blank_windows() {
+    let spec: serde_json::Value =
+        serde_json::from_str(include_str!("../capabilities/default.json")).unwrap();
+    let windows: Vec<&str> = spec["windows"]
+        .as_array()
+        .expect("default capability lists windows")
+        .iter()
+        .filter_map(|value| value.as_str())
+        .collect();
+    assert!(
+        windows.contains(&"home-*"),
+        "File → New Window labels home-* must be allowed to close themselves: {windows:?}"
+    );
+    assert!(windows.contains(&"main"));
+    assert!(windows.contains(&"proj-*"));
+    let permissions: Vec<&str> = spec["permissions"]
+        .as_array()
+        .expect("default capability lists permissions")
+        .iter()
+        .filter_map(|value| value.as_str())
+        .collect();
+    assert!(permissions.contains(&"core:window:allow-close"));
+    assert!(permissions.contains(&"core:window:allow-minimize"));
+    assert!(permissions.contains(&"core:window:allow-toggle-maximize"));
 }
 
 #[test]
@@ -2197,6 +2231,70 @@ fn foreign_project_notification_fallback_never_arms_focus_navigation() {
         )
         .map(|selection| (selection.label, selection.arm_focus_navigation)),
         Some(("main".to_string(), false)),
+    );
+}
+
+#[test]
+fn session_surfaces_include_every_window_of_the_owning_project() {
+    let active_projects = HashMap::from([
+        ("main".to_string(), "workspace".to_string()),
+        ("proj-workspace".to_string(), "workspace".to_string()),
+        ("proj-other".to_string(), "other".to_string()),
+        ("pet".to_string(), "workspace".to_string()),
+    ]);
+    let active_frames = HashMap::from([
+        ("main".to_string(), "session-a".to_string()),
+        ("proj-workspace".to_string(), "session-b".to_string()),
+        ("proj-other".to_string(), "session-c".to_string()),
+    ]);
+
+    assert_eq!(
+        super::session_surface_window_labels(
+            Some("main"),
+            "session-a",
+            Some("workspace"),
+            &active_projects,
+            &active_frames,
+        ),
+        vec!["main".to_string(), "proj-workspace".to_string()],
+    );
+}
+
+#[test]
+fn session_surfaces_never_fall_back_onto_a_foreign_project() {
+    let active_projects = HashMap::from([("main".to_string(), "project-b".to_string())]);
+    let active_frames = HashMap::from([("main".to_string(), "session-b".to_string())]);
+
+    assert!(super::session_surface_window_labels(
+        Some("main"),
+        "session-a",
+        Some("project-a"),
+        &active_projects,
+        &active_frames,
+    )
+    .is_empty());
+}
+
+#[test]
+fn session_surfaces_without_project_id_only_hit_windows_viewing_the_session() {
+    let active_projects = HashMap::from([
+        ("main".to_string(), "workspace".to_string()),
+        ("proj-workspace".to_string(), "workspace".to_string()),
+    ]);
+    let active_frames = HashMap::from([
+        ("main".to_string(), "session-a".to_string()),
+        ("proj-workspace".to_string(), "session-b".to_string()),
+    ]);
+
+    assert_eq!(
+        super::session_surface_window_labels(
+            Some("proj-workspace"),
+            "session-b",
+            None,
+            &active_projects,
+            &active_frames,
+        ),
+        vec!["proj-workspace".to_string()],
     );
 }
 
@@ -2460,4 +2558,77 @@ fn ui_watchdog_unfocused_silence_is_not_stale() {
     let mut none = None;
     ui_watchdog_note_unfocused(&mut none);
     assert!(none.is_none());
+}
+
+#[test]
+fn live_approvals_fall_back_to_the_process_default() {
+    let mut live = super::LiveApprovals::default();
+    live.default.scope = super::Scope::Ask;
+    let mut overlay = super::ApprovalPolicy::default();
+    overlay.scope = super::Scope::Full;
+    live.by_project.insert("proj-a".into(), overlay);
+    assert!(live.for_project("proj-a").full());
+    assert!(!live.for_project("proj-b").full());
+}
+
+#[tokio::test]
+async fn project_approval_overlay_does_not_change_the_global_policy() {
+    let path = std::env::temp_dir().join(format!(
+        "wisp_approval_overlay_{}.sqlite",
+        uuid::Uuid::new_v4()
+    ));
+    let store = wisp_store::Store::open(&path).await.unwrap();
+    super::save_json_setting(&store, "approval_scope", &"ask")
+        .await
+        .unwrap();
+    super::save_json_setting(
+        &store,
+        "tool_approvals",
+        &HashMap::<String, String>::from([("shell".into(), "ask".into())]),
+    )
+    .await
+    .unwrap();
+    super::save_json_setting(&store, "approval_scope:proj-a", &"full")
+        .await
+        .unwrap();
+    super::save_json_setting(
+        &store,
+        "tool_approvals:proj-a",
+        &HashMap::<String, String>::from([("shell".into(), "allow".into())]),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        super::load_approval_scope_for(&store, None).await.as_str(),
+        "ask"
+    );
+    assert_eq!(
+        super::load_approval_scope_for(&store, Some("proj-a"))
+            .await
+            .as_str(),
+        "full"
+    );
+    assert_eq!(
+        super::load_approval_scope_for(&store, Some("proj-b"))
+            .await
+            .as_str(),
+        "ask"
+    );
+    assert_eq!(
+        super::load_tool_approvals_for(&store, None)
+            .await
+            .get("shell")
+            .map(String::as_str),
+        Some("ask")
+    );
+    assert_eq!(
+        super::load_tool_approvals_for(&store, Some("proj-a"))
+            .await
+            .get("shell")
+            .map(String::as_str),
+        Some("allow")
+    );
+    drop(store);
+    let _ = std::fs::remove_file(path);
 }

--- a/src-tauri/src/memory_commands.rs
+++ b/src-tauri/src/memory_commands.rs
@@ -258,7 +258,7 @@ async fn resolve_memory_target(
     window_label: &str,
     project_id: Option<String>,
 ) -> Result<(String, String, MemoryManager), String> {
-    let ap = state.active(window_label);
+    let ap = state.require_active(window_label)?;
     let requested = project_id
         .map(|id| id.trim().to_string())
         .filter(|id| !id.is_empty());

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -222,6 +222,18 @@ fn sibling_key(profiles: &[ModelProfile], api_url: &str, exclude_id: &str) -> St
         .unwrap_or_default()
 }
 
+/// This profile's stored key, or a same-endpoint sibling's key when this
+/// profile was never given its own secret (common for a vision model added
+/// beside a chat model on the same API access).
+fn resolved_key(profiles: &[ModelProfile], id: &str, api_url: &str) -> String {
+    let own = key_for(id);
+    if !own.is_empty() {
+        own
+    } else {
+        sibling_key(profiles, api_url, id)
+    }
+}
+
 /// Write a pasted key to this profile.
 ///
 /// If this profile already had a key, also rotate every same-endpoint sibling
@@ -810,7 +822,12 @@ pub async fn active_config(store: &wisp_store::Store) -> (String, String, String
         .cloned()
         .unwrap_or_else(|| profiles[0].clone());
     let api_url = effective_api_url(&p);
-    (p.provider, api_url, p.model, key_for(&p.id))
+    (
+        p.provider,
+        api_url,
+        p.model,
+        resolved_key(&profiles, &p.id, &p.api_url),
+    )
 }
 
 pub(crate) const IMAGE_GENERATION_UNSUPPORTED: &str =
@@ -1003,7 +1020,7 @@ pub async fn vision_config(
         p.provider,
         api_url,
         p.model,
-        key_for(&p.id),
+        resolved_key(&profiles, &p.id, &p.api_url),
         p.max_tokens,
         p.reasoning_effort,
         p.service_tier,
@@ -1022,7 +1039,7 @@ pub async fn image_generation_config(
     Some((
         effective_api_url(p),
         p.model.clone(),
-        key_for(&p.id),
+        resolved_key(&profiles, &p.id, &p.api_url),
         ImageGenerationOptions {
             size: p.image_size.clone(),
             quality: p.image_quality.clone(),
@@ -1061,7 +1078,7 @@ pub async fn video_generation_config(
     Some((
         effective_api_url(p),
         p.model.clone(),
-        key_for(&p.id),
+        resolved_key(&profiles, &p.id, &p.api_url),
         VideoGenerationOptions {
             duration_secs: p.video_duration_secs.unwrap_or(defaults.duration_secs),
             aspect_ratio: p
@@ -1216,7 +1233,7 @@ pub async fn profile_llm(
         p.provider.clone(),
         effective_api_url(p),
         p.model.clone(),
-        key_for(&p.id),
+        resolved_key(&profiles, &p.id, &p.api_url),
         p.max_tokens,
         p.reasoning_effort.clone(),
         p.service_tier.clone(),
@@ -1227,14 +1244,18 @@ pub async fn profile_llm(
 /// exist. The returned string may still be empty when the profile has no key.
 pub async fn profile_key(store: &wisp_store::Store, id: &str) -> Option<String> {
     let profiles = ensure(store).await;
-    profiles.iter().any(|p| p.id == id).then(|| key_for(id))
+    let profile = profiles.iter().find(|p| p.id == id)?;
+    Some(resolved_key(&profiles, id, &profile.api_url))
 }
 
 /// Whether the active profile has a key stored (for `get_settings`).
 pub async fn active_has_key(store: &wisp_store::Store) -> bool {
     let profiles = ensure(store).await;
     let id = active_id(store, &profiles).await;
-    !key_for(&id).is_empty()
+    profiles
+        .iter()
+        .find(|p| p.id == id)
+        .is_some_and(|p| !resolved_key(&profiles, &p.id, &p.api_url).is_empty())
 }
 
 pub async fn active_supports_vision(store: &wisp_store::Store) -> bool {
@@ -1261,9 +1282,10 @@ async fn decorated(store: &wisp_store::Store) -> Vec<ModelProfile> {
     let image_generation = image_generation_id(store, &profiles).await;
     let video_generation = video_generation_id(store, &profiles).await;
     profiles
-        .into_iter()
+        .iter()
+        .cloned()
         .map(|mut p| {
-            p.has_api_key = !key_for(&p.id).is_empty();
+            p.has_api_key = !resolved_key(&profiles, &p.id, &p.api_url).is_empty();
             p.active = p.id == id;
             p.use_for_vision = vision.as_deref() == Some(p.id.as_str());
             p.use_for_image_generation = image_generation.as_deref() == Some(p.id.as_str());
@@ -2448,6 +2470,27 @@ mod tests {
         assert_eq!(key_for(&new_id), "sk-shared");
         let _ = secret_del(&secret_name(&existing_id));
         let _ = secret_del(&secret_name(&new_id));
+    }
+
+    #[test]
+    fn resolved_key_uses_a_same_endpoint_sibling_when_this_profile_has_none() {
+        let prefix = uuid::Uuid::new_v4();
+        let chat_id = format!("{prefix}-chat");
+        let vision_id = format!("{prefix}-vision");
+        let _ = secret_del(&secret_name(&chat_id));
+        let _ = secret_del(&secret_name(&vision_id));
+        secret_set(&secret_name(&chat_id), "sk-shared").unwrap();
+        let mut chat = test_profile(&chat_id, "flash", "deepseek-v4-flash");
+        chat.api_url = "https://api.deepseek.com".into();
+        let mut vision = test_profile(&vision_id, "vl", "qwen-vl");
+        vision.api_url = "https://api.deepseek.com/v1".into();
+        assert!(key_for(&vision_id).is_empty());
+        assert_eq!(
+            resolved_key(&[chat, vision.clone()], &vision_id, &vision.api_url),
+            "sk-shared"
+        );
+        let _ = secret_del(&secret_name(&chat_id));
+        let _ = secret_del(&secret_name(&vision_id));
     }
 
     #[test]

--- a/src-tauri/src/plugins.rs
+++ b/src-tauri/src/plugins.rs
@@ -6,7 +6,7 @@
 //! never executes package code; MCP entrypoints start only after a project-level
 //! enable action.
 
-use crate::{clear_idle_agents, AppState};
+use crate::{clear_idle_agents, clear_idle_agents_for_project, AppState};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, HashSet};
@@ -931,7 +931,7 @@ pub(super) async fn list_plugins(
     state: State<'_, AppState>,
     window: tauri::WebviewWindow,
 ) -> Result<Vec<PluginView>, String> {
-    let project = state.active(window.label());
+    let project = state.require_active(window.label())?;
     let bindings = state
         .store
         .list_project_plugins(&project.id)
@@ -1191,7 +1191,7 @@ pub(super) async fn set_plugin_enabled(
         .entry(project.id.clone())
         .or_default()
         .remove(&plugin_id);
-    clear_idle_agents(&state).await;
+    clear_idle_agents_for_project(&state, &project.id).await;
     Ok(())
 }
 

--- a/src-tauri/src/project_commands.rs
+++ b/src-tauri/src/project_commands.rs
@@ -1,6 +1,7 @@
 //! Project Commands split out of lib.rs; shared state/helpers stay in the crate root.
 
 use super::*;
+use std::collections::HashMap;
 use tauri::Manager;
 
 pub(crate) fn same_workspace_path(left: &Path, right: &Path) -> bool {
@@ -226,11 +227,57 @@ pub(super) async fn set_active_project(
     let root = ap.root.clone();
     state.set_active(label, ap);
     state.set_active_frame(label, None);
-    {
+    remember_window_project(&state.store, label, id).await;
+    if label == "main" {
         state.bootstrap.lock().unwrap().workspace = root.to_string_lossy().into_owned();
+        let _ = state.store.set_setting("active_project_id", id).await;
     }
-    let _ = state.store.set_setting("active_project_id", id).await;
     Ok((name, ws))
+}
+
+const WINDOW_ACTIVE_PROJECTS_KEY: &str = "window_active_projects";
+
+async fn load_window_active_projects(store: &Store) -> HashMap<String, String> {
+    store
+        .get_setting(WINDOW_ACTIVE_PROJECTS_KEY)
+        .await
+        .ok()
+        .flatten()
+        .and_then(|raw| serde_json::from_str(&raw).ok())
+        .unwrap_or_default()
+}
+
+/// Persist this window's last project. File → New Window views (`home-*`) are
+/// not restored on launch, so they must not overwrite another window's mapping.
+/// Only the `main` window still writes the legacy `active_project_id` fallback.
+async fn remember_window_project(store: &Store, label: &str, id: &str) {
+    if crate::app_state::is_blank_window_label(label) {
+        return;
+    }
+    let mut windows = load_window_active_projects(store).await;
+    windows.insert(label.to_string(), id.to_string());
+    let _ = store
+        .set_setting(
+            WINDOW_ACTIVE_PROJECTS_KEY,
+            &serde_json::to_string(&windows).unwrap_or_default(),
+        )
+        .await;
+}
+
+/// Project the `main` window should restore. Prefers `window_active_projects`
+/// so an extra window opening a different workspace cannot steal main's last
+/// project; falls back to the legacy global `active_project_id`.
+pub(crate) async fn startup_main_project_id(store: &Store) -> String {
+    let windows = load_window_active_projects(store).await;
+    if let Some(id) = windows.get("main") {
+        if store.get_project(id).await.ok().flatten().is_some() {
+            return id.clone();
+        }
+    }
+    match store.get_setting("active_project_id").await.ok().flatten() {
+        Some(id) if store.get_project(&id).await.ok().flatten().is_some() => id,
+        _ => "default".to_string(),
+    }
 }
 
 /// Brand string used when no project is open (home, or a window that has not
@@ -295,6 +342,24 @@ pub(super) async fn update_persisted_windows(store: &Store, id: &str, present: b
 
 pub(super) fn project_window_label(id: &str) -> String {
     format!("proj-{id}") // project ids are UUIDs or "default" — label-safe
+}
+
+/// File → New Window: a fresh GUI that lands on the Projects home screen and
+/// is not bound to any workspace until the user opens one in that window.
+/// Labels must stay on the `home-*` glob in `capabilities/default.json`, or
+/// the custom Windows title-bar close/minimize/maximize calls are denied.
+pub(super) fn next_blank_window_label() -> String {
+    format!("home-{}", Uuid::new_v4())
+}
+
+pub(super) fn blank_window_url() -> &'static str {
+    "index.html"
+}
+
+/// Offset a new File → New Window from its anchor so the extra GUI is obvious
+/// instead of covering the caller exactly.
+pub(super) fn cascaded_window_position(anchor_pos: (i32, i32), offset: i32) -> (i32, i32) {
+    (anchor_pos.0 + offset, anchor_pos.1 + offset)
 }
 
 /// URL for a dedicated project window. Ids are UUIDs or "default" — no
@@ -416,6 +481,61 @@ pub(super) async fn open_project_window(
         Some(window.label()),
     )
     .await
+}
+
+/// Open a blank GUI on the Projects home screen. The window has its own label
+/// and no `ActiveProject` until the user opens a workspace in it, so it cannot
+/// read or mutate another window's files, sessions, or runtimes.
+pub(super) async fn spawn_blank_window(
+    app: &AppHandle,
+    anchor_label: Option<&str>,
+) -> Result<String, String> {
+    let label = next_blank_window_label();
+    let url = tauri::WebviewUrl::App(blank_window_url().into());
+    let mut builder = tauri::WebviewWindowBuilder::new(app, &label, url)
+        .title(app_window_title(None))
+        .inner_size(1100.0, 760.0)
+        .resizable(true)
+        .on_navigation(crate::guard_webview_navigation);
+    let anchor = anchor_label
+        .and_then(|label| app.get_webview_window(label))
+        .or_else(|| app.get_webview_window("main"));
+    if let Some(anchor) = anchor {
+        if let Ok(pos) = anchor.outer_position() {
+            let scale = anchor.scale_factor().unwrap_or(1.0);
+            let offset = (36.0 * scale) as i32;
+            let (x, y) = cascaded_window_position((pos.x, pos.y), offset);
+            builder = builder.position(x as f64 / scale, y as f64 / scale);
+        }
+    }
+    #[cfg(target_os = "windows")]
+    let builder = builder.decorations(false).shadow(true);
+    let win = builder.build().map_err(|e| e.to_string())?;
+    crate::windows_snap::install_for_window(&win);
+    #[cfg(target_os = "macos")]
+    wire_macos_menu_events(&win);
+    let _ = win.eval(&format!(
+        "window.__WISP_DEV__ = {};",
+        cfg!(debug_assertions)
+    ));
+    let evt_app = app.clone();
+    let evt_label = label.clone();
+    win.on_window_event(move |ev| {
+        if matches!(ev, tauri::WindowEvent::Destroyed) {
+            let st = evt_app.state::<AppState>();
+            st.active.write().unwrap().remove(&evt_label);
+            st.active_frame.write().unwrap().remove(&evt_label);
+        }
+    });
+    Ok(label)
+}
+
+#[tauri::command]
+pub(super) async fn open_new_window(
+    app: AppHandle,
+    window: tauri::WebviewWindow,
+) -> Result<String, String> {
+    spawn_blank_window(&app, Some(window.label())).await
 }
 
 #[tauri::command]
@@ -725,14 +845,17 @@ pub(super) async fn get_project_info(
     state: State<'_, AppState>,
     window: tauri::WebviewWindow,
 ) -> Result<ProjectInfo, String> {
+    let _ = state.require_active(window.label())?;
     Ok(build_project_info(&state, window.label()).await)
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        app_window_title, read_project_agent_context, same_workspace_path,
-        write_project_agent_context, APP_WINDOW_TITLE,
+        app_window_title, blank_window_url, cascaded_window_position, load_window_active_projects,
+        next_blank_window_label, read_project_agent_context, remember_window_project,
+        same_workspace_path, startup_main_project_id, write_project_agent_context,
+        APP_WINDOW_TITLE,
     };
 
     #[test]
@@ -748,6 +871,21 @@ mod tests {
             app_window_title(Some("  fkbp1a  ")),
             "wisp science \u{2014} fkbp1a"
         );
+    }
+
+    #[test]
+    fn blank_window_url_does_not_bind_a_project() {
+        assert_eq!(blank_window_url(), "index.html");
+        assert!(!blank_window_url().contains("project="));
+        let label = next_blank_window_label();
+        assert!(crate::app_state::is_blank_window_label(&label));
+        assert_ne!(label, next_blank_window_label());
+    }
+
+    #[test]
+    fn cascaded_window_position_offsets_from_the_anchor() {
+        assert_eq!(cascaded_window_position((100, 50), 36), (136, 86));
+        assert_eq!(cascaded_window_position((-1600, -50), 36), (-1564, -14));
     }
 
     #[test]
@@ -780,5 +918,58 @@ mod tests {
         assert!(!root.join(".wisp").join("WISP.md").exists());
 
         let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn extra_windows_do_not_overwrite_main_last_project() {
+        let path = std::env::temp_dir().join(format!(
+            "wisp_window_projects_{}.sqlite",
+            uuid::Uuid::new_v4()
+        ));
+        let store = wisp_store::Store::open(&path).await.unwrap();
+        store
+            .create_project("main-project", "Main", "/ws/main")
+            .await
+            .unwrap();
+        store
+            .create_project("other-project", "Other", "/ws/other")
+            .await
+            .unwrap();
+        let _ = store
+            .set_setting("active_project_id", "main-project")
+            .await
+            .unwrap();
+
+        remember_window_project(&store, "main", "main-project").await;
+        remember_window_project(&store, "home-abc", "other-project").await;
+        remember_window_project(&store, "proj-other-project", "other-project").await;
+
+        let windows = load_window_active_projects(&store).await;
+        assert_eq!(
+            windows.get("main").map(String::as_str),
+            Some("main-project")
+        );
+        assert_eq!(
+            windows.get("proj-other-project").map(String::as_str),
+            Some("other-project")
+        );
+        assert!(
+            !windows.contains_key("home-abc"),
+            "blank File → New Window labels must not persist: {windows:?}"
+        );
+        assert_eq!(startup_main_project_id(&store).await, "main-project");
+
+        let _ = store
+            .set_setting("active_project_id", "other-project")
+            .await
+            .unwrap();
+        assert_eq!(
+            startup_main_project_id(&store).await,
+            "main-project",
+            "window_active_projects[main] must beat the legacy global id"
+        );
+
+        drop(store);
+        let _ = std::fs::remove_file(path);
     }
 }

--- a/src-tauri/src/session_commands.rs
+++ b/src-tauri/src/session_commands.rs
@@ -13,7 +13,7 @@ pub(super) async fn new_session(
     // running. Persisted history still ignores empty untitled frames; the UI
     // keeps the currently active draft visible until its first user turn is
     // stored, and an explicit rename makes the draft listable right away (#888).
-    let active = state.active(window.label());
+    let active = state.require_active(window.label())?;
     let ap = project_commands::load_active_project(&state, &active.id)
         .await?
         .0;

--- a/src-tauri/src/skill_commands.rs
+++ b/src-tauri/src/skill_commands.rs
@@ -1,15 +1,19 @@
 use super::{
-    clear_idle_agents, effective_enabled_skill_names, load_enabled_skill_names, load_skill_index,
-    load_skill_tags, normalize_tags, project_skill_catalog, save_enabled_skill_names,
-    save_skill_tags, skill_infos, AppState, SkillInfo,
+    clear_idle_agents, clear_idle_agents_for_project, effective_enabled_skill_names,
+    load_enabled_skill_names, load_skill_index, load_skill_tags, normalize_tags,
+    project_skill_catalog, save_enabled_skill_names, save_skill_tags, skill_infos, AppState,
+    SkillInfo,
 };
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tauri::{AppHandle, State};
 
-async fn list_skill_infos_for_project(state: &AppState, label: &str) -> Vec<SkillInfo> {
-    let ap = state.active(label);
+async fn list_skill_infos_for_project(
+    state: &AppState,
+    label: &str,
+) -> Result<Vec<SkillInfo>, String> {
+    let ap = state.require_active(label)?;
     let tags = load_skill_tags(&state.store).await;
     let (all, enabled) = project_skill_catalog(&state.store, &ap).await;
     let plugin_roots = crate::plugins::enabled_plugin_manifests(&state.store, &ap.id)
@@ -36,7 +40,7 @@ async fn list_skill_infos_for_project(state: &AppState, label: &str) -> Vec<Skil
             info.managed_by = Some(display_name.clone());
         }
     }
-    infos
+    Ok(infos)
 }
 
 #[tauri::command]
@@ -44,7 +48,7 @@ pub(super) async fn list_skills(
     state: State<'_, AppState>,
     window: tauri::WebviewWindow,
 ) -> Result<Vec<SkillInfo>, String> {
-    Ok(list_skill_infos_for_project(&state, window.label()).await)
+    list_skill_infos_for_project(&state, window.label()).await
 }
 
 #[tauri::command]
@@ -53,7 +57,7 @@ pub(super) async fn reload_skills(
     window: tauri::WebviewWindow,
 ) -> Result<Vec<SkillInfo>, String> {
     let label = window.label();
-    let mut project = state.active(label);
+    let mut project = state.require_active(label)?;
     let previous_names = project
         .skills
         .all()
@@ -72,9 +76,10 @@ pub(super) async fn reload_skills(
         save_enabled_skill_names(&state.store, &project.id, names).await?;
     }
 
+    let project_id = project.id.clone();
     state.set_active(label, project);
-    clear_idle_agents(&state).await;
-    Ok(list_skill_infos_for_project(&state, label).await)
+    clear_idle_agents_for_project(&state, &project_id).await;
+    list_skill_infos_for_project(&state, label).await
 }
 
 fn enabled_names_after_reload<'a>(
@@ -139,7 +144,7 @@ async fn update_skills_enabled(
         }
     }
     save_enabled_skill_names(&state.store, &ap.id, &current).await?;
-    clear_idle_agents(state).await;
+    clear_idle_agents_for_project(state, &ap.id).await;
     Ok(())
 }
 

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -2549,6 +2549,8 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
             return null;
           case "open_project_window":
             return `proj-${arg("id")}`;
+          case "open_new_window":
+            return "home-mock";
           case "get_bootstrap_status":
             return {
               skills_loaded: 12,

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -11683,7 +11683,12 @@ test("reverse preview selections anchor the action popup above the first selecte
   const popup = page.locator(".selection-popup");
   await expect(popup).toBeVisible();
   const anchorY = await popup.evaluate((element) => Number.parseFloat((element as HTMLElement).style.top));
-  expect(anchorY).toBeCloseTo(selection.top, 0);
+  // `selection_popup_y` keeps ≥120px clearance above the anchor. A heading
+  // that sits just under that (CI fonts often land ~117px) is clamped to 120
+  // instead of the raw selection.top; using the bottom of a reverse drag
+  // would still miss this by >20px.
+  const expectedY = Math.max(120, Math.round(selection.top));
+  expect(anchorY).toBeCloseTo(expectedY, 0);
   await expect.poll(() => popup.evaluate((element) => element.getBoundingClientRect().bottom))
     .toBeLessThan(selection.top);
 });
@@ -12186,16 +12191,28 @@ test("Windows titlebar menus close on Escape", async ({ browser }) => {
   await context.close();
 });
 
-test("File New Window asks the host for a second GUI", async ({ page }) => {
+test("File New Window asks the host for a second GUI", async ({ browser }) => {
+  // File/Edit/View live on the Windows integrated titlebar; Linux/macOS CI
+  // user agents never render that bar, so this must pin a Windows UA.
+  const context = await browser.newContext({
+    userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/136 Safari/537.36",
+  });
+  const page = await context.newPage();
+  await page.addInitScript(tauriMock);
   await page.goto("/");
+
   await page.getByRole("button", { name: "File", exact: true }).click();
   await page.getByRole("menuitem", { name: "New Window" }).click();
   await expect.poll(() => lastInvokeArgs(page, "open_new_window")).not.toBeNull();
 
-  await enterApp(page);
+  // Stay on this document so the invoke log is not wiped by enterApp()'s goto.
+  await page.locator(".proj-card-main").first().click();
+  await expect(newSessionButton(page)).toBeVisible();
   await page.getByRole("button", { name: "File", exact: true }).click();
   await page.getByRole("menuitem", { name: "New Window" }).click();
   await expect.poll(() => invokeCount(page, "open_new_window")).toBeGreaterThan(1);
+
+  await context.close();
 });
 
 test("Windows titlebar close asks the host to close this window", async ({ browser }) => {

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -3310,6 +3310,7 @@ test("Ctrl+P command palette runs commands and switches themes", async ({ page }
   await expect(input).toHaveAttribute("inputmode", "search");
   await expect(input).toHaveAttribute("autocomplete", "off");
   await expect(palette).toContainText("New session");
+  await expect(palette).toContainText("New Window");
   await expect(palette.locator(".action-palette-row", { hasText: "New session" })
     .locator(".action-shortcut")).toHaveText("Ctrl+N");
   await expect(palette.locator(".action-palette-row", { hasText: "Search" })
@@ -11964,6 +11965,7 @@ test("Windows uses the integrated title bar without covering the project landing
   // Home menus only list actions that work without an open project.
   await page.getByRole("button", { name: "File", exact: true }).click();
   await expect(page.getByRole("menuitem", { name: "New project" })).toBeVisible();
+  await expect(page.getByRole("menuitem", { name: "New Window" })).toBeVisible();
   await expect(page.getByRole("menuitem", { name: "Import project" })).toBeVisible();
   await expect(page.getByRole("menuitem", { name: "Scratch chat" })).toBeVisible();
   await expect(page.getByRole("menuitem", { name: "Open settings" })).toBeVisible();
@@ -12000,6 +12002,7 @@ test("Windows uses the integrated title bar without covering the project landing
   await page.getByRole("button", { name: "File", exact: true }).click();
   // Inside a workspace the menus flip back to the session-scoped set.
   await expect(page.getByRole("menuitem", { name: "New session" })).toBeVisible();
+  await expect(page.getByRole("menuitem", { name: "New Window" })).toBeVisible();
   await expect(page.getByRole("menuitem", { name: "New project" })).toHaveCount(0);
   const exportCurrentProject = page.getByRole("menuitem", { name: "Export current project" });
   await expect(exportCurrentProject).toBeEnabled();
@@ -12179,6 +12182,34 @@ test("Windows titlebar menus close on Escape", async ({ browser }) => {
   await expect(page.getByRole("menu")).toBeVisible();
   await page.keyboard.press("Escape");
   await expect(page.getByRole("menu")).toHaveCount(0);
+
+  await context.close();
+});
+
+test("File New Window asks the host for a second GUI", async ({ page }) => {
+  await page.goto("/");
+  await page.getByRole("button", { name: "File", exact: true }).click();
+  await page.getByRole("menuitem", { name: "New Window" }).click();
+  await expect.poll(() => lastInvokeArgs(page, "open_new_window")).not.toBeNull();
+
+  await enterApp(page);
+  await page.getByRole("button", { name: "File", exact: true }).click();
+  await page.getByRole("menuitem", { name: "New Window" }).click();
+  await expect.poll(() => invokeCount(page, "open_new_window")).toBeGreaterThan(1);
+});
+
+test("Windows titlebar close asks the host to close this window", async ({ browser }) => {
+  const context = await browser.newContext({
+    userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/136 Safari/537.36",
+  });
+  const page = await context.newPage();
+  await page.addInitScript(tauriMock);
+  await page.goto("/");
+
+  await page.locator(".window-close").click();
+  await expect.poll(() => page.evaluate(() =>
+    ((window as any).__skillInvokeLog ?? []).some((call: any) => call.cmd === "close")
+  )).toBeTruthy();
 
   await context.close();
 });

--- a/ui/src/app_support/palettes.rs
+++ b/ui/src/app_support/palettes.rs
@@ -478,6 +478,15 @@ pub(crate) fn ActionPalette(
                 true,
             ),
             (
+                "new-window",
+                "expand",
+                "command.new_window",
+                general.clone(),
+                "",
+                "new window gui 新建 窗口",
+                false,
+            ),
+            (
                 "search",
                 "search",
                 "command.search",

--- a/ui/src/i18n.rs
+++ b/ui/src/i18n.rs
@@ -1981,6 +1981,9 @@ fn lookup(locale: Locale, key: &str) -> Option<&'static str> {
         (Locale::En, "err.api_key_required") => Some("API key is required."),
         (Locale::En, "err.max_tokens_ceiling") => Some("{model} accepts at most {max} output tokens — lower Max output tokens."),
         (Locale::En, "err.unknown") => Some("Unknown error"),
+        (Locale::En, "err.blank_window_no_project") => {
+            Some("Open a project in this window before running that action.")
+        }
         (Locale::En, "err.validation_timeout") => Some("Validation timed out after 30s"),
         (Locale::En, "err.vision_probe_failed") => Some(" This check sent a test image because \"supports images\" is on. If the model has no vision support, turn that off and validate again."),
         (Locale::En, "err.skill_no_md") => Some("The selected folder has no SKILL.md."),
@@ -2378,6 +2381,7 @@ fn lookup(locale: Locale, key: &str) -> Option<&'static str> {
         (Locale::En, "command.group.help") => Some("Help"),
         (Locale::En, "command.no_results") => Some("No matching commands"),
         (Locale::En, "command.new_session") => Some("New session"),
+        (Locale::En, "command.new_window") => Some("New Window"),
         (Locale::En, "command.scratch") => Some("Scratch chat"),
         (Locale::En, "scratch.title") => Some("Scratch chat"),
         (Locale::En, "scratch.open") => Some("Scratch chat"),
@@ -4533,6 +4537,9 @@ Do not leave generated files in the project root.",
         (Locale::Zh, "err.api_key_required") => Some("API 密钥不能为空。"),
         (Locale::Zh, "err.max_tokens_ceiling") => Some("{model} 的最大输出 tokens 上限为 {max}，请调低「最大输出 tokens」。"),
         (Locale::Zh, "err.unknown") => Some("未知错误"),
+        (Locale::Zh, "err.blank_window_no_project") => {
+            Some("请先在此窗口打开一个项目，再执行该操作。")
+        }
         (Locale::Zh, "err.validation_timeout") => Some("验证超时（30 秒）"),
         (Locale::Zh, "err.vision_probe_failed") => Some(" 因为勾选了「支持图片」，本次验证发送了一张测试图片。如果该模型不支持图片，请取消勾选后重新验证。"),
         (Locale::Zh, "err.file_not_found") => Some("文件未找到：{path}"),
@@ -4922,6 +4929,7 @@ Do not leave generated files in the project root.",
         (Locale::Zh, "command.group.help") => Some("帮助"),
         (Locale::Zh, "command.no_results") => Some("没有匹配的命令"),
         (Locale::Zh, "command.new_session") => Some("新建会话"),
+        (Locale::Zh, "command.new_window") => Some("新建窗口"),
         (Locale::Zh, "command.scratch") => Some("随手一聊"),
         (Locale::Zh, "scratch.title") => Some("随手一聊"),
         (Locale::Zh, "scratch.open") => Some("随手一聊"),
@@ -5438,6 +5446,9 @@ pub fn localize_backend(locale: Locale, msg: &str) -> String {
         }
         "This project is busy. Try again when the current project operation finishes." => {
             t(locale, "projects.transfer.export_locked")
+        }
+        "Open a project in this window before running that action." => {
+            t(locale, "err.blank_window_no_project")
         }
         m if m.starts_with("Project workspace is not a directory: ") => {
             if locale == Locale::Zh {

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -9568,6 +9568,11 @@ fn App() -> impl IntoView {
                 }
             }
             "scratch" => open_scratch.call(()),
+            "new-window" => {
+                spawn_local(async move {
+                    let _ = invoke("open_new_window", JsValue::UNDEFINED).await;
+                });
+            }
             "search" => command_palette_open.set(true),
             "commands" => action_palette_open.set(true),
             "projects" => show_projects.set(true),
@@ -9702,6 +9707,7 @@ fn App() -> impl IntoView {
                 other => {
                     if let Some(action) = match other {
                         "new" => Some("new"),
+                        "new-window" => Some("new-window"),
                         "search" => Some("search"),
                         "commands" => Some("commands"),
                         "projects" => Some("projects"),

--- a/ui/src/window_titlebar.rs
+++ b/ui/src/window_titlebar.rs
@@ -9,6 +9,7 @@ type MenuItem = (&'static str, &'static str, &'static str); // action, i18n key,
 
 const FILE_ITEMS: &[MenuItem] = &[
     ("new", "command.new_session", "Ctrl+N"),
+    ("new-window", "command.new_window", ""),
     ("projects", "command.projects", ""),
     ("files", "command.files", ""),
     (
@@ -51,6 +52,7 @@ const VIEW_ITEMS: &[MenuItem] = &[
 // doing nothing, which reads as a bug.
 const HOME_FILE_ITEMS: &[MenuItem] = &[
     ("new-project", "projects.new", "Ctrl+N"),
+    ("new-window", "command.new_window", ""),
     ("import-project", "projects.import", ""),
     ("scratch", "command.scratch", "Ctrl+Shift+N"),
     ("settings", "command.settings", "Ctrl+,"),


### PR DESCRIPTION
> **暂不合并。** 方向拆成 feature issues，由 #1074 跟踪。本 PR 作为原型保留。
>
> - [ ] #1077 飞书/微信 IM 目标不被桌面发言抢走（可先合）
> - [ ] #1075 每个窗口记住自己上次打开的项目（可先合）
> - [ ] #1079 实时流、审批卡和浏览器清标签只进入所属项目窗口
> - [ ] #1076 共享 Chrome 按项目串行占用
> - [ ] #1080 File 菜单「新建窗口」打开空白项目首页
> - [ ] #1078 审批范围 / 单工具审批 / Skip approvals 按项目 overlay

## 为什么要这样做

希望两个 GUI 并排跑两个不同项目，互不干扰：实时预览、审批、浏览器、飞书/微信、上次打开的项目、审批策略都不能串到另一个项目。密钥、主题、模型和全局设置继续全应用共享。

## 修改的内容

### 新建窗口
- **修改方向**：第二个桌面窗口从项目首页起步，不继承当前窗口的工作区
- **内容**：
  - 菜单「新建窗口」打开新 GUI，落在项目首页
  - 新窗口不绑定已有项目，打开项目后才有工作区

### 实时界面隔离
- **修改方向**：直播事件只投到该会话所属项目的窗口
- **内容**：
  - Agent 流、审批卡、浏览器清标签提示不再全进程广播
  - 无对应窗口时，不会回落到另一个项目的主窗口

### 浏览器占用
- **修改方向**：一台真实 Chrome，按项目串行
- **内容**：
  - 同一项目可重入
  - 外项目调用会失败，并写明正被哪个项目占用

### IM 路由
- **修改方向**：飞书/微信有自己的目标项目，不被桌面发言抢走
- **内容**：
  - 只有 `/project`（以及该项目内的 `/session`、`/new`）改 IM 目标
  - 桌面发送只更新该项目的最近会话
  - 旧路由 JSON 会迁成 IM 目标

### 每窗口上次项目
- **修改方向**：各窗口记住自己上次打开的项目
- **内容**：
  - 第二窗口打开别的项目，不会覆盖主窗口重启后要恢复的项目
  - 空白新建窗口不写入持久化映射
  - 仅主窗口仍更新全局回退项和启动工作区显示

### 审批与插件范围
- **修改方向**：策略变更跟当前窗口的项目走
- **内容**：
  - 审批范围、单工具审批、Skip approvals 写成项目 overlay
  - 启用插件、开关技能、Reload skills 只失效该项目会话
  - 安装/删除插件文件仍全局生效

## 测试步骤

### 测试案例 1：新建窗口

1. 用菜单打开「新建窗口」
2. 确认新窗口在项目首页，没有带上原窗口的工作区
3. **预期结果**：新窗口出现，且不继承原窗口已打开的项目

### 测试案例 2：实时流不串台

1. 两窗口打开不同项目，各发一条会跑工具的消息
2. **预期结果**：流式输出和审批卡只出现在对应项目的窗口

### 测试案例 3：浏览器占用

1. 窗口 A 的 Agent 正在用浏览器工具
2. 窗口 B（另一项目）再调浏览器工具
3. **预期结果**：B 失败并说明浏览器正被 A 的项目占用；A 结束后 B 可以继续

### 测试案例 4：IM 不被桌面抢走

1. 在飞书或微信 `/project` 选项目 A
2. 桌面在项目 B 的窗口里发消息
3. 再从 IM 发普通消息
4. **预期结果**：IM 仍落在项目 A，不会跟到 B

### 测试案例 5：窗口记住各自上次项目

1. 主窗口打开项目 A，第二窗口打开项目 B
2. 重启应用
3. **预期结果**：主窗口仍恢复 A，不会变成 B

### 测试案例 6：审批按项目

1. 在项目 A 的窗口把审批范围改成 Full
2. 看项目 B 窗口的设置，并在 B 里触发一次需审批的工具
3. **预期结果**：B 的策略不变，仍按 B 自己的审批询问
