### PR TITLE
Pass Windows user-profile env vars to plugin MCP children

### DIFF
--- a/docs/feature-plugins.md
+++ b/docs/feature-plugins.md
@@ -86,6 +86,11 @@ rather than its entire workspace.
   installed plugin. Arguments are passed as an argv array, never through a
   shell. Child processes are terminated when their owning agent session is
   released.
+- Plugin MCP processes start from a cleared environment. Wisp copies only a
+  small non-secret allowlist: `PATH`, temp/locale/runtime plumbing, Windows
+  user-profile directories (`USERPROFILE`, `APPDATA`, `LOCALAPPDATA`,
+  `HOMEDRIVE`, `HOMEPATH`), and XDG directories when the host already has
+  them. Token variables such as `GH_TOKEN` and `GITHUB_TOKEN` are not copied.
 - Third-party MCP tool names may not replace an existing Wisp tool.
 - MCP Apps receive structured tool input/results in a script-only, opaque-origin
   iframe. Network origins are restricted to the resource's declared CSP. A live

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@
 
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex as StdMutex, RwLock as StdRwLock};
@@ -4947,6 +4948,53 @@ async fn wire_runtimes_and_mcp(
     finish_custom_mcp_wiring(result, registry, store, project_id, connector_allow).await
 }
 
