### PR TITLE
feat: 实时流、审批卡和浏览器清标签只进入所属项目窗口

### DIFF
--- a/src-tauri/src/acp.rs
+++ b/src-tauri/src/acp.rs
@@ -10,7 +10,7 @@ use std::{
     },
     time::Duration,
 };
-use tauri::{AppHandle, Emitter, State};
+use tauri::{AppHandle, State};
 use tokio::sync::Mutex;
 use uuid::Uuid;
 use wisp_acp::{
@@ -992,22 +992,17 @@ pub(crate) async fn run_acp_internal_turn(
     .await
 }
 
-/// `emit_to` the turn's own window when it has one; internal turns (review
-/// correction, channels) have no window and fall back to a broadcast.
+/// Route ACP UI to windows of this conversation's project. Internal turns
+/// (review, channels) have no originating window, but same-project peers
+/// still need the cards; other projects must not see them.
 fn emit_ask_event(
     app: &AppHandle,
-    window_label: Option<&str>,
+    frame_id: &str,
+    project_id: Option<&str>,
     event: &str,
     payload: serde_json::Value,
 ) {
-    match window_label {
-        Some(label) => {
-            let _ = app.emit_to(label, event, payload);
-        }
-        None => {
-            let _ = app.emit(event, payload);
-        }
-    }
+    crate::emit_to_session_surfaces(app, frame_id, project_id, event, &payload);
 }
 
 /// Surface new pending bridge `ask_user` rows to the UI. `acp_asks` doubles as
@@ -1016,7 +1011,7 @@ fn emit_ask_event(
 async fn surface_pending_asks(
     state: &AppState,
     app: &AppHandle,
-    window_label: Option<&str>,
+    project_id: Option<&str>,
     frame_id: &str,
 ) {
     let pending = state
@@ -1036,11 +1031,12 @@ async fn surface_pending_asks(
             .lock()
             .unwrap()
             .insert(frame_id.to_string());
-        state.device_hub.mark_needs_user(frame_id, None);
+        state.device_hub.mark_needs_user(frame_id, project_id);
         let payload: serde_json::Value = serde_json::from_str(&payload_json).unwrap_or_default();
         emit_ask_event(
             app,
-            window_label,
+            frame_id,
+            project_id,
             "ask-user-request",
             serde_json::json!({
                 "frameId": frame_id,
@@ -1056,7 +1052,7 @@ async fn surface_pending_asks(
 async fn settle_expired_asks(
     state: &AppState,
     app: &AppHandle,
-    window_label: Option<&str>,
+    project_id: Option<&str>,
     frame_id: &str,
 ) {
     let expired = state
@@ -1082,7 +1078,8 @@ async fn settle_expired_asks(
     for (request_id, _) in expired {
         emit_ask_event(
             app,
-            window_label,
+            frame_id,
+            project_id,
             "ask-user-resolved",
             serde_json::json!({
                 "frameId": frame_id,
@@ -1123,7 +1120,7 @@ async fn run_acp_turn_with_kind(
     .await;
     // Runs on every exit path, success or error — asks must never outlive
     // their turn as live cards.
-    settle_expired_asks(state, app, window_label, frame_id).await;
+    settle_expired_asks(state, app, Some(project.id.as_str()), frame_id).await;
     result
 }
 
@@ -1131,7 +1128,7 @@ async fn run_acp_turn_with_kind(
 async fn run_acp_turn_inner(
     state: &AppState,
     app: &AppHandle,
-    window_label: Option<&str>,
+    _window_label: Option<&str>,
     project: &ActiveProject,
     frame_id: &str,
     profile_id: Option<&str>,
@@ -1143,9 +1140,12 @@ async fn run_acp_turn_inner(
 ) -> Result<String, String> {
     let runtime = runtime_for(state, project, frame_id, profile_id).await?;
     if let Some(session_state) = runtime.session_state.lock().await.take() {
-        let _ = app.emit(
+        crate::emit_to_session_surfaces(
+            app,
+            frame_id,
+            Some(project.id.as_str()),
             "acp-session-state",
-            serde_json::json!({
+            &serde_json::json!({
                 "frameId": frame_id,
                 "modes": session_state.modes,
                 "configOptions": session_state.config_options,
@@ -1173,19 +1173,21 @@ async fn run_acp_turn_inner(
     }
     let mut next_seq = begin_acp_turn(&state.store, frame_id, message, turn_kind).await?;
     if turn_kind == AcpTurnKind::User {
-        crate::emit_agent_event(
+        crate::emit_agent_event_in(
             app,
             AgentEvent::User {
                 frame_id: frame_id.to_string(),
                 text: message.to_string(),
             },
+            Some(project.id.as_str()),
         );
-        crate::emit_agent_event(
+        crate::emit_agent_event_in(
             app,
             AgentEvent::MessageBoundary {
                 frame_id: frame_id.to_string(),
                 seq: next_seq - 1,
             },
+            Some(project.id.as_str()),
         );
     }
     let prompt = runtime.handle.prompt(runtime.session_id.clone(), content);
@@ -1202,7 +1204,7 @@ async fn run_acp_turn_inner(
         tokio::select! {
             result = &mut prompt => break result.map_err(|error| error.to_string())?,
             _ = ask_tick.tick() => {
-                surface_pending_asks(state, app, window_label, frame_id).await;
+                surface_pending_asks(state, app, Some(project.id.as_str()), frame_id).await;
             }
             event = runtime.handle.next_event() => match event {
                 Some(AcpSessionEvent::Update { kind, payload, .. }) => {
@@ -1215,7 +1217,7 @@ async fn run_acp_turn_inner(
                             } else {
                                 AgentEvent::Reasoning { frame_id: frame_id.to_string(), delta: text.to_string() }
                             };
-                            crate::emit_agent_event(app, event);
+                            crate::emit_agent_event_in(app, event, Some(project.id.as_str()));
                         }
                     } else {
                         if matches!(kind, AcpUpdateKind::ToolCall | AcpUpdateKind::ToolCallUpdate) {
@@ -1224,11 +1226,17 @@ async fn run_acp_turn_inner(
                         if kind == AcpUpdateKind::Plan {
                             plan = Some(payload.clone());
                         }
-                        let _ = app.emit("acp-session-update", serde_json::json!({
-                            "frameId": frame_id,
-                            "kind": format!("{kind:?}"),
-                            "payload": payload,
-                        }));
+                        crate::emit_to_session_surfaces(
+                            app,
+                            frame_id,
+                            Some(project.id.as_str()),
+                            "acp-session-update",
+                            &serde_json::json!({
+                                "frameId": frame_id,
+                                "kind": format!("{kind:?}"),
+                                "payload": payload,
+                            }),
+                        );
                     }
                 }
                 Some(AcpSessionEvent::Permission(request)) => {
@@ -1252,7 +1260,13 @@ async fn run_acp_turn_inner(
                     state.awaiting_confirm.lock().unwrap().insert(frame_id.to_string());
                     state.device_hub.mark_needs_user(frame_id, Some(&project.id));
                     crate::channels::publish_approval_request(&pending.remote_request);
-                    let _ = app.emit("permission-request", permission_event(frame_id, &request));
+                    crate::emit_to_session_surfaces(
+                        app,
+                        frame_id,
+                        Some(project.id.as_str()),
+                        "permission-request",
+                        &permission_event(frame_id, &request),
+                    );
                 }
                 Some(AcpSessionEvent::Exited { error }) => return Err(error.unwrap_or_else(|| "ACP Agent exited.".into())),
                 None => return Err("ACP Agent event stream closed.".into()),
@@ -1277,21 +1291,23 @@ async fn run_acp_turn_inner(
                 if let Some(text) = text_from_payload(&payload) {
                     if kind == AcpUpdateKind::AgentMessage {
                         assistant.push_str(text);
-                        crate::emit_agent_event(
+                        crate::emit_agent_event_in(
                             app,
                             AgentEvent::Text {
                                 frame_id: frame_id.to_string(),
                                 delta: text.to_string(),
                             },
+                            Some(project.id.as_str()),
                         );
                     } else if kind == AcpUpdateKind::AgentThought {
                         reasoning.push_str(text);
-                        crate::emit_agent_event(
+                        crate::emit_agent_event_in(
                             app,
                             AgentEvent::Reasoning {
                                 frame_id: frame_id.to_string(),
                                 delta: text.to_string(),
                             },
+                            Some(project.id.as_str()),
                         );
                     }
                 }
@@ -1308,9 +1324,12 @@ async fn run_acp_turn_inner(
                     if kind == AcpUpdateKind::Plan {
                         plan = Some(payload.clone());
                     }
-                    let _ = app.emit(
+                    crate::emit_to_session_surfaces(
+                        app,
+                        frame_id,
+                        Some(project.id.as_str()),
                         "acp-session-update",
-                        serde_json::json!({
+                        &serde_json::json!({
                             "frameId": frame_id,
                             "kind": format!("{kind:?}"),
                             "payload": payload,
@@ -1366,13 +1385,14 @@ async fn run_acp_turn_inner(
     )
     .await;
     if !resources.is_empty() {
-        crate::emit_agent_event(
+        crate::emit_agent_event_in(
             app,
             AgentEvent::Resources {
                 frame_id: frame_id.to_string(),
                 seq: next_seq,
                 resources: resources.iter().map(Into::into).collect(),
             },
+            Some(project.id.as_str()),
         );
     }
     cancel_pending_permissions(state, frame_id, &runtime).await;
@@ -1479,9 +1499,13 @@ async fn respond_acp_permission_inner(
         state.awaiting_confirm.lock().unwrap().remove(&frame_id);
         state.device_hub.resolve_needs_user(&frame_id);
     }
-    let _ = app.emit(
+    let project_id = state.store.frame_project_id(&frame_id).await.ok().flatten();
+    crate::emit_to_session_surfaces(
+        app,
+        &frame_id,
+        project_id.as_deref(),
         "permission-resolved",
-        serde_json::json!({
+        &serde_json::json!({
             "frameId": frame_id,
             "requestId": request_id,
         }),
@@ -1579,10 +1603,13 @@ pub(crate) async fn respond_ask_user(
         state.awaiting_confirm.lock().unwrap().remove(&frame_id);
         state.device_hub.resolve_needs_user(&frame_id);
     }
-    let _ = app.emit_to(
-        window.label(),
+    let project_id = state.store.frame_project_id(&frame_id).await.ok().flatten();
+    crate::emit_to_session_surfaces(
+        &app,
+        &frame_id,
+        project_id.as_deref(),
         "ask-user-resolved",
-        serde_json::json!({
+        &serde_json::json!({
             "frameId": frame_id,
             "requestId": request_id,
             "expired": false,
@@ -1625,9 +1652,12 @@ pub(crate) async fn set_acp_session_config(
         .await
         .map_err(|error| error.to_string())?;
     let value = serde_json::to_value(&options).map_err(|error| error.to_string())?;
-    let _ = app.emit(
+    crate::emit_to_session_surfaces(
+        &app,
+        &frame_id,
+        Some(project.id.as_str()),
         "acp-session-state",
-        serde_json::json!({
+        &serde_json::json!({
             "frameId": frame_id,
             "configOptions": value,
         }),

--- a/src-tauri/src/agent_turn.rs
+++ b/src-tauri/src/agent_turn.rs
@@ -814,7 +814,7 @@ pub(crate) async fn send_message_inner(
                     .await
                     .map_err(|error| error.to_string())?;
                 append_ui_event(&state.store, &frame_id, &mut event_seq, event.clone()).await;
-                emit_agent_event(&app, event);
+                emit_agent_event_in(&app, event, Some(&ap.id));
                 persist_and_emit_terminal_event(
                     state,
                     &app,
@@ -960,13 +960,14 @@ pub(crate) async fn send_message_inner(
                         )
                         .await;
                         if !resources.is_empty() {
-                            emit_agent_event(
+                            emit_agent_event_in(
                                 &resource_app,
                                 AgentEvent::Resources {
                                     frame_id: fid,
                                     seq,
                                     resources: resources.iter().map(Into::into).collect(),
                                 },
+                                Some(&resource_project_id),
                             );
                         }
                     }
@@ -1076,10 +1077,11 @@ pub(crate) async fn send_message_inner(
     let (live_event_handle, live_event_tx) = {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<AgentEvent>();
         let app = app.clone();
+        let project_id = ap.id.clone();
         let handle = tokio::spawn(coalesce_live_agent_events(
             rx,
             LIVE_EVENT_FLUSH_INTERVAL,
-            move |event| emit_agent_event_to_surfaces(&app, event),
+            move |event| emit_agent_event_to_surfaces_in(&app, event, Some(&project_id)),
         ));
         (handle, tx)
     };
@@ -1241,7 +1243,7 @@ pub(crate) async fn send_message_inner(
                 },
             )
             .await;
-            emit_browser_tab_cleanup(state, &app, &browser_turn_id).await;
+            emit_browser_tab_cleanup(state, &app, &frame_id, &ap.id, &browser_turn_id).await;
             Ok(frame_id)
         }
         Err(e) => {
@@ -1261,17 +1263,30 @@ pub(crate) async fn send_message_inner(
                 },
             )
             .await;
-            emit_browser_tab_cleanup(state, &app, &browser_turn_id).await;
+            emit_browser_tab_cleanup(state, &app, &frame_id, &ap.id, &browser_turn_id).await;
             Err(client_turn_error(turn_started, &message))
         }
     }
 }
 
-async fn emit_browser_tab_cleanup(state: &AppState, app: &AppHandle, turn_id: &str) {
+async fn emit_browser_tab_cleanup(
+    state: &AppState,
+    app: &AppHandle,
+    frame_id: &str,
+    project_id: &str,
+    turn_id: &str,
+) {
     if let browser_bridge::TabCleanupAction::Prompt(prompt) =
         state.browser_bridge.complete_turn(turn_id).await
     {
-        let _ = app.emit("browser-tab-cleanup", prompt);
+        emit_to_session_surfaces_filtered(
+            app,
+            frame_id,
+            Some(project_id),
+            "browser-tab-cleanup",
+            &prompt,
+            false,
+        );
     }
 }
 

--- a/src-tauri/src/app_state.rs
+++ b/src-tauri/src/app_state.rs
@@ -538,6 +538,13 @@ impl AppState {
             .cloned()
             .expect("main window active project is initialized at startup")
     }
+    pub(crate) fn bound_project_id(&self, label: &str) -> Option<String> {
+        self.active
+            .read()
+            .unwrap()
+            .get(label)
+            .map(|project| project.id.clone())
+    }
     pub(crate) fn set_active(&self, label: &str, ap: ActiveProject) {
         self.active.write().unwrap().insert(label.to_string(), ap);
     }
@@ -596,6 +603,37 @@ impl AppState {
             origin.get(frame_id).map(String::as_str),
             frame_id,
             project_id,
+            &active_projects,
+            &active_frames,
+        )
+    }
+
+    /// Windows currently bound to this session's project. Live agent, approval,
+    /// and browser-cleanup events use this set so a second project window never
+    /// receives another workspace's stream.
+    pub(crate) fn session_surface_labels(
+        &self,
+        frame_id: &str,
+        project_id: Option<&str>,
+    ) -> Vec<String> {
+        let active = self.active.read().unwrap();
+        let active_projects = active
+            .iter()
+            .map(|(label, project)| (label.clone(), project.id.clone()))
+            .collect::<HashMap<_, _>>();
+        let active_frames = self.active_frame.read().unwrap();
+        let inferred = project_id.map(str::to_string).or_else(|| {
+            active_frames.iter().find_map(|(label, viewed)| {
+                (viewed.as_str() == frame_id)
+                    .then(|| active.get(label).map(|project| project.id.clone()))
+                    .flatten()
+            })
+        });
+        let origin = self.notification_window.read().unwrap();
+        session_surface_window_labels(
+            origin.get(frame_id).map(String::as_str),
+            frame_id,
+            inferred.as_deref(),
             &active_projects,
             &active_frames,
         )

--- a/src-tauri/src/browser_bridge/mod.rs
+++ b/src-tauri/src/browser_bridge/mod.rs
@@ -3124,8 +3124,20 @@ impl Tool for WebAgentReadTool {
 #[tauri::command]
 pub async fn list_pending_browser_tab_cleanups(
     state: tauri::State<'_, crate::AppState>,
+    window: tauri::WebviewWindow,
 ) -> Result<Vec<BrowserTabCleanupPrompt>, String> {
-    Ok(state.browser_bridge.list_pending_cleanups().await)
+    let Some(project_id) = state.bound_project_id(window.label()) else {
+        return Ok(Vec::new());
+    };
+    let prompts = state.browser_bridge.list_pending_cleanups().await;
+    let mut kept = Vec::new();
+    for prompt in prompts {
+        match state.store.frame_project_id(&prompt.frame_id).await {
+            Ok(Some(owner)) if owner == project_id => kept.push(prompt),
+            _ => {}
+        }
+    }
+    Ok(kept)
 }
 
 #[tauri::command]

--- a/src-tauri/src/desktop_lifecycle.rs
+++ b/src-tauri/src/desktop_lifecycle.rs
@@ -6,7 +6,6 @@ use tauri::{
 };
 use tauri::{AppHandle, Emitter, Manager};
 
-#[cfg(target_os = "windows")]
 pub(crate) const PET_WINDOW_LABEL: &str = "pet";
 
 #[cfg(target_os = "windows")]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -267,6 +267,35 @@ enum AgentEvent {
     },
 }
 
+impl AgentEvent {
+    fn frame_id(&self) -> &str {
+        match self {
+            Self::User { frame_id, .. }
+            | Self::MessageBoundary { frame_id, .. }
+            | Self::Resources { frame_id, .. }
+            | Self::Text { frame_id, .. }
+            | Self::Reasoning { frame_id, .. }
+            | Self::ToolCall { frame_id, .. }
+            | Self::ToolResult { frame_id, .. }
+            | Self::ToolPresentation { frame_id, .. }
+            | Self::Usage { frame_id, .. }
+            | Self::Compaction { frame_id, .. }
+            | Self::CompactionStarted { frame_id, .. }
+            | Self::ContextWarning { frame_id, .. }
+            | Self::Diff { frame_id, .. }
+            | Self::FileChanged { frame_id, .. }
+            | Self::Stdout { frame_id, .. }
+            | Self::Done { frame_id, .. }
+            | Self::Error { frame_id, .. }
+            | Self::DelegationCompleted { frame_id, .. }
+            | Self::ReviewStarted { frame_id, .. }
+            | Self::ReviewFailed { frame_id, .. }
+            | Self::Review { frame_id, .. }
+            | Self::CorrectionStarted { frame_id, .. } => frame_id,
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Clone, PartialEq, Eq)]
 pub(crate) struct ConfirmRequest {
     /// Opaque, one-shot capability used by text-only remote approval surfaces.
@@ -294,8 +323,14 @@ impl ConfirmRequest {
     }
 }
 
-fn emit_confirm_request(app: &AppHandle, request: &ConfirmRequest) {
-    let _ = app.emit("confirm-request", request.clone());
+fn emit_confirm_request(app: &AppHandle, request: &ConfirmRequest, project_id: Option<&str>) {
+    emit_to_session_surfaces(
+        app,
+        &request.frame_id,
+        project_id,
+        "confirm-request",
+        request,
+    );
     channels::publish_approval_request(request);
 }
 
@@ -332,7 +367,7 @@ async fn request_image_resize_confirmation(
         .unwrap()
         .insert(frame_id.to_string());
     state.device_hub.mark_needs_user(frame_id, Some(project_id));
-    emit_confirm_request(app, &request);
+    emit_confirm_request(app, &request, Some(project_id));
     let approved = receive_confirm_decision(rx).await.approved();
     state.confirms.lock().unwrap().remove(frame_id);
     state.awaiting_confirm.lock().unwrap().remove(frame_id);
@@ -1787,7 +1822,8 @@ async fn persist_and_emit_terminal_event(
         Ok(mut seq) => append_ui_event(&state.store, frame_id, &mut seq, event.clone()).await,
         Err(error) => tracing::warn!("load terminal UI event sequence failed: {error}"),
     }
-    emit_agent_event(app, event);
+    let project_id = state.store.frame_project_id(frame_id).await.ok().flatten();
+    emit_agent_event_in(app, event, project_id.as_deref());
 }
 
 /// Keep the raw terminal records intact for support bundles. Historical
@@ -2194,6 +2230,70 @@ fn select_notification_window(
         .map(|label| selection(label, false))
 }
 
+/// Windows that should receive live session UI (agent stream, approvals).
+///
+/// Every window currently bound to the session's project sees the stream, so two
+/// views of the same workspace stay in sync. A window bound to a different
+/// project never does — unlike desktop notifications, live UI must not fall
+/// back onto a foreign workspace.
+fn session_surface_window_labels(
+    _origin: Option<&str>,
+    frame_id: &str,
+    project_id: Option<&str>,
+    active_projects: &HashMap<String, String>,
+    active_frames: &HashMap<String, String>,
+) -> Vec<String> {
+    let mut labels = if let Some(project_id) = project_id {
+        active_projects
+            .iter()
+            .filter(|(label, active_project)| {
+                label.as_str() != "pet" && active_project.as_str() == project_id
+            })
+            .map(|(label, _)| label.clone())
+            .collect::<Vec<_>>()
+    } else {
+        active_frames
+            .iter()
+            .filter(|(label, viewed)| viewed.as_str() == frame_id && label.as_str() != "pet")
+            .map(|(label, _)| label.clone())
+            .collect::<Vec<_>>()
+    };
+    labels.sort();
+    labels.dedup();
+    labels
+}
+
+/// Emit a live session event only to windows of that conversation's project.
+pub(crate) fn emit_to_session_surfaces<T: Clone + Serialize>(
+    app: &AppHandle,
+    frame_id: &str,
+    project_id: Option<&str>,
+    event: &str,
+    payload: &T,
+) {
+    emit_to_session_surfaces_filtered(app, frame_id, project_id, event, payload, true);
+}
+
+pub(crate) fn emit_to_session_surfaces_filtered<T: Clone + Serialize>(
+    app: &AppHandle,
+    frame_id: &str,
+    project_id: Option<&str>,
+    event: &str,
+    payload: &T,
+    include_pet: bool,
+) {
+    let state = app.state::<AppState>();
+    let mut labels = state.session_surface_labels(frame_id, project_id);
+    if include_pet {
+        labels.push(desktop_lifecycle::PET_WINDOW_LABEL.to_string());
+    }
+    labels.sort();
+    labels.dedup();
+    for label in labels {
+        let _ = app.emit_to(&label, event, payload.clone());
+    }
+}
+
 #[tauri::command]
 async fn update_mcp_app_context(
     state: State<'_, AppState>,
@@ -2309,7 +2409,7 @@ async fn request_mcp_app_tool_confirmation(
         .unwrap()
         .insert(frame_id.to_string());
     state.device_hub.mark_needs_user(frame_id, Some(project_id));
-    emit_confirm_request(app, &request);
+    emit_confirm_request(app, &request, Some(project_id));
     let decision = receive_confirm_decision(rx).await;
     state.confirms.lock().unwrap().remove(frame_id);
     state.awaiting_confirm.lock().unwrap().remove(frame_id);
@@ -2682,10 +2782,14 @@ impl TauriOutput {
         match &self.live_events {
             Some(tx) => {
                 if let Err(send_error) = tx.send(event) {
-                    emit_agent_event_to_surfaces(&self.app, send_error.0);
+                    emit_agent_event_to_surfaces_in(
+                        &self.app,
+                        send_error.0,
+                        Some(&self.project_id),
+                    );
                 }
             }
-            None => emit_agent_event_to_surfaces(&self.app, event),
+            None => emit_agent_event_to_surfaces_in(&self.app, event, Some(&self.project_id)),
         }
     }
 
@@ -2726,7 +2830,7 @@ impl TauriOutput {
             .insert(self.frame_id.clone());
         self.device_hub
             .mark_needs_user(&self.frame_id, Some(&self.project_id));
-        emit_confirm_request(&self.app, &request);
+        emit_confirm_request(&self.app, &request, Some(&self.project_id));
 
         // There is deliberately no timeout: lack of approval must never be
         // converted into a denial that lets the same agent turn continue.
@@ -2775,18 +2879,27 @@ impl TauriOutput {
     }
 }
 
-fn emit_agent_event_to_surfaces(app: &AppHandle, event: AgentEvent) {
+pub(crate) fn emit_agent_event_to_surfaces_in(
+    app: &AppHandle,
+    event: AgentEvent,
+    project_id: Option<&str>,
+) {
     if !matches!(event, AgentEvent::ToolPresentation { .. }) {
         channels::publish_agent_event(&event);
     }
-    let _ = app.emit("agent", event);
+    let frame_id = event.frame_id().to_string();
+    emit_to_session_surfaces(app, &frame_id, project_id, "agent", &event);
 }
 
 fn emit_agent_event(app: &AppHandle, event: AgentEvent) {
+    emit_agent_event_in(app, event, None);
+}
+
+pub(crate) fn emit_agent_event_in(app: &AppHandle, event: AgentEvent, project_id: Option<&str>) {
     app.state::<AppState>()
         .device_hub
-        .apply_agent_event(&event, None);
-    emit_agent_event_to_surfaces(app, event);
+        .apply_agent_event(&event, project_id);
+    emit_agent_event_to_surfaces_in(app, event, project_id);
 }
 
 fn should_persist_ui_event(event: &AgentEvent) -> bool {

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -3338,7 +3338,7 @@ fn App() -> impl IntoView {
     // wasm-bindgen only runs an async extern's JS body when the returned
     // future is polled, so we must await `listen` (not fire-and-forget it).
     spawn_local(async move {
-        let _ = listen("agent", &agent_js).await;
+        let _ = listen_current_window("agent", &agent_js).await;
     });
 
     // Confirm handler: render an inline approval card in the session thread
@@ -3411,7 +3411,7 @@ fn App() -> impl IntoView {
         .clone();
     std::mem::forget(confirm_cb);
     spawn_local(async move {
-        let _ = listen("confirm-request", &confirm_js).await;
+        let _ = listen_current_window("confirm-request", &confirm_js).await;
     });
 
     let browser_cleanup_pending = browser_tab_cleanup;
@@ -3435,7 +3435,7 @@ fn App() -> impl IntoView {
         .clone();
     std::mem::forget(browser_cleanup_cb);
     spawn_local(async move {
-        let _ = listen("browser-tab-cleanup", &browser_cleanup_js).await;
+        let _ = listen_current_window("browser-tab-cleanup", &browser_cleanup_js).await;
         if let Ok(value) =
             invoke_checked("list_pending_browser_tab_cleanups", JsValue::UNDEFINED).await
         {
@@ -3497,7 +3497,7 @@ fn App() -> impl IntoView {
         .clone();
     acp_permission_cb.forget();
     spawn_local(async move {
-        let _ = listen("permission-request", &acp_permission_js).await;
+        let _ = listen_current_window("permission-request", &acp_permission_js).await;
     });
 
     let acp_update_buf = delta_buf.clone();
@@ -3604,7 +3604,7 @@ fn App() -> impl IntoView {
         .clone();
     acp_update_cb.forget();
     spawn_local(async move {
-        let _ = listen("acp-session-update", &acp_update_js).await;
+        let _ = listen_current_window("acp-session-update", &acp_update_js).await;
     });
 
     let project_transfer_cb = Closure::wrap(Box::new(move |payload: JsValue| {
@@ -3644,7 +3644,7 @@ fn App() -> impl IntoView {
         .clone();
     acp_state_cb.forget();
     spawn_local(async move {
-        let _ = listen("acp-session-state", &acp_state_js).await;
+        let _ = listen_current_window("acp-session-state", &acp_state_js).await;
     });
 
     let acp_resolved_cb = Closure::wrap(Box::new(move |payload: JsValue| {
@@ -3670,7 +3670,7 @@ fn App() -> impl IntoView {
         .clone();
     acp_resolved_cb.forget();
     spawn_local(async move {
-        let _ = listen("permission-resolved", &acp_resolved_js).await;
+        let _ = listen_current_window("permission-resolved", &acp_resolved_js).await;
     });
 
     // ACP `ask_user`: the bridge parks the agent's question until the user
@@ -3702,7 +3702,7 @@ fn App() -> impl IntoView {
         .clone();
     ask_user_cb.forget();
     spawn_local(async move {
-        let _ = listen("ask-user-request", &ask_user_js).await;
+        let _ = listen_current_window("ask-user-request", &ask_user_js).await;
     });
 
     let ask_resolved_cb = Closure::wrap(Box::new(move |payload: JsValue| {


### PR DESCRIPTION
## Summary
- Agent 流、审批卡、ACP 会话更新、浏览器清标签提示改为 `emit_to_session_surfaces`，只投到该项目绑定的窗口。
- 前端 session 事件从进程级 `listen()` 改为 `listen_current_window()`，两窗口实时流不再串台。
- 无对应窗口时不会回落到另一个项目的主窗口。

Closes #1079
属于 #1074。拆自 #1072。

## Test plan
- [ ] 两窗口打开不同项目，各发一条会跑工具的消息
- [ ] 确认流式输出和审批卡只出现在对应项目的窗口
- [ ] 确认浏览器清标签提示不会出现在另一个项目窗口

Made with [Cursor](https://cursor.com)