### PR TITLE
feat(approvals): 审批范围与 Skip approvals 按项目 overlay

### DIFF
--- a/src-tauri/src/agent_turn.rs
+++ b/src-tauri/src/agent_turn.rs
@@ -113,6 +113,7 @@ pub(crate) async fn send_message_inner(
         explicit_scope = Some(scope);
     }
     let _project_activity = state.begin_project_activity(&ap.id)?;
+    ensure_project_live_approvals(state, &ap.id).await;
     let frame_scope = explicit_scope
         .clone()
         .unwrap_or_else(|| wisp_store::StateScope::mainline(ap.id.clone()));

--- a/src-tauri/src/app_state.rs
+++ b/src-tauri/src/app_state.rs
@@ -479,7 +479,9 @@ pub(crate) struct AppState {
     /// Sessions blocked on an inline approval card (Projects dashboard → Needs you).
     pub(crate) awaiting_confirm: Arc<StdMutex<HashSet<String>>>,
     /// Live per-tool approval policy, read on every tool call by `TauriOutput`.
-    pub(crate) approvals: Arc<StdRwLock<ApprovalPolicy>>,
+    /// Project overlays sit beside the process-wide default so two windows can
+    /// keep different scopes.
+    pub(crate) approvals: Arc<StdRwLock<LiveApprovals>>,
     /// Scoped approvals granted from the inline confirmation card.
     pub(crate) approval_grants: Arc<StdMutex<ApprovalGrants>>,
     /// Conversations whose approval prompts are bypassed for this app run.

--- a/src-tauri/src/connector_commands.rs
+++ b/src-tauri/src/connector_commands.rs
@@ -1,11 +1,13 @@
 use super::{
-    bio_domains, clear_idle_agents, connect_mcp, load_approval_scope, load_disabled_connectors,
-    load_mcp_connections, load_skip_connectors, load_tool_approvals, refresh_approval_policy,
-    save_json_setting, save_mcp_connections, AppState, ApprovalMode, McpConnection, McpHttpAuth,
-    McpTransport, Scope,
+    bio_domains, bound_window_project_id, clear_idle_agents, connect_mcp, load_approval_scope_for,
+    load_disabled_connectors, load_mcp_connections, load_skip_connectors_for,
+    load_tool_approvals_for, persist_approval_scope_overlay, persist_skip_connectors_overlay,
+    persist_tool_approval_overlay, refresh_approval_policy_for, save_json_setting,
+    save_mcp_connections, window_bound_project_id, AppState, McpConnection, McpHttpAuth,
+    McpTransport,
 };
 use serde::Serialize;
-use tauri::State;
+use tauri::{State, WebviewWindow};
 
 #[derive(Serialize, Clone)]
 pub(super) struct McpConnectionsView {
@@ -130,16 +132,21 @@ struct ConnectorInfo {
 #[derive(Serialize, Clone)]
 pub(super) struct ConnectorsView {
     connectors: Vec<ConnectorInfo>,
-    /// Global approval scope ("full" | "auto" | "ask").
+    /// Approval scope for this window's project, or the inherited global default.
     scope: String,
 }
 
 #[tauri::command]
-pub(super) async fn list_connectors(state: State<'_, AppState>) -> Result<ConnectorsView, String> {
+pub(super) async fn list_connectors(
+    state: State<'_, AppState>,
+    window: WebviewWindow,
+) -> Result<ConnectorsView, String> {
     let store = &state.store;
+    // Unbound windows show the inherited global defaults without writing them.
+    let project_id = window_bound_project_id(&state, window.label());
     let disabled = load_disabled_connectors(store).await;
-    let approvals = load_tool_approvals(store).await;
-    let skip = load_skip_connectors(store).await;
+    let approvals = load_tool_approvals_for(store, project_id.as_deref()).await;
+    let skip = load_skip_connectors_for(store, project_id.as_deref()).await;
 
     let mut connectors = vec![];
     for d in bio_domains() {
@@ -185,7 +192,10 @@ pub(super) async fn list_connectors(state: State<'_, AppState>) -> Result<Connec
             tools: vec![],
         });
     }
-    let scope = load_approval_scope(store).await.as_str().to_string();
+    let scope = load_approval_scope_for(store, project_id.as_deref())
+        .await
+        .as_str()
+        .to_string();
     Ok(ConnectorsView { connectors, scope })
 }
 
@@ -210,40 +220,40 @@ pub(super) async fn set_connector_enabled(
 }
 
 /// Set the approval mode ("allow" | "ask" | "deny") for a single tool. Enforced
-/// live on the next tool call — no session rebuild needed.
+/// live on the next tool call — no session rebuild needed. Writes the overlay
+/// for this window's project so a sibling window keeps its own policy.
 #[tauri::command]
 pub(super) async fn set_tool_approval(
     state: State<'_, AppState>,
+    window: WebviewWindow,
     tool: String,
     mode: String,
 ) -> Result<(), String> {
-    let mut approvals = load_tool_approvals(&state.store).await;
-    // Store only overrides; "allow" is the default, so drop it to stay compact.
-    if ApprovalMode::parse(&mode) == ApprovalMode::Allow {
-        approvals.remove(&tool);
-    } else {
-        approvals.insert(tool, ApprovalMode::parse(&mode).as_str().into());
-    }
-    save_json_setting(&state.store, "tool_approvals", &approvals).await?;
-    refresh_approval_policy(&state).await;
+    let project_id = persist_tool_approval_overlay(
+        &state.store,
+        bound_window_project_id(&state, window.label()),
+        tool,
+        mode,
+    )
+    .await?;
+    refresh_approval_policy_for(&state, Some(&project_id)).await;
     Ok(())
 }
 
-/// Set the global approval scope ("full" | "auto" | "ask"). Enforced live on
-/// the next tool call — no session rebuild needed.
+/// Set the approval scope ("full" | "auto" | "ask") for this window's project.
 #[tauri::command]
 pub(super) async fn set_approval_scope(
     state: State<'_, AppState>,
+    window: WebviewWindow,
     scope: String,
 ) -> Result<(), String> {
-    // Normalize through `Scope` so only the three valid values ever persist.
-    save_json_setting(
+    let project_id = persist_approval_scope_overlay(
         &state.store,
-        "approval_scope",
-        &Scope::parse(&scope).as_str(),
+        bound_window_project_id(&state, window.label()),
+        &scope,
     )
     .await?;
-    refresh_approval_policy(&state).await;
+    refresh_approval_policy_for(&state, Some(&project_id)).await;
     Ok(())
 }
 
@@ -251,18 +261,18 @@ pub(super) async fn set_approval_scope(
 #[tauri::command]
 pub(super) async fn set_connector_skip_approvals(
     state: State<'_, AppState>,
+    window: WebviewWindow,
     key: String,
     enabled: bool,
 ) -> Result<(), String> {
-    let mut skip = load_skip_connectors(&state.store).await;
-    if enabled {
-        skip.insert(key);
-    } else {
-        skip.remove(&key);
-    }
-    let list: Vec<String> = skip.into_iter().collect();
-    save_json_setting(&state.store, "skip_approval_connectors", &list).await?;
-    refresh_approval_policy(&state).await;
+    let project_id = persist_skip_connectors_overlay(
+        &state.store,
+        bound_window_project_id(&state, window.label()),
+        key,
+        enabled,
+    )
+    .await?;
+    refresh_approval_policy_for(&state, Some(&project_id)).await;
     Ok(())
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -745,7 +745,7 @@ impl Scope {
 /// `tool_connector` is static (built once from `domains.json`); `tools`/`skip`/
 /// `scope` mirror the persisted settings and are refreshed by the approval
 /// commands.
-#[derive(Default)]
+#[derive(Clone, Default)]
 struct ApprovalPolicy {
     /// Global scope layered over the per-tool modes below.
     scope: Scope,
@@ -755,6 +755,48 @@ struct ApprovalPolicy {
     skip: HashSet<String>,
     /// Tool name -> bundled connector (domain slug), for resolving `skip`.
     tool_connector: HashMap<String, String>,
+}
+
+/// Process-wide defaults plus per-project overlays written from a window that
+/// already has a workspace open. Running turns read the overlay for their
+/// `project_id`, so changing approvals in project A does not rewrite project B.
+#[derive(Clone, Default)]
+struct LiveApprovals {
+    default: ApprovalPolicy,
+    by_project: HashMap<String, ApprovalPolicy>,
+}
+
+impl LiveApprovals {
+    fn for_project(&self, project_id: &str) -> &ApprovalPolicy {
+        self.by_project.get(project_id).unwrap_or(&self.default)
+    }
+}
+
+/// Returned by approval overlay setters when the invoking window has no bound
+/// project. Must stay exact: tests and the UI match on this string.
+const BLANK_WINDOW_NO_PROJECT: &str = "Open a project in this window before running that action.";
+
+/// Project bound to this window only. Unlike [`AppState::active`], this never
+/// falls back to `main` — writing an overlay (or the unprefixed global keys)
+/// from an unbound window would leak into every project that still inherits
+/// the default.
+fn bound_window_project_id(state: &AppState, label: &str) -> Result<String, String> {
+    state
+        .active
+        .read()
+        .unwrap()
+        .get(label)
+        .map(|project| project.id.clone())
+        .ok_or_else(|| BLANK_WINDOW_NO_PROJECT.to_string())
+}
+
+fn window_bound_project_id(state: &AppState, label: &str) -> Option<String> {
+    state
+        .active
+        .read()
+        .unwrap()
+        .get(label)
+        .map(|project| project.id.clone())
 }
 
 impl ApprovalPolicy {
@@ -2003,6 +2045,26 @@ async fn clear_idle_agents(state: &AppState) {
     }
 }
 
+fn invalidate_idle_agents_owned(
+    sessions: &HashMap<String, Arc<SessionRuntime>>,
+    owned: &HashSet<String>,
+) {
+    for (frame_id, runtime) in sessions {
+        if owned.contains(frame_id) {
+            runtime.invalidate_cached_agent();
+        }
+    }
+}
+
+async fn clear_idle_agents_for_project(state: &AppState, project_id: &str) {
+    let owned: HashSet<String> = match state.store.list_sessions(project_id).await {
+        Ok(rows) => rows.into_iter().map(|(id, ..)| id).collect(),
+        Err(_) => return,
+    };
+    let sessions = state.sessions.lock().await;
+    invalidate_idle_agents_owned(&sessions, &owned);
+}
+
 async fn clear_session_agent(state: &AppState, frame_id: &str) {
     let runtime = state.sessions.lock().await.get(frame_id).cloned();
     if let Some(runtime) = runtime {
@@ -2376,6 +2438,7 @@ async fn call_mcp_app_tool(
         .await
         .map_err(|error| error.to_string())?
         .ok_or_else(|| MCP_APP_STALE_INSTANCE_ERROR.to_string())?;
+    ensure_project_live_approvals(&state, &project_id).await;
     // Plan mode and frozen-project gates match agent tool calls: read-only
     // tools stay available, everything else refuses.
     if plan_mode::session_plan_mode(&state.store, &frame_id).await
@@ -2388,7 +2451,7 @@ async fn call_mcp_app_tool(
     let host_approval = state
         .approvals
         .read()
-        .map(|policy| policy.mode_for(&name))
+        .map(|live| live.for_project(&project_id).mode_for(&name))
         .unwrap_or(wisp_tools::Approval::Allow);
     let full_permission = state
         .full_permission_sessions
@@ -2626,7 +2689,7 @@ struct TauriOutput {
     confirms: ConfirmMap,
     awaiting_confirm: Arc<StdMutex<HashSet<String>>>,
     /// Shared live approval policy (see `AppState::approvals`).
-    approvals: Arc<StdRwLock<ApprovalPolicy>>,
+    approvals: Arc<StdRwLock<LiveApprovals>>,
     /// Built-in plan mode for this session, read once per turn. ACP-bound
     /// frames never set it — their plan mode lives on the agent side.
     plan_mode: bool,
@@ -2969,7 +3032,7 @@ impl Output for TauriOutput {
     fn approval_mode(&self, tool: &str) -> wisp_tools::Approval {
         self.approvals
             .read()
-            .map(|p| p.mode_for(tool))
+            .map(|live| live.for_project(&self.project_id).mode_for(tool))
             .unwrap_or(wisp_tools::Approval::Allow)
     }
     fn restrict_read_paths_to_project(&self) -> bool {
@@ -3035,7 +3098,12 @@ impl Output for TauriOutput {
         if self.force_ask_mutations {
             return false;
         }
-        self.full_permission() || self.approvals.read().map(|p| p.full()).unwrap_or(false)
+        self.full_permission()
+            || self
+                .approvals
+                .read()
+                .map(|live| live.for_project(&self.project_id).full())
+                .unwrap_or(false)
     }
     fn force_ask_mutations(&self) -> bool {
         self.force_ask_mutations
@@ -3975,6 +4043,28 @@ async fn load_json_setting<T: serde::de::DeserializeOwned + Default>(
         .unwrap_or_default()
 }
 
+async fn load_json_setting_for_project<T: serde::de::DeserializeOwned + Default>(
+    store: &Store,
+    key: &str,
+    project_id: Option<&str>,
+) -> T {
+    if let Some(id) = project_id.filter(|id| !id.is_empty()) {
+        let specific = format!("{key}:{id}");
+        if let Some(raw) = store.get_setting(&specific).await.ok().flatten() {
+            if let Ok(value) = serde_json::from_str(&raw) {
+                return value;
+            }
+        }
+    }
+    load_json_setting(store, key).await
+}
+
+/// Overlay key for a bound project. Setters pass a resolved project id so they
+/// cannot write the unprefixed global default (`approval_scope`, …).
+fn project_setting_key(key: &str, project_id: &str) -> String {
+    format!("{key}:{project_id}")
+}
+
 async fn save_json_setting<T: Serialize>(store: &Store, key: &str, val: &T) -> Result<(), String> {
     let json = serde_json::to_string(val).map_err(|e| format!("{e}"))?;
     store
@@ -3993,13 +4083,11 @@ async fn load_disabled_connectors(store: &Store) -> HashSet<String> {
 }
 
 /// Persisted per-tool approvals (tool name -> "ask"/"deny"; "allow" omitted).
-async fn load_tool_approvals(store: &Store) -> HashMap<String, String> {
-    load_json_setting(store, "tool_approvals").await
-}
-
-/// Persisted global approval scope ("full" | "auto" | "ask"; default "ask").
-async fn load_approval_scope(store: &Store) -> Scope {
-    Scope::parse(&load_json_setting::<String>(store, "approval_scope").await)
+async fn load_tool_approvals_for(
+    store: &Store,
+    project_id: Option<&str>,
+) -> HashMap<String, String> {
+    load_json_setting_for_project(store, "tool_approvals", project_id).await
 }
 
 async fn load_approval_grants(store: &Store) -> ApprovalGrants {
@@ -4010,12 +4098,82 @@ async fn save_approval_grants(store: &Store, grants: &ApprovalGrants) -> Result<
     save_json_setting(store, "approval_grants", &grants.persisted()).await
 }
 
+/// Persisted approval scope ("full" | "auto" | "ask"; default "ask").
+async fn load_approval_scope_for(store: &Store, project_id: Option<&str>) -> Scope {
+    Scope::parse(
+        &load_json_setting_for_project::<String>(store, "approval_scope", project_id).await,
+    )
+}
+
 /// Connector keys with "Skip approvals" on.
-async fn load_skip_connectors(store: &Store) -> HashSet<String> {
-    load_json_setting::<Vec<String>>(store, "skip_approval_connectors")
+async fn load_skip_connectors_for(store: &Store, project_id: Option<&str>) -> HashSet<String> {
+    load_json_setting_for_project::<Vec<String>>(store, "skip_approval_connectors", project_id)
         .await
         .into_iter()
         .collect()
+}
+
+/// Persist overlay setters refuse to write until the window has a bound
+/// project. Returning `project_id` lets the caller refresh only that overlay.
+async fn persist_approval_scope_overlay(
+    store: &Store,
+    project_id: Result<String, String>,
+    scope: &str,
+) -> Result<String, String> {
+    let project_id = project_id?;
+    save_json_setting(
+        store,
+        &project_setting_key("approval_scope", &project_id),
+        &Scope::parse(scope).as_str(),
+    )
+    .await?;
+    Ok(project_id)
+}
+
+async fn persist_tool_approval_overlay(
+    store: &Store,
+    project_id: Result<String, String>,
+    tool: String,
+    mode: String,
+) -> Result<String, String> {
+    let project_id = project_id?;
+    let mut approvals = load_tool_approvals_for(store, Some(&project_id)).await;
+    // Store only overrides; "allow" is the default, so drop it to stay compact.
+    if ApprovalMode::parse(&mode) == ApprovalMode::Allow {
+        approvals.remove(&tool);
+    } else {
+        approvals.insert(tool, ApprovalMode::parse(&mode).as_str().into());
+    }
+    save_json_setting(
+        store,
+        &project_setting_key("tool_approvals", &project_id),
+        &approvals,
+    )
+    .await?;
+    Ok(project_id)
+}
+
+async fn persist_skip_connectors_overlay(
+    store: &Store,
+    project_id: Result<String, String>,
+    key: String,
+    enabled: bool,
+) -> Result<String, String> {
+    let project_id = project_id?;
+    let mut skip = load_skip_connectors_for(store, Some(&project_id)).await;
+    if enabled {
+        skip.insert(key);
+    } else {
+        skip.remove(&key);
+    }
+    let list: Vec<String> = skip.into_iter().collect();
+    save_json_setting(
+        store,
+        &project_setting_key("skip_approval_connectors", &project_id),
+        &list,
+    )
+    .await?;
+    Ok(project_id)
 }
 
 /// tool name -> bundled connector (domain slug). Static; built from domains.json.
@@ -4031,25 +4189,72 @@ fn build_tool_connector_map() -> HashMap<String, String> {
 
 /// Snapshot the persisted approval state into a fresh `ApprovalPolicy`.
 async fn build_approval_policy(store: &Store) -> ApprovalPolicy {
+    build_approval_policy_for(store, None).await
+}
+
+async fn build_approval_policy_for(store: &Store, project_id: Option<&str>) -> ApprovalPolicy {
     ApprovalPolicy {
-        scope: load_approval_scope(store).await,
-        tools: load_tool_approvals(store)
+        scope: load_approval_scope_for(store, project_id).await,
+        tools: load_tool_approvals_for(store, project_id)
             .await
             .into_iter()
             .map(|(k, v)| (k, ApprovalMode::parse(&v)))
             .collect(),
-        skip: load_skip_connectors(store).await,
+        skip: load_skip_connectors_for(store, project_id).await,
         tool_connector: build_tool_connector_map(),
     }
 }
 
+async fn project_has_approval_overlay(store: &Store, project_id: &str) -> bool {
+    for key in [
+        "approval_scope",
+        "tool_approvals",
+        "skip_approval_connectors",
+    ] {
+        if store
+            .get_setting(&format!("{key}:{project_id}"))
+            .await
+            .ok()
+            .flatten()
+            .is_some()
+        {
+            return true;
+        }
+    }
+    false
+}
+
 /// Reload the live approval policy after a settings change so running sessions
 /// see it on their next tool call (approval is enforced live, not per session).
+/// `None` reloads the process-wide default (unprefixed keys). Kept for
+/// global-default writers (connector enable/disable stays process-wide).
+#[allow(dead_code)]
 async fn refresh_approval_policy(state: &AppState) {
-    let policy = build_approval_policy(&state.store).await;
-    if let Ok(mut guard) = state.approvals.write() {
-        *guard = policy;
+    refresh_approval_policy_for(state, None).await;
+}
+
+async fn refresh_approval_policy_for(state: &AppState, project_id: Option<&str>) {
+    let policy = build_approval_policy_for(&state.store, project_id).await;
+    if let Ok(mut live) = state.approvals.write() {
+        match project_id.filter(|id| !id.is_empty()) {
+            Some(id) => {
+                live.by_project.insert(id.to_string(), policy);
+            }
+            None => live.default = policy,
+        }
     }
+}
+
+async fn ensure_project_live_approvals(state: &AppState, project_id: &str) {
+    let already = state
+        .approvals
+        .read()
+        .map(|live| live.by_project.contains_key(project_id))
+        .unwrap_or(false);
+    if already || !project_has_approval_overlay(&state.store, project_id).await {
+        return;
+    }
+    refresh_approval_policy_for(state, Some(project_id)).await;
 }
 
 async fn load_memory_enabled(store: &Store) -> bool {
@@ -6655,9 +6860,12 @@ pub fn run() {
             let bootstrap = StdMutex::new(startup.record("tool_probe", || {
                 app_commands::initial_bootstrap(&root, skills.all().len())
             }));
-            let approvals = Arc::new(StdRwLock::new(startup.record("approvals", || {
-                tauri::async_runtime::block_on(build_approval_policy(&store))
-            })));
+            let approvals = Arc::new(StdRwLock::new(LiveApprovals {
+                default: startup.record("approvals", || {
+                    tauri::async_runtime::block_on(build_approval_policy(&store))
+                }),
+                by_project: HashMap::new(),
+            }));
             let approval_grants = Arc::new(StdMutex::new(startup.record("approval_grants", || {
                 tauri::async_runtime::block_on(load_approval_grants(&store))
             })));

--- a/src-tauri/src/lib_tests.rs
+++ b/src-tauri/src/lib_tests.rs
@@ -1656,6 +1656,17 @@ fn scope_gates_per_tool_modes() {
 }
 
 #[test]
+fn live_approvals_fall_back_to_the_process_default() {
+    let mut live = super::LiveApprovals::default();
+    live.default.scope = super::Scope::Ask;
+    let mut overlay = super::ApprovalPolicy::default();
+    overlay.scope = super::Scope::Full;
+    live.by_project.insert("proj-a".into(), overlay);
+    assert!(live.for_project("proj-a").full());
+    assert!(!live.for_project("proj-b").full());
+}
+
+#[test]
 fn approval_grants_respect_scope_and_persistence() {
     use super::{ApprovalGrantKey, ApprovalGrants};
 
@@ -2460,4 +2471,151 @@ fn ui_watchdog_unfocused_silence_is_not_stale() {
     let mut none = None;
     ui_watchdog_note_unfocused(&mut none);
     assert!(none.is_none());
+}
+
+async fn open_temp_store(prefix: &str) -> (wisp_store::Store, PathBuf) {
+    let path = std::env::temp_dir().join(format!("{prefix}_{}.sqlite", uuid::Uuid::new_v4()));
+    let store = wisp_store::Store::open(&path).await.unwrap();
+    (store, path)
+}
+
+fn cleanup_temp_store(store: wisp_store::Store, path: PathBuf) {
+    drop(store);
+    let _ = std::fs::remove_file(&path);
+    let _ = std::fs::remove_file(path.with_extension("sqlite-wal"));
+    let _ = std::fs::remove_file(path.with_extension("sqlite-shm"));
+}
+
+#[tokio::test]
+async fn project_approval_overlay_does_not_change_the_global_policy() {
+    let (store, path) = open_temp_store("wisp_approval_overlay").await;
+    super::save_json_setting(&store, "approval_scope", &"ask")
+        .await
+        .unwrap();
+    super::save_json_setting(
+        &store,
+        "tool_approvals",
+        &HashMap::<String, String>::from([("shell".into(), "ask".into())]),
+    )
+    .await
+    .unwrap();
+
+    let written = super::persist_approval_scope_overlay(&store, Ok("proj-a".into()), "full")
+        .await
+        .unwrap();
+    assert_eq!(written, "proj-a");
+    super::persist_tool_approval_overlay(
+        &store,
+        Ok("proj-a".into()),
+        "shell".into(),
+        "allow".into(),
+    )
+    .await
+    .unwrap();
+    super::persist_skip_connectors_overlay(&store, Ok("proj-a".into()), "mcp_bio".into(), true)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        super::load_approval_scope_for(&store, None).await.as_str(),
+        "ask"
+    );
+    assert_eq!(
+        super::load_approval_scope_for(&store, Some("proj-a"))
+            .await
+            .as_str(),
+        "full"
+    );
+    assert_eq!(
+        super::load_approval_scope_for(&store, Some("proj-b"))
+            .await
+            .as_str(),
+        "ask"
+    );
+    assert_eq!(
+        store.get_setting("approval_scope:proj-a").await.unwrap(),
+        Some(serde_json::to_string("full").unwrap())
+    );
+    assert_eq!(
+        super::load_tool_approvals_for(&store, None)
+            .await
+            .get("shell")
+            .map(String::as_str),
+        Some("ask")
+    );
+    assert_eq!(
+        super::load_tool_approvals_for(&store, Some("proj-a"))
+            .await
+            .get("shell"),
+        None
+    );
+    assert!(super::load_skip_connectors_for(&store, Some("proj-a"))
+        .await
+        .contains("mcp_bio"));
+    assert!(!super::load_skip_connectors_for(&store, Some("proj-b"))
+        .await
+        .contains("mcp_bio"));
+    cleanup_temp_store(store, path);
+}
+
+#[tokio::test]
+async fn unbound_window_approval_overlay_setters_do_not_write_global_keys() {
+    let (store, path) = open_temp_store("wisp_approval_unbound").await;
+    let unbound = Err(super::BLANK_WINDOW_NO_PROJECT.to_string());
+
+    let scope_err = super::persist_approval_scope_overlay(&store, unbound.clone(), "full")
+        .await
+        .unwrap_err();
+    let tool_err =
+        super::persist_tool_approval_overlay(&store, unbound.clone(), "shell".into(), "ask".into())
+            .await
+            .unwrap_err();
+    let skip_err = super::persist_skip_connectors_overlay(&store, unbound, "mcp_bio".into(), true)
+        .await
+        .unwrap_err();
+
+    assert_eq!(scope_err, super::BLANK_WINDOW_NO_PROJECT);
+    assert_eq!(tool_err, super::BLANK_WINDOW_NO_PROJECT);
+    assert_eq!(skip_err, super::BLANK_WINDOW_NO_PROJECT);
+    assert!(store.get_setting("approval_scope").await.unwrap().is_none());
+    assert!(store.get_setting("tool_approvals").await.unwrap().is_none());
+    assert!(store
+        .get_setting("skip_approval_connectors")
+        .await
+        .unwrap()
+        .is_none());
+
+    super::persist_approval_scope_overlay(&store, Ok("proj-a".into()), "full")
+        .await
+        .unwrap();
+    assert!(store.get_setting("approval_scope").await.unwrap().is_none());
+    assert!(store
+        .get_setting("approval_scope:proj-a")
+        .await
+        .unwrap()
+        .is_some());
+    cleanup_temp_store(store, path);
+}
+
+#[test]
+fn project_approval_overlay_clears_idle_agents_only_for_that_project() {
+    use std::sync::atomic::Ordering;
+
+    let owned_runtime = Arc::new(SessionRuntime::new());
+    let other_runtime = Arc::new(SessionRuntime::new());
+    let mut sessions = HashMap::new();
+    sessions.insert("sess-a".into(), owned_runtime.clone());
+    sessions.insert("sess-b".into(), other_runtime.clone());
+    let owned = HashSet::from(["sess-a".to_string()]);
+
+    super::invalidate_idle_agents_owned(&sessions, &owned);
+
+    assert_eq!(
+        owned_runtime.agent_config_generation.load(Ordering::SeqCst),
+        1
+    );
+    assert_eq!(
+        other_runtime.agent_config_generation.load(Ordering::SeqCst),
+        0
+    );
 }

--- a/src-tauri/src/plugins.rs
+++ b/src-tauri/src/plugins.rs
@@ -6,7 +6,7 @@
 //! never executes package code; MCP entrypoints start only after a project-level
 //! enable action.
 
-use crate::{clear_idle_agents, AppState};
+use crate::{clear_idle_agents, clear_idle_agents_for_project, AppState};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, HashSet};
@@ -1191,7 +1191,7 @@ pub(super) async fn set_plugin_enabled(
         .entry(project.id.clone())
         .or_default()
         .remove(&plugin_id);
-    clear_idle_agents(&state).await;
+    clear_idle_agents_for_project(&state, &project.id).await;
     Ok(())
 }
 

--- a/src-tauri/src/skill_commands.rs
+++ b/src-tauri/src/skill_commands.rs
@@ -1,7 +1,8 @@
 use super::{
-    clear_idle_agents, effective_enabled_skill_names, load_enabled_skill_names, load_skill_index,
-    load_skill_tags, normalize_tags, project_skill_catalog, save_enabled_skill_names,
-    save_skill_tags, skill_infos, AppState, SkillInfo,
+    clear_idle_agents, clear_idle_agents_for_project, effective_enabled_skill_names,
+    load_enabled_skill_names, load_skill_index, load_skill_tags, normalize_tags,
+    project_skill_catalog, save_enabled_skill_names, save_skill_tags, skill_infos, AppState,
+    SkillInfo,
 };
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
@@ -72,8 +73,9 @@ pub(super) async fn reload_skills(
         save_enabled_skill_names(&state.store, &project.id, names).await?;
     }
 
+    let project_id = project.id.clone();
     state.set_active(label, project);
-    clear_idle_agents(&state).await;
+    clear_idle_agents_for_project(&state, &project_id).await;
     Ok(list_skill_infos_for_project(&state, label).await)
 }
 
@@ -139,7 +141,7 @@ async fn update_skills_enabled(
         }
     }
     save_enabled_skill_names(&state.store, &ap.id, &current).await?;
-    clear_idle_agents(state).await;
+    clear_idle_agents_for_project(state, &ap.id).await;
     Ok(())
 }
 


### PR DESCRIPTION
Closes #1078

属于 #1074。建议在 #1080 之后合，空白窗口 setter 失败路径才真正可点到。

## 用户问题

审批范围、单工具审批、Skip approvals 是进程级设置。窗口 A 改成 Full，窗口 B 也会变。空白窗口改审批不能写回全局默认，也不能 panic。

## 改动

- 写成项目 overlay：`approval_scope:{id}`、`tool_approvals:{id}`、`skip_approval_connectors:{id}`。
- 没有 overlay 的项目继承未加前缀的全局默认。
- 三个 setter 解析**该窗口自己绑定的项目**（不 fallback 到 `main`）。未绑定则返回 `Open a project in this window before running that action.`，**不写无前缀全局 key**，也不 `refresh_approval_policy_for(None)`。这是对 PR #1072 原型的修正。
- `LiveApprovals { default, by_project }`，turn 开始时加载该项目 overlay。
- 启用插件 / 开关技能 / Reload skills 只失效该项目会话；安装/删除插件文件仍全局。

## 测试

- 项目 A 写成 Full overlay，项目 B 仍是默认 Ask；key 为 `approval_scope:proj-a`
- 未绑定窗口 setter 返回 `BLANK_WINDOW_NO_PROJECT` 且不创建全局 key
- `invalidate_idle_agents_owned` 只 bump 该项目会话