### PR TITLE
feat(bio): native Sanger Cell Model Passports in cancer-models

### DIFF
--- a/crates/wisp-bio/src/cancer_models/mod.rs
+++ b/crates/wisp-bio/src/cancer_models/mod.rs
@@ -1,16 +1,24 @@
-//! Native `cancer-models` domain against the public cBioPortal REST API.
-//! Independently implemented from:
+//! Native `cancer-models` domain against the public cBioPortal REST API and
+//! the Sanger Cell Model Passports JSON:API. Independently implemented from:
 //!
 //! - [cBioPortal REST API](https://www.cbioportal.org/api/swagger-ui/index.html)
 //! - [OpenAPI v2](https://www.cbioportal.org/api/v2/api-docs) and
 //!   [v3](https://www.cbioportal.org/api/v3/api-docs)
 //! - [API clients](https://docs.cbioportal.org/web-API-and-Clients/)
 //! - [Clinical file format (OS_/DFS_/PFS_/DSS_ pairs)](https://docs.cbioportal.org/file-formats/)
+//! - [Sanger DepMap API](https://depmap.sanger.ac.uk/documentation/api/)
+//! - [Endpoints](https://depmap.sanger.ac.uk/documentation/api/endpoints/)
+//! - [Modifiers](https://depmap.sanger.ac.uk/documentation/api/modifiers/)
+//! - [Swagger](https://api.cellmodelpassports.sanger.ac.uk/swagger)
+//! - [JSON:API 1.0](https://jsonapi.org/)
 //!
-//! References reviewed 2026-09-06. The public instance is keyless. Sanger Cell
-//! Model Passports tools are not implemented (commercial-use license gate).
+//! References reviewed 2026-09-06. The public cBioPortal instance is keyless.
+//! Cell Model Passports / Sanger DepMap API is free for individual
+//! non-commercial use. Commercial use and embedding in third-party
+//! websites/apps require prior consent (depmap@sanger.ac.uk).
 //! Tests use invented records.
 
+mod sanger;
 #[cfg(test)]
 mod tests;
 
@@ -49,7 +57,7 @@ const CNA_EVENT_TYPES: &[&str] = &[
 const SURVIVAL_PREFIXES: &[&str] = &["OS_", "DFS_", "PFS_", "DSS_"];
 
 pub fn catalog() -> Vec<(&'static str, ToolSchema)> {
-    vec![
+    let mut tools = vec![
         (
             "cancer-models",
             ToolSchema::new(
@@ -149,13 +157,15 @@ pub fn catalog() -> Vec<(&'static str, ToolSchema)> {
                 }),
             ),
         ),
-    ]
+    ];
+    tools.extend(sanger::catalog());
+    tools
 }
 
 pub async fn call(bio: &NativeBio, name: &str, args: &Value) -> Result<Value> {
     tokio::time::timeout(Duration::from_secs(45), dispatch(bio, name, args))
         .await
-        .map_err(|_| anyhow!("cBioPortal request exceeded 45 seconds"))?
+        .map_err(|_| anyhow!("cancer-models request exceeded 45 seconds"))?
 }
 
 async fn dispatch(bio: &NativeBio, name: &str, args: &Value) -> Result<Value> {
@@ -166,6 +176,11 @@ async fn dispatch(bio: &NativeBio, name: &str, args: &Value) -> Result<Value> {
         "cbioportal_list_studies" => list_studies(bio, args).await,
         "cbioportal_mutation_frequency" => mutation_frequency(bio, args).await,
         "cbioportal_mutations_in_gene" => mutations_in_gene(bio, args).await,
+        "gene_dependencies" => sanger::gene_dependencies(bio, args).await,
+        "get_model" => sanger::get_model(bio, args).await,
+        "list_models" => sanger::list_models(bio, args).await,
+        "search_genes" => sanger::search_genes(bio, args).await,
+        "search_models" => sanger::search_models(bio, args).await,
         _ => bail!("unknown native biological tool: {name}"),
     }
 }
@@ -1079,14 +1094,14 @@ fn trim_text(value: &str, limit: usize) -> String {
     out
 }
 
