### PR TITLE
fix(browser): prefer shared Chrome and reconnect the daily profile

### DIFF
--- a/docs/browser-runtime-acceptance.md
+++ b/docs/browser-runtime-acceptance.md
@@ -2,10 +2,21 @@
 
 Use a Wisp build that bundles extension **0.3.1**. Load the unpacked extension from `browser_setup.extension_path` before testing.
 
+For #1107, test on Windows, macOS, and Linux with automatic launch enabled:
+close daily Chrome, call `browser_setup` with no action, and verify its normal
+profile opens a new-tab page and the installed extension reconnects. Repeat with
+`url: "https://example.com"` and verify that target opens directly. With shared
+already connected, neither call should open a second window or modify existing
+tabs. Let the extension worker sleep and retry to verify reconnection. Without
+the extension, expect installation guidance and no workspace fallback. An empty
+action must behave like an omitted action. Existing blank/new-tab pages are never
+cleaned up by startup; ordinary per-turn cleanup still applies only to recorded
+tool-created tabs.
+
 1. Connect extension 0.2.1 and confirm the app shows current 0.2.1 / bundled 0.3.1, the verified managed path, and the update actions. **Update extension** must return the manual fallback, open the extension page, and clear only after Reload reconnects as 0.3.1. With an extension that advertises `runtime_reload`, the same action must reconnect automatically. `browser_setup` then shows `update_required=false`, `extension_version` 0.3.1, and `required_protocol` 2.
 2. Open a WeChat article, `web_scan` with `mode=article`, confirm `images[]` includes the body figures, then `web_save_assets` copies them under the project `browser-assets/` with SHA-256. Do not use page `fetch`.
 3. `web_open_tab` on a GitHub repo and a Zenodo DOI returns a non-empty final `tab.url` / `tab.title`.
-4. `browser_setup` `action=start_workspace` opens a second Chrome. Both sessions stay connected. Omitting `session` after both are live returns `SESSION_REQUIRED`.
+4. `browser_setup` `action=start_workspace` opens a second Chrome only when the user explicitly requests isolation. Both sessions stay connected, and omitting `session` still uses `shared`; pass `session=workspace` to target the isolated browser.
 5. In an already-logged-in ChatGPT, Gemini, or Google AI Mode
    (`google.com/search?udm=50`) tab: `web_agent_send` → `web_agent_wait` →
    `web_agent_read` returns the assistant text and source links. Captcha/login

--- a/docs/browser-runtime-architecture.md
+++ b/docs/browser-runtime-architecture.md
@@ -18,7 +18,8 @@ Agent tools
 | `shared` | User's existing Chrome/Edge profile | Daily cookies and extensions | 18765 |
 | `workspace` | Chrome-family build launched with `%APPDATA%/science.wisp-science/browser-workspace` | Clean until the user signs in there | 18766 |
 
-Both can be connected at once. If they are, tools must pass `session`.
+Both can be connected at once. Omitting `session` always selects `shared`;
+workspace mode is used only when a tool explicitly passes `session=workspace`.
 
 ### Workspace mode needs a build that still loads unpacked extensions
 
@@ -81,7 +82,7 @@ The extension never writes project directories and never returns large base64 fi
 ## What the Runtime does
 
 - Multiplexes two WebSocket listeners
-- Browser Task Lease (`last_session` + explicit `session`)
+- Browser Task Lease with `shared` as the default and explicit `workspace` routing
 - Copies staged files into the project and hashes SHA-256
 - Starts/stops the workspace browser window and verifies it connected
 - Per-turn ledger of tabs Wisp created (`web_open_tab` / tab-create), closed at turn end or confirmed in the UI

--- a/skills/browser-use/SKILL.md
+++ b/skills/browser-use/SKILL.md
@@ -9,10 +9,11 @@ fold_cue: "instead_of=guessing-selectors use=web_scan first — it returns a uni
 Wisp talks to the **Browser Runtime**. Shared mode uses the user's daily
 Chrome via the unpacked extension — every action runs in their real
 profile: existing cookies, logins, extensions, and normal fingerprint all
