### PR TITLE
Improve responsive chat layout and conversation outline

### DIFF
--- a/docs/ui-design-principles.md
+++ b/docs/ui-design-principles.md
@@ -62,6 +62,7 @@
 ## Responsive workspace layout
 
 - The default 1100 px desktop window keeps the sidebar, conversation, and Inspector as resizable columns. The Inspector becomes a modal drawer only below 960 px, where preserving the conversation width takes priority.
+- Conversation messages, runtime controls, and the composer grow together with the available center pane, leaving 16 px outer gutters and capping the column at 1280 px on wide screens. Resizing the window or opening the Inspector recalculates that width through CSS; document/chat split views continue to fill their narrower chat pane.
 - Scrollable lists keep stable scrollbar gutters and contain overscroll so a nested list does not unexpectedly move the surrounding workspace.
 
 ## Dense settings lists

--- a/docs/ui-design-principles.md
+++ b/docs/ui-design-principles.md
@@ -55,6 +55,7 @@
 ## Topbar and inspector chrome
 
 - The conversation topbar keeps session tabs as the primary signal. Inbox, terminal, and inspector toggles live in `.topbar-actions`.
+- The conversation outline opens from a list icon and question count in the topbar, keeping navigation off the message canvas. Compact panes hide the count while retaining the labeled icon. The outline is a bounded, scrollable card with quieter numbers and timestamps; the selected question has an accent edge, and Escape closes the card before its parent surface.
 - Status text appears only when non-empty (or when an API-key action is required) and truncates with a `title` for the full value.
 - Specialist labels stay quiet text, not status pills.
 - Artifact type badges are neutral mono labels; only tabular data keeps a clay accent. Prefer `--ok` / `--err` / `--clay` over one-off HSL pill colors.

--- a/ui-tests/tests/chat-responsive.spec.ts
+++ b/ui-tests/tests/chat-responsive.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect, type Page } from "@playwright/test";
+import { tauriMock } from "./mock-tauri";
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(tauriMock);
+});
+
+async function openConversation(page: Page) {
+  await page.goto("/?mockLongSession=1");
+  await page.locator(".proj-card-main").first().click();
+  await expect(page.getByText("Newest page first question")).toBeVisible();
+  await expect(page.locator(".composer-inner")).toBeVisible();
+}
+
+async function columnWidth(page: Page) {
+  return page.locator(".composer-inner").evaluate((el) => el.getBoundingClientRect().width);
+}
+
+async function expectColumnsFit(page: Page) {
+  await expect.poll(() => page.evaluate(() => {
+    const pane = document.querySelector(".center")!.getBoundingClientRect();
+    const thread = document.querySelector(".thread")!.getBoundingClientRect();
+    const composer = document.querySelector(".composer-inner")!.getBoundingClientRect();
+    const runtime = document.querySelector(".session-runtime-strip")!.getBoundingClientRect();
+    const chat = document.querySelector(".chat")!;
+    return {
+      // Resizing across the sidebar breakpoint animates its width. Assert the
+      // final pane geometry, not a transient frame with extra chat space.
+      settled: [...document.querySelectorAll(".sidebar, .rightpane")]
+        .every((el) => el.getAnimations().every((animation) => animation.playState !== "running")),
+      aligned: Math.abs(thread.x - composer.x) <= 1
+        && Math.abs(thread.width - composer.width) <= 1
+        && Math.abs(runtime.x - composer.x) <= 1
+        && Math.abs(runtime.width - composer.width) <= 1,
+      inside: composer.left >= pane.left + 15 && composer.right <= pane.right - 15,
+      noOverflow: chat.scrollWidth <= chat.clientWidth + 1
+        && document.documentElement.scrollWidth <= innerWidth,
+      usable: composer.width > 300 && composer.bottom <= innerHeight,
+    };
+  })).toEqual({ settled: true, aligned: true, inside: true, noOverflow: true, usable: true });
+}
+
+test("conversation grows on wide windows, caps on ultrawide screens, and shrinks back", async ({ page }, testInfo) => {
+  await page.setViewportSize({ width: 800, height: 600 });
+  await openConversation(page);
+  await expectColumnsFit(page);
+  const narrowWidth = await columnWidth(page);
+  await page.screenshot({ path: testInfo.outputPath("narrow-conversation.png") });
+
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await expectColumnsFit(page);
+  // Regression: the former 920px cap wasted the additional desktop space.
+  await expect.poll(() => columnWidth(page)).toBeGreaterThan(1000);
+  const desktopWidth = await columnWidth(page);
+
+  await page.setViewportSize({ width: 1920, height: 1080 });
+  await expectColumnsFit(page);
+  await expect.poll(() => columnWidth(page)).toBeGreaterThan(desktopWidth + 100);
+  const wideWidth = await columnWidth(page);
+  await page.screenshot({ path: testInfo.outputPath("wide-conversation.png") });
+
+  await page.setViewportSize({ width: 3440, height: 1440 });
+  await expectColumnsFit(page);
+  await expect.poll(() => columnWidth(page)).toBeLessThanOrEqual(1281);
+  expect(await columnWidth(page)).toBeCloseTo(wideWidth, 0);
+
+  await page.setViewportSize({ width: 800, height: 600 });
+  await expectColumnsFit(page);
+  await expect.poll(async () => Math.abs(await columnWidth(page) - narrowWidth)).toBeLessThanOrEqual(1);
+});
+
+test("conversation follows available pane width when Inspector opens and closes", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await openConversation(page);
+  await expectColumnsFit(page);
+  const originalWidth = await columnWidth(page);
+
+  await page.getByRole("button", { name: "Toggle panel" }).click();
+  await expect(page.locator(".rightpane")).toBeVisible();
+  await expectColumnsFit(page);
+  await expect.poll(() => columnWidth(page)).toBeLessThan(originalWidth - 100);
+
+  await page.getByRole("button", { name: "Toggle panel" }).click();
+  await expect(page.locator(".rightpane")).toHaveCount(0);
+  await expectColumnsFit(page);
+  await expect.poll(async () => Math.abs(await columnWidth(page) - originalWidth)).toBeLessThanOrEqual(1);
+});

