### PR TITLE
fix(ui): keep workspace headers visible across session scrolling

### DIFF
--- a/docs/workspace-scrolling.md
+++ b/docs/workspace-scrolling.md
@@ -1,0 +1,18 @@
+# Workspace scrolling
+
+The desktop viewport and its three shell columns do not scroll. Only inner
+conversation, session-list, artifact-list, file and agent content areas scroll;
+project/session headers and right-panel tabs remain visible. Shell clipping uses
+`overflow: clip` because `overflow: hidden` still permits programmatic scrolling
+from focus and `scrollIntoView`; the body is fixed to the viewport so document
+scrolling cannot move all three headers together.
+
+Conversation jumps scroll the conversation container explicitly. Conversation
+reading positions remain per-session; switching conversations resets the mounted
+right-panel lists to the top so a previous session's deep offset is not reused.
+
+Manual check on Windows WebView2 and macOS: open two long conversations with
+many artifacts, scroll each column to the bottom, switch sessions repeatedly,
+and use conversation outline jumps. All three headers must stay visible and
+Artifacts/Agents/Files must remain clickable. Repeat with the artifact preview
+hidden, a small window, and a large file preview.

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -10690,6 +10690,48 @@ test("step commentary renders full Markdown before the overall turn finishes", a
   await expect(settledStep.locator("code")).toHaveText("normalized_counts.csv");
 });
 
