### PR TITLE
feat(ui): 实时流和审批卡只进入所属项目窗口

### DIFF
--- a/src-tauri/src/acp.rs
+++ b/src-tauri/src/acp.rs
@@ -10,7 +10,7 @@ use std::{
     },
     time::Duration,
 };
-use tauri::{AppHandle, Emitter, State};
+use tauri::{AppHandle, State};
 use tokio::sync::Mutex;
 use uuid::Uuid;
 use wisp_acp::{
@@ -992,22 +992,17 @@ pub(crate) async fn run_acp_internal_turn(
     .await
 }
 
-/// `emit_to` the turn's own window when it has one; internal turns (review
-/// correction, channels) have no window and fall back to a broadcast.
+/// Route ACP UI to windows of this conversation's project. Internal turns
+/// (review, channels) have no originating window, but same-project peers
+/// still need the cards; other projects must not see them.
 fn emit_ask_event(
     app: &AppHandle,
-    window_label: Option<&str>,
+    frame_id: &str,
+    project_id: Option<&str>,
     event: &str,
     payload: serde_json::Value,
 ) {
-    match window_label {
-        Some(label) => {
-            let _ = app.emit_to(label, event, payload);
-        }
-        None => {
-            let _ = app.emit(event, payload);
-        }
-    }
+    crate::emit_to_session_surfaces(app, frame_id, project_id, event, &payload);
 }
 
 /// Surface new pending bridge `ask_user` rows to the UI. `acp_asks` doubles as
@@ -1016,7 +1011,7 @@ fn emit_ask_event(
 async fn surface_pending_asks(
     state: &AppState,
     app: &AppHandle,
-    window_label: Option<&str>,
+    project_id: Option<&str>,
     frame_id: &str,
 ) {
     let pending = state
@@ -1036,11 +1031,12 @@ async fn surface_pending_asks(
             .lock()
             .unwrap()
             .insert(frame_id.to_string());
-        state.device_hub.mark_needs_user(frame_id, None);
+        state.device_hub.mark_needs_user(frame_id, project_id);
         let payload: serde_json::Value = serde_json::from_str(&payload_json).unwrap_or_default();
         emit_ask_event(
             app,
-            window_label,
+            frame_id,
+            project_id,
             "ask-user-request",
             serde_json::json!({
                 "frameId": frame_id,
@@ -1056,7 +1052,7 @@ async fn surface_pending_asks(
 async fn settle_expired_asks(
     state: &AppState,
     app: &AppHandle,
-    window_label: Option<&str>,
+    project_id: Option<&str>,
     frame_id: &str,
 ) {
     let expired = state
@@ -1082,7 +1078,8 @@ async fn settle_expired_asks(
     for (request_id, _) in expired {
         emit_ask_event(
             app,
-            window_label,
+            frame_id,
+            project_id,
             "ask-user-resolved",
             serde_json::json!({
                 "frameId": frame_id,
@@ -1123,7 +1120,7 @@ async fn run_acp_turn_with_kind(
     .await;
     // Runs on every exit path, success or error — asks must never outlive
     // their turn as live cards.
-    settle_expired_asks(state, app, window_label, frame_id).await;
+    settle_expired_asks(state, app, Some(project.id.as_str()), frame_id).await;
     result
 }
 
@@ -1131,7 +1128,7 @@ async fn run_acp_turn_with_kind(
 async fn run_acp_turn_inner(
     state: &AppState,
     app: &AppHandle,
-    window_label: Option<&str>,
+    _window_label: Option<&str>,
     project: &ActiveProject,
     frame_id: &str,
     profile_id: Option<&str>,
@@ -1143,9 +1140,12 @@ async fn run_acp_turn_inner(
 ) -> Result<String, String> {
     let runtime = runtime_for(state, project, frame_id, profile_id).await?;
     if let Some(session_state) = runtime.session_state.lock().await.take() {
-        let _ = app.emit(
+        crate::emit_to_session_surfaces(
+            app,
+            frame_id,
+            Some(project.id.as_str()),
             "acp-session-state",
-            serde_json::json!({
+            &serde_json::json!({
                 "frameId": frame_id,
                 "modes": session_state.modes,
                 "configOptions": session_state.config_options,
@@ -1173,19 +1173,21 @@ async fn run_acp_turn_inner(
     }
     let mut next_seq = begin_acp_turn(&state.store, frame_id, message, turn_kind).await?;
     if turn_kind == AcpTurnKind::User {
-        crate::emit_agent_event(
+        crate::emit_agent_event_in(
             app,
             AgentEvent::User {
                 frame_id: frame_id.to_string(),
                 text: message.to_string(),
             },
+            Some(project.id.as_str()),
         );
-        crate::emit_agent_event(
+        crate::emit_agent_event_in(
             app,
             AgentEvent::MessageBoundary {
                 frame_id: frame_id.to_string(),
                 seq: next_seq - 1,
             },
+            Some(project.id.as_str()),
         );
     }
     let prompt = runtime.handle.prompt(runtime.session_id.clone(), content);
@@ -1202,7 +1204,7 @@ async fn run_acp_turn_inner(
         tokio::select! {
             result = &mut prompt => break result.map_err(|error| error.to_string())?,
             _ = ask_tick.tick() => {
-                surface_pending_asks(state, app, window_label, frame_id).await;
+                surface_pending_asks(state, app, Some(project.id.as_str()), frame_id).await;
             }
             event = runtime.handle.next_event() => match event {
                 Some(AcpSessionEvent::Update { kind, payload, .. }) => {
@@ -1215,7 +1217,7 @@ async fn run_acp_turn_inner(
                             } else {
                                 AgentEvent::Reasoning { frame_id: frame_id.to_string(), delta: text.to_string() }
                             };
-                            crate::emit_agent_event(app, event);
+                            crate::emit_agent_event_in(app, event, Some(project.id.as_str()));
                         }
                     } else {
                         if matches!(kind, AcpUpdateKind::ToolCall | AcpUpdateKind::ToolCallUpdate) {
@@ -1224,11 +1226,17 @@ async fn run_acp_turn_inner(
                         if kind == AcpUpdateKind::Plan {
                             plan = Some(payload.clone());
                         }
-                        let _ = app.emit("acp-session-update", serde_json::json!({
-                            "frameId": frame_id,
-                            "kind": format!("{kind:?}"),
-                            "payload": payload,
-                        }));
+                        crate::emit_to_session_surfaces(
+                            app,
+                            frame_id,
+                            Some(project.id.as_str()),
+                            "acp-session-update",
+                            &serde_json::json!({
+                                "frameId": frame_id,
+                                "kind": format!("{kind:?}"),
+                                "payload": payload,
+                            }),
+                        );
                     }
                 }
                 Some(AcpSessionEvent::Permission(request)) => {
@@ -1252,7 +1260,13 @@ async fn run_acp_turn_inner(
                     state.awaiting_confirm.lock().unwrap().insert(frame_id.to_string());
                     state.device_hub.mark_needs_user(frame_id, Some(&project.id));
                     crate::channels::publish_approval_request(&pending.remote_request);
-                    let _ = app.emit("permission-request", permission_event(frame_id, &request));
+                    crate::emit_to_session_surfaces(
+                        app,
+                        frame_id,
+                        Some(project.id.as_str()),
+                        "permission-request",
+                        &permission_event(frame_id, &request),
+                    );
                 }
                 Some(AcpSessionEvent::Exited { error }) => return Err(error.unwrap_or_else(|| "ACP Agent exited.".into())),
                 None => return Err("ACP Agent event stream closed.".into()),
@@ -1277,21 +1291,23 @@ async fn run_acp_turn_inner(
                 if let Some(text) = text_from_payload(&payload) {
                     if kind == AcpUpdateKind::AgentMessage {
                         assistant.push_str(text);
-                        crate::emit_agent_event(
+                        crate::emit_agent_event_in(
                             app,
                             AgentEvent::Text {
                                 frame_id: frame_id.to_string(),
                                 delta: text.to_string(),
                             },
+                            Some(project.id.as_str()),
                         );
                     } else if kind == AcpUpdateKind::AgentThought {
                         reasoning.push_str(text);
-                        crate::emit_agent_event(
+                        crate::emit_agent_event_in(
                             app,
                             AgentEvent::Reasoning {
                                 frame_id: frame_id.to_string(),
                                 delta: text.to_string(),
                             },
+                            Some(project.id.as_str()),
                         );
                     }
                 }
@@ -1308,9 +1324,12 @@ async fn run_acp_turn_inner(
                     if kind == AcpUpdateKind::Plan {
                         plan = Some(payload.clone());
                     }
-                    let _ = app.emit(
+                    crate::emit_to_session_surfaces(
+                        app,
+                        frame_id,
+                        Some(project.id.as_str()),
                         "acp-session-update",
-                        serde_json::json!({
+                        &serde_json::json!({
                             "frameId": frame_id,
                             "kind": format!("{kind:?}"),
                             "payload": payload,
@@ -1366,13 +1385,14 @@ async fn run_acp_turn_inner(
     )
     .await;
     if !resources.is_empty() {
-        crate::emit_agent_event(
+        crate::emit_agent_event_in(
             app,
             AgentEvent::Resources {
                 frame_id: frame_id.to_string(),
                 seq: next_seq,
                 resources: resources.iter().map(Into::into).collect(),
             },
+            Some(project.id.as_str()),
         );
     }
     cancel_pending_permissions(state, frame_id, &runtime).await;
@@ -1479,9 +1499,13 @@ async fn respond_acp_permission_inner(
         state.awaiting_confirm.lock().unwrap().remove(&frame_id);
         state.device_hub.resolve_needs_user(&frame_id);
     }
-    let _ = app.emit(
+    let project_id = state.store.frame_project_id(&frame_id).await.ok().flatten();
+    crate::emit_to_session_surfaces(
+        app,
+        &frame_id,
+        project_id.as_deref(),
         "permission-resolved",
-        serde_json::json!({
+        &serde_json::json!({
             "frameId": frame_id,
             "requestId": request_id,
         }),
@@ -1538,7 +1562,7 @@ pub(crate) async fn respond_remote_permission(
 pub(crate) async fn respond_ask_user(
     state: State<'_, AppState>,
     app: AppHandle,
-    window: tauri::WebviewWindow,
+    _window: tauri::WebviewWindow,
     request_id: String,
     answer: String,
 ) -> Result<(), String> {
@@ -1579,10 +1603,15 @@ pub(crate) async fn respond_ask_user(
         state.awaiting_confirm.lock().unwrap().remove(&frame_id);
         state.device_hub.resolve_needs_user(&frame_id);
     }
-    let _ = app.emit_to(
-        window.label(),
+    // Route by the conversation's project, not the answering window's current
+    // binding. The window may have switched projects after the card appeared.
+    let project_id = state.store.frame_project_id(&frame_id).await.ok().flatten();
+    crate::emit_to_session_surfaces(
+        &app,
+        &frame_id,
+        project_id.as_deref(),
         "ask-user-resolved",
-        serde_json::json!({
+        &serde_json::json!({
             "frameId": frame_id,
             "requestId": request_id,
             "expired": false,
@@ -1625,9 +1654,12 @@ pub(crate) async fn set_acp_session_config(
         .await
         .map_err(|error| error.to_string())?;
     let value = serde_json::to_value(&options).map_err(|error| error.to_string())?;
-    let _ = app.emit(
+    crate::emit_to_session_surfaces(
+        &app,
+        &frame_id,
+        Some(project.id.as_str()),
         "acp-session-state",
-        serde_json::json!({
+        &serde_json::json!({
             "frameId": frame_id,
             "configOptions": value,
         }),

--- a/src-tauri/src/agent_turn.rs
+++ b/src-tauri/src/agent_turn.rs
@@ -814,7 +814,7 @@ pub(crate) async fn send_message_inner(
                     .await
                     .map_err(|error| error.to_string())?;
                 append_ui_event(&state.store, &frame_id, &mut event_seq, event.clone()).await;
-                emit_agent_event(&app, event);
+                emit_agent_event_in(&app, event, Some(ap.id.as_str()));
                 persist_and_emit_terminal_event(
                     state,
                     &app,
@@ -960,13 +960,14 @@ pub(crate) async fn send_message_inner(
                         )
                         .await;
                         if !resources.is_empty() {
-                            emit_agent_event(
+                            emit_agent_event_in(
                                 &resource_app,
                                 AgentEvent::Resources {
                                     frame_id: fid,
                                     seq,
                                     resources: resources.iter().map(Into::into).collect(),
                                 },
+                                Some(resource_project_id.as_str()),
                             );
                         }
                     }
@@ -1076,10 +1077,13 @@ pub(crate) async fn send_message_inner(
     let (live_event_handle, live_event_tx) = {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<AgentEvent>();
         let app = app.clone();
+        let live_project_id = ap.id.clone();
         let handle = tokio::spawn(coalesce_live_agent_events(
             rx,
             LIVE_EVENT_FLUSH_INTERVAL,
-            move |event| emit_agent_event_to_surfaces(&app, event),
+            move |event| {
+                emit_agent_event_to_surfaces_in(&app, event, Some(live_project_id.as_str()))
+            },
         ));
         (handle, tx)
     };
@@ -1241,7 +1245,7 @@ pub(crate) async fn send_message_inner(
                 },
             )
             .await;
-            emit_browser_tab_cleanup(state, &app, &browser_turn_id).await;
+            emit_browser_tab_cleanup(state, &app, &browser_turn_id, &ap.id).await;
             Ok(frame_id)
         }
         Err(e) => {
@@ -1261,17 +1265,29 @@ pub(crate) async fn send_message_inner(
                 },
             )
             .await;
-            emit_browser_tab_cleanup(state, &app, &browser_turn_id).await;
+            emit_browser_tab_cleanup(state, &app, &browser_turn_id, &ap.id).await;
             Err(client_turn_error(turn_started, &message))
         }
     }
 }
 
-async fn emit_browser_tab_cleanup(state: &AppState, app: &AppHandle, turn_id: &str) {
+async fn emit_browser_tab_cleanup(
+    state: &AppState,
+    app: &AppHandle,
+    turn_id: &str,
+    project_id: &str,
+) {
     if let browser_bridge::TabCleanupAction::Prompt(prompt) =
         state.browser_bridge.complete_turn(turn_id).await
     {
-        let _ = app.emit("browser-tab-cleanup", prompt);
+        emit_to_session_surfaces_filtered(
+            app,
+            &prompt.frame_id,
+            Some(project_id),
+            "browser-tab-cleanup",
+            &prompt,
+            false,
+        );
     }
 }
 

--- a/src-tauri/src/app_state.rs
+++ b/src-tauri/src/app_state.rs
@@ -470,9 +470,8 @@ pub(crate) struct AppState {
     /// frame id explicitly (`TauriOutput.frame_id`).
     pub(crate) active_frame: std::sync::RwLock<HashMap<String, String>>,
     /// Window that most recently submitted a user-routed turn for each session.
-    /// Agent events are process-wide, so every frontend window asks for the
-    /// same desktop notification. This origin lets the backend choose exactly
-    /// one window without conflating two conversations in the same project.
+    /// Live agent/approval UI is scoped to windows of the session's project;
+    /// this origin still picks which window owns the desktop notification.
     pub(crate) notification_window: std::sync::RwLock<HashMap<String, String>>,
     /// Per-session confirm channels, keyed by frame id.
     pub(crate) confirms: ConfirmMap,
@@ -596,6 +595,37 @@ impl AppState {
             origin.get(frame_id).map(String::as_str),
             frame_id,
             project_id,
+            &active_projects,
+            &active_frames,
+        )
+    }
+
+    /// Windows currently bound to this session's project. Live agent, approval,
+    /// and browser-cleanup events use this set so a second project window never
+    /// receives another workspace's stream.
+    pub(crate) fn session_surface_labels(
+        &self,
+        frame_id: &str,
+        project_id: Option<&str>,
+    ) -> Vec<String> {
+        let active = self.active.read().unwrap();
+        let active_projects = active
+            .iter()
+            .map(|(label, project)| (label.clone(), project.id.clone()))
+            .collect::<HashMap<_, _>>();
+        let active_frames = self.active_frame.read().unwrap();
+        let inferred = project_id.map(str::to_string).or_else(|| {
+            active_frames.iter().find_map(|(label, viewed)| {
+                (viewed.as_str() == frame_id)
+                    .then(|| active.get(label).map(|project| project.id.clone()))
+                    .flatten()
+            })
+        });
+        let origin = self.notification_window.read().unwrap();
+        session_surface_window_labels(
+            origin.get(frame_id).map(String::as_str),
+            frame_id,
+            inferred.as_deref(),
             &active_projects,
             &active_frames,
         )

--- a/src-tauri/src/delegation_completion.rs
+++ b/src-tauri/src/delegation_completion.rs
@@ -411,9 +411,10 @@ async fn dispatch_frame(app: AppHandle, frame_id: String) {
         // before either auto-resume or the next user turn.
         *runtime.agent.lock().await = None;
     }
+    let project_id = state.store.frame_project_id(&frame_id).await.ok().flatten();
     for delivery in &delivered {
         let result = delivery.result_json.clone().unwrap_or_default();
-        crate::emit_agent_event(
+        crate::emit_agent_event_in(
             &app,
             AgentEvent::DelegationCompleted {
                 frame_id: frame_id.clone(),
@@ -422,6 +423,7 @@ async fn dispatch_frame(app: AppHandle, frame_id: String) {
                 result,
                 auto_resume: delivery.auto_resume,
             },
+            project_id.as_deref(),
         );
     }
     let claimed = match state

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -267,6 +267,35 @@ enum AgentEvent {
     },
 }
 
+impl AgentEvent {
+    fn frame_id(&self) -> &str {
+        match self {
+            Self::User { frame_id, .. }
+            | Self::MessageBoundary { frame_id, .. }
+            | Self::Resources { frame_id, .. }
+            | Self::Text { frame_id, .. }
+            | Self::Reasoning { frame_id, .. }
+            | Self::ToolCall { frame_id, .. }
+            | Self::ToolResult { frame_id, .. }
+            | Self::ToolPresentation { frame_id, .. }
+            | Self::Usage { frame_id, .. }
+            | Self::Compaction { frame_id, .. }
+            | Self::CompactionStarted { frame_id, .. }
+            | Self::ContextWarning { frame_id, .. }
+            | Self::Diff { frame_id, .. }
+            | Self::FileChanged { frame_id, .. }
+            | Self::Stdout { frame_id, .. }
+            | Self::Done { frame_id, .. }
+            | Self::Error { frame_id, .. }
+            | Self::DelegationCompleted { frame_id, .. }
+            | Self::ReviewStarted { frame_id, .. }
+            | Self::ReviewFailed { frame_id, .. }
+            | Self::Review { frame_id, .. }
+            | Self::CorrectionStarted { frame_id, .. } => frame_id,
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Clone, PartialEq, Eq)]
 pub(crate) struct ConfirmRequest {
     /// Opaque, one-shot capability used by text-only remote approval surfaces.
@@ -294,8 +323,14 @@ impl ConfirmRequest {
     }
 }
 
-fn emit_confirm_request(app: &AppHandle, request: &ConfirmRequest) {
-    let _ = app.emit("confirm-request", request.clone());
+fn emit_confirm_request(app: &AppHandle, request: &ConfirmRequest, project_id: Option<&str>) {
+    emit_to_session_surfaces(
+        app,
+        &request.frame_id,
+        project_id,
+        "confirm-request",
+        request,
+    );
     channels::publish_approval_request(request);
 }
 
@@ -332,7 +367,7 @@ async fn request_image_resize_confirmation(
         .unwrap()
         .insert(frame_id.to_string());
     state.device_hub.mark_needs_user(frame_id, Some(project_id));
-    emit_confirm_request(app, &request);
+    emit_confirm_request(app, &request, Some(project_id));
     let approved = receive_confirm_decision(rx).await.approved();
     state.confirms.lock().unwrap().remove(frame_id);
     state.awaiting_confirm.lock().unwrap().remove(frame_id);
@@ -1787,7 +1822,8 @@ async fn persist_and_emit_terminal_event(
         Ok(mut seq) => append_ui_event(&state.store, frame_id, &mut seq, event.clone()).await,
         Err(error) => tracing::warn!("load terminal UI event sequence failed: {error}"),
     }
-    emit_agent_event(app, event);
+    let project_id = state.store.frame_project_id(frame_id).await.ok().flatten();
+    emit_agent_event_in(app, event, project_id.as_deref());
 }
 
 /// Keep the raw terminal records intact for support bundles. Historical
@@ -2194,6 +2230,81 @@ fn select_notification_window(
         .map(|label| selection(label, false))
 }
 
+/// Windows that should receive live session UI (agent stream, approvals).
+///
+/// Every window currently bound to the session's project sees the stream, so two
+/// views of the same workspace stay in sync. A window bound to a different
+/// project never does — unlike desktop notifications, live UI must not fall
+/// back onto a foreign workspace. Unbound File → New Window views and `pet`
+/// are excluded here; the pet overlay is added at emit time.
+fn session_surface_window_labels(
+    _origin: Option<&str>,
+    frame_id: &str,
+    project_id: Option<&str>,
+    active_projects: &HashMap<String, String>,
+    active_frames: &HashMap<String, String>,
+) -> Vec<String> {
+    let mut labels = if let Some(project_id) = project_id {
+        active_projects
+            .iter()
+            .filter(|(label, active_project)| {
+                label.as_str() != "pet" && active_project.as_str() == project_id
+            })
+            .map(|(label, _)| label.clone())
+            .collect::<Vec<_>>()
+    } else {
+        // Unknown owner: only windows already viewing this conversation.
+        // Never broadcast to `main` or to the origin's current (possibly
+        // foreign) project.
+        active_frames
+            .iter()
+            .filter(|(label, viewed)| viewed.as_str() == frame_id && label.as_str() != "pet")
+            .map(|(label, _)| label.clone())
+            .collect::<Vec<_>>()
+    };
+    labels.sort();
+    labels.dedup();
+    labels
+}
+
+/// Emit a live session event only to windows of that conversation's project.
+///
+/// `channels` / device-hub publishers stay process-wide; this helper is the
+/// GUI fan-out. The desktop pet listens for agent/approval activity, so it is
+/// included unless the caller is a window-local overlay such as browser-tab
+/// cleanup.
+pub(crate) fn emit_to_session_surfaces<T: Clone + Serialize>(
+    app: &AppHandle,
+    frame_id: &str,
+    project_id: Option<&str>,
+    event: &str,
+    payload: &T,
+) {
+    emit_to_session_surfaces_filtered(app, frame_id, project_id, event, payload, true);
+}
+
+pub(crate) fn emit_to_session_surfaces_filtered<T: Clone + Serialize>(
+    app: &AppHandle,
+    frame_id: &str,
+    project_id: Option<&str>,
+    event: &str,
+    payload: &T,
+    include_pet: bool,
+) {
+    let state = app.state::<AppState>();
+    let mut labels = state.session_surface_labels(frame_id, project_id);
+    if include_pet {
+        // The pet overlay is Windows-only; emit_to is a no-op if that window
+        // does not exist on this platform.
+        labels.push("pet".to_string());
+    }
+    labels.sort();
+    labels.dedup();
+    for label in labels {
+        let _ = app.emit_to(&label, event, payload.clone());
+    }
+}
+
 #[tauri::command]
 async fn update_mcp_app_context(
     state: State<'_, AppState>,
@@ -2309,7 +2420,7 @@ async fn request_mcp_app_tool_confirmation(
         .unwrap()
         .insert(frame_id.to_string());
     state.device_hub.mark_needs_user(frame_id, Some(project_id));
-    emit_confirm_request(app, &request);
+    emit_confirm_request(app, &request, Some(project_id));
     let decision = receive_confirm_decision(rx).await;
     state.confirms.lock().unwrap().remove(frame_id);
     state.awaiting_confirm.lock().unwrap().remove(frame_id);
@@ -2682,10 +2793,14 @@ impl TauriOutput {
         match &self.live_events {
             Some(tx) => {
                 if let Err(send_error) = tx.send(event) {
-                    emit_agent_event_to_surfaces(&self.app, send_error.0);
+                    emit_agent_event_to_surfaces_in(
+                        &self.app,
+                        send_error.0,
+                        Some(&self.project_id),
+                    );
                 }
             }
-            None => emit_agent_event_to_surfaces(&self.app, event),
+            None => emit_agent_event_to_surfaces_in(&self.app, event, Some(&self.project_id)),
         }
     }
 
@@ -2726,7 +2841,7 @@ impl TauriOutput {
             .insert(self.frame_id.clone());
         self.device_hub
             .mark_needs_user(&self.frame_id, Some(&self.project_id));
-        emit_confirm_request(&self.app, &request);
+        emit_confirm_request(&self.app, &request, Some(&self.project_id));
 
         // There is deliberately no timeout: lack of approval must never be
         // converted into a denial that lets the same agent turn continue.
@@ -2775,18 +2890,19 @@ impl TauriOutput {
     }
 }
 
-fn emit_agent_event_to_surfaces(app: &AppHandle, event: AgentEvent) {
+fn emit_agent_event_to_surfaces_in(app: &AppHandle, event: AgentEvent, project_id: Option<&str>) {
     if !matches!(event, AgentEvent::ToolPresentation { .. }) {
         channels::publish_agent_event(&event);
     }
-    let _ = app.emit("agent", event);
+    let frame_id = event.frame_id().to_string();
+    emit_to_session_surfaces(app, &frame_id, project_id, "agent", &event);
 }
 
-fn emit_agent_event(app: &AppHandle, event: AgentEvent) {
+pub(crate) fn emit_agent_event_in(app: &AppHandle, event: AgentEvent, project_id: Option<&str>) {
     app.state::<AppState>()
         .device_hub
-        .apply_agent_event(&event, None);
-    emit_agent_event_to_surfaces(app, event);
+        .apply_agent_event(&event, project_id);
+    emit_agent_event_to_surfaces_in(app, event, project_id);
 }
 
 fn should_persist_ui_event(event: &AgentEvent) -> bool {
@@ -5387,13 +5503,19 @@ async fn persist_review(
     }
 }
 
-fn emit_review(app: &AppHandle, frame_id: &str, report: review::ReviewReport) {
-    emit_agent_event(
+fn emit_review(
+    app: &AppHandle,
+    frame_id: &str,
+    report: review::ReviewReport,
+    project_id: Option<&str>,
+) {
+    emit_agent_event_in(
         app,
         AgentEvent::Review {
             frame_id: frame_id.to_string(),
             report,
         },
+        project_id,
     );
 }
 
@@ -5437,7 +5559,7 @@ async fn automatic_review(
         }
         Ok(mut report) => {
             persist_review(&state.store, frame_id, agent.ctx.messages.len(), &report).await;
-            emit_review(app, frame_id, report.clone());
+            emit_review(app, frame_id, report.clone(), Some(&output.project_id));
             if report.has_findings() {
                 agent.ctx.inject_user(review::correction_prompt(&report));
                 output.emit(AgentEvent::CorrectionStarted {
@@ -5472,7 +5594,7 @@ async fn automatic_review(
                     }
                 }
                 persist_review(&state.store, frame_id, agent.ctx.messages.len(), &report).await;
-                emit_review(app, frame_id, report);
+                emit_review(app, frame_id, report, Some(&output.project_id));
             }
         }
     }
@@ -5505,26 +5627,28 @@ async fn automatic_review_acp(
         return;
     }
 
-    emit_agent_event(
+    emit_agent_event_in(
         app,
         AgentEvent::ReviewStarted {
             frame_id: frame_id.to_string(),
         },
+        Some(project.id.as_str()),
     );
     match generate_review(state, frame_id, &msgs, Some(cancel)).await {
         Err(error) => {
             tracing::warn!("automatic ACP review failed for {frame_id}: {error}");
-            emit_agent_event(
+            emit_agent_event_in(
                 app,
                 AgentEvent::ReviewFailed {
                     frame_id: frame_id.to_string(),
                     message: error,
                 },
+                Some(project.id.as_str()),
             );
         }
         Ok(mut report) => {
             persist_review(&state.store, frame_id, msgs.len(), &report).await;
-            emit_review(app, frame_id, report.clone());
+            emit_review(app, frame_id, report.clone(), Some(project.id.as_str()));
             if report.has_findings() {
                 let model = match state.store.get_acp_session(frame_id).await {
                     Ok(Some(binding)) => {
@@ -5534,12 +5658,13 @@ async fn automatic_review_acp(
                     }
                     _ => "ACP Agent".into(),
                 };
-                emit_agent_event(
+                emit_agent_event_in(
                     app,
                     AgentEvent::CorrectionStarted {
                         frame_id: frame_id.to_string(),
                         model,
                     },
+                    Some(project.id.as_str()),
                 );
                 let correction_prompt = review::correction_prompt(&report);
                 let correction =
@@ -5547,12 +5672,13 @@ async fn automatic_review_acp(
                         .await;
                 if let Err(error) = correction {
                     tracing::warn!("automatic ACP correction failed for {frame_id}: {error}");
-                    emit_agent_event(
+                    emit_agent_event_in(
                         app,
                         AgentEvent::ReviewFailed {
                             frame_id: frame_id.to_string(),
                             message: format!("correction turn failed: {error}"),
                         },
+                        Some(project.id.as_str()),
                     );
                     report.set_status("unaddressed");
                 } else {
@@ -5566,12 +5692,13 @@ async fn automatic_review_acp(
                                     tracing::warn!(
                                     "automatic ACP follow-up review failed for {frame_id}: {error}"
                                 );
-                                    emit_agent_event(
+                                    emit_agent_event_in(
                                         app,
                                         AgentEvent::ReviewFailed {
                                             frame_id: frame_id.to_string(),
                                             message: format!("follow-up review failed: {error}"),
                                         },
+                                        Some(project.id.as_str()),
                                     );
                                     report.set_status("unaddressed");
                                 }
@@ -5581,12 +5708,13 @@ async fn automatic_review_acp(
                             tracing::warn!(
                                 "load corrected ACP transcript failed for {frame_id}: {error}"
                             );
-                            emit_agent_event(
+                            emit_agent_event_in(
                                 app,
                                 AgentEvent::ReviewFailed {
                                     frame_id: frame_id.to_string(),
                                     message: format!("load corrected transcript failed: {error}"),
                                 },
+                                Some(project.id.as_str()),
                             );
                             report.set_status("unaddressed");
                         }
@@ -5599,7 +5727,7 @@ async fn automatic_review_acp(
                     .map(|messages| messages.len())
                     .unwrap_or(msgs.len());
                 persist_review(&state.store, frame_id, message_count, &report).await;
-                emit_review(app, frame_id, report);
+                emit_review(app, frame_id, report, Some(project.id.as_str()));
             }
         }
     }
@@ -5716,32 +5844,35 @@ async fn review_session(
         {
             return Err("Nothing to review yet.".into());
         }
-        emit_agent_event(
+        emit_agent_event_in(
             &app,
             AgentEvent::ReviewStarted {
                 frame_id: frame_id.clone(),
             },
+            Some(project_id.as_str()),
         );
         let report = match generate_review(&state, &frame_id, &msgs, None).await {
             Ok(report) => report,
             Err(error) => {
-                emit_agent_event(
+                emit_agent_event_in(
                     &app,
                     AgentEvent::ReviewFailed {
                         frame_id: frame_id.clone(),
                         message: error.clone(),
                     },
+                    Some(project_id.as_str()),
                 );
                 return Err(error);
             }
         };
         persist_review(&state.store, &frame_id, msgs.len(), &report).await;
-        emit_agent_event(
+        emit_agent_event_in(
             &app,
             AgentEvent::Review {
                 frame_id: frame_id.clone(),
                 report,
             },
+            Some(project_id.as_str()),
         );
         Ok(())
     }

--- a/src-tauri/src/lib_tests.rs
+++ b/src-tauri/src/lib_tests.rs
@@ -2200,6 +2200,70 @@ fn foreign_project_notification_fallback_never_arms_focus_navigation() {
     );
 }
 
+#[test]
+fn session_surfaces_include_every_window_of_the_owning_project() {
+    let active_projects = HashMap::from([
+        ("main".to_string(), "workspace".to_string()),
+        ("proj-workspace".to_string(), "workspace".to_string()),
+        ("proj-other".to_string(), "other".to_string()),
+        ("pet".to_string(), "workspace".to_string()),
+    ]);
+    let active_frames = HashMap::from([
+        ("main".to_string(), "session-a".to_string()),
+        ("proj-workspace".to_string(), "session-b".to_string()),
+        ("proj-other".to_string(), "session-c".to_string()),
+    ]);
+
+    assert_eq!(
+        super::session_surface_window_labels(
+            Some("main"),
+            "session-a",
+            Some("workspace"),
+            &active_projects,
+            &active_frames,
+        ),
+        vec!["main".to_string(), "proj-workspace".to_string()],
+    );
+}
+
+#[test]
+fn session_surfaces_never_fall_back_onto_a_foreign_project() {
+    let active_projects = HashMap::from([("main".to_string(), "project-b".to_string())]);
+    let active_frames = HashMap::from([("main".to_string(), "session-b".to_string())]);
+
+    assert!(super::session_surface_window_labels(
+        Some("main"),
+        "session-a",
+        Some("project-a"),
+        &active_projects,
+        &active_frames,
+    )
+    .is_empty());
+}
+
+#[test]
+fn session_surfaces_without_project_id_only_hit_windows_viewing_the_session() {
+    let active_projects = HashMap::from([
+        ("main".to_string(), "workspace".to_string()),
+        ("proj-workspace".to_string(), "workspace".to_string()),
+    ]);
+    let active_frames = HashMap::from([
+        ("main".to_string(), "session-a".to_string()),
+        ("proj-workspace".to_string(), "session-b".to_string()),
+    ]);
+
+    assert_eq!(
+        super::session_surface_window_labels(
+            Some("proj-workspace"),
+            "session-b",
+            None,
+            &active_projects,
+            &active_frames,
+        ),
+        vec!["proj-workspace".to_string()],
+    );
+}
+
 // Queue (#433): the enqueue/driver protocol must (a) claim exactly one driver,
 // (b) drain FIFO, and (c) let a later enqueue re-claim after the queue empties —
 // otherwise an item enqueued just as the driver exits would strand with no runner.

--- a/src-tauri/src/turn_undo.rs
+++ b/src-tauri/src/turn_undo.rs
@@ -465,12 +465,13 @@ pub(super) async fn undo_turn(
             .await?;
     }
     for change in applied {
-        crate::emit_agent_event(
+        crate::emit_agent_event_in(
             &app,
             AgentEvent::FileChanged {
                 frame_id: frame_id.clone(),
                 path: change.path,
             },
+            Some(project.id.as_str()),
         );
     }
     Ok(preview)

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -12928,6 +12928,35 @@ test("desktop pet shows active Run titles and celebrates completion (#693)", asy
   await expect(pet.getByText("Done")).toBeVisible();
 });
 
+test("session events listen on the current window", async ({ page }) => {
+  await enterApp(page);
+  const windowEvents = [
+    "agent",
+    "confirm-request",
+    "browser-tab-cleanup",
+    "permission-request",
+    "acp-session-update",
+    "acp-session-state",
+    "permission-resolved",
+    "ask-user-request",
+    "ask-user-resolved",
+  ];
+  for (const event of windowEvents) {
+    await expect.poll(() => page.evaluate((name) =>
+      Boolean((window as any).__tauriListenerReady?.(name)), event
+    )).toBe(true);
+    await expect.poll(() => page.evaluate((name) =>
+      (window as any).__tauriListenerScope(name), event
+    )).toBe("window");
+  }
+  await expect.poll(() => page.evaluate(() =>
+    Boolean((window as any).__tauriListenerReady?.("bootstrap-status")),
+  )).toBe(true);
+  await expect.poll(() => page.evaluate(() =>
+    (window as any).__tauriListenerScope("bootstrap-status"),
+  )).toBe("app");
+});
+
 test("notification navigation opens the project and session that need the user (#499)", async ({ page }) => {
   await page.goto("/");
   await expect.poll(() => page.evaluate(() =>

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -2368,8 +2368,10 @@ fn App() -> impl IntoView {
         attach_chat_autoscroll();
     });
 
-    // Wire the agent event stream once. Every event carries the session frame
-    // id; route transcript mutations to `items` (active session) or the
+    // Wire the agent event stream once, on this native window only. Process-level
+    // listen() still receives emit_to aimed at another project window, so two
+    // workspaces would share one live stream. Every event carries the session
+    // frame id; route transcript mutations to `items` (active session) or the
     // `transcripts` cache (background session) so parallel conversations don't
     // interleave in the view.
     let items_cb = items;
@@ -3336,9 +3338,9 @@ fn App() -> impl IntoView {
     let agent_js = cb.as_ref().unchecked_ref::<js_sys::Function>().clone();
     std::mem::forget(cb);
     // wasm-bindgen only runs an async extern's JS body when the returned
-    // future is polled, so we must await `listen` (not fire-and-forget it).
+    // future is polled, so we must await `listen_current_window`.
     spawn_local(async move {
-        let _ = listen("agent", &agent_js).await;
+        let _ = listen_current_window("agent", &agent_js).await;
     });
 
     // Confirm handler: render an inline approval card in the session thread
@@ -3411,7 +3413,7 @@ fn App() -> impl IntoView {
         .clone();
     std::mem::forget(confirm_cb);
     spawn_local(async move {
-        let _ = listen("confirm-request", &confirm_js).await;
+        let _ = listen_current_window("confirm-request", &confirm_js).await;
     });
 
     let browser_cleanup_pending = browser_tab_cleanup;
@@ -3435,7 +3437,7 @@ fn App() -> impl IntoView {
         .clone();
     std::mem::forget(browser_cleanup_cb);
     spawn_local(async move {
-        let _ = listen("browser-tab-cleanup", &browser_cleanup_js).await;
+        let _ = listen_current_window("browser-tab-cleanup", &browser_cleanup_js).await;
         if let Ok(value) =
             invoke_checked("list_pending_browser_tab_cleanups", JsValue::UNDEFINED).await
         {
@@ -3497,7 +3499,7 @@ fn App() -> impl IntoView {
         .clone();
     acp_permission_cb.forget();
     spawn_local(async move {
-        let _ = listen("permission-request", &acp_permission_js).await;
+        let _ = listen_current_window("permission-request", &acp_permission_js).await;
     });
 
     let acp_update_buf = delta_buf.clone();
@@ -3604,7 +3606,7 @@ fn App() -> impl IntoView {
         .clone();
     acp_update_cb.forget();
     spawn_local(async move {
-        let _ = listen("acp-session-update", &acp_update_js).await;
+        let _ = listen_current_window("acp-session-update", &acp_update_js).await;
     });
 
     let project_transfer_cb = Closure::wrap(Box::new(move |payload: JsValue| {
@@ -3644,7 +3646,7 @@ fn App() -> impl IntoView {
         .clone();
     acp_state_cb.forget();
     spawn_local(async move {
-        let _ = listen("acp-session-state", &acp_state_js).await;
+        let _ = listen_current_window("acp-session-state", &acp_state_js).await;
     });
 
     let acp_resolved_cb = Closure::wrap(Box::new(move |payload: JsValue| {
@@ -3670,7 +3672,7 @@ fn App() -> impl IntoView {
         .clone();
     acp_resolved_cb.forget();
     spawn_local(async move {
-        let _ = listen("permission-resolved", &acp_resolved_js).await;
+        let _ = listen_current_window("permission-resolved", &acp_resolved_js).await;
     });
 
     // ACP `ask_user`: the bridge parks the agent's question until the user
@@ -3702,7 +3704,7 @@ fn App() -> impl IntoView {
         .clone();
     ask_user_cb.forget();
     spawn_local(async move {
-        let _ = listen("ask-user-request", &ask_user_js).await;
+        let _ = listen_current_window("ask-user-request", &ask_user_js).await;
     });
 
     let ask_resolved_cb = Closure::wrap(Box::new(move |payload: JsValue| {
@@ -3735,7 +3737,7 @@ fn App() -> impl IntoView {
         .clone();
     ask_resolved_cb.forget();
     spawn_local(async move {
-        let _ = listen("ask-user-resolved", &ask_resolved_js).await;
+        let _ = listen_current_window("ask-user-resolved", &ask_resolved_js).await;
     });
 
     let stop = move |_| {


### PR DESCRIPTION
Closes #1079

属于 #1074。

## 用户问题

后端即使 `emit_to` 指定窗口，前端若仍用进程级 `listen()`，每个窗口还是会收到别的窗口的事件。无对应窗口时也不能回落到另一个项目的主窗口。

## 改动

前端这些事件改为 `listen_current_window`（与 `open-session` 相同）：

- `agent`、`confirm-request`、`browser-tab-cleanup`
- `permission-request`、`acp-session-update`、`acp-session-state`
- `permission-resolved`、`ask-user-request`、`ask-user-resolved`

`bootstrap-status`、`channels-updated` 继续进程级监听。

后端 `emit_to` 只发给该会话所属项目的窗口；没有对应窗口时**不**回落外项目 `main`。

**`ask-user-resolved` 按 `frame_project_id` 投递，不用窗口当前项目。** 这是对 PR #1072 原型的修正。

## 测试

- `session_surfaces_include_every_window_of_the_owning_project`
- `session_surfaces_never_fall_back_onto_a_foreign_project`
- `session_surfaces_without_project_id_only_hit_windows_viewing_the_session`
- Playwright：`session events listen on the current window`（断言 `__tauriListenerScope`）
- `cd ui && cargo check --target wasm32-unknown-unknown`