-fn bound_page(n: u32) -> Result<usize> {
+pub(super) fn bound_page(n: u32) -> Result<usize> {
     if !(1..=MAX_RECORDS).contains(&n) {
         bail!("max_records must be between 1 and {MAX_RECORDS}");
     }
     Ok(n as usize)
 }
 
-fn require_id(value: &str, what: &str, max: usize) -> Result<String> {
+pub(super) fn require_id(value: &str, what: &str, max: usize) -> Result<String> {
     let trimmed = value.trim();
     if trimmed.is_empty() {
         bail!("{what} is required");
@@ -1168,7 +1183,7 @@ fn study_url(study_id: &str) -> String {
     format!("{PORTAL}/study/summary?id={}", path_segment(study_id))
 }
 
-fn path_segment(value: &str) -> String {
+pub(super) fn path_segment(value: &str) -> String {
     let mut out = String::new();
     for b in value.bytes() {
         match b {

--- a/crates/wisp-bio/src/cancer_models/sanger.rs
+++ b/crates/wisp-bio/src/cancer_models/sanger.rs
@@ -1,0 +1,720 @@
+//! Sanger Cell Model Passports JSON:API client.
+//!
+//! Independently implemented from:
+//! - <https://depmap.sanger.ac.uk/documentation/api/>
+//! - <https://depmap.sanger.ac.uk/documentation/api/endpoints/>
+//! - <https://depmap.sanger.ac.uk/documentation/api/modifiers/>
+//! - <https://api.cellmodelpassports.sanger.ac.uk/swagger>
+//! - <https://jsonapi.org/>
+//!
+//! Reviewed 2026-09-06. Individual non-commercial use is keyless; commercial
+//! use and embedding in third-party websites/apps need prior consent.
+
+use super::{bound_page, path_segment, require_id, NativeBio};
+use crate::http::Source;
+use anyhow::{bail, Context, Result};
+use reqwest::{Method, StatusCode};
+use serde::Deserialize;
+use serde_json::{json, Value};
+use std::time::Duration;
+use wisp_llm::ToolSchema;
+
+const CMP_API: &str = "https://api.cellmodelpassports.sanger.ac.uk";
+const CMP: Source = Source("Cell Model Passports", Duration::from_millis(500));
+const CMP_USAGE: &str = "Cell Model Passports / Sanger DepMap API is free for individual non-commercial use. Commercial use and embedding in third-party websites/apps require prior consent (depmap@sanger.ac.uk). https://depmap.sanger.ac.uk/documentation/api/";
+const MODEL_INCLUDE: &str = "sample.tissue,sample.cancer_type,model_msi_status";
+const FETCH_PAGE: u32 = 100;
+const MAX_PAGES: u32 = 8;
+const DEFAULT_RECORDS: u32 = 50;
+const LABEL_MAX: usize = 256;
+const LEAN_FLAGS: &[&str] = &[
+    "crispr_ko_available",
+    "mutations_available",
+    "rnaseq_available",
+];
+const DETAIL_FLAGS: &[&str] = &[
+    "mutations_available",
+    "cnv_available",
+    "expression_available",
+    "rnaseq_available",
+    "crispr_ko_available",
+    "drugs_available",
+    "fusions_available",
+    "methylation_available",
+    "proteomics_available",
+    "commercial_available",
+];
+
+pub(super) fn catalog() -> Vec<(&'static str, ToolSchema)> {
+    vec![
+        cmp_tool(
+            "gene_dependencies",
+            "CRISPR knock-out dependency scores for one official CMP gene symbol from GET /genes/{SIDG}/datasets/crispr_ko (never the unscoped /datasets/crispr_ko table). Resolves the symbol exactly, then returns a bounded page of Bayes-factor rows (higher BF = more essential) plus meta.count. Optional model_id (SIDM) restricts to one model. A capped page is not the complete screen.",
+            json!({
+                "type": "object", "additionalProperties": false,
+                "required": ["gene_symbol"],
+                "properties": {
+                    "gene_symbol": {"type": "string", "minLength": 1, "maxLength": 64},
+                    "model_id": {"type": "string", "minLength": 1, "maxLength": 128},
+                    "max_records": {"type": "integer", "minimum": 1, "maximum": 200, "default": 50}
+                }
+            }),
+        ),
+        cmp_tool(
+            "get_model",
+            "Retrieve one Sanger Cell Model Passports model by SIDM id (case-insensitive prefix) or exact name/synonym. SIDM uses GET /models/{id} with include=sample.tissue,sample.cancer_type,model_msi_status; names use a names/any filter. Unknown ids and empty documents fail; an ambiguous synonym fails listing candidate SIDM ids.",
+            json!({
+                "type": "object", "additionalProperties": false,
+                "required": ["model_id_or_name"],
+                "properties": {
+                    "model_id_or_name": {"type": "string", "minLength": 1, "maxLength": 256}
+                }
+            }),
+        ),
+        cmp_tool(
+            "list_models",
+            "List Sanger Cell Model Passports models (SIDM ids) from GET /models. Optional tissue and cancer_type are case-sensitive exact CMP names (e.g. Lung, Small Cell Lung Carcinoma) applied as nested JSON:API relationship filters. Returns a bounded page; total is meta.count when supplied. Unfiltered /models is ~2000 rows — a capped page is not the complete catalog.",
+            json!({
+                "type": "object", "additionalProperties": false,
+                "properties": {
+                    "tissue": {"type": "string", "minLength": 1, "maxLength": 256},
+                    "cancer_type": {"type": "string", "minLength": 1, "maxLength": 256},
+                    "max_records": {"type": "integer", "minimum": 1, "maximum": 200, "default": 50}
+                }
+            }),
+        ),
+        cmp_tool(
+            "search_genes",
+            "Search Sanger Cell Model Passports genes by official CMP symbol (GET /genes). exact=true uses op eq; otherwise case-insensitive substring (ilike %query%). Synonym search is not supported. Returns SIDG rows on a bounded page plus meta.count.",
+            json!({
+                "type": "object", "additionalProperties": false,
+                "required": ["query"],
+                "properties": {
+                    "query": {"type": "string", "minLength": 1, "maxLength": 64},
+                    "exact": {"type": "boolean", "default": false},
+                    "max_records": {"type": "integer", "minimum": 1, "maximum": 200, "default": 50}
+                }
+            }),
+        ),
+        cmp_tool(
+            "search_models",
+            "Search Sanger Cell Model Passports models via GET /search/{query} and keep resources with type=model. Returns the same lean rows as list_models on a bounded page. Prefer this when the exact CMP name/synonym is unknown.",
+            json!({
+                "type": "object", "additionalProperties": false,
+                "required": ["query"],
+                "properties": {
+                    "query": {"type": "string", "minLength": 1, "maxLength": 256},
+                    "max_records": {"type": "integer", "minimum": 1, "maximum": 200, "default": 50}
+                }
+            }),
+        ),
+    ]
+}
+
+fn cmp_tool(
+    name: &'static str,
+    description: &'static str,
+    parameters: Value,
+) -> (&'static str, ToolSchema) {
+    (
+        "cancer-models",
+        ToolSchema::new(name, &format!("{description} {CMP_USAGE}"), parameters),
+    )
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ListModels {
+    tissue: Option<String>,
+    cancer_type: Option<String>,
+    #[serde(default = "default_records")]
+    max_records: u32,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct GetModel {
+    model_id_or_name: String,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SearchModels {
+    query: String,
+    #[serde(default = "default_records")]
+    max_records: u32,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SearchGenes {
+    query: String,
+    #[serde(default)]
+    exact: bool,
+    #[serde(default = "default_records")]
+    max_records: u32,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct GeneDependencies {
+    gene_symbol: String,
+    model_id: Option<String>,
+    #[serde(default = "default_records")]
+    max_records: u32,
+}
+
+fn default_records() -> u32 {
+    DEFAULT_RECORDS
+}
+
+pub(super) async fn list_models(bio: &NativeBio, args: &Value) -> Result<Value> {
+    let args: ListModels = serde_json::from_value(args.clone())
+        .context("invalid Cell Model Passports model list arguments")?;
+    let cap = bound_page(args.max_records)?;
+    let tissue = optional_label(args.tissue.as_deref(), "tissue")?;
+    let cancer_type = optional_label(args.cancer_type.as_deref(), "cancer_type")?;
+    let mut extra = Vec::new();
+    let mut filters = Vec::new();
+    if let Some(tissue) = &tissue {
+        filters.push(has_rel(
+            "sample",
+            has_rel("tissue", eq_field("name", tissue)),
+        ));
+    }
+    if let Some(cancer_type) = &cancer_type {
+        filters.push(has_rel(
+            "sample",
+            has_rel("cancer_type", eq_field("name", cancer_type)),
+        ));
+    }
+    if !filters.is_empty() {
+        extra.push(("filter".into(), encode_filter(&filters)?));
+    }
+    let cmp = Cmp::new(bio);
+    let (mut models, total, truncated) =
+        collect_pages(&cmp, "models", &extra, cap, shape_model_row).await?;
+    models.sort_by(|a, b| field_text(a, "model_id").cmp(&field_text(b, "model_id")));
+    Ok(json!({
+        "source": CMP.0,
+        "source_url": CMP_API,
+        "tissue": tissue,
+        "cancer_type": cancer_type,
+        "total": total,
+        "returned": models.len(),
+        "truncated": truncated,
+        "models": models,
+    }))
+}
+
+pub(super) async fn get_model(bio: &NativeBio, args: &Value) -> Result<Value> {
+    let args: GetModel = serde_json::from_value(args.clone())
+        .context("invalid Cell Model Passports model arguments")?;
+    let ident = require_label(&args.model_id_or_name, "model_id_or_name")?;
+    let cmp = Cmp::new(bio);
+    let include = vec![("include".into(), MODEL_INCLUDE.to_string())];
+    let (resource, included) = if looks_like_sidm(&ident) {
+        let model_id = require_id(&ident.to_ascii_uppercase(), "model_id_or_name", 128)?;
+        let fetched = cmp
+            .get(&format!("models/{}", path_segment(&model_id)), &include)
+            .await?;
+        if fetched.not_found {
+            bail!("Cell Model Passports model {model_id} was not found");
+        }
+        fetched.require_ok(&format!("model {model_id}"))?;
+        let resource = data_resources(&fetched.value)
+            .into_iter()
+            .next()
+            .with_context(|| format!("Cell Model Passports model {model_id} was not found"))?;
+        (resource, included_resources(&fetched.value))
+    } else {
+        let filter = encode_filter(&[json!({"name": "names", "op": "any", "val": ident})])?;
+        let fetched = cmp
+            .get(
+                "models",
+                &[
+                    ("filter".into(), filter),
+                    ("include".into(), MODEL_INCLUDE.to_string()),
+                    ("page[size]".into(), "5".into()),
+                ],
+            )
+            .await?;
+        fetched.require_ok("model name lookup")?;
+        let resources = data_resources(&fetched.value);
+        if resources.is_empty() {
+            bail!("Cell Model Passports model {ident:?} was not found");
+        }
+        if resources.len() > 1 {
+            let ids: Vec<String> = resources
+                .iter()
+                .filter_map(|row| field_text(row, "id"))
+                .collect();
+            bail!("Cell Model Passports name {ident:?} is ambiguous: {ids:?}");
+        }
+        let resource = resources
+            .into_iter()
+            .next()
+            .context("Cell Model Passports omitted model data")?;
+        (resource, included_resources(&fetched.value))
+    };
+    let mut record = shape_model_detail(&resource, &included);
+    record["source"] = json!(CMP.0);
+    record["source_url"] = json!(CMP_API);
+    Ok(record)
+}
+
+pub(super) async fn search_models(bio: &NativeBio, args: &Value) -> Result<Value> {
+    let args: SearchModels = serde_json::from_value(args.clone())
+        .context("invalid Cell Model Passports model search arguments")?;
+    let cap = bound_page(args.max_records)?;
+    let query = require_label(&args.query, "query")?;
+    let cmp = Cmp::new(bio);
+    let fetched = cmp
+        .get(&format!("search/{}", path_segment(&query)), &[])
+        .await?;
+    fetched.require_ok(&format!("search {query}"))?;
+    let resources = data_resources(&fetched.value);
+    let dropped_other_types = resources
+        .iter()
+        .any(|row| field_text(row, "type").as_deref() != Some("model"));
+    let mut models: Vec<Value> = resources
+        .into_iter()
+        .filter(|row| field_text(row, "type").as_deref() == Some("model"))
+        .map(|row| shape_model_row(&row))
+        .collect();
+    let seen = models.len();
+    models.sort_by(|a, b| field_text(a, "model_id").cmp(&field_text(b, "model_id")));
+    let total = if dropped_other_types {
+        seen as u64
+    } else {
+        meta_count(&fetched.value).unwrap_or(seen as u64)
+    };
+    models.truncate(cap);
+    let truncated = (models.len() as u64) < total;
+    Ok(json!({
+        "source": CMP.0,
+        "source_url": CMP_API,
+        "query": query,
+        "total": total,
+        "returned": models.len(),
+        "truncated": truncated,
+        "models": models,
+    }))
+}
+
+pub(super) async fn search_genes(bio: &NativeBio, args: &Value) -> Result<Value> {
+    let args: SearchGenes = serde_json::from_value(args.clone())
+        .context("invalid Cell Model Passports gene search arguments")?;
+    let cap = bound_page(args.max_records)?;
+    let query = require_id(&args.query, "query", 64)?;
+    let filters = if args.exact {
+        vec![json!({"name": "symbol", "op": "eq", "val": query})]
+    } else {
+        vec![json!({"name": "symbol", "op": "ilike", "val": format!("%{query}%")})]
+    };
+    let extra = vec![("filter".into(), encode_filter(&filters)?)];
+    let cmp = Cmp::new(bio);
+    let (mut genes, total, truncated) =
+        collect_pages(&cmp, "genes", &extra, cap, shape_gene).await?;
+    genes.sort_by(|a, b| field_text(a, "gene_id").cmp(&field_text(b, "gene_id")));
+    Ok(json!({
+        "source": CMP.0,
+        "source_url": CMP_API,
+        "query": query,
+        "exact": args.exact,
+        "total": total,
+        "returned": genes.len(),
+        "truncated": truncated,
+        "genes": genes,
+    }))
+}
+
+pub(super) async fn gene_dependencies(bio: &NativeBio, args: &Value) -> Result<Value> {
+    let args: GeneDependencies = serde_json::from_value(args.clone())
+        .context("invalid Cell Model Passports gene dependency arguments")?;
+    let cap = bound_page(args.max_records)?;
+    let gene_symbol = require_id(&args.gene_symbol, "gene_symbol", 64)?;
+    let model_id = match args.model_id.as_deref() {
+        None => None,
+        Some(value) if value.trim().is_empty() => None,
+        Some(value) => {
+            let cleaned = require_id(value, "model_id", 128)?;
+            Some(if looks_like_sidm(&cleaned) {
+                cleaned.to_ascii_uppercase()
+            } else {
+                cleaned
+            })
+        }
+    };
+    let cmp = Cmp::new(bio);
+    let gene = resolve_gene(&cmp, &gene_symbol).await?;
+    let gene_id = field_text(&gene, "gene_id").context("Cell Model Passports gene omitted id")?;
+    // Unscoped /datasets/crispr_ko is ~19.5M rows; always gene-scoped.
+    let path = format!("genes/{}/datasets/crispr_ko", path_segment(&gene_id));
+    let mut extra = Vec::new();
+    if let Some(model_id) = &model_id {
+        extra.push((
+            "filter".into(),
+            encode_filter(&[has_rel("model", eq_field("id", model_id))])?,
+        ));
+    }
+    let (mut dependencies, total, truncated) =
+        collect_pages(&cmp, &path, &extra, cap, shape_dependency).await?;
+    dependencies.sort_by(|a, b| {
+        field_text(a, "model_id")
+            .cmp(&field_text(b, "model_id"))
+            .then_with(|| field_text(a, "source").cmp(&field_text(b, "source")))
+    });
+    Ok(json!({
+        "source": CMP.0,
+        "source_url": CMP_API,
+        "gene": gene,
+        "model_id": model_id,
+        "total": total,
+        "returned": dependencies.len(),
+        "truncated": truncated,
+        "dependencies": dependencies,
+    }))
+}
+
+struct Cmp<'a> {
+    bio: &'a NativeBio,
+}
+
+struct Fetched {
+    not_found: bool,
+    value: Value,
+    status: StatusCode,
+}
+
+impl Fetched {
+    fn require_ok(&self, what: &str) -> Result<()> {
+        if self.not_found {
+            bail!("Cell Model Passports did not find {what}");
+        }
+        if !self.status.is_success() {
+            bail!(
+                "Cell Model Passports returned HTTP {} for {what}",
+                self.status.as_u16()
+            );
+        }
+        Ok(())
+    }
+}
+
+impl<'a> Cmp<'a> {
+    fn new(bio: &'a NativeBio) -> Self {
+        Self { bio }
+    }
+
+    fn base(&self) -> String {
+        self.bio
+            .credential("CMP_BASE_URL")
+            .map(|value| value.trim_end_matches('/').to_string())
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| CMP_API.to_string())
+    }
+
+    async fn get(&self, path: &str, params: &[(String, String)]) -> Result<Fetched> {
+        let url = format!("{}/{}", self.base(), path.trim_start_matches('/'));
+        let response = self.bio.http().send(CMP, Method::GET, &url, params).await?;
+        decode(response)
+    }
+}
+
+fn decode(response: crate::http::Response) -> Result<Fetched> {
+    if response.status == StatusCode::NOT_FOUND {
+        return Ok(Fetched {
+            not_found: true,
+            value: Value::Null,
+            status: response.status,
+        });
+    }
+    if !response.status.is_success() {
+        return Ok(Fetched {
+            not_found: false,
+            value: Value::Null,
+            status: response.status,
+        });
+    }
+    let value: Value = serde_json::from_slice(&response.body)
+        .context("Cell Model Passports returned invalid JSON")?;
+    reject_jsonapi_errors(&value)?;
+    Ok(Fetched {
+        not_found: false,
+        value,
+        status: response.status,
+    })
+}
+
+fn reject_jsonapi_errors(value: &Value) -> Result<()> {
+    match value.get("errors").and_then(Value::as_array) {
+        Some(errors) if !errors.is_empty() => {
+            bail!("Cell Model Passports returned an error document")
+        }
+        _ => Ok(()),
+    }
+}
+
+async fn collect_pages(
+    cmp: &Cmp<'_>,
+    path: &str,
+    extra: &[(String, String)],
+    cap: usize,
+    map: fn(&Value) -> Value,
+) -> Result<(Vec<Value>, Option<u64>, bool)> {
+    let mut collected = Vec::new();
+    let mut total = None;
+    let mut exhausted = false;
+    for page in 1..=MAX_PAGES {
+        let mut params = extra.to_vec();
+        params.push(("page[size]".into(), FETCH_PAGE.to_string()));
+        params.push(("page[number]".into(), page.to_string()));
+        let fetched = cmp.get(path, &params).await?;
+        fetched.require_ok(path)?;
+        if page == 1 {
+            total = meta_count(&fetched.value);
+        }
+        let items = data_resources(&fetched.value);
+        let page_len = items.len();
+        for item in items {
+            collected.push(map(&item));
+            if collected.len() >= cap {
+                break;
+            }
+        }
+        if collected.len() >= cap {
+            break;
+        }
+        if page_len < FETCH_PAGE as usize {
+            exhausted = true;
+            break;
+        }
+        if total.is_some_and(|count| u64::from(page).saturating_mul(u64::from(FETCH_PAGE)) >= count)
+        {
+            exhausted = true;
+            break;
+        }
+    }
+    let truncated = match total {
+        Some(count) => (collected.len() as u64) < count,
+        None => !exhausted && collected.len() >= cap,
+    };
+    collected.truncate(cap);
+    Ok((collected, total, truncated))
+}
+
+async fn resolve_gene(cmp: &Cmp<'_>, symbol: &str) -> Result<Value> {
+    let filter = encode_filter(&[json!({"name": "symbol", "op": "eq", "val": symbol})])?;
+    let fetched = cmp
+        .get(
+            "genes",
+            &[("filter".into(), filter), ("page[size]".into(), "5".into())],
+        )
+        .await?;
+    fetched.require_ok(&format!("gene {symbol}"))?;
+    let resources = data_resources(&fetched.value);
+    if resources.is_empty() {
+        bail!("Cell Model Passports gene {symbol:?} was not found");
+    }
+    if resources.len() > 1 {
+        let ids: Vec<String> = resources
+            .iter()
+            .filter_map(|row| field_text(row, "id"))
+            .collect();
+        bail!("Cell Model Passports gene {symbol:?} is ambiguous: {ids:?}");
+    }
+    Ok(shape_gene(&resources[0]))
+}
+
+fn shape_model_row(resource: &Value) -> Value {
+    let attrs = attributes(resource);
+    let mut row = json!({
+        "model_id": field_text(resource, "id"),
+        "names": sorted_names(attrs),
+        "model_type": attrs.get("model_type").cloned().unwrap_or(Value::Null),
+        "growth_properties": attrs.get("growth_properties").cloned().unwrap_or(Value::Null),
+    });
+    copy_flags(&mut row, attrs, LEAN_FLAGS);
+    row
+}
+
+fn shape_model_detail(resource: &Value, included: &[Value]) -> Value {
+    let attrs = attributes(resource);
+    let mut record = json!({
+        "model_id": field_text(resource, "id"),
+        "names": sorted_names(attrs),
+        "model_type": attrs.get("model_type").cloned().unwrap_or(Value::Null),
+        "growth_properties": attrs.get("growth_properties").cloned().unwrap_or(Value::Null),
+        "model_treatment": attrs.get("model_treatment").cloned().unwrap_or(Value::Null),
+        "ploidy_wes": attrs.get("ploidy_wes").cloned().unwrap_or(Value::Null),
+        "ploidy_wgs": attrs.get("ploidy_wgs").cloned().unwrap_or(Value::Null),
+        "mutations_per_mb": attrs.get("mutations_per_mb").cloned().unwrap_or(Value::Null),
+        "tissue": Value::Null,
+        "cancer_type": Value::Null,
+        "msi_status": Value::Null,
+        "sample_id": rel_id(resource, "sample"),
+    });
+    copy_flags(&mut record, attrs, DETAIL_FLAGS);
+    for item in included {
+        let Some(kind) = field_text(item, "type") else {
+            continue;
+        };
+        let item_attrs = attributes(item);
+        match kind.as_str() {
+            "tissue" => record["tissue"] = json!(field_text(item_attrs, "name")),
+            "cancer_type" => record["cancer_type"] = json!(field_text(item_attrs, "name")),
+            "sample" => {
+                if record.get("sample_id").and_then(Value::as_str).is_none() {
+                    record["sample_id"] = json!(field_text(item, "id"));
+                }
+            }
+            "model_msi_status" if item_attrs.get("current") == Some(&Value::Bool(true)) => {
+                record["msi_status"] = item_attrs.get("msi_status").cloned().unwrap_or(Value::Null);
+            }
+            _ => {}
+        }
+    }
+    record
+}
+
+fn shape_gene(resource: &Value) -> Value {
+    let attrs = attributes(resource);
+    let mut row = json!({
+        "gene_id": field_text(resource, "id"),
+        "symbol": attrs.get("symbol").cloned().unwrap_or(Value::Null),
+        "hgnc_id": attrs.get("hgnc_id").cloned().unwrap_or(Value::Null),
+        "hgnc_status": attrs.get("hgnc_status").cloned().unwrap_or(Value::Null),
+        "location": attrs.get("location").cloned().unwrap_or(Value::Null),
+        "cancer_driver": attrs.get("cancer_driver").cloned().unwrap_or(Value::Null),
+        "tumour_suppressor": attrs.get("tumour_suppressor").cloned().unwrap_or(Value::Null),
+    });
+    if let Some(flag) = attrs.get("in_yusa_lib") {
+        row["in_yusa_lib"] = flag.clone();
+    }
+    row
+}
+
+fn shape_dependency(resource: &Value) -> Value {
+    let attrs = attributes(resource);
+    json!({
+        "gene_id": rel_id(resource, "gene"),
+        "model_id": rel_id(resource, "model"),
+        "source": attrs.get("source").cloned().unwrap_or(Value::Null),
+        "bf": attrs.get("bf").cloned().unwrap_or(Value::Null),
+        "bf_scaled": attrs.get("bf_scaled").cloned().unwrap_or(Value::Null),
+        "fc_clean": attrs.get("fc_clean").cloned().unwrap_or(Value::Null),
+        "fc_clean_qn": attrs.get("fc_clean_qn").cloned().unwrap_or(Value::Null),
+        "mageck_fdr": attrs.get("mageck_fdr").cloned().unwrap_or(Value::Null),
+        "qc_pass": attrs.get("qc_pass").cloned().unwrap_or(Value::Null),
+    })
+}
+
+fn copy_flags(target: &mut Value, attrs: &Value, keys: &[&str]) {
+    for key in keys {
+        if let Some(value) = attrs.get(*key) {
+            target[*key] = value.clone();
+        }
+    }
+}
+
+fn sorted_names(attrs: &Value) -> Vec<String> {
+    let mut names = match attrs.get("names") {
+        Some(Value::Array(items)) => items
+            .iter()
+            .filter_map(|item| item.as_str().map(str::to_string))
+            .collect(),
+        Some(Value::String(name)) if !name.is_empty() => vec![name.clone()],
+        _ => Vec::new(),
+    };
+    names.sort_by(|a, b| a.to_lowercase().cmp(&b.to_lowercase()));
+    names
+}
+
+fn attributes(resource: &Value) -> &Value {
+    resource.get("attributes").unwrap_or(resource)
+}
+
+fn data_resources(doc: &Value) -> Vec<Value> {
+    match doc.get("data") {
+        Some(Value::Array(items)) => items.clone(),
+        Some(obj) if obj.is_object() && obj.get("id").is_some() => vec![obj.clone()],
+        _ => Vec::new(),
+    }
+}
+
+fn included_resources(doc: &Value) -> Vec<Value> {
+    match doc.get("included") {
+        Some(Value::Array(items)) => items.clone(),
+        _ => Vec::new(),
+    }
+}
+
+fn meta_count(doc: &Value) -> Option<u64> {
+    let count = doc.get("meta")?.get("count")?;
+    match count {
+        Value::Number(number) => number
+            .as_u64()
+            .or_else(|| number.as_i64().and_then(|n| u64::try_from(n).ok())),
+        Value::String(text) => text.parse().ok(),
+        _ => None,
+    }
+}
+
+fn rel_id(resource: &Value, name: &str) -> Option<String> {
+    let data = resource.get("relationships")?.get(name)?.get("data")?;
+    match data {
+        Value::Object(_) => field_text(data, "id"),
+        Value::Array(items) => items.first().and_then(|item| field_text(item, "id")),
+        _ => None,
+    }
+}
+
+fn has_rel(name: &str, val: Value) -> Value {
+    json!({"name": name, "op": "has", "val": val})
+}
+
+fn eq_field(name: &str, val: &str) -> Value {
+    json!({"name": name, "op": "eq", "val": val})
+}
+
+fn encode_filter(filters: &[Value]) -> Result<String> {
+    serde_json::to_string(filters).context("failed to encode Cell Model Passports filter")
+}
+
+fn looks_like_sidm(value: &str) -> bool {
+    value.len() >= 4 && value[..4].eq_ignore_ascii_case("SIDM")
+}
+
+pub(super) fn require_label(value: &str, what: &str) -> Result<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        bail!("{what} is required");
+    }
+    if trimmed.len() > LABEL_MAX {
+        bail!("{what} exceeds {LABEL_MAX} characters");
+    }
+    if trimmed.chars().any(|ch| ch.is_control()) {
+        bail!("{what} must not contain control characters");
+    }
+    if trimmed.contains('/') || trimmed.contains('?') || trimmed.contains('#') {
+        bail!("{what} must not contain URL path characters");
+    }
+    Ok(trimmed.to_string())
+}
+
+fn optional_label(value: Option<&str>, what: &str) -> Result<Option<String>> {
+    match value {
+        None => Ok(None),
+        Some(text) if text.trim().is_empty() => Ok(None),
+        Some(text) => Ok(Some(require_label(text, what)?)),
+    }
+}
+
+fn field_text(value: &Value, key: &str) -> Option<String> {
+    match value.get(key) {
+        Some(Value::String(text)) if !text.is_empty() => Some(text.clone()),
+        Some(Value::Number(number)) => Some(number.to_string()),
+        _ => None,
+    }
+}

--- a/crates/wisp-bio/src/cancer_models/tests.rs
+++ b/crates/wisp-bio/src/cancer_models/tests.rs
@@ -325,10 +325,14 @@ fn fixture_router() -> Router {
 }
 
 #[test]
-fn catalog_registers_six_cbioportal_tools_on_cancer_models_slug() {
-    let names: Vec<_> = catalog()
+fn catalog_registers_eleven_cancer_models_tools() {
+    let tools: Vec<_> = catalog()
         .into_iter()
-        .map(|(domain, schema)| (domain, schema.function.name))
+        .map(|(domain, schema)| (domain, schema.function.name, schema.function.description))
+        .collect();
+    let names: Vec<_> = tools
+        .iter()
+        .map(|(domain, name, _)| (*domain, name.clone()))
         .collect();
     assert_eq!(
         names,
@@ -339,20 +343,44 @@ fn catalog_registers_six_cbioportal_tools_on_cancer_models_slug() {
             ("cancer-models", "cbioportal_list_studies".into()),
             ("cancer-models", "cbioportal_mutation_frequency".into()),
             ("cancer-models", "cbioportal_mutations_in_gene".into()),
+            ("cancer-models", "gene_dependencies".into()),
+            ("cancer-models", "get_model".into()),
+            ("cancer-models", "list_models".into()),
+            ("cancer-models", "search_genes".into()),
+            ("cancer-models", "search_models".into()),
         ]
     );
-    assert!(crate::contains_tool("cbioportal_list_studies"));
-    assert_eq!(
-        crate::domain_for_tool("cbioportal_list_studies"),
-        Some("cancer-models")
-    );
+    for name in [
+        "cbioportal_clinical_attributes",
+        "cbioportal_cna_in_gene",
+        "cbioportal_get_study",
+        "cbioportal_list_studies",
+        "cbioportal_mutation_frequency",
+        "cbioportal_mutations_in_gene",
+        "gene_dependencies",
+        "get_model",
+        "list_models",
+        "search_genes",
+        "search_models",
+    ] {
+        assert!(crate::contains_tool(name), "{name}");
+        assert_eq!(crate::domain_for_tool(name), Some("cancer-models"));
+    }
     assert!(crate::package_selects("mcp_cancer_models", "cancer-models"));
     assert!(crate::selected_by_package("mcp_cancer_models"));
-    assert!(!crate::contains_tool("list_models"));
-    assert!(!crate::contains_tool("get_model"));
-    assert!(!crate::contains_tool("search_models"));
-    assert!(!crate::contains_tool("search_genes"));
-    assert!(!crate::contains_tool("gene_dependencies"));
+    for (domain, name, description) in &tools {
+        if matches!(
+            name.as_str(),
+            "gene_dependencies" | "get_model" | "list_models" | "search_genes" | "search_models"
+        ) {
+            assert_eq!(*domain, "cancer-models");
+            assert!(
+                description.contains("non-commercial"),
+                "{name} missing usage notice"
+            );
+            assert!(description.contains("depmap@sanger.ac.uk"), "{name}");
+        }
+    }
 }
 
 #[test]
@@ -708,4 +736,677 @@ async fn missing_meta_count_is_null_not_zero() {
     assert_eq!(result["sample_count"], Value::Null);
     assert_eq!(result["patient_count"], Value::Null);
     assert_eq!(result["sequenced_sample_count"], 100);
+}
+
+fn cmp_test_bio(base: &str) -> NativeBio {
+    NativeBio::test_client(
+        &[("CMP_BASE_URL".into(), base.trim_end_matches('/').into())],
+        Http(reqwest::Client::builder().no_proxy().build().unwrap()),
+    )
+    .unwrap()
+}
+
+async fn cmp_serve(app: Router) -> (NativeBio, tokio::task::JoinHandle<()>) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let endpoint = format!("http://{}", listener.local_addr().unwrap());
+    let task = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    (cmp_test_bio(&endpoint), task)
+}
+
+fn percent_decode(raw: &str) -> String {
+    let bytes = raw.as_bytes();
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            if let Ok(value) =
+                u8::from_str_radix(std::str::from_utf8(&bytes[i + 1..i + 3]).unwrap_or(""), 16)
+            {
+                out.push(value);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(if bytes[i] == b'+' { b' ' } else { bytes[i] });
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+fn decode_query(query: &str) -> HashMap<String, String> {
+    let mut out = HashMap::new();
+    for pair in query.split('&') {
+        if pair.is_empty() {
+            continue;
+        }
+        let (key, value) = pair.split_once('=').unwrap_or((pair, ""));
+        out.insert(percent_decode(key), percent_decode(value));
+    }
+    out
+}
+
+fn cmp_model(id: &str, names: &[&str]) -> Value {
+    json!({
+        "id": id,
+        "type": "model",
+        "attributes": {
+            "names": names,
+            "model_type": "Cell Line",
+            "growth_properties": "Adherent",
+            "model_treatment": "Naive",
+            "ploidy_wes": 3.1,
+            "ploidy_wgs": 3.2,
+            "mutations_per_mb": 8.5,
+            "crispr_ko_available": true,
+            "mutations_available": true,
+            "rnaseq_available": false
+        }
+    })
+}
+
+fn jsonapi_list(rows: Vec<Value>, total: usize) -> Value {
+    json!({"data": rows, "meta": {"count": total}})
+}
+
+fn paginate(rows: &[Value], query: &str) -> Value {
+    let params = decode_query(query);
+    let size = params
+        .get("page[size]")
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(30);
+    let number = params
+        .get("page[number]")
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(1);
+    let start = size.saturating_mul(number.saturating_sub(1));
+    jsonapi_list(
+        rows.iter().skip(start).take(size).cloned().collect(),
+        rows.len(),
+    )
+}
+
+fn cmp_gene(id: &str, symbol: &str) -> Value {
+    json!({
+        "id": id,
+        "type": "gene",
+        "attributes": {
+            "symbol": symbol,
+            "hgnc_id": "HGNC:1",
+            "hgnc_status": "Approved",
+            "location": "12p12.1",
+            "cancer_driver": true,
+            "tumour_suppressor": false,
+            "in_yusa_lib": true
+        }
+    })
+}
+
+fn crispr_row(id: &str, model_id: &str, source: &str, bf: f64) -> Value {
+    json!({
+        "id": id,
+        "type": "crispr_ko",
+        "attributes": {
+            "source": source,
+            "bf": bf,
+            "bf_scaled": 0.5,
+            "fc_clean": -0.4,
+            "fc_clean_qn": "-0.3",
+            "mageck_fdr": 0.01,
+            "qc_pass": true
+        },
+        "relationships": {
+            "gene": {"data": {"type": "gene", "id": "SIDG00001"}},
+            "model": {"data": {"type": "model", "id": model_id}}
+        }
+    })
+}
+
+#[tokio::test]
+async fn rejects_empty_query_bounds_extra_keys_and_pathy_ids() {
+    let bio = cmp_test_bio("http://127.0.0.1:1");
+    let empty_search = bio
+        .call("search_models", &json!({"query": ""}))
+        .await
+        .unwrap_err()
+        .to_string();
+    let empty_genes = bio
+        .call("search_genes", &json!({"query": "   "}))
+        .await
+        .unwrap_err()
+        .to_string();
+    let zero = bio
+        .call("list_models", &json!({"max_records": 0}))
+        .await
+        .unwrap_err()
+        .to_string();
+    let too_many = bio
+        .call("list_models", &json!({"max_records": 201}))
+        .await
+        .unwrap_err()
+        .to_string();
+    let extra_key = bio
+        .call(
+            "list_models",
+            &json!({"tissue": "Lung", "api_key": "secret"}),
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+    let pathy = bio
+        .call("get_model", &json!({"model_id_or_name": "SIDM00001/../x"}))
+        .await
+        .unwrap_err()
+        .to_string();
+    let pathy_search = bio
+        .call("search_models", &json!({"query": "lung?x=1"}))
+        .await
+        .unwrap_err()
+        .to_string();
+    assert!(
+        empty_search.contains("required") || empty_search.contains("invalid"),
+        "{empty_search}"
+    );
+    assert!(
+        empty_genes.contains("required")
+            || empty_genes.contains("unsupported")
+            || empty_genes.contains("invalid"),
+        "{empty_genes}"
+    );
+    assert!(zero.contains("max_records"), "{zero}");
+    assert!(too_many.contains("max_records"), "{too_many}");
+    assert!(extra_key.contains("invalid"), "{extra_key}");
+    assert!(!extra_key.contains("secret"), "{extra_key}");
+    assert!(
+        pathy.contains("path") || pathy.contains("unsupported"),
+        "{pathy}"
+    );
+    assert!(pathy_search.contains("path"), "{pathy_search}");
+    assert!(super::sanger::require_label("Small Cell Lung Carcinoma", "cancer_type").is_ok());
+    assert!(super::sanger::require_label("Lung/Other", "tissue").is_err());
+    assert!(super::sanger::require_label("x".repeat(300).as_str(), "query").is_err());
+}
+
+#[tokio::test]
+async fn list_models_pages_filters_and_reports_total_vs_truncated() {
+    let captured = Arc::new(StdMutex::new(Vec::<String>::new()));
+    let seen = captured.clone();
+    let app = Router::new().route(
+        "/models",
+        get(move |uri: Uri| {
+            let seen = seen.clone();
+            async move {
+                let query = uri.query().unwrap_or("").to_string();
+                seen.lock().unwrap().push(query.clone());
+                let params = decode_query(&query);
+                let mut rows: Vec<Value> = (1..=150)
+                    .map(|i| cmp_model(&format!("SIDM{i:05}"), &["SYN-LUNG"]))
+                    .collect();
+                if let Some(filter) = params.get("filter") {
+                    if filter.contains("Lung") {
+                        rows.truncate(40);
+                    }
+                    if filter.contains("Small Cell Lung Carcinoma") {
+                        rows.truncate(12);
+                    }
+                }
+                axum::Json(paginate(&rows, &query))
+            }
+        }),
+    );
+    let (bio, server) = cmp_serve(app).await;
+    let capped = bio
+        .call("list_models", &json!({"max_records": 50}))
+        .await
+        .unwrap();
+    let filtered = bio
+        .call(
+            "list_models",
+            &json!({
+                "tissue": "Lung",
+                "cancer_type": "Small Cell Lung Carcinoma",
+                "max_records": 50
+            }),
+        )
+        .await
+        .unwrap();
+    let walked = bio
+        .call("list_models", &json!({"max_records": 200}))
+        .await
+        .unwrap();
+    server.abort();
+    let queries = captured.lock().unwrap().clone();
+    let decoded: Vec<HashMap<String, String>> = queries.iter().map(|q| decode_query(q)).collect();
+    assert!(
+        decoded
+            .iter()
+            .any(|q| q.get("page[size]").map(String::as_str) == Some("100")),
+        "{queries:?}"
+    );
+    assert!(
+        decoded
+            .iter()
+            .any(|q| q.get("page[number]").map(String::as_str) == Some("1")),
+        "{queries:?}"
+    );
+    assert!(
+        decoded
+            .iter()
+            .any(|q| q.get("page[number]").map(String::as_str) == Some("2")),
+        "{queries:?}"
+    );
+    let filter = decoded
+        .iter()
+        .find_map(|q| q.get("filter").cloned())
+        .expect("filter");
+    let parsed: Value = serde_json::from_str(&filter).unwrap();
+    assert!(filter.contains("\"op\":\"has\""), "{filter}");
+    assert!(filter.contains("Lung"), "{filter}");
+    assert!(filter.contains("Small Cell Lung Carcinoma"), "{filter}");
+    assert_eq!(parsed.as_array().map(Vec::len), Some(2));
+    assert_eq!(capped["source"], "Cell Model Passports");
+    assert_eq!(
+        capped["source_url"],
+        "https://api.cellmodelpassports.sanger.ac.uk"
+    );
+    assert_eq!(capped["total"], 150);
+    assert_eq!(capped["returned"], 50);
+    assert_eq!(capped["truncated"], true);
+    assert_eq!(capped["models"][0]["model_id"], "SIDM00001");
+    assert_eq!(capped["models"][0]["names"], json!(["SYN-LUNG"]));
+    assert_eq!(capped["models"][0]["crispr_ko_available"], true);
+    assert_eq!(filtered["tissue"], "Lung");
+    assert_eq!(filtered["cancer_type"], "Small Cell Lung Carcinoma");
+    assert_eq!(filtered["total"], 12);
+    assert_eq!(filtered["returned"], 12);
+    assert_eq!(filtered["truncated"], false);
+    assert_eq!(walked["returned"], 150);
+    assert_eq!(walked["truncated"], false);
+    assert!(queries.len() <= 8, "{queries:?}");
+}
+
+#[tokio::test]
+async fn get_model_uses_include_and_fails_unknown_or_ambiguous_names() {
+    let captured = Arc::new(StdMutex::new(Vec::<String>::new()));
+    let seen = captured.clone();
+    let app = Router::new()
+        .route(
+            "/models/{model_id}",
+            get({
+                let seen = seen.clone();
+                move |Path(model_id): Path<String>, uri: Uri| {
+                    let seen = seen.clone();
+                    async move {
+                        seen.lock()
+                            .unwrap()
+                            .push(format!("{}?{}", uri.path(), uri.query().unwrap_or("")));
+                        if model_id == "SIDM99999" {
+                            return axum::Json(json!({"data": null})).into_response();
+                        }
+                        if model_id != "SIDM00001" {
+                            return StatusCode::NOT_FOUND.into_response();
+                        }
+                        axum::Json(json!({
+                            "data": {
+                                "id": "SIDM00001",
+                                "type": "model",
+                                "attributes": {
+                                    "names": ["SYN-B", "syn-a"],
+                                    "model_type": "Cell Line",
+                                    "growth_properties": "Adherent",
+                                    "model_treatment": "Naive",
+                                    "ploidy_wes": 3.1,
+                                    "ploidy_wgs": 3.2,
+                                    "mutations_per_mb": 8.5,
+                                    "crispr_ko_available": true,
+                                    "mutations_available": true,
+                                    "rnaseq_available": false
+                                },
+                                "relationships": {
+                                    "sample": {"data": {"type": "sample", "id": "SIDS00001"}}
+                                },
+                                "links": {"self": "https://example.invalid/secret"}
+                            },
+                            "included": [
+                                {"id": "SIDS00001", "type": "sample", "attributes": {}},
+                                {"id": "t1", "type": "tissue", "attributes": {"name": "Lung"}},
+                                {"id": "c1", "type": "cancer_type", "attributes": {"name": "Small Cell Lung Carcinoma"}},
+                                {"id": "msi-old", "type": "model_msi_status", "attributes": {"msi_status": "MSS", "current": false}},
+                                {"id": "msi-now", "type": "model_msi_status", "attributes": {"msi_status": "MSI", "current": true}}
+                            ],
+                            "jsonapi": {"version": "1.0"},
+                            "links": {"self": "https://example.invalid/secret"}
+                        }))
+                        .into_response()
+                    }
+                }
+            }),
+        )
+        .route(
+            "/models",
+            get({
+                let seen = seen.clone();
+                move |uri: Uri| {
+                    let seen = seen.clone();
+                    async move {
+                        let query = uri.query().unwrap_or("").to_string();
+                        seen.lock().unwrap().push(query.clone());
+                        let params = decode_query(&query);
+                        let filter = params.get("filter").cloned().unwrap_or_default();
+                        if filter.contains("SYN-DUP") {
+                            return axum::Json(json!({
+                                "data": [
+                                    cmp_model("SIDM00001", &["SYN-DUP"]),
+                                    cmp_model("SIDM00002", &["SYN-DUP"])
+                                ]
+                            }))
+                            .into_response();
+                        }
+                        if filter.contains("MISSING") {
+                            return axum::Json(json!({"data": []})).into_response();
+                        }
+                        StatusCode::NOT_FOUND.into_response()
+                    }
+                }
+            }),
+        );
+    let (bio, server) = cmp_serve(app).await;
+    let found = bio
+        .call("get_model", &json!({"model_id_or_name": "sidm00001"}))
+        .await
+        .unwrap();
+    let unknown = bio
+        .call("get_model", &json!({"model_id_or_name": "SIDM99999"}))
+        .await
+        .unwrap_err()
+        .to_string();
+    let missing_name = bio
+        .call("get_model", &json!({"model_id_or_name": "MISSING"}))
+        .await
+        .unwrap_err()
+        .to_string();
+    let ambiguous = bio
+        .call("get_model", &json!({"model_id_or_name": "SYN-DUP"}))
+        .await
+        .unwrap_err()
+        .to_string();
+    server.abort();
+    let traffic = captured.lock().unwrap().clone();
+    assert!(
+        traffic
+            .iter()
+            .any(|row| row.contains("include=sample.tissue")),
+        "{traffic:?}"
+    );
+    assert_eq!(found["model_id"], "SIDM00001");
+    assert_eq!(found["names"], json!(["syn-a", "SYN-B"]));
+    assert_eq!(found["tissue"], "Lung");
+    assert_eq!(found["cancer_type"], "Small Cell Lung Carcinoma");
+    assert_eq!(found["msi_status"], "MSI");
+    assert_eq!(found["sample_id"], "SIDS00001");
+    assert_eq!(found["source"], "Cell Model Passports");
+    assert!(found.get("links").is_none());
+    assert!(found.get("jsonapi").is_none());
+    assert!(!found.to_string().contains("example.invalid"));
+    assert!(unknown.contains("was not found"), "{unknown}");
+    assert!(missing_name.contains("was not found"), "{missing_name}");
+    assert!(ambiguous.contains("ambiguous"), "{ambiguous}");
+    assert!(ambiguous.contains("SIDM00001"), "{ambiguous}");
+    assert!(ambiguous.contains("SIDM00002"), "{ambiguous}");
+}
+
+#[tokio::test]
+async fn search_models_keeps_type_model_only() {
+    let app = Router::new().route(
+        "/search/{query}",
+        get(|Path(query): Path<String>| async move {
+            assert_eq!(query, "SYN");
+            axum::Json(json!({
+                "data": [
+                    cmp_model("SIDM00002", &["SYN-2"]),
+                    {"id": "SIDG00001", "type": "gene", "attributes": {"symbol": "SYN1"}},
+                    cmp_model("SIDM00001", &["SYN-1"])
+                ]
+            }))
+        }),
+    );
+    let (bio, server) = cmp_serve(app).await;
+    let result = bio
+        .call("search_models", &json!({"query": "SYN"}))
+        .await
+        .unwrap();
+    server.abort();
+    assert_eq!(result["query"], "SYN");
+    assert_eq!(result["returned"], 2);
+    assert_eq!(result["total"], 2);
+    assert_eq!(result["truncated"], false);
+    assert_eq!(result["models"][0]["model_id"], "SIDM00001");
+    assert_eq!(result["models"][1]["model_id"], "SIDM00002");
+    assert!(result.to_string().contains("SYN-1"));
+    assert!(!result.to_string().contains("SIDG00001"));
+}
+
+#[tokio::test]
+async fn search_genes_exact_eq_versus_ilike() {
+    let captured = Arc::new(StdMutex::new(Vec::<String>::new()));
+    let seen = captured.clone();
+    let app = Router::new().route(
+        "/genes",
+        get(move |uri: Uri| {
+            let seen = seen.clone();
+            async move {
+                let query = uri.query().unwrap_or("").to_string();
+                seen.lock().unwrap().push(query.clone());
+                let params = decode_query(&query);
+                let filter = params.get("filter").cloned().unwrap_or_default();
+                let genes = vec![
+                    cmp_gene("SIDG00001", "SYN1"),
+                    cmp_gene("SIDG00002", "SYN12"),
+                ];
+                let matched: Vec<Value> = if filter.contains("\"op\":\"eq\"") {
+                    genes
+                        .into_iter()
+                        .filter(|gene| gene["attributes"]["symbol"] == "SYN1")
+                        .collect()
+                } else {
+                    genes
+                };
+                axum::Json(jsonapi_list(matched.clone(), matched.len()))
+            }
+        }),
+    );
+    let (bio, server) = cmp_serve(app).await;
+    let exact = bio
+        .call("search_genes", &json!({"query": "SYN1", "exact": true}))
+        .await
+        .unwrap();
+    let fuzzy = bio
+        .call("search_genes", &json!({"query": "SYN1", "exact": false}))
+        .await
+        .unwrap();
+    server.abort();
+    let queries = captured.lock().unwrap().clone();
+    let filters: Vec<String> = queries
+        .iter()
+        .map(|q| decode_query(q).get("filter").cloned().unwrap_or_default())
+        .collect();
+    assert!(
+        filters
+            .iter()
+            .any(|f| f.contains("\"op\":\"eq\"") && !f.contains('%')),
+        "{filters:?}"
+    );
+    assert!(
+        filters
+            .iter()
+            .any(|f| f.contains("\"op\":\"ilike\"") && f.contains("%SYN1%")),
+        "{filters:?}"
+    );
+    assert_eq!(exact["exact"], true);
+    assert_eq!(exact["returned"], 1);
+    assert_eq!(exact["genes"][0]["gene_id"], "SIDG00001");
+    assert_eq!(exact["genes"][0]["symbol"], "SYN1");
+    assert_eq!(fuzzy["returned"], 2);
+    assert_eq!(fuzzy["genes"][0]["gene_id"], "SIDG00001");
+    assert_eq!(fuzzy["genes"][1]["gene_id"], "SIDG00002");
+    assert_eq!(fuzzy["truncated"], false);
+}
+
+#[tokio::test]
+async fn gene_dependencies_uses_gene_scoped_path_and_model_filter() {
+    let captured = Arc::new(StdMutex::new(Vec::<String>::new()));
+    let seen = captured.clone();
+    let app = Router::new()
+        .route(
+            "/genes",
+            get({
+                let seen = seen.clone();
+                move |uri: Uri| {
+                    let seen = seen.clone();
+                    async move {
+                        seen.lock().unwrap().push(format!(
+                            "{}?{}",
+                            uri.path(),
+                            uri.query().unwrap_or("")
+                        ));
+                        axum::Json(jsonapi_list(vec![cmp_gene("SIDG00001", "SYN1")], 1))
+                    }
+                }
+            }),
+        )
+        .route(
+            "/genes/{gene_id}/datasets/crispr_ko",
+            get({
+                let seen = seen.clone();
+                move |Path(gene_id): Path<String>, uri: Uri| {
+                    let seen = seen.clone();
+                    async move {
+                        seen.lock().unwrap().push(format!(
+                            "{}?{}",
+                            uri.path(),
+                            uri.query().unwrap_or("")
+                        ));
+                        assert_eq!(gene_id, "SIDG00001");
+                        let params = decode_query(uri.query().unwrap_or(""));
+                        let mut rows = vec![
+                            crispr_row("volatile-b", "SIDM00002", "Sanger", 2.0),
+                            crispr_row("volatile-a", "SIDM00001", "Broad", 1.5),
+                            crispr_row("volatile-c", "SIDM00001", "Sanger", 1.2),
+                        ];
+                        if let Some(filter) = params.get("filter") {
+                            if filter.contains("SIDM00001") {
+                                rows.retain(|row| {
+                                    row["relationships"]["model"]["data"]["id"] == "SIDM00001"
+                                });
+                            }
+                        }
+                        let total = rows.len();
+                        axum::Json(jsonapi_list(rows, total))
+                    }
+                }
+            }),
+        )
+        .route(
+            "/datasets/crispr_ko",
+            get({
+                let seen = seen.clone();
+                move |uri: Uri| {
+                    let seen = seen.clone();
+                    async move {
+                        seen.lock().unwrap().push(uri.path().to_string());
+                        StatusCode::INTERNAL_SERVER_ERROR
+                    }
+                }
+            }),
+        );
+    let (bio, server) = cmp_serve(app).await;
+    let all = bio
+        .call(
+            "gene_dependencies",
+            &json!({"gene_symbol": "SYN1", "max_records": 50}),
+        )
+        .await
+        .unwrap();
+    let filtered = bio
+        .call(
+            "gene_dependencies",
+            &json!({"gene_symbol": "SYN1", "model_id": "sidm00001"}),
+        )
+        .await
+        .unwrap();
+    server.abort();
+    let traffic = captured.lock().unwrap().clone();
+    assert!(
+        traffic
+            .iter()
+            .any(|row| row.starts_with("/genes/SIDG00001/datasets/crispr_ko")),
+        "{traffic:?}"
+    );
+    assert!(
+        traffic
+            .iter()
+            .all(|row| row != "/datasets/crispr_ko" && !row.starts_with("/datasets/crispr_ko?")),
+        "{traffic:?}"
+    );
+    let model_filter = traffic
+        .iter()
+        .find(|row| row.contains("crispr_ko") && row.contains("filter="))
+        .map(|row| decode_query(row.split_once('?').map(|(_, q)| q).unwrap_or("")))
+        .and_then(|q| q.get("filter").cloned())
+        .expect("model filter");
+    assert!(model_filter.contains("\"op\":\"has\""), "{model_filter}");
+    assert!(model_filter.contains("SIDM00001"), "{model_filter}");
+    assert_eq!(all["gene"]["gene_id"], "SIDG00001");
+    assert_eq!(all["gene"]["symbol"], "SYN1");
+    assert_eq!(all["total"], 3);
+    assert_eq!(all["returned"], 3);
+    assert_eq!(all["truncated"], false);
+    assert_eq!(all["dependencies"][0]["model_id"], "SIDM00001");
+    assert_eq!(all["dependencies"][0]["source"], "Broad");
+    assert_eq!(all["dependencies"][1]["model_id"], "SIDM00001");
+    assert_eq!(all["dependencies"][1]["source"], "Sanger");
+    assert_eq!(all["dependencies"][0]["bf"], 1.5);
+    assert_eq!(all["dependencies"][0]["fc_clean_qn"], "-0.3");
+    assert!(!all.to_string().contains("volatile-"));
+    assert!(all["dependencies"][0].get("id").is_none());
+    assert_eq!(filtered["returned"], 2);
+    assert_eq!(filtered["model_id"], "SIDM00001");
+}
+
+#[tokio::test]
+async fn cmp_jsonapi_errors_and_http_429_do_not_echo_secrets() {
+    for (status, body, expected) in [
+        (
+            StatusCode::OK,
+            json!({"errors": [{"detail": "secret-token", "status": "400"}]}).to_string(),
+            "error document",
+        ),
+        (
+            StatusCode::TOO_MANY_REQUESTS,
+            "secret-token".into(),
+            "HTTP 429",
+        ),
+    ] {
+        let app = Router::new().route(
+            "/models",
+            get({
+                let body = body.clone();
+                move || {
+                    let body = body.clone();
+                    async move { (status, body).into_response() }
+                }
+            }),
+        );
+        let (bio, server) = cmp_serve(app).await;
+        let error = bio
+            .call("list_models", &json!({"tissue": "Lung"}))
+            .await
+            .unwrap_err()
+            .to_string();
+        server.abort();
+        assert!(
+            error.contains(expected),
+            "{error} did not contain {expected}"
+        );
+        assert!(!error.contains("secret-token"), "{error}");
+    }
 }


### PR DESCRIPTION
## Problem

Sanger Cell Model Passports (`list_models`, `get_model`, `search_models`, `search_genes`, `gene_dependencies`) was left on the vendored Python path behind the commercial-use / third-party-app gate. Native cancer-models already covers cBioPortal.

## Change

Independently authored JSON:API client against [api.cellmodelpassports.sanger.ac.uk](https://api.cellmodelpassports.sanger.ac.uk) ([docs](https://depmap.sanger.ac.uk/documentation/api/), reviewed 2026-09-06):

- `list_models` — GET `/models` with nested tissue/cancer_type `has` filters
- `get_model` — SIDM GET `/models/{id}` with includes, or names/`any`; unknown/ambiguous fail
- `search_models` — GET `/search/{query}`, `type==model` only
- `search_genes` — `/genes` `eq` / `ilike` on official symbol
- `gene_dependencies` — resolve symbol then GET `/genes/{SIDG}/datasets/crispr_ko` (never the unscoped 19.5M-row table)

Bounded pages (`max_records` default 50, max 200, at most 8×100). `meta.count` preserved; `truncated` when the page is a cap. `CMP_BASE_URL` for tests (not `CBIOPORTAL_BASE_URL`).

Non-commercial-use notice in every description: commercial use and third-party website/app embedding need prior consent (depmap@sanger.ac.uk).

## Tests

`cargo test -p wisp-bio --offline cancer_models` — separate CMP fake upstream; existing cBioPortal tests still pass.

## Files

- `crates/wisp-bio/src/cancer_models/sanger.rs` (new)
- `crates/wisp-bio/src/cancer_models/mod.rs`
- `crates/wisp-bio/src/cancer_models/tests.rs`