### PR TITLE
feat(bio): native KEGG REST in genes-ontologies

### DIFF
--- a/crates/wisp-bio/src/genes_ontologies/kegg.rs
+++ b/crates/wisp-bio/src/genes_ontologies/kegg.rs
@@ -1,0 +1,603 @@
+use super::{bound_u32, cred_base, looks_like_html};
+use crate::http::Source;
+use crate::NativeBio;
+use anyhow::{anyhow, bail, Context, Result};
+use reqwest::{Method, StatusCode};
+use serde::Deserialize;
+use serde_json::{json, Value};
+use std::collections::HashSet;
+use std::time::Duration;
+
+const KEGG: Source = Source("KEGG", Duration::from_millis(350));
+const KEGG_HOST: &str = "https://rest.kegg.jp";
+const KEGG_PAGE: &str = "https://www.kegg.jp";
+const MAX_IDS: usize = 50;
+const BATCH: usize = 10;
+const MAX_ID_LEN: usize = 64;
+const MAX_DB_LEN: usize = 32;
+const MAX_QUERY: usize = 256;
+const MAX_HITS: u32 = 200;
+const DEFAULT_HITS: u32 = 50;
+const FIELD_WIDTH: usize = 12;
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct GetKegg {
+    ids: Vec<String>,
+    #[serde(default)]
+    include_raw: bool,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SearchKegg {
+    query: String,
+    #[serde(default = "default_database")]
+    database: String,
+    option: Option<String>,
+    #[serde(default)]
+    exact_gene_symbol: bool,
+    #[serde(default = "default_max_hits")]
+    max_hits: u32,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct LinkKegg {
+    ids: Vec<String>,
+    target_db: String,
+    #[serde(default = "default_operation")]
+    operation: String,
+}
+
+fn default_database() -> String {
+    "hsa".into()
+}
+fn default_max_hits() -> u32 {
+    DEFAULT_HITS
+}
+fn default_operation() -> String {
+    "link".into()
+}
+
+pub(super) async fn get_kegg_entries(bio: &NativeBio, args: &Value) -> Result<Value> {
+    let args: GetKegg =
+        serde_json::from_value(args.clone()).context("invalid get_kegg_entries arguments")?;
+    let ids = require_kegg_ids(&args.ids)?;
+    let base = kegg_base(bio);
+    let mut fetched = Vec::new();
+    let mut source_url = String::new();
+    for chunk in ids.chunks(BATCH) {
+        let joined = join_dbentries(chunk);
+        if source_url.is_empty() {
+            source_url = format!("{KEGG_HOST}/get/{joined}");
+        }
+        let url = format!("{base}/get/{joined}");
+        let text = kegg_text(bio, &url, true).await?;
+        if text.trim().is_empty() {
+            continue;
+        }
+        fetched.extend(parse_get_body(&text)?);
+    }
+    let mut unused = fetched;
+    let mut records = Vec::new();
+    let mut missing = Vec::new();
+    for id in &ids {
+        match unused.iter().position(|(record, _)| record.matches(id)) {
+            Some(index) => {
+                let (record, raw) = unused.remove(index);
+                records.push(record.into_json(id, args.include_raw.then_some(raw)));
+            }
+            None => missing.push(id.clone()),
+        }
+    }
+    if !missing.is_empty() {
+        bail!("KEGG returned no entry for {}", missing.join(", "));
+    }
+    Ok(json!({
+        "source": "KEGG",
+        "source_url": source_url,
+        "ids": ids,
+        "returned": records.len(),
+        "records": records
+    }))
+}
+
+pub(super) async fn search_kegg(bio: &NativeBio, args: &Value) -> Result<Value> {
+    let args: SearchKegg =
+        serde_json::from_value(args.clone()).context("invalid search_kegg arguments")?;
+    let query = require_query(&args.query)?;
+    let database = require_kegg_token(&args.database, MAX_DB_LEN, "database")?;
+    let option = args
+        .option
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(require_find_option)
+        .transpose()?;
+    if option.is_some() && !formula_database(&database) {
+        bail!("option formula, exact_mass and mol_weight are valid only for compound or drug");
+    }
+    let cap = bound_u32(args.max_hits, 1, MAX_HITS, "max_hits")?;
+    let mut path = format!(
+        "find/{}/{}",
+        encode_kegg_segment(&database),
+        encode_kegg_segment(&query)
+    );
+    if let Some(option) = option.as_deref() {
+        path.push('/');
+        path.push_str(&encode_kegg_segment(option));
+    }
+    let text = kegg_text(bio, &format!("{}/{path}", kegg_base(bio)), true).await?;
+    let mut hits = parse_find(&text)?;
+    if args.exact_gene_symbol {
+        hits.retain(|(_, description)| exact_symbol_match(description, &query));
+    }
+    let total = hits.len();
+    let truncated = total > cap as usize;
+    let page: Vec<Value> = hits
+        .into_iter()
+        .take(cap as usize)
+        .map(|(entry_id, description)| json!({"entry_id": entry_id, "description": description}))
+        .collect();
+    let mut out = json!({
+        "source": "KEGG",
+        "source_url": format!("{KEGG_HOST}/{path}"),
+        "query": query,
+        "database": database,
+        "option": option,
+        "exact_gene_symbol": args.exact_gene_symbol,
+        "total_hits": total,
+        "returned": page.len(),
+        "truncated": truncated,
+        "records": page
+    });
+    if args.exact_gene_symbol {
+        out["n_matches"] = json!(total);
+    }
+    Ok(out)
+}
+
+pub(super) async fn link_kegg_ids(bio: &NativeBio, args: &Value) -> Result<Value> {
+    let args: LinkKegg =
+        serde_json::from_value(args.clone()).context("invalid link_kegg_ids arguments")?;
+    let ids = require_kegg_ids(&args.ids)?;
+    let target_db = require_kegg_token(&args.target_db, MAX_DB_LEN, "target_db")?;
+    let operation = require_operation(&args.operation)?;
+    let base = kegg_base(bio);
+    let mut pairs = Vec::new();
+    let mut source_url = String::new();
+    for chunk in ids.chunks(BATCH) {
+        let joined = join_dbentries(chunk);
+        let path = format!("{operation}/{}/{}", encode_kegg_segment(&target_db), joined);
+        if source_url.is_empty() {
+            source_url = format!("{KEGG_HOST}/{path}");
+        }
+        let text = kegg_text(bio, &format!("{base}/{path}"), true).await?;
+        if text.trim().is_empty() {
+            continue;
+        }
+        pairs.extend(parse_two_column(&text)?);
+    }
+    let mut hit: HashSet<String> = HashSet::new();
+    let mut records = Vec::new();
+    for (left, right) in pairs {
+        let source_id = map_query_id(&left, &ids);
+        hit.insert(source_id.clone());
+        records.push(json!({"source_id": source_id, "target_id": right}));
+    }
+    let missing: Vec<String> = ids
+        .iter()
+        .filter(|id| !hit.contains(*id))
+        .cloned()
+        .collect();
+    Ok(json!({
+        "source": "KEGG",
+        "source_url": source_url,
+        "operation": operation,
+        "target_db": target_db,
+        "query_ids": ids,
+        "returned": records.len(),
+        "missing_ids": missing,
+        "records": records
+    }))
+}
+
+async fn kegg_text(bio: &NativeBio, url: &str, empty_on_404: bool) -> Result<String> {
+    let response = bio.http().send(KEGG, Method::GET, url, &[]).await?;
+    match response.status {
+        StatusCode::OK => {
+            if looks_like_html(&response.body) {
+                bail!("KEGG returned HTML instead of text");
+            }
+            String::from_utf8(response.body).context("KEGG returned invalid UTF-8")
+        }
+        StatusCode::NOT_FOUND if empty_on_404 => Ok(String::new()),
+        StatusCode::BAD_REQUEST => bail!("KEGG rejected the request (HTTP 400)"),
+        status => bail!("KEGG returned HTTP {}", status.as_u16()),
+    }
+}
+
+fn kegg_base(bio: &NativeBio) -> String {
+    cred_base(bio, "KEGG_BASE_URL", KEGG_HOST)
+}
+
+fn require_kegg_ids(values: &[String]) -> Result<Vec<String>> {
+    let mut out = Vec::new();
+    let mut seen = HashSet::new();
+    for value in values {
+        let id = require_kegg_token(value, MAX_ID_LEN, "KEGG id")?;
+        if !seen.insert(id.clone()) {
+            bail!("duplicate KEGG id {id}");
+        }
+        out.push(id);
+    }
+    if out.is_empty() {
+        bail!("provide at least one KEGG id");
+    }
+    if out.len() > MAX_IDS {
+        bail!("{} ids exceeds the per-call bound of {MAX_IDS}", out.len());
+    }
+    Ok(out)
+}
+
+fn require_kegg_token(value: &str, max: usize, what: &str) -> Result<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() || trimmed.len() > max {
+        bail!("{what} must contain 1 to {max} characters");
+    }
+    if trimmed.contains("..")
+        || trimmed.contains('/')
+        || trimmed.contains('+')
+        || trimmed
+            .chars()
+            .any(|c| !(c.is_ascii_alphanumeric() || matches!(c, ':' | '-' | '_' | '.')))
+    {
+        bail!("{what} {trimmed:?} is not a KEGG identifier");
+    }
+    Ok(trimmed.to_string())
+}
+
+fn require_query(value: &str) -> Result<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() || trimmed.len() > MAX_QUERY {
+        bail!("query must contain 1 to {MAX_QUERY} characters");
+    }
+    if trimmed.contains("..") || trimmed.contains('/') {
+        bail!("query must not contain '/' or '..'");
+    }
+    Ok(trimmed.to_string())
+}
+
+fn require_operation(value: &str) -> Result<&'static str> {
+    match value.trim() {
+        "link" => Ok("link"),
+        "conv" => Ok("conv"),
+        other => bail!("operation must be link or conv (got {other})"),
+    }
+}
+
+fn require_find_option(value: &str) -> Result<String> {
+    match value {
+        "formula" | "exact_mass" | "mol_weight" => Ok(value.to_string()),
+        other => bail!("option must be formula, exact_mass or mol_weight (got {other})"),
+    }
+}
+
+fn formula_database(database: &str) -> bool {
+    matches!(database, "compound" | "cpd" | "drug" | "dr")
+}
+
+fn join_dbentries(ids: &[String]) -> String {
+    ids.iter()
+        .map(|id| encode_kegg_segment(id))
+        .collect::<Vec<_>>()
+        .join("+")
+}
+
+fn encode_kegg_segment(value: &str) -> String {
+    let mut out = String::new();
+    for b in value.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' | b':' | b'+' => {
+                out.push(b as char)
+            }
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
+}
+
+fn parse_get_body(text: &str) -> Result<Vec<(KeggRecord, String)>> {
+    if looks_like_html(text.as_bytes()) {
+        bail!("KEGG returned HTML instead of text");
+    }
+    let chunks = split_flat_records(text)?;
+    if chunks.is_empty() && !text.trim().is_empty() {
+        bail!("KEGG returned an unusable response");
+    }
+    let mut out = Vec::new();
+    for chunk in chunks {
+        out.push((parse_flat_record(&chunk)?, chunk));
+    }
+    Ok(out)
+}
+
+fn split_flat_records(text: &str) -> Result<Vec<String>> {
+    let mut records = Vec::new();
+    let mut current = String::new();
+    for line in text.lines() {
+        if current.is_empty() && line.trim().is_empty() {
+            continue;
+        }
+        current.push_str(line);
+        current.push('\n');
+        if line.trim() == "///" {
+            records.push(std::mem::take(&mut current));
+        }
+    }
+    if current.trim().is_empty() {
+        Ok(records)
+    } else {
+        Err(anyhow!("KEGG returned an unusable response"))
+    }
+}
+
+fn parse_flat_record(chunk: &str) -> Result<KeggRecord> {
+    let mut fields: Vec<(String, Vec<String>)> = Vec::new();
+    let mut current: Option<usize> = None;
+    for line in chunk.lines() {
+        if line.trim() == "///" {
+            break;
+        }
+        if line.trim().is_empty() {
+            continue;
+        }
+        let keyword = field_keyword(line);
+        let value = field_value(line);
+        if keyword.is_empty() {
+            if let Some(index) = current {
+                fields[index].1.push(value);
+            }
+        } else {
+            fields.push((keyword, vec![value]));
+            current = Some(fields.len() - 1);
+        }
+    }
+    let entry = field_lines(&fields, "ENTRY")
+        .first()
+        .map(|line| line.as_str())
+        .unwrap_or("");
+    let mut tokens = entry.split_whitespace();
+    let entry_id = tokens.next().unwrap_or("").to_string();
+    let entry_type = tokens.next().unwrap_or("").to_string();
+    if entry_id.is_empty() {
+        bail!("KEGG returned an unusable response");
+    }
+    Ok(KeggRecord {
+        entry_id,
+        entry_type,
+        name: parse_names(field_lines(&fields, "NAME")),
+        symbol: parse_symbols(field_lines(&fields, "SYMBOL")),
+        definition: joined_field(&fields, "DEFINITION")
+            .or_else(|| joined_field(&fields, "DESCRIPTION")),
+        organism: joined_field(&fields, "ORGANISM"),
+        formula: joined_field(&fields, "FORMULA"),
+        pathway: parse_id_names(field_lines(&fields, "PATHWAY")),
+        orthology: parse_id_names(field_lines(&fields, "ORTHOLOGY")),
+    })
+}
+
+fn field_keyword(line: &str) -> String {
+    if line.len() >= FIELD_WIDTH {
+        line[..FIELD_WIDTH].trim().to_string()
+    } else {
+        line.trim().to_string()
+    }
+}
+
+fn field_value(line: &str) -> String {
+    if line.len() >= FIELD_WIDTH {
+        line[FIELD_WIDTH..].trim_end().to_string()
+    } else {
+        String::new()
+    }
+}
+
+fn field_lines<'a>(fields: &'a [(String, Vec<String>)], key: &str) -> &'a [String] {
+    fields
+        .iter()
+        .find(|(name, _)| name == key)
+        .map(|(_, lines)| lines.as_slice())
+        .unwrap_or(&[])
+}
+
+fn joined_field(fields: &[(String, Vec<String>)], key: &str) -> Option<String> {
+    let text = field_lines(fields, key)
+        .iter()
+        .map(|line| line.trim())
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ");
+    if text.is_empty() {
+        None
+    } else {
+        Some(text)
+    }
+}
+
+fn parse_names(lines: &[String]) -> Vec<String> {
+    let mut names = Vec::new();
+    for line in lines {
+        for piece in line.split(';') {
+            let mut piece = piece.trim();
+            if let Some(rest) = piece.strip_prefix("(RefSeq)") {
+                piece = rest.trim();
+            }
+            if !piece.is_empty() {
+                names.push(piece.to_string());
+            }
+        }
+    }
+    names
+}
+
+fn parse_symbols(lines: &[String]) -> Vec<String> {
+    let mut symbols = Vec::new();
+    for line in lines {
+        for piece in line.split(',') {
+            let piece = piece.trim();
+            if !piece.is_empty() {
+                symbols.push(piece.to_string());
+            }
+        }
+    }
+    symbols
+}
+
+fn parse_id_names(lines: &[String]) -> Vec<Value> {
+    let mut out = Vec::new();
+    for line in lines {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        match trimmed.split_once(char::is_whitespace) {
+            Some((id, name)) => out.push(json!({"id": id, "name": name.trim()})),
+            None => out.push(json!({"id": trimmed, "name": ""})),
+        }
+    }
+    out
+}
+
+struct KeggRecord {
+    entry_id: String,
+    entry_type: String,
+    name: Vec<String>,
+    symbol: Vec<String>,
+    definition: Option<String>,
+    organism: Option<String>,
+    formula: Option<String>,
+    pathway: Vec<Value>,
+    orthology: Vec<Value>,
+}
+
+impl KeggRecord {
+    fn matches(&self, requested: &str) -> bool {
+        if requested == self.entry_id {
+            return true;
+        }
+        let Some((prefix, local)) = requested.split_once(':') else {
+            return false;
+        };
+        if local != self.entry_id {
+            return false;
+        }
+        match self
+            .organism
+            .as_deref()
+            .and_then(|value| value.split_whitespace().next())
+        {
+            Some(org) => org == prefix,
+            None => true,
+        }
+    }
+
+    fn into_json(self, requested: &str, raw: Option<String>) -> Value {
+        let mut record = json!({
+            "requested_id": requested,
+            "entry_id": self.entry_id,
+            "entry_type": self.entry_type,
+            "name": self.name,
+            "symbol": self.symbol,
+            "definition": self.definition,
+            "organism": self.organism,
+            "formula": self.formula,
+            "pathway": self.pathway,
+            "orthology": self.orthology,
+            "url": format!("{KEGG_PAGE}/entry/{requested}")
+        });
+        if let Some(raw) = raw {
+            record["raw"] = json!(raw);
+        }
+        record
+    }
+}
+
+fn parse_find(text: &str) -> Result<Vec<(String, String)>> {
+    if looks_like_html(text.as_bytes()) {
+        bail!("KEGG returned HTML instead of text");
+    }
+    let mut rows = Vec::new();
+    for line in text.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        match line.split_once('\t') {
+            Some((id, description)) => {
+                rows.push((id.trim().to_string(), description.trim().to_string()))
+            }
+            None => rows.push((line.trim().to_string(), String::new())),
+        }
+    }
+    Ok(rows)
+}
+
+fn exact_symbol_match(description: &str, query: &str) -> bool {
+    let symbols = description
+        .split_once(';')
+        .map(|(left, _)| left)
+        .unwrap_or(description);
+    let query = query.trim();
+    symbols
+        .split(',')
+        .map(str::trim)
+        .filter(|token| !token.is_empty())
+        .any(|token| token.eq_ignore_ascii_case(query))
+}
+
+fn parse_two_column(text: &str) -> Result<Vec<(String, String)>> {
+    if looks_like_html(text.as_bytes()) {
+        bail!("KEGG returned HTML instead of text");
+    }
+    let mut rows = Vec::new();
+    for line in text.lines() {
+        let line = line.trim_end();
+        if line.trim().is_empty() {
+            continue;
+        }
+        let Some((left, right)) = line.split_once('\t') else {
+            bail!("KEGG returned an unusable response");
+        };
+        let left = left.trim();
+        let right = right.trim();
+        if left.is_empty() || right.is_empty() {
+            continue;
+        }
+        rows.push((left.to_string(), right.to_string()));
+    }
+    Ok(rows)
+}
+
+fn map_query_id(returned: &str, query_ids: &[String]) -> String {
+    if query_ids.iter().any(|id| id == returned) {
+        return returned.to_string();
+    }
+    let local = returned
+        .split_once(':')
+        .map(|(_, rest)| rest)
+        .unwrap_or(returned);
+    for id in query_ids {
+        if id == local {
+            return id.clone();
+        }
+        let query_local = id
+            .split_once(':')
+            .map(|(_, rest)| rest)
+            .unwrap_or(id.as_str());
+        if query_local == local || query_local == returned {
+            return id.clone();
+        }
+    }
+    returned.to_string()
+}

