### PR TITLE
feat(browser): add needs_human verification handoff

### DIFF
--- a/crates/wisp-dto/src/lib.rs
+++ b/crates/wisp-dto/src/lib.rs
@@ -1701,6 +1701,42 @@ pub struct BrowserTabCleanupPrompt {
     pub tabs: Vec<BrowserTabCleanupItem>,
 }
 
+/// A tab whose current page needs the user to complete a human-verification
+/// challenge before browser automation may continue.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BrowserNeedsHumanTab {
+    #[serde(default)]
+    pub session: String,
+    pub tab_id: i64,
+    #[serde(default)]
+    pub url: String,
+    #[serde(default)]
+    pub title: String,
+    #[serde(default)]
+    pub reason: String,
+    #[serde(default)]
+    pub frame_id: String,
+    #[serde(default)]
+    pub turn_id: String,
+}
+
+/// Live set of tabs waiting on human verification. Replaces the previous
+/// snapshot each time it is emitted.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BrowserNeedsHumanPrompt {
+    #[serde(default)]
+    pub tabs: Vec<BrowserNeedsHumanTab>,
+}
+
+/// Result of re-scanning tabs the user marked as completed.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BrowserNeedsHumanConfirmResult {
+    #[serde(default)]
+    pub still_required: Vec<BrowserNeedsHumanTab>,
+    #[serde(default)]
+    pub cleared: Vec<BrowserNeedsHumanTab>,
+}
+
 /// Reply of `open_browser_extension_page`: managed extension path and whether
 /// a browser was launched on its extension-manager page.
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]

--- a/docs/browser-runtime-acceptance.md
+++ b/docs/browser-runtime-acceptance.md
@@ -14,3 +14,4 @@ Use a Wisp build that bundles extension **0.3.1**. Load the unpacked extension f
 Popup **Pause control** must fail later automations with `USER_CONTROLLING`.
 
 6. Open several tabs with `web_open_tab` in one turn. With **Settings → Browser → Automatically close browser tabs** off, the turn-end dialog lists only those tabs (not ones already open). Unchecking one and confirming closes the rest. Enabling the setting closes this turn's tabs without a dialog.
+7. Open ScienceDirect (or any Cloudflare **Are you a robot?** page). `web_scan` must show the in-app **Human verification needed** prompt, keep that tab open when auto-close is on, and refuse click/JS on that tab until **I completed verification** succeeds.

--- a/docs/real-browser-automation.md
+++ b/docs/real-browser-automation.md
@@ -50,10 +50,11 @@ launching a browser.
 Wisp records tabs it created during the current turn (by `tab_id`, including
 after in-tab navigation) and never includes tabs that were already open.
 When the setting is on, those tabs are closed when the turn ends (completed,
-stopped, or failed). When it is off, a confirmation lists them, all selected
-by default; uncheck any to keep, then close the rest or keep all. If the
-extension is disconnected at the end of the turn, the pending list is kept
-until it reconnects.
+stopped, or failed). Tabs waiting on human verification (`needs_human`) are
+skipped until the challenge is gone. When it is off, a confirmation lists them,
+all selected by default; uncheck any to keep, then close the rest or keep all.
+If the extension is disconnected at the end of the turn, the pending list is
+kept until it reconnects.
 
 The banner describes the answer on screen, not the session. It is derived from
 the browser tool results of the latest turn only, and a single successful
@@ -79,11 +80,17 @@ stable extension ID are accepted.
 
 When `web_scan` detects an **Are you a robot?** page together with a request to
 confirm that the visitor is human or complete a CAPTCHA challenge, it returns
-`human_intervention.required=true`. The Agent must stop browser automation, ask
-the user to complete the challenge manually in the current visible browser tab,
-and wait for confirmation. It then scans the same tab again and continues only
-after the challenge is gone. The persistent browser profile keeps any clearance
-cookie issued after the manual verification.
+`human_intervention.required=true` and marks that tab `needs_human`. Wisp shows
+a prompt asking you to complete the challenge in the visible browser tab. The
+Agent must stop browser automation, must not call `ask_user`, and must not
+click the challenge. After you confirm in the app, it scans the same tab again
+and continues only when the challenge is gone.
+
+While a tab is `needs_human`, **Automatically close browser tabs** skips it, and
+the turn-end cleanup dialog does not offer it. The persistent browser profile
+keeps any clearance cookie issued after the manual verification. Closing the
+browser window itself can still drop the page (and, if Chrome is set to clear
+cookies on exit, the clearance cookie).
 
 Wisp does not attempt to click, solve, or bypass CAPTCHA challenges. A page that
 merely mentions the phrase **Are you a robot?** without the accompanying

--- a/skills/browser-use/SKILL.md
+++ b/skills/browser-use/SKILL.md
@@ -156,9 +156,10 @@ they opened during the task, are theirs.
 ## Stop conditions (do not automate through these)
 
 - **Human verification / CAPTCHA:** if `web_scan` returns
-  `human_intervention.required=true`, stop, ask the user to complete the
-  challenge in the visible tab, and wait for their confirmation before
-  scanning again.
+  `human_intervention.required=true`, a Wisp prompt has already been shown.
+  Stop browser automation. Do not call `ask_user`. Do not click, solve, or
+  bypass the challenge. End your turn. The user confirms in the app after
+  completing it in the visible tab; the next message is their confirmation.
 - **Credentials:** never type passwords, card numbers, or one-time codes
   yourself. If a step needs a password, have the user sign in directly in
   the browser and continue once they confirm.

--- a/skills/browser-use/SKILL.md
+++ b/skills/browser-use/SKILL.md
@@ -157,9 +157,10 @@ they opened during the task, are theirs.
 
 - **Human verification / CAPTCHA:** if `web_scan` returns
   `human_intervention.required=true`, a Wisp prompt has already been shown.
-  Stop browser automation. Do not call `ask_user`. Do not click, solve, or
-  bypass the challenge. End your turn. The user confirms in the app after
-  completing it in the visible tab; the next message is their confirmation.
+  Stop browser automation. Do not open another in-app question about the
+  challenge. Do not click, solve, or bypass it. End your turn. The user
+  confirms in the app after completing it in the visible tab; the next
+  message is their confirmation.
 - **Credentials:** never type passwords, card numbers, or one-time codes
   yourself. If a step needs a password, have the user sign in directly in
   the browser and continue once they confirm.

--- a/src-tauri/src/browser_bridge/mod.rs
+++ b/src-tauri/src/browser_bridge/mod.rs
@@ -30,6 +30,7 @@ use tokio_tungstenite::{accept_hdr_async, WebSocketStream};
 use uuid::Uuid;
 use wisp_dto::{
     BrowserExtensionSetup, BrowserExtensionStatus, BrowserExtensionUpdateResult,
+    BrowserNeedsHumanConfirmResult, BrowserNeedsHumanPrompt, BrowserNeedsHumanTab,
     BrowserTabCleanupItem, BrowserTabCleanupPrompt,
 };
 use wisp_llm::ToolSchema;
@@ -64,6 +65,7 @@ const MAX_RESULT_CHARS: usize = 200_000;
 /// 5 MB decoded limit (base64 inflates by 4/3).
 const MAX_SCREENSHOT_B64: usize = 7 * 1024 * 1024;
 const PENDING_CLEANUP_KEY: &str = "browser_tab_cleanup_pending";
+const PENDING_NEEDS_HUMAN_KEY: &str = "browser_needs_human_pending";
 
 #[derive(Clone, Debug, Serialize)]
 pub struct BrowserTab {
@@ -178,6 +180,11 @@ pub struct BrowserBridge {
     /// Tabs `web_open_tab` / tab-create commands opened, keyed by turn id.
     turn_ledgers: Mutex<HashMap<String, TurnTabLedger>>,
     pending_cleanups: Mutex<HashMap<String, PendingCleanup>>,
+    /// Tabs whose current page needs a human to complete a CAPTCHA / robot
+    /// check. Keyed by `(session, tab_id)` so a later turn's auto-close cannot
+    /// take them, and so the UI can remind the user independently of the LLM.
+    needs_human: Mutex<HashMap<(String, i64), BrowserNeedsHumanTab>>,
+    needs_human_tx: Mutex<Option<mpsc::UnboundedSender<Vec<BrowserNeedsHumanTab>>>>,
 }
 
 #[derive(Clone, Debug)]
@@ -329,6 +336,8 @@ impl BrowserBridge {
             extension_update_lock: Mutex::new(()),
             turn_ledgers: Mutex::new(HashMap::new()),
             pending_cleanups: Mutex::new(HashMap::new()),
+            needs_human: Mutex::new(HashMap::new()),
+            needs_human_tx: Mutex::new(None),
         }
     }
 
