### PR TITLE
feat(cli): add a dedicated vision model for text-only primaries

### DIFF
--- a/crates/wisp-cli/src/eval.rs
+++ b/crates/wisp-cli/src/eval.rs
@@ -904,7 +904,11 @@ impl Tool for FixtureMcpTool {
     }
 }
 
-pub async fn run(live_config: Option<ProviderConfig>, options: &EvalOptions) -> Result<()> {
+pub async fn run(
+    live_config: Option<ProviderConfig>,
+    live_vision: Option<ProviderConfig>,
+    options: &EvalOptions,
+) -> Result<()> {
     validate_options(options)?;
     let suite = load_suite(options.suite.as_deref())?;
     validate_suite(&suite, options.mode)?;
@@ -943,12 +947,21 @@ pub async fn run(live_config: Option<ProviderConfig>, options: &EvalOptions) -> 
                 let defaults = suite.defaults.clone();
                 let options = options.clone();
                 let live_config = model_config.clone();
+                let live_vision = live_vision.clone();
                 let cases_per_model = selected.len() * options.repeat;
                 tasks.spawn(async move {
                     let _permit = permit;
                     let order =
                         model_index * cases_per_model + case_index * options.repeat + repetition;
-                    let result = run_case(case, repetition, defaults, live_config, options).await;
+                    let result = run_case(
+                        case,
+                        repetition,
+                        defaults,
+                        live_config,
+                        live_vision,
+                        options,
+                    )
+                    .await;
                     (order, result)
                 });
             }
@@ -1153,6 +1166,7 @@ async fn run_case(
     repetition: usize,
     defaults: EvalLimits,
     live_config: Option<ProviderConfig>,
+    live_vision: Option<ProviderConfig>,
     options: EvalOptions,
 ) -> Result<ScenarioResult> {
     let model = live_config
@@ -1190,6 +1204,7 @@ async fn run_case(
                 case.vision_script.clone(),
             )))
         }
+        EvalMode::Live => live_vision.map(ProviderSource::Live),
         _ => None,
     };
     let max_context = limits.max_context_tokens.unwrap_or(DEFAULT_MAX_CONTEXT);
@@ -1450,6 +1465,11 @@ fn build_agent(
         max_context,
         max_rounds,
     );
+    // A dedicated vision provider describes images for a text-only primary.
+    // Native image parts would be sent to the primary instead.
+    if vision.is_some() {
+        agent.ctx.supports_vision = false;
+    }
     agent.seed_system_prompt(&skills, Some(wisp_runs::runs_guidance()));
     Ok(agent)
 }
@@ -2273,7 +2293,7 @@ mod tests {
             .find(|case| case.id == "run-wait-without-sleep")
             .cloned()
             .expect("run-wait-without-sleep case");
-        let result = run_case(case, 1, suite.defaults, None, EvalOptions::default())
+        let result = run_case(case, 1, suite.defaults, None, None, EvalOptions::default())
             .await
             .unwrap();
         assert!(result.passed, "{:?}", result.failures);
@@ -2287,6 +2307,29 @@ mod tests {
         );
         assert!(
             result.tool_calls.iter().all(|call| call.name != "shell"),
+            "{:?}",
+            result.tool_calls
+        );
+    }
+
+    #[tokio::test]
+    async fn vision_fallback_case_uses_the_dedicated_vision_provider() {
+        let suite: EvalSuite = serde_yaml::from_str(BUILTIN_SUITE).unwrap();
+        let case = suite
+            .cases
+            .iter()
+            .find(|case| case.id == "vision-fallback")
+            .cloned()
+            .expect("vision-fallback case");
+        let result = run_case(case, 1, suite.defaults, None, None, EvalOptions::default())
+            .await
+            .unwrap();
+        assert!(result.passed, "{:?}", result.failures);
+        assert!(
+            result
+                .tool_calls
+                .iter()
+                .any(|call| call.name == "view_image"),
             "{:?}",
             result.tool_calls
         );
@@ -2348,6 +2391,7 @@ mod tests {
                 case,
                 1,
                 suite.defaults.clone(),
+                None,
                 None,
                 EvalOptions::default(),
             )
@@ -2507,6 +2551,7 @@ mod tests {
                 1,
                 suite.defaults.clone(),
                 None,
+                None,
                 EvalOptions::default(),
             )
             .await
@@ -2563,6 +2608,7 @@ mod tests {
                 case,
                 1,
                 suite.defaults.clone(),
+                None,
                 None,
                 EvalOptions::default(),
             )
@@ -2638,6 +2684,7 @@ mod tests {
                 case,
                 1,
                 suite.defaults.clone(),
+                None,
                 None,
                 EvalOptions::default(),
             )

--- a/crates/wisp-cli/src/main.rs
+++ b/crates/wisp-cli/src/main.rs
@@ -672,37 +672,59 @@ async fn register_mcp_tools(
     }
 }
 
