### PR TITLE
fix(reader): disable thinking and split long cited sessions

### DIFF
--- a/crates/wisp-llm/src/openai.rs
+++ b/crates/wisp-llm/src/openai.rs
@@ -193,7 +193,11 @@ impl OpenAiProvider {
         if !tools_json.is_empty() {
             body["tools"] = json!(tools_json);
         }
-        if let Some(effort) = &self.cfg.reasoning_effort {
+        if self.cfg.thinking_enabled == Some(false)
+            && crate::provider::is_deepseek_endpoint(&self.cfg.base_url, &self.cfg.model)
+        {
+            body["thinking"] = json!({ "type": "disabled" });
+        } else if let Some(effort) = &self.cfg.reasoning_effort {
             body["reasoning_effort"] = json!(effort);
         }
         if let Some(tier) = &self.cfg.service_tier {
@@ -1428,6 +1432,27 @@ mod tests {
             assert_eq!(body["service_tier"], "priority");
             assert_eq!(body["reasoning_effort"], "high");
         }
+    }
+
+    #[test]
+    fn deepseek_reader_disables_thinking_and_omits_effort() {
+        let mut cfg =
+            crate::ProviderConfig::openai("https://api.deepseek.com", "", "deepseek-v4-flash");
+        cfg.thinking_enabled = Some(false);
+        cfg.reasoning_effort = Some("high".into());
+        let provider = OpenAiProvider::new(cfg);
+        let body = provider.build_body(&[Message::user("hi")], &[], false);
+        assert_eq!(body["thinking"]["type"], "disabled");
+        assert!(body.get("reasoning_effort").is_none());
+    }
+
+    #[test]
+    fn thinking_toggle_is_omitted_for_non_deepseek_hosts() {
+        let mut cfg = crate::ProviderConfig::openai("https://api.openai.com/v1", "", "gpt-5.6-sol");
+        cfg.thinking_enabled = Some(false);
+        let provider = OpenAiProvider::new(cfg);
+        let body = provider.build_body(&[Message::user("hi")], &[], false);
+        assert!(body.get("thinking").is_none());
     }
 
     #[test]

--- a/crates/wisp-llm/src/provider.rs
+++ b/crates/wisp-llm/src/provider.rs
@@ -291,6 +291,13 @@ pub struct ProviderConfig {
     /// Reasoning effort: `reasoning.effort` / `reasoning_effort` for OpenAI,
     /// `output_config.effort` for Anthropic. None = provider default.
     pub reasoning_effort: Option<String>,
+    /// DeepSeek thinking toggle. `Some(false)` sends `thinking: { type:
+    /// "disabled" }` on Chat Completions and `reasoning.effort: none` on
+    /// Responses, so a compact JSON call cannot burn its output budget on
+    /// hidden CoT. None = omit (DeepSeek V4 defaults to thinking on). Ignored
+    /// for non-DeepSeek hosts so OpenAI/local gateways are not sent an unknown
+    /// field.
+    pub thinking_enabled: Option<bool>,
     /// OpenAI-compatible top-level `service_tier`. None = omit the field.
     pub service_tier: Option<String>,
     /// HTTP proxy override. `None`/empty = follow system/env proxy settings;
@@ -363,6 +370,7 @@ impl ProviderConfig {
             anthropic_version: "2023-06-01".into(),
             max_tokens: 8192,
             reasoning_effort: None,
+            thinking_enabled: None,
             service_tier: None,
             proxy: None,
         }
@@ -380,6 +388,7 @@ impl ProviderConfig {
             anthropic_version: "2023-06-01".into(),
             max_tokens: 8192,
             reasoning_effort: None,
+            thinking_enabled: None,
             service_tier: None,
             proxy: None,
         }
@@ -397,10 +406,22 @@ impl ProviderConfig {
             anthropic_version: "2023-06-01".into(),
             max_tokens: 8192,
             reasoning_effort: None,
+            thinking_enabled: None,
             service_tier: None,
             proxy: None,
         }
     }
+}
+
+/// True when the request will hit DeepSeek's thinking-mode default.
+///
+/// Match the public API host or a `deepseek-*` model id so a custom gateway
+/// that still serves V4 Flash/Pro gets the same toggle. Other OpenAI-compatible
+/// hosts must not receive `thinking`, which they reject.
+pub(crate) fn is_deepseek_endpoint(base_url: &str, model: &str) -> bool {
+    let url = base_url.to_ascii_lowercase();
+    let model = model.to_ascii_lowercase();
+    url.contains("deepseek.com") || model.starts_with("deepseek-")
 }
 
 /// Callbacks the agent loop receives while a streamed completion is in flight.

--- a/crates/wisp-llm/src/responses.rs
+++ b/crates/wisp-llm/src/responses.rs
@@ -63,7 +63,11 @@ impl OpenAiResponsesProvider {
         if !tools_json.is_empty() {
             body["tools"] = json!(tools_json);
         }
-        if let Some(effort) = &self.cfg.reasoning_effort {
+        if self.cfg.thinking_enabled == Some(false)
+            && crate::provider::is_deepseek_endpoint(&self.cfg.base_url, &self.cfg.model)
+        {
+            body["reasoning"] = json!({ "effort": "none" });
+        } else if let Some(effort) = &self.cfg.reasoning_effort {
             body["reasoning"] = json!({ "effort": effort });
         }
         if let Some(tier) = &self.cfg.service_tier {
@@ -664,6 +668,20 @@ mod tests {
         assert_eq!(body["model"], "gpt-5.6-sol");
         assert_eq!(body["service_tier"], "priority");
         assert_eq!(body["reasoning"]["effort"], "high");
+    }
+
+    #[test]
+    fn deepseek_reader_sets_reasoning_effort_none() {
+        let mut cfg = crate::provider::ProviderConfig::openai_responses(
+            "https://api.deepseek.com",
+            "sk-test",
+            "deepseek-v4-flash",
+        );
+        cfg.thinking_enabled = Some(false);
+        cfg.reasoning_effort = Some("high".into());
+        let provider = OpenAiResponsesProvider::new(cfg);
+        let body = provider.build_body(&[Message::user("hi")], &[]);
+        assert_eq!(body["reasoning"]["effort"], "none");
     }
 
     #[test]

--- a/docs/model-configuration.md
+++ b/docs/model-configuration.md
@@ -67,12 +67,15 @@ disabled during a running turn and hidden for unsupported providers and ACP
 Agents. ACP Fast Mode remains a separate Agent session configuration.
 
 The built-in Reader used by `#` session references inherits that profile's
-model and reasoning effort, but the first retrieval pass is capped at 2048
-output tokens. If hidden reasoning fills that budget, or the JSON lands in a
-thinking field instead of visible content, Reader retries once with the
-profile's full output budget and parses JSON from either field. If structured
-retrieval still fails, the cited transcript is injected in truncated form so
-the main turn can still use the reference.
+model, not its reasoning effort. Retrieval turns disable DeepSeek thinking
+(the V4 default is thinking-on at `high`) and cap each transcript chunk well
+below a 1M context window so a long session from another project cannot fill
+a single JSON-extraction call. The first pass is still capped at 2048 output
+tokens; if the JSON is truncated or lands in a thinking field, Reader retries
+once with the profile's full output budget and parses the last complete JSON
+object from either field. If structured retrieval still fails, a head-and-tail
+excerpt of the cited transcript is injected so the main turn can still use the
+reference.
 
 Model profiles describe model access and capabilities for the **built-in Wisp
 agent**. External coding agents (Codex / Claude via ACP) are configured under

--- a/src-tauri/src/project_reader.rs
+++ b/src-tauri/src/project_reader.rs
@@ -1,10 +1,10 @@
 //! Read-only, one-shot retrieval over saved sessions.
 //!
 //! The host owns fan-out and context budgeting: each session is an independent
-//! retrieval unit, and only a session that exceeds the selected Reader model's
-//! context window is split again. Model output is treated as an untrusted
-//! relevance judgment; every returned quote is tied back to a durable message
-//! sequence before it reaches the primary agent.
+//! retrieval unit, split into bounded chunks (further limited by the Reader
+//! model's context window). Model output is treated as an untrusted relevance
+//! judgment; every returned quote is tied back to a durable message sequence
+//! before it reaches the primary agent.
 
 use futures_util::{stream, StreamExt};
 use serde::Deserialize;
@@ -30,12 +30,15 @@ At most six evidence items.";
 const READER_OUTPUT_TOKENS: u64 = 2_048;
 const READER_PARALLELISM: usize = 4;
 const READER_TIMEOUT: Duration = Duration::from_secs(90);
+/// Independent of the model context window. A 1M-window flash model must not
+/// swallow a whole research session in one JSON-extraction call (#1084).
+const READER_CHUNK_TOKENS: usize = 16_384;
 const TOOL_TEXT_CAP: usize = 4_000;
 const SUMMARY_CAP: usize = 600;
 const QUOTE_CAP: usize = 320;
 const WHY_CAP: usize = 320;
 const INJECTION_CAP: usize = 60_000;
-const FALLBACK_SESSION_CAP: usize = 8_000;
+const FALLBACK_SESSION_CAP: usize = 24_000;
 
 #[derive(Clone, Debug)]
 struct SessionInput {
@@ -145,7 +148,8 @@ pub async fn read_references(
         + 1_024;
     let transcript_budget = usize::try_from(context_window)
         .unwrap_or(usize::MAX)
-        .saturating_sub(fixed_tokens);
+        .saturating_sub(fixed_tokens)
+        .min(READER_CHUNK_TOKENS);
     if transcript_budget < 256 {
         return Err(format!(
             "Reader model context window ({context_window} tokens) is too small for retrieval."
@@ -164,30 +168,28 @@ pub async fn read_references(
         inputs.push(SessionInput { info, messages });
     }
 
-    let (provider, api_url, model, api_key, profile_max_tokens, reasoning_effort, service_tier) =
+    let (provider, api_url, model, api_key, profile_max_tokens, _reasoning_effort, service_tier) =
         crate::specialists::specialist_llm(store, &reader).await;
-    let cfg = crate::build_provider_config(
+    let cfg = reader_provider_config(
         &provider,
         &api_url,
         &api_key,
         &model,
         READER_OUTPUT_TOKENS,
-        &reasoning_effort,
         &service_tier,
     )
     .map_err(|error| format!("Reader model is unavailable: {error}"))?;
     let llm: Arc<dyn Provider> = Arc::from(wisp_llm::build(cfg));
-    // A reasoning model can burn the compact Reader budget on hidden reasoning
-    // before writing any JSON (`max_output_tokens`, #784). Keep the profile's
+    // A reasoning model can still burn the compact Reader budget if the
+    // provider ignores the thinking-off toggle (#784). Keep the profile's
     // full budget on hand so a chunk that hits the limit can retry once.
     let retry_llm: Option<Arc<dyn Provider>> = if profile_max_tokens > READER_OUTPUT_TOKENS {
-        crate::build_provider_config(
+        reader_provider_config(
             &provider,
             &api_url,
             &api_key,
             &model,
             profile_max_tokens,
-            &reasoning_effort,
             &service_tier,
         )
         .ok()
@@ -235,6 +237,30 @@ pub async fn read_references(
     }
     let failed_tasks = task_count.saturating_sub(successful_tasks);
     Ok(Some(render_injection(&inputs, by_session, failed_tasks)))
+}
+
+/// Retrieval is a JSON extraction job, not a reasoning job. Do not inherit the
+/// bound profile's effort: DeepSeek V4 thinks at `high` by default and that
+/// CoT eats the 2048-token Reader cap before any JSON is written (#1019, #1084).
+fn reader_provider_config(
+    provider: &str,
+    api_url: &str,
+    api_key: &str,
+    model: &str,
+    max_tokens: u64,
+    service_tier: &str,
+) -> Result<wisp_llm::ProviderConfig, String> {
+    let mut cfg = crate::build_provider_config(
+        provider,
+        api_url,
+        api_key,
+        model,
+        max_tokens,
+        "",
+        service_tier,
+    )?;
+    cfg.thinking_enabled = Some(false);
+    Ok(cfg)
 }
 
 /// Resolve the durable sessions that a Reader request may inspect.
@@ -339,7 +365,7 @@ fn fallback_transcript(session: &SessionInput) -> String {
     if blocks.is_empty() {
         return "[empty saved transcript]".into();
     }
-    clip(
+    clip_head_tail(
         &blocks
             .iter()
             .map(render_block)
@@ -532,15 +558,33 @@ fn output_was_truncated(completion: &Completion) -> bool {
 }
 
 fn parse_result(raw: &str, chunk: &SessionChunk) -> Result<ChunkResult, String> {
-    let start = raw
-        .find('{')
-        .ok_or_else(|| "Reader returned no JSON object.".to_string())?;
-    let end = raw
-        .rfind('}')
-        .filter(|end| *end >= start)
-        .ok_or_else(|| "Reader returned incomplete JSON.".to_string())?;
-    let parsed: RawReaderResult = serde_json::from_str(&raw[start..=end])
-        .map_err(|error| format!("Invalid Reader JSON: {error}"))?;
+    let slices = json_object_slices(raw);
+    let mut last_error = None;
+    for candidate in slices.iter().rev() {
+        match parse_raw_reader(candidate) {
+            Ok(parsed) => return Ok(ground_reader_result(parsed, chunk)),
+            Err(error) => last_error = Some(error),
+        }
+    }
+    if last_error.is_none() && raw.contains('{') {
+        return Err("Reader returned incomplete JSON.".to_string());
+    }
+    Err(last_error.unwrap_or_else(|| "Reader returned no JSON object.".to_string()))
+}
+
+fn parse_raw_reader(candidate: &str) -> Result<RawReaderResult, String> {
+    let value: serde_json::Value =
+        serde_json::from_str(candidate).map_err(|error| format!("Invalid Reader JSON: {error}"))?;
+    let Some(object) = value.as_object() else {
+        return Err("Reader returned no JSON object.".into());
+    };
+    if !object.contains_key("summary") && !object.contains_key("evidence") {
+        return Err("Invalid Reader JSON: missing summary/evidence".into());
+    }
+    serde_json::from_value(value).map_err(|error| format!("Invalid Reader JSON: {error}"))
+}
+
+fn ground_reader_result(parsed: RawReaderResult, chunk: &SessionChunk) -> ChunkResult {
     let mut seen = HashSet::new();
     let evidence = parsed
         .evidence
@@ -564,10 +608,53 @@ fn parse_result(raw: &str, chunk: &SessionChunk) -> Result<ChunkResult, String> 
             })
         })
         .collect();
-    Ok(ChunkResult {
+    ChunkResult {
         summary: clip(parsed.summary.trim(), SUMMARY_CAP),
         evidence,
-    })
+    }
+}
+
+/// Complete `{...}` slices, string-aware, so CoT that copies code braces
+/// cannot glue a snippet onto the real Reader object (#1084).
+fn json_object_slices(raw: &str) -> Vec<&str> {
+    let mut out = Vec::new();
+    let mut depth = 0usize;
+    let mut start = 0usize;
+    let mut in_string = false;
+    let mut escape = false;
+    for (index, ch) in raw.char_indices() {
+        if depth == 0 {
+            if ch == '{' {
+                depth = 1;
+                start = index;
+                in_string = false;
+                escape = false;
+            }
+            continue;
+        }
+        if in_string {
+            if escape {
+                escape = false;
+            } else if ch == '\\' {
+                escape = true;
+            } else if ch == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+        match ch {
+            '"' => in_string = true,
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    out.push(&raw[start..index + ch.len_utf8()]);
+                }
+            }
+            _ => {}
+        }
+    }
+    out
 }
 
 fn render_injection(
@@ -900,6 +987,29 @@ fn clip(text: &str, cap: usize) -> String {
     text[..end].to_string()
 }
 
+/// Keep the start (the question) and the end (scripts, results) of a cited
+/// transcript so a failed Reader call does not drop the content the user
+/// actually asked about (#1084).
+fn clip_head_tail(text: &str, cap: usize) -> String {
+    if text.len() <= cap {
+        return text.to_string();
+    }
+    const MARKER: &str = "\n[…transcript truncated…]\n";
+    let keep = cap.saturating_sub(MARKER.len()).max(2);
+    let mut head = keep / 2;
+    while head > 0 && !text.is_char_boundary(head) {
+        head -= 1;
+    }
+    let mut tail_start = text.len().saturating_sub(keep - head);
+    while tail_start < text.len() && !text.is_char_boundary(tail_start) {
+        tail_start += 1;
+    }
+    if tail_start <= head {
+        return clip(text, cap);
+    }
+    format!("{}{}{}", &text[..head], MARKER, &text[tail_start..])
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1130,6 +1240,30 @@ mod tests {
     }
 
     #[test]
+    fn long_session_splits_even_when_model_window_is_huge() {
+        let messages = seq_messages(vec![
+            Message::user("A".repeat(20_000)),
+            Message::assistant("a".repeat(20_000)),
+            Message::user("B".repeat(20_000)),
+            Message::assistant("b".repeat(20_000)),
+        ]);
+        let chunks = chunk_session(&messages, READER_CHUNK_TOKENS);
+        assert!(
+            chunks.len() > 1,
+            "a 1M-window budget must still split a long session: {chunks:#?}"
+        );
+        assert!(chunks
+            .iter()
+            .all(|chunk| estimated_tokens(&chunk.transcript) <= READER_CHUNK_TOKENS));
+        assert!(chunks[0].transcript.contains("seq=1 USER"));
+        assert!(chunks
+            .last()
+            .unwrap()
+            .transcript
+            .contains("seq=4 ASSISTANT"));
+    }
+
+    #[test]
     fn reader_json_is_bounded_and_grounded_to_chunk_sequences() {
         let chunk = SessionChunk {
             transcript: "[message seq=7 USER]\nmeasured value 42".into(),
@@ -1147,6 +1281,22 @@ mod tests {
         .unwrap();
         assert_eq!(result.evidence.len(), 1);
         assert_eq!(result.evidence[0].message_seq, 7);
+        assert_eq!(result.evidence[0].quote, "value 42");
+    }
+
+    #[test]
+    fn reader_json_ignores_code_braces_in_reasoning() {
+        let chunk = SessionChunk {
+            transcript: "[message seq=7 USER]\nmeasured value 42".into(),
+            sources: HashMap::from([(7, "measured value 42".into())]),
+        };
+        let result = parse_result(
+            r#"Looking at fn main() { let x = {"a": 1}; }
+            {"summary":"relevant","evidence":[{"message_seq":7,"quote":"value 42","why":"direct result"}]}"#,
+            &chunk,
+        )
+        .unwrap();
+        assert_eq!(result.evidence.len(), 1);
         assert_eq!(result.evidence[0].quote, "value 42");
     }
 
@@ -1365,6 +1515,32 @@ mod tests {
         assert!(note.contains("measured value 42"));
         assert!(note.contains("Prior run"));
         assert!(note.contains("no JSON object"));
+    }
+
+    #[test]
+    fn fallback_transcript_keeps_head_and_tail() {
+        let head = "find the analysis script";
+        let tail = "fn important_script() { run_pipeline() }";
+        let middle = "UNIQUE_MIDDLE_SENTINEL";
+        let body = format!(
+            "{head}\n{}\n{middle}\n{}\n{tail}",
+            "x".repeat(20_000),
+            "y".repeat(20_000)
+        );
+        let sessions = vec![sample_session("Prior run", &body)];
+        let results = vec![TaskResult {
+            session_index: 0,
+            chunk_index: 0,
+            result: Err("Reader returned no JSON object.".into()),
+        }];
+        let note = failure_injection(&results, &sessions);
+        assert!(note.contains(head), "{note}");
+        assert!(note.contains(tail), "{note}");
+        assert!(note.contains("transcript truncated"), "{note}");
+        assert!(
+            !note.contains(middle),
+            "middle of a long cited transcript should be dropped"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #1084

## User-facing problem

Using `#` to cite a session from another project in 1.8.1 still failed structured retrieval. Reader returned a truncated transcript, and the agent fell back to walking that project's files. This is the leftover of #1019: the send no longer aborts, but the cited content is still not recovered.

The default Reader is `deepseek-v4-flash`. V4 thinking is on at `high` unless disabled. Reader inherited that default, stuffed a whole 1M-window session into one JSON call, and parsed the first `{` to last `}`. Hidden CoT burned the 2048-token output cap (retry 8192). On total failure, only the first 8k characters of the transcript were injected, so scripts at the end of a long session were dropped.

## What changed

- Reader no longer inherits the bound profile's reasoning effort. DeepSeek Chat Completions send `thinking: { type: "disabled" }`; Responses send `reasoning.effort: none`. Non-DeepSeek hosts are unchanged so OpenAI/local gateways are not sent an unknown field.
- Transcript chunks are capped at 16,384 tokens independently of the model context window, so a long other-project session splits instead of becoming one giant extraction call.
- JSON parse takes the last complete object that has `summary` or `evidence`, so CoT that copies code braces cannot glue a snippet onto the real payload.
- If structured retrieval still fails, the fallback keeps head and tail of the cited transcript (24k characters) instead of an 8k head-only clip.

## Tests

- `wisp-llm`: DeepSeek Chat Completions omit effort and send `thinking.disabled`; Responses send `reasoning.effort: none`; non-DeepSeek hosts do not get a `thinking` field.
- `project_reader`: long sessions split under a huge window; JSON with extra code braces still grounds; fallback keeps the question and a later script and drops the middle.

```bash
cargo test -p wisp-llm --lib
cargo test -p wisp-tauri --lib -- project_reader::
```

## Manual smoke

1. Bind Reader to `deepseek-v4-flash` (onboarding default).
2. In project A, `#` a long session from project B that contains a script near the end.
3. Ask for that script and send.
4. Confirm the turn uses structured evidence (or at least a head+tail transcript that still contains the script), not a parse-failure stub that only has the start of the session.

## Known limitations

- Thinking is disabled only on DeepSeek hosts / `deepseek-*` model ids. A non-DeepSeek reasoning model bound to Reader can still burn the 2048-token cap; the existing larger-budget retry remains.
- `#project` is still current-project only; other projects are cited as individual `#` session chips.