### PR TITLE
feat(desktop): File 菜单「新建窗口」打开空白项目首页

### DIFF
--- a/docs/workspace-navigation.md
+++ b/docs/workspace-navigation.md
@@ -6,8 +6,9 @@ in the sidebar, but it is not treated as the last conversation. Opening a
 specific conversation from Recent sessions or search still takes priority.
 
 Choose another workspace from the sidebar workspace menu to switch the current
-window in place. A separate window is opened only by an action explicitly
-labelled **Open in new window**.
+window in place. **File → New Window** opens a blank GUI on the Projects home
+screen; it does not inherit the current workspace. A dedicated project window
+is opened by any action labelled **Open in new window**.
 
 Each window title includes the open workspace name
 (`wisp science — my-project`) so the taskbar, Alt-Tab, and macOS title bar can

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -2,7 +2,7 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "Main window IPC: core APIs and agent event stream",
-  "windows": ["main", "proj-*"],
+  "windows": ["main", "proj-*", "home-*"],
   "remote": {
     "urls": ["http://localhost:1421", "http://127.0.0.1:1421"]
   },

--- a/src-tauri/src/agent_turn.rs
+++ b/src-tauri/src/agent_turn.rs
@@ -87,7 +87,7 @@ pub(crate) async fn send_message_inner(
     if !resume && message.trim().is_empty() {
         return Err("message is empty".into());
     }
-    let mut ap = state.active(window_label);
+    let mut ap = state.require_active(window_label)?;
     let mut explicit_scope = None;
     // A session belongs to one project for life, but the per-window active slot
     // can drift while it keeps running (another project opened in this window,

--- a/src-tauri/src/app_commands.rs
+++ b/src-tauri/src/app_commands.rs
@@ -207,7 +207,7 @@ pub(super) async fn upload_to_context(
             }
         }
     };
