### PR TITLE
Fix source editor caret and text alignment

### DIFF
--- a/docs/superpowers/specs/2026-07-14-wisp-runtime-design.md
+++ b/docs/superpowers/specs/2026-07-14-wisp-runtime-design.md
@@ -645,7 +645,10 @@ picker's displayed context and the context a run is sent to never disagree. When
 no context can host the language there is no binding or runtime inspector.
 
 The source pane is directly editable for `.R`/`.py` workspace files: a
-highlighted mirror sits under a transparent textarea, unsaved drafts are held
+highlighted mirror sits under a transparent textarea. The input, highlighted
+text, line numbers, and selection layer use the same code font, size, and line
+height from Appearance settings; the toolbar keeps the separate UI size.
+Unsaved drafts are held
 outside the component so an agent `FileChanged` remount cannot drop them, and
 Ctrl+S (or the Save chip) persists through the workspace-scoped `save_file`
 command — user-driven like `execute_runtime`, outside agent tool approval.

--- a/ui-tests/tests/editor-alignment.spec.ts
+++ b/ui-tests/tests/editor-alignment.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from "@playwright/test";
+import { tauriMock } from "./mock-tauri";
+
+for (const variant of [
+  { name: "default", ui: 14, code: 12, font: "" },
+  { name: "custom", ui: 20, code: 16, font: "Courier New" },
+]) {
+  test(`source editor caret and highlight share text metrics (${variant.name})`, async ({ page }, testInfo) => {
+    await page.addInitScript(tauriMock);
+    await page.addInitScript(({ ui, code, font }) => {
+      localStorage.setItem("wisp-ui-font-size", String(ui));
+      localStorage.setItem("wisp-code-font-size", String(code));
+      localStorage.setItem("wisp-font-mono", font);
+    }, variant);
+    await page.goto("/");
+    await page.locator(".proj-card-main").first().click();
+    await page.getByRole("button", { name: "Files", exact: true }).click();
+    await page.locator('[data-workspace-path="analysis.R"]').click({ button: "right" });
+    await page.locator(".ctx-menu").getByRole("button", { name: "Open in center" }).click();
+    const editor = page.getByRole("textbox", { name: "Source editor" });
+    const source = 'plot(1:10)\nkjhk\n\tplot(2:11)\nplot(3:12)\nplot(4:13)\n';
+    await expect(editor).toBeVisible();
+    await editor.fill(source);
+    const mirror = page.locator(".rp-code-edit-stack .rp-code-body code");
+    await expect(mirror).toHaveAttribute("data-hl", "1");
+    await expect(mirror).toHaveText(source + "\n", { useInnerText: false });
+    await page.evaluate(() => document.fonts.ready);
+    await editor.press("ArrowLeft");
+    await page.locator(".rp-code-editor").screenshot({ path: testInfo.outputPath("editor.png"), caret: "initial" });
+
+    const metrics = await page.locator(".rp-code-editor").evaluate(root => {
+      const read = (selector: string) => {
+        const style = getComputedStyle(root.querySelector(selector)!);
+        return { font: style.fontFamily, size: style.fontSize, line: style.lineHeight,
+          spacing: style.letterSpacing, tab: style.tabSize };
+      };
+      return {
+        input: read(".rp-code-input"), body: read(".rp-code-body"),
+        code: read(".rp-code-body code"), gutter: read(".rp-code-gutter"),
+        selection: read(".rp-code-selection-layer"),
+      };
+    });
+    await testInfo.attach("text-metrics", { body: JSON.stringify(metrics), contentType: "application/json" });
+    expect(metrics.input.size).toBe(`${variant.code}px`);
+    for (const [layer, style] of Object.entries(metrics)) {
+      expect(style, layer).toEqual(metrics.input);
+    }
+    // The toolbar remains at the independently configured UI size.
+    await expect(page.locator("[data-editor-run]")).toHaveCSS("font-size", `${variant.ui}px`);
+
+    // Clicking glyphs in the visible mirror must place the native textarea
+    // caret at the corresponding offset, including a tab and later lines.
+    for (const offset of [4, source.indexOf("kjhk") + 3, source.indexOf("plot(2") + 4, source.indexOf("plot(4") + 4]) {
+      const point = await mirror.evaluate((root, offset) => {
+        const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+        let remaining = offset;
+        while (walker.nextNode()) {
+          const node = walker.currentNode as Text;
+          if (remaining >= node.length) { remaining -= node.length; continue; }
+          const range = document.createRange();
+          range.setStart(node, remaining);
+          range.setEnd(node, remaining + 1);
+          const rect = range.getBoundingClientRect();
+          return { x: rect.left + rect.width * 0.2, y: rect.top + rect.height / 2 };
+        }
+        throw new Error("Missing source glyph");
+      }, offset);
+      await page.mouse.click(point.x, point.y);
+      expect(await editor.evaluate(el => (el as HTMLTextAreaElement).selectionStart)).toBe(offset);
+    }
+  });
+}

