### PR TITLE
fix(desktop): 空白新建窗口未绑定项目时不再 panic

### DIFF
--- a/src-tauri/src/acp.rs
+++ b/src-tauri/src/acp.rs
@@ -221,7 +221,7 @@ pub(crate) async fn get_acp_session_agent(
     window: tauri::WebviewWindow,
     frame_id: String,
 ) -> Result<Option<String>, String> {
-    let project = state.active(window.label());
+    let project = state.require_active(window.label())?;
     if state
         .store
         .frame_project_id(&frame_id)
@@ -252,7 +252,7 @@ pub(crate) async fn get_acp_session_state(
     window: tauri::WebviewWindow,
     frame_id: String,
 ) -> Result<Option<serde_json::Value>, String> {
-    let project = state.active(window.label());
+    let project = state.require_active(window.label())?;
     if state
         .store
         .frame_project_id(&frame_id)
@@ -1629,7 +1629,7 @@ pub(crate) async fn set_acp_session_config(
     config_id: String,
     value: serde_json::Value,
 ) -> Result<serde_json::Value, String> {
-    let project = state.active(window.label());
+    let project = state.require_active(window.label())?;
     if state
         .store
         .frame_project_id(&frame_id)
@@ -1678,7 +1678,7 @@ pub(crate) async fn set_acp_session_mode(
     frame_id: String,
     mode_id: String,
 ) -> Result<String, String> {
-    let project = state.active(window.label());
+    let project = state.require_active(window.label())?;
     if state
         .store
         .frame_project_id(&frame_id)

--- a/src-tauri/src/app_commands.rs
+++ b/src-tauri/src/app_commands.rs
@@ -430,7 +430,7 @@ pub(super) async fn get_capabilities(
     let skills = skill_infos(&catalog, &tags, enabled.as_ref());
     let skill_counts = capability_skill_counts(&skills);
     let mcp_counts = capability_mcp_counts(&state.store, &ap).await;
-    let mut project = build_project_info(&state, window.label()).await;
+    let mut project = build_project_info(&state, window.label()).await?;
     project.skill_count = skill_counts.total();
     project.mcp_server_count = mcp_counts.total();
     Ok(Capabilities {

--- a/src-tauri/src/app_state.rs
+++ b/src-tauri/src/app_state.rs
@@ -533,13 +533,8 @@ impl AppState {
     /// Snapshot a window's active project. Falls back to the "main" window's
     /// project (always initialized at startup) for un-scoped or early calls.
     /// File → New Window views (`home-*`) never inherit another window's
-    /// workspace — they must open a project first.
-    pub(crate) fn active(&self, label: &str) -> ActiveProject {
-        self.require_active(label)
-            .unwrap_or_else(|err| panic!("{err}"))
-    }
-    /// Like [`Self::active`], but blank File → New Window views without a bound
-    /// project return an error instead of leaking the main window's workspace.
+    /// workspace — they must open a project first, and commands must return
+    /// that error instead of panicking (a panic exits every window).
     pub(crate) fn require_active(&self, label: &str) -> Result<ActiveProject, String> {
         lookup_window_binding(&self.active.read().unwrap(), label).cloned()
     }
@@ -702,5 +697,18 @@ mod tests {
             "project-b"
         );
         assert_eq!(*lookup_window_binding(&bound, "main").unwrap(), "project-a");
+    }
+
+    #[test]
+    fn unbound_home_window_lookup_is_a_returned_error() {
+        let mut bound = HashMap::new();
+        bound.insert("main".to_string(), "project-a");
+        let err =
+            lookup_window_binding(&bound, "home-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee").unwrap_err();
+        assert_eq!(err, BLANK_WINDOW_NO_PROJECT);
+        assert!(
+            !err.contains("panic"),
+            "window commands must return this error; panicking exits every window"
+        );
     }
 }

--- a/src-tauri/src/approval_commands.rs
+++ b/src-tauri/src/approval_commands.rs
@@ -163,7 +163,7 @@ pub(super) async fn get_session_full_permission(
     window: tauri::WebviewWindow,
     session_id: String,
 ) -> Result<bool, String> {
-    let project = state.active(window.label());
+    let project = state.require_active(window.label())?;
     ensure_project_frame(&state, &project.id, &session_id).await?;
     Ok(session_full_permission(&state, &session_id))
 }
@@ -175,7 +175,7 @@ pub(super) async fn set_session_full_permission(
     session_id: String,
     enabled: bool,
 ) -> Result<bool, String> {
-    let project = state.active(window.label());
+    let project = state.require_active(window.label())?;
     ensure_project_frame(&state, &project.id, &session_id).await?;
     {
         let mut sessions = state

--- a/src-tauri/src/artifact_commands.rs
+++ b/src-tauri/src/artifact_commands.rs
@@ -456,7 +456,7 @@ pub(super) fn missing_files(
     window: tauri::WebviewWindow,
     paths: Vec<String>,
 ) -> Result<Vec<String>, String> {
-    let ap = state.active(window.label());
+    let ap = state.require_active(window.label())?;
     Ok(paths
         .into_iter()
         .filter(|p| {

--- a/src-tauri/src/codex_import.rs
+++ b/src-tauri/src/codex_import.rs
@@ -1487,7 +1487,7 @@ async fn import_sessions(
     context_id: Option<String>,
     provider: ImportProvider,
 ) -> Result<ExternalImportSummary, String> {
-    let ap = state.active(window.label());
+    let ap = state.require_active(window.label())?;
     let _project_activity = state.begin_project_activity(&ap.id)?;
     let model_id = super::models::active_profile_id(&state.store).await;
     let context_id = context_id.unwrap_or_else(|| "local".into());

--- a/src-tauri/src/delegation_completion.rs
+++ b/src-tauri/src/delegation_completion.rs
@@ -101,7 +101,7 @@ pub(crate) async fn get_session_agent_completion(
     window: tauri::WebviewWindow,
     session_id: String,
 ) -> Result<AgentCompletionSettings, String> {
-    let project = state.active(window.label());
+    let project = state.require_active(window.label())?;
     match state
         .store
         .frame_project_id(&session_id)
@@ -125,7 +125,7 @@ pub(crate) async fn set_session_agent_completion(
     policy: AgentCompletionPolicy,
     auto_resume: bool,
 ) -> Result<AgentCompletionSettings, String> {
-    let project = state.active(window.label());
+    let project = state.require_active(window.label())?;
     let settings = save_session_completion_settings(
         &state.store,
         &project.id,

--- a/src-tauri/src/delegation_runtime.rs
+++ b/src-tauri/src/delegation_runtime.rs
@@ -152,7 +152,7 @@ pub(crate) async fn get_session_delegation_enabled(
     window: tauri::WebviewWindow,
     session_id: String,
 ) -> Result<bool, String> {
-    let project = state.active(window.label());
+    let project = state.require_active(window.label())?;
     ensure_project_frame(&state.store, &project.id, &session_id).await?;
     Ok(session_delegation_enabled(&state.store, &session_id).await)
 }
@@ -184,7 +184,7 @@ pub(crate) async fn list_agent_workflows(
     window: tauri::WebviewWindow,
     session_id: Option<String>,
 ) -> Result<Vec<AgentWorkflowSnapshot>, String> {
-    let project = state.active(window.label());
+    let project = state.require_active(window.label())?;
     let Some(session_id) = session_id else {
         return Ok(vec![]);
     };
@@ -413,12 +413,15 @@ pub(crate) async fn create_dynamic_agent_workflow_draft(
     .await
 }
 
+/// Workflow Studio editor options for the window's bound project.
+/// File → New Window (`home-*`) has no project yet; return an error instead of
+/// panicking, which would exit every open window.
 #[tauri::command]
 pub(crate) async fn get_dynamic_agent_options(
     state: State<'_, crate::AppState>,
     window: tauri::WebviewWindow,
 ) -> Result<dynamic_workflow::DynamicAgentEditorOptions, String> {
-    let project = state.active(window.label());
+    let project = state.require_active(window.label())?;
     let frame_id = state.active_frame(window.label());
     let policy = dynamic_delegation_policy_for_project(
         &state.store,
@@ -584,7 +587,7 @@ pub(crate) async fn get_agent_workflow_result(
     workflow_id: String,
     step_id: String,
 ) -> Result<AgentWorkflowResultDetail, String> {
-    let project = state.active(window.label());
+    let project = state.require_active(window.label())?;
     load_agent_workflow_result(&state.store, &project.id, &workflow_id, &step_id).await
 }
 
@@ -643,7 +646,7 @@ pub(crate) async fn approve_agent_workflow(
     workflow_id: String,
     expected_version: i64,
 ) -> Result<AgentWorkflowSnapshot, String> {
-    let project = state.active(window.label());
+    let project = state.require_active(window.label())?;
     let current = project_workflow(&state.store, &project.id, &workflow_id).await?;
     require_workflow_delegation(&state.store, &current).await?;
     let automatic = current.mode == "automatic";
@@ -669,7 +672,7 @@ pub(crate) async fn cancel_agent_workflow(
     window: tauri::WebviewWindow,
     workflow_id: String,
 ) -> Result<(), String> {
-    let project = state.active(window.label());
+    let project = state.require_active(window.label())?;
     let workflow = project_workflow(&state.store, &project.id, &workflow_id).await?;
     if workflow.status != AgentWorkflowStatus::Running {
         return Err("Only a running Agent workflow can be cancelled.".into());
@@ -692,7 +695,7 @@ pub(crate) async fn discard_agent_workflow(
     window: tauri::WebviewWindow,
     workflow_id: String,
 ) -> Result<(), String> {
-    let project = state.active(window.label());
+    let project = state.require_active(window.label())?;
     let workflow = project_workflow(&state.store, &project.id, &workflow_id).await?;
     // Cancel a running workflow before discarding; deleting mid-flight would
     // orphan the live attempt.
@@ -714,7 +717,7 @@ pub(crate) async fn retry_agent_workflow(
     workflow_id: String,
     budget_overrides: Option<HashMap<String, dynamic_workflow::AgentBudgetProposal>>,
 ) -> Result<AgentWorkflowSnapshot, String> {
-    let project = state.active(window.label());
+    let project = state.require_active(window.label())?;
     let snapshot = match budget_overrides.filter(|overrides| !overrides.is_empty()) {
         Some(overrides) => {
             let frame_id = state.active_frame(window.label());
@@ -942,7 +945,7 @@ pub(crate) async fn run_agent_workflow(
     window: tauri::WebviewWindow,
     workflow_id: String,
 ) -> Result<DelegationExecutionResult, String> {
-    let project = state.active(window.label());
+    let project = state.require_active(window.label())?;
     let _project_activity = state.begin_project_activity(&project.id)?;
     execute_agent_workflow(
         &state.store,

--- a/src-tauri/src/file_browser.rs
+++ b/src-tauri/src/file_browser.rs
@@ -488,7 +488,7 @@ pub(super) fn search_files(
     query: String,
     limit: Option<usize>,
 ) -> Result<Vec<FileSearchHit>, String> {
-    let ap = state.active(window.label());
+    let ap = state.require_active(window.label())?;
     let q = query.trim();
     if q.is_empty() {
         return Ok(vec![]);
@@ -511,7 +511,7 @@ pub(super) fn list_dir(
     window: WebviewWindow,
     path: Option<String>,
 ) -> Result<Vec<DirEntry>, String> {
-    let ap = state.active(window.label());
+    let ap = state.require_active(window.label())?;
     let rel = path.unwrap_or_else(|| ".".into());
     let dir = wisp_tools::safety::resolve_under_root(&ap.root, &rel)?;
     if !dir.is_dir() {
@@ -1319,7 +1319,7 @@ pub(super) fn read_file(
     path: String,
     max_bytes: Option<u64>,
 ) -> Result<FileContent, String> {
-    read_file_at(&state.active(window.label()).root, path, max_bytes)
+    read_file_at(&state.require_active(window.label())?.root, path, max_bytes)
 }
 
 #[tauri::command]
@@ -1329,7 +1329,11 @@ pub(super) fn read_file_bytes(
     path: String,
     max_bytes: Option<u64>,
 ) -> Result<Response, String> {
-    let bytes = read_file_bytes_at(&state.active(window.label()).root, &path, max_bytes)?;
+    let bytes = read_file_bytes_at(
+        &state.require_active(window.label())?.root,
+        &path,
+        max_bytes,
+    )?;
     Ok(Response::new(bytes))
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -811,8 +811,8 @@ impl LiveApprovals {
 /// project. Must stay exact: tests and the UI match on this string.
 const BLANK_WINDOW_NO_PROJECT: &str = "Open a project in this window before running that action.";
 
-/// Project bound to this window only. Unlike [`AppState::active`], this never
-/// falls back to `main` — writing an overlay (or the unprefixed global keys)
+/// Project bound to this window only. Unlike [`AppState::require_active`], this
+/// never falls back to `main` — writing an overlay (or the unprefixed global keys)
 /// from an unbound window would leak into every project that still inherits
 /// the default.
 fn bound_window_project_id(state: &AppState, label: &str) -> Result<String, String> {
@@ -5974,7 +5974,7 @@ async fn test_reviewer_backend(
     }
     reviewer.instructions = review::REVIEWER_RUBRIC.to_string();
 
-    let project = state.active(window.label());
+    let project = state.require_active(window.label())?;
     let _project_activity = state.begin_project_activity(&project.id)?;
     let session_acp_profile_id = match state.active_frame(window.label()) {
         Some(frame_id) => state
@@ -6201,7 +6201,7 @@ async fn side_chat(
             .await
             .map_err(|error| error.to_string())?
             .ok_or_else(|| "Session project was not found.".to_string())?,
-        None => state.active(window.label()).id,
+        None => state.require_active(window.label())?.id,
     };
     let _project_activity = state.begin_project_activity(&project_id)?;
     let Some(ref frame_id) = frame_id else {
@@ -6254,7 +6254,7 @@ async fn side_chat(
     // ACP side chat: one-shot, read-only answer from the selected ACP Agent,
     // running in the active project root. Never touches the main thread.
     let answer = if let Some(agent_id) = acp_agent_id.as_deref().filter(|id| !id.is_empty()) {
-        let cwd = state.active(window.label()).root;
+        let cwd = state.require_active(window.label())?.root;
         acp::acp_side_chat_once(&state, &cwd, agent_id, &prompt).await?
     } else {
         http_llm?
@@ -6349,8 +6349,8 @@ fn list_memory_files(memory: &MemoryManager) -> Vec<MemoryFile> {
         .collect()
 }
 
-async fn build_project_info(state: &AppState, label: &str) -> ProjectInfo {
-    let ap = state.active(label);
+async fn build_project_info(state: &AppState, label: &str) -> Result<ProjectInfo, String> {
+    let ap = state.require_active(label)?;
     let (_, _, _, api_key) = load_settings(&state.store).await;
     let mcp = list_mcp_servers(&ap.root);
     // Prefer the user-set project name (Project Settings) over the folder name.
@@ -6371,7 +6371,7 @@ async fn build_project_info(state: &AppState, label: &str) -> ProjectInfo {
     } else {
         db_name
     };
-    ProjectInfo {
+    Ok(ProjectInfo {
         id: ap.id.clone(),
         name,
         root: ap.root.to_string_lossy().into_owned(),
@@ -6379,7 +6379,7 @@ async fn build_project_info(state: &AppState, label: &str) -> ProjectInfo {
         mcp_server_count: mcp.len(),
         memory_file_count: count_memory_files(&ap.memory),
         has_api_key: !api_key.is_empty(),
-    }
+    })
 }
 
 /// Tell the webview whether we're in dev (keep native context menu / DevTools).

--- a/src-tauri/src/method_search.rs
+++ b/src-tauri/src/method_search.rs
@@ -904,7 +904,7 @@ pub(crate) async fn get_method_search_run(
     window: tauri::WebviewWindow,
     run_id: String,
 ) -> Result<MethodSearchRunDetails, String> {
-    let project = state.active(window.label());
+    let project = state.require_active(window.label())?;
     method_search_details(&state.store, &project.root, &project.id, &run_id).await
 }
 
@@ -914,7 +914,7 @@ pub(crate) async fn pause_method_search(
     window: tauri::WebviewWindow,
     run_id: String,
 ) -> Result<MethodSearchRunDetails, String> {
-    let project = state.active(window.label());
+    let project = state.require_active(window.label())?;
     let _activity = state.begin_project_activity(&project.id)?;
     method_search_details(&state.store, &project.root, &project.id, &run_id).await?;
     if !state
@@ -1163,7 +1163,7 @@ pub(crate) async fn cancel_method_search(
     window: tauri::WebviewWindow,
     run_id: String,
 ) -> Result<MethodSearchRunDetails, String> {
-    let project = state.active(window.label());
+    let project = state.require_active(window.label())?;
     let _activity = state.begin_project_activity(&project.id)?;
     let details = method_search_details(&state.store, &project.root, &project.id, &run_id).await?;
     if details.run.status.is_terminal() {

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -1336,7 +1336,7 @@ pub async fn get_session_model(
     window: tauri::WebviewWindow,
     session_id: String,
 ) -> Result<String, String> {
-    let project = state.active(window.label());
+    let project = state.require_active(window.label())?;
     if state
         .store
         .frame_project_id(&session_id)
@@ -1365,7 +1365,7 @@ pub async fn get_session_reasoning_effort(
     window: tauri::WebviewWindow,
     session_id: String,
 ) -> Result<Option<String>, String> {
-    let project = state.active(window.label());
+    let project = state.require_active(window.label())?;
     if state
         .store
         .frame_project_id(&session_id)
@@ -1389,7 +1389,7 @@ pub async fn get_session_service_tier(
     window: tauri::WebviewWindow,
     session_id: String,
 ) -> Result<Option<String>, String> {
-    let project = state.active(window.label());
+    let project = state.require_active(window.label())?;
     if state
         .store
         .frame_project_id(&session_id)

--- a/src-tauri/src/plan_mode.rs
+++ b/src-tauri/src/plan_mode.rs
@@ -72,7 +72,7 @@ pub(crate) async fn get_session_plan_mode(
     window: tauri::WebviewWindow,
     session_id: String,
 ) -> Result<Option<bool>, String> {
-    let project = state.active(window.label());
+    let project = state.require_active(window.label())?;
     ensure_project_frame(&state.store, &project.id, &session_id).await?;
     if matches!(state.store.get_acp_session(&session_id).await, Ok(Some(_))) {
         return Ok(None);

--- a/src-tauri/src/project_commands.rs
+++ b/src-tauri/src/project_commands.rs
@@ -847,8 +847,7 @@ pub(super) async fn get_project_info(
     state: State<'_, AppState>,
     window: tauri::WebviewWindow,
 ) -> Result<ProjectInfo, String> {
-    let _ = state.require_active(window.label())?;
-    Ok(build_project_info(&state, window.label()).await)
+    build_project_info(&state, window.label()).await
 }
 
 #[cfg(test)]

--- a/src-tauri/src/scheduler.rs
+++ b/src-tauri/src/scheduler.rs
@@ -220,7 +220,7 @@ pub(crate) async fn create_schedule(
         start_at,
         now,
     )?;
-    let project_id = state.active(window.label()).id;
+    let project_id = state.require_active(window.label())?.id;
     if let Some(frame_id) = args.frame_id.as_deref() {
         let owner = state
             .store
@@ -259,7 +259,7 @@ pub(crate) async fn list_schedules(
     state: State<'_, AppState>,
     window: tauri::WebviewWindow,
 ) -> Result<Vec<ScheduleRecord>, String> {
-    let project_id = state.active(window.label()).id;
+    let project_id = state.require_active(window.label())?.id;
     state
         .store
         .list_schedules(&project_id)

--- a/src-tauri/src/scratch_commands.rs
+++ b/src-tauri/src/scratch_commands.rs
@@ -11,10 +11,24 @@ pub(super) fn is_scratch_project_id(id: &str) -> bool {
 
 #[derive(Clone)]
 pub(super) struct ScratchWindow {
-    prev_project_id: String,
+    prev_project_id: Option<String>,
     scratch_project_id: String,
     session_id: String,
     sandbox_path: PathBuf,
+}
+
+/// Previous workspace to restore when scratch chat closes. File → New Window
+/// (`home-*`) has no binding, so scratch can start there and return to home.
+fn scratch_restore_project_id(
+    label: &str,
+    bound_project_id: Result<String, String>,
+) -> Result<Option<String>, String> {
+    match bound_project_id {
+        Ok(id) if is_scratch_project_id(&id) => Err("Scratch chat is already active.".into()),
+        Ok(id) => Ok(Some(id)),
+        Err(_) if is_blank_window_label(label) => Ok(None),
+        Err(err) => Err(err),
+    }
 }
 
 fn scratch_sandbox_root(app_data: &Path) -> PathBuf {
@@ -78,7 +92,12 @@ async fn destroy_scratch_window(state: &AppState, label: &str, scratch: ScratchW
     if state.active_frame(label).as_deref() == Some(scratch.session_id.as_str()) {
         state.set_active_frame(label, None);
     }
-    let _ = set_active_project(state, label, &scratch.prev_project_id).await;
+    if let Some(prev_project_id) = scratch.prev_project_id.as_deref() {
+        let _ = set_active_project(state, label, prev_project_id).await;
+    } else {
+        state.active.write().unwrap().remove(label);
+        state.set_active_frame(label, None);
+    }
 }
 
 async fn close_scratch_for_window(state: &AppState, label: &str) {
@@ -103,10 +122,8 @@ pub(super) async fn start_scratch_chat(
     let label = window.label().to_string();
     close_scratch_for_window(state.inner(), &label).await;
 
-    let prev = state.active(&label);
-    if is_scratch_project_id(&prev.id) {
-        return Err("Scratch chat is already active.".into());
-    }
+    let prev_project_id =
+        scratch_restore_project_id(&label, state.require_active(&label).map(|ap| ap.id))?;
 
     let uuid = Uuid::new_v4().to_string();
     let sandbox_path = scratch_sandbox_root(&state.app_data).join(&uuid);
@@ -131,7 +148,7 @@ pub(super) async fn start_scratch_chat(
     state.scratch.write().unwrap().insert(
         label,
         ScratchWindow {
-            prev_project_id: prev.id,
+            prev_project_id,
             scratch_project_id: project_id.clone(),
             session_id: session_id.clone(),
             sandbox_path,
@@ -211,5 +228,26 @@ mod tests {
         assert!(store.get_project(&fresh_id).await.unwrap().is_some());
         assert!(fresh_dir.exists());
         let _ = std::fs::remove_dir_all(&app_data);
+    }
+
+    #[test]
+    fn scratch_from_a_blank_window_has_no_project_to_restore() {
+        assert_eq!(
+            scratch_restore_project_id("home-1", Err(BLANK_WINDOW_NO_PROJECT.into())).unwrap(),
+            None
+        );
+        assert_eq!(
+            scratch_restore_project_id("main", Err(BLANK_WINDOW_NO_PROJECT.into())).unwrap_err(),
+            BLANK_WINDOW_NO_PROJECT
+        );
+        assert_eq!(
+            scratch_restore_project_id("proj-abc", Ok("workspace-1".into())).unwrap(),
+            Some("workspace-1".into())
+        );
+        assert_eq!(
+            scratch_restore_project_id("main", Ok(format!("{SCRATCH_PROJECT_PREFIX}open")))
+                .unwrap_err(),
+            "Scratch chat is already active."
+        );
     }
 }

--- a/src-tauri/src/seed.rs
+++ b/src-tauri/src/seed.rs
@@ -82,7 +82,7 @@ pub(super) fn load_demo_cmd(
     window: tauri::WebviewWindow,
     id: String,
 ) -> Result<Demo, String> {
-    let ap = state.active(window.label());
+    let ap = state.require_active(window.label())?;
     extract_demo_assets(&id, &ap.root)?;
     load_demo(&id).ok_or_else(|| format!("demo '{id}' not found"))
 }

--- a/src-tauri/src/session_export.rs
+++ b/src-tauri/src/session_export.rs
@@ -391,7 +391,7 @@ pub(super) async fn get_artifact_provenance(
         None => state.active_frame(window.label()),
     };
     let Some(fid) = frame_id else { return Ok(None) };
-    let ap = state.active(window.label());
+    let ap = state.require_active(window.label())?;
     artifact_provenance_for_path(&state.store, &fid, &ap.root, &path).await
 }
 
@@ -469,7 +469,7 @@ pub(super) async fn export_session(
         return Err("No messages to export.".into());
     }
 
-    let ap = state.active(window.label());
+    let ap = state.require_active(window.label())?;
     let stored_artifacts = state
         .store
         .list_artifacts(&session_id)

--- a/src-tauri/src/session_import.rs
+++ b/src-tauri/src/session_import.rs
@@ -335,7 +335,7 @@ pub(super) async fn import_session_archive(
             .map_err(|e| format!("{e}"))??
     };
 
-    let ap = state.active(window.label());
+    let ap = state.require_active(window.label())?;
     let model_id = models::active_profile_id(&state.store).await;
     let source_path = archive_path.to_string_lossy().into_owned();
     let (frame_id, status) =

--- a/src-tauri/src/skill_portfolio.rs
+++ b/src-tauri/src/skill_portfolio.rs
@@ -120,7 +120,7 @@ pub(crate) async fn plan_skill_portfolio(
         return Err("Choose a planning model.".into());
     }
 
-    let project = state.active(window.label());
+    let project = state.require_active(window.label())?;
     let frame_id = state.active_frame(window.label());
     let policy = delegation_runtime::dynamic_delegation_policy_for_project(
         &state.store,

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -1562,7 +1562,12 @@ fn App() -> impl IntoView {
     });
     let agent_panel = AgentPanelState::new(active_session);
     let workflow_studio_state = AgentPanelState::new(active_session);
-    refresh_agent_resources(workflow_studio_state, specialists);
+    create_effect(move |_| {
+        if project_info.get().is_none() {
+            return;
+        }
+        refresh_agent_resources(workflow_studio_state, specialists);
+    });
     let file_source = create_rw_signal("local".to_string());
     let file_query = create_rw_signal(String::new());
     let file_cwd = create_rw_signal(".".to_string());


### PR DESCRIPTION
## Summary
- 跟进 #1074 / #1080：File → New Window 打开的空白 `home-*` 窗口没有绑定 `ActiveProject`。第二个窗口一启动就会调用 `get_dynamic_agent_options` 等项目作用域命令；旧的 `active()` 在未绑定时 panic，整个进程（含第一个窗口）一起退出，项目列表来不及渲染，只剩硬编码示例卡。
- 窗口命令改为 `require_active()`，未绑定项目时返回错误而不是 panic。首页在绑定项目前不再拉取 Workflow Studio 等依赖项目的接口。空白窗口上的「随手一聊」可以启动，关闭后回到未绑定状态。
- 这是独立的崩溃修复小 PR，不改隔离策略本身。

## Test plan
- [x] `cargo test -p wisp-tauri --lib blank_window`
- [x] `cd ui && cargo check --target wasm32-unknown-unknown`
- [x] Windows 本机编译当前 main 后：第一个窗口项目列表正常；File → 新建窗口后第二窗口只显示示例项目并卡顿闪退（修复前）
- [x] 应用本修复后重新编译：第二窗口能列出全部项目，进程不再退出；可在空白窗口打开已有项目并行工作

## Known limitations
- 空白窗口在打开项目之前，依赖项目的命令仍会返回 “Open a project in this window before running that action.”，这是预期行为。
- 未覆盖真实 SSH / GPU / 网络路径。

Closes nothing; related to #1080 #1074.

Made with [Cursor](https://cursor.com)