### PR TITLE
feat: 审批范围、单工具审批与 Skip approvals 按项目 overlay

### DIFF
--- a/src-tauri/src/app_state.rs
+++ b/src-tauri/src/app_state.rs
@@ -478,8 +478,9 @@ pub(crate) struct AppState {
     pub(crate) confirms: ConfirmMap,
     /// Sessions blocked on an inline approval card (Projects dashboard → Needs you).
     pub(crate) awaiting_confirm: Arc<StdMutex<HashSet<String>>>,
-    /// Live per-tool approval policy, read on every tool call by `TauriOutput`.
-    pub(crate) approvals: Arc<StdRwLock<ApprovalPolicy>>,
+    /// Per-project approval policies, read on every tool call by `TauriOutput`.
+    /// Key "" holds the global default; project ids override with their overlay.
+    pub(crate) approvals: Arc<StdRwLock<HashMap<String, ApprovalPolicy>>>,
     /// Scoped approvals granted from the inline confirmation card.
     pub(crate) approval_grants: Arc<StdMutex<ApprovalGrants>>,
     /// Conversations whose approval prompts are bypassed for this app run.
@@ -537,6 +538,15 @@ impl AppState {
             .or_else(|| map.get("main"))
             .cloned()
             .expect("main window active project is initialized at startup")
+    }
+    /// Project id bound to a specific window, if any. Returns `None` for
+    /// blank home windows that have no project yet.
+    pub(crate) fn bound_project_id(&self, label: &str) -> Option<String> {
+        self.active
+            .read()
+            .unwrap()
+            .get(label)
+            .map(|project| project.id.clone())
     }
     pub(crate) fn set_active(&self, label: &str, ap: ActiveProject) {
         self.active.write().unwrap().insert(label.to_string(), ap);

--- a/src-tauri/src/connector_commands.rs
+++ b/src-tauri/src/connector_commands.rs
@@ -1,8 +1,8 @@
 use super::{
     bio_domains, clear_idle_agents, connect_mcp, load_approval_scope, load_disabled_connectors,
-    load_mcp_connections, load_skip_connectors, load_tool_approvals, refresh_approval_policy,
-    save_json_setting, save_mcp_connections, AppState, ApprovalMode, McpConnection, McpHttpAuth,
-    McpTransport, Scope,
+    load_json_setting, load_mcp_connections, load_skip_connectors, load_tool_approvals,
+    refresh_approval_policy, refresh_approval_policy_for, save_json_setting, save_mcp_connections,
+    AppState, ApprovalMode, McpConnection, McpHttpAuth, McpTransport, Scope,
 };
 use serde::Serialize;
 use tauri::State;
@@ -135,7 +135,10 @@ pub(super) struct ConnectorsView {
 }
 
 #[tauri::command]
-pub(super) async fn list_connectors(state: State<'_, AppState>) -> Result<ConnectorsView, String> {
+pub(super) async fn list_connectors(
+    state: State<'_, AppState>,
+    window: tauri::WebviewWindow,
+) -> Result<ConnectorsView, String> {
     let store = &state.store;
     let disabled = load_disabled_connectors(store).await;
     let approvals = load_tool_approvals(store).await;
@@ -185,7 +188,17 @@ pub(super) async fn list_connectors(state: State<'_, AppState>) -> Result<Connec
             tools: vec![],
         });
     }
-    let scope = load_approval_scope(store).await.as_str().to_string();
+    let scope = if let Some(project_id) = state.bound_project_id(window.label()) {
+        let key = format!("project:{project_id}:approval_scope");
+        let val = load_json_setting::<String>(store, &key).await;
+        if val.is_empty() {
+            load_approval_scope(store).await.as_str().to_string()
+        } else {
+            Scope::parse(&val).as_str().to_string()
+        }
+    } else {
+        load_approval_scope(store).await.as_str().to_string()
+    };
     Ok(ConnectorsView { connectors, scope })
 }
 
@@ -229,21 +242,24 @@ pub(super) async fn set_tool_approval(
     Ok(())
 }
 
-/// Set the global approval scope ("full" | "auto" | "ask"). Enforced live on
-/// the next tool call — no session rebuild needed.
+/// Set the approval scope ("full" | "auto" | "ask"). When called from a
+/// window bound to a project, writes a per-project overlay; otherwise
+/// writes the global default. Enforced live on the next tool call.
 #[tauri::command]
 pub(super) async fn set_approval_scope(
     state: State<'_, AppState>,
+    window: tauri::WebviewWindow,
     scope: String,
 ) -> Result<(), String> {
-    // Normalize through `Scope` so only the three valid values ever persist.
-    save_json_setting(
-        &state.store,
-        "approval_scope",
-        &Scope::parse(&scope).as_str(),
-    )
-    .await?;
-    refresh_approval_policy(&state).await;
+    let normalized = Scope::parse(&scope).as_str().to_string();
+    if let Some(project_id) = state.bound_project_id(window.label()) {
+        let key = format!("project:{project_id}:approval_scope");
+        save_json_setting(&state.store, &key, &normalized).await?;
+        refresh_approval_policy_for(&state, &project_id).await;
+    } else {
+        save_json_setting(&state.store, "approval_scope", &normalized).await?;
+        refresh_approval_policy(&state).await;
+    }
     Ok(())
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -716,7 +716,7 @@ impl ApprovalMode {
 /// `Auto` silences per-tool prompts but a dangerous command still asks. `Full`
 /// auto-approves everything, dangerous commands included. An explicit per-tool
 /// `Deny` survives every scope: it's a hard block, not a prompt.
-#[derive(Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 enum Scope {
     Full,
     Auto,
@@ -2388,7 +2388,12 @@ async fn call_mcp_app_tool(
     let host_approval = state
         .approvals
         .read()
-        .map(|policy| policy.mode_for(&name))
+        .map(|map| {
+            map.get(&project_id)
+                .or_else(|| map.get(""))
+                .map(|p| p.mode_for(&name))
+                .unwrap_or(wisp_tools::Approval::Allow)
+        })
         .unwrap_or(wisp_tools::Approval::Allow);
     let full_permission = state
         .full_permission_sessions
@@ -2625,8 +2630,8 @@ struct TauriOutput {
     device_hub: Arc<device_hub::DeviceHub>,
     confirms: ConfirmMap,
     awaiting_confirm: Arc<StdMutex<HashSet<String>>>,
-    /// Shared live approval policy (see `AppState::approvals`).
-    approvals: Arc<StdRwLock<ApprovalPolicy>>,
+    /// Per-project approval policies (see `AppState::approvals`).
+    approvals: Arc<StdRwLock<HashMap<String, ApprovalPolicy>>>,
     /// Built-in plan mode for this session, read once per turn. ACP-bound
     /// frames never set it — their plan mode lives on the agent side.
     plan_mode: bool,
@@ -2969,7 +2974,12 @@ impl Output for TauriOutput {
     fn approval_mode(&self, tool: &str) -> wisp_tools::Approval {
         self.approvals
             .read()
-            .map(|p| p.mode_for(tool))
+            .map(|map| {
+                map.get(&self.project_id)
+                    .or_else(|| map.get(""))
+                    .map(|p| p.mode_for(tool))
+                    .unwrap_or(wisp_tools::Approval::Allow)
+            })
             .unwrap_or(wisp_tools::Approval::Allow)
     }
     fn restrict_read_paths_to_project(&self) -> bool {
@@ -3035,7 +3045,17 @@ impl Output for TauriOutput {
         if self.force_ask_mutations {
             return false;
         }
-        self.full_permission() || self.approvals.read().map(|p| p.full()).unwrap_or(false)
+        self.full_permission()
+            || self
+                .approvals
+                .read()
+                .map(|map| {
+                    map.get(&self.project_id)
+                        .or_else(|| map.get(""))
+                        .map(|p| p.full())
+                        .unwrap_or(false)
+                })
+                .unwrap_or(false)
     }
     fn force_ask_mutations(&self) -> bool {
         self.force_ask_mutations
@@ -4030,9 +4050,20 @@ fn build_tool_connector_map() -> HashMap<String, String> {
 }
 
 /// Snapshot the persisted approval state into a fresh `ApprovalPolicy`.
-async fn build_approval_policy(store: &Store) -> ApprovalPolicy {
+/// When `project_id` is given and a project-scoped scope override exists,
+/// the returned policy uses that override instead of the global scope.
+async fn build_approval_policy(store: &Store, project_id: Option<&str>) -> ApprovalPolicy {
+    let scope = if let Some(pid) = project_id {
+        let key = format!("project:{pid}:approval_scope");
+        match load_json_setting::<String>(store, &key).await.as_str() {
+            "" => load_approval_scope(store).await,
+            s => Scope::parse(s),
+        }
+    } else {
+        load_approval_scope(store).await
+    };
     ApprovalPolicy {
-        scope: load_approval_scope(store).await,
+        scope,
         tools: load_tool_approvals(store)
             .await
             .into_iter()
@@ -4046,9 +4077,17 @@ async fn build_approval_policy(store: &Store) -> ApprovalPolicy {
 /// Reload the live approval policy after a settings change so running sessions
 /// see it on their next tool call (approval is enforced live, not per session).
 async fn refresh_approval_policy(state: &AppState) {
-    let policy = build_approval_policy(&state.store).await;
+    let global = build_approval_policy(&state.store, None).await;
     if let Ok(mut guard) = state.approvals.write() {
-        *guard = policy;
+        guard.insert(String::new(), global);
+    }
+}
+
+/// Reload the approval policy for a specific project.
+async fn refresh_approval_policy_for(state: &AppState, project_id: &str) {
+    let policy = build_approval_policy(&state.store, Some(project_id)).await;
+    if let Ok(mut guard) = state.approvals.write() {
+        guard.insert(project_id.to_string(), policy);
     }
 }
 
@@ -6656,7 +6695,10 @@ pub fn run() {
                 app_commands::initial_bootstrap(&root, skills.all().len())
             }));
             let approvals = Arc::new(StdRwLock::new(startup.record("approvals", || {
-                tauri::async_runtime::block_on(build_approval_policy(&store))
+                let global = tauri::async_runtime::block_on(build_approval_policy(&store, None));
+                let mut map = HashMap::new();
+                map.insert(String::new(), global);
+                map
             })));
             let approval_grants = Arc::new(StdMutex::new(startup.record("approval_grants", || {
                 tauri::async_runtime::block_on(load_approval_grants(&store))

--- a/src-tauri/src/lib_tests.rs
+++ b/src-tauri/src/lib_tests.rs
@@ -16,6 +16,7 @@ use super::{
     SkillInfo, StartupReport, StartupTimeline, MAX_PENDING_UI_EVENT_BYTES,
     UI_STREAM_OUTPUT_MAX_BYTES, UI_TOOL_RESULT_MAX_CHARS,
 };
+use super::{build_approval_policy, Scope};
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::{atomic::AtomicBool, Arc};
@@ -2460,4 +2461,32 @@ fn ui_watchdog_unfocused_silence_is_not_stale() {
     let mut none = None;
     ui_watchdog_note_unfocused(&mut none);
     assert!(none.is_none());
+}
+
+#[tokio::test]
+async fn per_project_approval_scope_overrides_global() {
+    let tmp = std::env::temp_dir().join(format!("wisp_approval_{}.sqlite", uuid::Uuid::new_v4()));
+    let store = wisp_store::Store::open(&tmp).await.unwrap();
+
+    // Global scope defaults to "ask".
+    let global = build_approval_policy(&store, None).await;
+    assert_eq!(global.scope, Scope::Ask);
+
+    // No project override → same as global.
+    let proj = build_approval_policy(&store, Some("proj-1")).await;
+    assert_eq!(proj.scope, Scope::Ask);
+
+    // Write a project override.
+    store
+        .set_setting("project:proj-1:approval_scope", "\"full\"")
+        .await
+        .unwrap();
+    let proj = build_approval_policy(&store, Some("proj-1")).await;
+    assert_eq!(proj.scope, Scope::Full);
+
+    // Global still unchanged.
+    let global = build_approval_policy(&store, None).await;
+    assert_eq!(global.scope, Scope::Ask);
+
+    let _ = std::fs::remove_file(tmp);
 }


### PR DESCRIPTION
## Summary
- 审批范围写成项目 overlay（`project:{id}:approval_scope`），无 overlay 的项目继承全局默认。
- `list_connectors` / `set_approval_scope` 按当前窗口解析项目；空白窗口改审批写全局默认，不 panic。
- 内存中的 `ApprovalPolicy` 改为按项目 id 索引，两个窗口可以各自一份策略。

Closes #1078
属于 #1074。拆自 #1072。

## Test plan
- [ ] 在项目 A 窗口把审批范围改成 Full
- [ ] 看项目 B 窗口的设置，并在 B 里触发一次需审批的工具
- [ ] 确认 B 的策略不变，仍按 B 自己的审批询问
- [ ] `cargo test -p wisp-tauri -- per_project_approval`

Made with [Cursor](https://cursor.com)