### PR TITLE
fix(runtime): prevent guessed generation guards on first REPL calls

### DIFF
--- a/crates/wisp-runtime/src/manager.rs
+++ b/crates/wisp-runtime/src/manager.rs
@@ -447,9 +447,24 @@ impl RuntimeManager {
                 .get(key)
                 .cloned()
                 .ok_or_else(|| {
-                    anyhow!(
-                        "runtime is not started; load the required objects before executing this source"
-                    )
+                    let mut message = "runtime is not started; ".to_string();
+                    if let Some(expected) = options.expected_generation {
+                        message.push_str(&format!(
+                            "expected_runtime_generation={expected} requires an existing runtime of that generation; it does not start one. "
+                        ));
+                        if options.required_objects.is_empty() {
+                            message.push_str(
+                                "For initialization code that needs no prior runtime state, omit expected_runtime_generation on the first call. If prior state was expected, restore it explicitly before retrying."
+                            );
+                        }
+                    }
+                    if !options.required_objects.is_empty() {
+                        message.push_str(&format!(
+                            "required_objects={:?} requires existing bindings. Initialize and load these objects in a separate call without required_objects or expected_runtime_generation, then retry this source with verified preconditions.",
+                            options.required_objects
+                        ));
+                    }
+                    anyhow!(message)
                 })?;
             // The registry lookup bypasses `session`, so this branch is the only
             // place that still has to reject a runtime started elsewhere.
@@ -462,7 +477,7 @@ impl RuntimeManager {
         if let Some(expected) = options.expected_generation {
             if info.generation != expected {
                 return Err(anyhow!(
-                    "runtime generation changed: expected {expected}, current {}; reload or rebind the required objects explicitly",
+                    "runtime generation changed: expected_runtime_generation={expected}, current {}; verify and restore the runtime state before retrying; do not guess a replacement generation",
                     info.generation
                 ));
             }
@@ -1461,6 +1476,49 @@ mod tests {
             .unwrap_err();
         assert!(error.to_string().contains("runtime is not started"));
         assert_eq!(launcher.launches.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn missing_runtime_errors_identify_each_precondition_without_launching() {
+        let launcher = FakeLauncher::default();
+        let manager = manager(&launcher);
+        let key = RuntimeKey::local_python("project-a");
+        let cwd = PathBuf::from("project-a");
+
+        for (expected_generation, required_objects) in [
+            (Some(1), vec![]),
+            (None, vec!["value".to_string()]),
+            (Some(1), vec!["value".to_string()]),
+        ] {
+            let error = manager
+                .execute_with_options(
+                    &key,
+                    &cwd,
+                    "set:9",
+                    RuntimeExecutionOptions {
+                        expected_generation,
+                        required_objects: required_objects.clone(),
+                        ..RuntimeExecutionOptions::default()
+                    },
+                )
+                .await
+                .unwrap_err()
+                .to_string();
+            assert!(error.contains("runtime is not started"), "{error}");
+            assert_eq!(
+                error.contains("expected_runtime_generation=1"),
+                expected_generation.is_some(),
+                "{error}"
+            );
+            if required_objects.is_empty() {
+                assert!(error.contains("omit expected_runtime_generation on the first call"));
+                assert!(!error.contains("required_objects"));
+            } else {
+                assert!(error.contains("required_objects=[\"value\"]"), "{error}");
+                assert!(error.contains("separate call"), "{error}");
+            }
+            assert_eq!(launcher.launches.load(Ordering::SeqCst), 0);
+        }
     }
 
     /// The guarded path looks the session up straight out of the registry, which

--- a/crates/wisp-runtime/src/tool.rs
+++ b/crates/wisp-runtime/src/tool.rs
@@ -398,6 +398,9 @@ fn required_objects_arg(args: &serde_json::Value) -> Result<Vec<String>, String>
     Ok(names)
 }
 
+// Retain strict guards for legacy callers, but do not advertise this host-state
+// precondition in model schemas: models may fill optional integers with a
+// guessed 1, which prevents a first cell from lazily starting its runtime.
 fn expected_generation_arg(args: &serde_json::Value) -> Result<Option<u64>, String> {
     let Some(value) = args.get("expected_runtime_generation") else {
         return Ok(None);
@@ -540,7 +543,6 @@ impl Tool for ReplTool {
                     "code": { "type": "string", "description": "Python code to execute (statements or a single expression). Provide exactly one of code or script_path" },
                     "script_path": { "type": "string", "description": "Project-relative .py file whose exact UTF-8 content is executed in this persistent runtime. Provide exactly one of code or script_path. The path is always resolved in the local project root, so an ssh: context needs the script present locally; only its content crosses the connection" },
                     "required_objects": { "type": "array", "items": { "type": "string" }, "maxItems": 64, "description": "Top-level binding names (not attribute paths such as adata.X) that must already exist in this runtime before execution; a missing/dead/restarted runtime fails instead of lazy-starting empty" },
-                    "expected_runtime_generation": { "type": "integer", "minimum": 1, "description": "Optional generation guard from a previous runtime-script result" },
                     "context_id": { "type": "string", "description": "Execution context id; defaults to local (for example local, ssh:gpu, or wsl:Ubuntu)" }
                 }
             }),
@@ -600,7 +602,6 @@ impl Tool for RTool {
                     "code": { "type": "string", "description": "R code to execute (one or more expressions). Provide exactly one of code or script_path" },
                     "script_path": { "type": "string", "description": "Project-relative .R file whose exact UTF-8 content is executed in this persistent runtime. Provide exactly one of code or script_path. The path is always resolved in the local project root, so an ssh: context needs the script present locally; only its content crosses the connection" },
                     "required_objects": { "type": "array", "items": { "type": "string" }, "maxItems": 64, "description": "Top-level binding names (not attribute paths such as obj$slot) that must already exist in this runtime before execution; a missing/dead/restarted runtime fails instead of lazy-starting empty" },
-                    "expected_runtime_generation": { "type": "integer", "minimum": 1, "description": "Optional generation guard from a previous runtime-script result" },
                     "context_id": { "type": "string", "description": "Execution context id; defaults to local (for example local, ssh:gpu, or wsl:Ubuntu)" }
                 }
             }),
@@ -727,13 +728,8 @@ mod tests {
                 "{parameters}"
             );
             let properties = parameters["properties"].as_object().unwrap();
-            for name in [
-                "code",
-                "script_path",
-                "required_objects",
-                "expected_runtime_generation",
-                "context_id",
-            ] {
+            assert!(!properties.contains_key("expected_runtime_generation"));
+            for name in ["code", "script_path", "required_objects", "context_id"] {
                 assert!(properties.contains_key(name), "missing {name}");
             }
             for name in ["code", "script_path"] {
@@ -861,6 +857,72 @@ mod tests {
             expected_generation_arg(&serde_json::json!({"expected_runtime_generation": 0}))
                 .is_err()
         );
+    }
+
+    #[tokio::test]
+    async fn guessed_first_generation_reports_recovery_and_preserves_legacy_guards() {
+        let root = unique_tmp("runtime_guessed_generation");
+        let env = recording_env(root.clone());
+        for language in ["python", "r"] {
+            let launcher = EchoLauncher::default();
+            let manager = RuntimeManager::new(Arc::new(launcher.clone()));
+            let (tool, key): (Box<dyn Tool>, _) = if language == "python" {
+                (
+                    Box::new(ReplTool::new(manager.clone(), "p")),
+                    RuntimeKey::local_python("p"),
+                )
+            } else {
+                (
+                    Box::new(RTool::new(manager.clone(), "p")),
+                    RuntimeKey::r("p", LOCAL_CONTEXT_ID),
+                )
+            };
+            // Original failing assistant arguments, including empty optional fields.
+            let mut args = serde_json::json!({
+                "code": "1 + 1",
+                "context_id": "local",
+                "expected_runtime_generation": 1,
+                "required_objects": [],
+                "script_path": ""
+            });
+            let result = tool.run(&args, &env).await;
+            assert!(!result.success);
+            assert!(result.content.contains("expected_runtime_generation=1"));
+            assert!(result
+                .content
+                .contains("omit expected_runtime_generation on the first call"));
+            assert!(!result.content.contains("load the required objects"));
+            assert!(manager.list().is_empty());
+            assert!(launcher.seen.lock().unwrap().is_empty());
+
+            args.as_object_mut()
+                .unwrap()
+                .remove("expected_runtime_generation");
+            let result = tool.run(&args, &env).await;
+            assert!(result.success, "{}", result.content);
+            assert_eq!(launcher.seen.lock().unwrap().len(), 1);
+
+            // A known generation still works for old callers. A stale one must
+            // never be ignored or replaced with the currently registered value.
+            args["expected_runtime_generation"] = serde_json::json!(1);
+            assert!(tool.run(&args, &env).await.success);
+            let replacement = manager.restart(key.clone(), root.clone()).await.unwrap();
+            assert!(replacement.generation > 1);
+            let result = tool.run(&args, &env).await;
+            assert!(!result.success);
+            assert!(result.content.contains("expected_runtime_generation"));
+            assert!(result.content.contains("runtime generation changed"));
+            assert_eq!(launcher.seen.lock().unwrap().len(), 2);
+
+            manager.stop(&key).await.unwrap();
+            manager.dismiss_dead(&replacement.runtime_id).unwrap();
+            let result = tool.run(&args, &env).await;
+            assert!(!result.success);
+            assert!(manager.list().is_empty());
+            assert_eq!(launcher.seen.lock().unwrap().len(), 2);
+            manager.shutdown_all().await;
+        }
+        std::fs::remove_dir_all(root).unwrap();
     }
 
     #[test]

--- a/docs/superpowers/specs/2026-07-14-wisp-runtime-design.md
+++ b/docs/superpowers/specs/2026-07-14-wisp-runtime-design.md
@@ -546,7 +546,7 @@ The existing `python` tool remains backward-compatible and can also execute a
 saved project script without leaving the runtime:
 
 ```text
-python(code? | script_path?, required_objects?, expected_runtime_generation?, context_id?)
+python(code? | script_path?, required_objects?, context_id?)
 ```
 
 - Exactly one of `code` or `script_path` is required. The schema keeps both
@@ -566,18 +566,34 @@ python(code? | script_path?, required_objects?, expected_runtime_generation?, co
   non-empty, the tool never lazily starts an empty runtime, and it rejects a
   runtime started in another directory instead of falling back to a new one; the
   worker checks the bindings before evaluating any source.
-- `expected_runtime_generation` optionally rejects a restarted/replaced runtime.
+- `expected_runtime_generation` is no longer advertised in the Python/R model
+  tool schemas: filling this optional integer with a guessed `1` prevents the
+  first call from starting a runtime. Legacy callers may still pass it, and the
+  host API retains `RuntimeExecutionOptions.expected_generation`; both strictly
+  require an existing runtime of the specified generation. The host never
+  silently drops a supplied guard or substitutes the current generation.
+  Missing-runtime errors identify the failed fields and explain recovery.
+  Initialization code that needs no prior state should omit the generation
+  guard and omit `required_objects` (or pass `[]`). Code relying on previous
+  state must restore that state explicitly before retrying.
 
 The new R tool mirrors it:
 
 ```text
-r(code? | script_path?, required_objects?, expected_runtime_generation?, context_id?)
+r(code? | script_path?, required_objects?, context_id?)
 ```
 
 Its `script_path` must name a project-relative `.R` file. Script paths are source
 artifacts, not process-launch instructions: both languages execute the saved
 source inside their existing persistent namespace. Results from script execution
 include the project-relative path, SHA-256, runtime id, and generation.
+
+For example, a first call can use
+`{"code":"1 + 1","context_id":"local","required_objects":[],"script_path":""}`.
+Blank optional source strings count as absent. Adding
+`"expected_runtime_generation":1` asserts that generation 1 already exists;
+it is not a startup request. The CLI's `python repl wired` message only confirms
+tool registration, not that a Python process has started.
 
 Tool descriptions state that variables and loaded data persist per
 project/context/language, that package installation belongs to an explicitly chosen


### PR DESCRIPTION
## Problem

Python/R first calls can fail before launching a runtime when a model fills the optional `expected_runtime_generation` argument with a guessed `1`. That argument requires an already-existing generation; the previous error incorrectly told callers with `required_objects: []` to load required objects. Repeating the same failed call can then trigger the agent's loop guard.

## Changes

- `crates/wisp-runtime/src/tool.rs`: remove generation from both model-facing schemas while retaining strict parsing and validation for legacy callers. No new abstractions.
- `crates/wisp-runtime/src/manager.rs`: identify the failing generation/object preconditions and explain how to initialize or restore runtime state before retrying.
- Update the runtime design documentation with the supported schema, legacy guard behavior, and first-call example.

An initialization call with `code`, `script_path: ""`, and `required_objects: []` succeeds when generation is omitted. An explicitly supplied guard is never silently ignored or replaced with the current generation. Loop detection remains unchanged.

## Validation

- `cargo fmt --all -- --check` passed.
- `cargo test -p wisp-runtime --offline`: 76 tests passed.
- `WISP_CATALOG_OFFLINE=1 cargo test --workspace --offline`: 1,974 tests passed, 0 failed. The full run required execution outside the sandbox so existing mock HTTP tests could bind loopback ports.
- Added fake-runtime regression coverage for the reported argument shape in Python and R, successful first-call recovery, valid legacy guards, stale guards after restart/removal, and generation/object error combinations without launching a runtime.

## Manual smoke / follow-up

- With an updated CLI or desktop build and a fresh conversation, execute Python initialization with `{"code":"1 + 1","context_id":"local","required_objects":[],"script_path":""}` and confirm lazy startup succeeds.
- In a fresh runtime scope, submit the same arguments with `expected_runtime_generation: 1`; confirm the error names that field and instructs initialization code to omit it. Remove the field and retry.
- Repeat for R in a context where Rscript/jsonlite already exist.
- Re-run the two affected Astra benchmark questions with a fixed binary revision and fresh conversations, keeping results separate from the mixed-version run. This has not been performed; the original benchmark logs and live model API were not available for this verification.

Existing conversation history can still replay the legacy argument and must follow the recovery hint. This change does not add automatic generation tracking/injection or weaken explicitly requested generation checks.
