### PR TITLE
feat(bio): native PubMed domain in Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4242,6 +4242,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "roxmltree"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7150,6 +7159,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "wisp-bio"
+version = "1.9.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "axum",
+ "chrono",
+ "reqwest 0.12.28",
+ "roxmltree",
+ "serde",
+ "serde_json",
+ "tokio",
+ "wisp-llm",
+ "wisp-tools",
+]
+
+[[package]]
 name = "wisp-cli"
 version = "1.9.0"
 dependencies = [
@@ -7164,6 +7190,7 @@ dependencies = [
  "tokio",
  "tracing-subscriber",
  "uuid",
+ "wisp-bio",
  "wisp-core",
  "wisp-llm",
  "wisp-mcp",
@@ -7393,6 +7420,7 @@ dependencies = [
  "windows",
  "winreg 0.55.0",
  "wisp-acp",
+ "wisp-bio",
  "wisp-core",
  "wisp-dto",
  "wisp-llm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/wisp-skills",
     "crates/wisp-runtime",
     "crates/wisp-mcp",
+    "crates/wisp-bio",
     "crates/wisp-acp",
     "crates/wisp-cli",
     "crates/wisp-runs",
@@ -68,6 +69,7 @@ wisp-store = { path = "crates/wisp-store" }
 wisp-skills = { path = "crates/wisp-skills" }
 wisp-runtime = { path = "crates/wisp-runtime" }
 wisp-mcp = { path = "crates/wisp-mcp" }
+wisp-bio = { path = "crates/wisp-bio" }
 wisp-acp = { path = "crates/wisp-acp" }
 wisp-runs = { path = "crates/wisp-runs" }
 wisp-paths = { path = "crates/wisp-paths" }

--- a/crates/wisp-bio/Cargo.toml
+++ b/crates/wisp-bio/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "wisp-bio"
+description = "Native biological data retrieval for Wisp hosts."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+async-trait = "0.1"
+chrono = { workspace = true }
+reqwest = { workspace = true }
+roxmltree = "0.21"
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+wisp-llm = { workspace = true }
+wisp-tools = { workspace = true }
+
+[dev-dependencies]
+axum = { workspace = true }

--- a/crates/wisp-bio/src/http.rs
+++ b/crates/wisp-bio/src/http.rs
@@ -1,0 +1,154 @@
+//! Bounded HTTP for the independently authored data clients. Credentials belong
+//! to provider request builders; transport errors never print URLs or bodies.
+use anyhow::{anyhow, bail, Context, Result};
+use reqwest::{Method, StatusCode};
+use serde_json::Value;
+use std::{
+    collections::HashMap,
+    sync::{Arc, LazyLock},
+    time::Duration,
+};
+use tokio::{sync::Mutex, time::Instant};
+
+pub(crate) const MAX_RESPONSE: usize = 4 * 1024 * 1024;
+type Pace = Arc<Mutex<Option<Instant>>>;
+static PACERS: LazyLock<std::sync::Mutex<HashMap<&'static str, Pace>>> =
+    LazyLock::new(|| std::sync::Mutex::new(HashMap::new()));
+
+#[derive(Clone, Copy)]
+pub(crate) struct Source(pub &'static str, pub Duration);
+pub(crate) const NCBI: Source = Source("NCBI", Duration::from_millis(350));
+pub(crate) const PMC_IDCONV: Source = Source("PMC ID Converter", Duration::from_millis(350));
+pub(crate) const EUROPE_PMC: Source = Source("Europe PMC", Duration::from_millis(500));
+
+#[derive(Clone)]
+pub(crate) struct Http(pub reqwest::Client);
+
+pub(crate) struct Response {
+    pub status: StatusCode,
+    pub body: Vec<u8>,
+    source: &'static str,
+}
+
+impl Response {
+    pub fn check(&self) -> Result<()> {
+        if !self.status.is_success() {
+            bail!("{} returned HTTP {}", self.source, self.status.as_u16());
+        }
+        Ok(())
+    }
+    pub fn json(self) -> Result<Value> {
+        self.check()?;
+        serde_json::from_slice(&self.body).context("upstream returned invalid JSON")
+    }
+    pub fn text(self) -> Result<String> {
+        self.check()?;
+        String::from_utf8(self.body).context("upstream returned invalid UTF-8")
+    }
+}
+
+impl Http {
+    pub fn new() -> Result<Self> {
+        Ok(Self(
+            reqwest::Client::builder()
+                .user_agent(concat!("wisp-science/", env!("CARGO_PKG_VERSION")))
+                .connect_timeout(Duration::from_secs(10))
+                .timeout(Duration::from_secs(20))
+                .redirect(reqwest::redirect::Policy::none())
+                .build()?,
+        ))
+    }
+
+    pub async fn send(
+        &self,
+        source: Source,
+        method: Method,
+        url: &str,
+        params: &[(String, String)],
+    ) -> Result<Response> {
+        let pacer = PACERS
+            .lock()
+            .unwrap()
+            .entry(source.0)
+            .or_insert_with(|| Arc::new(Mutex::new(None)))
+            .clone();
+        for attempt in 0..2 {
+            {
+                let mut last = pacer.lock().await;
+                if let Some(previous) = *last {
+                    tokio::time::sleep_until(previous + source.1).await;
+                }
+                *last = Some(Instant::now());
+            }
+            let request = self.0.request(method.clone(), url);
+            let request = if method == Method::GET {
+                request.query(params)
+            } else {
+                request.form(params)
+            };
+            let mut response = request
+                .send()
+                .await
+                .map_err(|_| anyhow!("{} connection failed or timed out", source.0))?;
+            let status = response.status();
+            if attempt == 0 && (status == StatusCode::TOO_MANY_REQUESTS || status.is_server_error())
+            {
+                let delay = response
+                    .headers()
+                    .get(reqwest::header::RETRY_AFTER)
+                    .map(|header| header.to_str().ok().and_then(retry_delay))
+                    .unwrap_or(Some(2));
+                if let Some(delay) = delay.filter(|seconds| *seconds <= 5) {
+                    drop(response);
+                    tokio::time::sleep(Duration::from_secs(delay)).await;
+                    continue;
+                }
+            }
+            // Error bodies can echo credentials. Callers classify by status.
+            if !status.is_success() {
+                return Ok(Response {
+                    status,
+                    body: Vec::new(),
+                    source: source.0,
+                });
+            }
+            if response
+                .content_length()
+                .is_some_and(|n| n > MAX_RESPONSE as u64)
+            {
+                bail!(
+                    "{} response exceeded 4 MiB; request fewer records",
+                    source.0
+                );
+            }
+            let mut body = Vec::new();
+            while let Some(chunk) = response
+                .chunk()
+                .await
+                .map_err(|_| anyhow!("{} response could not be read", source.0))?
+            {
+                if body.len() + chunk.len() > MAX_RESPONSE {
+                    bail!(
+                        "{} response exceeded 4 MiB; request fewer records",
+                        source.0
+                    );
+                }
+                body.extend_from_slice(&chunk);
+            }
+            return Ok(Response {
+                status,
+                body,
+                source: source.0,
+            });
+        }
+        unreachable!("second attempt returns a response")
+    }
+}
+
+fn retry_delay(value: &str) -> Option<u64> {
+    value.parse().ok().or_else(|| {
+        chrono::DateTime::parse_from_rfc2822(value)
+            .ok()
+            .map(|date| (date.timestamp() - chrono::Utc::now().timestamp()).max(0) as u64)
+    })
+}

--- a/crates/wisp-bio/src/lib.rs
+++ b/crates/wisp-bio/src/lib.rs
@@ -1,0 +1,201 @@
+//! Native scientific retrieval shared by desktop, CLI and the ACP MCP bridge.
+//!
+//! Provider behavior is implemented from the operators' API documentation.
+//! This crate does not import the legacy Python bundle or its schemas.
+
+mod http;
+mod pubmed;
+mod xml;
+
+use async_trait::async_trait;
+use serde_json::{json, Value};
+use std::sync::Arc;
+use wisp_llm::ToolSchema;
+use wisp_tools::{Tool, ToolEnv, ToolResult};
+
+pub use pubmed::PubMed;
+
+pub fn selected_by_package(package: &str) -> bool {
+    matches!(package, "mcp_bio" | "mcp_pubmed")
+}
+
+pub fn contains_tool(name: &str) -> bool {
+    catalog()
+        .iter()
+        .any(|(_, schema)| schema.function.name == name)
+}
+
+/// Only implemented operations belong in this catalog. Domain identifiers also
+/// identify the host's persisted connector settings and capability grants.
+pub fn catalog() -> Vec<(&'static str, ToolSchema)> {
+    vec![
+        (
+            "pubmed",
+            ToolSchema::new(
+                "search_articles",
+                "Search PubMed with an Entrez query. Returns matching PMIDs, the total match count and a bounded page. Use get_article_metadata to retrieve citation summaries. PubMed permits retrieval of only the first 10,000 search matches.",
+                json!({
+                    "type": "object", "additionalProperties": false,
+                    "required": ["query"],
+                    "properties": {
+                        "query": {"type": "string", "minLength": 1, "maxLength": 8192},
+                        "max_results": {"type": "integer", "minimum": 1, "maximum": 200, "default": 20},
+                        "retstart": {"type": "integer", "minimum": 0, "maximum": 9999, "default": 0},
+                        "sort": {"type": "string", "enum": ["relevance", "pub_date", "author", "journal_name"], "default": "relevance"},
+                        "datetype": {"type": "string", "enum": ["pdat", "edat", "mdat"], "default": "pdat"},
+                        "date_from": {"type": "string", "description": "Start date: YYYY, YYYY/MM or YYYY/MM/DD. Supply both dates."},
+                        "date_to": {"type": "string", "description": "End date in the same format as date_from."}
+                    }
+                }),
+            ),
+        ),
+        (
+            "pubmed",
+            ToolSchema::new(
+                "get_article_metadata",
+                "Retrieve NCBI PubMed metadata for up to 200 PMIDs: citation summaries, article identifiers and abstracts when available. Missing records are reported individually. This retrieves metadata, not article full text.",
+                json!({
+                    "type": "object", "additionalProperties": false,
+                    "required": ["pmids"],
+                    "properties": {
+                        "pmids": {"type": "array", "minItems": 1, "maxItems": 200,
+                            "items": {"type": "string", "pattern": "^[1-9][0-9]{0,11}$"}}
+                    }
+                }),
+            ),
+        ),
+        (
+            "pubmed",
+            ToolSchema::new(
+                "convert_article_ids",
+                "Convert a same-type batch of PMID, PMCID or DOI identifiers with the NCBI PMC ID Converter. Conversions are returned only when the article is in PubMed Central. Missing and unconverted identifiers are listed. Embargoed records include live status and release date when the converter supplies them. At most 200 identifiers per request.",
+                json!({
+                    "type": "object", "additionalProperties": false,
+                    "required": ["ids"],
+                    "properties": {
+                        "ids": {"type": "array", "minItems": 1, "maxItems": 200,
+                            "items": {"type": "string", "minLength": 1, "maxLength": 256}},
+                        "id_type": {"type": "string", "enum": ["pmid", "pmcid", "doi"], "default": "pmid"}
+                    }
+                }),
+            ),
+        ),
+        (
+            "pubmed",
+            ToolSchema::new(
+                "find_related_articles",
+                "Find Entrez records linked to PubMed articles with NCBI ELink. Supported link names are pubmed_pubmed (similar articles), pubmed_pmc, pubmed_gene, pubmed_protein and pubmed_nucleotide. Related PubMed articles keep NCBI's ranking. The response is a bounded page, not the complete neighbor set.",
+                json!({
+                    "type": "object", "additionalProperties": false,
+                    "required": ["pmids"],
+                    "properties": {
+                        "pmids": {"type": "array", "minItems": 1, "maxItems": 20,
+                            "items": {"type": "string", "pattern": "^[1-9][0-9]{0,11}$"}},
+                        "link_type": {"type": "string",
+                            "enum": ["pubmed_pubmed", "pubmed_pmc", "pubmed_gene", "pubmed_protein", "pubmed_nucleotide"],
+                            "default": "pubmed_pubmed"},
+                        "max_results": {"type": "integer", "minimum": 1, "maximum": 200, "default": 20}
+                    }
+                }),
+            ),
+        ),
+        (
+            "pubmed",
+            ToolSchema::new(
+                "lookup_article_by_citation",
+                "Match bibliographic citations to PubMed IDs with NCBI ECitMatch. Each citation is encoded as journal|year|volume|first_page|author|key as documented by E-utilities. Matched and unmatched citations are reported separately.",
+                json!({
+                    "type": "object", "additionalProperties": false,
+                    "required": ["citations"],
+                    "properties": {
+                        "citations": {"type": "array", "minItems": 1, "maxItems": 25, "items": {
+                            "type": "object", "additionalProperties": false,
+                            "required": ["journal"],
+                            "properties": {
+                                "journal": {"type": "string", "minLength": 1, "maxLength": 256},
+                                "year": {"type": ["integer", "string"]},
+                                "volume": {"type": "string", "maxLength": 64},
+                                "first_page": {"type": "string", "maxLength": 64},
+                                "author": {"type": "string", "maxLength": 256},
+                                "key": {"type": "string", "maxLength": 64}
+                            }
+                        }}
+                    }
+                }),
+            ),
+        ),
+        (
+            "pubmed",
+            ToolSchema::new(
+                "get_full_text_article",
+                "Retrieve Open Access full-text XML from Europe PMC for PMC articles. Distinguishes identifiers that are not found, not in the Europe PMC open-access subset, and OA records whose XML is unavailable. An empty body is not treated as successful evidence. At most five PMCIDs per request.",
+                json!({
+                    "type": "object", "additionalProperties": false,
+                    "required": ["pmc_ids"],
+                    "properties": {
+                        "pmc_ids": {"type": "array", "minItems": 1, "maxItems": 5,
+                            "items": {"type": "string", "minLength": 1, "maxLength": 32}}
+                    }
+                }),
+            ),
+        ),
+        (
+            "pubmed",
+            ToolSchema::new(
+                "get_copyright_status",
+                "Report metadata availability, accessible full text, and stated licenses for PubMed articles using Europe PMC core metadata and PMC ID Converter embargo fields. An open-access flag is not a reuse grant. Does not call the retired PMC OA Web Service.",
+                json!({
+                    "type": "object", "additionalProperties": false,
+                    "required": ["pmids"],
+                    "properties": {
+                        "pmids": {"type": "array", "minItems": 1, "maxItems": 50,
+                            "items": {"type": "string", "pattern": "^[1-9][0-9]{0,11}$"}}
+                    }
+                }),
+            ),
+        ),
+    ]
+}
+
+pub fn tools(client: Arc<PubMed>) -> Vec<Box<dyn Tool>> {
+    catalog()
+        .into_iter()
+        .map(|(_, schema)| {
+            Box::new(BioTool {
+                schema,
+                client: client.clone(),
+            }) as Box<dyn Tool>
+        })
+        .collect()
+}
+
+struct BioTool {
+    schema: ToolSchema,
+    client: Arc<PubMed>,
+}
+
+#[async_trait]
+impl Tool for BioTool {
+    fn name(&self) -> &str {
+        &self.schema.function.name
+    }
+
+    fn schema(&self) -> ToolSchema {
+        self.schema.clone()
+    }
+
+    fn defer_schema(&self) -> bool {
+        true
+    }
+
+    fn read_only(&self) -> bool {
+        true
+    }
+
+    async fn run(&self, args: &Value, _env: &dyn ToolEnv) -> ToolResult {
+        match self.client.call(self.name(), args).await {
+            Ok(value) => ToolResult::ok(value.to_string()),
+            Err(error) => ToolResult::fail(error.to_string()),
+        }
+    }
+}

--- a/crates/wisp-bio/src/pubmed.rs
+++ b/crates/wisp-bio/src/pubmed.rs
@@ -1,0 +1,390 @@
+//! Native PubMed-domain clients, independently implemented from:
+//! - NCBI E-utilities (https://www.ncbi.nlm.nih.gov/books/NBK25497/,
+//!   https://www.ncbi.nlm.nih.gov/books/NBK25499/)
+//! - PMC ID Converter (https://pmc.ncbi.nlm.nih.gov/tools/id-converter-api/)
+//! - Europe PMC Articles REST (https://europepmc.org/RestfulWebService)
+//!
+//! References reviewed 2026-09-06. The retired PMC OA Web Service
+//! (https://pmc.ncbi.nlm.nih.gov/tools/oa-service/) is not used.
+//! Tests use invented records.
+
+mod citations;
+mod europepmc;
+mod ids;
+mod records;
+mod related;
+#[cfg(test)]
+mod tests;
+
+use crate::http::{Http, NCBI};
+use anyhow::{anyhow, bail, Context, Result};
+use reqwest::Method;
+use serde::Deserialize;
+use serde_json::{json, Value};
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+const NCBI_EUTILS: &str = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/";
+const IDCONV: &str = "https://pmc.ncbi.nlm.nih.gov/tools/idconv/api/v1/articles/";
+const EUROPE_PMC_REST: &str = "https://www.ebi.ac.uk/europepmc/webservices/rest/";
+
+pub struct PubMed {
+    pub(crate) http: Http,
+    api_key: Option<String>,
+    email: Option<String>,
+    pub(crate) ncbi: String,
+    pub(crate) idconv: String,
+    pub(crate) europepmc: String,
+}
+
+impl PubMed {
+    /// The desktop supplies keyring-backed values; the CLI supplies its env.
+    /// Credentials are held in memory and are never included in tool results.
+    pub fn new(credentials: &[(String, String)]) -> Result<Self> {
+        let credential = |name| {
+            credentials
+                .iter()
+                .find(|(key, value)| key == name && !value.is_empty())
+                .map(|(_, value)| value.clone())
+        };
+        Ok(Self {
+            http: Http::new()?,
+            api_key: credential("NCBI_API_KEY"),
+            email: credential("NCBI_EMAIL"),
+            ncbi: NCBI_EUTILS.into(),
+            idconv: IDCONV.into(),
+            europepmc: EUROPE_PMC_REST.into(),
+        })
+    }
+
+    pub async fn call(&self, name: &str, args: &Value) -> Result<Value> {
+        tokio::time::timeout(Duration::from_secs(45), self.dispatch(name, args))
+            .await
+            .map_err(|_| anyhow!("PubMed request exceeded 45 seconds"))?
+    }
+
+    async fn dispatch(&self, name: &str, args: &Value) -> Result<Value> {
+        match name {
+            "search_articles" => {
+                let args: Search = serde_json::from_value(args.clone())
+                    .context("invalid PubMed search arguments")?;
+                let mut params = args.params()?;
+                params.extend([
+                    ("db".into(), "pubmed".into()),
+                    ("retmode".into(), "json".into()),
+                ]);
+                params.extend(self.ncbi_identity());
+                let raw = self.ncbi_json("esearch.fcgi", params).await?;
+                search_result(&raw, &args)
+            }
+            "get_article_metadata" => {
+                let args: Summaries = serde_json::from_value(args.clone())
+                    .context("invalid PubMed metadata arguments")?;
+                validate_pmids(&args.pmids)?;
+                let mut params = vec![
+                    ("db".into(), "pubmed".into()),
+                    ("retmode".into(), "json".into()),
+                    ("id".into(), args.pmids.join(",")),
+                ];
+                params.extend(self.ncbi_identity());
+                let raw = self.ncbi_json("esummary.fcgi", params).await?;
+                let mut result = summary_result(&raw, &args.pmids)?;
+                result["metadata_level"] = json!("citation_and_abstract");
+                let found = result["records"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .map(|record| record["pmid"].as_str().unwrap())
+                    .collect::<Vec<_>>()
+                    .join(",");
+                if found.is_empty() {
+                    return Ok(result);
+                }
+                let mut fetch = vec![
+                    ("db".into(), "pubmed".into()),
+                    ("retmode".into(), "xml".into()),
+                    ("id".into(), found),
+                ];
+                fetch.extend(self.ncbi_identity());
+                let xml = self.ncbi_text("efetch.fcgi", fetch).await?;
+                let abstracts = parse_abstracts(xml.as_bytes())?;
+                for record in result["records"].as_array_mut().unwrap() {
+                    let text = abstracts
+                        .get(record["pmid"].as_str().unwrap())
+                        .context("PubMed omitted a record when retrieving abstracts")?;
+                    record["abstract"] = if text.trim().is_empty() {
+                        Value::Null
+                    } else {
+                        json!(text)
+                    };
+                }
+                Ok(result)
+            }
+            "convert_article_ids" => ids::convert(self, args).await,
+            "find_related_articles" => related::find(self, args).await,
+            "lookup_article_by_citation" => citations::lookup(self, args).await,
+            "get_full_text_article" => europepmc::full_text(self, args).await,
+            "get_copyright_status" => europepmc::copyright(self, args).await,
+            _ => bail!("unknown native biological tool: {name}"),
+        }
+    }
+
+    pub(super) fn ncbi_identity(&self) -> Vec<(String, String)> {
+        let mut params = vec![("tool".into(), "wisp-science".into())];
+        if let Some(key) = &self.api_key {
+            params.push(("api_key".into(), key.clone()));
+        }
+        if let Some(email) = &self.email {
+            params.push(("email".into(), email.clone()));
+        }
+        params
+    }
+
+    pub(super) async fn ncbi_json(
+        &self,
+        path: &str,
+        params: Vec<(String, String)>,
+    ) -> Result<Value> {
+        let value = self
+            .http
+            .send(NCBI, Method::POST, &format!("{}{path}", self.ncbi), &params)
+            .await?
+            .json()?;
+        if value.get("error").is_some() || value.get("ERROR").is_some() {
+            bail!("PubMed rejected the request");
+        }
+        Ok(value)
+    }
+
+    pub(super) async fn ncbi_text(
+        &self,
+        path: &str,
+        params: Vec<(String, String)>,
+    ) -> Result<String> {
+        self.http
+            .send(NCBI, Method::POST, &format!("{}{path}", self.ncbi), &params)
+            .await?
+            .text()
+    }
+}
+
+fn parse_abstracts(xml: &[u8]) -> Result<BTreeMap<String, String>> {
+    let text = std::str::from_utf8(xml).context("invalid PubMed record XML")?;
+    let doc = crate::xml::parse(text)?;
+    if !doc.root_element().has_tag_name("PubmedArticleSet") {
+        bail!("PubMed returned an unexpected record document");
+    }
+    let mut records = BTreeMap::new();
+    for entry in doc
+        .root_element()
+        .children()
+        .filter(|node| node.has_tag_name("PubmedArticle") || node.has_tag_name("PubmedBookArticle"))
+    {
+        let citation = crate::xml::child(entry, "MedlineCitation")
+            .or_else(|| crate::xml::child(entry, "BookDocument"))
+            .context("PubMed record omitted its PMID")?;
+        let id =
+            crate::xml::field(citation, &["PMID"]).context("PubMed record omitted its PMID")?;
+        let article = crate::xml::child(citation, "Article").unwrap_or(citation);
+        let parts: Vec<_> = crate::xml::child(article, "Abstract")
+            .into_iter()
+            .flat_map(|node| node.children())
+            .filter(|node| node.has_tag_name("AbstractText"))
+            .filter_map(crate::xml::text)
+            .collect();
+        records.insert(id, parts.join("\n"));
+    }
+    Ok(records)
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Search {
+    query: String,
+    #[serde(default = "default_limit")]
+    max_results: usize,
+    #[serde(default)]
+    retstart: usize,
+    sort: Option<String>,
+    datetype: Option<String>,
+    date_from: Option<String>,
+    date_to: Option<String>,
+}
+
+fn default_limit() -> usize {
+    20
+}
+
+impl Search {
+    fn params(&self) -> Result<Vec<(String, String)>> {
+        if self.query.trim().is_empty() || self.query.len() > 8192 {
+            bail!("query must contain 1 to 8192 bytes of text");
+        }
+        if !(1..=200).contains(&self.max_results)
+            || self.retstart >= 10_000
+            || self.max_results > 10_000 - self.retstart
+        {
+            bail!("request 1 to 200 records within PubMed's first 10,000 matches");
+        }
+        let sort = match self.sort.as_deref().unwrap_or("relevance") {
+            "relevance" => "relevance",
+            "pub_date" => "pub_date",
+            "author" => "Author",
+            "journal_name" => "JournalName",
+            _ => bail!("sort must be relevance, pub_date, author or journal_name"),
+        };
+        let datetype = self.datetype.as_deref().unwrap_or("pdat");
+        if !matches!(datetype, "pdat" | "edat" | "mdat") {
+            bail!("datetype must be pdat, edat or mdat");
+        }
+        let mut params = vec![
+            ("term".into(), self.query.clone()),
+            ("retmax".into(), self.max_results.to_string()),
+            ("retstart".into(), self.retstart.to_string()),
+            ("sort".into(), sort.into()),
+            ("datetype".into(), datetype.into()),
+        ];
+        match (&self.date_from, &self.date_to) {
+            (None, None) => {}
+            (Some(start), Some(end)) => {
+                if !valid_date(start) || !valid_date(end) {
+                    bail!("dates must be YYYY, YYYY/MM or YYYY/MM/DD");
+                }
+                params.push(("mindate".into(), start.clone()));
+                params.push(("maxdate".into(), end.clone()));
+            }
+            _ => bail!("provide both date_from and date_to"),
+        }
+        Ok(params)
+    }
+}
+
+fn valid_date(value: &str) -> bool {
+    let parts: Vec<_> = value.split('/').collect();
+    if !(1..=3).contains(&parts.len())
+        || parts[0].len() != 4
+        || parts
+            .iter()
+            .any(|part| !part.bytes().all(|b| b.is_ascii_digit()))
+        || parts.iter().skip(1).any(|part| part.len() != 2)
+    {
+        return false;
+    }
+    let year = parts[0].parse::<i32>().unwrap_or(0);
+    let month = parts.get(1).map_or(1, |part| part.parse().unwrap_or(0));
+    let day = parts.get(2).map_or(1, |part| part.parse().unwrap_or(0));
+    year > 0 && chrono::NaiveDate::from_ymd_opt(year, month, day).is_some()
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Summaries {
+    pmids: Vec<String>,
+}
+
+fn validate_pmids(pmids: &[String]) -> Result<()> {
+    if !(1..=200).contains(&pmids.len()) || pmids.iter().any(|id| require_pmid(id).is_err()) {
+        bail!("provide 1 to 200 positive numeric PMID strings");
+    }
+    Ok(())
+}
+
+fn require_pmid(id: &str) -> Result<&str> {
+    if id.is_empty()
+        || id.len() > 12
+        || id.starts_with('0')
+        || !id.bytes().all(|b| b.is_ascii_digit())
+    {
+        bail!("provide 1 to 200 positive numeric PMID strings");
+    }
+    Ok(id)
+}
+
+fn json_id(value: &Value) -> Option<String> {
+    match value {
+        Value::String(text) if !text.is_empty() => Some(text.clone()),
+        Value::Number(number) => Some(number.to_string()),
+        _ => None,
+    }
+}
+
+fn json_flag(value: &Value) -> Option<bool> {
+    match value {
+        Value::Bool(flag) => Some(*flag),
+        Value::String(text) => match text.to_ascii_lowercase().as_str() {
+            "y" | "yes" | "true" | "1" => Some(true),
+            "n" | "no" | "false" | "0" => Some(false),
+            _ => None,
+        },
+        Value::Number(number) if number.as_u64() == Some(1) => Some(true),
+        Value::Number(number) if number.as_u64() == Some(0) => Some(false),
+        _ => None,
+    }
+}
+
+fn search_result(raw: &Value, args: &Search) -> Result<Value> {
+    let result = raw
+        .get("esearchresult")
+        .context("PubMed omitted search results")?;
+    if result.get("ERROR").is_some() || result.get("errorlist").is_some() {
+        bail!("PubMed rejected the search expression");
+    }
+    let total = result["count"]
+        .as_str()
+        .and_then(|s| s.parse::<u64>().ok())
+        .context("PubMed omitted the search count")?;
+    let ids: Vec<String> = serde_json::from_value(result["idlist"].clone())
+        .context("PubMed returned an invalid PMID list")?;
+    if !ids.is_empty() {
+        validate_pmids(&ids).context("PubMed returned invalid identifiers")?;
+    }
+    if ids.len() > args.max_results
+        || (ids.is_empty() && (args.retstart as u64) < total)
+        || args.retstart as u64 + ids.len() as u64 > total.max(args.retstart as u64)
+    {
+        bail!("PubMed returned inconsistent pagination");
+    }
+    let next = args.retstart + ids.len();
+    Ok(json!({
+        "source": "NCBI PubMed", "query": args.query, "total": total,
+        "retstart": args.retstart, "returned": ids.len(), "pmids": ids,
+        "has_more": (next as u64) < total,
+        "next_retstart": if !ids.is_empty() && (next as u64) < total && next < 10_000 { Some(next) } else { None },
+        "retrieval_ceiling": 10_000,
+        "query_translation": result.get("querytranslation")
+    }))
+}
+
+fn summary_result(raw: &Value, requested: &[String]) -> Result<Value> {
+    let result = raw
+        .get("result")
+        .and_then(Value::as_object)
+        .context("PubMed omitted citation summaries")?;
+    if !result.get("uids").is_some_and(Value::is_array) {
+        bail!("PubMed omitted the citation identifier list");
+    }
+    let mut records = Vec::new();
+    let mut missing = Vec::new();
+    for id in requested {
+        match result
+            .get(id)
+            .filter(|record| record.is_object() && record.get("error").is_none())
+        {
+            Some(record) => {
+                if record["uid"].as_str() != Some(id.as_str()) {
+                    bail!("PubMed returned an inconsistent citation identifier");
+                }
+                records.push(json!({
+                    "pmid": id, "url": format!("https://pubmed.ncbi.nlm.nih.gov/{id}/"),
+                    "summary": record
+                }));
+            }
+            None => missing.push(id),
+        }
+    }
+    Ok(json!({
+        "source": "NCBI PubMed", "metadata_level": "citation_summary",
+        "requested": requested, "returned": records.len(), "records": records,
+        "missing_pmids": missing
+    }))
+}

--- a/crates/wisp-bio/src/pubmed/citations.rs
+++ b/crates/wisp-bio/src/pubmed/citations.rs
@@ -1,0 +1,179 @@
+//! NCBI ECitMatch. Official reference (reviewed 2026-09-06):
+//! https://www.ncbi.nlm.nih.gov/books/NBK25499/
+use super::PubMed;
+use anyhow::{bail, Context, Result};
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+pub(super) const SOURCE_URL: &str = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/ecitmatch.cgi";
+
+#[derive(Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Citation {
+    journal: String,
+    #[serde(default)]
+    year: Option<Value>,
+    #[serde(default)]
+    volume: Option<String>,
+    #[serde(default)]
+    first_page: Option<String>,
+    #[serde(default)]
+    author: Option<String>,
+    #[serde(default)]
+    key: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Lookup {
+    citations: Vec<Citation>,
+}
+
+pub(super) async fn lookup(client: &PubMed, args: &Value) -> Result<Value> {
+    let args: Lookup =
+        serde_json::from_value(args.clone()).context("invalid citation lookup arguments")?;
+    let (bdata, citations) = encode(&args.citations)?;
+    let mut params = vec![
+        ("db".into(), "pubmed".into()),
+        ("rettype".into(), "xml".into()),
+        ("bdata".into(), bdata),
+    ];
+    params.extend(client.ncbi_identity());
+    let body = client.ncbi_text("ecitmatch.cgi", params).await?;
+    citmatch_result(&body, &citations)
+}
+
+fn encode(citations: &[Citation]) -> Result<(String, Vec<Citation>)> {
+    if !(1..=25).contains(&citations.len()) {
+        bail!("provide 1 to 25 citations");
+    }
+    let mut encoded = Vec::new();
+    let mut prepared = Vec::new();
+    for (index, citation) in citations.iter().enumerate() {
+        let journal = citation.journal.trim();
+        if journal.is_empty() || journal.len() > 256 {
+            bail!("each citation needs a journal name");
+        }
+        let mut item = citation.clone();
+        if item
+            .key
+            .as_ref()
+            .map(|k| k.trim().is_empty())
+            .unwrap_or(true)
+        {
+            item.key = Some(format!("c{}", index + 1));
+        }
+        let year = year_field(&item.year)?;
+        let line = format!(
+            "{}|{}|{}|{}|{}|{}|",
+            plus(journal),
+            plus(&year),
+            plus(item.volume.as_deref().unwrap_or("")),
+            plus(item.first_page.as_deref().unwrap_or("")),
+            plus(item.author.as_deref().unwrap_or("")),
+            plus(item.key.as_deref().unwrap_or(""))
+        );
+        encoded.push(line);
+        prepared.push(item);
+    }
+    Ok((encoded.join("\r"), prepared))
+}
+
+fn year_field(value: &Option<Value>) -> Result<String> {
+    match value {
+        None => Ok(String::new()),
+        Some(Value::String(s)) => Ok(s.trim().to_string()),
+        Some(Value::Number(n)) => Ok(n.to_string()),
+        Some(_) => bail!("year must be an integer or string"),
+    }
+}
+
+fn plus(value: &str) -> String {
+    value.split_whitespace().collect::<Vec<_>>().join("+")
+}
+
+fn citmatch_result(body: &str, requested: &[Citation]) -> Result<Value> {
+    if body.trim().is_empty() {
+        bail!("NCBI ECitMatch returned an empty response");
+    }
+    if body.trim_start().starts_with('<') {
+        bail!("NCBI ECitMatch rejected the request");
+    }
+    let mut matched = Vec::new();
+    let mut unmatched = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for line in body.lines().map(str::trim).filter(|line| !line.is_empty()) {
+        let fields: Vec<&str> = line.split('|').collect();
+        if fields.len() < 7 {
+            bail!("NCBI ECitMatch returned a malformed citation line");
+        }
+        let key = fields[5].replace('+', " ");
+        let pmid = fields[6].trim();
+        let citation = requested
+            .iter()
+            .find(|item| item.key.as_deref() == Some(key.trim()))
+            .or_else(|| {
+                requested
+                    .iter()
+                    .find(|item| !seen.contains(item.key.as_deref().unwrap_or("")))
+            });
+        let Some(citation) = citation else {
+            continue;
+        };
+        seen.insert(citation.key.clone().unwrap_or_default());
+        let record = json!({
+            "key": citation.key,
+            "journal": citation.journal,
+            "year": year_field(&citation.year).ok(),
+            "volume": citation.volume,
+            "first_page": citation.first_page,
+            "author": citation.author,
+            "pmid": if is_pmid(pmid) { json!(pmid) } else { Value::Null },
+            "url": if is_pmid(pmid) {
+                json!(format!("https://pubmed.ncbi.nlm.nih.gov/{pmid}/"))
+            } else {
+                Value::Null
+            }
+        });
+        if is_pmid(pmid) {
+            matched.push(record);
+        } else {
+            let mut record = record;
+            record["reason"] = json!(if pmid.is_empty() { "not matched" } else { pmid });
+            unmatched.push(record);
+        }
+    }
+    for citation in requested {
+        if !seen.contains(citation.key.as_deref().unwrap_or("")) {
+            unmatched.push(json!({
+                "key": citation.key,
+                "journal": citation.journal,
+                "reason": "not matched"
+            }));
+        }
+    }
+    Ok(json!({
+        "source": "NCBI ECitMatch",
+        "source_url": SOURCE_URL,
+        "requested": requested.len(),
+        "matched": matched,
+        "unmatched": unmatched
+    }))
+}
+
+fn is_pmid(value: &str) -> bool {
+    super::require_pmid(value).is_ok()
+}
+
+#[cfg(test)]
+pub(super) fn encode_args(args: Value) -> Result<String> {
+    let args: Lookup = serde_json::from_value(args)?;
+    Ok(encode(&args.citations)?.0)
+}
+
+#[cfg(test)]
+pub(super) fn parse_body(body: &str, args: Value) -> Result<Value> {
+    let args: Lookup = serde_json::from_value(args)?;
+    let (_, citations) = encode(&args.citations)?;
+    citmatch_result(body, &citations)
+}

--- a/crates/wisp-bio/src/pubmed/europepmc.rs
+++ b/crates/wisp-bio/src/pubmed/europepmc.rs
@@ -1,0 +1,299 @@
+//! Europe PMC Articles REST. Official references (reviewed 2026-09-06):
+//! - https://europepmc.org/RestfulWebService (core metadata and `{PMCID}/fullTextXML`)
+//! - https://pmc.ncbi.nlm.nih.gov/tools/id-converter-api/ (embargo live / release-date)
+//! - https://pmc.ncbi.nlm.nih.gov/tools/oa-service/ (retired; never called)
+//!
+//! `get_copyright_status` mapping away from the retired PMC OA Web Service:
+//! - `copyright.statement` / `year` / `holder` were OA-service fields and are omitted.
+//!   A stated license is Europe PMC core `license` when present.
+//! - `license.type` / `url` from the OA service are not reproduced. The native
+//!   `license.name` is the Europe PMC `license` string.
+//! - Legacy `license.is_open_access` is `is_open_access` from Europe PMC
+//!   `isOpenAccess`. That flag is access, not a reuse grant.
+//! - `reuse_permission` is `unknown` unless a license string is present, in which
+//!   case it is `license_stated`. An OA boolean never becomes `reuse_granted`.
+//! - Metadata availability, accessible full text (`inEPMC`), and reuse are
+//!   separate fields. Converter `live` / `release-date` are embargo attributes.
+use super::{ids, json_flag, json_id, records, PubMed};
+use crate::http::EUROPE_PMC;
+use anyhow::{anyhow, bail, Context, Result};
+use reqwest::Method;
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+pub(super) const SEARCH_URL: &str = "https://www.ebi.ac.uk/europepmc/webservices/rest/search";
+pub(super) const REST_URL: &str = "https://www.ebi.ac.uk/europepmc/webservices/rest/";
+pub(super) const CONTRACT_NOTE: &str = "Open-access metadata is not a reuse grant. Copyright and license fields come from Europe PMC core metadata and PMC ID Converter embargo attributes; the retired PMC OA Web Service is not used.";
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FullText {
+    pmc_ids: Vec<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Copyright {
+    pmids: Vec<String>,
+}
+
+pub(super) async fn full_text(client: &PubMed, args: &Value) -> Result<Value> {
+    let args: FullText =
+        serde_json::from_value(args.clone()).context("invalid full-text arguments")?;
+    if !(1..=5).contains(&args.pmc_ids.len()) {
+        bail!("provide 1 to 5 PMCIDs");
+    }
+    let pmc_ids = args
+        .pmc_ids
+        .iter()
+        .map(|id| {
+            records::pmc_id(id)
+                .ok_or_else(|| anyhow!("PMCID values must be PMC followed by digits"))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let query = pmc_ids
+        .iter()
+        .map(|id| format!("PMCID:{id}"))
+        .collect::<Vec<_>>()
+        .join(" OR ");
+    let hits = epmc_hits(&search_core(client, &query, pmc_ids.len()).await?)?;
+    let mut by_id = std::collections::HashMap::new();
+    for hit in &hits {
+        if let Some(id) = json_id(&hit["pmcid"]).and_then(|value| records::pmc_id(&value)) {
+            by_id.insert(id, hit);
+        }
+    }
+    let mut records_out = Vec::new();
+    let mut not_found = Vec::new();
+    let mut not_open_access = Vec::new();
+    let mut xml_unavailable = Vec::new();
+    for pmcid in &pmc_ids {
+        let Some(hit) = by_id.get(pmcid) else {
+            not_found.push(pmcid.clone());
+            continue;
+        };
+        let pmid = json_id(&hit["pmid"]);
+        let doi = json_id(&hit["doi"]);
+        if json_flag(&hit["isOpenAccess"]) != Some(true) {
+            not_open_access.push(json!({
+                "pmcid": pmcid,
+                "pmid": pmid,
+                "doi": doi,
+                "is_open_access": false,
+                "in_europe_pmc": json_flag(&hit["inEPMC"]),
+                "detail": "article is not in the Europe PMC open-access full-text subset"
+            }));
+            continue;
+        }
+        let url = format!("{pmcid}/fullTextXML");
+        let response = client
+            .http
+            .send(
+                EUROPE_PMC,
+                Method::GET,
+                &format!("{}{url}", client.europepmc),
+                &[],
+            )
+            .await?;
+        match response.status.as_u16() {
+            200 => {
+                let Ok(text) = String::from_utf8(response.body) else {
+                    xml_unavailable.push(json!({
+                        "pmcid": pmcid,
+                        "detail": "full-text XML was not valid UTF-8"
+                    }));
+                    continue;
+                };
+                if text.trim().is_empty() {
+                    xml_unavailable.push(json!({
+                        "pmcid": pmcid,
+                        "detail": "Europe PMC returned empty full-text XML"
+                    }));
+                    continue;
+                }
+                match records::full_text(&text, pmcid) {
+                    Ok(extracted) => {
+                        let mut record = extracted;
+                        record["pmcid"] = json!(pmcid);
+                        record["pmid"] = json!(pmid);
+                        record["doi"] = json!(doi);
+                        record["availability"] = json!("open_access_xml");
+                        record["url"] = json!(format!(
+                            "https://www.ebi.ac.uk/europepmc/webservices/rest/{pmcid}/fullTextXML"
+                        ));
+                        record["europe_pmc_url"] = json!(format!(
+                            "https://europepmc.org/article/PMC/{}",
+                            pmcid.trim_start_matches("PMC")
+                        ));
+                        records_out.push(record);
+                    }
+                    Err(error) => xml_unavailable.push(json!({
+                        "pmcid": pmcid,
+                        "detail": error.to_string()
+                    })),
+                }
+            }
+            404 => xml_unavailable.push(json!({
+                "pmcid": pmcid,
+                "pmid": pmid,
+                "detail": "open-access metadata is present but full-text XML is unavailable"
+            })),
+            other => bail!("Europe PMC returned HTTP {other}"),
+        }
+    }
+    Ok(json!({
+        "source": "Europe PMC",
+        "source_url": REST_URL,
+        "requested": pmc_ids,
+        "returned": records_out.len(),
+        "records": records_out,
+        "not_found": not_found,
+        "not_open_access": not_open_access,
+        "xml_unavailable": xml_unavailable
+    }))
+}
+
+pub(super) async fn copyright(client: &PubMed, args: &Value) -> Result<Value> {
+    let args: Copyright =
+        serde_json::from_value(args.clone()).context("invalid copyright arguments")?;
+    super::validate_pmids(&args.pmids)?;
+    if args.pmids.len() > 50 {
+        bail!("provide 1 to 50 PMIDs");
+    }
+    // EXT_ID is not unique across Europe PMC sources; the documented unique
+    // MEDLINE lookup is EXT_ID:… AND SRC:MED. Without SRC:MED, a colliding
+    // PMC/AGR/PPR hit can fill the bounded page and drop the PubMed row.
+    let query = medline_pmid_query(&args.pmids);
+    let hits = epmc_hits(&search_core(client, &query, args.pmids.len()).await?)?;
+    let mut by_pmid = std::collections::HashMap::new();
+    for hit in &hits {
+        if !is_medline_hit(hit) {
+            continue;
+        }
+        if let Some(id) = json_id(&hit["pmid"]).or_else(|| json_id(&hit["id"])) {
+            by_pmid.insert(id, hit);
+        }
+    }
+    let converter = ids::convert(client, &json!({"ids": args.pmids, "id_type": "pmid"})).await?;
+    let mut embargo = std::collections::HashMap::new();
+    if let Some(records) = converter.get("records").and_then(Value::as_array) {
+        for record in records {
+            if let Some(pmid) = json_id(&record["pmid"]) {
+                embargo.insert(pmid, record);
+            }
+        }
+    }
+    let mut records_out = Vec::new();
+    let mut missing = Vec::new();
+    for pmid in &args.pmids {
+        let Some(hit) = by_pmid.get(pmid) else {
+            missing.push(pmid.clone());
+            continue;
+        };
+        let pmcid = json_id(&hit["pmcid"]).and_then(|value| records::pmc_id(&value));
+        let doi = json_id(&hit["doi"]);
+        let license_name = json_id(&hit["license"]).filter(|name| !name.is_empty());
+        let is_open_access = json_flag(&hit["isOpenAccess"]);
+        let full_text_accessible = json_flag(&hit["inEPMC"]);
+        let embargo_record = embargo.get(pmid);
+        let reuse_permission = if license_name.is_some() {
+            "license_stated"
+        } else {
+            "unknown"
+        };
+        records_out.push(json!({
+            "pmid": pmid,
+            "pmcid": pmcid,
+            "doi": doi,
+            "urls": {
+                "pubmed": format!("https://pubmed.ncbi.nlm.nih.gov/{pmid}/"),
+                "pmc": pmcid.as_ref().map(|id| format!("https://www.ncbi.nlm.nih.gov/pmc/articles/{id}/")),
+                "doi": doi.as_ref().map(|id| format!("https://doi.org/{id}")),
+                "europe_pmc": format!("https://europepmc.org/article/MED/{pmid}")
+            },
+            "metadata_available": true,
+            "full_text_accessible": full_text_accessible,
+            "is_open_access": is_open_access,
+            "reuse_permission": reuse_permission,
+            "license": license_name.as_ref().map(|name| json!({"name": name})),
+            "embargo": embargo_record.map(|record| json!({
+                "live": record.get("live"),
+                "release_date": record.get("release_date")
+            })),
+            "notice": "An open-access flag is not a reuse license."
+        }));
+    }
+    Ok(json!({
+        "source": "Europe PMC core metadata; NCBI PMC ID Converter embargo fields",
+        "sources": [
+            {"name": "Europe PMC", "url": SEARCH_URL},
+            {"name": "NCBI PMC ID Converter", "url": ids::SOURCE_URL}
+        ],
+        "contract_note": CONTRACT_NOTE,
+        "requested": args.pmids,
+        "returned": records_out.len(),
+        "records": records_out,
+        "missing_pmids": missing
+    }))
+}
+
+async fn search_core(client: &PubMed, query: &str, page_size: usize) -> Result<Value> {
+    let params = vec![
+        ("query".into(), query.into()),
+        ("resultType".into(), "core".into()),
+        ("format".into(), "json".into()),
+        ("pageSize".into(), page_size.max(1).to_string()),
+    ];
+    let value = client
+        .http
+        .send(
+            EUROPE_PMC,
+            Method::GET,
+            &format!("{}search", client.europepmc),
+            &params,
+        )
+        .await?
+        .json()?;
+    if value.get("error").is_some() || value.get("errMsg").is_some() || value.get("ERROR").is_some()
+    {
+        bail!("Europe PMC rejected the request");
+    }
+    Ok(value)
+}
+
+fn epmc_hits(raw: &Value) -> Result<Vec<Value>> {
+    match raw.get("resultList").and_then(|v| v.get("result")) {
+        None if is_zero_hits(raw) => Ok(Vec::new()),
+        Some(Value::Array(items)) => Ok(items.clone()),
+        Some(obj) if obj.is_object() => Ok(vec![obj.clone()]),
+        Some(_) => bail!("Europe PMC returned invalid search results"),
+        None => bail!("Europe PMC omitted search results"),
+    }
+}
+
+fn is_zero_hits(raw: &Value) -> bool {
+    match raw.get("hitCount") {
+        Some(Value::Number(n)) => n.as_u64() == Some(0),
+        Some(Value::String(s)) => s == "0",
+        _ => false,
+    }
+}
+
+fn medline_pmid_query(pmids: &[String]) -> String {
+    pmids
+        .iter()
+        .map(|id| format!("(EXT_ID:{id} AND SRC:MED)"))
+        .collect::<Vec<_>>()
+        .join(" OR ")
+}
+
+fn is_medline_hit(hit: &Value) -> bool {
+    hit.get("source")
+        .and_then(Value::as_str)
+        .is_some_and(|src| src.eq_ignore_ascii_case("MED"))
+}
+
+#[cfg(test)]
+pub(super) fn medline_query_for_test(pmids: &[String]) -> String {
+    medline_pmid_query(pmids)
+}

--- a/crates/wisp-bio/src/pubmed/ids.rs
+++ b/crates/wisp-bio/src/pubmed/ids.rs
@@ -1,0 +1,170 @@
+//! NCBI PMC ID Converter. Official reference (reviewed 2026-09-06):
+//! https://pmc.ncbi.nlm.nih.gov/tools/id-converter-api/
+use super::{json_flag, json_id, records, PubMed};
+use crate::http::PMC_IDCONV;
+use anyhow::{bail, Context, Result};
+use reqwest::Method;
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+pub(super) const SOURCE_URL: &str = "https://pmc.ncbi.nlm.nih.gov/tools/idconv/api/v1/articles/";
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Convert {
+    ids: Vec<String>,
+    #[serde(default = "default_id_type")]
+    id_type: String,
+}
+
+fn default_id_type() -> String {
+    "pmid".into()
+}
+
+pub(super) async fn convert(client: &PubMed, args: &Value) -> Result<Value> {
+    let args: Convert =
+        serde_json::from_value(args.clone()).context("invalid identifier conversion arguments")?;
+    let (id_type, ids) = convert_params(&args)?;
+    let mut params = vec![
+        ("ids".into(), ids.join(",")),
+        ("idtype".into(), id_type.clone()),
+        ("format".into(), "json".into()),
+        ("tool".into(), "wisp-science".into()),
+    ];
+    if let Some(email) = &client.email {
+        params.push(("email".into(), email.clone()));
+    }
+    let raw = client
+        .http
+        .send(PMC_IDCONV, Method::GET, &client.idconv, &params)
+        .await?
+        .json()?;
+    if raw.get("status").and_then(Value::as_str) == Some("error") || raw.get("error").is_some() {
+        bail!("PMC ID Converter rejected the request");
+    }
+    convert_result(&raw, &ids, &id_type)
+}
+
+fn convert_params(args: &Convert) -> Result<(String, Vec<String>)> {
+    let id_type = match args.id_type.as_str() {
+        "pmid" | "pmcid" | "doi" => args.id_type.clone(),
+        _ => bail!("id_type must be pmid, pmcid or doi"),
+    };
+    if !(1..=200).contains(&args.ids.len()) {
+        bail!("provide 1 to 200 identifiers of a single type");
+    }
+    let ids = args
+        .ids
+        .iter()
+        .map(|id| normalize_id(id, &id_type))
+        .collect::<Result<Vec<_>>>()?;
+    Ok((id_type, ids))
+}
+
+fn normalize_id(id: &str, id_type: &str) -> Result<String> {
+    let id = id.trim();
+    match id_type {
+        "pmid" => super::require_pmid(id).map(str::to_string),
+        "pmcid" => records::pmc_id(id)
+            .ok_or_else(|| anyhow::anyhow!("PMCID values must be PMC followed by digits")),
+        "doi" => {
+            if id.len() <= 256
+                && id.starts_with("10.")
+                && id.contains('/')
+                && !id.chars().any(char::is_whitespace)
+            {
+                Ok(id.to_string())
+            } else {
+                bail!("DOI values must start with 10. and contain a slash");
+            }
+        }
+        _ => bail!("id_type must be pmid, pmcid or doi"),
+    }
+}
+
+pub(super) fn convert_result(raw: &Value, requested: &[String], id_type: &str) -> Result<Value> {
+    let records_in = raw
+        .get("records")
+        .and_then(Value::as_array)
+        .context("PMC ID Converter omitted records")?;
+    let mut by_id = std::collections::HashMap::new();
+    for record in records_in {
+        if let Some(key) =
+            json_id(&record["requested-id"]).or_else(|| json_id(&record["requested_id"]))
+        {
+            by_id
+                .entry(normalize_match(&key, id_type))
+                .or_insert(record);
+        }
+    }
+    let mut records = Vec::new();
+    let mut missing = Vec::new();
+    let mut unconverted = Vec::new();
+    for id in requested {
+        let Some(record) = by_id.get(id).copied() else {
+            missing.push(id.clone());
+            continue;
+        };
+        if record.get("status").and_then(Value::as_str) == Some("error")
+            || record.get("errmsg").is_some()
+            || record.get("error").is_some()
+        {
+            unconverted.push(json!({
+                "requested_id": id,
+                "reason": record.get("errmsg").and_then(json_id)
+                    .or_else(|| record.get("error").and_then(json_id))
+                    .unwrap_or_else(|| "converter could not map this identifier".into())
+            }));
+            continue;
+        }
+        let pmid = json_id(&record["pmid"]);
+        let pmcid = json_id(&record["pmcid"]).and_then(|value| records::pmc_id(&value));
+        let doi = json_id(&record["doi"]);
+        if pmcid.is_none() {
+            unconverted.push(json!({
+                "requested_id": id,
+                "pmid": pmid,
+                "doi": doi,
+                "reason": "article is not in PubMed Central; the converter only maps PMC holdings"
+            }));
+            continue;
+        }
+        let pmcid = pmcid.unwrap();
+        let live = json_flag(&record["live"]);
+        let release_date =
+            json_id(&record["release-date"]).or_else(|| json_id(&record["release_date"]));
+        records.push(json!({
+            "requested_id": id,
+            "pmid": pmid,
+            "pmcid": pmcid,
+            "doi": doi,
+            "live": live,
+            "release_date": release_date,
+            "in_pmc": true,
+            "url": format!("https://www.ncbi.nlm.nih.gov/pmc/articles/{pmcid}/")
+        }));
+    }
+    Ok(json!({
+        "source": "NCBI PMC ID Converter",
+        "source_url": SOURCE_URL,
+        "id_type": id_type,
+        "requested": requested,
+        "returned": records.len(),
+        "records": records,
+        "missing_ids": missing,
+        "unconverted_ids": unconverted
+    }))
+}
+
+fn normalize_match(value: &str, id_type: &str) -> String {
+    match id_type {
+        "pmcid" => records::pmc_id(value).unwrap_or_else(|| value.to_string()),
+        _ => value.to_string(),
+    }
+}
+
+#[cfg(test)]
+pub(super) fn parse_args(args: Value) -> Result<(String, Vec<String>)> {
+    let args: Convert = serde_json::from_value(args)?;
+    convert_params(&args)
+}

--- a/crates/wisp-bio/src/pubmed/records.rs
+++ b/crates/wisp-bio/src/pubmed/records.rs
@@ -1,0 +1,56 @@
+//! JATS helpers for Europe PMC full-text XML. References: JATS
+//! (https://jats.nlm.nih.gov/). Examples in tests are synthetic.
+use crate::xml::{self, child, field, path, text};
+use anyhow::{bail, Context, Result};
+use serde_json::{json, Value};
+
+pub(super) fn pmc_id(value: &str) -> Option<String> {
+    let value = value.trim();
+    let number = value
+        .strip_prefix("PMC")
+        .or_else(|| value.strip_prefix("pmc"))
+        .unwrap_or(value);
+    (!number.is_empty()
+        && !number.starts_with('0')
+        && number.len() <= 12
+        && number.bytes().all(|b| b.is_ascii_digit()))
+    .then(|| format!("PMC{number}"))
+}
+
+pub(super) fn full_text(xml_text: &str, expected_id: &str) -> Result<Value> {
+    let doc = xml::parse(xml_text)?;
+    let root = doc.root_element();
+    if !root.has_tag_name("article") {
+        bail!("Europe PMC returned an unexpected article document");
+    }
+    let meta =
+        path(root, &["front", "article-meta"]).context("JATS article omitted its metadata")?;
+    for id in meta.children().filter(|n| n.has_tag_name("article-id")) {
+        if matches!(id.attribute("pub-id-type"), Some("pmc" | "pmcid")) {
+            if text(id).and_then(|s| pmc_id(&s)).as_deref() != Some(expected_id) {
+                bail!("Europe PMC full text does not match the requested PMCID");
+            }
+        }
+    }
+    let abstracts = meta
+        .children()
+        .filter(|n| n.has_tag_name("abstract"))
+        .collect::<Vec<_>>();
+    let abstract_node = abstracts
+        .iter()
+        .find(|n| n.attribute("abstract-type").is_none())
+        .or(abstracts.first());
+    let abstract_text = abstract_node.map(|n| xml::prose(*n, &["kwd-group"]));
+    let sections: Vec<_> = child(root, "body")
+        .into_iter()
+        .flat_map(|n| n.children())
+        .filter(|n| n.has_tag_name("sec") || n.has_tag_name("p"))
+        .map(|n| xml::prose(n, &["fig", "table-wrap", "ref-list"]))
+        .filter(|text| !text.is_empty())
+        .collect();
+    Ok(json!({
+        "title": field(meta, &["title-group", "article-title"]),
+        "abstract": abstract_text,
+        "full_text": sections.join("\n\n")
+    }))
+}

--- a/crates/wisp-bio/src/pubmed/related.rs
+++ b/crates/wisp-bio/src/pubmed/related.rs
@@ -1,0 +1,173 @@
+//! NCBI ELink related records. Official reference (reviewed 2026-09-06):
+//! https://www.ncbi.nlm.nih.gov/books/NBK25499/
+use super::{json_id, PubMed};
+use anyhow::{bail, Context, Result};
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+pub(super) const SOURCE_URL: &str = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/elink.fcgi";
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Related {
+    pmids: Vec<String>,
+    #[serde(default = "default_link")]
+    link_type: String,
+    #[serde(default = "default_limit")]
+    max_results: usize,
+}
+
+fn default_link() -> String {
+    "pubmed_pubmed".into()
+}
+
+fn default_limit() -> usize {
+    20
+}
+
+struct Spec {
+    link_name: &'static str,
+    db: &'static str,
+    cmd: &'static str,
+    max_results: usize,
+    pmids: Vec<String>,
+}
+
+pub(super) async fn find(client: &PubMed, args: &Value) -> Result<Value> {
+    let args: Related =
+        serde_json::from_value(args.clone()).context("invalid related-article arguments")?;
+    let spec = spec(&args)?;
+    let mut params = vec![
+        ("dbfrom".into(), "pubmed".into()),
+        ("db".into(), spec.db.into()),
+        ("linkname".into(), spec.link_name.into()),
+        ("cmd".into(), spec.cmd.into()),
+        ("id".into(), spec.pmids.join(",")),
+        ("retmode".into(), "json".into()),
+    ];
+    params.extend(client.ncbi_identity());
+    let raw = client.ncbi_json("elink.fcgi", params).await?;
+    related_result(&raw, &spec)
+}
+
+fn spec(args: &Related) -> Result<Spec> {
+    super::validate_pmids(&args.pmids)?;
+    if args.pmids.len() > 20 {
+        bail!("provide 1 to 20 PMIDs");
+    }
+    if !(1..=200).contains(&args.max_results) {
+        bail!("max_results must be 1 to 200");
+    }
+    let (link_name, db, cmd) = match args.link_type.as_str() {
+        "pubmed_pubmed" => ("pubmed_pubmed", "pubmed", "neighbor_score"),
+        "pubmed_pmc" => ("pubmed_pmc", "pmc", "neighbor"),
+        "pubmed_gene" => ("pubmed_gene", "gene", "neighbor"),
+        "pubmed_protein" => ("pubmed_protein", "protein", "neighbor"),
+        "pubmed_nucleotide" => ("pubmed_nucleotide", "nuccore", "neighbor"),
+        _ => bail!(
+            "link_type must be pubmed_pubmed, pubmed_pmc, pubmed_gene, pubmed_protein or pubmed_nucleotide"
+        ),
+    };
+    Ok(Spec {
+        link_name,
+        db,
+        cmd,
+        max_results: args.max_results,
+        pmids: args.pmids.clone(),
+    })
+}
+
+fn related_result(raw: &Value, spec: &Spec) -> Result<Value> {
+    let linksets = raw
+        .get("linksets")
+        .and_then(Value::as_array)
+        .context("NCBI ELink omitted linksets")?;
+    if linksets
+        .iter()
+        .any(|set| set.get("ERROR").is_some() || set.get("error").is_some())
+    {
+        bail!("NCBI ELink rejected the request");
+    }
+    let mut links = Vec::new();
+    for set in linksets {
+        let dbs = set
+            .get("linksetdbs")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        let matched = dbs
+            .iter()
+            .find(|db| db.get("linkname").and_then(Value::as_str) == Some(spec.link_name));
+        let Some(db) = matched.or_else(|| dbs.first()) else {
+            continue;
+        };
+        let Some(entries) = db.get("links").and_then(Value::as_array) else {
+            continue;
+        };
+        for entry in entries {
+            let (id, score) = match entry {
+                Value::String(id) => (Some(id.clone()), None),
+                Value::Number(n) => (Some(n.to_string()), None),
+                Value::Object(obj) => (
+                    obj.get("id").and_then(json_id),
+                    obj.get("score").and_then(json_id),
+                ),
+                _ => (None, None),
+            };
+            let Some(id) = id.filter(|id| !id.is_empty()) else {
+                continue;
+            };
+            links.push((id, score));
+        }
+    }
+    let has_more = links.len() > spec.max_results;
+    links.truncate(spec.max_results);
+    let records: Vec<Value> = links
+        .into_iter()
+        .map(|(id, score)| {
+            json!({
+                "id": id,
+                "score": score,
+                "url": record_url(spec.db, &id)
+            })
+        })
+        .collect();
+    Ok(json!({
+        "source": "NCBI ELink",
+        "source_url": SOURCE_URL,
+        "link_name": spec.link_name,
+        "dbfrom": "pubmed",
+        "dbto": spec.db,
+        "requested_pmids": spec.pmids,
+        "returned": records.len(),
+        "has_more": has_more,
+        "ranking": "upstream_elink_order",
+        "records": records
+    }))
+}
+
+fn record_url(db: &str, id: &str) -> String {
+    match db {
+        "pubmed" => format!("https://pubmed.ncbi.nlm.nih.gov/{id}/"),
+        "pmc" => {
+            let pmcid = super::records::pmc_id(id).unwrap_or_else(|| format!("PMC{id}"));
+            format!("https://www.ncbi.nlm.nih.gov/pmc/articles/{pmcid}/")
+        }
+        "gene" => format!("https://www.ncbi.nlm.nih.gov/gene/{id}"),
+        "protein" => format!("https://www.ncbi.nlm.nih.gov/protein/{id}"),
+        _ => format!("https://www.ncbi.nlm.nih.gov/nuccore/{id}"),
+    }
+}
+
+#[cfg(test)]
+pub(super) fn parse_spec(args: Value) -> Result<(String, usize, Vec<String>)> {
+    let args: Related = serde_json::from_value(args)?;
+    let spec = spec(&args)?;
+    Ok((spec.link_name.into(), spec.max_results, spec.pmids))
+}
+
+#[cfg(test)]
+pub(super) fn parse_related(raw: &Value, args: Value) -> Result<Value> {
+    let args: Related = serde_json::from_value(args)?;
+    related_result(raw, &spec(&args)?)
+}

--- a/crates/wisp-bio/src/pubmed/tests.rs
+++ b/crates/wisp-bio/src/pubmed/tests.rs
@@ -1,0 +1,780 @@
+use super::*;
+use crate::http::{Http, MAX_RESPONSE};
+use axum::{
+    extract::{Path, Query},
+    http::{StatusCode, Uri},
+    response::IntoResponse,
+    routing::{get, post},
+    Router,
+};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex as StdMutex};
+
+#[test]
+fn validates_queries_and_upstream_retrieval_boundary() {
+    for args in [
+        json!({"query": " "}),
+        json!({"query": "x", "max_results": 0}),
+        json!({"query": "x", "max_results": 201}),
+        json!({"query": "x", "retstart": 9999, "max_results": 2}),
+        json!({"query": "x", "date_from": "2024"}),
+        json!({"query": "x", "date_from": "2023/02/29", "date_to": "2024/01/01"}),
+        json!({"query": "x", "sort": "invalid"}),
+    ] {
+        let search: Search = serde_json::from_value(args).unwrap();
+        assert!(search.params().is_err());
+    }
+    assert!(serde_json::from_value::<Search>(json!({"query": "x", "api_key": "secret"})).is_err());
+    let search: Search = serde_json::from_value(json!({
+        "query": "gene[Title] & study", "retstart": 9999, "max_results": 1,
+        "sort": "author", "date_from": "2024/02/29", "date_to": "2024/03/01"
+    }))
+    .unwrap();
+    let params = search.params().unwrap();
+    assert!(params.contains(&("sort".into(), "Author".into())));
+    assert!(params.contains(&("term".into(), "gene[Title] & study".into())));
+    let result = search_result(
+        &json!({"esearchresult": {
+            "count": "12000", "idlist": ["123"]
+        }}),
+        &search,
+    )
+    .unwrap();
+    assert_eq!(result["total"], 12000);
+    assert_eq!(result["has_more"], true);
+    assert_eq!(result["next_retstart"], Value::Null);
+}
+
+#[test]
+fn distinguishes_empty_results_from_malformed_or_rejected_responses() {
+    let search: Search = serde_json::from_value(json!({"query": "fictional query"})).unwrap();
+    let result = search_result(
+        &json!({"esearchresult": {
+            "count": "0", "idlist": []
+        }}),
+        &search,
+    )
+    .unwrap();
+    assert_eq!(result["returned"], 0);
+    assert_eq!(result["has_more"], false);
+    for raw in [
+        json!({}),
+        json!({"esearchresult": {"count": "unknown", "idlist": []}}),
+        json!({"esearchresult": {"count": "0", "idlist": ["123"]}}),
+        json!({"esearchresult": {"count": "3", "idlist": []}}),
+        json!({"esearchresult": {"count": "0", "idlist": [], "errorlist": {"fieldsnotfound": ["oops"]}}}),
+    ] {
+        assert!(search_result(&raw, &search).is_err());
+    }
+}
+
+#[test]
+fn summaries_preserve_requested_order_duplicates_and_missing_ids() {
+    let ids = vec!["123".into(), "456".into(), "123".into()];
+    let result = summary_result(
+        &json!({"result": {
+        "uids": ["123"], "123": {"uid": "123", "title": "Synthetic citation", "articleids": [{"idtype": "doi", "value": "10.example/synthetic"}]}
+    }}),
+        &ids,
+    )
+    .unwrap();
+    assert_eq!(result["returned"], 2);
+    assert_eq!(result["missing_pmids"], json!(["456"]));
+    assert_eq!(result["records"][0], result["records"][1]);
+    assert_eq!(
+        result["records"][0]["url"],
+        "https://pubmed.ncbi.nlm.nih.gov/123/"
+    );
+    assert!(summary_result(&json!({"result": {}}), &ids).is_err());
+    assert!(summary_result(
+        &json!({"result": {"uids": ["123"], "123": {"uid": "456"}}}),
+        &ids
+    )
+    .is_err());
+    for ids in [
+        vec![],
+        vec!["123&api_key=oops".into()],
+        vec!["0".into()],
+        vec!["1".into(); 201],
+    ] {
+        assert!(validate_pmids(&ids).is_err());
+    }
+}
+
+fn test_client(base: &str) -> PubMed {
+    let mut client = PubMed::new(&[
+        ("NCBI_API_KEY".into(), "synthetic-key&value".into()),
+        ("NCBI_EMAIL".into(), "operator@example.test".into()),
+    ])
+    .unwrap();
+    client.ncbi = base.to_string();
+    client.idconv = format!("{base}idconv");
+    client.europepmc = base.to_string();
+    client.http = Http(reqwest::Client::builder().no_proxy().build().unwrap());
+    client
+}
+
+async fn mock(
+    status: StatusCode,
+    body: String,
+) -> (PubMed, Arc<StdMutex<String>>, tokio::task::JoinHandle<()>) {
+    let captured = Arc::new(StdMutex::new(String::new()));
+    let request_body = captured.clone();
+    let app = Router::new().route(
+        "/esearch.fcgi",
+        post(move |body_in: String| {
+            *request_body.lock().unwrap() = body_in;
+            let body = body.clone();
+            async move { (status, [("retry-after", "60")], body).into_response() }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let endpoint = format!("http://{}/", listener.local_addr().unwrap());
+    let task = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    (test_client(&endpoint), captured, task)
+}
+
+#[tokio::test]
+async fn http_contract_encodes_queries_and_credentials_without_python() {
+    let (client, captured, server) = mock(
+        StatusCode::OK,
+        json!({
+            "esearchresult": {"count": "3", "idlist": ["123"], "querytranslation": "synthetic"}
+        })
+        .to_string(),
+    )
+    .await;
+    let result = client
+        .call(
+            "search_articles",
+            &json!({
+                "query": "gene[Title] & study", "max_results": 1
+            }),
+        )
+        .await
+        .unwrap();
+    server.abort();
+    assert_eq!(result["next_retstart"], 1);
+    let body = captured.lock().unwrap();
+    assert!(body.contains("term=gene%5BTitle%5D+%26+study"));
+    assert!(body.contains("api_key=synthetic-key%26value"));
+    assert!(body.contains("email=operator%40example.test"));
+    assert!(body.contains("tool=wisp-science"));
+    assert!(!result.to_string().contains("synthetic-key"));
+}
+
+#[tokio::test]
+async fn rejects_upstream_errors_and_oversized_responses_without_echoing_secrets() {
+    for (status, body, expected) in [
+        (
+            StatusCode::TOO_MANY_REQUESTS,
+            "synthetic-key".into(),
+            "HTTP 429",
+        ),
+        (
+            StatusCode::OK,
+            json!({"error": "invalid api_key synthetic-key"}).to_string(),
+            "rejected",
+        ),
+        (
+            StatusCode::OK,
+            " ".repeat(MAX_RESPONSE + 1),
+            "exceeded 4 MiB",
+        ),
+    ] {
+        let (client, _, server) = mock(status, body).await;
+        let error = client
+            .call("search_articles", &json!({"query": "synthetic"}))
+            .await
+            .unwrap_err()
+            .to_string();
+        server.abort();
+        assert!(error.contains(expected), "{error}");
+        assert!(!error.contains("synthetic-key"));
+    }
+}
+
+#[test]
+fn catalog_uses_deferred_read_only_tools() {
+    let expected = [
+        "search_articles",
+        "get_article_metadata",
+        "convert_article_ids",
+        "find_related_articles",
+        "lookup_article_by_citation",
+        "get_full_text_article",
+        "get_copyright_status",
+    ];
+    let catalog: Vec<_> = crate::catalog()
+        .into_iter()
+        .map(|(domain, schema)| (domain, schema.function.name))
+        .collect();
+    assert_eq!(
+        catalog,
+        expected
+            .iter()
+            .map(|name| ("pubmed", (*name).to_string()))
+            .collect::<Vec<_>>()
+    );
+    let tools = crate::tools(Arc::new(PubMed::new(&[]).unwrap()));
+    let mut names = std::collections::HashSet::new();
+    for tool in tools {
+        assert!(tool.defer_schema());
+        assert!(tool.read_only());
+        assert!(names.insert(tool.name().to_string()));
+        assert_eq!(tool.name(), tool.schema().function.name);
+    }
+    assert_eq!(names.len(), 7);
+}
+
+#[test]
+fn abstracts_handle_inline_markup_entities_sections_and_book_records() {
+    let xml = br#"<?xml version="1.0"?><PubmedArticleSet>
+      <PubmedArticle><MedlineCitation><PMID>123</PMID><Article><Abstract>
+        <AbstractText>One <i>synthetic</i> study &amp; &#945;.</AbstractText>
+        <AbstractText>Second section.</AbstractText>
+      </Abstract></Article></MedlineCitation><PubmedData><ReferenceList><Reference><ArticleIdList><PMID>999</PMID></ArticleIdList></Reference></ReferenceList></PubmedData></PubmedArticle>
+      <PubmedBookArticle><BookDocument><PMID>456</PMID><Abstract><AbstractText><![CDATA[A < B]]></AbstractText></Abstract></BookDocument></PubmedBookArticle>
+      <PubmedArticle><MedlineCitation><PMID>789</PMID><Article /></MedlineCitation></PubmedArticle>
+    </PubmedArticleSet>"#;
+    let records = parse_abstracts(xml).unwrap();
+    assert_eq!(records["123"], "One synthetic study & α.\nSecond section.");
+    assert_eq!(records["456"], "A < B");
+    assert_eq!(records["789"], "");
+    assert!(!records.contains_key("999"));
+    for xml in [
+        b"<eFetchResult><ERROR>failure</ERROR></eFetchResult>".as_slice(),
+        b"<PubmedArticleSet><PubmedArticle>",
+        b"<PubmedArticleSet><PubmedArticle /></wrong>",
+        b"<PubmedArticleSet/><OtherRoot/>",
+        b"<PubmedArticleSet/>unexpected text",
+    ] {
+        assert!(
+            parse_abstracts(xml).is_err(),
+            "{}",
+            String::from_utf8_lossy(xml)
+        );
+    }
+    assert!(parse_abstracts(b"<PubmedArticleSet />").unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn metadata_combines_citations_and_abstracts_without_a_live_upstream() {
+    let app = Router::new()
+        .route("/esummary.fcgi", post(|| async { axum::Json(json!({"result": {
+            "uids": ["123"], "123": {"uid": "123", "title": "Invented study"}
+        }})) }))
+        .route("/efetch.fcgi", post(|| async {
+            "<PubmedArticleSet><PubmedArticle><MedlineCitation><PMID>123</PMID><Article><Abstract><AbstractText>Invented abstract.</AbstractText></Abstract></Article></MedlineCitation></PubmedArticle></PubmedArticleSet>"
+        }));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let endpoint = format!("http://{}/", listener.local_addr().unwrap());
+    let client = test_client(&endpoint);
+    let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    let result = client
+        .call("get_article_metadata", &json!({"pmids": ["123", "456"]}))
+        .await
+        .unwrap();
+    server.abort();
+    assert_eq!(result["records"][0]["summary"]["title"], "Invented study");
+    assert_eq!(result["records"][0]["abstract"], "Invented abstract.");
+    assert_eq!(result["missing_pmids"], json!(["456"]));
+    assert_eq!(result["metadata_level"], "citation_and_abstract");
+}
+
+#[test]
+fn convert_encodes_same_type_batches_and_reports_missing_embargoed_and_unconverted() {
+    assert!(ids::parse_args(json!({"ids": ["1", "PMC2"], "id_type": "pmid"})).is_err());
+    assert!(ids::parse_args(json!({"ids": ["10.example/synthetic"], "id_type": "pmid"})).is_err());
+    assert!(
+        ids::parse_args(json!({"ids": (1..=201).map(|n| n.to_string()).collect::<Vec<_>>()}))
+            .is_err()
+    );
+    let (id_type, ids) =
+        ids::parse_args(json!({"ids": ["3531190", "PMC555"], "id_type": "pmcid"})).unwrap();
+    assert_eq!(id_type, "pmcid");
+    assert_eq!(ids, vec!["PMC3531190", "PMC555"]);
+    let result = ids::convert_result(
+        &json!({"status": "ok", "records": [
+            {"requested-id": "1", "pmid": 1, "pmcid": "PMC555", "doi": "10.example/synthetic", "live": false, "release-date": "2027-03-04"},
+            {"requested-id": "3", "pmid": "3", "status": "error", "errmsg": "invalid article id"},
+            {"requested-id": "4", "pmid": "4"}
+        ]}),
+        &["1".into(), "2".into(), "3".into(), "4".into()],
+        "pmid",
+    )
+    .unwrap();
+    assert_eq!(result["source"], "NCBI PMC ID Converter");
+    assert_eq!(result["source_url"], ids::SOURCE_URL);
+    assert!(!result["source_url"]
+        .as_str()
+        .unwrap()
+        .contains("oa-service"));
+    assert!(!result["source_url"].as_str().unwrap().contains("oa.fcgi"));
+    assert_eq!(result["records"][0]["pmcid"], "PMC555");
+    assert_eq!(result["records"][0]["live"], false);
+    assert_eq!(result["records"][0]["release_date"], "2027-03-04");
+    assert_eq!(result["missing_ids"], json!(["2"]));
+    assert_eq!(result["unconverted_ids"][0]["requested_id"], "3");
+    assert_eq!(result["unconverted_ids"][1]["requested_id"], "4");
+    assert!(result["unconverted_ids"][1]["reason"]
+        .as_str()
+        .unwrap()
+        .contains("not in PubMed Central"));
+}
+
+#[test]
+fn elink_preserves_upstream_ranking_and_bounds_the_page() {
+    assert!(
+        related::parse_spec(json!({"pmids": ["1"], "link_type": "pubmed_pubmed_citedin"})).is_err()
+    );
+    let result = related::parse_related(
+        &json!({"linksets": [{"dbfrom": "pubmed", "ids": [10], "linksetdbs": [{
+            "dbto": "pubmed", "linkname": "pubmed_pubmed", "links": [
+                {"id": "301", "score": "9"},
+                {"id": 302, "score": 8},
+                {"id": "303", "score": "1"}
+            ]
+        }]}]}),
+        json!({"pmids": ["10"], "max_results": 2}),
+    )
+    .unwrap();
+    assert_eq!(result["ranking"], "upstream_elink_order");
+    assert_eq!(result["has_more"], true);
+    assert_eq!(
+        result["records"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|record| record["id"].as_str().unwrap())
+            .collect::<Vec<_>>(),
+        vec!["301", "302"]
+    );
+    assert_eq!(result["records"][0]["score"], "9");
+    assert!(related::parse_related(
+        &json!({"linksets": [{"ERROR": "invalid uid"}]}),
+        json!({"pmids": ["10"]})
+    )
+    .is_err());
+}
+
+#[test]
+fn citmatch_encodes_documented_pipes_and_splits_matched_from_unmatched() {
+    let encoded = citations::encode_args(json!({"citations": [
+        {"journal": "proc natl acad sci u s a", "year": 1991, "volume": "88", "first_page": "3248", "author": "mann bj", "key": "Art1"},
+        {"journal": "science", "year": "1987", "first_page": "182"}
+    ]}))
+    .unwrap();
+    assert_eq!(
+        encoded,
+        "proc+natl+acad+sci+u+s+a|1991|88|3248|mann+bj|Art1|\rscience|1987||182||c2|"
+    );
+    let result = citations::parse_body(
+        "proc+natl+acad+sci+u+s+a|1991|88|3248|mann+bj|Art1|20142531\nscience|1987||182||c2|NOT_FOUND\n",
+        json!({"citations": [
+            {"journal": "proc natl acad sci u s a", "year": 1991, "volume": "88", "first_page": "3248", "author": "mann bj", "key": "Art1"},
+            {"journal": "science", "year": "1987", "first_page": "182"}
+        ]}),
+    )
+    .unwrap();
+    assert_eq!(result["matched"][0]["pmid"], "20142531");
+    assert_eq!(result["unmatched"][0]["key"], "c2");
+    assert!(citations::parse_body(
+        "<eLinkResult/>",
+        json!({"citations": [{"journal": "Nature"}]})
+    )
+    .is_err());
+}
+
+#[tokio::test]
+async fn convert_dispatches_through_the_id_converter_without_python_or_oa_service() {
+    let captured = Arc::new(StdMutex::new(Vec::<String>::new()));
+    let seen = captured.clone();
+    let app = Router::new().route(
+        "/idconv",
+        get(move |uri: Uri| {
+            seen.lock().unwrap().push(uri.to_string());
+            async move {
+                axum::Json(json!({
+                    "status": "ok",
+                    "records": [
+                        {"requested-id": "1", "pmid": "1", "pmcid": "PMC555", "live": true},
+                        {"requested-id": "2", "pmid": "2"}
+                    ]
+                }))
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let endpoint = format!("http://{}/", listener.local_addr().unwrap());
+    let client = test_client(&endpoint);
+    let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    let result = client
+        .call(
+            "convert_article_ids",
+            &json!({"ids": ["1", "2", "3"], "id_type": "pmid"}),
+        )
+        .await
+        .unwrap();
+    server.abort();
+    let urls = captured.lock().unwrap().join(" ");
+    assert!(urls.contains("ids=1%2C2"));
+    assert!(urls.contains("idtype=pmid"));
+    assert!(urls.contains("format=json"));
+    assert!(urls.contains("email=operator%40example.test"));
+    assert!(!urls.contains("api_key"));
+    assert!(!urls.contains("oa.fcgi"));
+    assert!(!urls.contains("oa-service"));
+    assert_eq!(result["records"][0]["pmcid"], "PMC555");
+    assert_eq!(result["unconverted_ids"][0]["requested_id"], "2");
+    assert_eq!(result["missing_ids"], json!(["3"]));
+    assert!(!result.to_string().contains("synthetic-key"));
+}
+
+#[tokio::test]
+async fn related_articles_dispatch_preserves_elink_order() {
+    let captured = Arc::new(StdMutex::new(String::new()));
+    let body = captured.clone();
+    let app = Router::new().route(
+        "/elink.fcgi",
+        post(move |request: String| {
+            *body.lock().unwrap() = request;
+            async move {
+                axum::Json(
+                    json!({"linksets": [{"dbfrom": "pubmed", "ids": ["10"], "linksetdbs": [{
+                        "dbto": "pubmed", "linkname": "pubmed_pubmed",
+                        "links": [{"id": "301", "score": "20"}, {"id": "302", "score": "10"}]
+                    }]}]}),
+                )
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let client = test_client(&format!("http://{}/", listener.local_addr().unwrap()));
+    let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    let result = client
+        .call(
+            "find_related_articles",
+            &json!({"pmids": ["10"], "link_type": "pubmed_pubmed", "max_results": 1}),
+        )
+        .await
+        .unwrap();
+    server.abort();
+    let request = captured.lock().unwrap().clone();
+    assert!(request.contains("linkname=pubmed_pubmed"));
+    assert!(request.contains("cmd=neighbor_score"));
+    assert!(request.contains("id=10"));
+    assert_eq!(result["records"][0]["id"], "301");
+    assert_eq!(result["returned"], 1);
+    assert_eq!(result["has_more"], true);
+}
+
+#[tokio::test]
+async fn citation_lookup_dispatch_reports_matched_and_unmatched() {
+    let app = Router::new().route(
+        "/ecitmatch.cgi",
+        post(|body: String| async move {
+            assert!(body.contains("bdata=nature%7C2020%7C580%7C123%7Csmith%7Ck1%7C"));
+            "nature|2020|580|123|smith|k1|999\nlancet|2021||||k2|NOT_FOUND\n"
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let client = test_client(&format!("http://{}/", listener.local_addr().unwrap()));
+    let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    let result = client
+        .call(
+            "lookup_article_by_citation",
+            &json!({"citations": [
+                {"journal": "nature", "year": 2020, "volume": "580", "first_page": "123", "author": "smith", "key": "k1"},
+                {"journal": "lancet", "year": 2021, "key": "k2"}
+            ]}),
+        )
+        .await
+        .unwrap();
+    server.abort();
+    assert_eq!(result["matched"][0]["pmid"], "999");
+    assert_eq!(result["unmatched"][0]["key"], "k2");
+    assert_eq!(result["source"], "NCBI ECitMatch");
+}
+
+#[tokio::test]
+async fn full_text_dispatch_distinguishes_not_found_not_oa_and_xml_unavailable() {
+    const JATS: &str = r#"<article><front><article-meta>
+        <article-id pub-id-type="pmcid">PMC555</article-id>
+        <title-group><article-title>Invented OA article</article-title></title-group>
+        <abstract><p>Invented abstract.</p></abstract>
+      </article-meta></front>
+      <body><sec><title>Intro</title><p>Invented body text.</p></sec></body></article>"#;
+    let app = Router::new()
+        .route(
+            "/search",
+            get(|Query(params): Query<HashMap<String, String>>| async move {
+                assert_eq!(params.get("resultType").map(String::as_str), Some("core"));
+                assert_eq!(params.get("format").map(String::as_str), Some("json"));
+                axum::Json(json!({
+                    "hitCount": 3,
+                    "resultList": {"result": [
+                        {"pmcid": "PMC555", "pmid": "1", "isOpenAccess": "Y", "inEPMC": "Y", "title": "Invented OA article"},
+                        {"pmcid": "PMC556", "pmid": "2", "isOpenAccess": "N", "inEPMC": "Y"},
+                        {"pmcid": "PMC557", "pmid": "3", "isOpenAccess": "Y", "inEPMC": "Y"}
+                    ]}
+                }))
+            }),
+        )
+        .route(
+            "/{id}/fullTextXML",
+            get(|Path(id): Path<String>| async move {
+                match id.as_str() {
+                    "PMC555" => JATS.to_string().into_response(),
+                    "PMC557" => StatusCode::NOT_FOUND.into_response(),
+                    other => panic!("unexpected PMCID {other}"),
+                }
+            }),
+        );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let client = test_client(&format!("http://{}/", listener.local_addr().unwrap()));
+    let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    let result = client
+        .call(
+            "get_full_text_article",
+            &json!({"pmc_ids": ["PMC555", "PMC556", "PMC557", "PMC558"]}),
+        )
+        .await
+        .unwrap();
+    server.abort();
+    assert_eq!(result["records"][0]["pmcid"], "PMC555");
+    assert!(result["records"][0]["full_text"]
+        .as_str()
+        .unwrap()
+        .contains("Invented body text"));
+    assert_eq!(result["not_open_access"][0]["pmcid"], "PMC556");
+    assert_eq!(result["xml_unavailable"][0]["pmcid"], "PMC557");
+    assert_eq!(result["not_found"], json!(["PMC558"]));
+    assert_ne!(result["records"].as_array().unwrap().len(), 0);
+}
+
+#[tokio::test]
+async fn copyright_dispatch_keeps_oa_flag_distinct_from_reuse_and_skips_retired_oa_service() {
+    let captured = Arc::new(StdMutex::new(Vec::<String>::new()));
+    let seen = captured.clone();
+    let app = Router::new()
+        .route(
+            "/search",
+            get({
+                let seen = seen.clone();
+                move |uri: Uri| {
+                    seen.lock().unwrap().push(uri.to_string());
+                    async move {
+                        axum::Json(json!({
+                            "hitCount": 2,
+                            "resultList": {"result": [
+                                {"source": "MED", "pmid": "1", "pmcid": "PMC555", "isOpenAccess": "Y", "inEPMC": "Y", "license": "cc by", "doi": "10.example/synthetic"},
+                                {"source": "MED", "pmid": "2", "pmcid": "PMC556", "isOpenAccess": "Y", "inEPMC": "N"}
+                            ]}
+                        }))
+                    }
+                }
+            }),
+        )
+        .route(
+            "/idconv",
+            get({
+                let seen = seen.clone();
+                move |uri: Uri| {
+                    seen.lock().unwrap().push(uri.to_string());
+                    async move {
+                        axum::Json(json!({
+                            "status": "ok",
+                            "records": [
+                                {"requested-id": "1", "pmid": "1", "pmcid": "PMC555", "live": false, "release-date": "2027-01-01"},
+                                {"requested-id": "2", "pmid": "2", "pmcid": "PMC556", "live": true}
+                            ]
+                        }))
+                    }
+                }
+            }),
+        );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let client = test_client(&format!("http://{}/", listener.local_addr().unwrap()));
+    let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    let result = client
+        .call("get_copyright_status", &json!({"pmids": ["1", "2", "3"]}))
+        .await
+        .unwrap();
+    server.abort();
+    let urls = captured.lock().unwrap().join(" ");
+    assert!(urls.contains("/search"));
+    assert!(urls.contains("SRC%3AMED") || urls.contains("SRC:MED"));
+    assert!(urls.contains("/idconv"));
+    assert!(!urls.contains("oa.fcgi"));
+    assert!(!urls.contains("oa-service"));
+    assert!(!urls.contains("pmc/utils/oa"));
+    assert!(result["contract_note"]
+        .as_str()
+        .unwrap()
+        .contains("not a reuse grant"));
+    assert_eq!(result["records"][0]["is_open_access"], true);
+    assert_eq!(result["records"][0]["reuse_permission"], "license_stated");
+    assert_eq!(result["records"][0]["embargo"]["live"], false);
+    assert_eq!(result["records"][1]["is_open_access"], true);
+    assert_eq!(result["records"][1]["full_text_accessible"], false);
+    assert_eq!(result["records"][1]["reuse_permission"], "unknown");
+    assert!(result["records"][1].get("reuse_granted").is_none());
+    assert_eq!(result["missing_pmids"], json!(["3"]));
+    assert!(!result.to_string().contains("synthetic-key"));
+}
+
+#[test]
+fn copyright_medline_query_uses_documented_unique_ext_id_form() {
+    assert_eq!(
+        europepmc::medline_query_for_test(&["526631".into(), "2".into()]),
+        "(EXT_ID:526631 AND SRC:MED) OR (EXT_ID:2 AND SRC:MED)"
+    );
+}
+
+#[tokio::test]
+async fn copyright_scopes_pmids_to_medline_so_colliding_sources_do_not_consume_the_page() {
+    let captured = Arc::new(StdMutex::new(String::new()));
+    let seen = captured.clone();
+    let app = Router::new()
+        .route(
+            "/search",
+            get({
+                let seen = seen.clone();
+                move |Query(params): Query<HashMap<String, String>>| {
+                    let query = params.get("query").cloned().unwrap_or_default();
+                    *seen.lock().unwrap() = query.clone();
+                    let page_size = params.get("pageSize").cloned().unwrap_or_default();
+                    async move {
+                        // A bare EXT_ID matches MEDLINE and PMC. With pageSize equal
+                        // to the PMID count, the PMC hit would occupy the only slot.
+                        let scoped = query.contains("SRC:MED") && query.contains("EXT_ID:526631");
+                        let results = if scoped {
+                            json!([{
+                                "source": "MED",
+                                "id": "526631",
+                                "pmid": "526631",
+                                "pmcid": "PMC999",
+                                "isOpenAccess": "Y",
+                                "inEPMC": "Y",
+                                "license": "cc by"
+                            }])
+                        } else {
+                            json!([{
+                                "source": "PMC",
+                                "id": "526631",
+                                "pmcid": "PMC526631",
+                                "isOpenAccess": "N"
+                            }])
+                        };
+                        (
+                            [("x-page-size", page_size)],
+                            axum::Json(json!({
+                                "hitCount": 2,
+                                "resultList": {"result": results}
+                            })),
+                        )
+                    }
+                }
+            }),
+        )
+        .route(
+            "/idconv",
+            get(|| async {
+                axum::Json(json!({
+                    "status": "ok",
+                    "records": [{
+                        "requested-id": "526631",
+                        "pmid": "526631",
+                        "pmcid": "PMC999",
+                        "live": true
+                    }]
+                }))
+            }),
+        );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let client = test_client(&format!("http://{}/", listener.local_addr().unwrap()));
+    let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    let result = client
+        .call("get_copyright_status", &json!({"pmids": ["526631"]}))
+        .await
+        .unwrap();
+    server.abort();
+    let query = captured.lock().unwrap().clone();
+    assert!(
+        query.contains("(EXT_ID:526631 AND SRC:MED)"),
+        "copyright lookup must use the unique MEDLINE form, got {query}"
+    );
+    assert_eq!(result["missing_pmids"], json!([]));
+    assert_eq!(result["records"][0]["pmid"], "526631");
+    assert_eq!(result["records"][0]["license"]["name"], "cc by");
+    assert_eq!(result["returned"], 1);
+}
+
+#[tokio::test]
+async fn convert_rejects_http_429_and_malformed_json_without_echoing_secrets() {
+    for (status, body, expected) in [
+        (
+            StatusCode::TOO_MANY_REQUESTS,
+            "synthetic-key".into(),
+            "HTTP 429",
+        ),
+        (StatusCode::OK, "{not-json".into(), "invalid JSON"),
+        (
+            StatusCode::OK,
+            json!({"status": "error", "error": "synthetic-key"}).to_string(),
+            "rejected",
+        ),
+    ] {
+        let app = Router::new().route(
+            "/idconv",
+            get({
+                let body = body.clone();
+                move || {
+                    let body = body.clone();
+                    async move { (status, [("retry-after", "60")], body).into_response() }
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let client = test_client(&format!("http://{}/", listener.local_addr().unwrap()));
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        let error = client
+            .call("convert_article_ids", &json!({"ids": ["1"]}))
+            .await
+            .unwrap_err()
+            .to_string();
+        server.abort();
+        assert!(error.contains(expected), "{error}");
+        assert!(!error.contains("synthetic-key"));
+    }
+}
+
+#[test]
+fn full_text_jats_rejects_malformed_or_mismatched_documents() {
+    assert!(records::full_text("<not-article/>", "PMC555").is_err());
+    assert!(records::full_text(
+        "<article><front><article-meta><article-id pub-id-type=\"pmcid\">PMC1</article-id></article-meta></front></article>",
+        "PMC555",
+    )
+    .is_err());
+    let parsed = records::full_text(
+        "<article><front><article-meta><article-id pub-id-type=\"pmcid\">PMC555</article-id><title-group><article-title>Invented</article-title></title-group></article-meta></front><body><p>Body.</p></body></article>",
+        "PMC555",
+    )
+    .unwrap();
+    assert_eq!(parsed["title"], "Invented");
+    assert!(parsed["full_text"].as_str().unwrap().contains("Body"));
+}
+
+#[test]
+fn default_endpoints_do_not_include_the_retired_oa_service() {
+    let client = PubMed::new(&[]).unwrap();
+    for url in [&client.ncbi, &client.idconv, &client.europepmc] {
+        assert!(!url.contains("oa.fcgi"), "{url}");
+        assert!(!url.contains("oa-service"), "{url}");
+        assert!(!url.contains("pmc/utils/oa"), "{url}");
+    }
+    assert_eq!(client.idconv, IDCONV);
+    assert_eq!(client.europepmc, EUROPE_PMC_REST);
+}

--- a/crates/wisp-bio/src/xml.rs
+++ b/crates/wisp-bio/src/xml.rs
@@ -1,0 +1,87 @@
+//! XML helpers for NCBI metadata and Europe PMC JATS. No external entity resolver
+//! is installed; DTD declarations cannot read files or access the network.
+use anyhow::{bail, Context, Result};
+use roxmltree::{Document, Node, ParsingOptions};
+
+pub(crate) fn parse(text: &str) -> Result<Document<'_>> {
+    let doc = Document::parse_with_options(
+        text,
+        ParsingOptions {
+            allow_dtd: true,
+            nodes_limit: 100_000,
+            entity_resolver: None,
+        },
+    )
+    .context("upstream returned invalid XML")?;
+    // roxmltree's node/expansion limits bound memory; cap depth as well before
+    // processing arbitrary nested JATS with our formatting helpers.
+    for node in doc.descendants().filter(|node| node.is_element()) {
+        if node.ancestors().take(129).count() > 128 {
+            bail!("XML nesting exceeds 128 levels");
+        }
+    }
+    Ok(doc)
+}
+
+pub(crate) fn child<'a, 'i>(node: Node<'a, 'i>, name: &str) -> Option<Node<'a, 'i>> {
+    node.children().find(|n| n.has_tag_name(name))
+}
+
+pub(crate) fn path<'a, 'i>(node: Node<'a, 'i>, names: &[&str]) -> Option<Node<'a, 'i>> {
+    names.iter().try_fold(node, |node, name| child(node, name))
+}
+
+pub(crate) fn text(node: Node<'_, '_>) -> Option<String> {
+    let value: String = node
+        .descendants()
+        .filter(|n| n.is_text())
+        .filter_map(|n| n.text())
+        .collect();
+    let value = value.trim();
+    (!value.is_empty()).then(|| value.to_string())
+}
+
+pub(crate) fn field(node: Node<'_, '_>, names: &[&str]) -> Option<String> {
+    path(node, names).and_then(text)
+}
+
+/// Preserve inline word boundaries and separate block text, excluding selected
+/// subtrees (captions, references or keyword metadata).
+pub(crate) fn prose(node: Node<'_, '_>, excluded: &[&str]) -> String {
+    fn visit(node: Node<'_, '_>, excluded: &[&str], out: &mut String) {
+        if node.is_text() {
+            out.push_str(node.text().unwrap_or_default());
+            return;
+        }
+        if node.has_tag_name("title")
+            && node.parent().is_some_and(|p| p.has_tag_name("abstract"))
+            && text(node).is_some_and(|text| text.eq_ignore_ascii_case("abstract"))
+        {
+            return;
+        }
+        if excluded.iter().any(|name| node.has_tag_name(*name))
+            || node.attribute("sec-type") == Some("kwd-group")
+        {
+            return;
+        }
+        let block = ["p", "sec", "title", "abstract", "list-item"]
+            .iter()
+            .any(|name| node.has_tag_name(*name));
+        if block {
+            out.push('\n');
+        }
+        for child in node.children() {
+            visit(child, excluded, out);
+        }
+        if block {
+            out.push('\n');
+        }
+    }
+    let mut out = String::new();
+    visit(node, excluded, &mut out);
+    out.lines()
+        .map(|line| line.split_whitespace().collect::<Vec<_>>().join(" "))
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n")
+}

--- a/crates/wisp-cli/Cargo.toml
+++ b/crates/wisp-cli/Cargo.toml
@@ -23,6 +23,7 @@ uuid = { workspace = true }
 async-trait = "0.1"
 wisp-runtime = { workspace = true }
 wisp-mcp = { workspace = true }
+wisp-bio = { workspace = true }
 wisp-llm = { workspace = true }
 wisp-core = { workspace = true }
 wisp-skills = { workspace = true }

--- a/crates/wisp-cli/src/main.rs
+++ b/crates/wisp-cli/src/main.rs
@@ -644,6 +644,7 @@ async fn wire_mcp(agent: &mut Agent, command: &str, args: &[String], jsonl: bool
                 std::sync::Arc::new(client),
                 &format!("{command} {}", args.join(" ")),
                 jsonl,
+                false,
             )
             .await
         }
@@ -656,9 +657,14 @@ async fn register_mcp_tools(
     client: std::sync::Arc<wisp_mcp::McpClient>,
     label: &str,
     jsonl: bool,
+    skip_native_bio: bool,
 ) {
     match client.tools_list().await {
         Ok(tools) => {
+            let tools: Vec<_> = tools
+                .into_iter()
+                .filter(|tool| !skip_native_bio || !wisp_bio::contains_tool(&tool.name))
+                .collect();
             let n = tools.len();
             for t in tools {
                 agent.add_tool(Box::new(wisp_mcp::McpTool::new(t, client.clone())));
@@ -1028,6 +1034,24 @@ async fn main() -> Result<()> {
         );
     }
 
+    let bio_package = std::env::var("WISP_MCP_PKG").unwrap_or_else(|_| "mcp_bio".into());
+    let native_bio =
+        std::env::var("WISP_MCP_COMMAND").is_err() && wisp_bio::selected_by_package(&bio_package);
+    if native_bio {
+        let credentials = ["NCBI_API_KEY", "NCBI_EMAIL"]
+            .into_iter()
+            .filter_map(|name| std::env::var(name).ok().map(|value| (name.into(), value)))
+            .collect::<Vec<_>>();
+        match wisp_bio::PubMed::new(&credentials) {
+            Ok(client) => {
+                for tool in wisp_bio::tools(std::sync::Arc::new(client)) {
+                    agent.add_tool(tool);
+                }
+            }
+            Err(error) => setup_message(jsonl, format_args!("native PubMed: {error}")),
+        }
+    }
+
     // MCP server: WISP_MCP_COMMAND overrides; otherwise WISP_MCP_PKG launches
     // the bundled bio-tools server (<pkg> e.g. mcp_pubmed) via the venv python.
     if let Ok(cmdline) = std::env::var("WISP_MCP_COMMAND") {
@@ -1056,6 +1080,7 @@ async fn main() -> Result<()> {
                     std::sync::Arc::new(client),
                     &format!("bio-tools:{pkg}"),
                     jsonl,
+                    native_bio,
                 )
                 .await
             }

--- a/docs/development.md
+++ b/docs/development.md
@@ -100,8 +100,34 @@ and take precedence when both exist.
 
 ### Bundled bio-tools MCP
 
-`WISP_MCP_PKG=mcp_pubmed` launches `mcp-servers/bio-tools/run_server.py
-mcp_pubmed` inside the uv venv. Install the server's dependencies first:
+The native PubMed domain lives in `crates/wisp-bio/`. All seven PubMed operations
+(`search_articles`, `get_article_metadata`, `convert_article_ids`,
+`find_related_articles`, `lookup_article_by_citation`, `get_full_text_article`,
+`get_copyright_status`) use independently authored Rust clients in the desktop,
+CLI and ACP MCP bridge. They keep deferred tool discovery and PubMed connector
+controls. Search and metadata use NCBI E-utilities; identifier conversion uses
+the PMC ID Converter; related records use ELink; citation lookup uses ECitMatch;
+OA full text and copyright/access metadata use Europe PMC core plus converter
+embargo fields. The retired PMC OA Web Service is not called. An open-access
+flag is not treated as a reuse grant.
+
+These operations do not execute Python. The remaining 226 default operations
+still use the vendored bundle during migration; their launcher and Python
+dependencies remain necessary. Native tools replace their legacy registrations,
+including under `WISP_MCP_PKG=mcp_pubmed`; native failures do not fall back to the
+vendored implementation. `WISP_MCP_COMMAND` continues to override the bundled
+tools entirely. Desktop NCBI credentials come from the existing keyring-backed
+settings; the CLI reads `NCBI_API_KEY` and `NCBI_EMAIL` from its environment.
+
+See the [native service migration design](superpowers/specs/2026-09-06-native-bio-services-design.md)
+for the complete removal scope and provenance requirements. Completing the PubMed
+domain does not remove the vendored tree or resolve the provenance of the
+remaining bundle.
+
+`WISP_MCP_PKG=mcp_pubmed` selects the native PubMed catalog. Other
+`WISP_MCP_PKG` values still launch `mcp-servers/bio-tools/run_server.py`
+inside the uv venv for unmigrated domains. Install those tools' dependencies
+first:
 
 ```bash
 uv pip install mcp requests
@@ -127,6 +153,7 @@ wisp-science/
 │  ├─ wisp-skills/  SKILL.md discovery + search_skills/use_skill progressive loading
 │  ├─ wisp-runtime/ project-scoped Python/R runtime manager + REPL tools
 │  ├─ wisp-mcp/     stdio JSON-RPC MCP client + McpTool adapter (bundled bio-tools)
+│  ├─ wisp-bio/     Native biological database clients shared by all hosts
 │  ├─ wisp-acp/     ACP v1 stdio client for external coding agents
 │  ├─ wisp-sync/    Encrypted snapshot protocol + self-hosted relay server
 │  ├─ wisp-runs/    Run control plane (run_in_context / monitor_run / harvest)

--- a/docs/superpowers/specs/2026-09-06-native-bio-services-design.md
+++ b/docs/superpowers/specs/2026-09-06-native-bio-services-design.md
@@ -1,0 +1,292 @@
+# Native Rust biological data services
+
+Date: 2026-09-06
+Status: PubMed domain implemented in Rust; other domains remain on the vendored Python path; removal incomplete
+
+## Current implementation slice
+
+`crates/wisp-bio/` implements the seven PubMed operations: `search_articles`,
+`get_article_metadata`, `convert_article_ids`, `find_related_articles`,
+`lookup_article_by_citation`, `get_full_text_article`, and `get_copyright_status`.
+Desktop, CLI and the ACP bridge register them natively and exclude the
+corresponding legacy registrations. Native descriptors are included in the
+settings inventory even if the Python bundle is missing. Delegation can discover
+the native PubMed operations without managed Python.
+
+The independently authored result contracts are explicit: search returns `pmids`,
+`total`, `returned`, `retstart`, `next_retstart`, `has_more` and the upstream
+retrieval ceiling; metadata returns `records` containing PMID/source URL, the
+NCBI citation `summary` and an `abstract` string or null, plus `missing_pmids`.
+An absent EFetch record is an error, rather than evidence that no abstract exists.
+The previously advertised `title` search sort is not included: the official
+PubMed ESearch reference documents relevance, publication date, author and
+journal ordering. Date filters use the documented YYYY[/MM[/DD]] notation.
+Identifier conversion uses the PMC ID Converter (same-type batches of at most
+200 PMID / PMCID / DOI values; missing and unconverted IDs listed; embargo
+`live` / `release_date` preserved). Related records use NCBI ELink link names
+`pubmed_pubmed`, `pubmed_pmc`, `pubmed_gene`, `pubmed_protein`, and
+`pubmed_nucleotide`, preserving upstream ranking on a bounded page. Citation
+lookup uses ECitMatch `journal|year|volume|first_page|author|key` strings and
+reports matched versus unmatched citations. Full text uses Europe PMC
+`{PMCID}/fullTextXML` and distinguishes not-found, not-OA, and XML-unavailable
+rather than returning success-shaped empty evidence.
+
+`get_copyright_status` does not call the retired PMC OA Web Service. Mapping
+from that legacy shape:
+
+- `copyright.statement` / `year` / `holder` are omitted; they were OA-service
+  fields. A stated license is Europe PMC core `license` when present
+  (`license.name`).
+- Legacy `license.is_open_access` is `is_open_access` from Europe PMC
+  `isOpenAccess`. That flag is access, not a reuse grant.
+- `reuse_permission` is `unknown` unless a license string is present, in which
+  case it is `license_stated`. An OA boolean never becomes a reuse grant.
+- Metadata availability, accessible full text (`inEPMC` → `full_text_accessible`),
+  and reuse are separate fields. Converter `live` / `release_date` are embargo
+  attributes.
+
+The remaining 226 operations still run through Python. No vendored provider,
+schema, attribution or packaging resource has been removed by this slice. It is
+not a completed replacement of the 233-tool surface.
+
+Offline regression checks cover request encoding, secrets, upstream errors,
+response limits, pagination, malformed XML, nested abstract markup, missing
+records, domain filters and delegated authorization. Before release, manually
+smoke a PubMed search, metadata, identifier conversion, related-article, citation, full-text and copyright query in the desktop, CLI and ACP bridge;
+disable the PubMed connector and verify its tools disappear, then restore it.
+Check a custom MCP connection still operates and inspect the native tool results
+for source identifiers and pagination/missing-record information.
+
+## Problem and scope
+
+The bundled biological tools currently ship an externally vendored Python
+implementation, copied connector schemas and descriptions, and upstream-specific
+operational assumptions. The desktop, CLI and ACP MCP bridge all start that
+implementation. A replacement must address the implementation and metadata
+provenance as well as remove Python from the biological data retrieval path.
+
+The current inventory is 23 domains and 247 declared tools. The serving gate
+excludes 14 tools, leaving 233 callable tools before user settings and capability
+grants. This inventory is a functional migration baseline, not a specification to
+translate line by line. An implemented Rust tool must have independently written
+descriptions, parameter definitions, result formatting and tests.
+
+Deliver domain-sized changes. Do not expose unfinished tools or replace working
+operations with generic HTTP passthroughs merely to reach an inventory count.
+Previously excluded KEGG, CADD, PanglaoDB and Sanger Cell Model Passports operations
+remain excluded from the default migration target.
+
+This change concerns `mcp-servers/bio-tools/`. Other vendored assets, bundled
+skills and Python/R scientific computing runtimes have separate provenance and
+remain outside this migration's scope.
+
+## Implementation provenance
+
+- Use database operators' published API documentation as implementation sources.
+  Record links and review dates for each provider alongside its implementation.
+- Existing tool identifiers and observed user requirements are compatibility
+  inputs. Do not translate vendored functions, copy their docstrings, reuse their
+  schema JSON or import their test fixtures into the replacement.
+- Write synthetic response fixtures that exercise the documented upstream wire
+  formats, with no live credentials or copied publications in test data.
+- Keep existing attribution while corresponding material is still shipped. At
+  removal, review attribution entries individually; do not remove notices for
+  unrelated assets.
+- This is not a claim of a formal clean-room process: the existing implementation
+  has already been inspected. Changing programming language is not itself a
+  determination of copyright or API/data licensing status.
+
+The current attribution file references a nonexistent
+`mcp-servers/bio-tools/src/lib/` path and a missing bio-tools `NOTICE` file. These
+are provenance gaps to resolve during removal, not evidence of a blanket license
+for the entire bundle.
+
+## Runtime architecture
+
+Add `crates/wisp-bio/` as the shared biological service implementation. There is
+a concrete dependency boundary: the CLI, desktop agent and ACP bridge need the
+same catalog and dispatch behavior, without Tauri, Python or an MCP subprocess.
+
+```text
+Desktop registry ----\
+CLI registry --------> wisp-bio -> reqwest -> documented database APIs
+ACP MCP bridge -----/
+
+Custom MCP connections -> existing wisp-mcp client -> external MCP servers
+```
+
+Use the existing `wisp_tools::Tool` contract for native registration. Retrieval
+tools set `defer_schema()` so the existing `search_mcp_tools` / `use_mcp_tool`
+gateway keeps its current behavior. Set `read_only()` per operation; an upstream
+job submission or upload needs explicit classification instead of inheriting a
+blanket read-only flag.
+
+The ACP bridge retains its existing MCP protocol and exposes the same native
+tool implementations. It does not start a second Rust server process. A separate
+standalone bio MCP binary is not required for this migration.
+
+Use a small native catalog tying together each implemented tool's identifier,
+domain, description and input schema. The settings tree and runtime dispatch
+must consume the same implemented inventory. Avoid a second handwritten tool
+list that can advertise unavailable operations.
+
+Reuse workspace `reqwest`, `tokio`, `serde`, `serde_json`, `anyhow` and the existing
+tool contract. Add an XML parser only for a provider that requires XML. Do not
+build an endpoint DSL, a generic plugin system, a new job system or a cache
+framework in the first domain replacement.
+
+## HTTP and data behavior
+
+- Each provider owns its documented endpoint paths, argument validation,
+  pagination and response parsing. Tools accept scientific identifiers and
+  queries, not arbitrary credential-bearing URLs.
+- Share clients and upstream pacing within the host process. Do not create a
+  fresh rate limiter per tool or per conversation. Separate bridge processes
+  and other applications may still share an upstream IP quota; handle 429
+  without claiming process-local pacing is a global quota guarantee.
+- Bound connect time, total tool duration, retries, response bytes and returned
+  records. Retry only suitable transient failures; honor bounded Retry-After.
+  Cancellation must stop further pages and retries.
+- Report requested/returned identifiers, missing records and whether more data
+  exists. Preserve upstream totals where supplied; unknown is not zero and a
+  capped page is not a complete dataset. Respect source-specific retrieval
+  ceilings and pagination ordering.
+- Detect upstream errors even when HTTP status is 200. Return failures through
+  `ToolResult::fail` and the MCP bridge's error result rather than success-shaped
+  error text or empty scientific evidence.
+- Include provider identity, upstream identifiers and source links in results.
+  Querying does not automatically persist `Paper`, `Artifact` or `DataAsset`
+  records; use existing explicit save/register flows for that work.
+- Keep large scientific payloads as references and metadata by default. Full
+  text, alignments and structure payloads require explicit, bounded operations.
+- Distinguish metadata availability, accessible full text and reuse permissions;
+  an open-access boolean alone must not become a blanket reuse assertion.
+
+## Credentials and host integration
+
+Desktop credentials continue to come from `models::service_env()` backed by the
+existing keyring. Pass only the needed values into native provider construction;
+do not mutate global environment variables or introduce a SQLite secret store.
+CLI credentials can come from its environment. Do not log request URLs containing
+keys, upstream request bodies echoing secrets, or raw credential structures.
+
+Preserve domain slugs used by disabled-connector settings and capability grants.
+Preserve old tool names where their argument and result contracts can be honored
+with independently authored code. If a contract changes, provide a documented
+mapping and update dependent skills/tests; retaining a name while silently
+changing its meaning is not compatibility.
+
+Keep the stable `mcp_bio` connector identity where existing grants and persisted
+references depend on it. A native implementation should not accidentally bypass
+tool denial, planning mode, connector disabling or delegated capability limits.
+
+The three runtime entry points must switch together for each migrated operation:
+
+| Entry point | Existing integration to replace |
+| --- | --- |
+| Desktop agent | `src-tauri/src/lib.rs::wire_runtimes_and_mcp` |
+| CLI | `crates/wisp-cli/src/main.rs` bundled MCP registration |
+| ACP bridge | `src-tauri/src/mcp_bridge.rs::register_bundled_bio_tools` and bio route dispatch |
+| Settings/catalog | `src-tauri/src/lib.rs::bio_domains`, `list_mcp_servers` |
+| Connector settings | `src-tauri/src/connector_commands.rs::list_connectors` |
+| Delegation resources | `src-tauri/src/delegation_resources.rs::bundled_connector_resources`; remove the Python prerequisite for migrated domains |
+| Delegated authorization | `src-tauri/src/delegation_runtime.rs::granted_connector_identity`; retain catalog-based identity checks |
+| Startup diagnostics | `src-tauri/src/app_commands.rs` bundle existence check |
+
+`WISP_MCP_COMMAND` remains the custom stdio override. During migration, define
+`WISP_MCP_PKG` explicitly: a migrated domain selects native tools, an unmigrated
+domain retains its temporary legacy path, and `mcp_bio` selects the available
+aggregate. On final removal, retain documented domain selection or issue a clear
+configuration error; never silently ignore an old selection.
+
+## Incremental migration and removal
+
+1. Replace one useful domain end to end, beginning with PubMed literature
+   retrieval. Add the shared crate only with working operations and offline
+   tests. Wire native tools through all three hosts and verify settings/grants.
+2. Register each migrated operation exactly once. Exclude it from legacy MCP
+   registration before adding its native equivalent. A native failure must not
+   silently fall back to the vendored implementation.
+3. Replace subsequent domains in bounded changes. Track each operation's status,
+   official documentation, contract compatibility and tests. Remove obsolete
+   provider files once no remaining legacy domain imports them.
+4. Partial migration still ships legacy code. It must not be described as a
+   completed vendored-code removal or as resolving the whole provenance issue.
+5. After coverage is complete, delete the vendored directory and its launcher;
+   remove the Tauri resource mapping, legacy path helpers, Python launch code,
+   directory-derived catalog and obsolete startup diagnostics.
+6. Review Python requirements against actual kernel imports before removing
+   MCP-only dependencies. Keep Python/R runtime setup needed for scientific
+   computing and keep external MCP client support.
+7. Update developer/user documentation, capability text and attribution. Do not
+   describe the 87 Python packages as 87 databases. Do not rewrite Git history
+   or past release artifacts as part of a source-tree migration.
+
+## Domain coverage baseline
+
+Counts are current callable tools, not a requirement for the new API to have
+exactly the same number of separately advertised schemas.
+
+| Domain | Callable tools | Data sources |
+| --- | ---: | --- |
+| pubmed | 7 | NCBI PubMed/PMC, Europe PMC |
+| literature | 9 | OpenAlex, arXiv |
+| biorxiv | 7 | bioRxiv, medRxiv |
+| biomart | 8 | BioMart |
+| genes-ontologies | 7 | MyGene, OLS, QuickGO, Reactome, UniProt |
+| genomes | 11 | Ensembl, UCSC |
+| variants | 15 | gnomAD, ClinVar, dbSNP |
+| human-genetics | 14 | GWAS Catalog, eQTL Catalogue, PheWeb |
+| clinical-genomics | 20 | ClinGen, CIViC, Open Targets |
+| expression | 12 | GTEx |
+| cellguide | 5 | CELLxGENE CellGuide |
+| regulation | 16 | ENCODE, JASPAR, UniBind |
+| protein-annotation | 13 | InterPro/Pfam, Human Protein Atlas, STRING |
+| rna | 9 | Rfam |
+| structures-interactions | 16 | PDB, AlphaFold DB, EMDB, Complex Portal, IntAct |
+| omics-archives | 17 | GEO, ArrayExpress, MetaboLights, MGnify, PRIDE |
+| cancer-models | 6 | cBioPortal |
+| clinical-trials | 6 | ClinicalTrials.gov |
+| drug-regulatory | 7 | openFDA |
+| chembl | 6 | ChEMBL |
+| chemistry | 12 | PubChem, ChEBI, Rhea, BindingDB |
+| zinc | 5 | ZINC22 |
+| research-resources | 5 | Antibody Registry, Grants.gov |
+| **Total** | **233** | |
+
+## Verification and completion
+
+Use pure parser/request-builder tests and synthetic fixtures. Where HTTP behavior
+requires an integration check, use an in-process fake upstream, never a real
+database, key, network dependency or external compute resource. Cover malformed
+responses, empty results, partial pages, duplicate/missing IDs, upstream errors,
+credential redaction, response limits and cancellation where implemented.
+
+Host checks must demonstrate native retrieval without Python, disabled-domain
+and delegated-grant enforcement, no duplicate tool names, deferred discovery,
+planning-mode classification and error propagation through the ACP bridge.
+
+Run the repository's narrow checks first, then formatting and workspace tests;
+Tauri/UI changes also require the wasm check and Playwright suite. MCP integration
+changes require the existing `wisp-mcp` smoke example. Source provenance review
+and optional live provider smoke checks are separate from automated tests.
+
+Completion means all retained capabilities are implemented and verified, the
+three hosts use the native implementation, no shipped runtime/catalog file loads
+vendored bio-tools, and packaging/docs/attributions reflect that final state.
+
+## Initial primary sources
+
+Reviewed 2026-09-06:
+
+- [NCBI E-utilities overview and usage requirements](https://www.ncbi.nlm.nih.gov/books/NBK25497/).
+- [NCBI E-utilities parameters and retrieval limits](https://www.ncbi.nlm.nih.gov/books/NBK25499/).
+- [PMC ID Converter API](https://pmc.ncbi.nlm.nih.gov/tools/id-converter-api/).
+- [Europe PMC REST API](https://europepmc.org/RestfulWebService): core metadata and
+  Open Access full-text XML retrieval.
+- [PMC OA service retirement](https://pmc.ncbi.nlm.nih.gov/tools/oa-service/): the
+  official page now states that the old OA Web Service is no longer available.
+  Do not recreate that retired dependency for copyright/license metadata.
+
+Before implementing each additional provider, retrieve and record its current
+official API reference. Do not use the vendored source as substitute documentation.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -62,6 +62,7 @@ wisp-skills = { workspace = true }
 wisp-store = { workspace = true }
 wisp-runtime = { workspace = true }
 wisp-mcp = { workspace = true }
+wisp-bio = { workspace = true }
 wisp-acp = { workspace = true }
 wisp-paths = { workspace = true }
 wisp-sync = { workspace = true }

--- a/src-tauri/src/app_commands.rs
+++ b/src-tauri/src/app_commands.rs
@@ -538,9 +538,9 @@ pub(super) fn initial_bootstrap(workspace: &std::path::Path, skills: usize) -> B
         );
     }
     if wisp_paths::bio_tools_dir().is_none() {
-        status
-            .errors
-            .push("Bundled bio-tools MCP catalog not found.".into());
+        status.errors.push(
+            "Legacy bio-tools bundle not found; only native biological tools are available.".into(),
+        );
     }
     status
 }

--- a/src-tauri/src/delegation_resources.rs
+++ b/src-tauri/src/delegation_resources.rs
@@ -675,12 +675,16 @@ fn bundled_connector_resources(
     disabled: &HashSet<String>,
     managed_python: bool,
 ) -> Vec<ConnectorResource> {
-    if !managed_python {
-        return Vec::new();
-    }
     domains
         .into_iter()
         .filter(|domain| !disabled.contains(&domain.slug))
+        .map(|mut domain| {
+            if !managed_python {
+                domain.tools.retain(|tool| wisp_bio::contains_tool(tool));
+            }
+            domain
+        })
+        .filter(|domain| !domain.tools.is_empty())
         .map(|domain| ConnectorResource {
             class: if LITERATURE_CONNECTORS.contains(&domain.slug.as_str()) {
                 ConnectorClass::Literature
@@ -830,7 +834,11 @@ mod tests {
                 crate::BioDomain {
                     slug: "pubmed".into(),
                     name: "PubMed".into(),
-                    tools: vec!["search_pubmed".into()],
+                    tools: vec![
+                        "search_articles".into(),
+                        "find_related_articles".into(),
+                        "python_only_pubmed".into(),
+                    ],
                 },
                 crate::BioDomain {
                     slug: "uniprot".into(),
@@ -844,7 +852,16 @@ mod tests {
         assert_eq!(resources.len(), 1);
         assert_eq!(resources[0].id, "uniprot");
         assert_eq!(resources[0].class, ConnectorClass::External);
-        assert!(bundled_connector_resources(domains(), &HashSet::new(), false).is_empty());
+        let native = bundled_connector_resources(domains(), &HashSet::new(), false);
+        assert_eq!(native.len(), 1);
+        assert_eq!(native[0].id, "pubmed");
+        assert!(native[0].fingerprint.contains("search_articles"));
+        assert!(native[0].fingerprint.contains("find_related_articles"));
+        assert!(!native[0].fingerprint.contains("python_only_pubmed"));
+        assert!(
+            bundled_connector_resources(domains(), &HashSet::from(["pubmed".into()]), false)
+                .is_empty()
+        );
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -874,19 +874,20 @@ struct BioDomain {
     tools: Vec<String>,
 }
 
-/// Read the static `mcp_bio/domains.json` connector map. Empty if the bundle is
-/// absent (dev checkouts without the vendored bio-tools).
+/// Merge the remaining legacy catalog with native tools. Native retrieval stays
+/// discoverable even when the Python bundle is absent.
 fn bio_domains() -> Vec<BioDomain> {
-    let Some(dir) = wisp_paths::bio_tools_dir() else {
-        return vec![];
-    };
-    let path = dir.join("lib").join("mcp_bio").join("domains.json");
-    let Ok(text) = std::fs::read_to_string(&path) else {
-        return vec![];
-    };
-    let Ok(map) = serde_json::from_str::<BTreeMap<String, Vec<String>>>(&text) else {
-        return vec![];
-    };
+    let mut map = wisp_paths::bio_tools_dir()
+        .and_then(|dir| std::fs::read_to_string(dir.join("lib/mcp_bio/domains.json")).ok())
+        .and_then(|text| serde_json::from_str::<BTreeMap<String, Vec<String>>>(&text).ok())
+        .unwrap_or_default();
+    for (domain, schema) in wisp_bio::catalog() {
+        let tools = map.entry(domain.into()).or_default();
+        if !tools.contains(&schema.function.name) {
+            tools.push(schema.function.name);
+            tools.sort();
+        }
+    }
     map.into_iter()
         .map(|(slug, tools)| BioDomain {
             name: domain_display_name(&slug),
@@ -4949,8 +4950,29 @@ async fn wire_runtimes_and_mcp(
                 Err(e) => result.errors.push(format!("MCP command: {e}")),
             }
         }
-    } else if let Some(env) = &py_env {
+    } else {
         let pkg = std::env::var("WISP_MCP_PKG").unwrap_or_else(|_| "mcp_bio".into());
+        let native_selected = wisp_bio::selected_by_package(&pkg);
+        if native_selected
+            && !disabled.contains("pubmed")
+            && connector_allow.is_none_or(|allow| allow.contains("pubmed"))
+        {
+            match wisp_bio::PubMed::new(&service_env) {
+                Ok(client) => {
+                    for tool in wisp_bio::tools(std::sync::Arc::new(client)) {
+                        if registry.get(tool.name()).is_some() {
+                            result
+                                .errors
+                                .push(format!("tool name collision: {}", tool.name()));
+                        } else {
+                            result.added_tools.push(tool.name().into());
+                            registry.add(tool);
+                        }
+                    }
+                }
+                Err(error) => result.errors.push(format!("Native PubMed: {error}")),
+            }
+        }
         // mcp_bio serves all 247 tools; drop disabled domains' tools at
         // registration. Skip the launch entirely if every domain is off.
         let blocked = |slug: &str| {
@@ -4961,12 +4983,19 @@ async fn wire_runtimes_and_mcp(
         } else {
             !domains.is_empty() && domains.iter().all(|domain| blocked(&domain.slug))
         };
-        let skip: HashSet<String> = domains
+        let mut skip: HashSet<String> = domains
             .iter()
             .filter(|d| blocked(&d.slug))
             .flat_map(|d| d.tools.iter().cloned())
             .collect();
-        if !all_off {
+        if native_selected {
+            skip.extend(
+                wisp_bio::catalog()
+                    .into_iter()
+                    .map(|(_, schema)| schema.function.name),
+            );
+        }
+        if let Some(env) = py_env.as_ref().filter(|_| !all_off) {
             match wisp_mcp::McpClient::launch_bio_tools(&env.python(), &pkg, &service_env).await {
                 Ok(client) => {
                     match register_mcp_filtered(
@@ -6305,11 +6334,11 @@ fn mcp_lib_dir(_root: &std::path::Path) -> Option<PathBuf> {
 }
 
 fn list_mcp_servers(root: &std::path::Path) -> Vec<String> {
-    let Some(lib) = mcp_lib_dir(root) else {
-        return vec![];
-    };
-    let mut out = vec![];
-    if let Ok(rd) = std::fs::read_dir(&lib) {
+    let mut out = wisp_bio::catalog()
+        .into_iter()
+        .map(|(domain, _)| format!("mcp_{}", domain.replace('-', "_")))
+        .collect::<Vec<_>>();
+    if let Some(rd) = mcp_lib_dir(root).and_then(|lib| std::fs::read_dir(lib).ok()) {
         for ent in rd.flatten() {
             let name = ent.file_name().to_string_lossy().into_owned();
             if name.starts_with("mcp_") && ent.path().join("server.py").is_file() {
@@ -6318,6 +6347,7 @@ fn list_mcp_servers(root: &std::path::Path) -> Vec<String> {
         }
     }
     out.sort();
+    out.dedup();
     out
 }
 

--- a/src-tauri/src/mcp_bridge.rs
+++ b/src-tauri/src/mcp_bridge.rs
@@ -45,6 +45,13 @@ struct JsonRpcIn {
 
 #[derive(Clone)]
 enum Route {
+    NativeBio {
+        connector_id: String,
+        client: Arc<wisp_bio::PubMed>,
+        remote_name: String,
+        description: String,
+        input_schema: Value,
+    },
     Bio {
         connector_id: String,
         client: Arc<wisp_mcp::McpClient>,
@@ -265,9 +272,9 @@ impl BridgeServer {
                 || (matches!(name, "wisp_list_skills" | "wisp_use_skill") && self.has_skill_grant())
                 || self.routes.get(name).is_some_and(|route| {
                     let connector_id = match route {
-                        Route::Bio { connector_id, .. } | Route::Custom { connector_id, .. } => {
-                            connector_id
-                        }
+                        Route::Bio { connector_id, .. }
+                        | Route::Custom { connector_id, .. }
+                        | Route::NativeBio { connector_id, .. } => connector_id,
                     };
                     self.allowed_connectors().contains(connector_id)
                 })
@@ -476,11 +483,13 @@ impl BridgeServer {
         if all_off {
             return;
         }
-        let skip: HashSet<String> = domains
+        let mut skip: HashSet<String> = domains
             .iter()
             .filter(|d| blocked(&d.slug))
             .flat_map(|d| d.tools.iter().cloned())
             .collect();
+        let pkg = std::env::var("WISP_MCP_PKG").unwrap_or_else(|_| "mcp_bio".into());
+        self.register_native_bio_tools(&pkg, &mut skip);
         let tool_connectors = domains
             .iter()
             .flat_map(|domain| {
@@ -495,7 +504,6 @@ impl BridgeServer {
         let Ok(env) = wisp_runtime::PythonEnv::ensure_venv(&self.cfg.app_data) else {
             return;
         };
-        let pkg = std::env::var("WISP_MCP_PKG").unwrap_or_else(|_| "mcp_bio".into());
         let client = match wisp_mcp::McpClient::launch_bio_tools(
             &env.python(),
             &pkg,
@@ -532,6 +540,42 @@ impl BridgeServer {
                 },
             );
         }
+    }
+
+    fn register_native_bio_tools(&mut self, package: &str, skip: &mut HashSet<String>) {
+        if !wisp_bio::selected_by_package(package) {
+            return;
+        }
+        let catalog = wisp_bio::catalog();
+        let enabled: Vec<_> = catalog
+            .iter()
+            .filter(|(_, schema)| !skip.contains(&schema.function.name))
+            .collect();
+        if !enabled.is_empty() {
+            match wisp_bio::PubMed::new(&crate::models::service_env()) {
+                Ok(client) => {
+                    let client = Arc::new(client);
+                    for (domain, schema) in enabled {
+                        let tool = &schema.function;
+                        if !self.is_reserved(&tool.name) {
+                            self.routes.insert(
+                                tool.name.clone(),
+                                Route::NativeBio {
+                                    connector_id: (*domain).into(),
+                                    client: client.clone(),
+                                    remote_name: tool.name.clone(),
+                                    description: tool.description.clone(),
+                                    input_schema: tool.parameters.clone(),
+                                },
+                            );
+                        }
+                    }
+                }
+                Err(error) => tracing::warn!("native PubMed unavailable: {error}"),
+            }
+        }
+        // A failed or disabled native operation never falls back to Python.
+        skip.extend(catalog.into_iter().map(|(_, schema)| schema.function.name));
     }
 
     async fn register_custom_mcp_tools(&mut self) {
@@ -622,6 +666,12 @@ impl BridgeServer {
                         description,
                         input_schema,
                         ..
+                    }
+                    | Route::NativeBio {
+                        remote_name,
+                        description,
+                        input_schema,
+                        ..
                     } => (
                         if description.trim().is_empty() {
                             format!("Bundled Wisp bio MCP tool `{remote_name}`.")
@@ -666,6 +716,16 @@ impl BridgeServer {
             .cloned()
             .ok_or_else(|| anyhow!("unknown Wisp bridge tool '{name}'"))?;
         let (client, remote_name) = match route {
+            Route::NativeBio {
+                client,
+                remote_name,
+                ..
+            } => {
+                return Ok(match client.call(&remote_name, args).await {
+                    Ok(value) => (value.to_string(), false),
+                    Err(error) => (error.to_string(), true),
+                });
+            }
             Route::Bio {
                 client,
                 remote_name,
@@ -1506,6 +1566,83 @@ pub fn run_mcp_bridge_cli() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn native_bio_registration_honors_filters_grants_and_errors_without_python() {
+        let base = std::env::temp_dir().join(format!("wisp_native_bio_{}", uuid::Uuid::new_v4()));
+        let project_root = base.join("project");
+        std::fs::create_dir_all(&project_root).unwrap();
+        let mut server = BridgeServer::new(BridgeConfig {
+            app_data: base.join("app-data"),
+            project_root,
+            resource_root: None,
+            project_id: "project-a".into(),
+            frame_id: None,
+            allowed_tools: Some(HashSet::from([
+                crate::delegation_resources::connector_token("pubmed"),
+            ])),
+        })
+        .await
+        .unwrap();
+        server.bundled_bio_tools_loaded = true;
+        server.custom_mcp_tools_loaded = true;
+        let mut skip = HashSet::new();
+        server.register_native_bio_tools("mcp_chembl", &mut skip);
+        assert!(server.routes.is_empty());
+        let mut disabled = wisp_bio::catalog()
+            .into_iter()
+            .map(|(_, schema)| schema.function.name)
+            .collect();
+        server.register_native_bio_tools("mcp_bio", &mut disabled);
+        assert!(server.routes.is_empty());
+        server.register_native_bio_tools("mcp_bio", &mut skip);
+        let native: std::collections::BTreeSet<_> = wisp_bio::catalog()
+            .into_iter()
+            .map(|(_, schema)| schema.function.name)
+            .collect();
+        assert_eq!(
+            native.iter().map(|name| name.as_str()).collect::<Vec<_>>(),
+            [
+                "convert_article_ids",
+                "find_related_articles",
+                "get_article_metadata",
+                "get_copyright_status",
+                "get_full_text_article",
+                "lookup_article_by_citation",
+                "search_articles",
+            ]
+        );
+        assert_eq!(native.len(), 7);
+        assert_eq!(server.routes.len(), 7);
+        assert_eq!(skip.len(), 7);
+        for name in &native {
+            assert!(matches!(server.routes[name], Route::NativeBio { .. }));
+            assert!(skip.contains(name));
+        }
+        assert!(server.tool_authorized("search_articles"));
+        assert!(server.tool_authorized("convert_article_ids"));
+        assert!(!wisp_runtime::PythonEnv::managed(&server.cfg.app_data)
+            .python()
+            .exists());
+        let error = server
+            .tools_call(json!({
+                "name": "search_articles", "arguments": {"query": ""}
+            }))
+            .await
+            .unwrap();
+        assert_eq!(error["isError"], true);
+        assert!(error.to_string().contains("query must contain"));
+        server.cfg.allowed_tools = Some(HashSet::new());
+        assert!(!server.tool_authorized("search_articles"));
+        assert!(server
+            .tools_call(json!({
+                "name": "search_articles", "arguments": {"query": ""}
+            }))
+            .await
+            .is_err());
+        drop(server);
+        let _ = std::fs::remove_dir_all(base);
+    }
 
     #[test]
     fn sanitizes_custom_tool_parts() {


### PR DESCRIPTION
## Problem

The bundled PubMed tools still ran through vendored Python MCP (`mcp-servers/bio-tools`). That path copies connector schemas, depends on managed Python, and the copyright tool called the retired PMC OA Web Service.

## Change

Add `crates/wisp-bio` as the shared native PubMed catalog and dispatch used by desktop, CLI, and the ACP bridge. All seven PubMed operations are independently authored from current operator docs (not translated Python schemas):

| Tool | Upstream |
| --- | --- |
| `search_articles` | NCBI ESearch |
| `get_article_metadata` | NCBI ESummary + EFetch |
| `convert_article_ids` | PMC ID Converter (≤200, same type; missing/unconverted/embargo) |
| `find_related_articles` | NCBI ELink (`pubmed_pubmed`, `pubmed_pmc`, `pubmed_gene`, `pubmed_protein`, `pubmed_nucleotide`; ranking preserved, page bounded) |
| `lookup_article_by_citation` | NCBI ECitMatch (`journal\|year\|volume\|first_page\|author\|key`) |
| `get_full_text_article` | Europe PMC `{PMCID}/fullTextXML` (not-found / not-OA / XML-unavailable) |
| `get_copyright_status` | Europe PMC core + ID Converter embargo fields |

Native tools are registered once from the catalog, excluded from Python MCP registration, and never fall back to Python on failure. Disabled pubmed / denied grants hide them. `WISP_MCP_COMMAND` still overrides the bundled set.

`get_copyright_status` does not call the retired OA Web Service. `is_open_access` is an access flag, not a reuse grant (`reuse_permission` is `unknown` or `license_stated`). MEDLINE lookups use `(EXT_ID:{pmid} AND SRC:MED)` so colliding PMC/other-source hits cannot consume the result page.

## Tests

- Offline `wisp-bio` tests with synthetic fixtures and in-process fake upstreams (request encoding, 429, malformed XML/JSON, missing IDs, ELink ranking, full-text unavailability, OA-flag-is-not-reuse, SRC:MED collision).
- Host registration test asserts all seven names are native routes, appear on the skip list, stay hidden when pubmed is disabled/ungranted, and error through the ACP error result without managed Python.

## Manual smoke (optional)

Live NCBI/Europe PMC smoke is not required for this PR. If checking locally: search and metadata, convert a PMID that is and is not in PMC, related articles, citation match, OA full text, and copyright; then disable the PubMed connector and confirm the tools disappear.

## Limitations / follow-up

- The other 22 domains (226 callable tools) still use the vendored Python bundle. `mcp-servers/bio-tools/` is not deleted.
- This is not a completed provenance cleanup of the remaining bundle.
- KEGG, CADD, PanglaoDB, and Sanger Cell Model Passports remain excluded from the default migration target.