--- a/ui-tests/tests/chat-responsive.spec.ts
+++ b/ui-tests/tests/chat-responsive.spec.ts
@@ -85,3 +85,65 @@ test("conversation follows available pane width when Inspector opens and closes"
   await expectColumnsFit(page);
   await expect.poll(async () => Math.abs(await columnWidth(page) - originalWidth)).toBeLessThanOrEqual(1);
 });
+
+for (const colorScheme of ["light", "dark"] as const) {
+  test(`outline navigation stays above messages and fits compact windows (${colorScheme})`, async ({ page }, testInfo) => {
+    await page.emulateMedia({ colorScheme });
+    await page.setViewportSize({ width: 800, height: 600 });
+    await openConversation(page);
+    const toggle = page.getByTestId("conversation-outline-toggle");
+    const outline = page.getByTestId("conversation-outline");
+    const count = toggle.locator(".conversation-outline-count");
+    await expect(count).toBeVisible();
+    const questionCount = Number(await count.textContent());
+    expect(questionCount).toBeGreaterThan(1);
+    await expect(toggle).toHaveAttribute("title", `Show conversation outline · ${questionCount} questions`);
+    // The collapsed control must never cover user bubbles or their timestamps.
+    await expect.poll(async () => {
+      const button = (await toggle.boundingBox())!;
+      const chat = (await page.locator(".chat-stage").boundingBox())!;
+      return button.y + button.height <= chat.y;
+    }).toBe(true);
+    await page.screenshot({ path: testInfo.outputPath("outline-closed.png"), animations: "disabled" });
+
+    await toggle.click();
+    await expect(outline).toBeVisible();
+    await expect(toggle).toHaveAttribute("aria-expanded", "true");
+    await expect(outline.locator(".conversation-outline-item")).toHaveCount(questionCount);
+    await expect.poll(() => outline.locator(".conversation-outline-list").evaluate((el) =>
+      el.scrollHeight > el.clientHeight,
+    )).toBe(true);
+    await expect.poll(() => outline.evaluate((el) => {
+      const card = el.getBoundingClientRect();
+      const chat = el.closest(".chat-stage")!.getBoundingClientRect();
+      return card.height <= 480 && card.bottom <= chat.bottom && card.right <= chat.right;
+    })).toBe(true);
+    await page.screenshot({ path: testInfo.outputPath("outline-open.png"), animations: "disabled" });
+    // The toolbar control also closes the card without moving into the panel.
+    await toggle.click();
+    await expect(outline).toHaveCount(0);
+    await expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+    await page.setViewportSize({ width: 600, height: 600 });
+    await expect(count).toBeHidden();
+    await expect(toggle).toBeVisible();
+    const toolbar = (await page.locator(".topbar-actions").boundingBox())!;
+    expect(toolbar.x + toolbar.width).toBeLessThanOrEqual(600);
+    await toggle.focus();
+    await page.keyboard.press("Enter");
+    await expect(outline).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(outline).toHaveCount(0);
+  });
+}
+
+test("outline Escape closes only the card and keeps Inspector open", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await openConversation(page);
+  await page.getByRole("button", { name: "Toggle panel" }).click();
+  await expect(page.locator(".rightpane")).toBeVisible();
+  await page.getByTestId("conversation-outline-toggle").click();
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("conversation-outline")).toHaveCount(0);
+  await expect(page.locator(".rightpane")).toBeVisible();
+});

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -28,6 +28,18 @@ async function expectInsideViewport(locator: Locator, width: number, height: num
   expect(box!.y + box!.height).toBeLessThanOrEqual(height);
 }
 