--- a/crates/wisp-bio/src/genes_ontologies/mod.rs
+++ b/crates/wisp-bio/src/genes_ontologies/mod.rs
@@ -1,5 +1,6 @@
 //! Native `genes-ontologies` domain against MyGene.info, UniProt, OLS4,
-//! QuickGO and the Reactome Analysis Service. Independently implemented from:
+//! QuickGO, the Reactome Analysis Service and KEGG REST. Independently
+//! implemented from:
 //!
 //! - [MyGene.info v3 query](https://docs.mygene.info/en/latest/doc/query_service.html)
 //! - [UniProt REST entry and search](https://www.uniprot.org/help/api_retrieve_entries)
@@ -7,10 +8,12 @@
 //! - [OLS4 REST API](https://www.ebi.ac.uk/ols4/ols3help)
 //! - [QuickGO REST API](https://www.ebi.ac.uk/QuickGO/api/index.html)
 //! - [Reactome Analysis Service](https://reactome.org/AnalysisService)
+//! - [KEGG API Manual](https://www.kegg.jp/kegg/rest/keggapi.html)
+//! - [KEGG copyright and disclaimer](https://www.kegg.jp/kegg/legal.html)
 //!
-//! References reviewed 2026-09-06. KEGG REST is excluded (license gate).
-//! Tests use invented records.
+//! References reviewed 2026-09-06. Tests use invented records.
 