-fn provider_config() -> Result<ProviderConfig> {
-    let kind = match env("WISP_PROVIDER", "openai").to_ascii_lowercase().as_str() {
-        "anthropic" => "anthropic".to_string(),
-        "openai_responses" | "openai-responses" | "responses" => "openai_responses".to_string(),
-        _ => "openai".to_string(),
-    };
-    let api_key = env("WISP_API_KEY", "");
-    let base_url = env(
-        "WISP_API_URL",
-        match kind.as_str() {
-            "anthropic" => "https://api.anthropic.com",
-            "openai_responses" => "https://api.openai.com/v1",
-            _ => "https://api.deepseek.com",
-        },
-    );
-    let model = env(
-        "WISP_MODEL",
-        match kind.as_str() {
-            "anthropic" => "claude-sonnet-5",
-            "openai_responses" => "gpt-5.5",
-            _ => "deepseek-v4-flash",
-        },
-    );
-    if api_key.is_empty() {
-        anyhow::bail!("WISP_API_KEY is not set (required). Set it to your provider API key.");
+fn parse_provider_kind(raw: &str) -> String {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "anthropic" => "anthropic".into(),
+        "openai_responses" | "openai-responses" | "responses" => "openai_responses".into(),
+        _ => "openai".into(),
     }
-    let mut cfg = match kind.as_str() {
+}
+
+fn default_provider_url(kind: &str) -> &'static str {
+    match kind {
+        "anthropic" => "https://api.anthropic.com",
+        "openai_responses" => "https://api.openai.com/v1",
+        _ => "https://api.deepseek.com",
+    }
+}
+
+fn default_provider_model(kind: &str) -> &'static str {
+    match kind {
+        "anthropic" => "claude-sonnet-5",
+        "openai_responses" => "gpt-5.5",
+        _ => "deepseek-v4-flash",
+    }
+}
+
+fn env_opt(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn build_named_provider_config(
+    kind: &str,
+    base_url: String,
+    api_key: String,
+    model: String,
+) -> ProviderConfig {
+    match kind {
         "anthropic" => ProviderConfig::anthropic(base_url, api_key, model),
         "openai_responses" => ProviderConfig::openai_responses(base_url, api_key, model),
         _ => ProviderConfig::openai(base_url, api_key, model),
-    };
+    }
+}
+
+fn provider_config() -> Result<ProviderConfig> {
+    let kind = parse_provider_kind(&env("WISP_PROVIDER", "openai"));
+    let api_key = env("WISP_API_KEY", "");
+    let base_url = env("WISP_API_URL", default_provider_url(&kind));
+    let model = env("WISP_MODEL", default_provider_model(&kind));
+    if api_key.is_empty() {
+        anyhow::bail!("WISP_API_KEY is not set (required). Set it to your provider API key.");
+    }
+    let mut cfg = build_named_provider_config(&kind, base_url, api_key, model);
     cfg.max_tokens = parse_wisp_max_tokens(std::env::var("WISP_MAX_TOKENS").ok().as_deref())
         .unwrap_or(DEFAULT_HEADLESS_MAX_TOKENS);
     if let Some(effort) =
@@ -711,6 +733,67 @@ fn provider_config() -> Result<ProviderConfig> {
         cfg.reasoning_effort = Some(effort);
     }
     Ok(cfg)
+}
+
+/// Dedicated image-analysis model used when the primary chat model cannot see.
+/// `WISP_VISION_MODEL` is the gate; provider/url/key fall back to the primary
+/// `WISP_*` values when omitted.
+fn vision_provider_from_values(
+    model: Option<&str>,
+    provider: Option<&str>,
+    api_url: Option<&str>,
+    api_key: Option<&str>,
+    fallback_provider: Option<&str>,
+    fallback_url: Option<&str>,
+    fallback_key: Option<&str>,
+) -> Result<Option<ProviderConfig>> {
+    let model = model.map(str::trim).filter(|value| !value.is_empty());
+    let provider = provider.map(str::trim).filter(|value| !value.is_empty());
+    let api_url = api_url.map(str::trim).filter(|value| !value.is_empty());
+    if model.is_none() && provider.is_none() && api_url.is_none() {
+        return Ok(None);
+    }
+    let Some(model) = model else {
+        bail!(
+            "WISP_VISION_MODEL is required when WISP_VISION_PROVIDER or WISP_VISION_API_URL is set"
+        );
+    };
+    let kind = parse_provider_kind(provider.unwrap_or(fallback_provider.unwrap_or("openai")));
+    let base_url = api_url
+        .map(str::to_string)
+        .or_else(|| provider.map(|_| default_provider_url(&kind).to_string()))
+        .or_else(|| fallback_url.map(str::to_string))
+        .unwrap_or_else(|| default_provider_url(&kind).to_string());
+    let api_key = api_key
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .or_else(|| {
+            fallback_key
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+        })
+        .unwrap_or("");
+    if api_key.is_empty() {
+        bail!("WISP_VISION_API_KEY or WISP_API_KEY is required for the dedicated vision model");
+    }
+    Ok(Some(build_named_provider_config(
+        &kind,
+        base_url,
+        api_key.to_string(),
+        model.to_string(),
+    )))
+}
+
+fn vision_provider_config() -> Result<Option<ProviderConfig>> {
+    vision_provider_from_values(
+        env_opt("WISP_VISION_MODEL").as_deref(),
+        env_opt("WISP_VISION_PROVIDER").as_deref(),
+        env_opt("WISP_VISION_API_URL").as_deref(),
+        env_opt("WISP_VISION_API_KEY").as_deref(),
+        env_opt("WISP_PROVIDER").as_deref(),
+        env_opt("WISP_API_URL").as_deref(),
+        env_opt("WISP_API_KEY").as_deref(),
+    )
 }
 
 const DEFAULT_HEADLESS_MAX_TOKENS: u64 = 32_768;
