### PR TITLE
feat(bio): native CADD scores in variants

### DIFF
--- a/crates/wisp-bio/src/variants/cadd.rs
+++ b/crates/wisp-bio/src/variants/cadd.rs
@@ -1,0 +1,373 @@
+use super::{cadd_base, json_i64, json_string, NativeBio};
+use crate::http::Source;
+use anyhow::{bail, Context, Result};
+use reqwest::Method;
+use serde::Deserialize;
+use serde_json::{json, Value};
+use std::collections::BTreeSet;
+use std::time::Duration;
+
+const CADD: Source = Source("CADD", Duration::from_millis(500));
+const CADD_DOCS: &str = "https://cadd.gs.washington.edu/api";
+const DEFAULT_VERSION: &str = "GRCh38-v1.7";
+const MAX_RANGE_BP: i64 = 100;
+const RANGE_HEADER: [&str; 6] = ["Chrom", "Pos", "Ref", "Alt", "RawScore", "PHRED"];
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct PositionScores {
+    chrom: String,
+    pos: i64,
+    #[serde(default = "default_version")]
+    version: String,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct VariantScore {
+    chrom: String,
+    pos: i64,
+    #[serde(rename = "ref")]
+    reference: String,
+    alt: String,
+    #[serde(default = "default_version")]
+    version: String,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(super) struct RangeScores {
+    chrom: String,
+    start: i64,
+    end: i64,
+    #[serde(default = "default_version")]
+    version: String,
+}
+
+fn default_version() -> String {
+    DEFAULT_VERSION.into()
+}
+
+pub(super) async fn position_scores(bio: &NativeBio, args: &Value) -> Result<Value> {
+    let args: PositionScores =
+        serde_json::from_value(args.clone()).context("invalid cadd_position_scores arguments")?;
+    let version = require_version(&args.version)?;
+    let chrom = require_chrom(&args.chrom)?;
+    let pos = require_pos(args.pos, "pos")?;
+    let records = fetch_position(bio, &version, &chrom, pos).await?;
+    Ok(json!({
+        "source": "CADD",
+        "source_url": CADD_DOCS,
+        "query": {
+            "type": "position",
+            "version": version,
+            "chrom": chrom,
+            "pos": pos
+        },
+        "records": records
+    }))
+}
+
+pub(super) async fn variant_score(bio: &NativeBio, args: &Value) -> Result<Value> {
+    let args: VariantScore =
+        serde_json::from_value(args.clone()).context("invalid cadd_variant_score arguments")?;
+    let version = require_version(&args.version)?;
+    let chrom = require_chrom(&args.chrom)?;
+    let pos = require_pos(args.pos, "pos")?;
+    let reference = require_allele(&args.reference, "ref")?;
+    let alt = require_allele(&args.alt, "alt")?;
+    if reference == alt {
+        bail!("ref and alt must differ");
+    }
+    let records = fetch_position(bio, &version, &chrom, pos).await?;
+    let actual_ref = records[0]["ref"].as_str().unwrap_or("");
+    if !actual_ref.eq_ignore_ascii_case(&reference) {
+        bail!(
+            "CADD {version} {chrom}:{pos}: query ref={reference} but the reference allele is {actual_ref} (wrong build or typo)"
+        );
+    }
+    if let Some(record) = records.iter().find(|row| {
+        row["alt"]
+            .as_str()
+            .is_some_and(|value| value.eq_ignore_ascii_case(&alt))
+    }) {
+        return Ok(json!({
+            "source": "CADD",
+            "source_url": CADD_DOCS,
+            "query": {
+                "type": "variant",
+                "version": version,
+                "chrom": chrom,
+                "pos": pos,
+                "ref": reference,
+                "alt": alt
+            },
+            "record": record
+        }));
+    }
+    let alts: Vec<&str> = records
+        .iter()
+        .filter_map(|row| row["alt"].as_str())
+        .collect();
+    bail!(
+        "no CADD row for alt={alt} at {version} {chrom}:{pos} (alts present: {})",
+        alts.join(", ")
+    )
+}
+
+pub(super) async fn range_scores(bio: &NativeBio, args: &Value) -> Result<Value> {
+    let args: RangeScores =
+        serde_json::from_value(args.clone()).context("invalid cadd_range_scores arguments")?;
+    let version = require_version(&args.version)?;
+    let chrom = require_chrom(&args.chrom)?;
+    let (start, end, span) = require_span(args.start, args.end)?;
+    let path = format!("{version}/{chrom}:{start}-{end}");
+    let payload = cadd_get(bio, &path).await?;
+    let records = parse_range(&payload)?;
+    if records.is_empty() {
+        bail!("no CADD rows for {version} {chrom}:{start}-{end}");
+    }
+    let positions: BTreeSet<i64> = records
+        .iter()
+        .filter_map(|row| json_i64(&row["pos"]))
+        .collect();
+    Ok(json!({
+        "source": "CADD",
+        "source_url": CADD_DOCS,
+        "query": {
+            "type": "range",
+            "version": version,
+            "chrom": chrom,
+            "start": start,
+            "end": end
+        },
+        "n_records": records.len(),
+        "n_positions_scored": positions.len(),
+        "span_bp": span,
+        "truncated": false,
+        "records": records
+    }))
+}
+
+async fn fetch_position(
+    bio: &NativeBio,
+    version: &str,
+    chrom: &str,
+    pos: i64,
+) -> Result<Vec<Value>> {
+    let path = format!("{version}/{chrom}:{pos}");
+    let payload = cadd_get(bio, &path).await?;
+    let records = parse_position(&payload)?;
+    if records.is_empty() {
+        bail!("no CADD rows for {version} {chrom}:{pos}");
+    }
+    Ok(records)
+}
+
+async fn cadd_get(bio: &NativeBio, path: &str) -> Result<Value> {
+    let url = format!("{}/{path}", cadd_base(bio));
+    bio.http().send(CADD, Method::GET, &url, &[]).await?.json()
+}
+
+fn parse_position(payload: &Value) -> Result<Vec<Value>> {
+    let rows = payload
+        .as_array()
+        .context("CADD position response must be a JSON list")?;
+    let mut records = Vec::with_capacity(rows.len());
+    for row in rows {
+        if !row.is_object() {
+            bail!("CADD position row is missing required keys");
+        }
+        records.push(score_record(
+            &row["Chrom"],
+            &row["Pos"],
+            &row["Ref"],
+            &row["Alt"],
+            &row["RawScore"],
+            &row["PHRED"],
+        )?);
+    }
+    sort_records(&mut records);
+    Ok(records)
+}
+
+fn parse_range(payload: &Value) -> Result<Vec<Value>> {
+    let rows = payload
+        .as_array()
+        .context("CADD range response must be a JSON list")?;
+    if rows.is_empty() {
+        return Ok(Vec::new());
+    }
+    let header = rows[0]
+        .as_array()
+        .context("CADD range response had an unexpected header")?;
+    if header.len() != RANGE_HEADER.len()
+        || header
+            .iter()
+            .zip(RANGE_HEADER)
+            .any(|(got, want)| got.as_str() != Some(want))
+    {
+        bail!("CADD range response had an unexpected header");
+    }
+    let mut records = Vec::with_capacity(rows.len().saturating_sub(1));
+    for row in &rows[1..] {
+        let cells = row
+            .as_array()
+            .filter(|cells| cells.len() == RANGE_HEADER.len())
+            .context("CADD range row is missing required keys")?;
+        records.push(score_record(
+            &cells[0], &cells[1], &cells[2], &cells[3], &cells[4], &cells[5],
+        )?);
+    }
+    sort_records(&mut records);
+    Ok(records)
+}
+
+fn score_record(
+    chrom: &Value,
+    pos: &Value,
+    reference: &Value,
+    alt: &Value,
+    raw_score: &Value,
+    phred: &Value,
+) -> Result<Value> {
+    let chrom = json_string(chrom).context("CADD omitted Chrom")?;
+    let pos = json_i64(pos)
+        .filter(|value| *value >= 1)
+        .context("CADD omitted Pos")?;
+    let reference = json_string(reference).context("CADD omitted Ref")?;
+    let alt = json_string(alt).context("CADD omitted Alt")?;
+    let raw_score = decimal_string(raw_score, "RawScore")?;
+    let phred = decimal_string(phred, "PHRED")?;
+    Ok(json!({
+        "chrom": chrom,
+        "pos": pos,
+        "ref": reference,
+        "alt": alt,
+        "raw_score": raw_score,
+        "phred": phred
+    }))
+}
+
+fn decimal_string(value: &Value, what: &str) -> Result<String> {
+    match value {
+        Value::String(text) if !text.is_empty() => Ok(text.clone()),
+        Value::Number(number) => Ok(number.to_string()),
+        _ => bail!("CADD omitted {what}"),
+    }
+}
+
+fn sort_records(records: &mut [Value]) {
+    records.sort_by(|a, b| {
+        a["chrom"]
+            .as_str()
+            .unwrap_or("")
+            .cmp(b["chrom"].as_str().unwrap_or(""))
+            .then_with(|| {
+                json_i64(&a["pos"])
+                    .unwrap_or(0)
+                    .cmp(&json_i64(&b["pos"]).unwrap_or(0))
+            })
+            .then_with(|| {
+                a["ref"]
+                    .as_str()
+                    .unwrap_or("")
+                    .cmp(b["ref"].as_str().unwrap_or(""))
+            })
+            .then_with(|| {
+                a["alt"]
+                    .as_str()
+                    .unwrap_or("")
+                    .cmp(b["alt"].as_str().unwrap_or(""))
+            })
+    });
+}
+
+pub(super) fn require_version(raw: &str) -> Result<String> {
+    let text = raw.trim();
+    let Some(rest) = text
+        .strip_prefix("GRCh37-v")
+        .or_else(|| text.strip_prefix("GRCh38-v"))
+    else {
+        bail!(
+            "CADD version must look like GRCh38-v1.7 (build prefix required; a bare v1.7 is rejected)"
+        );
+    };
+    let numeric = match rest.strip_suffix("_inclAnno") {
+        Some(numeric) => numeric,
+        None if rest.contains("_inclAnno") => {
+            bail!(
+                "CADD version must look like GRCh38-v1.7 (build prefix required; a bare v1.7 is rejected)"
+            );
+        }
+        None => rest,
+    };
+    let mut parts = numeric.split('.');
+    let major = parts.next().unwrap_or("");
+    let minor = parts.next().unwrap_or("");
+    if parts.next().is_some()
+        || major.is_empty()
+        || minor.is_empty()
+        || !major.bytes().all(|b| b.is_ascii_digit())
+        || !minor.bytes().all(|b| b.is_ascii_digit())
+    {
+        bail!(
+            "CADD version must look like GRCh38-v1.7 (build prefix required; a bare v1.7 is rejected)"
+        );
+    }
+    Ok(text.to_string())
+}
+
+pub(super) fn require_chrom(raw: &str) -> Result<String> {
+    let text = raw.trim();
+    let text = match text.get(..3) {
+        Some(prefix) if prefix.eq_ignore_ascii_case("chr") => &text[3..],
+        _ => text,
+    };
+    if text.is_empty() || text.len() > 2 {
+        bail!("CADD chromosome must be 1–22, X or Y (nuclear SNVs only)");
+    }
+    let upper = text.to_ascii_uppercase();
+    if let Ok(n) = upper.parse::<u8>() {
+        if (1..=22).contains(&n) {
+            return Ok(n.to_string());
+        }
+    } else if upper == "X" || upper == "Y" {
+        return Ok(upper);
+    }
+    if matches!(upper.as_str(), "M" | "MT") {
+        bail!("CADD scores nuclear SNVs only; mitochondrial contigs are rejected");
+    }
+    bail!("CADD chromosome must be 1–22, X or Y (nuclear SNVs only)")
+}
+
+fn require_pos(value: i64, what: &str) -> Result<i64> {
+    if value < 1 {
+        bail!("{what} must be a positive 1-based position");
+    }
+    Ok(value)
+}
+
+pub(super) fn require_allele(raw: &str, what: &str) -> Result<String> {
+    let text = raw.trim().to_ascii_uppercase();
+    if text.len() != 1 || !matches!(text.as_bytes()[0], b'A' | b'C' | b'G' | b'T') {
+        bail!("{what} must be one of A/C/G/T");
+    }
+    Ok(text)
+}
+
+pub(super) fn require_span(start: i64, end: i64) -> Result<(i64, i64, i64)> {
+    let start = require_pos(start, "start")?;
+    let end = require_pos(end, "end")?;
+    if end < start {
+        bail!("end must be ≥ start");
+    }
+    let span = end
+        .checked_sub(start)
+        .and_then(|delta| delta.checked_add(1))
+        .context("CADD range is too large")?;
+    if span > MAX_RANGE_BP {
+        bail!("CADD range spans {span} bp; maximum is {MAX_RANGE_BP} bp (split into consecutive windows)");
+    }
+    Ok((start, end, span))
+}

--- a/crates/wisp-bio/src/variants/mod.rs
+++ b/crates/wisp-bio/src/variants/mod.rs
@@ -1,6 +1,9 @@
-//! Native `variants` domain against gnomAD, ClinVar and dbSNP.
+//! Native `variants` domain against CADD, gnomAD, ClinVar and dbSNP.
 //! Independently implemented from:
 //!
+//! - [CADD API](https://cadd.gs.washington.edu/api)
+//! - [CADD info / PHRED](https://cadd.gs.washington.edu/info)
+//! - [CADD v1.7 (NAR 2024)](https://academic.oup.com/nar/article/52/D1/D1143/7511313)
 //! - [gnomAD GraphQL API](https://gnomad.broadinstitute.org/help/how-do-i-query-a-batch-of-variants-do-you-have-an-api)
 //!   (10 requests / IP / 60 s; POST `https://gnomad.broadinstitute.org/api`)
 //! - [gnomAD DatasetId / StructuralVariantDatasetId](https://github.com/broadinstitute/gnomad-browser/blob/main/graphql-api/src/graphql/types/dataset-id.graphql)
@@ -10,9 +13,11 @@
 //! - [NCBI Variation Services](https://api.ncbi.nlm.nih.gov/variation/v0/) (`GET /refsnp/{rsid}`)
 //! - [dbSNP Entrez fields](https://www.ncbi.nlm.nih.gov/snp/docs/entrez_help)
 //!
-//! References reviewed 2026-09-06. CADD is not implemented (non-commercial
-//! license gate). Tests use invented records.
+//! References reviewed 2026-09-06. CADD scores are free for non-commercial
+//! use; commercial use requires a license from the University of Washington.
+//! Tests use invented records.
 
+mod cadd;
 mod clinvar;
 mod dbsnp;
 mod gnomad;
@@ -31,6 +36,7 @@ use wisp_llm::ToolSchema;
 
 const NCBI_EUTILS: &str = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/";
 const NCBI_VARIATION: &str = "https://api.ncbi.nlm.nih.gov/variation/v0";
+const CADD_API: &str = "https://cadd.gs.washington.edu/api/v1.0";
 pub(super) const GNOMAD_API: &str = "https://gnomad.broadinstitute.org/api";
 const GNOMAD_BROWSER: &str = "https://gnomad.broadinstitute.org";
 const CLINVAR_BROWSER: &str = "https://www.ncbi.nlm.nih.gov/clinvar/";
@@ -69,6 +75,60 @@ static GNOMAD_PACE: Mutex<Option<Instant>> = Mutex::const_new(None);
 
 pub fn catalog() -> Vec<(&'static str, ToolSchema)> {
     vec![
+        tool(
+            "cadd_position_scores",
+            "Return CADD raw and PHRED scores for every possible SNV at one nuclear position (up to three alts). PHRED is a rank score relative to all possible substitutions (PHRED ≥ 20 ≈ top 1%). Default version is GRCh38-v1.7; versions must be GRCh37-vX.Y or GRCh38-vX.Y (optional _inclAnno). CADD scores are free for non-commercial use; commercial use requires a license from the University of Washington. The API is experimental and not for high-throughput retrieval of thousands of variants.",
+            json!({
+                "type": "object", "additionalProperties": false,
+                "required": ["chrom", "pos"],
+                "properties": {
+                    "chrom": {"type": "string", "minLength": 1, "maxLength": 8,
+                        "description": "Chromosome 1–22, X or Y; a chr prefix is stripped. Mitochondrial contigs are rejected."},
+                    "pos": {"type": "integer", "minimum": 1,
+                        "description": "1-based position on the build embedded in version."},
+                    "version": {"type": "string", "minLength": 8, "maxLength": 32, "default": "GRCh38-v1.7",
+                        "description": "CADD release with genome-build prefix, e.g. GRCh38-v1.7. A bare v1.7 is rejected."}
+                }
+            }),
+        ),
+        tool(
+            "cadd_range_scores",
+            "Return CADD raw and PHRED scores for every SNV in a nuclear window of at most 100 bp (1-based inclusive). PHRED is a rank score relative to all possible substitutions (PHRED ≥ 20 ≈ top 1%). Default version is GRCh38-v1.7; versions must be GRCh37-vX.Y or GRCh38-vX.Y (optional _inclAnno). The 100 bp cap is enforced client-side. CADD scores are free for non-commercial use; commercial use requires a license from the University of Washington. The API is experimental and not for high-throughput retrieval of thousands of variants.",
+            json!({
+                "type": "object", "additionalProperties": false,
+                "required": ["chrom", "start", "end"],
+                "properties": {
+                    "chrom": {"type": "string", "minLength": 1, "maxLength": 8,
+                        "description": "Chromosome 1–22, X or Y; a chr prefix is stripped. Mitochondrial contigs are rejected."},
+                    "start": {"type": "integer", "minimum": 1,
+                        "description": "Window start (1-based, inclusive)."},
+                    "end": {"type": "integer", "minimum": 1,
+                        "description": "Window end (inclusive); end − start + 1 must be ≤ 100."},
+                    "version": {"type": "string", "minLength": 8, "maxLength": 32, "default": "GRCh38-v1.7",
+                        "description": "CADD release with genome-build prefix, e.g. GRCh38-v1.7. A bare v1.7 is rejected."}
+                }
+            }),
+        ),
+        tool(
+            "cadd_variant_score",
+            "Return the CADD raw and PHRED score for one nuclear SNV (chrom, pos, ref, alt). PHRED is a rank score relative to all possible substitutions (PHRED ≥ 20 ≈ top 1%). The reference allele is checked against CADD at that position so a wrong build or typo fails instead of returning a score for the wrong locus. Default version is GRCh38-v1.7; versions must be GRCh37-vX.Y or GRCh38-vX.Y (optional _inclAnno). CADD scores are free for non-commercial use; commercial use requires a license from the University of Washington. The API is experimental and not for high-throughput retrieval of thousands of variants.",
+            json!({
+                "type": "object", "additionalProperties": false,
+                "required": ["chrom", "pos", "ref", "alt"],
+                "properties": {
+                    "chrom": {"type": "string", "minLength": 1, "maxLength": 8,
+                        "description": "Chromosome 1–22, X or Y; a chr prefix is stripped. Mitochondrial contigs are rejected."},
+                    "pos": {"type": "integer", "minimum": 1,
+                        "description": "1-based position on the build embedded in version."},
+                    "ref": {"type": "string", "minLength": 1, "maxLength": 1,
+                        "description": "Reference allele A/C/G/T; must match the genome at pos."},
+                    "alt": {"type": "string", "minLength": 1, "maxLength": 1,
+                        "description": "Alternate allele A/C/G/T, different from ref."},
+                    "version": {"type": "string", "minLength": 8, "maxLength": 32, "default": "GRCh38-v1.7",
+                        "description": "CADD release with genome-build prefix, e.g. GRCh38-v1.7. A bare v1.7 is rejected."}
+                }
+            }),
+        ),
         tool(
             "get_variant",
             "Look up one gnomAD short variant by chrom-pos-ref-alt on the chosen dataset and return population allele counts. Default dataset is gnomad_r4 (GRCh38 exomes+genomes). Absent variants set found=false rather than inventing frequencies. Use search_variants to resolve an rsID first.",
@@ -272,6 +332,9 @@ pub async fn call(bio: &NativeBio, name: &str, args: &Value) -> Result<Value> {
 
 async fn dispatch(bio: &NativeBio, name: &str, args: &Value) -> Result<Value> {
     match name {
+        "cadd_position_scores" => cadd::position_scores(bio, args).await,
+        "cadd_range_scores" => cadd::range_scores(bio, args).await,
+        "cadd_variant_score" => cadd::variant_score(bio, args).await,
         "get_variant" => gnomad::get_variant(bio, args).await,
         "search_variants" => gnomad::search_variants(bio, args).await,
         "gene_variants" => gnomad::gene_variants(bio, args).await,
@@ -317,6 +380,10 @@ fn sv_dataset_property() -> Value {
 
 fn gnomad_api(bio: &NativeBio) -> String {
     override_url(bio, "GNOMAD_API_URL", GNOMAD_API)
+}
+
+fn cadd_base(bio: &NativeBio) -> String {
+    override_url(bio, "CADD_BASE_URL", CADD_API)
 }
 
 fn eutils_base(bio: &NativeBio) -> String {

--- a/crates/wisp-bio/src/variants/tests.rs
+++ b/crates/wisp-bio/src/variants/tests.rs
@@ -20,6 +20,7 @@ fn test_bio(base: &str) -> NativeBio {
             ("GNOMAD_API_URL".into(), format!("{base}/api")),
             ("NCBI_EUTILS_URL".into(), format!("{base}/")),
             ("NCBI_VARIATION_URL".into(), format!("{base}/variation/v0")),
+            ("CADD_BASE_URL".into(), format!("{base}/cadd")),
         ],
         Http(reqwest::Client::builder().no_proxy().build().unwrap()),
     )
@@ -33,8 +34,71 @@ async fn serve(app: Router) -> (NativeBio, tokio::task::JoinHandle<()>) {
     (test_bio(&endpoint), task)
 }
 
+async fn cadd_serve(app: Router) -> (NativeBio, tokio::task::JoinHandle<()>) {
+    serve(Router::new().nest("/cadd", app)).await
+}
+
+fn cadd_position_rows() -> Value {
+    json!([
+        {
+            "Alt": "T",
+            "Chrom": "4",
+            "PHRED": "0.010",
+            "Pos": "9001",
+            "RawScore": "0.003",
+            "Ref": "A"
+        },
+        {
+            "Alt": "C",
+            "Chrom": "4",
+            "PHRED": "0.850",
+            "Pos": "9001",
+            "RawScore": "-0.251851",
+            "Ref": "A"
+        },
+        {
+            "Alt": "G",
+            "Chrom": "4",
+            "PHRED": "15.20",
+            "Pos": "9001",
+            "RawScore": "1.234567",
+            "Ref": "A"
+        }
+    ])
+}
+
+fn cadd_two_alts() -> Value {
+    json!([
+        {
+            "Alt": "G",
+            "Chrom": "4",
+            "PHRED": "15.20",
+            "Pos": "9001",
+            "RawScore": "1.234567",
+            "Ref": "A"
+        },
+        {
+            "Alt": "C",
+            "Chrom": "4",
+            "PHRED": "0.850",
+            "Pos": "9001",
+            "RawScore": "-0.251851",
+            "Ref": "A"
+        }
+    ])
+}
+
+fn cadd_range_rows() -> Value {
+    json!([
+        ["Chrom", "Pos", "Ref", "Alt", "RawScore", "PHRED"],
+        ["4", "9002", "A", "T", "0.121712", "2.838"],
+        ["4", "9001", "A", "G", "1.234567", "15.20"],
+        ["4", "9001", "A", "C", "-0.251851", "0.850"]
+    ])
+}
+
 #[test]
-fn catalog_registers_fifteen_variant_tools_and_skips_cadd() {
+fn catalog_registers_eighteen_variant_tools_including_cadd() {
     let names: Vec<_> = catalog()
         .into_iter()
         .map(|(domain, schema)| (domain, schema.function.name))
@@ -42,6 +106,9 @@ fn catalog_registers_fifteen_variant_tools_and_skips_cadd() {
     assert_eq!(
         names,
         vec![
+            ("variants", "cadd_position_scores".into()),
+            ("variants", "cadd_range_scores".into()),
+            ("variants", "cadd_variant_score".into()),
             ("variants", "get_variant".into()),
             ("variants", "search_variants".into()),
             ("variants", "gene_variants".into()),
@@ -59,13 +126,36 @@ fn catalog_registers_fifteen_variant_tools_and_skips_cadd() {
             ("variants", "dbsnp_search_by_region".into()),
         ]
     );
+    assert_eq!(names.len(), 18);
     assert!(crate::contains_tool("get_variant"));
+    assert!(crate::contains_tool("cadd_variant_score"));
+    assert!(crate::contains_tool("cadd_position_scores"));
+    assert!(crate::contains_tool("cadd_range_scores"));
     assert_eq!(crate::domain_for_tool("get_variant"), Some("variants"));
+    assert_eq!(
+        crate::domain_for_tool("cadd_position_scores"),
+        Some("variants")
+    );
     assert!(crate::package_selects("mcp_variants", "variants"));
     assert!(crate::selected_by_package("mcp_variants"));
-    assert!(!crate::contains_tool("cadd_variant_score"));
-    assert!(!crate::contains_tool("cadd_position_scores"));
-    assert!(!crate::contains_tool("cadd_range_scores"));
+    for name in [
+        "cadd_position_scores",
+        "cadd_range_scores",
+        "cadd_variant_score",
+    ] {
+        let description = catalog()
+            .into_iter()
+            .find(|(_, schema)| schema.function.name == name)
+            .unwrap()
+            .1
+            .function
+            .description;
+        assert!(
+            description.contains("non-commercial") && description.contains("experimental"),
+            "{name}: {description}"
+        );
+        assert!(description.contains("PHRED ≥ 20"), "{name}: {description}");
+    }
 }
 
 #[test]
@@ -657,4 +747,344 @@ async fn rejects_rate_limits_missing_email_and_oversized_bodies() {
     .unwrap_err()
     .to_string();
     assert!(error.contains("not both"), "{error}");
+}
+
+#[test]
+fn cadd_rejects_bare_version_mito_ref_eq_alt_span_and_unknown_fields() {
+    assert!(cadd::require_version("v1.7").is_err());
+    assert!(cadd::require_version("GRCh38-v1.7").is_ok());
+    assert!(cadd::require_version("GRCh37-v1.6").is_ok());
+    assert!(cadd::require_version("GRCh38-v1.7_inclAnno").is_ok());
+    assert!(cadd::require_version("GRCh38-v1.7_inclanno").is_err());
+    assert_eq!(cadd::require_chrom("chr4").unwrap(), "4");
+    assert_eq!(cadd::require_chrom("X").unwrap(), "X");
+    assert!(cadd::require_chrom("MT").is_err());
+    assert!(cadd::require_chrom("M").is_err());
+    assert!(cadd::require_chrom("chrM").is_err());
+    assert_eq!(cadd::require_allele("a", "ref").unwrap(), "A");
+    assert!(cadd::require_allele("N", "alt").is_err());
+    assert!(cadd::require_span(1, 100).is_ok());
+    assert!(cadd::require_span(1, 101).is_err());
+    assert!(cadd::require_span(20, 10).is_err());
+    assert!(serde_json::from_value::<cadd::PositionScores>(json!({
+        "chrom": "4", "pos": 9001, "api_key": "secret"
+    }))
+    .is_err());
+    assert!(serde_json::from_value::<cadd::VariantScore>(json!({
+        "chrom": "4", "pos": 9001, "ref": "A", "alt": "T", "api_key": "secret"
+    }))
+    .is_err());
+    assert!(serde_json::from_value::<cadd::RangeScores>(json!({
+        "chrom": "4", "start": 1, "end": 2, "api_key": "secret"
+    }))
+    .is_err());
+}
+
+#[tokio::test]
+async fn cadd_rejects_invalid_args_before_http() {
+    let hits = Arc::new(StdMutex::new(Vec::<String>::new()));
+    let seen = hits.clone();
+    let app = Router::new().route(
+        "/{version}/{coord}",
+        get(move |Path((version, coord)): Path<(String, String)>| {
+            let seen = seen.clone();
+            async move {
+                seen.lock().unwrap().push(format!("{version}/{coord}"));
+                axum::Json(cadd_position_rows())
+            }
+        }),
+    );
+    let (bio, server) = cadd_serve(app).await;
+    for (tool, args, needle) in [
+        (
+            "cadd_position_scores",
+            json!({"chrom": "4", "pos": 9001, "version": "v1.7"}),
+            "bare v1.7",
+        ),
+        (
+            "cadd_position_scores",
+            json!({"chrom": "MT", "pos": 9001}),
+            "mitochondrial",
+        ),
+        (
+            "cadd_variant_score",
+            json!({"chrom": "4", "pos": 9001, "ref": "A", "alt": "A"}),
+            "must differ",
+        ),
+        (
+            "cadd_range_scores",
+            json!({"chrom": "4", "start": 1, "end": 101}),
+            "101 bp",
+        ),
+        (
+            "cadd_position_scores",
+            json!({"chrom": "4", "pos": 9001, "api_key": "secret"}),
+            "invalid cadd_position_scores arguments",
+        ),
+    ] {
+        let error = bio.call(tool, &args).await.unwrap_err().to_string();
+        assert!(error.contains(needle), "{tool} {args}: {error}");
+        assert!(!error.contains("secret"), "{error}");
+    }
+    server.abort();
+    assert!(hits.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn cadd_position_parses_capitalized_objects_sorts_and_reports_source_url() {
+    let hits = Arc::new(StdMutex::new(Vec::<String>::new()));
+    let seen = hits.clone();
+    let app = Router::new().route(
+        "/{version}/{coord}",
+        get(move |Path((version, coord)): Path<(String, String)>| {
+            let seen = seen.clone();
+            async move {
+                seen.lock().unwrap().push(format!("{version}/{coord}"));
+                axum::Json(cadd_position_rows())
+            }
+        }),
+    );
+    let (bio, server) = cadd_serve(app).await;
+    let result = bio
+        .call(
+            "cadd_position_scores",
+            &json!({"chrom": "chr4", "pos": 9001}),
+        )
+        .await
+        .unwrap();
+    server.abort();
+    let traffic = hits.lock().unwrap().clone();
+    assert_eq!(traffic, vec!["GRCh38-v1.7/4:9001".to_string()]);
+    assert_eq!(result["source"], "CADD");
+    assert_eq!(result["source_url"], "https://cadd.gs.washington.edu/api");
+    assert_eq!(
+        result["query"],
+        json!({"type": "position", "version": "GRCh38-v1.7", "chrom": "4", "pos": 9001})
+    );
+    assert_eq!(result["records"][0]["alt"], "C");
+    assert_eq!(result["records"][1]["alt"], "G");
+    assert_eq!(result["records"][2]["alt"], "T");
+    assert_eq!(result["records"][0]["pos"], 9001);
+    assert_eq!(result["records"][0]["raw_score"], "-0.251851");
+    assert_eq!(result["records"][0]["phred"], "0.850");
+}
+
+#[tokio::test]
+async fn cadd_variant_checks_reference_and_alt() {
+    let app = Router::new().route(
+        "/{version}/{coord}",
+        get(
+            |Path((_version, coord)): Path<(String, String)>| async move {
+                assert_eq!(coord, "4:9001");
+                axum::Json(cadd_two_alts())
+            },
+        ),
+    );
+    let (bio, server) = cadd_serve(app).await;
+    let hit = bio
+        .call(
+            "cadd_variant_score",
+            &json!({"chrom": "4", "pos": 9001, "ref": "A", "alt": "c"}),
+        )
+        .await
+        .unwrap();
+    assert_eq!(hit["query"]["type"], "variant");
+    assert_eq!(hit["record"]["alt"], "C");
+    assert_eq!(hit["record"]["raw_score"], "-0.251851");
+    assert_eq!(hit["record"]["phred"], "0.850");
+    assert_eq!(hit["source_url"], "https://cadd.gs.washington.edu/api");
+
+    let wrong_ref = bio
+        .call(
+            "cadd_variant_score",
+            &json!({"chrom": "4", "pos": 9001, "ref": "C", "alt": "T"}),
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(wrong_ref.contains("wrong build or typo"), "{wrong_ref}");
+    assert!(wrong_ref.contains("query ref=C"), "{wrong_ref}");
+    assert!(wrong_ref.contains("reference allele is A"), "{wrong_ref}");
+
+    let missing_alt = bio
+        .call(
+            "cadd_variant_score",
+            &json!({"chrom": "4", "pos": 9001, "ref": "A", "alt": "T"}),
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+    server.abort();
+    assert!(missing_alt.contains("alt=T"), "{missing_alt}");
+    assert!(missing_alt.contains("alts present: C, G"), "{missing_alt}");
+}
+
+#[tokio::test]
+async fn cadd_range_parses_header_rows_and_oversized_never_hits_http() {
+    let hits = Arc::new(StdMutex::new(0u32));
+    let seen = hits.clone();
+    let app = Router::new().route(
+        "/{version}/{coord}",
+        get(move |Path((version, coord)): Path<(String, String)>| {
+            let seen = seen.clone();
+            async move {
+                *seen.lock().unwrap() += 1;
+                assert_eq!(version, "GRCh38-v1.7");
+                assert_eq!(coord, "4:9001-9002");
+                axum::Json(cadd_range_rows())
+            }
+        }),
+    );
+    let (bio, server) = cadd_serve(app).await;
+    let result = bio
+        .call(
+            "cadd_range_scores",
+            &json!({"chrom": "4", "start": 9001, "end": 9002}),
+        )
+        .await
+        .unwrap();
+    assert_eq!(result["n_records"], 3);
+    assert_eq!(result["n_positions_scored"], 2);
+    assert_eq!(result["span_bp"], 2);
+    assert_eq!(result["truncated"], false);
+    assert_eq!(result["records"][0]["pos"], 9001);
+    assert_eq!(result["records"][0]["alt"], "C");
+    assert_eq!(result["records"][0]["raw_score"], "-0.251851");
+    assert_eq!(result["records"][1]["alt"], "G");
+    assert_eq!(result["records"][2]["pos"], 9002);
+    assert_eq!(*hits.lock().unwrap(), 1);
+
+    let error = bio
+        .call(
+            "cadd_range_scores",
+            &json!({"chrom": "4", "start": 1, "end": 101}),
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+    server.abort();
+    assert!(error.contains("101 bp"), "{error}");
+    assert_eq!(*hits.lock().unwrap(), 1);
+}
+
+#[tokio::test]
+async fn cadd_empty_list_is_not_success() {
+    let app = Router::new().route(
+        "/{version}/{coord}",
+        get(|| async { axum::Json(json!([])) }),
+    );
+    let (bio, server) = cadd_serve(app).await;
+    let position = bio
+        .call("cadd_position_scores", &json!({"chrom": "4", "pos": 9001}))
+        .await
+        .unwrap_err()
+        .to_string();
+    let variant = bio
+        .call(
+            "cadd_variant_score",
+            &json!({"chrom": "4", "pos": 9001, "ref": "A", "alt": "T"}),
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+    let range = bio
+        .call(
+            "cadd_range_scores",
+            &json!({"chrom": "4", "start": 9001, "end": 9002}),
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+    server.abort();
+    assert!(
+        position.contains("no CADD rows for GRCh38-v1.7 4:9001"),
+        "{position}"
+    );
+    assert!(
+        variant.contains("no CADD rows for GRCh38-v1.7 4:9001"),
+        "{variant}"
+    );
+    assert!(
+        range.contains("no CADD rows for GRCh38-v1.7 4:9001-9002"),
+        "{range}"
+    );
+}
+
+#[tokio::test]
+async fn cadd_http_errors_do_not_echo_bodies() {
+    for status in [
+        StatusCode::INTERNAL_SERVER_ERROR,
+        StatusCode::TOO_MANY_REQUESTS,
+    ] {
+        let app = Router::new().route(
+            "/{version}/{coord}",
+            get(move || async move {
+                (status, [("retry-after", "60")], "secret-token").into_response()
+            }),
+        );
+        let (bio, server) = cadd_serve(app).await;
+        let error = bio
+            .call("cadd_position_scores", &json!({"chrom": "4", "pos": 9001}))
+            .await
+            .unwrap_err()
+            .to_string();
+        server.abort();
+        assert!(
+            error.contains(&format!("HTTP {}", status.as_u16())),
+            "{error}"
+        );
+        assert!(!error.contains("secret-token"), "{error}");
+    }
+}
+
+#[tokio::test]
+async fn unknown_cadd_tool_fails_and_real_names_dispatch() {
+    let app = Router::new().route(
+        "/{version}/{coord}",
+        get(
+            |Path((_version, coord)): Path<(String, String)>| async move {
+                if coord.contains('-') {
+                    axum::Json(cadd_range_rows()).into_response()
+                } else {
+                    axum::Json(cadd_two_alts()).into_response()
+                }
+            },
+        ),
+    );
+    let (bio, server) = cadd_serve(app).await;
+    let unknown = bio
+        .call(
+            "cadd_get_variant_score",
+            &json!({"chrom": "4", "pos": 9001}),
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(
+        unknown.contains("unknown native biological tool"),
+        "{unknown}"
+    );
+
+    let position = bio
+        .call("cadd_position_scores", &json!({"chrom": "4", "pos": 9001}))
+        .await
+        .unwrap();
+    let variant = bio
+        .call(
+            "cadd_variant_score",
+            &json!({"chrom": "4", "pos": 9001, "ref": "A", "alt": "G"}),
+        )
+        .await
+        .unwrap();
+    let range = bio
+        .call(
+            "cadd_range_scores",
+            &json!({"chrom": "4", "start": 9001, "end": 9002}),
+        )
+        .await
+        .unwrap();
+    server.abort();
+    assert_eq!(position["records"].as_array().unwrap().len(), 2);
+    assert_eq!(variant["record"]["alt"], "G");
+    assert_eq!(range["n_records"], 3);
 }


### PR DESCRIPTION
## Problem

CADD (`cadd_variant_score`, `cadd_position_scores`, `cadd_range_scores`) was left on the vendored Python path behind the non-commercial license gate. Native variants already covers gnomAD, ClinVar and dbSNP.

## Change

Independently authored Rust client against the [CADD API](https://cadd.gs.washington.edu/api) (reviewed 2026-09-06):

- `cadd_position_scores` — `GET /api/v1.0/{version}/{chrom}:{pos}` (list of objects)
- `cadd_variant_score` — one position GET, then verify ref and select alt (wrong build fails instead of a plausible wrong-locus score)
- `cadd_range_scores` — header+rows; 100 bp cap client-side (upstream does not reliably reject oversized ranges)

Versions must be `GRCh37-vX.Y` / `GRCh38-vX.Y` (optional `_inclAnno`); bare `v1.7` is rejected because upstream returns HTTP 200 `[]`. Default `GRCh38-v1.7`. `raw_score`/`phred` kept as decimal strings. Empty `[]` is an error.

Non-commercial-use notice in every description. The API is experimental and not for high-throughput retrieval of thousands of variants.

## Tests

`cargo test -p wisp-bio --offline variants` — invented records, ref mismatch, 100 bp cap without HTTP, 429 without echoing bodies.

## Files

- `crates/wisp-bio/src/variants/cadd.rs` (new)
- `crates/wisp-bio/src/variants/mod.rs`
- `crates/wisp-bio/src/variants/tests.rs`