+mod kegg;
 #[cfg(test)]
 mod tests;
 
@@ -96,6 +99,24 @@ pub fn catalog() -> Vec<(&'static str, ToolSchema)> {
             }),
         ),
         tool(
+            "get_kegg_entries",
+            concat!(
+                "Retrieve KEGG entries (genes, pathways, compounds and other databases) via GET /get/{id1}+{id2}+... as official flat-file records (https://www.kegg.jp/kegg/rest/keggapi.html). At most 10 identifiers per HTTP request, batched sequentially; at most 50 unique ids per call. Parses ENTRY, NAME, SYMBOL, DEFINITION/DESCRIPTION, ORGANISM, FORMULA, PATHWAY and ORTHOLOGY. An identifier with no returned record is an error. include_raw adds the flat-file chunk including the /// terminator. Each record includes a KEGG entry URL.",
+                " KEGG REST is for academic use of the KEGG website/API; non-academic use requires a commercial license from Pathway Solutions (https://www.kegg.jp/kegg/legal.html). Academic users who provide KEGG as a service need the academic service-provider license. This client queries rest.kegg.jp; it does not redistribute the KEGG database."
+            ),
+            json!({
+                "type": "object", "additionalProperties": false,
+                "required": ["ids"],
+                "properties": {
+                    "ids": {
+                        "type": "array", "minItems": 1, "maxItems": 50,
+                        "items": {"type": "string", "minLength": 1, "maxLength": 64}
+                    },
+                    "include_raw": {"type": "boolean", "default": false}
+                }
+            }),
+        ),
+        tool(
             "get_ontology_term",
             "Look up one OLS4 term by ontology id plus CURIE, short form or IRI (GET /api/ontologies/{id}/terms). Without relation: label, synonyms, description, obsolete flag and optional direct parents. With relation: a bounded page of related terms (parents, children, ancestors, descendants, or the hierarchical* variants). Related-term retrieval reports the OLS page total; a capped page is not the complete neighbourhood. Unknown terms are errors, not empty evidence.",
             json!({
@@ -129,6 +150,25 @@ pub fn catalog() -> Vec<(&'static str, ToolSchema)> {
                         "type": "array", "minItems": 1, "maxItems": 20,
                         "items": {"type": "string", "minLength": 1, "maxLength": 64}
                     }
+                }
+            }),
+        ),
+        tool(
+            "link_kegg_ids",
+            concat!(
+                "Cross-reference KEGG identifiers with GET /link/{target_db}/{ids} or convert outside identifiers with GET /conv/{target_db}/{ids} (https://www.kegg.jp/kegg/rest/keggapi.html). Requires 1 to 50 explicit ids; database-wide dumps are not supported. Batches 10 ids per request. Two-column tab text is returned as source_id/target_id using the caller's id spelling. Inputs with zero hits appear in missing_ids; an empty mapping is success.",
+                " KEGG REST is for academic use of the KEGG website/API; non-academic use requires a commercial license from Pathway Solutions (https://www.kegg.jp/kegg/legal.html). Academic users who provide KEGG as a service need the academic service-provider license. This client queries rest.kegg.jp; it does not redistribute the KEGG database."
+            ),
+            json!({
+                "type": "object", "additionalProperties": false,
+                "required": ["ids", "target_db"],
+                "properties": {
+                    "ids": {
+                        "type": "array", "minItems": 1, "maxItems": 50,
+                        "items": {"type": "string", "minLength": 1, "maxLength": 64}
+                    },
+                    "target_db": {"type": "string", "minLength": 1, "maxLength": 32},
+                    "operation": {"type": "string", "enum": ["link", "conv"], "default": "link"}
                 }
             }),
         ),