-    let ap = state.active(window.label());
+    let ap = state.require_active(window.label())?;
     let frame_id = state.active_frame(window.label());
     crate::run_context::submit_local_uploads_to_context(
         &state.store,
@@ -424,7 +424,7 @@ pub(super) async fn get_capabilities(
     state: State<'_, AppState>,
     window: tauri::WebviewWindow,
 ) -> Result<Capabilities, String> {
-    let ap = state.active(window.label());
+    let ap = state.require_active(window.label())?;
     let tags = load_skill_tags(&state.store).await;
     let (catalog, enabled) = project_skill_catalog(&state.store, &ap).await;
     let skills = skill_infos(&catalog, &tags, enabled.as_ref());
@@ -641,7 +641,7 @@ pub(super) fn reveal_in_file_manager(
     path: String,
 ) -> Result<(), String> {
     use tauri_plugin_opener::OpenerExt;
-    let ap = state.active(window.label());
+    let ap = state.require_active(window.label())?;
     let real = wisp_tools::safety::validate_file_path(&ap.root, &path)?;
     if !real.exists() {
         return Err(format!("file not found: {path}"));
@@ -659,7 +659,7 @@ pub(super) fn open_workspace_path(
     path: String,
 ) -> Result<(), String> {
     use tauri_plugin_opener::OpenerExt;
-    let ap = state.active(window.label());
+    let ap = state.require_active(window.label())?;
     let real = wisp_tools::safety::validate_file_path(&ap.root, &path)?;
     if !real.exists() {
         return Err(format!("file not found: {path}"));

--- a/src-tauri/src/app_state.rs
+++ b/src-tauri/src/app_state.rs
@@ -532,12 +532,16 @@ impl AppState {
     }
     /// Snapshot a window's active project. Falls back to the "main" window's
     /// project (always initialized at startup) for un-scoped or early calls.
+    /// File → New Window views (`home-*`) never inherit another window's
+    /// workspace — they must open a project first.
     pub(crate) fn active(&self, label: &str) -> ActiveProject {
-        let map = self.active.read().unwrap();
-        map.get(label)
-            .or_else(|| map.get("main"))
-            .cloned()
-            .expect("main window active project is initialized at startup")
+        self.require_active(label)
+            .unwrap_or_else(|err| panic!("{err}"))
+    }
+    /// Like [`Self::active`], but blank File → New Window views without a bound
+    /// project return an error instead of leaking the main window's workspace.
+    pub(crate) fn require_active(&self, label: &str) -> Result<ActiveProject, String> {
+        lookup_window_binding(&self.active.read().unwrap(), label).cloned()
     }
     pub(crate) fn set_active(&self, label: &str, ap: ActiveProject) {
         self.active.write().unwrap().insert(label.to_string(), ap);
@@ -634,15 +638,39 @@ impl AppState {
     }
 }
 
+pub(crate) const BLANK_WINDOW_NO_PROJECT: &str =
+    "Open a project in this window before running that action.";
+
 /// File → New Window labels (`home-<uuid>`). Those views are not restored on
 /// launch, so they must not be written into `window_active_projects`.
 pub(crate) fn is_blank_window_label(label: &str) -> bool {
     label.starts_with("home-") && label.len() > "home-".len()
 }
 
+/// Resolve which project a window command may touch.
+///
+/// A File → New Window view has its own label and no binding until the user
+/// opens a project in that GUI. Falling back to `main` would let that window
+/// read or mutate another project's workspace, sessions, and runtimes.
+pub(crate) fn lookup_window_binding<'a, T>(
+    bound: &'a HashMap<String, T>,
+    label: &str,
+) -> Result<&'a T, String> {
+    if let Some(value) = bound.get(label) {
+        return Ok(value);
+    }
+    if is_blank_window_label(label) {
+        return Err(BLANK_WINDOW_NO_PROJECT.into());
+    }
+    bound
+        .get("main")
+        .ok_or_else(|| "main window active project is initialized at startup".into())
+}
+
 #[cfg(test)]
 mod tests {
-    use super::is_blank_window_label;
+    use super::{is_blank_window_label, lookup_window_binding, BLANK_WINDOW_NO_PROJECT};
+    use std::collections::HashMap;
 
     #[test]
     fn blank_window_labels_are_home_prefixed() {
@@ -654,5 +682,25 @@ mod tests {
         assert!(!is_blank_window_label("main"));
         assert!(!is_blank_window_label("proj-default"));
         assert!(!is_blank_window_label("pet"));
+    }
+
+    #[test]
+    fn blank_windows_do_not_inherit_the_main_project() {
+        let mut bound = HashMap::new();
+        bound.insert("main".to_string(), "project-a");
+        assert_eq!(
+            lookup_window_binding(&bound, "home-1").unwrap_err(),
+            BLANK_WINDOW_NO_PROJECT
+        );
+        assert_eq!(
+            *lookup_window_binding(&bound, "proj-default").unwrap(),
+            "project-a"
+        );
+        bound.insert("home-1".to_string(), "project-b");
+        assert_eq!(
+            *lookup_window_binding(&bound, "home-1").unwrap(),
+            "project-b"
+        );
+        assert_eq!(*lookup_window_binding(&bound, "main").unwrap(), "project-a");
     }
 }

--- a/src-tauri/src/exploration_commands.rs
+++ b/src-tauri/src/exploration_commands.rs
@@ -782,7 +782,7 @@ pub(crate) async fn working_project_for_active_frame(
     match state.active_frame(window_label) {
         Some(frame_id) => working_project_for_frame(state, &frame_id).await,
         None => {
-            let project = state.active(window_label);
+            let project = state.require_active(window_label)?;
             Ok((project.clone(), StateScope::mainline(project.id.clone())))
         }
     }
@@ -893,7 +893,7 @@ pub(crate) async fn start_exploration(
         .await
         .map_err(|error| error.to_string())?
         .ok_or_else(|| coded_error(ERR_HISTORY_UNAVAILABLE, "source conversation not found"))?;
-    let active = state.active(window.label());
+    let active = state.require_active(window.label())?;
     if owner.project_id() != active.id || !matches!(owner, StateScope::Mainline { .. }) {
         return Err("Source conversation does not belong to the active mainline".into());
     }
@@ -964,7 +964,7 @@ pub(crate) async fn list_project_explorations(
     state: State<'_, AppState>,
     window: WebviewWindow,
 ) -> Result<Vec<ExplorationSummary>, String> {
-    let project = state.active(window.label());
+    let project = state.require_active(window.label())?;
     state
         .store
         .list_project_explorations(&project.id)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3362,6 +3362,7 @@ struct MacMenuLabels {
     help: &'static str,
     theme: &'static str,
     new_session: &'static str,
+    new_window: &'static str,
     projects: &'static str,
     files: &'static str,
     export_current_project: &'static str,
@@ -3405,6 +3406,7 @@ fn mac_menu_labels(locale: AppMenuLocale) -> MacMenuLabels {
             help: "帮助",
             theme: "主题",
             new_session: "新建会话",
+            new_window: "新建窗口",
             projects: "项目",
             files: "文件",
             export_current_project: "导出当前项目",
@@ -3444,6 +3446,7 @@ fn mac_menu_labels(locale: AppMenuLocale) -> MacMenuLabels {
             help: "Help",
             theme: "Theme",
             new_session: "New Session",
+            new_window: "New Window",
             projects: "Projects",
             files: "Files",
             export_current_project: "Export Current Project",
@@ -3486,10 +3489,11 @@ fn build_menu_item(
     builder.build(app)
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", test))]
 fn mac_menu_action(id: &str) -> Option<&'static str> {
     match id {
         "action.new" => Some("new"),
+        "action.new-window" => Some("new-window"),
         "action.projects" => Some("projects"),
         "action.files" => Some("files"),
         "action.export-current-project" => Some("export-current-project"),
@@ -3568,6 +3572,10 @@ fn install_macos_app_menu(app: &AppHandle, locale_tag: &str) -> Result<(), Strin
     let file_menu = SubmenuBuilder::new(app, labels.file)
         .item(
             &build_menu_item(app, "action.new", labels.new_session, Some("CmdOrCtrl+N"))
+                .map_err(|error| error.to_string())?,
+        )
+        .item(
+            &build_menu_item(app, "action.new-window", labels.new_window, None)
                 .map_err(|error| error.to_string())?,
         )
         .item(
@@ -7290,6 +7298,7 @@ pub fn run() {
             project_commands::create_project,
             project_commands::open_project,
             project_commands::open_project_window,
+            project_commands::open_new_window,
             project_commands::delete_project,
             project_commands::get_project_settings,
             project_commands::update_project,

--- a/src-tauri/src/lib_tests.rs
+++ b/src-tauri/src/lib_tests.rs
@@ -612,7 +612,6 @@ fn mac_menu_locale_includes_english_edit_labels() {
     assert_eq!(labels.select_all, "Select All");
 }
 
-#[cfg(target_os = "macos")]
 #[test]
 fn mac_menu_action_maps_update_and_settings_ids() {
     assert_eq!(
@@ -621,6 +620,10 @@ fn mac_menu_action_maps_update_and_settings_ids() {
     );
     assert_eq!(super::mac_menu_action("action.star-us"), Some("star-us"));
     assert_eq!(super::mac_menu_action("action.settings"), Some("settings"));
+    assert_eq!(
+        super::mac_menu_action("action.new-window"),
+        Some("new-window")
+    );
     assert_eq!(super::mac_menu_action("action.unknown"), None);
 }
 
@@ -2007,6 +2010,7 @@ fn capability_skill_counts_use_enabled_bundled_vs_project_added_inventory() {
 fn macos_close_hides_only_main_window_when_not_quitting() {
     assert!(should_hide_app_on_macos_close("main", false));
     assert!(!should_hide_app_on_macos_close("proj-default", false));
+    assert!(!should_hide_app_on_macos_close("home-1", false));
     assert!(!should_hide_app_on_macos_close("main", true));
 }
 
@@ -2014,6 +2018,7 @@ fn macos_close_hides_only_main_window_when_not_quitting() {
 fn windows_close_to_tray_applies_only_to_the_main_window() {
     assert!(should_hide_workspace_on_close("main"));
     assert!(!should_hide_workspace_on_close("proj-default"));
+    assert!(!should_hide_workspace_on_close("home-1"));
     assert!(!should_hide_workspace_on_close("pet"));
 }
 
@@ -2038,6 +2043,34 @@ fn project_window_url_carries_the_target_session() {
         super::project_commands::project_window_url("abc", Some("s1")),
         "index.html?project=abc&session=s1"
     );
+    assert_eq!(super::project_commands::blank_window_url(), "index.html");
+}
+
+#[test]
+fn default_capability_grants_ipc_to_blank_windows() {
+    let spec: serde_json::Value =
+        serde_json::from_str(include_str!("../capabilities/default.json")).unwrap();
+    let windows: Vec<&str> = spec["windows"]
+        .as_array()
+        .expect("default capability lists windows")
+        .iter()
+        .filter_map(|value| value.as_str())
+        .collect();
+    assert!(
+        windows.contains(&"home-*"),
+        "File → New Window labels home-* must be allowed to close themselves: {windows:?}"
+    );
+    assert!(windows.contains(&"main"));
+    assert!(windows.contains(&"proj-*"));
+    let permissions: Vec<&str> = spec["permissions"]
+        .as_array()
+        .expect("default capability lists permissions")
+        .iter()
+        .filter_map(|value| value.as_str())
+        .collect();
+    assert!(permissions.contains(&"core:window:allow-close"));
+    assert!(permissions.contains(&"core:window:allow-minimize"));
+    assert!(permissions.contains(&"core:window:allow-toggle-maximize"));
 }
 
 #[test]

--- a/src-tauri/src/memory_commands.rs
+++ b/src-tauri/src/memory_commands.rs
@@ -258,7 +258,7 @@ async fn resolve_memory_target(
     window_label: &str,
     project_id: Option<String>,
 ) -> Result<(String, String, MemoryManager), String> {
-    let ap = state.active(window_label);
+    let ap = state.require_active(window_label)?;
     let requested = project_id
         .map(|id| id.trim().to_string())
         .filter(|id| !id.is_empty());
@@ -381,12 +381,14 @@ pub(super) async fn write_memory_file(
     content: String,
     project_id: Option<String>,
 ) -> Result<Vec<MemoryFile>, String> {
-    let target_project_id = project_id
+    let target_project_id = match project_id
         .as_deref()
         .map(str::trim)
         .filter(|id| !id.is_empty())
-        .map(str::to_string)
-        .unwrap_or_else(|| state.active(window.label()).id);
+    {
+        Some(id) => id.to_string(),
+        None => state.require_active(window.label())?.id,
+    };
     let _project_activity = state.begin_project_activity(&target_project_id)?;
     let (id, _, memory) = resolve_memory_target(&state, window.label(), project_id).await?;
     let scope = require_writable_memory_target(&state, window.label(), &id).await?;
@@ -410,12 +412,14 @@ pub(super) async fn delete_memory_file(
     name: String,
     project_id: Option<String>,
 ) -> Result<Vec<MemoryFile>, String> {
-    let target_project_id = project_id
+    let target_project_id = match project_id
         .as_deref()
         .map(str::trim)
         .filter(|id| !id.is_empty())
-        .map(str::to_string)
-        .unwrap_or_else(|| state.active(window.label()).id);
+    {
+        Some(id) => id.to_string(),
+        None => state.require_active(window.label())?.id,
+    };
     let _project_activity = state.begin_project_activity(&target_project_id)?;
     let (id, _, memory) = resolve_memory_target(&state, window.label(), project_id).await?;
     let scope = require_writable_memory_target(&state, window.label(), &id).await?;
@@ -437,12 +441,14 @@ pub(super) async fn clear_memory(
     window: tauri::WebviewWindow,
     project_id: Option<String>,
 ) -> Result<Vec<MemoryFile>, String> {
-    let target_project_id = project_id
+    let target_project_id = match project_id
         .as_deref()
         .map(str::trim)
         .filter(|id| !id.is_empty())
-        .map(str::to_string)
-        .unwrap_or_else(|| state.active(window.label()).id);
+    {
+        Some(id) => id.to_string(),
+        None => state.require_active(window.label())?.id,
+    };
     let _project_activity = state.begin_project_activity(&target_project_id)?;
     let (id, _, memory) = resolve_memory_target(&state, window.label(), project_id).await?;
     let scope = require_writable_memory_target(&state, window.label(), &id).await?;

--- a/src-tauri/src/plugins.rs
+++ b/src-tauri/src/plugins.rs
@@ -931,7 +931,7 @@ pub(super) async fn list_plugins(
     state: State<'_, AppState>,
     window: tauri::WebviewWindow,
 ) -> Result<Vec<PluginView>, String> {
-    let project = state.active(window.label());
+    let project = state.require_active(window.label())?;
     let bindings = state
         .store
         .list_project_plugins(&project.id)
@@ -1143,7 +1143,7 @@ pub(super) async fn set_plugin_enabled(
     version: String,
     enabled: bool,
 ) -> Result<(), String> {
-    let project = state.active(window.label());
+    let project = state.require_active(window.label())?;
     let installation = state
         .store
         .get_plugin_installation(&plugin_id, &version)

--- a/src-tauri/src/project_commands.rs
+++ b/src-tauri/src/project_commands.rs
@@ -229,7 +229,7 @@ pub(super) async fn set_active_project(
     state.set_active_frame(label, None);
     remember_window_project(&state.store, label, id).await;
     // Extra windows must not steal the main window's restore mapping or the
-    // startup workspace display.
+    // startup workspace display. remember_window_project already skips home-*.
     if label == "main" {
         state.bootstrap.lock().unwrap().workspace = root.to_string_lossy().into_owned();
         let _ = state.store.set_setting("active_project_id", id).await;
@@ -344,6 +344,24 @@ pub(super) async fn update_persisted_windows(store: &Store, id: &str, present: b
 
 pub(super) fn project_window_label(id: &str) -> String {
     format!("proj-{id}") // project ids are UUIDs or "default" — label-safe
+}
+
+/// File → New Window: a fresh GUI that lands on the Projects home screen and
+/// is not bound to any workspace until the user opens one in that window.
+/// Labels must stay on the `home-*` glob in `capabilities/default.json`, or
+/// the custom Windows title-bar close/minimize/maximize calls are denied.
+pub(super) fn next_blank_window_label() -> String {
+    format!("home-{}", Uuid::new_v4())
+}
+
+pub(super) fn blank_window_url() -> &'static str {
+    "index.html"
+}
+
+/// Offset a new File → New Window from its anchor so the extra GUI is obvious
+/// instead of covering the caller exactly.
+pub(super) fn cascaded_window_position(anchor_pos: (i32, i32), offset: i32) -> (i32, i32) {
+    (anchor_pos.0 + offset, anchor_pos.1 + offset)
 }
 
 /// URL for a dedicated project window. Ids are UUIDs or "default" — no
@@ -467,6 +485,57 @@ pub(super) async fn open_project_window(
     .await
 }
 
+/// Open a blank GUI on the Projects home screen. The window has its own label
+/// and no `ActiveProject` until the user opens a workspace in it, so it cannot
+/// read or mutate another window's files, sessions, or runtimes.
+pub(super) async fn spawn_blank_window(
+    app: &AppHandle,
+    anchor_label: Option<&str>,
+) -> Result<String, String> {
+    let label = next_blank_window_label();
+    let url = tauri::WebviewUrl::App(blank_window_url().into());
+    let mut builder = tauri::WebviewWindowBuilder::new(app, &label, url)
+        .title(app_window_title(None))
+        .inner_size(1100.0, 760.0)
+        .resizable(true)
+        .on_navigation(crate::guard_webview_navigation);
+    let anchor = anchor_label
+        .and_then(|label| app.get_webview_window(label))
+        .or_else(|| app.get_webview_window("main"));
+    if let Some(anchor) = anchor {
+        if let Ok(pos) = anchor.outer_position() {
+            let scale = anchor.scale_factor().unwrap_or(1.0);
+            let offset = (36.0 * scale) as i32;
+            let (x, y) = cascaded_window_position((pos.x, pos.y), offset);
+            builder = builder.position(x as f64 / scale, y as f64 / scale);
+        }
+    }
+    #[cfg(target_os = "windows")]
+    let builder = builder.decorations(false).shadow(true);
+    let win = builder.build().map_err(|e| e.to_string())?;
+    crate::windows_snap::install_for_window(&win);
+    #[cfg(target_os = "macos")]
+    wire_macos_menu_events(&win);
+    let evt_app = app.clone();
+    let evt_label = label.clone();
+    win.on_window_event(move |ev| {
+        if matches!(ev, tauri::WindowEvent::Destroyed) {
+            let st = evt_app.state::<AppState>();
+            st.active.write().unwrap().remove(&evt_label);
+            st.active_frame.write().unwrap().remove(&evt_label);
+        }
+    });
+    Ok(label)
+}
+
+#[tauri::command]
+pub(super) async fn open_new_window(
+    app: AppHandle,
+    window: tauri::WebviewWindow,
+) -> Result<String, String> {
+    spawn_blank_window(&app, Some(window.label())).await
+}
+
 #[tauri::command]
 pub(super) async fn delete_project(
     state: State<'_, AppState>,
@@ -496,8 +565,12 @@ pub(super) async fn delete_project(
     // legitimately be deleted while it's still the backend's *active* one
     // (returning to the list is a frontend-only nav — it never told the backend
     // to leave). Delete it, then fall back to the always-present "default"
-    // workspace so `active` never dangles at a deleted project.
-    let was_active = state.active(window.label()).id == id;
+    // workspace so `active` never dangles at a deleted project. An unbound
+    // File → New Window (`home-*`) must not treat `main` as active or panic.
+    let was_active = state
+        .require_active(window.label())
+        .map(|ap| ap.id == id)
+        .unwrap_or(false);
     // Stop the deleted project's own running sessions (gather frame ids before
     // the store cascade removes them); other projects keep running (#52).
     cancel_project_sessions(state.inner(), &id).await;
@@ -634,7 +707,7 @@ async fn settings_project(
 ) -> Result<(String, PathBuf, String, String), String> {
     let id = match requested_id.map(str::trim).filter(|id| !id.is_empty()) {
         Some(id) => id.to_string(),
-        None => state.active(window_label).id,
+        None => state.require_active(window_label)?.id,
     };
     let (name, description, workspace) = state
         .store
@@ -680,7 +753,7 @@ pub(super) async fn get_project_run_retention(
     state: State<'_, AppState>,
     window: tauri::WebviewWindow,
 ) -> Result<ProjectRunRetention, String> {
-    let ap = state.active(window.label());
+    let ap = state.require_active(window.label())?;
     let (run_retention_days, failed_run_retention_days, orphan_file_retention_days) = state
         .store
         .project_run_retention(&ap.id)
@@ -701,7 +774,7 @@ pub(super) async fn set_project_run_retention(
     failed_run_retention_days: Option<i64>,
     orphan_file_retention_days: Option<i64>,
 ) -> Result<ProjectRunRetention, String> {
-    let ap = state.active(window.label());
+    let ap = state.require_active(window.label())?;
     let _project_activity = state.begin_project_activity(&ap.id)?;
     state
         .store
@@ -774,15 +847,17 @@ pub(super) async fn get_project_info(
     state: State<'_, AppState>,
     window: tauri::WebviewWindow,
 ) -> Result<ProjectInfo, String> {
+    let _ = state.require_active(window.label())?;
     Ok(build_project_info(&state, window.label()).await)
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        app_window_title, load_window_active_projects, read_project_agent_context,
-        remember_window_project, same_workspace_path, startup_main_project_id,
-        write_project_agent_context, APP_WINDOW_TITLE,
+        app_window_title, blank_window_url, cascaded_window_position, load_window_active_projects,
+        next_blank_window_label, read_project_agent_context, remember_window_project,
+        same_workspace_path, startup_main_project_id, write_project_agent_context,
+        APP_WINDOW_TITLE,
     };
 
     #[test]
@@ -798,6 +873,21 @@ mod tests {
             app_window_title(Some("  fkbp1a  ")),
             "wisp science \u{2014} fkbp1a"
         );
+    }
+
+    #[test]
+    fn blank_window_url_does_not_bind_a_project() {
+        assert_eq!(blank_window_url(), "index.html");
+        assert!(!blank_window_url().contains("project="));
+        let label = next_blank_window_label();
+        assert!(crate::app_state::is_blank_window_label(&label));
+        assert_ne!(label, next_blank_window_label());
+    }
+
+    #[test]
+    fn cascaded_window_position_offsets_from_the_anchor() {
+        assert_eq!(cascaded_window_position((100, 50), 36), (136, 86));
+        assert_eq!(cascaded_window_position((-1600, -50), 36), (-1564, -14));
     }
 
     #[test]

--- a/src-tauri/src/session_commands.rs
+++ b/src-tauri/src/session_commands.rs
@@ -13,7 +13,7 @@ pub(super) async fn new_session(
     // running. Persisted history still ignores empty untitled frames; the UI
     // keeps the currently active draft visible until its first user turn is
     // stored, and an explicit rename makes the draft listable right away (#888).
-    let active = state.active(window.label());
+    let active = state.require_active(window.label())?;
     let ap = project_commands::load_active_project(&state, &active.id)
         .await?
         .0;
@@ -36,7 +36,7 @@ pub(super) async fn branch_session(
     user_index: Option<usize>,
     checkpoint_kind: Option<String>,
 ) -> Result<String, String> {
-    let active = state.active(window.label());
+    let active = state.require_active(window.label())?;
     let ap = project_commands::load_active_project(&state, &active.id)
         .await?
         .0;
@@ -144,7 +144,7 @@ pub(super) async fn preview_session_branch_merge(
     window: tauri::WebviewWindow,
     id: String,
 ) -> Result<wisp_store::SessionBranchMergePreview, String> {
-    let project = state.active(window.label());
+    let project = state.require_active(window.label())?;
     state
         .store
         .preview_session_branch_merge(&id, &project.id)
@@ -205,7 +205,7 @@ pub(super) async fn summarize_session_branch_merge(
     current_version: Option<String>,
     user_guidance: Option<String>,
 ) -> Result<String, String> {
-    let project = state.active(window.label());
+    let project = state.require_active(window.label())?;
     let preview = state
         .store
         .preview_session_branch_merge(&id, &project.id)
@@ -261,7 +261,7 @@ pub(super) async fn merge_session_branch_summary(
     expected_guard_hash: String,
     summary: String,
 ) -> Result<wisp_store::SessionBranchMerge, String> {
-    let project = state.active(window.label());
+    let project = state.require_active(window.label())?;
     let _project_activity = state.begin_project_activity(&project.id)?;
     exploration_commands::require_writable_scope(
         &state.store,
@@ -365,7 +365,7 @@ pub(super) async fn list_sessions_page(
     window: tauri::WebviewWindow,
     cursor: Option<SessionCursor>,
 ) -> Result<SessionPage, String> {
-    let ap = state.active(window.label());
+    let ap = state.require_active(window.label())?;
     let mut rows = state
         .store
         .list_sessions_page(
@@ -491,7 +491,7 @@ pub(super) async fn reload_project_rules(
     window: tauri::WebviewWindow,
     frame_id: String,
 ) -> Result<bool, String> {
-    let ap = state.active(window.label());
+    let ap = state.require_active(window.label())?;
     let owner = state
         .store
         .frame_project_id(&frame_id)
@@ -547,7 +547,7 @@ pub(super) async fn list_folders(
     state: State<'_, AppState>,
     window: tauri::WebviewWindow,
 ) -> Result<Vec<FolderInfo>, String> {
-    let ap = state.active(window.label());
+    let ap = state.require_active(window.label())?;
     let rows = state
         .store
         .list_folders(&ap.id)
@@ -565,7 +565,7 @@ pub(super) async fn create_folder(
     window: tauri::WebviewWindow,
     name: String,
 ) -> Result<FolderInfo, String> {
-    let ap = state.active(window.label());
+    let ap = state.require_active(window.label())?;
     let _project_activity = state.begin_project_activity(&ap.id)?;
     let id = Uuid::new_v4().to_string();
     state
@@ -586,7 +586,7 @@ pub(super) async fn rename_folder(
     id: String,
     name: String,
 ) -> Result<(), String> {
-    let ap = state.active(window.label());
+    let ap = state.require_active(window.label())?;
     let _project_activity = state.begin_project_activity(&ap.id)?;
     state
         .store
@@ -602,7 +602,7 @@ pub(super) async fn delete_folder(
     window: tauri::WebviewWindow,
     id: String,
 ) -> Result<(), String> {
-    let ap = state.active(window.label());
+    let ap = state.require_active(window.label())?;
     let _project_activity = state.begin_project_activity(&ap.id)?;
     state
         .store
@@ -619,7 +619,7 @@ pub(super) async fn move_session(
     id: String,
     folder_id: Option<String>,
 ) -> Result<(), String> {
-    let ap = state.active(window.label());
+    let ap = state.require_active(window.label())?;
     let _project_activity = state.begin_project_activity(&ap.id)?;
     state
         .store
@@ -637,7 +637,7 @@ pub(super) async fn transfer_session_to_project(
     target_project_id: String,
     mode: String,
 ) -> Result<String, String> {
-    let source = state.active(window.label());
+    let source = state.require_active(window.label())?;
     if target_project_id == source.id {
         return Err("Source and target projects must be different.".into());
     }
@@ -744,7 +744,7 @@ pub(super) async fn delete_session(
     window: tauri::WebviewWindow,
     id: String,
 ) -> Result<(), String> {
-    let ap = state.active(window.label());
+    let ap = state.require_active(window.label())?;
     let _project_activity = state.begin_project_activity(&ap.id)?;
     let owner = state
         .store
@@ -824,7 +824,7 @@ pub(super) async fn rename_session(
     id: String,
     title: String,
 ) -> Result<(), String> {
-    let ap = state.active(window.label());
+    let ap = state.require_active(window.label())?;
     let _project_activity = state.begin_project_activity(&ap.id)?;
     state
         .store
@@ -841,7 +841,7 @@ pub(super) async fn set_session_pinned(
     id: String,
     pinned: bool,
 ) -> Result<(), String> {
-    let ap = state.active(window.label());
+    let ap = state.require_active(window.label())?;
     let _project_activity = state.begin_project_activity(&ap.id)?;
     state
         .store
@@ -863,7 +863,7 @@ pub(super) async fn latest_used_session(
     state: State<'_, AppState>,
     window: tauri::WebviewWindow,
 ) -> Result<Option<String>, String> {
-    let ap = state.active(window.label());
+    let ap = state.require_active(window.label())?;
     let Some(id) = state
         .store
         .latest_used_session_id(&ap.id)

--- a/src-tauri/src/skill_commands.rs
+++ b/src-tauri/src/skill_commands.rs
@@ -9,8 +9,11 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tauri::{AppHandle, State};
 
-async fn list_skill_infos_for_project(state: &AppState, label: &str) -> Vec<SkillInfo> {
-    let ap = state.active(label);
+async fn list_skill_infos_for_project(
+    state: &AppState,
+    label: &str,
+) -> Result<Vec<SkillInfo>, String> {
+    let ap = state.require_active(label)?;
     let tags = load_skill_tags(&state.store).await;
     let (all, enabled) = project_skill_catalog(&state.store, &ap).await;
     let plugin_roots = crate::plugins::enabled_plugin_manifests(&state.store, &ap.id)
@@ -37,7 +40,7 @@ async fn list_skill_infos_for_project(state: &AppState, label: &str) -> Vec<Skil
             info.managed_by = Some(display_name.clone());
         }
     }
-    infos
+    Ok(infos)
 }
 
 #[tauri::command]
@@ -45,7 +48,7 @@ pub(super) async fn list_skills(
     state: State<'_, AppState>,
     window: tauri::WebviewWindow,
 ) -> Result<Vec<SkillInfo>, String> {
-    Ok(list_skill_infos_for_project(&state, window.label()).await)
+    list_skill_infos_for_project(&state, window.label()).await
 }
 
 #[tauri::command]
@@ -54,7 +57,7 @@ pub(super) async fn reload_skills(
     window: tauri::WebviewWindow,
 ) -> Result<Vec<SkillInfo>, String> {
     let label = window.label();
-    let mut project = state.active(label);
+    let mut project = state.require_active(label)?;
     let previous_names = project
         .skills
         .all()
@@ -76,7 +79,7 @@ pub(super) async fn reload_skills(
     let project_id = project.id.clone();
     state.set_active(label, project);
     clear_idle_agents_for_project(&state, &project_id).await;
-    Ok(list_skill_infos_for_project(&state, label).await)
+    list_skill_infos_for_project(&state, label).await
 }
 
 fn enabled_names_after_reload<'a>(
@@ -119,7 +122,7 @@ async fn update_skills_enabled(
     names: Vec<String>,
     enabled: bool,
 ) -> Result<(), String> {
-    let ap = state.active(label);
+    let ap = state.require_active(label)?;
     let mut current = effective_enabled_skill_names(&state.store, &ap)
         .await
         .unwrap_or_else(|| ap.skills.all().iter().map(|s| s.name.clone()).collect());
@@ -221,8 +224,8 @@ pub(super) async fn install_skill(
     let skill_name = tokio::task::spawn_blocking(move || install_skill_source(&src, &skills_dir))
         .await
         .map_err(|e| format!("{e}"))??;
-    reload_host_skill_index(&state, window.label());
-    let ap = state.active(window.label());
+    reload_host_skill_index(&state, window.label())?;
+    let ap = state.require_active(window.label())?;
     if let Some(mut enabled) = load_enabled_skill_names(&state.store, &ap.id).await {
         enabled.insert(skill_name.clone());
         save_enabled_skill_names(&state.store, &ap.id, &enabled).await?;
@@ -327,7 +330,7 @@ pub(super) async fn remove_skill(
     tokio::fs::remove_dir_all(&dir)
         .await
         .map_err(|e| format!("{e}"))?;
-    let ap = state.active(window.label());
+    let ap = state.require_active(window.label())?;
     if let Some(mut enabled) = load_enabled_skill_names(&state.store, &ap.id).await {
         enabled.remove(&name);
         let _ = save_enabled_skill_names(&state.store, &ap.id, &enabled).await;
@@ -335,15 +338,16 @@ pub(super) async fn remove_skill(
     let mut tags = load_skill_tags(&state.store).await;
     tags.remove(&name);
     let _ = save_skill_tags(&state.store, &tags).await;
-    reload_host_skill_index(&state, window.label());
+    reload_host_skill_index(&state, window.label())?;
     clear_idle_agents(&state).await;
     Ok(())
 }
 
-fn reload_host_skill_index(state: &AppState, label: &str) {
-    let mut ap = state.active(label);
+fn reload_host_skill_index(state: &AppState, label: &str) -> Result<(), String> {
+    let mut ap = state.require_active(label)?;
     ap.skills = Arc::new(load_skill_index(&ap.root));
     state.set_active(label, ap);
+    Ok(())
 }
 
 pub(super) fn copy_dir_recursive(from: &Path, to: &Path) -> std::io::Result<()> {

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -2549,6 +2549,8 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
             return null;
           case "open_project_window":
             return `proj-${arg("id")}`;
+          case "open_new_window":
+            return "home-mock";
           case "get_bootstrap_status":
             return {
               skills_loaded: 12,

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -3310,6 +3310,7 @@ test("Ctrl+P command palette runs commands and switches themes", async ({ page }
   await expect(input).toHaveAttribute("inputmode", "search");
   await expect(input).toHaveAttribute("autocomplete", "off");
   await expect(palette).toContainText("New session");
+  await expect(palette).toContainText("New Window");
   await expect(palette.locator(".action-palette-row", { hasText: "New session" })
     .locator(".action-shortcut")).toHaveText("Ctrl+N");
   await expect(palette.locator(".action-palette-row", { hasText: "Search" })
@@ -11682,7 +11683,10 @@ test("reverse preview selections anchor the action popup above the first selecte
   const popup = page.locator(".selection-popup");
   await expect(popup).toBeVisible();
   const anchorY = await popup.evaluate((element) => Number.parseFloat((element as HTMLElement).style.top));
-  expect(anchorY).toBeCloseTo(selection.top, 0);
+  // selection_popup_y keeps ≥120px clearance. CI fonts often land the heading
+  // just under that (~117px), so the popup clamps to 120 instead of selection.top.
+  const expectedY = Math.max(120, Math.round(selection.top));
+  expect(anchorY).toBeCloseTo(expectedY, 0);
   await expect.poll(() => popup.evaluate((element) => element.getBoundingClientRect().bottom))
     .toBeLessThan(selection.top);
 });
@@ -11964,6 +11968,7 @@ test("Windows uses the integrated title bar without covering the project landing
   // Home menus only list actions that work without an open project.
   await page.getByRole("button", { name: "File", exact: true }).click();
   await expect(page.getByRole("menuitem", { name: "New project" })).toBeVisible();
+  await expect(page.getByRole("menuitem", { name: "New Window" })).toBeVisible();
   await expect(page.getByRole("menuitem", { name: "Import project" })).toBeVisible();
   await expect(page.getByRole("menuitem", { name: "Scratch chat" })).toBeVisible();
   await expect(page.getByRole("menuitem", { name: "Open settings" })).toBeVisible();
@@ -12000,6 +12005,7 @@ test("Windows uses the integrated title bar without covering the project landing
   await page.getByRole("button", { name: "File", exact: true }).click();
   // Inside a workspace the menus flip back to the session-scoped set.
   await expect(page.getByRole("menuitem", { name: "New session" })).toBeVisible();
+  await expect(page.getByRole("menuitem", { name: "New Window" })).toBeVisible();
   await expect(page.getByRole("menuitem", { name: "New project" })).toHaveCount(0);
   const exportCurrentProject = page.getByRole("menuitem", { name: "Export current project" });
   await expect(exportCurrentProject).toBeEnabled();
@@ -12179,6 +12185,30 @@ test("Windows titlebar menus close on Escape", async ({ browser }) => {
   await expect(page.getByRole("menu")).toBeVisible();
   await page.keyboard.press("Escape");
   await expect(page.getByRole("menu")).toHaveCount(0);
+
+  await context.close();
+});
+
+test("File New Window asks the host for a second GUI", async ({ browser }) => {
+  // File/Edit/View live on the Windows integrated titlebar; Linux/macOS CI
+  // user agents never render that bar, so this must pin a Windows UA.
+  const context = await browser.newContext({
+    userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/136 Safari/537.36",
+  });
+  const page = await context.newPage();
+  await page.addInitScript(tauriMock);
+  await page.goto("/");
+
+  await page.getByRole("button", { name: "File", exact: true }).click();
+  await page.getByRole("menuitem", { name: "New Window" }).click();
+  await expect.poll(() => lastInvokeArgs(page, "open_new_window")).not.toBeNull();
+
+  // Stay on this document so the invoke log is not wiped by enterApp()'s goto.
+  await page.locator(".proj-card-main").first().click();
+  await expect(newSessionButton(page)).toBeVisible();
+  await page.getByRole("button", { name: "File", exact: true }).click();
+  await page.getByRole("menuitem", { name: "New Window" }).click();
+  await expect.poll(() => invokeCount(page, "open_new_window")).toBeGreaterThan(1);
 
   await context.close();
 });

--- a/ui/src/app_support/palettes.rs
+++ b/ui/src/app_support/palettes.rs
@@ -478,6 +478,15 @@ pub(crate) fn ActionPalette(
                 true,
             ),
             (
+                "new-window",
+                "expand",
+                "command.new_window",
+                general.clone(),
+                "",
+                "new window gui 新建 窗口",
+                false,
+            ),
+            (
                 "search",
                 "search",
                 "command.search",

--- a/ui/src/i18n.rs
+++ b/ui/src/i18n.rs
@@ -1981,6 +1981,9 @@ fn lookup(locale: Locale, key: &str) -> Option<&'static str> {
         (Locale::En, "err.api_key_required") => Some("API key is required."),
         (Locale::En, "err.max_tokens_ceiling") => Some("{model} accepts at most {max} output tokens — lower Max output tokens."),
         (Locale::En, "err.unknown") => Some("Unknown error"),
+        (Locale::En, "err.blank_window_no_project") => {
+            Some("Open a project in this window before running that action.")
+        }
         (Locale::En, "err.validation_timeout") => Some("Validation timed out after 30s"),
         (Locale::En, "err.vision_probe_failed") => Some(" This check sent a test image because \"supports images\" is on. If the model has no vision support, turn that off and validate again."),
         (Locale::En, "err.skill_no_md") => Some("The selected folder has no SKILL.md."),
@@ -2378,6 +2381,7 @@ fn lookup(locale: Locale, key: &str) -> Option<&'static str> {
         (Locale::En, "command.group.help") => Some("Help"),
         (Locale::En, "command.no_results") => Some("No matching commands"),
         (Locale::En, "command.new_session") => Some("New session"),
+        (Locale::En, "command.new_window") => Some("New Window"),
         (Locale::En, "command.scratch") => Some("Scratch chat"),
         (Locale::En, "scratch.title") => Some("Scratch chat"),
         (Locale::En, "scratch.open") => Some("Scratch chat"),
@@ -4533,6 +4537,9 @@ Do not leave generated files in the project root.",
         (Locale::Zh, "err.api_key_required") => Some("API 密钥不能为空。"),
         (Locale::Zh, "err.max_tokens_ceiling") => Some("{model} 的最大输出 tokens 上限为 {max}，请调低「最大输出 tokens」。"),
         (Locale::Zh, "err.unknown") => Some("未知错误"),
+        (Locale::Zh, "err.blank_window_no_project") => {
+            Some("请先在此窗口打开一个项目，再执行该操作。")
+        }
         (Locale::Zh, "err.validation_timeout") => Some("验证超时（30 秒）"),
         (Locale::Zh, "err.vision_probe_failed") => Some(" 因为勾选了「支持图片」，本次验证发送了一张测试图片。如果该模型不支持图片，请取消勾选后重新验证。"),
         (Locale::Zh, "err.file_not_found") => Some("文件未找到：{path}"),
@@ -4922,6 +4929,7 @@ Do not leave generated files in the project root.",
         (Locale::Zh, "command.group.help") => Some("帮助"),
         (Locale::Zh, "command.no_results") => Some("没有匹配的命令"),
         (Locale::Zh, "command.new_session") => Some("新建会话"),
+        (Locale::Zh, "command.new_window") => Some("新建窗口"),
         (Locale::Zh, "command.scratch") => Some("随手一聊"),
         (Locale::Zh, "scratch.title") => Some("随手一聊"),
         (Locale::Zh, "scratch.open") => Some("随手一聊"),
@@ -5438,6 +5446,9 @@ pub fn localize_backend(locale: Locale, msg: &str) -> String {
         }
         "This project is busy. Try again when the current project operation finishes." => {
             t(locale, "projects.transfer.export_locked")
+        }
+        "Open a project in this window before running that action." => {
+            t(locale, "err.blank_window_no_project")
         }
         m if m.starts_with("Project workspace is not a directory: ") => {
             if locale == Locale::Zh {

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -9570,6 +9570,11 @@ fn App() -> impl IntoView {
                 }
             }
             "scratch" => open_scratch.call(()),
+            "new-window" => {
+                spawn_local(async move {
+                    let _ = invoke("open_new_window", JsValue::UNDEFINED).await;
+                });
+            }
             "search" => command_palette_open.set(true),
             "commands" => action_palette_open.set(true),
             "projects" => show_projects.set(true),
@@ -9704,6 +9709,7 @@ fn App() -> impl IntoView {
                 other => {
                     if let Some(action) = match other {
                         "new" => Some("new"),
+                        "new-window" => Some("new-window"),
                         "search" => Some("search"),
                         "commands" => Some("commands"),
                         "projects" => Some("projects"),

--- a/ui/src/window_titlebar.rs
+++ b/ui/src/window_titlebar.rs
@@ -9,6 +9,7 @@ type MenuItem = (&'static str, &'static str, &'static str); // action, i18n key,
 
 const FILE_ITEMS: &[MenuItem] = &[
     ("new", "command.new_session", "Ctrl+N"),
+    ("new-window", "command.new_window", ""),
     ("projects", "command.projects", ""),
     ("files", "command.files", ""),
     (
@@ -51,6 +52,7 @@ const VIEW_ITEMS: &[MenuItem] = &[
 // doing nothing, which reads as a bug.
 const HOME_FILE_ITEMS: &[MenuItem] = &[
     ("new-project", "projects.new", "Ctrl+N"),
+    ("new-window", "command.new_window", ""),
     ("import-project", "projects.import", ""),
     ("scratch", "command.scratch", "Ctrl+Shift+N"),
     ("settings", "command.settings", "Ctrl+,"),


### PR DESCRIPTION
Closes #1080

属于 #1074。建议在 #1075 之后合，避免 `set_active_project` 冲突。

## 用户问题

现有「在新窗口中打开」会带上某个已有项目。需要再开一个空白 GUI，从项目首页起步；未绑定项目时，删除/设置类命令不能 panic，也不能落到 `main` 的工作区。

## 改动

- File / 命令面板 / macOS 菜单「新建窗口」调用 `open_new_window`。
- 新窗口 label 为 `home-<uuid>`，URL 为 `index.html`（无 `?project=`），不继承当前工作区。
- capabilities 增加 `home-*`。
- `require_active`：未绑定的 `home-*` 返回 `err.blank_window_no_project`（`Open a project in this window before running that action.`），不 fallback 到 `main`。
- 只有 `main` 写入 `active_project_id`，空白窗口不覆盖上次项目。
- 首页删除项目在未绑定窗口上不 panic（不当成 main 为 active）。

## 测试

- `blank_windows_do_not_inherit_the_main_project`
- `blank_window_url_does_not_bind_a_project`
- `default_capability_grants_ipc_to_blank_windows`
- Playwright：`File New Window asks the host for a second GUI`（Windows UA）
- wasm `cargo check`

## 已知限制

未把 #1075 的 `window_active_projects` 整张映射带进来；本 PR 只保证空白窗口 / 第二窗口不覆盖 `main` 的全局回退项。每窗口记住自己的项目由 #1075 负责。