+/// Host environment keys copied into a plugin MCP child after `env_clear()`.
+/// Keep this a non-secret allowlist: runtime plumbing plus user-config
+/// directories. Do not add `GH_TOKEN`, `GITHUB_TOKEN`, or other secrets.
+const PLUGIN_MCP_ENV_PASSTHROUGH: &[&str] = &[
+    "PATH",
+    "HOME",
+    "USERPROFILE",
+    "APPDATA",
+    "LOCALAPPDATA",
+    "HOMEDRIVE",
+    "HOMEPATH",
+    "XDG_CONFIG_HOME",
+    "XDG_DATA_HOME",
+    "XDG_CACHE_HOME",
+    "TMPDIR",
+    "TEMP",
+    "TMP",
+    "LANG",
+    "LC_ALL",
+    "SYSTEMROOT",
+    "SYSTEMDRIVE",
+    "PATHEXT",
+    "COMSPEC",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "ALL_PROXY",
+    "NO_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "all_proxy",
+    "no_proxy",
+];
+
+fn plugin_mcp_passthrough_env_from<F>(mut lookup: F) -> Vec<(OsString, OsString)>
+where
+    F: FnMut(&str) -> Option<OsString>,
+{
+    PLUGIN_MCP_ENV_PASSTHROUGH
+        .iter()
+        .filter_map(|&key| lookup(key).map(|value| (OsString::from(key), value)))
+        .collect()
+}
+
+fn plugin_mcp_passthrough_env() -> Vec<(OsString, OsString)> {
+    plugin_mcp_passthrough_env_from(|key| std::env::var_os(key))
+}
+
 async fn connect_plugin_mcp(
     launch: &plugins::PluginMcpLaunch,
 ) -> anyhow::Result<wisp_mcp::McpClient> {
@@ -4955,34 +5003,10 @@ async fn connect_plugin_mcp(
         .args(&launch.args)
         .current_dir(&launch.cwd)
         .env_clear();
-    // Preserve only the small platform environment needed by common runtimes.
-    // Package-declared variables are added below; no shell is involved.
-    const PASSTHROUGH: &[&str] = &[
-        "PATH",
-        "HOME",
-        "TMPDIR",
-        "TEMP",
-        "TMP",
-        "LANG",
-        "LC_ALL",
-        "SYSTEMROOT",
-        "SYSTEMDRIVE",
-        "PATHEXT",
-        "COMSPEC",
-        "HTTP_PROXY",
-        "HTTPS_PROXY",
-        "ALL_PROXY",
-        "NO_PROXY",
-        "http_proxy",
-        "https_proxy",
-        "all_proxy",
-        "no_proxy",
-    ];
-    for key in PASSTHROUGH {
-        if let Some(value) = std::env::var_os(key) {
-            command.env(key, value);
-        }
-    }
+    // Preserve only the small platform environment needed by common runtimes
+    // and user-config directories. Package-declared variables are added below;
+    // no shell is involved, and host token variables are not copied.
+    command.envs(plugin_mcp_passthrough_env());
     command
         .envs(&launch.env)
         .env("WISP_PLUGIN_ROOT", &launch.install_root)

--- a/src-tauri/src/lib_tests.rs
+++ b/src-tauri/src/lib_tests.rs
@@ -17,6 +17,7 @@ use super::{
     UI_STREAM_OUTPUT_MAX_BYTES, UI_TOOL_RESULT_MAX_CHARS,
 };
 use std::collections::{HashMap, HashSet};
+use std::ffi::OsString;
 use std::path::PathBuf;
 use std::sync::{atomic::AtomicBool, Arc};
 
@@ -2876,4 +2877,146 @@ fn native_connector_inventory_matches_dispatch_without_python_resources() {
     let servers = super::list_mcp_servers(std::path::Path::new("nonexistent-wisp-project"));
     assert!(servers.contains(&"mcp_pubmed".to_string()));
     assert_eq!(servers.len(), super::bio_domains().len());
+}
+
+#[test]
+fn plugin_mcp_passthrough_allowlist_keeps_user_dirs_and_excludes_github_tokens() {
+    for key in [
+        "HOME",
+        "USERPROFILE",
+        "APPDATA",
+        "LOCALAPPDATA",
+        "HOMEDRIVE",
+        "HOMEPATH",
+        "XDG_CONFIG_HOME",
+        "XDG_DATA_HOME",
+        "XDG_CACHE_HOME",
+    ] {
+        assert!(
+            super::PLUGIN_MCP_ENV_PASSTHROUGH.contains(&key),
+            "{key} must stay on the plugin MCP allowlist"
+        );
+    }
+    for key in ["GH_TOKEN", "GITHUB_TOKEN", "GH_ENTERPRISE_TOKEN"] {
+        assert!(
+            !super::PLUGIN_MCP_ENV_PASSTHROUGH.contains(&key),
+            "{key} must not be copied into plugin MCP children"
+        );
+    }
+}
+
+#[test]
+fn plugin_mcp_passthrough_copies_user_dirs_without_github_tokens() {
+    let env = super::plugin_mcp_passthrough_env_from(|key| match key {
+        "USERPROFILE" => Some(OsString::from(r"C:\Users\wisp-plugin-test")),
+        "APPDATA" => Some(OsString::from(r"C:\Users\wisp-plugin-test\AppData\Roaming")),
+        "LOCALAPPDATA" => Some(OsString::from(r"C:\Users\wisp-plugin-test\AppData\Local")),
+        "HOMEDRIVE" => Some(OsString::from("C:")),
+        "HOMEPATH" => Some(OsString::from(r"\Users\wisp-plugin-test")),
+        "HOME" => Some(OsString::from("/home/wisp-plugin-test")),
+        "XDG_CONFIG_HOME" => Some(OsString::from("/home/wisp-plugin-test/.config")),
+        "GH_TOKEN" | "GITHUB_TOKEN" => Some(OsString::from("should-not-leak")),
+        _ => None,
+    });
+    let map = env
+        .into_iter()
+        .map(|(key, value)| (key.into_string().unwrap(), value.into_string().unwrap()))
+        .collect::<HashMap<_, _>>();
+    assert_eq!(map["USERPROFILE"], r"C:\Users\wisp-plugin-test");
+    assert_eq!(map["APPDATA"], r"C:\Users\wisp-plugin-test\AppData\Roaming");
+    assert_eq!(
+        map["LOCALAPPDATA"],
+        r"C:\Users\wisp-plugin-test\AppData\Local"
+    );
+    assert_eq!(map["HOME"], "/home/wisp-plugin-test");
+    assert_eq!(map["XDG_CONFIG_HOME"], "/home/wisp-plugin-test/.config");
+    assert!(!map.contains_key("GH_TOKEN"));
+    assert!(!map.contains_key("GITHUB_TOKEN"));
+    assert!(!map.values().any(|value| value.contains("should-not-leak")));
+}
+
+#[test]
+fn plugin_mcp_subprocess_sees_user_dirs_but_not_github_tokens() {
+    let pairs = super::plugin_mcp_passthrough_env_from(|key| match key {
+        "USERPROFILE" => Some(OsString::from(r"C:\Users\wisp-plugin-test")),
+        "APPDATA" => Some(OsString::from(r"C:\Users\wisp-plugin-test\AppData\Roaming")),
+        "LOCALAPPDATA" => Some(OsString::from(r"C:\Users\wisp-plugin-test\AppData\Local")),
+        "HOME" => Some(OsString::from("/home/wisp-plugin-test")),
+        "XDG_CONFIG_HOME" => Some(OsString::from("/home/wisp-plugin-test/.config")),
+        "GH_TOKEN" | "GITHUB_TOKEN" => Some(OsString::from("should-not-leak")),
+        "PATH" | "SYSTEMROOT" | "SYSTEMDRIVE" | "PATHEXT" | "COMSPEC" | "TEMP" | "TMP"
+        | "TMPDIR" | "LANG" | "LC_ALL" => std::env::var_os(key),
+        _ => None,
+    });
+
+    let mut command = std::process::Command::new("unused");
+    command.env("GH_TOKEN", "should-not-leak");
+    command.env("GITHUB_TOKEN", "should-not-leak");
+    command.env_clear();
+    command.envs(pairs.iter().cloned());
+    let assigned = command
+        .get_envs()
+        .map(|(key, value)| {
+            (
+                key.to_string_lossy().into_owned(),
+                value.map(|value| value.to_string_lossy().into_owned()),
+            )
+        })
+        .collect::<HashMap<_, _>>();
+    assert_eq!(
+        assigned.get("APPDATA").and_then(Option::as_deref),
+        Some(r"C:\Users\wisp-plugin-test\AppData\Roaming")
+    );
+    assert_eq!(
+        assigned.get("USERPROFILE").and_then(Option::as_deref),
+        Some(r"C:\Users\wisp-plugin-test")
+    );
+    assert!(!assigned.contains_key("GH_TOKEN"));
+    assert!(!assigned.contains_key("GITHUB_TOKEN"));
+
+    let dump = dump_child_env(&pairs);
+    assert!(
+        dump.lines().any(|line| line
+            .eq_ignore_ascii_case(r"APPDATA=C:\Users\wisp-plugin-test\AppData\Roaming")
+            || line == r"APPDATA=C:\Users\wisp-plugin-test\AppData\Roaming"),
+        "child missing APPDATA: {dump}"
+    );
+    assert!(
+        dump.lines().any(|line| line
+            .eq_ignore_ascii_case(r"USERPROFILE=C:\Users\wisp-plugin-test")
+            || line == r"USERPROFILE=C:\Users\wisp-plugin-test"),
+        "child missing USERPROFILE: {dump}"
+    );
+    assert!(
+        !dump.contains("should-not-leak"),
+        "child leaked a GitHub token: {dump}"
+    );
+    assert!(
+        !dump
+            .lines()
+            .any(|line| line.to_ascii_uppercase().starts_with("GH_TOKEN=")
+                || line.to_ascii_uppercase().starts_with("GITHUB_TOKEN=")),
+        "child inherited a GitHub token variable: {dump}"
+    );
+}
+
+fn dump_child_env(pairs: &[(OsString, OsString)]) -> String {
+    let mut command = if cfg!(windows) {
+        let comspec = std::env::var_os("COMSPEC")
+            .unwrap_or_else(|| OsString::from(r"C:\Windows\System32\cmd.exe"));
+        let mut command = std::process::Command::new(comspec);
+        command.args(["/C", "set"]);
+        command
+    } else {
+        std::process::Command::new("/usr/bin/env")
+    };
+    command.env_clear();
+    command.envs(pairs.iter().cloned());
+    let output = command.output().expect("spawn plugin MCP env dump");
+    assert!(
+        output.status.success(),
+        "env dump failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).into_owned()
 }


### PR DESCRIPTION
## User-facing problem

On Windows, plugin MCP children start from a cleared environment. The previous allowlist kept `HOME` (usually empty on Windows) but not `USERPROFILE` / `APPDATA` / `LOCALAPPDATA`. CLIs such as `gh` then look unauthenticated even when the host already has a working GitHub CLI login in the system credential store.

Closes #1162.

## What changed

- Copy Windows user-profile directories and XDG config/data/cache dirs into plugin MCP processes when the host has them.
- Keep the default **minimum environment**. `GH_TOKEN`, `GITHUB_TOKEN`, and other secrets are still not copied.
- Document the allowlist in `docs/feature-plugins.md`.
- Unrelated Windows blockers that made `cargo test --workspace` fail locally: compare artifact snapshot paths with `dunce` (8.3 / `\\?\` mismatch), expect lowercased resource-lease paths, drop SQLite stores before deleting temp dirs, and look up proxy env overrides case-insensitively.

## Tests

Plugin MCP:

- Allowlist includes `USERPROFILE` / `APPDATA` / `LOCALAPPDATA` / `HOMEDRIVE` / `HOMEPATH` / XDG dirs.
- Host `GH_TOKEN` / `GITHUB_TOKEN` are not copied.
- After `env_clear()`, a child process sees `APPDATA` and `USERPROFILE` and does not see GitHub token variables.

Full suite on this Windows checkout:

```text
cargo fmt --all -- --check
cargo test --workspace --offline
```

All workspace crates passed, including `wisp-tauri --lib` (827) and `wisp-tools --lib` (62). No failures.

## Manual smoke

After this lands in a Windows desktop build:

1. Keep the host `gh auth status` login.
2. Enable a plugin that probes `gh` without reading tokens (for example Scientific Figure Library).
3. Plugin auth status should use the existing GitHub CLI login instead of returning `not_authenticated`.

## Limitations / follow-up

- This does not pass through tokens. Plugins that insist on `GH_TOKEN` still need the user to log in with GitHub CLI or declare a non-secret env var in the plugin manifest.
- User-configured custom MCP stdio connections are unchanged; they keep inheriting their own command environment.