@@ -185,6 +225,24 @@ pub fn catalog() -> Vec<(&'static str, ToolSchema)> {
             }),
         ),
         tool(
+            "search_kegg",
+            concat!(
+                "Search KEGG identifier and name fields via GET /find/{database}/{query} (substring match; https://www.kegg.jp/kegg/rest/keggapi.html). database defaults to hsa; use an organism code or a find-database from the KEGG API manual. option formula, exact_mass or mol_weight is allowed only for compound or drug. exact_gene_symbol keeps rows whose comma-separated symbol list (tokens before the first semicolon in the description) contains the query as a whole token, case-insensitive. No hits is success. The page is bounded (default 50, at most 200); truncated means further hits exist.",
+                " KEGG REST is for academic use of the KEGG website/API; non-academic use requires a commercial license from Pathway Solutions (https://www.kegg.jp/kegg/legal.html). Academic users who provide KEGG as a service need the academic service-provider license. This client queries rest.kegg.jp; it does not redistribute the KEGG database."
+            ),
+            json!({
+                "type": "object", "additionalProperties": false,
+                "required": ["query"],
+                "properties": {
+                    "query": {"type": "string", "minLength": 1, "maxLength": 256},
+                    "database": {"type": "string", "minLength": 1, "maxLength": 32, "default": "hsa"},
+                    "option": {"type": "string", "enum": ["formula", "exact_mass", "mol_weight"]},
+                    "exact_gene_symbol": {"type": "boolean", "default": false},
+                    "max_hits": {"type": "integer", "minimum": 1, "maximum": 200, "default": 50}
+                }
+            }),
+        ),
+        tool(
             "search_ontology_terms",
             "Search OLS4 term labels and synonyms (GET /api/search). Restrict with ontologies (lowercase OLS ids such as go, efo, cl, chebi). exact requests a whole-string match; include_obsolete adds obsolete terms. The response is a bounded page (default 25, at most 100) and reports numFound versus returned; a capped page is not the complete hit list. Each term includes CURIE, IRI, ontology and an OLS class URL.",
             json!({
@@ -224,9 +282,12 @@ async fn dispatch(bio: &NativeBio, name: &str, args: &Value) -> Result<Value> {
         "query_genes" => query_genes(bio, args).await,
         "get_uniprot_entries" => get_uniprot_entries(bio, args).await,
         "get_go_annotations" => get_go_annotations(bio, args).await,
+        "get_kegg_entries" => kegg::get_kegg_entries(bio, args).await,
         "get_ontology_term" => get_ontology_term(bio, args).await,
+        "link_kegg_ids" => kegg::link_kegg_ids(bio, args).await,
         "list_ontologies" => list_ontologies(bio, args).await,
         "map_reactome_pathways" => map_reactome_pathways(bio, args).await,
+        "search_kegg" => kegg::search_kegg(bio, args).await,
         "search_ontology_terms" => search_ontology_terms(bio, args).await,
         _ => bail!("unknown native biological tool: {name}"),
     }
@@ -1511,7 +1572,7 @@ fn retry_after_seconds(value: &str) -> Option<u64> {
     value.parse().ok()
 }
 
-fn looks_like_html(body: &[u8]) -> bool {
+pub(super) fn looks_like_html(body: &[u8]) -> bool {
     let text = std::str::from_utf8(body).unwrap_or("").trim_start();
     let prefix: String = text
         .chars()
@@ -1725,7 +1786,7 @@ fn token_param(value: &str, max: usize, what: &str) -> Result<String> {
     Ok(trimmed.to_string())
 }
 
-fn bound_u32(value: u32, min: u32, max: u32, what: &str) -> Result<u32> {
+pub(super) fn bound_u32(value: u32, min: u32, max: u32, what: &str) -> Result<u32> {
     if !(min..=max).contains(&value) {
         bail!("{what} must be between {min} and {max}");
     }
@@ -1879,7 +1940,7 @@ fn reactome_base(bio: &NativeBio) -> String {
     cred_base(bio, "REACTOME_BASE_URL", REACTOME_HOST)
 }
 
-fn cred_base(bio: &NativeBio, name: &str, fallback: &str) -> String {
+pub(super) fn cred_base(bio: &NativeBio, name: &str, fallback: &str) -> String {
     bio.credential(name)
         .map(|value| value.trim_end_matches('/').to_string())
         .filter(|value| !value.is_empty())

--- a/crates/wisp-bio/src/genes_ontologies/tests.rs
+++ b/crates/wisp-bio/src/genes_ontologies/tests.rs
@@ -19,7 +19,8 @@ fn test_bio(base: &str) -> NativeBio {
             ("UNIPROT_BASE_URL".into(), base.clone()),
             ("OLS_BASE_URL".into(), base.clone()),
             ("QUICKGO_BASE_URL".into(), base.clone()),
-            ("REACTOME_BASE_URL".into(), base),
+            ("REACTOME_BASE_URL".into(), base.clone()),
+            ("KEGG_BASE_URL".into(), base),
         ],
         Http(reqwest::Client::builder().no_proxy().build().unwrap()),
     )
@@ -34,7 +35,7 @@ async fn serve(app: Router) -> (NativeBio, tokio::task::JoinHandle<()>) {
 }
 
 #[test]
-fn catalog_registers_seven_genes_ontologies_tools_and_skips_kegg() {
+fn catalog_registers_ten_genes_ontologies_tools_including_kegg() {
     let names: Vec<_> = catalog()
         .into_iter()
         .map(|(domain, schema)| (domain, schema.function.name))
@@ -43,17 +44,20 @@ fn catalog_registers_seven_genes_ontologies_tools_and_skips_kegg() {
         names,
         vec![
             ("genes-ontologies", "get_go_annotations".into()),
+            ("genes-ontologies", "get_kegg_entries".into()),
             ("genes-ontologies", "get_ontology_term".into()),
             ("genes-ontologies", "get_uniprot_entries".into()),
+            ("genes-ontologies", "link_kegg_ids".into()),
             ("genes-ontologies", "list_ontologies".into()),
             ("genes-ontologies", "map_reactome_pathways".into()),
             ("genes-ontologies", "query_genes".into()),
+            ("genes-ontologies", "search_kegg".into()),
             ("genes-ontologies", "search_ontology_terms".into()),
         ]
     );
     for kegg in ["get_kegg_entries", "search_kegg", "link_kegg_ids"] {
-        assert!(!crate::contains_tool(kegg), "{kegg}");
-        assert_eq!(crate::domain_for_tool(kegg), None);
+        assert!(crate::contains_tool(kegg), "{kegg}");
+        assert_eq!(crate::domain_for_tool(kegg), Some("genes-ontologies"));
     }
     assert_eq!(
         crate::domain_for_tool("query_genes"),
@@ -637,18 +641,410 @@ async fn reactome_rate_limit_does_not_echo_request_body() {
 }
 
 #[tokio::test]
-async fn kegg_operations_are_not_dispatched() {
+async fn kegg_rejects_malformed_arguments() {
     let (bio, server) = serve(Router::new()).await;
-    for name in ["get_kegg_entries", "search_kegg", "link_kegg_ids"] {
-        let error = genes_ontologies_call(&bio, name).await;
-        assert!(error.contains("unknown native biological tool"), "{error}");
-    }
+    let empty = bio
+        .call("get_kegg_entries", &json!({"ids": []}))
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(empty.contains("at least one"), "{empty}");
+    let duplicates = bio
+        .call(
+            "get_kegg_entries",
+            &json!({"ids": ["syn:2001", "syn:2001"]}),
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(duplicates.contains("duplicate"), "{duplicates}");
+    let too_many: Vec<String> = (1..=51).map(|n| format!("syn:{n}")).collect();
+    let overflow = bio
+        .call("get_kegg_entries", &json!({"ids": too_many}))
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(overflow.contains("50"), "{overflow}");
+    let unknown_op = bio
+        .call(
+            "link_kegg_ids",
+            &json!({"ids": ["syn:2001"], "target_db": "pathway", "operation": "dump"}),
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(
+        unknown_op.contains("operation") && unknown_op.contains("link"),
+        "{unknown_op}"
+    );
+    let formula_on_org = bio
+        .call(
+            "search_kegg",
+            &json!({"query": "C6H12O6", "database": "hsa", "option": "formula"}),
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(
+        formula_on_org.contains("compound") || formula_on_org.contains("drug"),
+        "{formula_on_org}"
+    );
+    let extra = bio
+        .call(
+            "get_kegg_entries",
+            &json!({"ids": ["syn:2001"], "api_key": "secret-token"}),
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(
+        extra.contains("unknown field") || extra.contains("invalid get_kegg_entries"),
+        "{extra}"
+    );
+    assert!(!extra.contains("secret-token"), "{extra}");
     server.abort();
 }
 
-async fn genes_ontologies_call(bio: &NativeBio, name: &str) -> String {
-    crate::genes_ontologies::call(bio, name, &json!({"ids": ["hsa:7157"]}))
+#[tokio::test]
+async fn get_kegg_entries_batches_and_parses_flat_file() {
+    let seen = Arc::new(StdMutex::new(Vec::<String>::new()));
+    let traffic = seen.clone();
+    let app = Router::new().route(
+        "/get/{*ids}",
+        get(move |uri: Uri| {
+            let traffic = traffic.clone();
+            async move {
+                traffic.lock().unwrap().push(uri.to_string());
+                let rest = uri.path().strip_prefix("/get/").unwrap_or(uri.path());
+                let decoded = decode_kegg_path(rest);
+                let mut body = String::new();
+                for id in decoded.split('+') {
+                    let local = id.rsplit_once(':').map(|(_, rest)| rest).unwrap_or(id);
+                    let Ok(n) = local.parse::<u32>() else {
+                        continue;
+                    };
+                    if !(2001..=2011).contains(&n) {
+                        continue;
+                    }
+                    if !body.is_empty() {
+                        body.push('\n');
+                    }
+                    body.push_str(&synthetic_gene_entry(id));
+                }
+                body
+            }
+        }),
+    );
+    let (bio, server) = serve(app).await;
+    let ids: Vec<String> = (2001..=2011).map(|n| format!("syn:{n}")).collect();
+    let result = bio
+        .call(
+            "get_kegg_entries",
+            &json!({"ids": ids, "include_raw": true}),
+        )
+        .await
+        .unwrap();
+    let missing = bio
+        .call(
+            "get_kegg_entries",
+            &json!({"ids": ["syn:2001", "syn:2099"]}),
+        )
         .await
         .unwrap_err()
-        .to_string()
+        .to_string();
+    server.abort();
+    let urls = seen.lock().unwrap().clone();
+    assert_eq!(urls.len(), 3, "{urls:?}");
+    assert!(
+        urls[0].contains("syn:2001")
+            && urls[0].contains("syn:2010")
+            && !urls[0].contains("syn:2011"),
+        "{}",
+        urls[0]
+    );
+    assert!(
+        urls[1].contains("syn:2011") && !urls[1].contains("syn:2001"),
+        "{}",
+        urls[1]
+    );
+    assert_eq!(plus_count(&urls[0]), 9);
+    assert_eq!(result["source"], "KEGG");
+    assert_eq!(
+        result["source_url"],
+        "https://rest.kegg.jp/get/syn:2001+syn:2002+syn:2003+syn:2004+syn:2005+syn:2006+syn:2007+syn:2008+syn:2009+syn:2010"
+    );
+    assert_eq!(result["returned"], 11);
+    assert_eq!(result["records"][0]["requested_id"], "syn:2001");
+    assert_eq!(result["records"][0]["entry_id"], "2001");
+    assert_eq!(result["records"][0]["entry_type"], "CDS");
+    assert_eq!(result["records"][0]["name"], json!(["SYN2001"]));
+    assert_eq!(
+        result["records"][0]["symbol"],
+        json!(["SYN2001", "ALT2001"])
+    );
+    assert_eq!(
+        result["records"][0]["pathway"],
+        json!([
+            {"id": "syn00010", "name": "Synthetic glycolysis"},
+            {"id": "syn00020", "name": "Synthetic citrate cycle"}
+        ])
+    );
+    assert_eq!(
+        result["records"][0]["url"],
+        "https://www.kegg.jp/entry/syn:2001"
+    );
+    assert!(result["records"][0]["raw"]
+        .as_str()
+        .unwrap()
+        .contains("///"));
+    assert_eq!(result["records"][10]["requested_id"], "syn:2011");
+    assert!(missing.contains("syn:2099"), "{missing}");
+}
+
+#[tokio::test]
+async fn search_kegg_parses_find_tsv_and_filters_exact_symbols() {
+    let app = Router::new().route(
+        "/find/{*rest}",
+        get(|uri: Uri| async move {
+            let rest = uri.path().strip_prefix("/find/").unwrap_or(uri.path());
+            if rest.contains("C6H12O6") {
+                return "syn:C99999\tsynthetic hexose\n".to_string();
+            }
+            "\
+syn:2001\tSYN1, ALT1; synthetic protein one\n\
+syn:2101\tSYN1BP, OTHER; synthetic binding protein\n\
+syn:2003\tSYN1; synthetic protein one isoform\n\
+syn:3000\tUNRELATED; decoy record\n"
+                .to_string()
+        }),
+    );
+    let (bio, server) = serve(app).await;
+    let page = bio
+        .call(
+            "search_kegg",
+            &json!({"query": "SYN1", "database": "syn", "max_hits": 2}),
+        )
+        .await
+        .unwrap();
+    let exact = bio
+        .call(
+            "search_kegg",
+            &json!({
+                "query": "SYN1",
+                "database": "syn",
+                "exact_gene_symbol": true
+            }),
+        )
+        .await
+        .unwrap();
+    let none = bio
+        .call(
+            "search_kegg",
+            &json!({
+                "query": "NOSUCH",
+                "database": "syn",
+                "exact_gene_symbol": true
+            }),
+        )
+        .await
+        .unwrap();
+    let formula = bio
+        .call(
+            "search_kegg",
+            &json!({
+                "query": "C6H12O6",
+                "database": "compound",
+                "option": "formula"
+            }),
+        )
+        .await
+        .unwrap();
+    server.abort();
+    assert_eq!(page["source"], "KEGG");
+    assert_eq!(page["source_url"], "https://rest.kegg.jp/find/syn/SYN1");
+    assert_eq!(page["total_hits"], 4);
+    assert_eq!(page["returned"], 2);
+    assert_eq!(page["truncated"], true);
+    assert_eq!(page["records"][0]["entry_id"], "syn:2001");
+    assert_eq!(exact["n_matches"], 2);
+    assert_eq!(exact["total_hits"], 2);
+    assert_eq!(exact["truncated"], false);
+    let exact_ids: Vec<_> = exact["records"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|row| row["entry_id"].as_str().unwrap())
+        .collect();
+    assert_eq!(exact_ids, vec!["syn:2001", "syn:2003"]);
+    assert_eq!(none["n_matches"], 0);
+    assert_eq!(none["returned"], 0);
+    assert_eq!(formula["records"][0]["entry_id"], "syn:C99999");
+    assert_eq!(
+        formula["source_url"],
+        "https://rest.kegg.jp/find/compound/C6H12O6/formula"
+    );
+}
+
+#[tokio::test]
+async fn link_kegg_ids_maps_tsv_reports_missing_and_batches() {
+    let seen = Arc::new(StdMutex::new(Vec::<String>::new()));
+    let traffic = seen.clone();
+    let app = Router::new()
+        .route(
+            "/link/{*rest}",
+            get(move |uri: Uri| {
+                let traffic = traffic.clone();
+                async move {
+                    traffic.lock().unwrap().push(uri.to_string());
+                    let rest = uri.path().strip_prefix("/link/").unwrap_or(uri.path());
+                    let decoded = decode_kegg_path(rest);
+                    let ids = decoded.split('/').nth(1).unwrap_or("");
+                    let mut body = String::new();
+                    for id in ids.split('+') {
+                        let local = id.rsplit_once(':').map(|(_, rest)| rest).unwrap_or(id);
+                        let echoed = format!("syn:{local}");
+                        if local == "2001" {
+                            body.push_str(&format!(
+                                "{echoed}\tpath:syn00010\n{echoed}\tpath:syn00020\n"
+                            ));
+                        } else if local == "2002" {
+                            body.push_str(&format!("{echoed}\tpath:syn00010\n"));
+                        }
+                    }
+                    body
+                }
+            }),
+        )
+        .route(
+            "/conv/{*rest}",
+            get(|| async { "syn:2001\tncbi-geneid:9001\n".to_string() }),
+        );
+    let (bio, server) = serve(app).await;
+    let mut ids: Vec<String> = vec!["2001".into()];
+    ids.extend((2002..=2011).map(|n| format!("syn:{n}")));
+    let result = bio
+        .call(
+            "link_kegg_ids",
+            &json!({"ids": ids, "target_db": "pathway"}),
+        )
+        .await
+        .unwrap();
+    let conv = bio
+        .call(
+            "link_kegg_ids",
+            &json!({
+                "ids": ["syn:2001"],
+                "target_db": "ncbi-geneid",
+                "operation": "conv"
+            }),
+        )
+        .await
+        .unwrap();
+    server.abort();
+    let urls = seen.lock().unwrap().clone();
+    assert_eq!(urls.len(), 2, "{urls:?}");
+    assert!(urls[0].contains("/link/pathway/"), "{}", urls[0]);
+    assert!(
+        urls[0].contains("2001") && !urls[0].contains("syn:2011"),
+        "{}",
+        urls[0]
+    );
+    assert!(
+        urls[1].contains("syn:2011") && !urls[1].contains("2001"),
+        "{}",
+        urls[1]
+    );
+    assert_eq!(plus_count(&urls[0]), 9);
+    assert_eq!(result["source"], "KEGG");
+    assert_eq!(result["operation"], "link");
+    assert_eq!(result["target_db"], "pathway");
+    assert_eq!(result["returned"], 3);
+    assert_eq!(result["records"][0]["source_id"], "2001");
+    assert_eq!(result["records"][0]["target_id"], "path:syn00010");
+    let missing: Vec<_> = result["missing_ids"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(missing.contains(&"syn:2011"), "{missing:?}");
+    assert!(!missing.iter().any(|id| *id == "2001" || *id == "syn:2002"));
+    assert_eq!(conv["operation"], "conv");
+    assert_eq!(conv["records"][0]["target_id"], "ncbi-geneid:9001");
+    assert_eq!(conv["missing_ids"], json!([]));
+}
+
+#[tokio::test]
+async fn kegg_http_errors_do_not_echo_response_bodies() {
+    for (status, expected) in [
+        (StatusCode::BAD_REQUEST, "HTTP 400"),
+        (StatusCode::TOO_MANY_REQUESTS, "HTTP 429"),
+    ] {
+        let app = Router::new().route(
+            "/get/{*ids}",
+            get(move || async move {
+                (status, [("retry-after", "60")], "secret-token").into_response()
+            }),
+        );
+        let (bio, server) = serve(app).await;
+        let error = bio
+            .call("get_kegg_entries", &json!({"ids": ["syn:2001"]}))
+            .await
+            .unwrap_err()
+            .to_string();
+        server.abort();
+        assert!(
+            error.contains(expected),
+            "{error} did not contain {expected}"
+        );
+        assert!(!error.contains("secret-token"), "{error}");
+    }
+}
+
+#[tokio::test]
+async fn kegg_oversized_body_uses_max_response() {
+    let app = Router::new().route(
+        "/get/{*ids}",
+        get(|| async { (StatusCode::OK, " ".repeat(MAX_RESPONSE + 1)).into_response() }),
+    );
+    let (bio, server) = serve(app).await;
+    let error = bio
+        .call("get_kegg_entries", &json!({"ids": ["syn:2001"]}))
+        .await
+        .unwrap_err()
+        .to_string();
+    server.abort();
+    assert!(error.contains("exceeded 4 MiB"), "{error}");
+}
+
+fn decode_kegg_path(value: &str) -> String {
+    value
+        .replace("%3A", ":")
+        .replace("%3a", ":")
+        .replace("%2B", "+")
+        .replace("%2b", "+")
+}
+
+fn plus_count(url: &str) -> usize {
+    url.matches('+').count() + url.matches("%2B").count() + url.matches("%2b").count()
+}
+
+fn synthetic_gene_entry(requested: &str) -> String {
+    let local = requested
+        .rsplit_once(':')
+        .map(|(_, rest)| rest)
+        .unwrap_or(requested);
+    [
+        format!("ENTRY       {local}              CDS       T00001"),
+        format!("NAME        (RefSeq) SYN{local}"),
+        format!("SYMBOL      SYN{local}, ALT{local}"),
+        format!("DEFINITION  synthetic protein {local}"),
+        "ORGANISM    syn  Synthetic organism".to_string(),
+        "PATHWAY     syn00010  Synthetic glycolysis".to_string(),
+        "            syn00020  Synthetic citrate cycle".to_string(),
+        format!("ORTHOLOGY   K{local}  synthetic dehydrogenase {local}"),
+        "///".to_string(),
+        String::new(),
+    ]
+    .join("\n")
 }


### PR DESCRIPTION
## Problem

KEGG REST (`get_kegg_entries`, `search_kegg`, `link_kegg_ids`) was left on the vendored Python path behind the license gate. Native genes-ontologies already covers MyGene, UniProt, OLS, QuickGO and Reactome.

## Change

Independently authored Rust client against the [KEGG API Manual](https://www.kegg.jp/kegg/rest/keggapi.html) (reviewed 2026-09-06):

- `get_kegg_entries` — batched `/get` (10 ids/request, 50/call), 12-column flat-file parse; missing ids fail
- `search_kegg` — `/find`, optional compound/drug `formula|exact_mass|mol_weight`, client-side exact gene-symbol tokens; empty hits succeed
- `link_kegg_ids` — `/link` or `/conv` with explicit ids; `missing_ids` reported; no database-wide dumps

Paced at 350 ms. `KEGG_BASE_URL` for tests. Academic-use notice in every tool description ([KEGG legal](https://www.kegg.jp/kegg/legal.html)); the client queries rest.kegg.jp and does not redistribute KEGG.

## Tests

`cargo test -p wisp-bio --offline genes_ontologies` — axum fake upstream, invented records, 400/429 without echoing bodies.

## Files

- `crates/wisp-bio/src/genes_ontologies/kegg.rs` (new)
- `crates/wisp-bio/src/genes_ontologies/mod.rs`
- `crates/wisp-bio/src/genes_ontologies/tests.rs`