-apply. Workspace mode can launch a separate Chrome profile. If both are
-connected, pass `session: "shared"` or `session: "workspace"`. If
+apply. Workspace mode can launch a separate Chrome profile. Omitting
+`session` always uses shared, even when workspace is connected. Pass
+`session: "workspace"` only when the user explicitly requests isolation. If
 Settings → Browser has **Open browser automatically** enabled (the
-default) and no extension is connected, Wisp may start the installed
+default) and the shared extension is disconnected, Wisp may start the installed
 Chrome/Chromium/Edge so the extension can reconnect. That is still the
 user's profile, not Playwright or Selenium.
 
@@ -24,6 +25,12 @@ the workspace extension has connected, and otherwise closes the window
 and fails with `WORKSPACE_EXTENSION_BLOCKED`. On that error: relay the
 message, do not retry `start_workspace`, do not claim any workspace page
 was opened or read, and get the shared session working instead.
+
+Start with `browser_setup` without an action (an empty action is also a status
+check). If the task supplies a target URL, pass it as `url` so a disconnected
+daily browser opens that page directly; otherwise startup uses its new-tab page.
+A connected shared browser is reused without opening another window. Startup
+does not close existing tabs, including pre-existing blank or new-tab pages.
 
 For figures/code extraction use `web_scan` with `mode: "article"` then
 `web_save_assets`. For an already-logged-in in-browser chat (ChatGPT,

--- a/src-tauri/src/browser_bridge/mod.rs
+++ b/src-tauri/src/browser_bridge/mod.rs
@@ -159,7 +159,6 @@ struct RefusedConnection {
 #[derive(Default)]
 struct BridgeState {
     sessions: HashMap<String, SessionState>,
-    last_session: Option<String>,
     startup_error: Option<String>,
     workspace_pid: Option<u32>,
     last_refusal: Option<RefusedConnection>,
@@ -291,7 +290,7 @@ fn session_requires_update(meta: &SessionMeta, bundled_version: Option<&str>) ->
         || extension_version_outdated(&meta.extension_version, bundled_version)
 }
 
-fn session_name_locked(state: &BridgeState, requested: Option<&str>) -> Result<String, String> {
+fn resolve_session_name(requested: Option<&str>) -> Result<String, String> {
     if let Some(name) = requested {
         if name != "shared" && name != "workspace" {
             return Err(errors::structured(
@@ -302,32 +301,7 @@ fn session_name_locked(state: &BridgeState, requested: Option<&str>) -> Result<S
         }
         return Ok(name.to_string());
     }
-    let connected: Vec<&str> = ["shared", "workspace"]
-        .into_iter()
-        .filter(|name| {
-            state
-                .sessions
-                .get(*name)
-                .and_then(|session| session.client.as_ref())
-                .is_some()
-        })
-        .collect();
-    if connected.is_empty() {
-        return Ok("shared".into());
-    }
-    if connected.len() == 1 {
-        return Ok(connected[0].to_string());
-    }
-    if let Some(last) = state.last_session.as_deref() {
-        if connected.iter().any(|name| *name == last) {
-            return Ok(last.to_string());
-        }
-    }
-    Err(errors::structured(
-        errors::SESSION_REQUIRED,
-        "shared and workspace are both connected; pass session=shared or session=workspace",
-        false,
-    ))
+    Ok("shared".into())
 }
 
 #[allow(dead_code)]
@@ -458,19 +432,17 @@ impl BrowserBridge {
         let state = self.state.lock().await;
         let extension_path = self.verified_extension_path();
         let extension_ready = extension_path.is_some();
-        // A live extension connection is the only proof that live retrieval
-        // works. It outranks an unverifiable bundled copy: a user who loaded the
-        // extension from another folder still browses fine, and reporting
-        // extension_missing there told the model and the UI "no live retrieval"
-        // on every turn (#921).
-        let any_connected = ["shared", "workspace"].into_iter().any(|name| {
-            state
-                .sessions
-                .get(name)
-                .and_then(|session| session.client.as_ref())
-                .is_some()
-        });
-        let status = if any_connected {
+        // A live shared extension connection is the only proof that the default
+        // live-retrieval route works. It outranks an unverifiable bundled copy: a
+        // user who loaded the extension from another folder still browses fine,
+        // and reporting extension_missing there told the model and the UI "no
+        // live retrieval" on every turn (#921).
+        let shared_connected = state
+            .sessions
+            .get("shared")
+            .and_then(|session| session.client.as_ref())
+            .is_some();
+        let status = if shared_connected {
             "connected"
         } else if state.startup_error.is_some() {
             "error"
@@ -504,9 +476,7 @@ impl BrowserBridge {
         let bundled_extension_version = bundled_manifest_version(&self.bundled_extension_dir);
         let shared = session_summary(&state, "shared", bundled_extension_version.as_deref());
         let workspace = session_summary(&state, "workspace", bundled_extension_version.as_deref());
-        let reload_required = [&shared, &workspace]
-            .into_iter()
-            .any(|session| session["reload_required"] == Value::Bool(true));
+        let reload_required = shared["reload_required"] == Value::Bool(true);
         let assistant_instruction = match (live_retrieval, reload_required) {
             (true, false) => path_instruction.to_string(),
             (true, true) => format!("{STALE_ASSISTANT_INSTRUCTION} {path_instruction}"),
@@ -818,13 +788,13 @@ impl BrowserBridge {
     ) -> Result<BrowserExecution, String> {
         let id = Uuid::new_v4().to_string();
         let (response_tx, response_rx) = oneshot::channel();
-        self.ensure_extension().await;
+        self.ensure_extension(session).await;
         let (session_name, tab_id) = {
             let mut state = self.state.lock().await;
             if let Some(error) = &state.startup_error {
                 return Err(self.unavailable_message(error));
             }
-            let session_name = session_name_locked(&state, session)?;
+            let session_name = resolve_session_name(session)?;
             let slot = session_slot(&mut state, &session_name);
             if slot.meta.paused {
                 return Err(errors::structured(
@@ -839,7 +809,6 @@ impl BrowserBridge {
             let tab_id = select_tab(slot, requested_tab)?;
             slot.selected_tab = Some(tab_id);
             slot.pending.insert(id.clone(), response_tx);
-            state.last_session = Some(session_name.clone());
             let payload = request_payload(&id, Some(tab_id), code, timeout);
             if client.tx.send(Message::Text(payload.into())).is_err() {
                 if let Some(slot) = state.sessions.get_mut(client.session.as_str()) {
@@ -901,7 +870,7 @@ impl BrowserBridge {
         code: String,
         timeout: Duration,
     ) -> Result<(String, BridgeReply), String> {
-        self.ensure_extension().await;
+        self.ensure_extension(session).await;
         let id = Uuid::new_v4().to_string();
         let (response_tx, response_rx) = oneshot::channel();
         let session_name = {
@@ -909,7 +878,7 @@ impl BrowserBridge {
             if let Some(error) = &state.startup_error {
                 return Err(self.unavailable_message(error));
             }
-            let session_name = session_name_locked(&state, session)?;
+            let session_name = resolve_session_name(session)?;
             let slot = session_slot(&mut state, &session_name);
             if slot.meta.paused {
                 return Err(errors::structured(
@@ -922,7 +891,6 @@ impl BrowserBridge {
                 return Err(self.unavailable_message("browser extension is not connected"));
             };
             slot.pending.insert(id.clone(), response_tx);
-            state.last_session = Some(session_name.clone());
             let payload = request_payload(&id, None, &code, timeout);
             if client.tx.send(Message::Text(payload.into())).is_err() {
                 if let Some(slot) = state.sessions.get_mut(client.session.as_str()) {
@@ -980,11 +948,12 @@ impl BrowserBridge {
         session: Option<&str>,
         capability: &str,
     ) -> Result<String, String> {
+        self.ensure_extension(session).await;
         let state = self.state.lock().await;
         if let Some(error) = &state.startup_error {
             return Err(self.unavailable_message(error));
         }
-        let session_name = session_name_locked(&state, session)?;
+        let session_name = resolve_session_name(session)?;
         let Some(slot) = state.sessions.get(&session_name) else {
             return Err(self.unavailable_message("browser extension is not connected"));
         };
@@ -1107,12 +1076,12 @@ impl BrowserBridge {
     }
 
     async fn tabs(&self) -> Result<Vec<BrowserTab>, String> {
-        self.ensure_extension().await;
+        self.ensure_extension(None).await;
         let state = self.state.lock().await;
         if let Some(error) = &state.startup_error {
             return Err(self.unavailable_message(error));
         }
-        let session_name = session_name_locked(&state, None)?;
+        let session_name = resolve_session_name(None)?;
         let Some(slot) = state.sessions.get(&session_name) else {
             return Err(self.unavailable_message("browser extension is not connected"));
         };
@@ -1123,11 +1092,12 @@ impl BrowserBridge {
     }
 
     async fn tabs_on(&self, session: Option<&str>) -> Result<Vec<BrowserTab>, String> {
+        self.ensure_extension(session).await;
         let state = self.state.lock().await;
         if let Some(error) = &state.startup_error {
             return Err(self.unavailable_message(error));
         }
-        let session_name = session_name_locked(&state, session)?;
+        let session_name = resolve_session_name(session)?;
         let Some(slot) = state.sessions.get(&session_name) else {
             return Err(self.unavailable_message("browser extension is not connected"));
         };
@@ -1149,8 +1119,20 @@ impl BrowserBridge {
     /// If the extension is down and auto-launch is on, start the user's
     /// Chrome/Chromium/Edge so the already-installed unpacked extension can
     /// reconnect. Never used from tests (`can_launch` is false on `new()`).
-    async fn ensure_extension(&self) {
-        if self.client_connected().await {
+    async fn ensure_extension(&self, session: Option<&str>) {
+        self.ensure_extension_with(session, || spawn_user_browser(None), AUTO_LAUNCH_WAIT)
+            .await;
+    }
+
+    async fn ensure_extension_with(
+        &self,
+        session: Option<&str>,
+        launch: impl FnOnce() -> Result<(), String>,
+        wait: Duration,
+    ) {
+        // Auto-launch owns only the default shared profile. Workspace mode is
+        // opt-in and starts exclusively through browser_setup.start_workspace.
+        if session.is_some_and(|name| name != "shared") || self.session_connected("shared").await {
             return;
         }
         if !self.can_launch {
@@ -1167,16 +1149,16 @@ impl BrowserBridge {
             return;
         }
         let _guard = self.launch_lock.lock().await;
-        if self.client_connected().await {
+        if self.session_connected("shared").await {
             return;
         }
-        if let Err(error) = spawn_user_browser() {
+        if let Err(error) = launch() {
             tracing::warn!(target: "wisp", "browser auto-launch failed: {error}");
             return;
         }
-        let deadline = tokio::time::Instant::now() + AUTO_LAUNCH_WAIT;
+        let deadline = tokio::time::Instant::now() + wait;
         while tokio::time::Instant::now() < deadline {
-            if self.client_connected().await {
+            if self.session_connected("shared").await {
                 return;
             }
             tokio::time::sleep(Duration::from_millis(250)).await;
@@ -1665,7 +1647,7 @@ impl BrowserBridge {
             return Ok(());
         }
         let state = self.state.lock().await;
-        let session_name = match session_name_locked(&state, session) {
+        let session_name = match resolve_session_name(session) {
             Ok(name) => name,
             Err(_) => return Ok(()),
         };
@@ -1934,9 +1916,15 @@ impl BrowserBridge {
 
 /// Start the user's existing Chrome/Chromium/Edge so the unpacked Wisp
 /// extension can reconnect. Does not use a temporary automation profile.
-fn spawn_user_browser() -> Result<(), String> {
+fn spawn_user_browser(url: Option<&str>) -> Result<(), String> {
     let (program, args) = first_available_browser()
         .ok_or_else(|| "no Chrome, Chromium, or Edge browser was found".to_string())?;
+    let mut args = shared_browser_launch_args(&program, args);
+    if let Some(url) = url {
+        *args
+            .last_mut()
+            .expect("shared launch always includes a URL") = url.into();
+    }
     let mut command = std::process::Command::new(&program);
     command
         .args(&args)
@@ -1952,6 +1940,17 @@ fn spawn_user_browser() -> Result<(), String> {
         .spawn()
         .map(|_| ())
         .map_err(|error| format!("failed to start {}: {error}", program.display()))
+}
+
+fn shared_browser_launch_args(program: &Path, mut args: Vec<String>) -> Vec<String> {
+    if program.ends_with("open") {
+        args.push("--args".into());
+    }
+    args.push(format!(
+        "{}/",
+        extensions_page_url(program, &args).replace("extensions", "newtab")
+    ));
+    args
 }
 
 fn first_available_browser() -> Option<(PathBuf, Vec<String>)> {
@@ -2538,11 +2537,12 @@ impl Tool for BrowserSetupTool {
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(
             self.name(),
-            "Call when the user asks to configure, install, set up, update, or connect the real browser, and before any live page retrieval. Wisp verifies the bundled extension and maintains extension_path in a stable application-data directory. Copy extension_path character-for-character and never convert it between Windows, WSL, macOS, or Linux. If status is not connected, live_retrieval is false: do not answer live, latest, current, or URL-specific questions from prior knowledge; relay the steps and wait. If refused_connection is present, relay its explanation. If update_required is true, call this tool again with action=update_extension; compatible extensions reload automatically, while older extensions return manual_reload_required with the exact path. If extension_path_verified is false, report the validation error and never invent a path.",
+            "Call with no action before live page retrieval. The default is the user's shared daily Chrome profile: Wisp reuses it when connected and, when automatic launch is enabled, starts that normal profile so its installed extension can reconnect. Workspace is never a fallback; call action=start_workspace only when the user explicitly requests an isolated browser. Wisp verifies the bundled extension and maintains extension_path in a stable application-data directory. Copy extension_path character-for-character and never convert it between Windows, WSL, macOS, or Linux. If status is not connected, live_retrieval is false: do not answer live, latest, current, or URL-specific questions from prior knowledge; relay the steps and wait. If refused_connection is present, relay its explanation. If update_required is true, call this tool again with action=update_extension; compatible extensions reload automatically, while older extensions return manual_reload_required with the exact path. If extension_path_verified is false, report the validation error and never invent a path.",
             json!({
                 "type": "object",
                 "properties": {
-                    "action": { "type": "string", "description": "Optional: update_extension (verifies the managed shared extension and attempts automatic reload), start_workspace (returns only once the workspace extension connects), or stop_workspace" }
+                    "action": { "type": "string", "description": "Usually omit this for shared Chrome status/auto-launch. update_extension verifies the managed shared extension and attempts automatic reload. start_workspace and stop_workspace are only for a user-explicit isolated workspace browser." },
+                    "url": { "type": "string", "description": "Optional target http(s) URL for automatically launching disconnected shared Chrome; otherwise opens the new-tab page. Connected Chrome is left untouched." }
                 },
                 "additionalProperties": false
             }),
@@ -2557,7 +2557,12 @@ impl Tool for BrowserSetupTool {
         if let Err(fail) = occupy_or_fail(&self.bridge, env) {
             return fail;
         }
-        if let Some(action) = args.get("action").and_then(Value::as_str) {
+        if let Some(action) = args
+            .get("action")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|action| !action.is_empty())
+        {
             let result = match action {
                 "update_extension" => {
                     let result = self.bridge.update_extension().await;
@@ -2579,9 +2584,25 @@ impl Tool for BrowserSetupTool {
                 Err(error) => ToolResult::fail(error),
             };
         }
-        self.bridge.ensure_extension().await;
-        let mut info = self.bridge.setup_info().await;
         let filters = browser_url_filters::load(&self.store).await;
+        let url = args
+            .get("url")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|url| !url.is_empty());
+        if let Some(url) = url {
+            if !matches!(url::Url::parse(url), Ok(parsed) if matches!(parsed.scheme(), "http" | "https") && parsed.host_str().is_some())
+            {
+                return ToolResult::fail("url must be an absolute http:// or https:// address");
+            }
+            if let Some(rule) = filters.blocked(url) {
+                return ToolResult::fail(browser_url_filters::block_message(url, rule));
+            }
+        }
+        self.bridge
+            .ensure_extension_with(None, || spawn_user_browser(url), AUTO_LAUNCH_WAIT)
+            .await;
+        let mut info = self.bridge.setup_info().await;
         info["url_filters"] = json!({
             "block": filters.block,
             "prefer": filters.prefer,
@@ -2618,7 +2639,7 @@ impl Tool for WebScanTool {
                     "switch_tab_id": { "type": ["integer", "string"], "description": "Tab id returned by this tool; selects that tab for this and later calls" },
                     "text_only": { "type": "boolean", "description": "Return page text without the actionable-element snapshot" },
                     "mode": { "type": "string", "description": "default | text | article. article adds images[], figures[], code_blocks[]" },
-                    "session": { "type": "string", "description": "shared or workspace" }
+                    "session": { "type": "string", "description": "shared (default) or workspace (only when the user explicitly requested isolation)" }
                 }
             }),
         )
@@ -2751,7 +2772,7 @@ impl Tool for WebExecuteJsTool {
                     "script": { "type": "string", "description": "JavaScript, or a JSON command such as {\"cmd\":\"cdp\",\"method\":\"Input.dispatchMouseEvent\",\"params\":{...}}" },
                     "switch_tab_id": { "type": ["integer", "string"], "description": "Tab id returned by web_scan" },
                     "timeout_ms": { "type": "integer", "minimum": 1, "maximum": 60000, "description": "Execution timeout in milliseconds (default 15000)" },
-                    "session": { "type": "string", "description": "shared or workspace" }
+                    "session": { "type": "string", "description": "shared (default) or workspace (only when the user explicitly requested isolation)" }
                 },
                 "required": ["script"]
             }),
@@ -2884,7 +2905,7 @@ impl Tool for WebOpenTabTool {
                 "properties": {
                     "url": { "type": "string", "description": "Absolute http:// or https:// URL to open" },
                     "active": { "type": "boolean", "description": "Focus the new tab (default false)" },
-                    "session": { "type": "string", "description": "shared or workspace" }
+                    "session": { "type": "string", "description": "shared (default) or workspace (only when the user explicitly requested isolation)" }
                 },
                 "required": ["url"]
             }),
@@ -2975,7 +2996,7 @@ impl Tool for WebScreenshotTool {
                     "full_page": { "type": "boolean" },
                     "selector": { "type": "string" },
                     "save_path": { "type": "string", "description": "Optional project-relative PNG path. Screenshots are not original figures." },
-                    "session": { "type": "string" }
+                    "session": { "type": "string", "description": "shared (default) or workspace (only when the user explicitly requested isolation)" }
                 }
             }),
         )
@@ -3140,7 +3161,7 @@ impl Tool for WebSaveAssetsTool {
                     "urls": { "type": "array", "items": { "type": "string" }, "description": "http(s) asset URLs" },
                     "referrer": { "type": "string" },
                     "dest_dir": { "type": "string", "description": "Project-relative destination, default browser-assets" },
-                    "session": { "type": "string" },
+                    "session": { "type": "string", "description": "shared (default) or workspace (only when the user explicitly requested isolation)" },
                     "switch_tab_id": { "type": ["integer", "string"] }
                 },
                 "required": ["urls"]
@@ -3302,11 +3323,11 @@ impl Tool for WebAgentSendTool {
         "web_agent_send"
     }
     fn schema(&self) -> ToolSchema {
-        ToolSchema::new(self.name(), "Send one prompt to a signed-in in-browser chat composer (ChatGPT, Gemini, or Google AI Mode). Requires an already-open tab at chatgpt.com, gemini.google.com, or google.com/search?udm=50. Does not type passwords. session is required when both browsers are connected.", json!({
+        ToolSchema::new(self.name(), "Send one prompt to a signed-in in-browser chat composer (ChatGPT, Gemini, or Google AI Mode). Requires an already-open tab at chatgpt.com, gemini.google.com, or google.com/search?udm=50. Does not type passwords. Defaults to the shared daily browser; pass workspace only when the user explicitly requested isolation.", json!({
             "type": "object",
             "properties": {
                 "prompt": { "type": "string" },
-                "session": { "type": "string" },
+                "session": { "type": "string", "description": "shared (default) or workspace (only when the user explicitly requested isolation)" },
                 "switch_tab_id": { "type": ["integer", "string"] }
             },
             "required": ["prompt"]
@@ -3415,7 +3436,7 @@ impl Tool for WebAgentWaitTool {
         ToolSchema::new(self.name(), "Wait until the in-browser chat turn looks complete (stop control gone / assistant text stable). Works on ChatGPT, Gemini, and Google AI Mode. Uses the Wait Engine, not document.complete.", json!({
             "type": "object",
             "properties": {
-                "session": { "type": "string" },
+                "session": { "type": "string", "description": "shared (default) or workspace (only when the user explicitly requested isolation)" },
                 "switch_tab_id": { "type": ["integer", "string"] },
                 "timeout_ms": { "type": "integer" }
             }
@@ -3495,7 +3516,7 @@ impl Tool for WebAgentReadTool {
             json!({
                 "type": "object",
                 "properties": {
-                    "session": { "type": "string" },
+                    "session": { "type": "string", "description": "shared (default) or workspace (only when the user explicitly requested isolation)" },
                     "switch_tab_id": { "type": ["integer", "string"] }
                 }
             }),
@@ -4373,17 +4394,118 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn both_sessions_require_an_explicit_session_argument() {
+    async fn omitted_session_prefers_shared_when_both_are_connected() {
         let bridge = Arc::new(BrowserBridge::new(PathBuf::from("extension")));
         let (tx_a, _rx_a) = mpsc::unbounded_channel();
         let (tx_b, _rx_b) = mpsc::unbounded_channel();
         bridge.install_client_on(1, tx_a, "shared").await;
         bridge.install_client_on(2, tx_b, "workspace").await;
-        let err = WebScanTool::new(bridge)
+        bridge
+            .handle_text(
+                2,
+                r#"{"type":"ext_ready","tabs":[{"id":22,"url":"https://workspace.example","title":"Workspace","active":true}]}"#,
+            )
+            .await;
+        let result = WebScanTool::new(bridge)
             .run(&json!({ "tabs_only": true }), &NoEnv(PathBuf::from(".")))
             .await;
-        assert!(!err.success);
-        assert!(err.content.contains("SESSION_REQUIRED"));
+        assert!(result.success, "{}", result.content);
+        assert_eq!(
+            serde_json::from_str::<Value>(&result.content).unwrap()["tabs"],
+            json!([])
+        );
+    }
+
+    #[tokio::test]
+    async fn workspace_only_does_not_make_default_setup_connected() {
+        let bridge = Arc::new(BrowserBridge::new(PathBuf::from("extension")));
+        let (tx, _rx) = mpsc::unbounded_channel();
+        bridge.install_client_on(1, tx, "workspace").await;
+
+        let info = bridge.setup_info().await;
+        assert_eq!(info["status"], "extension_missing");
+        assert_eq!(info["live_retrieval"], false);
+        assert_eq!(info["sessions"]["workspace"]["connected"], true);
+        assert_eq!(info["sessions"]["shared"]["connected"], false);
+        assert!(bridge.tabs_on(None).await.is_err());
+        assert!(bridge.tabs_on(Some("workspace")).await.is_ok());
+    }
+
+    #[test]
+    fn shared_launch_uses_normal_profile_and_new_tab_on_each_platform() {
+        for (program, args, expected) in [
+            ("chrome.exe", vec![], vec!["chrome://newtab/"]),
+            ("msedge.exe", vec![], vec!["edge://newtab/"]),
+            (
+                "/usr/bin/open",
+                vec!["-a", "Google Chrome"],
+                vec!["-a", "Google Chrome", "--args", "chrome://newtab/"],
+            ),
+        ] {
+            let actual = shared_browser_launch_args(
+                Path::new(program),
+                args.into_iter().map(String::from).collect(),
+            );
+            assert_eq!(actual, expected);
+        }
+    }
+
+    #[tokio::test]
+    async fn automatic_launch_targets_only_disconnected_shared() {
+        let (store, tmp) = empty_store().await;
+        let bridge =
+            BrowserBridge::construct(PathBuf::from("extension"), Some(store.clone()), true);
+        let (tx, _rx) = mpsc::unbounded_channel();
+        bridge.install_client_on(1, tx, "workspace").await;
+        let launches = std::sync::atomic::AtomicUsize::new(0);
+        let launch = || {
+            launches.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(())
+        };
+        bridge
+            .ensure_extension_with(Some("workspace"), launch, Duration::ZERO)
+            .await;
+        assert_eq!(launches.load(std::sync::atomic::Ordering::SeqCst), 0);
+        bridge
+            .ensure_extension_with(None, launch, Duration::ZERO)
+            .await;
+        assert_eq!(launches.load(std::sync::atomic::Ordering::SeqCst), 1);
+        let (tx, _rx_shared) = mpsc::unbounded_channel();
+        bridge.install_client_on(2, tx, "shared").await;
+        bridge
+            .ensure_extension_with(None, launch, Duration::ZERO)
+            .await;
+        assert_eq!(launches.load(std::sync::atomic::Ordering::SeqCst), 1);
+        assert!(bridge.state.lock().await.workspace_pid.is_none());
+        let _ = std::fs::remove_file(tmp);
+    }
+
+    #[tokio::test]
+    async fn blank_setup_action_is_a_shared_status_check() {
+        let bridge = Arc::new(BrowserBridge::new(PathBuf::from("extension")));
+        let (store, tmp) = empty_store().await;
+        let tool = BrowserSetupTool::new(bridge, store);
+        assert!(tool
+            .schema()
+            .function
+            .description
+            .contains("Workspace is never a fallback"));
+        let result = tool
+            .run(&json!({ "action": "  " }), &NoEnv(PathBuf::from(".")))
+            .await;
+
+        assert!(result.success, "{}", result.content);
+        assert_eq!(
+            serde_json::from_str::<Value>(&result.content).unwrap()["live_retrieval"],
+            false
+        );
+        for url in ["file:///tmp/private", "javascript:alert(1)", "https://"] {
+            let result = tool
+                .run(&json!({ "url": url }), &NoEnv(PathBuf::from(".")))
+                .await;
+            assert!(!result.success, "{url}");
+        }
+        let _ = std::fs::remove_file(tmp);
     }
 
     #[test]


### PR DESCRIPTION
Daily Chrome tasks could choose the isolated workspace browser, briefly open a doomed blank window, and miss the user's connected profile. Tools now default to shared Chrome, reconnect only that profile, and keep workspace routing explicit. `browser_setup` accepts an empty action as a status check and an optional validated target URL for startup; otherwise startup opens the browser's new-tab page.

Closes #1107.

Changes: shared routing, connection/status checks and tool descriptions in `browser_bridge/mod.rs`; daily-profile startup arguments; bundled browser-use instructions and browser acceptance/architecture docs. No new persistent abstraction. Startup does not clean up user tabs.

Validation: formatting and diff checks passed; 52 browser bridge tests passed on the final commit (default routing, workspace-only state, empty action, invalid URL, fake auto-launch and platform launch arguments); wasm check passed; full workspace passed with local process/network access; npm ci and Playwright completed with 492 passed / 2 skipped. The initial sandboxed workspace run failed in the unrelated CLI run-wait test; the unrestricted full run passed.

Manual smoke: on Windows/macOS/Linux install the extension once, close daily Chrome and run browser_setup with and without a target URL; verify reconnect and direct target/new-tab opening. Repeat with Chrome connected and with its extension worker asleep. Missing/stale extensions should produce guidance, without workspace fallback. Explicit workspace remains usable. Existing user tabs must remain untouched.

Limitations/follow-up: real Chrome/profile and service-worker wake verification requires the manual platform checks above. This change does not install extensions silently or close startup tabs.
