### PR TITLE
fix(ui): resolve registered figure filename links

### DIFF
--- a/ui/src/app_support/markdown.rs
+++ b/ui/src/app_support/markdown.rs
@@ -221,6 +221,10 @@ pub(crate) fn artifact_file_paths(a: &Artifact) -> Vec<String> {
                     out.push(name);
                 }
             }
+            let name = normalize_path(&a.name);
+            if !out.contains(&name) {
+                out.push(name);
+            }
             out
         }
         _ => vec![normalize_path(&a.name)],
@@ -822,6 +826,30 @@ mod art_ref_marker_tests {
         assert!(out.contains(r#"data-art-idx="0""#));
         assert!(!out.contains(r#"data-art-idx="1""#));
         assert!(!out.contains("</button></button>"));
+    }
+
+    #[test]
+    fn filename_link_matches_registered_artifact_location() {
+        let artifact = Artifact {
+            id: "artifact-patho-double".into(),
+            name: "patho_double.png".into(),
+            kind: "image",
+            data: PreviewData::File {
+                path: "artifact:artifact-patho-double".into(),
+                kind: "image".into(),
+            },
+            location: Some("figures/patho_double.png".into()),
+            source_item: usize::MAX,
+            superseded: false,
+            source_discarded: false,
+        };
+
+        let html = replace_file_links(
+            r#"<p><a href="patho_double.png">patho_double.png</a></p>"#.into(),
+            &[artifact],
+        );
+        assert!(html.contains(r#"class="art-ref" data-art-idx="0""#));
+        assert!(!html.contains(r#"href="patho_double.png""#));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

A registered artifact keeps an opaque `artifact:<id>` preview path and its workspace location separately. Filename-only links such as `patho_double.png` were matched only against the opaque path basename, so the click bypassed the registered Figure artifact and attempted to read a nonexistent root-level file, producing Windows `os error 2`.

Closes #1108.

## Changes

- Include the artifact display filename among the shared file-link aliases.
- Add a regression test proving a filename-only PNG link is replaced with the registered artifact reference.

## Tests

- `cargo fmt --all -- --check`
- `cargo test --manifest-path ui/Cargo.toml` (320 passed)
- `cargo check --target wasm32-unknown-unknown` from `ui/`
- `npm ci` and `npx playwright test` from `ui-tests/` (490 passed, 2 skipped)
- `cargo test --workspace` (one unrelated timing-sensitive run-lease test failed under full-suite load; `cargo test -p wisp-runs run_context::tests::auto_harvest_skips_collect_when_already_harvested -- --exact --nocapture` passed in isolation)

## Manual smoke

1. On Windows, generate or register `figures/patho_double.png`.
2. Open a filename-only `patho_double.png` link from the conversation.
3. Confirm the Figure preview opens without `os error 2`.

## Known limitations / follow-up

Duplicate display filenames retain the existing first-match behavior. Add explicit disambiguation only if a real duplicate-name workflow requires it.