### PR TITLE
feat: 每个窗口记住自己上次打开的项目

### DIFF
--- a/docs/workspace-navigation.md
+++ b/docs/workspace-navigation.md
@@ -7,7 +7,9 @@ specific conversation from Recent sessions or search still takes priority.
 
 Choose another workspace from the sidebar workspace menu to switch the current
 window in place. A separate window is opened only by an action explicitly
-labelled **Open in new window**.
+labelled **Open in new window**. Each window remembers its own last project;
+opening a workspace in a second window does not change what the first window
+restores after a restart.
 
 Each window title includes the open workspace name
 (`wisp science — my-project`) so the taskbar, Alt-Tab, and macOS title bar can

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6617,10 +6617,7 @@ pub fn run() {
                     .create_project("default", "Workspace", &legacy_ws)
                     .await
                     .ok();
-                let active_id = match store.get_setting("active_project_id").await.ok().flatten() {
-                    Some(id) if store.get_project(&id).await.ok().flatten().is_some() => id,
-                    _ => "default".to_string(),
-                };
+                let active_id = project_commands::startup_main_project_id(&store).await;
                 let (_, dir) = store
                     .get_project(&active_id)
                     .await

--- a/src-tauri/src/project_commands.rs
+++ b/src-tauri/src/project_commands.rs
@@ -226,11 +226,58 @@ pub(super) async fn set_active_project(
     let root = ap.root.clone();
     state.set_active(label, ap);
     state.set_active_frame(label, None);
-    {
+    remember_window_project(&state.store, label, id).await;
+    if label == "main" {
         state.bootstrap.lock().unwrap().workspace = root.to_string_lossy().into_owned();
+        let _ = state.store.set_setting("active_project_id", id).await;
     }
-    let _ = state.store.set_setting("active_project_id", id).await;
     Ok((name, ws))
+}
+
+const WINDOW_ACTIVE_PROJECTS_KEY: &str = "window_active_projects";
+
+async fn load_window_active_projects(store: &Store) -> HashMap<String, String> {
+    store
+        .get_setting(WINDOW_ACTIVE_PROJECTS_KEY)
+        .await
+        .ok()
+        .flatten()
+        .and_then(|raw| serde_json::from_str(&raw).ok())
+        .unwrap_or_default()
+}
+
+/// Persist this window's last project. Blank File → New Window views (`home-*`)
+/// are not restored on launch, so they must not overwrite another window's
+/// mapping. Only the `main` window still writes the legacy `active_project_id`
+/// fallback.
+async fn remember_window_project(store: &Store, label: &str, id: &str) {
+    if label.starts_with("home-") {
+        return;
+    }
+    let mut windows = load_window_active_projects(store).await;
+    windows.insert(label.to_string(), id.to_string());
+    let _ = store
+        .set_setting(
+            WINDOW_ACTIVE_PROJECTS_KEY,
+            &serde_json::to_string(&windows).unwrap_or_default(),
+        )
+        .await;
+}
+
+/// Project the `main` window should restore. Prefers `window_active_projects`
+/// so an extra window opening a different workspace cannot steal main's last
+/// project; falls back to the legacy global `active_project_id`.
+pub(crate) async fn startup_main_project_id(store: &Store) -> String {
+    let windows = load_window_active_projects(store).await;
+    if let Some(id) = windows.get("main") {
+        if store.get_project(id).await.ok().flatten().is_some() {
+            return id.clone();
+        }
+    }
+    match store.get_setting("active_project_id").await.ok().flatten() {
+        Some(id) if store.get_project(&id).await.ok().flatten().is_some() => id,
+        _ => "default".to_string(),
+    }
 }
 
 /// Brand string used when no project is open (home, or a window that has not
@@ -731,7 +778,8 @@ pub(super) async fn get_project_info(
 #[cfg(test)]
 mod tests {
     use super::{
-        app_window_title, read_project_agent_context, same_workspace_path,
+        app_window_title, load_window_active_projects, read_project_agent_context,
+        remember_window_project, same_workspace_path, startup_main_project_id,
         write_project_agent_context, APP_WINDOW_TITLE,
     };
 
@@ -780,5 +828,58 @@ mod tests {
         assert!(!root.join(".wisp").join("WISP.md").exists());
 
         let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn extra_windows_do_not_overwrite_main_last_project() {
+        let path = std::env::temp_dir().join(format!(
+            "wisp_window_projects_{}.sqlite",
+            uuid::Uuid::new_v4()
+        ));
+        let store = wisp_store::Store::open(&path).await.unwrap();
+        store
+            .create_project("main-project", "Main", "/ws/main")
+            .await
+            .unwrap();
+        store
+            .create_project("other-project", "Other", "/ws/other")
+            .await
+            .unwrap();
+        let _ = store
+            .set_setting("active_project_id", "main-project")
+            .await
+            .unwrap();
+
+        remember_window_project(&store, "main", "main-project").await;
+        remember_window_project(&store, "home-abc", "other-project").await;
+        remember_window_project(&store, "proj-other-project", "other-project").await;
+
+        let windows = load_window_active_projects(&store).await;
+        assert_eq!(
+            windows.get("main").map(String::as_str),
+            Some("main-project")
+        );
+        assert_eq!(
+            windows.get("proj-other-project").map(String::as_str),
+            Some("other-project")
+        );
+        assert!(
+            !windows.contains_key("home-abc"),
+            "blank home-* window labels must not persist: {windows:?}"
+        );
+        assert_eq!(startup_main_project_id(&store).await, "main-project");
+
+        let _ = store
+            .set_setting("active_project_id", "other-project")
+            .await
+            .unwrap();
+        assert_eq!(
+            startup_main_project_id(&store).await,
+            "main-project",
+            "window_active_projects[main] must beat the legacy global id"
+        );
+
+        drop(store);
+        let _ = std::fs::remove_file(path);
     }
 }


### PR DESCRIPTION
## Summary
- 各窗口独立记住上次打开的项目，第二窗口打开别的项目不会覆盖主窗口重启后要恢复的项目。
- 空白新建窗口不写入持久化映射。
- 仅主窗口仍更新全局回退项和启动工作区显示。

Closes #1075
属于 #1074。拆自 #1072。

## Test plan
- [ ] 主窗口打开项目 A，第二窗口打开项目 B
- [ ] 重启应用
- [ ] 确认主窗口仍恢复 A，不会变成 B

Made with [Cursor](https://cursor.com)