+test("long workspace scrolling keeps all headers visible across session switches (#1110)", async ({ page }) => {
+  await enterApp(page);
+  await composer(page).fill("make volcano.png");
+  await page.getByRole("button", { name: "Send" }).click();
+  await page.getByRole("button", { name: "Toggle panel" }).click();
+  await page.locator(".rp-tabs").getByRole("button", { name: /^Artifacts/ }).click();
+  const tiles = page.locator(".rp-tiles");
+  await expect(tiles).toBeVisible();
+  await tiles.evaluate((el) => {
+    const content = document.createElement("div");
+    content.style.cssText = "min-height:4000px;flex-shrink:0";
+    const end = document.createElement("button");
+    end.textContent = "Last artifact";
+    content.appendChild(end);
+    el.appendChild(content);
+    el.scrollTop = el.scrollHeight;
+  });
+  await expect.poll(() => tiles.evaluate((el) => el.scrollTop)).toBeGreaterThan(0);
+  // A focus/outline jump must not turn clipped shell ancestors into scrollers.
+  await page.evaluate(() => {
+    for (const selector of [".app", ".sidebar", ".center", ".rightpane"]) {
+      const shell = document.querySelector<HTMLElement>(selector)!;
+      const overflow = document.createElement("div");
+      overflow.style.cssText = "position:absolute;top:1800px;width:1px;height:1px";
+      shell.appendChild(overflow);
+      overflow.scrollIntoView({ block: "start" });
+      shell.scrollTop = 600;
+    }
+  });
+  const viewport = page.viewportSize()!;
+  for (const selector of [".sidebar-head", ".center > .topbar", ".rp-tabs"]) {
+    await expectInsideViewport(page.locator(selector), viewport.width, viewport.height);
+  }
+  await newSessionButton(page).click();
+  await composer(page).fill("make second.png");
+  await page.getByRole("button", { name: "Send" }).click();
+  await expect.poll(() => tiles.evaluate((el) => el.scrollTop)).toBe(0);
+  for (const name of ["Agents", "Files", "Artifacts"]) {
+    await page.locator(".rp-tabs").getByRole("button", { name: new RegExp(`^${name}`) }).click();
+  }
+});
+
 test("chat keeps the user's reading position when streaming finishes (#670)", async ({ page }) => {
   await enterApp(page);
   await composer(page).fill("SCROLLTEST");

--- a/ui/src/scroll.js
+++ b/ui/src/scroll.js
@@ -2,6 +2,13 @@
 
 const hooks = new Map();
 const chatPositions = new Map();
+let panelSession = null;
+
+function scrollWithin(scroller, target) {
+  if (!scroller || !scroller.contains(target)) return;
+  scroller.scrollTop += target.getBoundingClientRect().top
+    - scroller.getBoundingClientRect().top - scroller.clientTop;
+}
 
 // ponytail: single chat scroller, so the jump pill id is a constant.
 const JUMP_PILL_ID = "chat-jump-pill";
@@ -224,7 +231,7 @@ export function attach_chat_scroll(scrollerId, contentId) {
     jumpTo: (el) => {
       jumping = true;
       setFollow(false);
-      el.scrollIntoView({ block: "start" });
+      scrollWithin(scroller, el);
       parkHere();
       jumping = false;
     },
@@ -285,6 +292,12 @@ export function attach_chat_scroll(scrollerId, contentId) {
  * asynchronous transcript load without overwriting the saved state.
  * @param {string} scrollerId @param {string} sessionId */
 export function switch_chat_scroll(scrollerId, sessionId) {
+  if (panelSession !== sessionId) {
+    panelSession = sessionId;
+    document.querySelectorAll(".rightpane .rp-tiles, .rightpane .agents-pane, .rightpane .fb-list").forEach((el) => {
+      el.scrollTop = 0;
+    });
+  }
   hooks.get(scrollerId)?.switchSession(sessionId);
 }
 
@@ -386,7 +399,7 @@ export function jump_chat_scroll(scrollerId, selector) {
         hook.jumpTo(target);
         return;
       }
-      target.scrollIntoView({ block: "start" });
+      scrollWithin(document.getElementById(scrollerId), target);
     });
   });
 }

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -280,10 +280,15 @@ html, body {
 /* Fixed-viewport desktop shell: the title bar (when present) and .app split the
    viewport via flex, so the window never grows a page-level scrollbar. Avoids the
    brittle `100vh` + `:has()` arithmetic that left a ~38px master scrollbar on some
-   WebView2 builds (issue #279). overflow:hidden guarantees no page scroll. */
-body { display: flex; flex-direction: column; overflow: hidden; }
+   WebView2 builds (issue #279). Fix the body to the viewport as well: hiding a
+   scrollbar alone still permits focus/anchor scrolling of the document. */
+html { overflow: clip; }
+body { position: fixed; inset: 0; display: flex; flex-direction: column; overflow: clip; }
 
-.app { flex: 1 1 auto; min-height: 0; display: flex; flex-direction: row; overflow: hidden; }
+.app { flex: 1 1 auto; min-height: 0; display: flex; flex-direction: row; overflow: clip; }
+/* Shell columns must never become hidden scroll containers: scrollIntoView
+   and focus can scroll overflow:hidden ancestors and take all headers away. */
+.app > :is(.sidebar, .center, .rightpane) { min-height: 0; overflow: clip; }
 
 @keyframes motion-fade-in {
   from { opacity: 0; }

--- a/ui/src/styles/right-pane.css
+++ b/ui/src/styles/right-pane.css
@@ -315,7 +315,7 @@ button.run-status:hover { filter:brightness(0.96); }
 .notebook-output .nb-out-latex { margin-top:8px; padding:10px 12px; overflow:auto; border:1px solid var(--border); border-radius: var(--radius-xs); background:var(--bg-sunken); }
 .notebook-output .nb-out-omitted { margin-top:8px; padding:8px 10px; border-left:3px solid var(--warn); color:var(--text-muted); background:var(--bg-sunken); }
 
-.rp-artifacts-body { display: flex; flex-direction: column; flex: 1 1 auto; min-height: 0; }
+.rp-artifacts-body { display: flex; flex-direction: column; flex: 1 1 auto; min-height: 0; overflow: clip; }
 .rp-artifacts-body.preview-hidden .rp-tiles {
   max-height: none; flex: 1 1 auto; border-bottom: none;
 }
@@ -346,7 +346,7 @@ button.run-status:hover { filter:brightness(0.96); }
 .rp-tiles {
   display: flex; flex-direction: column; gap: 6px;
   padding: 12px; border-bottom: 1px solid var(--border);
-  flex: 0 0 auto; max-height: min(240px, 34vh); overflow-y: auto;
+  flex: 0 0 auto; min-height: 0; max-height: min(240px, 34vh); overflow-y: auto; overscroll-behavior: contain;
   background: var(--bg-sunken);
 }
 .rp-tile {


### PR DESCRIPTION
Long-content focus/outline jumps could scroll hidden shell ancestors and move the workspace headers out of view. Fix the body to the viewport, make shell columns non-scrolling clipping boundaries, and scroll conversation jumps inside the chat container only. Switching conversations resets mounted right-panel list offsets.

Closes #1110.

Changes: shell/artifact CSS boundaries, bounded chat jumps and panel reset in scroll.js, Playwright regression, and docs/workspace-scrolling.md. Conversation reading-position restoration is retained.

Validation: formatting/diff checks and wasm check passed. The new regression fails on the old UI with a header above the viewport and passes on this branch. npm ci and full Playwright completed with 493 passed / 2 skipped. Full workspace was run and stopped at two unchanged wisp-runs timing tests (auto_harvest_skips_collect_when_already_harvested and ssh_harvest_collect_renews_parent_lease_past_expiry; 168 other Run tests passed); both passed when run individually against the identical, unchanged wisp-runs source.

Manual smoke: on Windows WebView2 and macOS open long conversations with many artifacts, scroll to the end, switch sessions repeatedly and jump through the outline. Project title, session title and Artifacts/Agents/Files tabs must remain visible and clickable. Repeat with hidden preview and a narrow window.

Limitations: automated UI validation uses Chromium and a mocked bridge. Native WebView2/macOS smoke remains required for platform confirmation.