+async function waitForTranscriptFonts(page: Page) {
+  // font-display: swap can change wrapping after the transcript is visible.
+  // Let font layout and scroll anchoring settle before recording a pixel
+  // bookmark; a later, correctly compensated scrollTop is a different value.
+  await page.evaluate(async () => {
+    await document.fonts.ready;
+    await new Promise<void>((resolve) =>
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+    );
+  });
+}
+
 async function openModelsSettings(page: Page) {
   await globalSettingsButton(page).click();
   await page.getByRole("button", { name: "Models" }).click();
@@ -11211,6 +11223,7 @@ test("closing a center-file tab restores the conversation reading position", asy
   await page.locator(".proj-card-main").first().click();
   const scroller = page.locator("#chat-scroller");
   await expect(page.getByText(/Window page 0 row 19/)).toBeVisible();
+  await waitForTranscriptFonts(page);
   await scroller.evaluate((element) => {
     element.scrollTop = Math.max(120, element.scrollHeight / 3);
     element.dispatchEvent(new WheelEvent("wheel", { deltaY: -80, bubbles: true }));
@@ -11483,27 +11496,42 @@ test("opening a long conversation lands at the latest message and stays stable o
     .toBeGreaterThan(readingPosition + 400);
 });
 
-test("switching conversations restores each reading position (#849)", async ({ page }) => {
-  await page.goto("/?mockLongPages=8");
-  await page.locator(".proj-card-main").first().click();
+for (const delayedFont of [false, true]) {
+  test(`switching conversations restores each reading position (#849)${delayedFont ? " with delayed fonts" : ""}`, async ({ page }) => {
+    let releaseFont = () => {};
+    if (delayedFont) {
+      const fontGate = new Promise<void>((resolve) => { releaseFont = resolve; });
+      await page.route("**/fonts/source-serif-4-latin.woff2", async (route) => {
+        await fontGate;
+        await route.continue();
+      });
+    }
+    await page.goto("/?mockLongPages=8", { waitUntil: "domcontentloaded" });
+    await page.locator(".proj-card-main").first().click();
 
-  const scroller = page.locator("#chat-scroller");
-  await expect(page.getByText(/Window page 0 row 19/)).toBeVisible();
-  await scroller.evaluate((element) => {
-    element.scrollTop = Math.max(120, element.scrollHeight / 3);
-    element.dispatchEvent(new WheelEvent("wheel", { deltaY: -80, bubbles: true }));
+    const scroller = page.locator("#chat-scroller");
+    await expect(page.getByText(/Window page 0 row 19/)).toBeVisible();
+    if (delayedFont) {
+      await expect.poll(() => page.evaluate(() => document.fonts.status)).toBe("loading");
+    }
+    releaseFont();
+    await waitForTranscriptFonts(page);
+    await scroller.evaluate((element) => {
+      element.scrollTop = Math.max(120, element.scrollHeight / 3);
+      element.dispatchEvent(new WheelEvent("wheel", { deltaY: -80, bubbles: true }));
+    });
+    const readingTop = await scroller.evaluate((element) => element.scrollTop);
+
+    await newSessionButton(page).click();
+    await expect(page.locator(".empty")).toBeVisible();
+    await page.locator(".side-item.ses", { hasText: "Long transcript" }).click();
+    await expect(page.getByText(/Window page 0 row 19/)).toBeVisible();
+    await expect.poll(() => scroller.evaluate((element) => element.scrollTop))
+      .toBeGreaterThan(readingTop - 40);
+    await expect.poll(() => scroller.evaluate((element) => element.scrollTop))
+      .toBeLessThan(readingTop + 40);
   });
-  const readingTop = await scroller.evaluate((element) => element.scrollTop);
-
-  await newSessionButton(page).click();
-  await expect(page.locator(".empty")).toBeVisible();
-  await page.locator(".side-item.ses", { hasText: "Long transcript" }).click();
-  await expect(page.getByText(/Window page 0 row 19/)).toBeVisible();
-  await expect.poll(() => scroller.evaluate((element) => element.scrollTop))
-    .toBeGreaterThan(readingTop - 40);
-  await expect.poll(() => scroller.evaluate((element) => element.scrollTop))
-    .toBeLessThan(readingTop + 40);
-});
+}
 
 test("a thread rebuild clamp does not park a followed view at the top (#927)", async ({ page }) => {
   await page.goto("/?mockLongPages=8");

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -11610,6 +11610,7 @@ test("conversation outline loads and jumps to an older user question", async ({ 
   );
   await expect(oldestOutline.locator(".conversation-outline-time")).not.toBeEmpty();
   await oldestOutline.click();
+  await expect(oldestOutline).toHaveAttribute("aria-current", "location");
 
   await expect.poll(() => lastInvokeArgs(page, "load_session")).toMatchObject({
     id: "long-session",

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -10586,6 +10586,24 @@ fn App() -> impl IntoView {
                 }}
                 <div class="spacer"></div>
                 <div class="topbar-actions">
+                {move || {
+                    let count = conversation_outline.with(|rows| rows.len());
+                    (count > 0 && (!center_file_open.get() || center_split.get())).then(|| view! {
+                        <button type="button" class="icon-btn conversation-outline-toggle"
+                            class:active=move || conversation_outline_open.get()
+                            data-testid="conversation-outline-toggle"
+                            title=move || format!("{} · {}",
+                                t(locale.get(), "outline.show"),
+                                tf(locale.get(), "outline.questions_n", &[("n", &count.to_string())]))
+                            aria-label=move || t(locale.get(), "outline.show")
+                            aria-expanded=move || conversation_outline_open.get().to_string()
+                            aria-controls="conversation-outline-panel"
+                            on:click=move |_| conversation_outline_open.update(|open| *open = !*open)>
+                            {compose_icon("list")}
+                            <span class="conversation-outline-count" aria-hidden="true">{count}</span>
+                        </button>
+                    })
+                }}
                 <button type="button" class="icon-btn" data-testid="share-topbar"
                     title=move || {
                         if can_share.get() {
@@ -12087,6 +12105,7 @@ fn App() -> impl IntoView {
                                     type="button"
                                     class="conversation-outline-item"
                                     class:active=move || conversation_outline_selected.get() == Some(target)
+                                    aria-current=move || if conversation_outline_selected.get() == Some(target) { "location" } else { "false" }
                                     aria-label=aria_label
                                     title=title
                                     prop:disabled=move || {
@@ -12127,38 +12146,10 @@ fn App() -> impl IntoView {
                             }
                         })
                         .collect_view();
-                    let stride = (rows.len() + 27) / 28;
-                    let marks = rows
-                        .iter()
-                        .step_by(stride.max(1))
-                        .map(|entry| {
-                            let width = 45 + entry.text.chars().count().min(40);
-                            let target = entry.user_index;
-                            view! {
-                                <span
-                                    class="conversation-outline-mark"
-                                    class:active=move || conversation_outline_selected.get() == Some(target)
-                                    style=format!("width:{width}%")
-                                ></span>
-                            }
-                        })
-                        .collect_view();
                     view! {
-                        <button
-                            type="button"
-                            class="conversation-outline-toggle"
-                            class:is-hidden=move || conversation_outline_mounted.get()
-                            data-testid="conversation-outline-toggle"
-                            title=move || t(locale.get(), "outline.show")
-                            aria-label=move || t(locale.get(), "outline.show")
-                            aria-expanded=move || conversation_outline_open.get().to_string()
-                            aria-hidden=move || conversation_outline_mounted.get().to_string()
-                            on:click=move |_| conversation_outline_open.set(true)
-                        >
-                            <span class="conversation-outline-marks" aria-hidden="true">{marks}</span>
-                        </button>
                         {conversation_outline_mounted.get().then(|| view! {
                             <nav
+                                id="conversation-outline-panel"
                                 class="conversation-outline-panel"
                                 class:is-open=move || conversation_outline_open.get()
                                 data-testid="conversation-outline"
@@ -12167,6 +12158,7 @@ fn App() -> impl IntoView {
                                 prop:inert=move || !conversation_outline_open.get()
                             >
                                 <header>
+                                    <span class="conversation-outline-heading-icon" aria-hidden="true">{compose_icon("list")}</span>
                                     <div>
                                         <strong>{move || t(locale.get(), "outline.title")}</strong>
                                         <span>{move || tf(locale.get(), "outline.questions_n", &[("n", &count)])}</span>

--- a/ui/src/styles/chat.css
+++ b/ui/src/styles/chat.css
@@ -487,34 +487,23 @@
 }
 .chat-jump-pill:hover { color: var(--text); background: var(--bg-elev); border-color: var(--border-strong); }
 
-.conversation-outline-toggle {
-  position: absolute; z-index: 12; top: 50%; right: 10px; display: flex; width: 34px;
-  max-height: min(360px, calc(100% - 24px)); padding: 9px 7px; transform: translateY(-50%);
-  overflow: hidden; border: 1px solid var(--border); border-radius: var(--radius-sm);
-  background: color-mix(in srgb, var(--bg-elev) 92%, transparent); color: var(--text-faint);
-  box-shadow: var(--shadow-sm); backdrop-filter: blur(8px); cursor: pointer;
-  transition:
-    opacity var(--motion-duration-fast) var(--motion-ease-standard),
-    transform var(--motion-duration-fast) var(--motion-ease-standard),
-    visibility 0s;
+.conversation-outline-toggle { width: auto; min-width: 30px; gap: 5px; padding: 0 7px; }
+.conversation-outline-toggle svg { width: 16px; height: 16px; flex: 0 0 auto; }
+.conversation-outline-count { font-size: 10px; font-weight: 600; font-variant-numeric: tabular-nums; }
+.conversation-outline-toggle:focus-visible, .conversation-outline-item:focus-visible {
+  outline: 2px solid var(--clay); outline-offset: 2px;
 }
-.conversation-outline-toggle.is-hidden {
-  opacity: 0; visibility: hidden; pointer-events: none;
-  transform: translateY(-50%) translateX(6px);
-  transition-delay: 0s, 0s, var(--motion-duration-fast);
+@container (max-width: 620px) {
+  .conversation-outline-toggle { width: 30px; padding: 0; }
+  .conversation-outline-count { display: none; }
 }
-.conversation-outline-toggle:hover, .conversation-outline-toggle:focus-visible {
-  border-color: var(--border-strong); color: var(--text-muted); background: var(--bg-elev);
-}
-.conversation-outline-marks { display: flex; width: 100%; flex-direction: column; align-items: flex-end; gap: 4px; }
-.conversation-outline-mark { display: block; min-width: 8px; height: 1px; border-radius: 999px; background: currentColor; opacity: .55; }
-.conversation-outline-mark.active { height: 2px; background: var(--clay); opacity: 1; }
 .conversation-outline-panel {
-  position: absolute; z-index: 13; top: 12px; right: 12px; bottom: 12px;
-  display: flex; width: min(310px, calc(100% - 24px)); min-width: 0; flex-direction: column;
-  overflow: hidden; border: 1px solid var(--border-strong); border-radius: var(--radius-sm);
-  background: color-mix(in srgb, var(--bg-elev) 96%, transparent);
-  box-shadow: 0 14px 42px rgba(0,0,0,.16); backdrop-filter: blur(12px);
+  position: absolute; z-index: 13; top: 12px; right: 12px;
+  display: flex; width: min(320px, calc(100% - 24px)); min-width: 0; flex-direction: column;
+  max-height: min(480px, calc(100% - 24px));
+  overflow: hidden; border: 1px solid var(--border); border-radius: var(--radius);
+  background: var(--bg-elev); color: var(--text);
+  box-shadow: 0 8px 28px rgba(0,0,0,.12);
   opacity: 0; visibility: hidden; pointer-events: none;
   transform: translate3d(var(--motion-distance-md), 0, 0);
   transition:
@@ -528,8 +517,6 @@
   animation: motion-drawer-in var(--motion-duration-medium) var(--motion-ease-decelerate) both;
 }
 @media (prefers-reduced-motion: reduce) {
-  .conversation-outline-toggle,
-  .conversation-outline-toggle.is-hidden,
   .conversation-outline-panel,
   .conversation-outline-panel.is-open {
     animation: none;
@@ -537,27 +524,29 @@
   }
 }
 .conversation-outline-panel > header {
-  display: flex; min-height: 52px; flex: 0 0 auto; align-items: center; gap: 10px;
-  padding: 8px 9px 8px 14px; border-bottom: 1px solid var(--border);
+  display: flex; min-height: 58px; flex: 0 0 auto; align-items: center; gap: 10px;
+  padding: 10px 12px; border-bottom: 1px solid var(--border); box-sizing: border-box;
 }
+.conversation-outline-heading-icon { display: flex; align-items: center; justify-content: center; width: 30px; height: 30px; border-radius: var(--radius-xs); background: var(--clay-soft); }
+.conversation-outline-heading-icon svg { width: 16px; height: 16px; color: var(--clay); }
 .conversation-outline-panel > header > div { display: flex; min-width: 0; flex: 1; flex-direction: column; gap: 1px; }
 .conversation-outline-panel > header strong { color: var(--text); font-size: 13px; }
 .conversation-outline-panel > header span { color: var(--text-faint); font-size: 10.5px; }
-.conversation-outline-list { min-height: 0; flex: 1 1 auto; overflow-y: auto; padding: 6px; }
+.conversation-outline-list { min-height: 0; flex: 1 1 auto; overflow-y: auto; overscroll-behavior: contain; padding: 8px; }
 .conversation-outline-item {
   display: grid; width: 100%; grid-template-columns: 24px minmax(0, 1fr); gap: 7px;
-  align-items: start; padding: 8px; border: 0; border-radius: var(--radius-xs); background: transparent;
+  align-items: start; padding: 10px 8px; border: 0; border-radius: var(--radius-xs); background: transparent;
   color: var(--text-muted); font: inherit; text-align: left; cursor: pointer;
 }
 .conversation-outline-item:hover { background: var(--surface-hover); color: var(--text); }
-.conversation-outline-item.active { background: var(--clay-soft); color: var(--text); }
+.conversation-outline-item.active { background: var(--clay-soft); color: var(--text); box-shadow: inset 2px 0 var(--clay); }
 .conversation-outline-item:disabled { opacity: .45; cursor: wait; }
 .conversation-outline-number {
   display: inline-flex; width: 22px; height: 22px; align-items: center; justify-content: center;
-  border-radius: var(--radius-xs); background: var(--bg-sunken); color: var(--text-faint);
+  color: var(--text-faint);
   font-size: 10px; font-variant-numeric: tabular-nums;
 }
-.conversation-outline-item.active .conversation-outline-number { background: var(--clay); color: var(--on-clay); }
+.conversation-outline-item.active .conversation-outline-number { color: var(--clay); font-weight: 600; }
 .conversation-outline-copy { display: flex; min-width: 0; flex-direction: column; gap: 2px; }
 .conversation-outline-text {
   display: -webkit-box; overflow: hidden; font-size: 12.5px; line-height: 1.45;

--- a/ui/src/styles/chat.css
+++ b/ui/src/styles/chat.css
@@ -3,8 +3,9 @@
   flex: 1 1 0; min-width: min(360px, 100%); display: flex; flex-direction: column;
   background: var(--bg-app);
   container-type: inline-size;
-  /* Scale with the center pane; cap keeps prose readable on ultra-wide layouts. */
-  --chat-col-max: min(100%, 920px);
+  /* Fill the available pane with a small gutter; only cap ultra-wide layouts.
+     Keep messages, runtime controls, and the composer on the same column. */
+  --chat-col-max: min(calc(100% - 32px), 1280px);
 }
 .center-tabs { display: flex; align-items: center; gap: 4px; min-width: 0; overflow-x: auto; flex: 1 1 auto; scrollbar-width: none; box-sizing: border-box; }
 .center-tabs::-webkit-scrollbar { display: none; }


### PR DESCRIPTION
## Problem and resulting behavior

Closes #1168.

Enlarging the window left messages and the composer capped at 920px, wasting horizontal space. The shared chat column now fills its available pane with 16px outer gutters and a 1280px upper bound. Messages, runtime controls, and the composer resize together when the window or Inspector changes size.

The collapsed conversation outline also overlaid user messages and timestamps in narrow windows. It now opens from a list icon and question count in the topbar. Compact panes retain the icon and hide the count. The expanded outline is a bounded, scrollable card with quieter numbers and timestamps, an accent edge for the selected question, and keyboard focus styling. Clicking the toolbar button again or pressing Escape closes the card.

## Files and coverage

- `ui/src/styles/chat.css`: responsive column sizing and the outline card/toolbar styling.
- `ui/src/main.rs`: move the outline control into the topbar, use the shared list icon, expose the selected location accessibly, and remove the floating marks.
- `ui-tests/tests/chat-responsive.spec.ts`: resize from 800×600 through desktop/ultrawide sizes and back, inspect column alignment/overflow, open/close Inspector, and cover light/dark outline rendering, compact controls, keyboard access, bounded scrolling, and immediate Escape with Inspector still open.
- `ui-tests/tests/ui.spec.ts`: verify the selected outline item after jumping to an older question. Scroll restoration checks await web fonts and scroll anchoring before recording pixel positions, including a deliberately delayed font response. This prevents comparing a fallback-font bookmark (1046px in the reproduction) against its correctly compensated 1119px position. The existing ±40px assertion is retained.
- `docs/ui-design-principles.md`: document the width rules and outline interaction. No new abstraction or dependency.

## Validation

- [CI on commit `3bcef8a4`](https://github.com/xuzhougeng/wisp-science/actions/runs/34229686138): **all seven checks passed**. This includes workspace tests and wasm UI checks on Rust stable and 1.88.0, headless agent checks on Linux/macOS/Windows, and the release-notes helper.
- Linux Playwright full suite: **553 passed, 2 skipped, no failures or retries**.
- Font-loading and scroll-restoration regressions: **15 passed** across three local repetitions, including a deliberately delayed font response. The existing ±40px restoration assertion remains unchanged.
- Local formatting, wasm UI check, seven focused layout/outline regressions, and `npm ci` passed.
- Visually inspected collapsed and expanded outlines in light and dark modes.
- Local native test execution encountered existing MCP transport permission and runtime exit-status failures; the complete workspace tests passed on both CI toolchains.

## Manual smoke steps and limits

1. Open an existing conversation on macOS or Windows. Resize from about 800×600 to desktop/fullscreen/ultrawide dimensions and back. Messages, runtime controls, and the composer should expand together, retain gutters, and stop growing at the upper bound.
2. Confirm the collapsed outline no longer overlays messages. Open its topbar control, scroll to an older question, and jump to it. Close with the toolbar button or Escape. Open Inspector and then the outline; an immediate Escape should close only the outline.
3. Check the outline in both light and dark modes and in a compact pane. Open a document/chat split and verify its available chat width remains usable.

The original layout issue was reproduced in the installed macOS 1.10.0 app. The modified UI is verified with the mocked browser build; a rebuilt native application has not been smoke-tested. Short conversations still leave free vertical space above the bottom-anchored composer. Zoom shortcuts suggested in the issue comments remain a separate follow-up.
