### PR TITLE
fix(acp): show explicit no-fallback notice on failed turns

### DIFF
--- a/crates/wisp-dto/src/lib.rs
+++ b/crates/wisp-dto/src/lib.rs
@@ -11,6 +11,10 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::rc::Rc;
 
+/// Identifies a stopped ACP turn in persisted errors and invoke rejections.
+/// The UI must not offer native HTTP transcript recovery for these errors.
+pub const ACP_TURN_ERROR_PREFIX: &str = "ACP turn failed: ";
+
 #[derive(Deserialize, Serialize, Clone, Copy, Debug, Default, Hash, PartialEq, Eq)]
 pub struct ContextUsage {
     #[serde(default)]

--- a/docs/acp-agents.md
+++ b/docs/acp-agents.md
@@ -126,6 +126,15 @@ npm install -g @agentclientprotocol/claude-agent-acp
 - Permission cards show the exact options the agent returns; choose one to continue.
 - If the agent advertises session config options (model, mode, …), open the compact ACP model menu beside Send to adjust them.
 - Stop cancels the active ACP turn for the bound session.
+- ACP startup, authentication, disconnect, and resume/load failures stop the
+  request. The error card retains the original error and explicitly says Wisp
+  did not fall back to an HTTP model. It offers no native transcript **Resume**
+  action: check the ACP connection/login and send the message again. To use an
+  HTTP model, start a new conversation and select it explicitly; HTTP API usage
+  may incur separate charges. A legacy HTTP value in `frames.model` does not
+  override an existing `acp_sessions` binding.
+- When the first send creates the conversation, a startup failure before ACP
+  binds it keeps the selected ACP Agent in the picker for the next send.
 - After restart, Wisp reconnects only when the same profile fingerprint and project path still match and the agent supports resume/load. Editing Command/Arguments creates a new fingerprint; start a fresh session.
 
 Wisp injects its scientific MCP bridge into the ACP session, so the external

--- a/src-tauri/src/acp.rs
+++ b/src-tauri/src/acp.rs
@@ -1190,7 +1190,7 @@ async fn run_acp_turn_with_kind(
     // Runs on every exit path, success or error — asks must never outlive
     // their turn as live cards.
     settle_expired_asks(state, app, Some(project.id.as_str()), frame_id).await;
-    result
+    result.map_err(|error| format!("{}{error}", wisp_dto::ACP_TURN_ERROR_PREFIX))
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -4843,6 +4843,16 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string 
             lastMessageBySession[fid] = msg;
             sessionModels[fid] ??= activeHttpModelId();
             const acpAgentId = arg("acpAgentId") ?? acpBindings[fid];
+            if (acpAgentId && String(msg).startsWith("ACPFAIL ")) {
+              const detail = String(msg).slice("ACPFAIL ".length);
+              // Startup can fail before a binding or user message exists.
+              if (detail !== "Agent process exited during startup") {
+                acpBindings[fid] = acpAgentId;
+              }
+              const message = `ACP turn failed: ${detail}`;
+              emit("agent", { kind: "Error", frame_id: fid, message });
+              throw new Error(`[turn-started] ${message}`);
+            }
             if (acpAgentId && String(msg).includes("ACPTHINK")) {
               // Codex-style ordering: visible commentary streams first, then
               // reasoning, then tool activity. The UI must preserve those as

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -1287,6 +1287,43 @@ test("selecting an ACP Agent from a populated HTTP session starts a fresh sessio
   expect(secondSend.sessionId).not.toBe(firstSend.sessionId);
 });
 
+for (const [locale, detail] of [
+  ["en", "Agent process exited during startup"],
+  ["en", "api: 401 unauthorized"],
+  ["zh", "api: 403 forbidden"],
+  ["zh", "This ACP Agent cannot resume or load the saved session."],
+  ["en", "api: 400 context window exceeded"],
+]) {
+  test(`ACP failure explains HTTP fallback and billing (${locale}, ${detail}) (#1118)`, async ({ page }) => {
+    await page.goto(`/?mockLocale=${locale}`);
+    await page.locator(".proj-card-main").first().click();
+    await page.locator(".model-picker-btn").click();
+    await page.getByRole("button", { name: /Test ACP Agent/ }).click();
+    await composer(page).fill(`ACPFAIL ${detail}`);
+    await composer(page).press("Enter");
+
+    const error = page.locator(".finding.err");
+    await expect(error).toContainText(detail);
+    await expect(error.locator(".finding-body")).toContainText(
+      locale === "zh" ? "未回退（fallback）到 HTTP 模型" : "did not fall back to an HTTP model",
+    );
+    await expect(error.locator(".finding-body")).toContainText(
+      locale === "zh" ? "可能产生额外费用" : "may incur separate charges",
+    );
+    await expect(error.getByRole("button", { name: locale === "zh" ? "继续执行" : "Resume", exact: true })).toHaveCount(0);
+    await expect(page.getByTestId("context-recovery-modal")).toHaveCount(0);
+    await expect(page.locator(".model-picker-label")).toHaveText("Test ACP Agent");
+    expect(await invokeCount(page, "send_message")).toBe(1);
+
+    await composer(page).fill("retry with the same ACP Agent");
+    await composer(page).press("Enter");
+    await expect(page.getByText("Hello from ACP.")).toBeVisible();
+    expect(await lastInvokeArgs(page, "send_message")).toMatchObject({ acpAgentId: "acp-test" });
+    expect(await invokeCount(page, "send_message")).toBe(2);
+    expect(await invokeCount(page, "set_active_model")).toBe(0);
+  });
+}
+
 test("restored ACP model options are usable before sending a message (#1112)", async ({ page }) => {
   await openMockPlanSession(page, "acp");
   await expect(page.locator(".model-picker-btn")).toContainText("Test ACP Agent");

--- a/ui/src/chat_render.rs
+++ b/ui/src/chat_render.rs
@@ -1519,12 +1519,13 @@ pub(crate) fn render_item(
                 .to_string();
             let copy = msg.clone();
             let hint_src = msg.clone();
+            let can_resume = can_modify && !msg.starts_with(crate::dto::ACP_TURN_ERROR_PREFIX);
             view! {
                 <div class="finding err">
                     <div class="finding-head">
                         <span class="finding-tag">{move || format!("● {}", t(locale.get(), "chat.error"))}</span>
                         <span class="finding-title">{msg}</span>
-                        {can_modify.then(|| view! {
+                        {can_resume.then(|| view! {
                             <button type="button" class="tool-btn"
                                 disabled=move || busy.get()
                                 on:click=move |_| on_resume.call(ui_index)>

--- a/ui/src/i18n.rs
+++ b/ui/src/i18n.rs
@@ -2111,6 +2111,7 @@ fn lookup(locale: Locale, key: &str) -> Option<&'static str> {
         (Locale::En, "chat.video_preview_unavailable") => Some("Generated video preview unavailable"),
         (Locale::En, "err.hint.balance") => Some("The provider account is out of credit. Top up on the provider's billing page, then retry."),
         (Locale::En, "err.hint.auth") => Some("The API key was rejected. Check the API key in Settings → Models."),
+        (Locale::En, "err.hint.acp_no_fallback") => Some("This ACP request stopped. Wisp did not fall back to an HTTP model. Check the ACP Agent's connection and sign-in, then send your message again. To use an HTTP model, start a new conversation and select it explicitly; HTTP API usage may incur separate charges."),
         (Locale::En, "err.hint.context") => Some("The conversation exceeds the model's context limit. Send /compact to fold old turns, start a new session, or switch to a model with a larger context window."),
         (Locale::En, "err.hint.image") => Some("This model does not accept image input. Remove the images or switch to a vision-capable model."),
         (Locale::En, "err.hint.model_name") => Some("The provider does not recognize the configured model name. Check the model name in Settings → Models."),
@@ -4674,6 +4675,7 @@ Do not leave generated files in the project root.",
         (Locale::Zh, "chat.video_preview_unavailable") => Some("无法预览生成的视频"),
         (Locale::Zh, "err.hint.balance") => Some("服务商账户余额不足。请前往服务商官网充值后重试。"),
         (Locale::Zh, "err.hint.auth") => Some("API 密钥被拒绝。请在 设置 → 模型 中检查 API 密钥。"),
+        (Locale::Zh, "err.hint.acp_no_fallback") => Some("本次 ACP 请求已停止，Wisp 未回退（fallback）到 HTTP 模型。请检查 ACP Agent 的连接和登录状态后重新发送消息。如需使用 HTTP 模型，请新建会话并明确选择；HTTP API 调用可能产生额外费用。"),
         (Locale::Zh, "err.hint.context") => Some("对话长度超出模型上下文上限。发送 /compact 压缩旧轮次，或新开会话，或换用上下文更大的模型。"),
         (Locale::Zh, "err.hint.image") => Some("当前模型不支持图片输入。请移除消息中的图片，或换用支持视觉的模型。"),
         (Locale::Zh, "err.hint.model_name") => Some("服务商不识别所配置的模型名。请在 设置 → 模型 中核对模型名。"),
@@ -5595,6 +5597,9 @@ pub fn is_context_limit_error(msg: &str) -> bool {
 }
 
 fn api_error_hint_key(msg: &str) -> Option<&'static str> {
+    if msg.starts_with(crate::dto::ACP_TURN_ERROR_PREFIX) {
+        return Some("err.hint.acp_no_fallback");
+    }
     if !msg.contains("api: ") && !msg.contains("http: ") {
         return None;
     }
@@ -5755,6 +5760,29 @@ mod api_error_hint_tests {
     fn no_hint_for_non_api_errors() {
         assert_eq!(hint_key("stream ended without completion"), None);
         assert_eq!(hint_key("tool `python` failed: NameError"), None);
+    }
+
+    #[test]
+    fn acp_failures_explain_no_fallback_and_never_offer_http_recovery() {
+        for detail in [
+            "Agent process exited",
+            "api: 401 unauthorized",
+            "api: 403 forbidden",
+            "This ACP Agent cannot resume or load the saved session.",
+            "api: 400 context window exceeded",
+            "api: 400 unknown variant image_url",
+        ] {
+            let error = format!("{}{detail}", crate::dto::ACP_TURN_ERROR_PREFIX);
+            for locale in [Locale::En, Locale::Zh] {
+                let hint = t(locale, "err.hint.acp_no_fallback");
+                assert_eq!(api_error_hint(locale, &error), Some(hint.clone()));
+                let localized = localize_backend(locale, &error);
+                assert!(localized.contains(detail));
+                assert!(localized.contains(&hint));
+            }
+            assert!(!is_context_limit_error(&error));
+            assert!(!is_image_unsupported(&error));
+        }
     }
 
     #[test]

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -4044,6 +4044,11 @@ fn App() -> impl IntoView {
                 }
                 pending_service_tier.set(None);
             }
+            // Keep the selection even if ACP startup fails before its binding
+            // exists. The new frame id was not available in the model picker.
+            if let Some(agent_id) = &agent_id {
+                provisional_acp_selection.set(Some((id.clone(), agent_id.clone())));
+            }
             // Mark the turn pending before touching active_session so the
             // session→ACP lookup effect does not clear a just-selected agent
             // while send_message is still binding a newly activated session.


### PR DESCRIPTION
ACP startup failures could clear the selected agent before a session binding existed, leaving the next send on the default HTTP model. Failed ACP turns also offered native transcript recovery without explaining the backend or potential API charges.

This change keeps the provisional ACP selection after startup failure and shows a bilingual error-card notice: the request stopped without HTTP fallback; using an HTTP model requires explicitly selecting it in a new conversation and may incur separate charges. ACP errors retain their original details and no longer offer native Resume, image rollback, or context compaction recovery.

Refs #1118.

## Changes

- `crates/wisp-dto` and `src-tauri/src/acp.rs`: share an ACP error prefix across persisted events and invoke errors.
- `ui/src/main.rs`, `chat_render.rs`, and `i18n.rs`: preserve the selected ACP agent, display the notice, and suppress inappropriate HTTP recovery actions.
- `ui-tests`: cover startup failure before binding, 401, 403, unsupported resume/load, and context-limit errors; verify retries retain ACP without switching HTTP models.
- `docs/acp-agents.md`: explain failure handling, retry steps, and the billing notice.

## Validation

- `cargo fmt --all -- --check` and `git diff --check` passed.
- `WISP_CATALOG_OFFLINE=1 cargo test --workspace --offline`: 1666 passed, 1 ignored.
- UI unit tests: 324 passed.
- UI `cargo check --target wasm32-unknown-unknown --offline` passed.
- `npm ci` and full Playwright suite: 503 passed, 2 skipped; all 5 new regression cases passed.

## Manual smoke steps

- Select an ACP agent before the first send, make startup fail, and verify the error card explains no HTTP fallback and possible API charges.
- Verify the picker still shows ACP, native Resume is absent, and sending again uses the same ACP agent.
- Repeat with a bound ACP session after authentication or resume/load failure; check both English and Chinese.

## Limitations and follow-up

Automated validation uses local fixtures and a mocked Tauri bridge; no live ACP provider or paid API was used. Existing stored errors are not rewritten. This change does not introduce a confirmed HTTP fallback flow or alter ACP binding persistence. No additional work is required for the scoped notice.