--- a/ui/src/styles/alignment.css
+++ b/ui/src/styles/alignment.css
@@ -162,8 +162,9 @@
    highlight.js theme's `pre code.hljs { padding: 1em }`, which otherwise wins
    once highlighting lands and shifts the body 1em off the line-number gutter.
    `white-space: pre` (not pre-wrap) keeps long source lines scrolling like
-   the workspace editor instead of wrapping mid-token. */
-.rp-code .rp-code-body code { display: block; white-space: pre; overflow-wrap: normal; word-break: normal; background: none; border: none; padding: 0; }
+   the workspace editor instead of wrapping mid-token. Inherit the font so the
+   browser's default code font cannot diverge from the textarea and gutter. */
+.rp-code .rp-code-body code { font: inherit; display: block; white-space: pre; overflow-wrap: normal; word-break: normal; background: none; border: none; padding: 0; }
 .rp-code-body .hljs { background: none; }
 
 /* --- Editable center source (R/Python): highlighted mirror under a

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -2957,10 +2957,10 @@ button.workflow-graph-port.output.active {
 }
 
 /* User-adjustable typography. Controls use the UI size; monospaced preview
-   surfaces use the independently configurable code size. */
+   surfaces (including the transparent source input) use the independent code size. */
 body { font-size: var(--ui-font-size, 14px); }
 :where(button, input, select, textarea) { font-size: var(--ui-font-size, 14px) !important; }
-:where(code, pre, .rp-code-body, .notebook-source) { font-size: var(--code-font-size, 12px) !important; }
+:where(code, pre, .rp-code-body, .rp-code-input, .notebook-source) { font-size: var(--code-font-size, 12px) !important; }
 
 .list { display: flex; flex-direction: column; gap: 4px; }
 


### PR DESCRIPTION
The source editor's caret was taller than the displayed text and drifted away on later lines. Its transparent textarea picked up the global UI font size (14px by default), while the highlighted mirror used the code size (12px). The nested `<code>` could also use the browser's default monospace font instead of the editor's configured family.

- Include `.rp-code-input` in the existing code typography rule, keeping the caret, mirror, selection layer, and gutter on the same code size. Toolbar controls retain the independent UI size.
- Make highlighted code inherit the editor font.
- Add Playwright coverage for default and custom font settings, matching rendered metrics, and mouse-to-caret positions on multiple lines and after a tab. Update the runtime editor documentation.

Validation:
- Before the fix, both new regression cases failed (input 14px vs code 12px; input 20px vs code 16px).
- After the fix, both new cases and the existing R edit/save/run test pass. Before/after screenshots were inspected.
- Passed: `cargo fmt --all -- --check` and wasm32 UI check.
- Passed: `WISP_CATALOG_OFFLINE=1 cargo test --workspace --offline` — 1,983 tests.
- Full Playwright run (`npx playwright test --fully-parallel --workers=4`): 544 passed, 2 skipped for optional external Motif/SnapGene fixtures, 1 existing ACP authentication test timed out while clicking its test button. That exact case passed on a single-worker rerun (1.8s) with no code changes.
- GitHub headless checks passed on Windows, macOS, and Linux. Remaining GitHub checks may still be running.

Manual smoke: open an R/Python workspace file in the center editor, type several lines, click within visible text, and drag a selection. Change UI and code sizes independently under Appearance, including a custom code font; confirm caret, selected text, and line numbers remain aligned. No native Windows/macOS desktop smoke was performed.

This is a separate CSS fix from #1166; it introduces no new editor/runtime abstraction.