@@ -362,8 +371,11 @@ impl BrowserBridge {
             extension_update_lock: Mutex::new(()),
             turn_ledgers: Mutex::new(HashMap::new()),
             pending_cleanups: Mutex::new(HashMap::new()),
+            needs_human: Mutex::new(HashMap::new()),
+            needs_human_tx: Mutex::new(None),
         });
         bridge.load_pending_cleanups().await;
+        bridge.load_pending_needs_human().await;
         match TcpListener::bind(BRIDGE_ADDR).await {
             Ok(listener) => {
                 let task_bridge = bridge.clone();
@@ -1216,6 +1228,17 @@ impl BrowserBridge {
         drop(ledgers);
         drop(pending);
         self.persist_pending().await;
+        let mut human = self.needs_human.lock().await;
+        let before = human.len();
+        human.retain(|(session_name, tab_id), _| {
+            !(session_name == session && id_set.contains(tab_id))
+        });
+        let changed = human.len() != before;
+        drop(human);
+        if changed {
+            self.persist_needs_human().await;
+            self.emit_needs_human().await;
+        }
     }
 
     fn still_open_tabs(state: &BridgeState, tabs: &[TrackedTab]) -> Vec<TrackedTab> {
@@ -1374,9 +1397,25 @@ impl BrowserBridge {
             Some(store) => browser_url_filters::auto_close_tabs_enabled(store).await,
             None => false,
         };
-        let prompt = Self::prompt_from_tabs(&ledger.turn_id, &ledger.frame_id, &tabs);
+        let held_keys: HashSet<(String, i64)> =
+            self.needs_human.lock().await.keys().cloned().collect();
+        let held_this_turn = tabs
+            .iter()
+            .any(|tab| held_keys.contains(&(tab.session.clone(), tab.tab_id)));
+        let closeable: Vec<TrackedTab> = tabs
+            .into_iter()
+            .filter(|tab| !held_keys.contains(&(tab.session.clone(), tab.tab_id)))
+            .collect();
+        if held_this_turn {
+            self.emit_needs_human().await;
+        }
+        if closeable.is_empty() {
+            return TabCleanupAction::None;
+        }
+        let prompt = Self::prompt_from_tabs(&ledger.turn_id, &ledger.frame_id, &closeable);
         if auto_close {
-            let items: Vec<BrowserTabCleanupItem> = tabs.iter().map(TrackedTab::to_item).collect();
+            let items: Vec<BrowserTabCleanupItem> =
+                closeable.iter().map(TrackedTab::to_item).collect();
             match self.close_items(&items).await {
                 Ok(_) => TabCleanupAction::Closed,
                 Err(_) => {
@@ -1429,6 +1468,262 @@ impl BrowserBridge {
     pub(crate) async fn dismiss_cleanup(&self, turn_id: &str) {
         self.pending_cleanups.lock().await.remove(turn_id);
         self.persist_pending().await;
+    }
+
+    pub(crate) async fn set_needs_human_sink(
+        &self,
+        tx: mpsc::UnboundedSender<Vec<BrowserNeedsHumanTab>>,
+    ) {
+        *self.needs_human_tx.lock().await = Some(tx);
+    }
+
+    pub(crate) async fn list_needs_human(&self) -> BrowserNeedsHumanPrompt {
+        BrowserNeedsHumanPrompt {
+            tabs: self.snapshot_needs_human().await,
+        }
+    }
+
+    async fn snapshot_needs_human(&self) -> Vec<BrowserNeedsHumanTab> {
+        let mut tabs: Vec<BrowserNeedsHumanTab> =
+            self.needs_human.lock().await.values().cloned().collect();
+        tabs.sort_by(|left, right| {
+            left.session
+                .cmp(&right.session)
+                .then(left.tab_id.cmp(&right.tab_id))
+        });
+        tabs
+    }
+
+    async fn emit_needs_human(&self) {
+        let tabs = self.snapshot_needs_human().await;
+        if let Some(tx) = self.needs_human_tx.lock().await.as_ref() {
+            let _ = tx.send(tabs);
+        }
+    }
+
+    async fn persist_needs_human(&self) {
+        let Some(store) = &self.store else {
+            return;
+        };
+        let tabs = self.snapshot_needs_human().await;
+        let json = serde_json::to_string(&tabs).unwrap_or_else(|_| "[]".into());
+        let _ = store.set_setting(PENDING_NEEDS_HUMAN_KEY, &json).await;
+    }
+
+    async fn load_pending_needs_human(&self) {
+        let Some(store) = &self.store else {
+            return;
+        };
+        let Some(raw) = store
+            .get_setting(PENDING_NEEDS_HUMAN_KEY)
+            .await
+            .ok()
+            .flatten()
+        else {
+            return;
+        };
+        let Ok(tabs) = serde_json::from_str::<Vec<BrowserNeedsHumanTab>>(&raw) else {
+            return;
+        };
+        let mut map = self.needs_human.lock().await;
+        for tab in tabs {
+            if tab.tab_id != 0 && !tab.session.is_empty() {
+                map.insert((tab.session.clone(), tab.tab_id), tab);
+            }
+        }
+    }
+
+    async fn apply_human_verification(
+        &self,
+        session: &str,
+        tab_id: i64,
+        page: &Value,
+        frame_id: &str,
+        turn_id: &str,
+    ) {
+        match human_verification_handoff(page) {
+            Some(handoff) => {
+                let reason = handoff
+                    .get("reason")
+                    .and_then(Value::as_str)
+                    .unwrap_or("captcha_challenge")
+                    .to_string();
+                let url = page
+                    .get("url")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string();
+                let title = page
+                    .get("title")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string();
+                let mut map = self.needs_human.lock().await;
+                let key = (session.to_string(), tab_id);
+                let inserted = !map.contains_key(&key);
+                let turn_changed = map
+                    .get(&key)
+                    .is_some_and(|existing| !turn_id.is_empty() && existing.turn_id != turn_id);
+                let entry = map.entry(key).or_insert_with(|| BrowserNeedsHumanTab {
+                    session: session.to_string(),
+                    tab_id,
+                    url: url.clone(),
+                    title: title.clone(),
+                    reason: reason.clone(),
+                    frame_id: frame_id.to_string(),
+                    turn_id: turn_id.to_string(),
+                });
+                if !url.is_empty() {
+                    entry.url = url;
+                }
+                if !title.is_empty() {
+                    entry.title = title;
+                }
+                entry.reason = reason;
+                if entry.frame_id.is_empty() && !frame_id.is_empty() {
+                    entry.frame_id = frame_id.to_string();
+                }
+                if !turn_id.is_empty() {
+                    entry.turn_id = turn_id.to_string();
+                }
+                drop(map);
+                self.persist_needs_human().await;
+                if inserted || turn_changed {
+                    self.emit_needs_human().await;
+                }
+            }
+            None => {
+                let removed = self
+                    .needs_human
+                    .lock()
+                    .await
+                    .remove(&(session.to_string(), tab_id))
+                    .is_some();
+                if removed {
+                    self.persist_needs_human().await;
+                    self.emit_needs_human().await;
+                }
+            }
+        }
+    }
+
+    async fn refuse_if_needs_human(
+        &self,
+        session: Option<&str>,
+        requested_tab: Option<i64>,
+        script: &str,
+    ) -> Result<(), String> {
+        let pending: HashSet<(String, i64)> =
+            self.needs_human.lock().await.keys().cloned().collect();
+        if pending.is_empty() {
+            return Ok(());
+        }
+        let state = self.state.lock().await;
+        let session_name = match session_name_locked(&state, session) {
+            Ok(name) => name,
+            Err(_) => return Ok(()),
+        };
+        if let Some(ids) = close_ids_from_script(script) {
+            if ids
+                .iter()
+                .any(|id| pending.contains(&(session_name.clone(), *id)))
+            {
+                return Err(needs_human_block_message());
+            }
+        }
+        if script_allowed_during_needs_human(script) {
+            return Ok(());
+        }
+        let Some(slot) = state.sessions.get(&session_name) else {
+            return Ok(());
+        };
+        let Ok(tab_id) = select_tab(slot, requested_tab) else {
+            return Ok(());
+        };
+        if pending.contains(&(session_name, tab_id)) {
+            return Err(needs_human_block_message());
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn confirm_needs_human(
+        &self,
+        tabs: &[BrowserNeedsHumanTab],
+    ) -> Result<BrowserNeedsHumanConfirmResult, String> {
+        let targets = if tabs.is_empty() {
+            self.snapshot_needs_human().await
+        } else {
+            tabs.to_vec()
+        };
+        let mut still_required = Vec::new();
+        let mut cleared = Vec::new();
+        for tab in targets {
+            match self
+                .execute_on(
+                    Some(&tab.session),
+                    Some(tab.tab_id),
+                    TEXT_SCAN_SCRIPT,
+                    Duration::from_millis(DEFAULT_TIMEOUT_MS),
+                )
+                .await
+            {
+                Ok(execution) => {
+                    self.apply_human_verification(
+                        &execution.session,
+                        execution.tab_id,
+                        &execution.value,
+                        &tab.frame_id,
+                        &tab.turn_id,
+                    )
+                    .await;
+                    if human_verification_handoff(&execution.value).is_some() {
+                        still_required.push(
+                            self.needs_human
+                                .lock()
+                                .await
+                                .get(&(execution.session.clone(), execution.tab_id))
+                                .cloned()
+                                .unwrap_or(tab),
+                        );
+                    } else {
+                        cleared.push(tab);
+                    }
+                }
+                Err(error)
+                    if error.contains("is not available")
+                        || error.contains("no HTTP(S) tabs")
+                        || error.contains("no browser tab is selected") =>
+                {
+                    self.needs_human
+                        .lock()
+                        .await
+                        .remove(&(tab.session.clone(), tab.tab_id));
+                    self.persist_needs_human().await;
+                    self.emit_needs_human().await;
+                    cleared.push(tab);
+                }
+                Err(error) => return Err(error),
+            }
+        }
+        Ok(BrowserNeedsHumanConfirmResult {
+            still_required,
+            cleared,
+        })
+    }
+
+    pub(crate) async fn focus_needs_human_tab(
+        &self,
+        session: &str,
+        tab_id: i64,
+    ) -> Result<(), String> {
+        let code = json!({ "cmd": "tabs", "method": "switch", "tabId": tab_id }).to_string();
+        self.send_command_on(
+            Some(session),
+            code,
+            Duration::from_millis(DEFAULT_TIMEOUT_MS),
+        )
+        .await
+        .map(|_| ())
     }
 
     async fn retry_pending_auto_close(&self) {
@@ -2095,9 +2390,27 @@ fn human_verification_handoff(page: &Value) -> Option<Value> {
     Some(json!({
         "required": true,
         "reason": "captcha_challenge",
-        "instruction": "Stop browser automation and ask the user to complete the human-verification challenge manually in this current visible browser tab. Wait for the user to confirm completion before scanning the same tab again.",
-        "resume": "After the user confirms, call web_scan on the same tab and continue only when the challenge is no longer detected."
+        "instruction": "A verification prompt has been shown in the Wisp app. Stop browser automation. Do not call ask_user and do not click, solve, or bypass the challenge. End your turn. The user will confirm in the app after completing the challenge in the visible browser tab.",
+        "resume": "After the user confirms, a follow-up message arrives. Call web_scan on the same tab and continue only when the challenge is no longer detected."
     }))
+}
+
+fn needs_human_block_message() -> String {
+    "This tab needs human verification. Do not automate the challenge. Wait for the user to complete it in the visible browser tab and confirm in the Wisp app.".into()
+}
+
+fn script_allowed_during_needs_human(script: &str) -> bool {
+    let Some(value) = json_command(script) else {
+        return false;
+    };
+    match value.get("cmd").and_then(Value::as_str) {
+        Some("control") => true,
+        Some("tabs") => matches!(
+            value.get("method").and_then(Value::as_str),
+            None | Some("switch") | Some("query") | Some("list")
+        ),
+        _ => false,
+    }
 }
 
 const SCAN_SCRIPT: &str = r##"(() => {
@@ -2233,7 +2546,7 @@ impl Tool for WebScanTool {
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(
             self.name(),
-            "Read visible content and actionable elements from the user's real, persistent Chrome/Chromium session. The browser keeps its existing cookies, login state, extensions, GPU/WebGL behavior, and normal profile fingerprint. Waits until the tab's document is complete before reading (or until timeout). The result includes ready and page.ready_state; if ready is false, scan again instead of clicking a partial page. Use tabs_only first when the target tab is unclear. If the result contains human_intervention.required=true, stop browser automation, ask the user to complete the challenge in the current visible tab, and wait for confirmation before scanning again.",
+            "Read visible content and actionable elements from the user's real, persistent Chrome/Chromium session. The browser keeps its existing cookies, login state, extensions, GPU/WebGL behavior, and normal profile fingerprint. Waits until the tab's document is complete before reading (or until timeout). The result includes ready and page.ready_state; if ready is false, scan again instead of clicking a partial page. Use tabs_only first when the target tab is unclear. If the result contains human_intervention.required=true, a verification prompt has been shown to the user: stop browser automation, do not call ask_user, do not click the challenge, and end your turn.",
             json!({
                 "type": "object",
                 "properties": {
@@ -2265,7 +2578,7 @@ impl Tool for WebScanTool {
         }
     }
 
-    async fn run(&self, args: &Value, _env: &dyn ToolEnv) -> ToolResult {
+    async fn run(&self, args: &Value, env: &dyn ToolEnv) -> ToolResult {
         let session = match session_arg(args) {
             Ok(session) => session,
             Err(error) => return ToolResult::fail(error),
@@ -2319,6 +2632,15 @@ impl Tool for WebScanTool {
             .await
         {
             Ok(execution) => {
+                self.bridge
+                    .apply_human_verification(
+                        &execution.session,
+                        execution.tab_id,
+                        &execution.value,
+                        env.frame_id().unwrap_or(""),
+                        env.turn_id().unwrap_or(""),
+                    )
+                    .await;
                 let handoff = human_verification_handoff(&execution.value);
                 ToolResult::ok(render_json(&merge_ready_wait(
                     json!({
@@ -2355,7 +2677,7 @@ impl Tool for WebExecuteJsTool {
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(
             self.name(),
-            "Execute JavaScript in a tab from the user's real, persistent Chrome/Chromium session. The extension waits until the tab's document is complete before running the script, and waits again if the script navigates. The result includes ready; if ready is false, scan again before clicking. Call web_scan first and do not guess selectors. To close tabs, never call window.close(); send {\"cmd\":\"tabs\",\"method\":\"close\",\"tabIds\":[...]} using ids returned by web_open_tab/web_scan. If web_scan reports human_intervention.required=true, do not automate the challenge; wait for the user to complete it and confirm before continuing. For a task that will trigger multiple file downloads, first tell the user how to allow automatic multiple downloads for the trusted target site at chrome://settings/content/automaticDownloads or edge://settings/content/automaticDownloads, then wait for confirmation; until confirmed, trigger at most one file download. A JSON script with cmd='cdp' may call one Chrome DevTools Protocol method for trusted input or other advanced browser actions.",
+            "Execute JavaScript in a tab from the user's real, persistent Chrome/Chromium session. The extension waits until the tab's document is complete before running the script, and waits again if the script navigates. The result includes ready; if ready is false, scan again before clicking. Call web_scan first and do not guess selectors. To close tabs, never call window.close(); send {\"cmd\":\"tabs\",\"method\":\"close\",\"tabIds\":[...]} using ids returned by web_open_tab/web_scan. If web_scan reports human_intervention.required=true, do not automate the challenge; a verification prompt has been shown to the user. For a task that will trigger multiple file downloads, first tell the user how to allow automatic multiple downloads for the trusted target site at chrome://settings/content/automaticDownloads or edge://settings/content/automaticDownloads, then wait for confirmation; until confirmed, trigger at most one file download. A JSON script with cmd='cdp' may call one Chrome DevTools Protocol method for trusted input or other advanced browser actions.",
             json!({
                 "type": "object",
                 "properties": {
@@ -2419,6 +2741,13 @@ impl Tool for WebExecuteJsTool {
             Ok(session) => session,
             Err(error) => return ToolResult::fail(error),
         };
+        if let Err(error) = self
+            .bridge
+            .refuse_if_needs_human(session.as_deref(), tab_id, script)
+            .await
+        {
+            return ToolResult::fail(error);
+        }
         match self
             .bridge
             .execute_on(
@@ -3150,6 +3479,33 @@ pub async fn dismiss_browser_tab_cleanup(
     Ok(())
 }
 
+#[tauri::command]
+pub async fn list_pending_browser_needs_human(
+    state: tauri::State<'_, crate::AppState>,
+) -> Result<BrowserNeedsHumanPrompt, String> {
+    Ok(state.browser_bridge.list_needs_human().await)
+}
+
+#[tauri::command]
+pub async fn confirm_browser_needs_human(
+    state: tauri::State<'_, crate::AppState>,
+    tabs: Vec<BrowserNeedsHumanTab>,
+) -> Result<BrowserNeedsHumanConfirmResult, String> {
+    state.browser_bridge.confirm_needs_human(&tabs).await
+}
+
+#[tauri::command]
+pub async fn focus_browser_needs_human(
+    state: tauri::State<'_, crate::AppState>,
+    session: String,
+    tab_id: i64,
+) -> Result<(), String> {
+    state
+        .browser_bridge
+        .focus_needs_human_tab(&session, tab_id)
+        .await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -3271,12 +3627,23 @@ mod tests {
         assert!(handoff["instruction"]
             .as_str()
             .unwrap()
-            .contains("Wait for the user to confirm"));
+            .contains("verification prompt"));
+        assert!(handoff["instruction"]
+            .as_str()
+            .unwrap()
+            .contains("Do not call ask_user"));
         assert!(human_verification_handoff(&json!({
             "title": "Browser automation article",
             "text": "This article asks: Are you a robot?"
         }))
         .is_none());
+        let sciencedirect = human_verification_handoff(&json!({
+            "title": "Just a moment...",
+            "url": "https://www.sciencedirect.com/science/article/pii/S000",
+            "text": "Are you a robot?\nPlease confirm you are a human by completing the captcha challenge below."
+        }))
+        .unwrap();
+        assert_eq!(sciencedirect["reason"], "captcha_challenge");
     }
 
     #[tokio::test]
@@ -4156,6 +4523,38 @@ mod tests {
         }
     }
 
+    async fn reply_scan(
+        bridge: &BrowserBridge,
+        rx: &mut mpsc::UnboundedReceiver<Message>,
+        url: &str,
+        title: &str,
+        text: &str,
+    ) {
+        let outbound = rx.recv().await.unwrap().into_text().unwrap();
+        let outbound: Value = serde_json::from_str(&outbound).unwrap();
+        let id = outbound["id"].as_str().unwrap();
+        bridge
+            .handle_text(
+                1,
+                &json!({
+                    "type": "result",
+                    "id": id,
+                    "result": {
+                        "url": url,
+                        "title": title,
+                        "text": text,
+                        "ready_state": "complete"
+                    }
+                })
+                .to_string(),
+            )
+            .await;
+    }
+
+    fn captcha_text() -> &'static str {
+        "Are you a robot? Please confirm you are a human by completing the captcha challenge below."
+    }
+
     async fn reply_open_tab(
         bridge: &BrowserBridge,
         rx: &mut mpsc::UnboundedReceiver<Message>,
@@ -4462,6 +4861,337 @@ mod tests {
         assert_eq!(child_prompt.tabs.len(), 1);
         assert_eq!(child_prompt.tabs[0].session, "workspace");
         assert_eq!(child_prompt.tabs[0].tab_id, 31);
+        let _ = std::fs::remove_file(tmp);
+    }
+
+    #[tokio::test]
+    async fn captcha_scan_marks_needs_human_and_skips_auto_close() {
+        let (store, tmp) = empty_store().await;
+        store
+            .set_setting(browser_url_filters::AUTO_CLOSE_TABS_KEY, "true")
+            .await
+            .unwrap();
+        let bridge = Arc::new(BrowserBridge::new_with_store(
+            PathBuf::from("extension"),
+            store.clone(),
+        ));
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        bridge.install_client(1, tx).await;
+
+        let env = TurnEnv {
+            root: PathBuf::from("."),
+            turn_id: "turn-human".into(),
+            frame_id: "frame-human".into(),
+        };
+        for (id, url, title) in [
+            (11, "https://keep.example/paper", "Paper"),
+            (
+                12,
+                "https://www.sciencedirect.com/science",
+                "Just a moment...",
+            ),
+        ] {
+            let opening = {
+                let bridge = bridge.clone();
+                let store = store.clone();
+                let env = env.clone();
+                tokio::spawn(async move {
+                    WebOpenTabTool::new(bridge, store)
+                        .run(&json!({ "url": url }), &env)
+                        .await
+                })
+            };
+            reply_open_tab(&bridge, &mut rx, id, url, title).await;
+            assert!(opening.await.unwrap().success);
+        }
+
+        let scanning = {
+            let bridge = bridge.clone();
+            let env = env.clone();
+            tokio::spawn(async move {
+                WebScanTool::new(bridge)
+                    .run(&json!({ "switch_tab_id": 12 }), &env)
+                    .await
+            })
+        };
+        reply_scan(
+            &bridge,
+            &mut rx,
+            "https://www.sciencedirect.com/science",
+            "Just a moment...",
+            captcha_text(),
+        )
+        .await;
+        let scan = scanning.await.unwrap();
+        assert!(scan.success);
+        assert!(scan.content.contains("\"required\": true"));
+        let pending = bridge.list_needs_human().await;
+        assert_eq!(pending.tabs.len(), 1);
+        assert_eq!(pending.tabs[0].tab_id, 12);
+        assert_eq!(pending.tabs[0].frame_id, "frame-human");
+
+        let closing = {
+            let bridge = bridge.clone();
+            tokio::spawn(async move { bridge.complete_turn("turn-human").await })
+        };
+        reply_close_tabs(&bridge, &mut rx, &[11]).await;
+        match closing.await.unwrap() {
+            TabCleanupAction::Closed => {}
+            other => panic!("expected closed, got {other:?}"),
+        }
+        assert_eq!(bridge.list_needs_human().await.tabs.len(), 1);
+        let _ = std::fs::remove_file(tmp);
+    }
+
+    #[tokio::test]
+    async fn complete_turn_prompt_excludes_needs_human_tabs() {
+        let (store, tmp) = empty_store().await;
+        let bridge = Arc::new(BrowserBridge::new_with_store(
+            PathBuf::from("extension"),
+            store.clone(),
+        ));
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        bridge.install_client(1, tx).await;
+        let env = TurnEnv {
+            root: PathBuf::from("."),
+            turn_id: "turn-prompt".into(),
+            frame_id: "frame-prompt".into(),
+        };
+        for (id, url) in [(21, "https://keep.example"), (22, "https://robot.example")] {
+            let opening = {
+                let bridge = bridge.clone();
+                let store = store.clone();
+                let env = env.clone();
+                tokio::spawn(async move {
+                    WebOpenTabTool::new(bridge, store)
+                        .run(&json!({ "url": url }), &env)
+                        .await
+                })
+            };
+            reply_open_tab(&bridge, &mut rx, id, url, "T").await;
+            assert!(opening.await.unwrap().success);
+        }
+        let scanning = {
+            let bridge = bridge.clone();
+            let env = env.clone();
+            tokio::spawn(async move {
+                WebScanTool::new(bridge)
+                    .run(&json!({ "switch_tab_id": 22 }), &env)
+                    .await
+            })
+        };
+        reply_scan(
+            &bridge,
+            &mut rx,
+            "https://robot.example",
+            "Are you a robot?",
+            captcha_text(),
+        )
+        .await;
+        assert!(scanning.await.unwrap().success);
+
+        let TabCleanupAction::Prompt(prompt) = bridge.complete_turn("turn-prompt").await else {
+            panic!("expected prompt");
+        };
+        assert_eq!(prompt.tabs.len(), 1);
+        assert_eq!(prompt.tabs[0].tab_id, 21);
+        let _ = std::fs::remove_file(tmp);
+    }
+
+    #[tokio::test]
+    async fn execute_js_is_refused_on_a_needs_human_tab() {
+        let (store, tmp) = empty_store().await;
+        let bridge = Arc::new(BrowserBridge::new_with_store(
+            PathBuf::from("extension"),
+            store.clone(),
+        ));
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        bridge.install_client(1, tx).await;
+        let env = TurnEnv {
+            root: PathBuf::from("."),
+            turn_id: "turn-js".into(),
+            frame_id: "frame-js".into(),
+        };
+        let opening = {
+            let bridge = bridge.clone();
+            let store = store.clone();
+            let env = env.clone();
+            tokio::spawn(async move {
+                WebOpenTabTool::new(bridge, store)
+                    .run(&json!({ "url": "https://robot.example" }), &env)
+                    .await
+            })
+        };
+        reply_open_tab(&bridge, &mut rx, 33, "https://robot.example", "Robot").await;
+        assert!(opening.await.unwrap().success);
+        let scanning = {
+            let bridge = bridge.clone();
+            let env = env.clone();
+            tokio::spawn(async move {
+                WebScanTool::new(bridge)
+                    .run(&json!({ "switch_tab_id": 33 }), &env)
+                    .await
+            })
+        };
+        reply_scan(
+            &bridge,
+            &mut rx,
+            "https://robot.example",
+            "Are you a robot?",
+            captcha_text(),
+        )
+        .await;
+        assert!(scanning.await.unwrap().success);
+
+        let result = WebExecuteJsTool::new(bridge.clone(), store)
+            .run(
+                &json!({
+                    "switch_tab_id": 33,
+                    "script": "document.querySelector('button').click()"
+                }),
+                &env,
+            )
+            .await;
+        assert!(!result.success);
+        assert!(result.content.contains("human verification"));
+        let _ = std::fs::remove_file(tmp);
+    }
+
+    #[tokio::test]
+    async fn confirm_needs_human_clears_when_challenge_is_gone() {
+        let (store, tmp) = empty_store().await;
+        let bridge = Arc::new(BrowserBridge::new_with_store(
+            PathBuf::from("extension"),
+            store.clone(),
+        ));
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        bridge.install_client(1, tx).await;
+        let env = TurnEnv {
+            root: PathBuf::from("."),
+            turn_id: "turn-confirm".into(),
+            frame_id: "frame-confirm".into(),
+        };
+        let opening = {
+            let bridge = bridge.clone();
+            let store = store.clone();
+            let env = env.clone();
+            tokio::spawn(async move {
+                WebOpenTabTool::new(bridge, store)
+                    .run(
+                        &json!({ "url": "https://www.sciencedirect.com/science" }),
+                        &env,
+                    )
+                    .await
+            })
+        };
+        reply_open_tab(
+            &bridge,
+            &mut rx,
+            44,
+            "https://www.sciencedirect.com/science",
+            "Just a moment...",
+        )
+        .await;
+        assert!(opening.await.unwrap().success);
+        let scanning = {
+            let bridge = bridge.clone();
+            let env = env.clone();
+            tokio::spawn(async move {
+                WebScanTool::new(bridge)
+                    .run(&json!({ "switch_tab_id": 44 }), &env)
+                    .await
+            })
+        };
+        reply_scan(
+            &bridge,
+            &mut rx,
+            "https://www.sciencedirect.com/science",
+            "Just a moment...",
+            captcha_text(),
+        )
+        .await;
+        assert!(scanning.await.unwrap().success);
+
+        let confirming = {
+            let bridge = bridge.clone();
+            tokio::spawn(async move { bridge.confirm_needs_human(&[]).await })
+        };
+        reply_scan(
+            &bridge,
+            &mut rx,
+            "https://www.sciencedirect.com/science/article/pii/S000",
+            "Article",
+            "Abstract of the paper.",
+        )
+        .await;
+        let result = confirming.await.unwrap().unwrap();
+        assert!(result.still_required.is_empty());
+        assert_eq!(result.cleared.len(), 1);
+        assert!(bridge.list_needs_human().await.tabs.is_empty());
+        let _ = std::fs::remove_file(tmp);
+    }
+
+    #[tokio::test]
+    async fn confirm_needs_human_keeps_waiting_when_challenge_remains() {
+        let (store, tmp) = empty_store().await;
+        let bridge = Arc::new(BrowserBridge::new_with_store(
+            PathBuf::from("extension"),
+            store.clone(),
+        ));
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        bridge.install_client(1, tx).await;
+        let env = TurnEnv {
+            root: PathBuf::from("."),
+            turn_id: "turn-still".into(),
+            frame_id: "frame-still".into(),
+        };
+        let opening = {
+            let bridge = bridge.clone();
+            let store = store.clone();
+            let env = env.clone();
+            tokio::spawn(async move {
+                WebOpenTabTool::new(bridge, store)
+                    .run(&json!({ "url": "https://robot.example" }), &env)
+                    .await
+            })
+        };
+        reply_open_tab(&bridge, &mut rx, 55, "https://robot.example", "Robot").await;
+        assert!(opening.await.unwrap().success);
+        let scanning = {
+            let bridge = bridge.clone();
+            let env = env.clone();
+            tokio::spawn(async move {
+                WebScanTool::new(bridge)
+                    .run(&json!({ "switch_tab_id": 55 }), &env)
+                    .await
+            })
+        };
+        reply_scan(
+            &bridge,
+            &mut rx,
+            "https://robot.example",
+            "Are you a robot?",
+            captcha_text(),
+        )
+        .await;
+        assert!(scanning.await.unwrap().success);
+
+        let confirming = {
+            let bridge = bridge.clone();
+            tokio::spawn(async move { bridge.confirm_needs_human(&[]).await })
+        };
+        reply_scan(
+            &bridge,
+            &mut rx,
+            "https://robot.example",
+            "Are you a robot?",
+            captcha_text(),
+        )
+        .await;
+        let result = confirming.await.unwrap().unwrap();
+        assert_eq!(result.still_required.len(), 1);
+        assert!(result.cleared.is_empty());
+        assert_eq!(bridge.list_needs_human().await.tabs.len(), 1);
         let _ = std::fs::remove_file(tmp);
     }
 

--- a/src-tauri/src/dto_contract_tests.rs
+++ b/src-tauri/src/dto_contract_tests.rs
@@ -395,6 +395,34 @@ fn browser_tab_cleanup_prompt_contract() {
 }
 
 #[test]
+fn browser_needs_human_prompt_contract() {
+    let prompt = wisp_dto::BrowserNeedsHumanPrompt {
+        tabs: vec![wisp_dto::BrowserNeedsHumanTab {
+            session: "shared".into(),
+            tab_id: 12,
+            url: "https://www.sciencedirect.com/science".into(),
+            title: "Just a moment...".into(),
+            reason: "captcha_challenge".into(),
+            frame_id: "frame-1".into(),
+            turn_id: "turn-1".into(),
+        }],
+    };
+    let dto: wisp_dto::BrowserNeedsHumanPrompt = roundtrip(&prompt);
+    assert_eq!(dto.tabs.len(), 1);
+    assert_eq!(dto.tabs[0].session, "shared");
+    assert_eq!(dto.tabs[0].tab_id, 12);
+    assert_eq!(dto.tabs[0].reason, "captcha_challenge");
+    assert_eq!(dto.tabs[0].frame_id, "frame-1");
+    let result = wisp_dto::BrowserNeedsHumanConfirmResult {
+        still_required: dto.tabs.clone(),
+        cleared: Vec::new(),
+    };
+    let dto: wisp_dto::BrowserNeedsHumanConfirmResult = roundtrip(&result);
+    assert_eq!(dto.still_required[0].tab_id, 12);
+    assert!(dto.cleared.is_empty());
+}
+
+#[test]
 fn mcp_connection_list_contract_redacts_secrets() {
     let backend = crate::McpConnection {
         id: "conn-1".into(),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6671,6 +6671,8 @@ pub fn run() {
                     store.clone(),
                 ))
             });
+            let (needs_human_tx, mut needs_human_rx) = tokio::sync::mpsc::unbounded_channel();
+            tauri::async_runtime::block_on(browser_bridge.set_needs_human_sink(needs_human_tx));
             let device_hub = Arc::new(device_hub::DeviceHub::default());
             let device_bridge = Arc::new(device_bridge::DeviceBridge::new(
                 device_hub.clone(),
@@ -6716,6 +6718,17 @@ pub fn run() {
                 scratch: std::sync::RwLock::new(HashMap::new()),
             };
             app.manage(state);
+            {
+                let handle = app.handle().clone();
+                tauri::async_runtime::spawn(async move {
+                    while let Some(tabs) = needs_human_rx.recv().await {
+                        let _ = handle.emit(
+                            "browser-needs-human",
+                            wisp_dto::BrowserNeedsHumanPrompt { tabs },
+                        );
+                    }
+                });
+            }
             app.manage(app_updates::PendingAppUpdate::default());
             app.manage(terminal_sessions::TerminalManager::new());
             app.manage(channels::ChannelManager::new());
@@ -7002,6 +7015,9 @@ pub fn run() {
             browser_bridge::list_pending_browser_tab_cleanups,
             browser_bridge::confirm_browser_tab_cleanup,
             browser_bridge::dismiss_browser_tab_cleanup,
+            browser_bridge::list_pending_browser_needs_human,
+            browser_bridge::confirm_browser_needs_human,
+            browser_bridge::focus_browser_needs_human,
             settings_commands::get_settings,
             settings_commands::set_settings,
             configure::get_appearance_prefs,

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -526,6 +526,7 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
   let mockBrowserAutoLaunch = true;
   let mockBrowserAutoCloseTabs = false;
   let mockPendingBrowserTabCleanups: any[] = [];
+  let mockPendingBrowserNeedsHuman: any[] = [];
   let mockQuickActions = [{
     id: "literature_research",
     name: "Research literature",
@@ -2646,6 +2647,19 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
             mockPendingBrowserTabCleanups = mockPendingBrowserTabCleanups.filter((row: any) => row.turn_id !== turnId);
             return null;
           }
+          case "list_pending_browser_needs_human":
+            return { tabs: mockPendingBrowserNeedsHuman };
+          case "confirm_browser_needs_human": {
+            const tabs = plain(arg("tabs") ?? []);
+            const still = Boolean((window as any).__mockNeedsHumanStillRequired);
+            if (still) {
+              return { still_required: tabs, cleared: [] };
+            }
+            mockPendingBrowserNeedsHuman = [];
+            return { still_required: [], cleared: tabs };
+          }
+          case "focus_browser_needs_human":
+            return null;
           case "set_browser_url_filters": {
             const next = plain(arg("filters") ?? {});
             mockBrowserUrlFilters = {

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -10375,6 +10375,77 @@ test("browser tab cleanup confirms selected tabs and Escape keeps them", async (
   )).toBe(true);
 });
 
+test("browser needs-human overlay reminds, confirms, and Escape snoozes", async ({ page }) => {
+  await enterApp(page);
+  const prompt = {
+    tabs: [
+      {
+        session: "shared",
+        tab_id: 12,
+        url: "https://www.sciencedirect.com/science",
+        title: "Just a moment...",
+        reason: "captcha_challenge",
+        frame_id: "s1",
+        turn_id: "turn-human",
+      },
+    ],
+  };
+  await emitTauriEvent(page, "browser-needs-human", prompt);
+  const dialog = page.getByTestId("browser-needs-human");
+  await expect(dialog).toBeVisible();
+  await expect(dialog).toContainText("Human verification needed");
+  await expect(dialog).toContainText("Just a moment...");
+  await page.getByTestId("browser-needs-human-row-12").click();
+  await expect.poll(() => lastInvokeArgs(page, "focus_browser_needs_human")).toMatchObject({
+    session: "shared",
+    tabId: 12,
+  });
+
+  await page.evaluate(() => { (window as any).__mockNeedsHumanStillRequired = true; });
+  await page.getByTestId("browser-needs-human-done").click();
+  await expect(page.getByTestId("browser-needs-human-error")).toContainText("still on the page");
+  await expect(dialog).toBeVisible();
+
+  await page.evaluate(() => { (window as any).__mockNeedsHumanStillRequired = false; });
+  await page.getByTestId("browser-needs-human-done").click();
+  await expect(dialog).toHaveCount(0);
+  await expect.poll(() => lastInvokeArgs(page, "confirm_browser_needs_human")).toMatchObject({
+    tabs: [{ tab_id: 12 }],
+  });
+  await expect.poll(() => lastInvokeArgs(page, "send_message")).toMatchObject({
+    sessionId: "s1",
+    message: "I completed the human verification in the browser. Continue.",
+  });
+
+  await emitTauriEvent(page, "browser-needs-human", prompt);
+  await expect(page.getByTestId("browser-needs-human")).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("browser-needs-human")).toHaveCount(0);
+});
+
+test("browser needs-human Escape closes only the overlay while settings stay open", async ({ page }) => {
+  await enterApp(page);
+  await openSettingsSection(page, "Browser");
+  await expect(page.getByTestId("browser-url-filters")).toBeVisible();
+  await emitTauriEvent(page, "browser-needs-human", {
+    tabs: [
+      {
+        session: "shared",
+        tab_id: 7,
+        url: "https://www.sciencedirect.com/science",
+        title: "Are you a robot?",
+        reason: "captcha_challenge",
+        frame_id: "s1",
+        turn_id: "turn-settings",
+      },
+    ],
+  });
+  await expect(page.getByTestId("browser-needs-human")).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("browser-needs-human")).toHaveCount(0);
+  await expect(page.getByTestId("browser-url-filters")).toBeVisible();
+});
+
 test("browser tab cleanup Escape closes only the overlay while settings stay open", async ({ page }) => {
   await enterApp(page);
   await openSettingsSection(page, "Browser");

--- a/ui/src/app_overlays.rs
+++ b/ui/src/app_overlays.rs
@@ -529,6 +529,110 @@ pub(crate) fn BrowserTabCleanupOverlay(
     }
 }
 
+pub(crate) fn present_browser_needs_human(
+    pending: RwSignal<Option<BrowserNeedsHumanPrompt>>,
+    error: RwSignal<Option<String>>,
+    prompt: BrowserNeedsHumanPrompt,
+) {
+    error.set(None);
+    if prompt.tabs.is_empty() {
+        pending.set(None);
+        return;
+    }
+    pending.set(Some(prompt));
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct BrowserNeedsHumanOverlayState {
+    pub(crate) locale: RwSignal<Locale>,
+    pub(crate) pending: RwSignal<Option<BrowserNeedsHumanPrompt>>,
+    pub(crate) busy: RwSignal<bool>,
+    pub(crate) error: RwSignal<Option<String>>,
+}
+
+#[component]
+pub(crate) fn BrowserNeedsHumanOverlay(
+    state: BrowserNeedsHumanOverlayState,
+    on_later: Callback<()>,
+    on_done: Callback<Vec<BrowserNeedsHumanTab>>,
+    on_show: Callback<BrowserNeedsHumanTab>,
+) -> impl IntoView {
+    let BrowserNeedsHumanOverlayState {
+        locale,
+        pending,
+        busy,
+        error,
+    } = state;
+    view! {
+        {move || pending.get().map(|prompt| {
+            let tabs = prompt.tabs.clone();
+            view! {
+                <div class="overlay" data-testid="browser-needs-human">
+                    <div class="modal confirm-modal browser-tab-cleanup-modal"
+                        role="dialog" aria-modal="true"
+                        aria-labelledby="browser-needs-human-title">
+                        <h2 id="browser-needs-human-title">
+                            {move || t(locale.get(), "browser.needs_human.title")}
+                        </h2>
+                        <div class="hint">
+                            {move || t(locale.get(), "browser.needs_human.body")}
+                        </div>
+                        <div class="hint">
+                            {move || t(locale.get(), "browser.needs_human.hint")}
+                        </div>
+                        <div class="browser-tab-cleanup-list" data-testid="browser-needs-human-list">
+                            {tabs.iter().cloned().map(|tab| {
+                                let show_tab = tab.clone();
+                                view! {
+                                    <button type="button" class="browser-tab-cleanup-row browser-needs-human-row"
+                                        data-testid=format!("browser-needs-human-row-{}", tab.tab_id)
+                                        disabled=move || busy.get()
+                                        on:click=move |_| on_show.call(show_tab.clone())>
+                                        <span class="browser-tab-cleanup-body">
+                                            <strong>{if tab.title.trim().is_empty() {
+                                                tab.url.clone()
+                                            } else {
+                                                tab.title.clone()
+                                            }}</strong>
+                                            <span class="browser-tab-cleanup-url">{tab.url.clone()}</span>
+                                            <span class="browser-tab-cleanup-url">
+                                                {move || t(locale.get(), "browser.needs_human.show")}
+                                            </span>
+                                        </span>
+                                    </button>
+                                }
+                            }).collect_view()}
+                        </div>
+                        {move || error.get().map(|text| view! {
+                            <div class="settings-status fail" data-testid="browser-needs-human-error">{text}</div>
+                        })}
+                        <div class="row">
+                            <button type="button"
+                                data-testid="browser-needs-human-later"
+                                disabled=move || busy.get()
+                                on:click=move |_| on_later.call(())>
+                                {move || t(locale.get(), "browser.needs_human.later")}
+                            </button>
+                            <button type="button" class="primary"
+                                data-testid="browser-needs-human-done"
+                                disabled=move || busy.get()
+                                on:click=move |_| {
+                                    let tabs = pending
+                                        .get_untracked()
+                                        .map(|prompt| prompt.tabs)
+                                        .unwrap_or_default();
+                                    on_done.call(tabs);
+                                }>
+                                {move || t(locale.get(), "browser.needs_human.done")}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            }
+        })}
+    }
+}
+
 #[derive(Clone, Copy)]
 pub(crate) struct UpdateCheckOverlayState {
     pub(crate) locale: RwSignal<Locale>,

--- a/ui/src/i18n.rs
+++ b/ui/src/i18n.rs
@@ -1320,6 +1320,15 @@ fn lookup(locale: Locale, key: &str) -> Option<&'static str> {
         (Locale::En, "browser.cleanup.close") => Some("Close selected"),
         (Locale::En, "browser.cleanup.keep") => Some("Keep all"),
         (Locale::En, "browser.cleanup.error") => Some("Could not close the selected tabs. The extension may be disconnected."),
+        (Locale::En, "browser.needs_human.title") => Some("Human verification needed"),
+        (Locale::En, "browser.needs_human.body") => Some("This page needs you to complete a human-verification challenge in the visible browser tab. Wisp will not click or bypass it, and will keep the tab open until you finish."),
+        (Locale::En, "browser.needs_human.hint") => Some("Complete the challenge in the browser. Do not close that tab or quit the browser until it succeeds."),
+        (Locale::En, "browser.needs_human.done") => Some("I completed verification"),
+        (Locale::En, "browser.needs_human.later") => Some("Later"),
+        (Locale::En, "browser.needs_human.show") => Some("Show this tab"),
+        (Locale::En, "browser.needs_human.still") => Some("The challenge is still on the page. Complete it in the browser tab, then try again."),
+        (Locale::En, "browser.needs_human.error") => Some("Could not re-check the tab. The browser extension may be disconnected."),
+        (Locale::En, "browser.needs_human.continue") => Some("I completed the human verification in the browser. Continue."),
         (Locale::En, "browser.offline.eyebrow") => Some("No live retrieval"),
         (Locale::En, "browser.offline.title") => Some("This answer has no live web results"),
         (Locale::En, "browser.offline.body") => Some("The browser extension is not connected. This reply is based only on the model's existing knowledge."),
@@ -3869,6 +3878,15 @@ Do not leave generated files in the project root.",
         (Locale::Zh, "browser.cleanup.close") => Some("关闭所选"),
         (Locale::Zh, "browser.cleanup.keep") => Some("全部保留"),
         (Locale::Zh, "browser.cleanup.error") => Some("无法关闭所选标签页。浏览器扩展可能已断开。"),
+        (Locale::Zh, "browser.needs_human.title") => Some("需要完成人机验证"),
+        (Locale::Zh, "browser.needs_human.body") => Some("当前页面需要你在可见的浏览器标签里完成人机验证。Wisp 不会点击或绕过验证，并会在你完成前保留这个标签。"),
+        (Locale::Zh, "browser.needs_human.hint") => Some("请在浏览器中完成验证。成功前不要关闭该标签，也不要退出浏览器。"),
+        (Locale::Zh, "browser.needs_human.done") => Some("我已完成验证"),
+        (Locale::Zh, "browser.needs_human.later") => Some("稍后"),
+        (Locale::Zh, "browser.needs_human.show") => Some("显示此标签"),
+        (Locale::Zh, "browser.needs_human.still") => Some("页面上仍有验证。请在浏览器标签中完成后再试。"),
+        (Locale::Zh, "browser.needs_human.error") => Some("无法复查该标签。浏览器扩展可能已断开。"),
+        (Locale::Zh, "browser.needs_human.continue") => Some("我已在浏览器中完成人机验证，请继续。"),
         (Locale::Zh, "browser.offline.eyebrow") => Some("未联网检索"),
         (Locale::Zh, "browser.offline.title") => Some("本次回答未包含任何联网检索结果"),
         (Locale::Zh, "browser.offline.body") => Some("浏览器扩展未连接。该回答仅基于模型已有知识，不是实时检索结果。"),
@@ -5861,6 +5879,23 @@ mod queue_label_tests {
             tf(Locale::Zh, "browser.cleanup.body", &[("n", "18")]),
             "本轮 Wisp 打开了 18 个标签页，默认将全部关闭。你可以取消选择需要保留的页面。"
         );
+    }
+
+    #[test]
+    fn browser_needs_human_labels_exist_in_both_locales() {
+        assert_eq!(
+            t(Locale::En, "browser.needs_human.title"),
+            "Human verification needed"
+        );
+        assert_eq!(
+            t(Locale::Zh, "browser.needs_human.title"),
+            "需要完成人机验证"
+        );
+        assert_eq!(
+            t(Locale::En, "browser.needs_human.done"),
+            "I completed verification"
+        );
+        assert_eq!(t(Locale::Zh, "browser.needs_human.done"), "我已完成验证");
     }
 
     #[test]

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -27,7 +27,8 @@ use agent_workflows::{
     agent_workflows_panel, refresh_agent_resources, refresh_agent_workflows, AgentPanelState,
 };
 use app_overlays::{
-    advance_browser_tab_cleanup, present_browser_tab_cleanup, BrowserTabCleanupOverlay,
+    advance_browser_tab_cleanup, present_browser_needs_human, present_browser_tab_cleanup,
+    BrowserNeedsHumanOverlay, BrowserNeedsHumanOverlayState, BrowserTabCleanupOverlay,
     BrowserTabCleanupOverlayState, ContextRecoveryOverlay, ContextRecoveryOverlayState,
     ExternalLinkConfirm, ProjectExportPrompt, ProjectExportPromptState, ProjectTransferOverlay,
     ProjectTransferOverlayState, SshConnectivityOverlay, SshConnectivityOverlayState,
@@ -1042,6 +1043,9 @@ fn App() -> impl IntoView {
     let browser_tab_cleanup_selected = create_rw_signal(HashSet::<(String, i64)>::new());
     let browser_tab_cleanup_busy = create_rw_signal(false);
     let browser_tab_cleanup_error = create_rw_signal(None::<String>);
+    let browser_needs_human = create_rw_signal(None::<BrowserNeedsHumanPrompt>);
+    let browser_needs_human_busy = create_rw_signal(false);
+    let browser_needs_human_error = create_rw_signal(None::<String>);
     // "不再提醒更新" opt-out; loaded on startup, mirrored by the settings toggle.
     let update_check_enabled = create_rw_signal(true);
     // Set when a send fails because no API key is configured, so the status bar
@@ -3451,6 +3455,28 @@ fn App() -> impl IntoView {
                         prompt,
                     );
                 }
+            }
+        }
+    });
+    let browser_human_pending = browser_needs_human;
+    let browser_human_error = browser_needs_human_error;
+    let browser_human_cb = Closure::wrap(Box::new(move |payload: JsValue| {
+        if let Ok(prompt) = serde_wasm_bindgen::from_value::<BrowserNeedsHumanPrompt>(payload) {
+            present_browser_needs_human(browser_human_pending, browser_human_error, prompt);
+        }
+    }) as Box<dyn FnMut(JsValue)>);
+    let browser_human_js = browser_human_cb
+        .as_ref()
+        .unchecked_ref::<js_sys::Function>()
+        .clone();
+    std::mem::forget(browser_human_cb);
+    spawn_local(async move {
+        let _ = listen("browser-needs-human", &browser_human_js).await;
+        if let Ok(value) =
+            invoke_checked("list_pending_browser_needs_human", JsValue::UNDEFINED).await
+        {
+            if let Ok(prompt) = serde_wasm_bindgen::from_value::<BrowserNeedsHumanPrompt>(value) {
+                present_browser_needs_human(browser_human_pending, browser_human_error, prompt);
             }
         }
     });
@@ -8222,6 +8248,14 @@ fn App() -> impl IntoView {
             external_link_confirm.set(None);
             return;
         }
+        if browser_needs_human.get().is_some() {
+            ev.prevent_default();
+            if !browser_needs_human_busy.get() {
+                browser_needs_human.set(None);
+                browser_needs_human_error.set(None);
+            }
+            return;
+        }
         if browser_tab_cleanup.get().is_some() {
             ev.prevent_default();
             if !browser_tab_cleanup_busy.get() {
@@ -10010,6 +10044,88 @@ fn App() -> impl IntoView {
                         Err(err) => {
                             browser_tab_cleanup_busy.set(false);
                             browser_tab_cleanup_error.set(Some(js_error_text(err)));
+                        }
+                    }
+                });
+            })
+        />
+        <BrowserNeedsHumanOverlay
+            state=BrowserNeedsHumanOverlayState {
+                locale,
+                pending: browser_needs_human,
+                busy: browser_needs_human_busy,
+                error: browser_needs_human_error,
+            }
+            on_later=Callback::new(move |_| {
+                if browser_needs_human_busy.get_untracked() {
+                    return;
+                }
+                browser_needs_human.set(None);
+                browser_needs_human_error.set(None);
+            })
+            on_show=Callback::new(move |tab: BrowserNeedsHumanTab| {
+                if browser_needs_human_busy.get_untracked() {
+                    return;
+                }
+                spawn_local(async move {
+                    let arg = to_value(&serde_json::json!({
+                        "session": tab.session,
+                        "tabId": tab.tab_id,
+                    })).unwrap();
+                    let _ = invoke_checked("focus_browser_needs_human", arg).await;
+                });
+            })
+            on_done=Callback::new(move |tabs: Vec<BrowserNeedsHumanTab>| {
+                if browser_needs_human_busy.get_untracked() {
+                    return;
+                }
+                browser_needs_human_busy.set(true);
+                browser_needs_human_error.set(None);
+                let continue_message = t(locale.get_untracked(), "browser.needs_human.continue");
+                let still_message = t(locale.get_untracked(), "browser.needs_human.still");
+                let fail_message = t(locale.get_untracked(), "browser.needs_human.error");
+                let fallback_session = active_session.get_untracked();
+                spawn_local(async move {
+                    let arg = to_value(&serde_json::json!({ "tabs": tabs })).unwrap();
+                    match invoke_checked("confirm_browser_needs_human", arg).await {
+                        Ok(value) => {
+                            let result = serde_wasm_bindgen::from_value::<BrowserNeedsHumanConfirmResult>(value)
+                                .unwrap_or_default();
+                            browser_needs_human_busy.set(false);
+                            if result.still_required.is_empty() {
+                                let frame_id = result
+                                    .cleared
+                                    .first()
+                                    .map(|tab| tab.frame_id.clone())
+                                    .filter(|id| !id.is_empty())
+                                    .or(fallback_session);
+                                browser_needs_human.set(None);
+                                browser_needs_human_error.set(None);
+                                if let Some(session_id) = frame_id {
+                                    let args = to_value(&SendMessageArgs {
+                                        session_id: Some(session_id),
+                                        message: continue_message,
+                                        attachments: vec![],
+                                        references: vec![],
+                                        resume: false,
+                                        acp_agent_id: None,
+                                        guide: None,
+                                        replace: None,
+                                    }).unwrap();
+                                    let _ = invoke_checked("send_message", args).await;
+                                }
+                            } else {
+                                present_browser_needs_human(
+                                    browser_needs_human,
+                                    browser_needs_human_error,
+                                    BrowserNeedsHumanPrompt { tabs: result.still_required },
+                                );
+                                browser_needs_human_error.set(Some(still_message));
+                            }
+                        }
+                        Err(_) => {
+                            browser_needs_human_busy.set(false);
+                            browser_needs_human_error.set(Some(fail_message));
                         }
                     }
                 });

--- a/ui/src/styles/modals.css
+++ b/ui/src/styles/modals.css
@@ -62,6 +62,10 @@
   font-size: 12px; color: var(--text-faint); overflow: hidden;
   text-overflow: ellipsis; white-space: nowrap;
 }
+button.browser-needs-human-row {
+  width: 100%; text-align: left; cursor: pointer;
+}
+button.browser-needs-human-row .browser-tab-cleanup-body { opacity: 1; }
 /* /share preview dialog. Row selectors stay scoped to .share-modal so they
    outrank the generic `.modal label` / `.modal input` rules above. */
 .share-modal { max-width: 560px; overflow: hidden; }


### PR DESCRIPTION
## User-facing problem

When a real-browser task hits a human-verification page (ScienceDirect / Cloudflare *Are you a robot?*), the agent stopped and waited — but **Automatically close browser tabs** still closed that tab at turn end. The challenge UI disappeared, so the user could not finish verification. The existing `human_intervention` flag was only a tool JSON hint for the model, not an app prompt.

Fixes #1085.

## What changed

Human verification is now a first-class `needs_human` runtime state:

1. **Detect.** `web_scan` still uses the existing *Are you a robot?* + *confirm you are a human* / *captcha challenge* heuristic (covers ScienceDirect’s Cloudflare interstitial). Matching tabs are stored as `needs_human`.
2. **Remind.** Wisp shows an in-app dialog: complete the challenge in the visible browser tab, then click **I completed verification**. The agent is told not to call `ask_user` (that ends the turn and would trigger auto-close). Clicking a listed tab focuses it.
3. **Protect.** Turn-end auto-close and the cleanup dialog skip `needs_human` tabs. Click/JS on those tabs is refused until the challenge is gone.
4. **Resume.** **I completed verification** re-scans the same tab. If the challenge remains, the dialog stays. If it is gone, Wisp sends a continue message so the agent can scan again.

Escape snoozes the dialog only; the tab stays protected. If this turn still has a `needs_human` tab when it ends, the dialog is shown again.

Wisp does not click, solve, or bypass CAPTCHA.

## Tests

- Bridge: scan marks `needs_human` and skips auto-close; cleanup prompt excludes those tabs; `web_execute_js` is refused; confirm clears when the challenge is gone and keeps waiting when it remains; ScienceDirect-like copy still matches.
- DTO contract for the prompt / confirm payload.
- i18n labels in en/zh.
- Playwright: overlay remind → still-required error → confirm + `send_message`; Escape closes only the overlay while Settings stays open.

## Manual smoke

1. Enable **Settings → Browser → Automatically close browser tabs**.
2. Ask the agent to open a ScienceDirect article (or any Cloudflare *Are you a robot?* page) in the real browser.
3. Confirm the **Human verification needed** dialog appears and the challenge tab stays open after the turn ends.
4. Complete the challenge in the browser, click **I completed verification**, and confirm the agent continues.
5. Press Escape on the dialog with Settings open: only the dialog closes.

## Known limitations

- Detection is still the existing main-document text heuristic. Widget-only / iframe challenges with little page text may not mark `needs_human`.
- Closing the whole browser window can still drop the page. If Chrome is set to clear cookies on exit, the clearance cookie is also lost; Wisp only keeps the tab while the window remains.
- Escape snoozes the reminder; the tab stays open, but the user must wait for the next scan/turn-end or complete verification without the dialog.