@@ -812,7 +895,12 @@ async fn main() -> Result<()> {
         } else {
             None
         };
-        return eval::run(live_config, options).await;
+        let live_vision = if options.mode == eval::EvalMode::Live {
+            vision_provider_config()?
+        } else {
+            None
+        };
+        return eval::run(live_config, live_vision, options).await;
     }
     let cfg = match provider_config() {
         Ok(cfg) => cfg,
@@ -846,6 +934,17 @@ async fn main() -> Result<()> {
     let skills = Arc::new(SkillIndex::load(&skill_paths(&root)));
     let memory = Arc::new(MemoryManager::new(&root));
 
+    let vision_cfg = match vision_provider_config() {
+        Ok(cfg) => cfg,
+        Err(error) => {
+            if command == CliCommand::Rpc {
+                rpc::startup_error(&error);
+            } else if jsonl {
+                JsonlOutput::new(std::io::stdout()).error(&error);
+            }
+            return Err(error);
+        }
+    };
     let mut agent = Agent::new(
         cfg,
         skills.clone(),
@@ -854,10 +953,13 @@ async fn main() -> Result<()> {
         max_context,
         max_iter,
         true,
-        None,
+        vision_cfg.clone(),
     );
     agent.ctx.supports_vision = parse_wisp_vision(std::env::var("WISP_VISION").ok().as_deref())
         .unwrap_or(DEFAULT_HEADLESS_VISION);
+    if let Some(vision) = &vision_cfg {
+        setup_message(jsonl, format_args!("vision model wired ({})", vision.model));
+    }
     let run_store = wisp_runs::open_project_store(&root, runs::CLI_PROJECT_ID, "CLI").await?;
     let run_manager = wisp_runs::RunManager::new();
     runs::register_run_tools(
@@ -1270,6 +1372,90 @@ mod tests {
             parse_wisp_vision(Some("nope")).unwrap_or(DEFAULT_HEADLESS_VISION),
             false
         );
+    }
+
+    #[test]
+    fn dedicated_vision_model_is_optional_until_any_vision_env_is_set() {
+        assert!(
+            vision_provider_from_values(None, None, None, None, None, None, None)
+                .unwrap()
+                .is_none()
+        );
+        let err =
+            vision_provider_from_values(None, Some("openai"), None, Some("sk"), None, None, None)
+                .unwrap_err()
+                .to_string();
+        assert!(err.contains("WISP_VISION_MODEL"), "{err}");
+    }
+
+    #[test]
+    fn dedicated_vision_model_falls_back_to_primary_endpoint() {
+        let cfg = vision_provider_from_values(
+            Some("qwen-vl"),
+            None,
+            None,
+            None,
+            Some("openai"),
+            Some("https://api.example.com/v1"),
+            Some("primary-key"),
+        )
+        .unwrap()
+        .expect("vision config");
+        assert_eq!(cfg.model, "qwen-vl");
+        assert_eq!(cfg.base_url, "https://api.example.com/v1");
+        assert_eq!(cfg.api_key, "primary-key");
+    }
+
+    #[test]
+    fn dedicated_vision_model_uses_its_own_provider_url_and_key() {
+        let cfg = vision_provider_from_values(
+            Some("gpt-4o-mini"),
+            Some("openai_responses"),
+            Some("https://api.openai.com/v1"),
+            Some("vision-key"),
+            Some("anthropic"),
+            Some("https://api.anthropic.com"),
+            Some("primary-key"),
+        )
+        .unwrap()
+        .expect("vision config");
+        assert_eq!(cfg.model, "gpt-4o-mini");
+        assert_eq!(cfg.base_url, "https://api.openai.com/v1");
+        assert_eq!(cfg.api_key, "vision-key");
+        assert!(matches!(cfg.kind, wisp_llm::ProviderKind::OpenAiResponses));
+    }
+
+    #[test]
+    fn dedicated_vision_provider_without_url_uses_that_provider_default() {
+        let cfg = vision_provider_from_values(
+            Some("claude-sonnet-5"),
+            Some("anthropic"),
+            None,
+            Some("sk"),
+            Some("openai"),
+            Some("https://api.deepseek.com"),
+            Some("primary-key"),
+        )
+        .unwrap()
+        .expect("vision config");
+        assert_eq!(cfg.base_url, "https://api.anthropic.com");
+        assert!(matches!(cfg.kind, wisp_llm::ProviderKind::Anthropic));
+    }
+
+    #[test]
+    fn dedicated_vision_model_requires_an_api_key() {
+        let err = vision_provider_from_values(
+            Some("qwen-vl"),
+            Some("openai"),
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("WISP_VISION_API_KEY"), "{err}");
     }
 
     #[test]

--- a/docs/basic-configuration.md
+++ b/docs/basic-configuration.md
@@ -531,6 +531,11 @@ export WISP_PROVIDER="openai"            # openai / openai_responses / anthropic
 export WISP_API_URL="https://api.deepseek.com"
 export WISP_MODEL="deepseek-v4-flash"
 export WISP_API_KEY="<your-provider-key>"
+# Optional: a vision model used to describe images for a text-only primary.
+export WISP_VISION_PROVIDER="openai"
+export WISP_VISION_API_URL="https://api.openai.com/v1"
+export WISP_VISION_MODEL="gpt-4o-mini"
+# export WISP_VISION_API_KEY="<vision-key>"  # defaults to WISP_API_KEY
 ```
 
 Windows PowerShell：
@@ -540,6 +545,9 @@ $env:WISP_PROVIDER = "openai"
 $env:WISP_API_URL  = "https://api.deepseek.com"
 $env:WISP_MODEL    = "deepseek-v4-flash"
 $env:WISP_API_KEY  = "<your-provider-key>"
+$env:WISP_VISION_PROVIDER = "openai"
+$env:WISP_VISION_API_URL  = "https://api.openai.com/v1"
+$env:WISP_VISION_MODEL    = "gpt-4o-mini"
 ```
 
 不要把真实 Key 写进脚本或提交到 Git。桌面端的系统密钥环配置不会自动成为 CLI 环境变量。

--- a/docs/development.md
+++ b/docs/development.md
@@ -77,6 +77,11 @@ Eval and the long-lived JSONL RPC protocol:
 | `WISP_PROVIDER`      | CLI API provider: `openai` (default), `openai_responses`, or `anthropic` |
 | `WISP_API_URL`       | API root; defaults to DeepSeek / OpenAI / Anthropic           |
 | `WISP_MODEL`         | Model name                                                    |
+| `WISP_VISION`        | `1`/`true` if the primary model can read images natively (default off) |
+| `WISP_VISION_MODEL`  | Dedicated image-analysis model when the primary model cannot see |
+| `WISP_VISION_PROVIDER` | Vision provider kind; defaults to `WISP_PROVIDER`           |
+| `WISP_VISION_API_URL` | Vision API root; defaults to `WISP_API_URL` or the provider default |
+| `WISP_VISION_API_KEY` | Optional vision key; defaults to `WISP_API_KEY`             |
 | `WISP_MAX_CONTEXT`   | Context budget (default 1,000,000)                            |
 | `WISP_MAX_ITER`      | Max agent iterations per turn (default 100; 0 = unlimited)    |
 | `WISP_SKILLS_PATH`   | Extra `;`/`:`-separated SKILL.md catalog dirs                 |

--- a/docs/headless-agent-testing.md
+++ b/docs/headless-agent-testing.md
@@ -81,8 +81,12 @@ are zero. Cached input is excluded from the billable input estimate.
 
 Use `--mode live` to run the same declarative suite against the configured
 provider. Live mode requires the normal `WISP_API_KEY`, `WISP_PROVIDER`, and
-`WISP_MODEL` environment variables. Scripted steps are ignored in live mode;
-live suites should use tolerant semantic assertions rather than exact prose.
+`WISP_MODEL` environment variables. For a text-only primary model, set
+`WISP_VISION_MODEL` (and optionally `WISP_VISION_PROVIDER`,
+`WISP_VISION_API_URL`, `WISP_VISION_API_KEY`) so `view_image` is described by
+a dedicated vision model instead of being sent to the chat model. Scripted
+steps are ignored in live mode; live suites should use tolerant semantic
+assertions rather than exact prose.
 
 ### Memory and compaction dataset
 

--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -301,6 +301,10 @@ $env:WISP_PROVIDER = "openai"           # openai, openai_responses, or anthropic
 $env:WISP_API_URL  = "https://api.deepseek.com"
 $env:WISP_MODEL    = "deepseek-v4-flash"
 $env:WISP_API_KEY  = "<your provider key>"
+# Optional dedicated vision model when the primary chat model cannot see images:
+$env:WISP_VISION_PROVIDER = "openai"
+$env:WISP_VISION_API_URL  = "https://api.openai.com/v1"
+$env:WISP_VISION_MODEL    = "gpt-4o-mini"
 cargo run -p wisp-cli
 ```
 


### PR DESCRIPTION
## User-facing problem

CLI benchmarks against a text-only primary model scored poorly on image work. `view_image` either sent pixels to a model that cannot see them, or failed because no vision provider was configured. Desktop already supports a separate vision profile; headless CLI did not.

## What changed

- `WISP_VISION_MODEL` enables a dedicated image-analysis model. Optional `WISP_VISION_PROVIDER`, `WISP_VISION_API_URL`, and `WISP_VISION_API_KEY` override the primary `WISP_*` values.
- Interactive, `run`, `rpc`, and live `eval` wire that model as the agent vision provider. Images are described for the primary instead of being attached natively.
- This is separate from `WISP_VISION=1`, which still means the **primary** model can read images itself.

## Tests

- Unit tests for optional/required vision env combinations, provider/url/key fallback, and missing API key.
- Offline eval case `vision-fallback` now asserts the dedicated vision provider path.

## Manual smoke

```bash
export WISP_PROVIDER=openai
export WISP_API_URL=https://api.deepseek.com
export WISP_MODEL=deepseek-v4-flash
export WISP_API_KEY=<primary-key>
export WISP_VISION_PROVIDER=openai
export WISP_VISION_API_URL=https://api.openai.com/v1
export WISP_VISION_MODEL=gpt-4o-mini
# export WISP_VISION_API_KEY=<vision-key>  # defaults to WISP_API_KEY
wisp-science run --output jsonl "Inspect a figure in this project."
```

Confirm the trajectory uses `view_image` and a vision-model description rather than sending image parts to the primary model.

## Known limitations

- `WISP_VISION=1` still sends images to the primary model and does not use the dedicated describer.
- No separate vision max-tokens / reasoning-effort env vars; the describer uses the provider default output cap.