### PR TITLE
fix(acp): restore per-session model and configuration options

### DIFF
--- a/crates/wisp-dto/src/lib.rs
+++ b/crates/wisp-dto/src/lib.rs
@@ -2082,7 +2082,7 @@ pub struct AcpSessionUpdate {
     pub payload: serde_json::Value,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AcpSessionState {
     pub frame_id: String,

--- a/docs/acp-agents.md
+++ b/docs/acp-agents.md
@@ -4,6 +4,14 @@ Wisp can run an external coding agent through the [Agent Client Protocol](https:
 
 ACP Agents are **not** HTTP model profiles. Settings → Models configures API providers for the built-in Wisp agent. ACP configures a separate local process that owns its own session, tools, and auth.
 
+Each conversation retains its own agent binding when switching sessions or
+restarting Wisp. Model/reasoning configuration options are cached per conversation
+and launch-profile fingerprint, including subsequent agent option updates. When
+an agent omits options from load/resume, Wisp restores the last received list;
+an explicitly empty list clears it. Restored controls work before the first
+message by resuming the bound agent when a setting is changed. Older sessions
+without a saved list must receive options once before Wisp can cache them.
+
 ## Prerequisites
 
 1. Install Node.js (needed for the official npm ACP adapters).

--- a/src-tauri/src/acp.rs
+++ b/src-tauri/src/acp.rs
@@ -251,7 +251,7 @@ pub(crate) async fn get_acp_session_state(
     state: State<'_, AppState>,
     window: tauri::WebviewWindow,
     frame_id: String,
-) -> Result<Option<serde_json::Value>, String> {
+) -> Result<Option<wisp_dto::AcpSessionState>, String> {
     let project = state.require_active(window.label())?;
     if state
         .store
@@ -271,13 +271,20 @@ pub(crate) async fn get_acp_session_state(
     else {
         return Ok(None);
     };
-    Ok(state
+    let modes = state
         .store
         .get_setting(&available_modes_key(&binding.profile_fingerprint))
         .await
         .map_err(|error| error.to_string())?
         .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok())
-        .map(|modes| serde_json::json!({ "availableModes": modes })))
+        .map(|modes| serde_json::json!({ "availableModes": modes }));
+    let options =
+        cached_config_options(&state.store, &frame_id, &binding.profile_fingerprint).await?;
+    Ok(Some(wisp_dto::AcpSessionState {
+        frame_id,
+        modes,
+        config_options: options.and_then(|value| value.as_array().cloned()),
+    }))
 }
 
 #[tauri::command]
@@ -555,6 +562,61 @@ fn available_modes_key(profile_fingerprint: &str) -> String {
     format!("acp.available_modes.{profile_fingerprint}")
 }
 
+fn config_options_key(frame_id: &str, fingerprint: &str) -> String {
+    format!("acp.config_options.{frame_id}.{fingerprint}")
+}
+
+async fn cached_config_options(
+    store: &wisp_store::Store,
+    frame_id: &str,
+    fingerprint: &str,
+) -> Result<Option<serde_json::Value>, String> {
+    Ok(store
+        .get_setting(&config_options_key(frame_id, fingerprint))
+        .await
+        .map_err(|error| error.to_string())?
+        .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok())
+        .filter(serde_json::Value::is_array))
+}
+
+async fn cache_config_options(
+    store: &wisp_store::Store,
+    frame_id: &str,
+    fingerprint: &str,
+    options: &serde_json::Value,
+) -> Result<(), String> {
+    if !options.is_array() {
+        return Ok(());
+    }
+    store
+        .set_setting(
+            &config_options_key(frame_id, fingerprint),
+            &options.to_string(),
+        )
+        .await
+        .map_err(|error| error.to_string())
+}
+
+async fn restore_config_options(
+    store: &wisp_store::Store,
+    frame_id: &str,
+    fingerprint: &str,
+    session: &mut wisp_acp::AcpSessionState,
+) -> Result<(), String> {
+    if let Some(options) = &session.config_options {
+        cache_config_options(
+            store,
+            frame_id,
+            fingerprint,
+            &serde_json::to_value(options).map_err(|error| error.to_string())?,
+        )
+        .await?;
+    } else if let Some(options) = cached_config_options(store, frame_id, fingerprint).await? {
+        session.config_options = serde_json::from_value(options).ok();
+    }
+    Ok(())
+}
+
 async fn runtime_for(
     state: &AppState,
     project: &ActiveProject,
@@ -626,7 +688,7 @@ async fn runtime_for(
             .map_err(|error| error.to_string())?,
     );
     let bridge = vec![mcp_server(state, project, frame_id, None)?];
-    let (session_id, session_state) = if let Some(binding) = &binding {
+    let (session_id, mut session_state) = if let Some(binding) = &binding {
         let id = SessionId::new(binding.agent_session_id.clone());
         match handle
             .resume_session(id.clone(), &cwd, bridge.clone())
@@ -669,6 +731,13 @@ async fn runtime_for(
             )
             .await;
     }
+    restore_config_options(
+        &state.store,
+        frame_id,
+        &profile_fingerprint,
+        &mut session_state,
+    )
+    .await?;
     let runtime = Arc::new(AcpRuntime {
         profile_id: profile.id.clone(),
         fingerprint: profile_fingerprint.clone(),
@@ -1208,6 +1277,11 @@ async fn run_acp_turn_inner(
             }
             event = runtime.handle.next_event() => match event {
                 Some(AcpSessionEvent::Update { kind, payload, .. }) => {
+                    if kind == AcpUpdateKind::ConfigOptions {
+                        if let Some(options) = payload.get("configOptions") {
+                            cache_config_options(&state.store, frame_id, &runtime.fingerprint, options).await?;
+                        }
+                    }
                     if matches!(kind, AcpUpdateKind::AgentMessage | AcpUpdateKind::AgentThought) {
                         if let Some(text) = text_from_payload(&payload) {
                             let target = if kind == AcpUpdateKind::AgentMessage { &mut assistant } else { &mut reasoning };
@@ -1288,6 +1362,12 @@ async fn run_acp_turn_inner(
         };
         match event {
             AcpSessionEvent::Update { kind, payload, .. } => {
+                if kind == AcpUpdateKind::ConfigOptions {
+                    if let Some(options) = payload.get("configOptions") {
+                        cache_config_options(&state.store, frame_id, &runtime.fingerprint, options)
+                            .await?;
+                    }
+                }
                 if let Some(text) = text_from_payload(&payload) {
                     if kind == AcpUpdateKind::AgentMessage {
                         assistant.push_str(text);
@@ -1640,13 +1720,7 @@ pub(crate) async fn set_acp_session_config(
     {
         return Err("Session does not belong to the active project.".into());
     }
-    let runtime = state
-        .acp_sessions
-        .lock()
-        .await
-        .get(&frame_id)
-        .cloned()
-        .ok_or_else(|| "ACP session is not active.".to_string())?;
+    let runtime = runtime_for(&state, &project, &frame_id, None).await?;
     let value = serde_json::from_value(value).map_err(|error| error.to_string())?;
     let options = runtime
         .handle
@@ -1654,6 +1728,10 @@ pub(crate) async fn set_acp_session_config(
         .await
         .map_err(|error| error.to_string())?;
     let value = serde_json::to_value(&options).map_err(|error| error.to_string())?;
+    cache_config_options(&state.store, &frame_id, &runtime.fingerprint, &value).await?;
+    if let Some(pending) = runtime.session_state.lock().await.as_mut() {
+        pending.config_options = Some(options);
+    }
     crate::emit_to_session_surfaces(
         &app,
         &frame_id,
@@ -2007,6 +2085,71 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(completed, "review complete");
+    }
+
+    #[tokio::test]
+    async fn config_options_survive_restart_without_crossing_session_or_profile() {
+        let tmp = std::env::temp_dir().join(format!("wisp_acp_configs_{}.sqlite", Uuid::new_v4()));
+        let store = wisp_store::Store::open(&tmp).await.unwrap();
+        let options = serde_json::json!([{ "id": "model", "name": "Model", "type": "select", "currentValue": "fast", "options": [{"value":"fast","name":"Fast"}, {"value":"smart","name":"Smart"}] }]);
+        let mut fresh = wisp_acp::AcpSessionState {
+            modes: None,
+            config_options: Some(serde_json::from_value(options.clone()).unwrap()),
+        };
+        restore_config_options(&store, "a", "profile-a", &mut fresh)
+            .await
+            .unwrap();
+        let mut updated = options.clone();
+        updated[0]["currentValue"] = serde_json::json!("smart");
+        cache_config_options(&store, "a", "profile-a", &updated)
+            .await
+            .unwrap();
+        cache_config_options(&store, "b", "profile-b", &options)
+            .await
+            .unwrap();
+        drop(store);
+        let store = wisp_store::Store::open(&tmp).await.unwrap();
+        let mut resumed = wisp_acp::AcpSessionState {
+            modes: None,
+            config_options: None,
+        };
+        restore_config_options(&store, "a", "profile-a", &mut resumed)
+            .await
+            .unwrap();
+        assert_eq!(
+            serde_json::to_value(resumed.config_options.unwrap()).unwrap(),
+            updated
+        );
+        assert_eq!(
+            cached_config_options(&store, "b", "profile-b")
+                .await
+                .unwrap(),
+            Some(options)
+        );
+        assert!(cached_config_options(&store, "a", "profile-b")
+            .await
+            .unwrap()
+            .is_none());
+        let mut cleared = wisp_acp::AcpSessionState {
+            modes: None,
+            config_options: Some(vec![]),
+        };
+        restore_config_options(&store, "a", "profile-a", &mut cleared)
+            .await
+            .unwrap();
+        cache_config_options(&store, "a", "profile-a", &serde_json::Value::Null)
+            .await
+            .unwrap();
+        let mut loaded = wisp_acp::AcpSessionState {
+            modes: None,
+            config_options: None,
+        };
+        restore_config_options(&store, "a", "profile-a", &mut loaded)
+            .await
+            .unwrap();
+        assert_eq!(loaded.config_options, Some(vec![]));
+        drop(store);
+        let _ = std::fs::remove_file(tmp);
     }
 
     #[tokio::test]

--- a/src-tauri/src/dto_contract_tests.rs
+++ b/src-tauri/src/dto_contract_tests.rs
@@ -8,6 +8,19 @@
 
 use serde_json::json;
 
+#[test]
+fn restored_acp_session_state_contract() {
+    let backend = wisp_dto::AcpSessionState {
+        frame_id: "frame-a".into(),
+        modes: Some(json!({"availableModes": [{"id":"plan","name":"Plan"}]})),
+        config_options: Some(vec![json!({"id":"model","currentValue":"smart"})]),
+    };
+    let ui: wisp_dto::AcpSessionState = roundtrip(&backend);
+    assert_eq!(ui.frame_id, "frame-a");
+    assert_eq!(ui.config_options.unwrap()[0]["currentValue"], "smart");
+    assert_eq!(ui.modes.unwrap()["availableModes"][0]["id"], "plan");
+}
+
 fn roundtrip<T: serde::Serialize, D: serde::de::DeserializeOwned>(value: &T) -> D {
     let json = serde_json::to_value(value).expect("backend value must serialize");
     serde_json::from_value(json).expect("UI DTO must accept the backend payload")

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -3041,7 +3041,9 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
             const frameId = String(arg("frameId") ?? "");
             if (!acpBindings[frameId]) return null;
             return {
-              availableModes: mockPlanFlow === "compat"
+              frameId,
+              configOptions: [{ id: "model", name: "Model", type: "select", currentValue: "smart", options: [{ value: "fast", name: "Fast" }, { value: "smart", name: "Smart" }] }],
+              modes: { availableModes: mockPlanFlow === "compat"
                 ? [
                     { id: "default", name: "Default" },
                     { id: "agent", name: "Agent" },
@@ -3049,7 +3051,7 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
                 : [
                     { id: "default", name: "Default" },
                     { id: "plan", name: "Plan" },
-                  ],
+                  ] },
             };
           }
           case "get_acp_session_agent":

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -1287,6 +1287,22 @@ test("selecting an ACP Agent from a populated HTTP session starts a fresh sessio
   expect(secondSend.sessionId).not.toBe(firstSend.sessionId);
 });
 
+test("restored ACP model options are usable before sending a message (#1112)", async ({ page }) => {
+  await openMockPlanSession(page, "acp");
+  await expect(page.locator(".model-picker-btn")).toContainText("Test ACP Agent");
+  await page.locator(".model-picker-btn").click();
+  const config = page.getByTestId("acp-session-config");
+  await expect(config.getByLabel("Model", { exact: true })).toHaveValue("smart");
+  await config.getByLabel("Model", { exact: true }).selectOption("fast");
+  await expect.poll(() => lastInvokeArgs(page, "set_acp_session_config")).toMatchObject({ frameId: "s1", configId: "model", value: { value: "fast" } });
+  await page.keyboard.press("Escape");
+  await newSessionButton(page).click();
+  await page.locator('[data-session-id="s1"]').click();
+  await expect(page.locator(".model-picker-btn")).toContainText("Test ACP Agent");
+  await page.locator(".model-picker-btn").click();
+  await expect(config.getByLabel("Model", { exact: true })).toHaveValue("fast");
+});
+
 test("ACP turn maps config, overlapping tools, plan, usage, and exact permission response", async ({ page }) => {
   await enterApp(page);
   await newSessionButton(page).click();

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -1280,7 +1280,8 @@ fn App() -> impl IntoView {
         let Some(session_id) = active_session.get() else {
             return;
         };
-        if acp_session_modes.with_untracked(|all| all.contains_key(&session_id)) {
+        if acp_session_modes.with_untracked(|all| all.contains_key(&session_id))
+            && acp_session_configs.with_untracked(|all| all.contains_key(&session_id)) {
             return;
         }
         spawn_local(async move {
@@ -1288,14 +1289,17 @@ fn App() -> impl IntoView {
             let Ok(value) = invoke_checked("get_acp_session_state", args).await else {
                 return;
             };
-            let Ok(Some(modes)) =
-                serde_wasm_bindgen::from_value::<Option<serde_json::Value>>(value)
+            let Ok(Some(state)) =
+                serde_wasm_bindgen::from_value::<Option<AcpSessionState>>(value)
             else {
                 return;
             };
-            acp_session_modes.update(|all| {
-                all.entry(session_id).or_insert(modes);
-            });
+            if let Some(modes) = state.modes {
+                acp_session_modes.update(|all| { all.entry(session_id.clone()).or_insert(modes); });
+            }
+            if let Some(options) = state.config_options {
+                acp_session_configs.update(|all| { all.entry(session_id).or_insert(options); });
+            }
         });
     });
 


### PR DESCRIPTION
Restored ACP conversations lost model/reasoning controls when load/resume omitted configOptions. Cache options per frame and launch-profile fingerprint, save new-session/options-update/set-config results, and restore the cache only when the agent omits the list. Explicit empty lists clear it. Changing a restored option resumes the bound agent before setting it, and updates pending initial state so the next turn cannot revert the selection.

Closes #1112.

Existing per-conversation agent binding is retained; recovery still resolves the stored profile and validates its fingerprint. Changes: ACP persistence/recovery and configuration paths; shared serializable AcpSessionState DTO and UI restoration; bridge fixtures, regression tests and ACP documentation. No new table or dependency.

Validation: formatting/diff checks, full cargo test --workspace, 27 targeted ACP-related tests and wasm check passed. Coverage includes store reopen/session/profile isolation, updated options, explicit empty-list recovery and DTO serialization. Three targeted Playwright tests passed, including changing a restored model before sending any message and switching away/back. npm ci and full Playwright completed with 493 passed / 2 skipped.

Manual smoke: attach two conversations to different ACP agents and choose distinct models, restart Wisp, switch repeatedly, and change the restored model before sending. Verify each bound agent/model is retained even if load/resume returns no options. Push a config update and restart again.

Limitations: sessions created before this cache existed need to receive options at least once. Cached options are last-known state, refreshed by agent responses/notifications; real adapter compatibility remains a manual check. Cache storage follows the existing ACP settings pattern.
