### PR TITLE
Fix Escape ordering when Inspector becomes a compact drawer

### DIFF
--- a/docs/ui-design-principles.md
+++ b/docs/ui-design-principles.md
@@ -62,7 +62,7 @@
 
 ## Responsive workspace layout
 
-- The default 1100 px desktop window keeps the sidebar, conversation, and Inspector as resizable columns. The Inspector becomes a modal drawer only below 960 px, where preserving the conversation width takes priority.
+- The default 1100 px desktop window keeps the sidebar, conversation, and Inspector as resizable columns. At 960 px and below, the Inspector becomes a modal drawer, preserving the conversation width. After shrinking the window, Escape closes the drawer's own menu first, then the drawer, then any composer menu or conversation outline it covered. Each press dismisses only the topmost layer; growing back restores the split-pane order.
 - Conversation messages, runtime controls, and the composer grow together with the available center pane, leaving 16 px outer gutters and capping the column at 1280 px on wide screens. Resizing the window or opening the Inspector recalculates that width through CSS; document/chat split views continue to fill their narrower chat pane.
 - Scrollable lists keep stable scrollbar gutters and contain overscroll so a nested list does not unexpectedly move the surrounding workspace.
 

--- a/ui-tests/tests/chat-responsive.spec.ts
+++ b/ui-tests/tests/chat-responsive.spec.ts
@@ -147,3 +147,59 @@ test("outline Escape closes only the card and keeps Inspector open", async ({ pa
   await expect(page.getByTestId("conversation-outline")).toHaveCount(0);
   await expect(page.locator(".rightpane")).toBeVisible();
 });
+
+for (const width of [960, 800, 640]) {
+  test(`shrinking to ${width}px closes Inspector layers before covered composer menus`, async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await openConversation(page);
+    await page.getByRole("button", { name: "Toggle panel" }).click();
+    const panel = page.locator(".rightpane");
+    await page.getByRole("button", { name: "Agent options" }).click();
+    const agentMenu = page.getByRole("menu", { name: "Agent options" });
+    await agentMenu.getByRole("button", { name: /^Compute/ }).click();
+    const computeMenu = page.getByRole("menu", { name: "Compute" });
+    await expect(computeMenu).toBeVisible();
+
+    await page.setViewportSize({ width, height: 600 });
+    await expect(panel).toHaveCSS("position", "fixed");
+    await panel.getByRole("button", { name: "Add panel" }).click();
+    await page.keyboard.press("Escape");
+    await expect(panel.locator(".rp-tab-add-menu")).toHaveCount(0);
+    await expect(panel).toBeVisible();
+    await expect(computeMenu).toBeVisible();
+
+    // The drawer is now above the composer. One press closes just that layer,
+    // without moving focus between Escape presses.
+    await page.keyboard.press("Escape");
+    await expect(panel).toHaveCount(0);
+    await expect(agentMenu).toBeVisible();
+    await expect(computeMenu).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(computeMenu).toHaveCount(0);
+    await expect(agentMenu).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(agentMenu).toHaveCount(0);
+  });
+}
+
+test("outline Escape follows Inspector stacking when the window shrinks and grows", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await openConversation(page);
+  await page.getByRole("button", { name: "Toggle panel" }).click();
+  await page.getByTestId("conversation-outline-toggle").click();
+  await page.setViewportSize({ width: 800, height: 600 });
+  await expect(page.locator(".rightpane")).toHaveCSS("position", "fixed");
+  await page.keyboard.press("Escape");
+  await expect(page.locator(".rightpane")).toHaveCount(0);
+  await expect(page.getByTestId("conversation-outline")).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("conversation-outline")).toHaveCount(0);
+
+  await page.getByRole("button", { name: "Toggle panel" }).click();
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await expect(page.locator(".rightpane")).not.toHaveCSS("position", "fixed");
+  await page.getByTestId("conversation-outline-toggle").click();
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("conversation-outline")).toHaveCount(0);
+  await expect(page.locator(".rightpane")).toBeVisible();
+});

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -8659,6 +8659,24 @@ fn App() -> impl IntoView {
             artifact_menu.set(None);
             return;
         }
+        // Match the drawer breakpoint in right-pane.css. Resizing can leave
+        // composer menus open underneath the Inspector's modal backdrop.
+        // Its own menus (and the floating runtime inspector) still close first;
+        // otherwise Escape dismisses the drawer, preserving the covered layer.
+        if show_right.get() && viewport_size().0 <= 960.0 {
+            ev.prevent_default();
+            if runtime_environment_pinned.get() {
+                runtime_environment.set(None);
+                runtime_environment_pinned.set(false);
+            } else if right_tab_add_menu_open.get() {
+                right_tab_add_menu_open.set(false);
+            } else if side_chat_model_menu_open.get() {
+                side_chat_model_menu_open.set(false);
+            } else {
+                show_right.set(false);
+            }
+            return;
+        }
         if show_proj_menu.get() {
             ev.prevent_default();
             show_proj_menu.set(false);


### PR DESCRIPTION
## Problem and resulting behavior

Opening Inspector and Agent options, then shrinking the window to 960 px or less, turns Inspector into a modal drawer over the composer menu. Escape previously dismissed the covered composer menu first, leaving the visible drawer (or its Add panel menu) open. The same problem affected the conversation outline.

Escape now follows the compact layout's visible stacking: an Inspector menu closes first, then the drawer, then the covered composer menu or outline. Each press preserves the other layers. Resizing back above 960 px retains the existing split-pane behavior, and a pinned runtime inspector still takes precedence over the drawer.

## Changed files and tests

- `ui/src/main.rs`: prioritize the modal drawer and its menus in the window Escape stack at the CSS breakpoint. No new abstraction or dependency.
- `ui-tests/tests/chat-responsive.spec.ts`: add regressions at 960, 800, and 640 px with nested composer and Inspector menus, plus an outline shrink/grow round trip. Press Escape immediately, without manually moving focus.
- `docs/ui-design-principles.md`: document the drawer breakpoint and dismissal order.

## Validation

- Reproduced manually in the installed macOS app with Inspector, Agent options, window resizing, and Escape.
- Before the fix, both focused regression scenarios failed because Escape left the top layer open.
- After the fix, all nine responsive layout and Escape tests passed.
- `cargo fmt --all -- --check`, `git diff --check`, and the wasm UI check passed.
- Local full Playwright run: 555 passed, 2 skipped, and 2 page-initialization timeouts before either test reached its scenario. Both affected tests then passed three repetitions each (6/6).
- Local `cargo test --workspace --no-fail-fast` completed with the existing MCP transport permission and runtime worker exit-status failures; all other targets passed.
- [CI on commit `e43b61bd`](https://github.com/xuzhougeng/wisp-science/actions/runs/34232935485): **all seven checks passed**, including workspace tests and wasm checks on stable and Rust 1.88.0, all three OS headless checks, and **557 UI tests passed, 2 skipped, no failures or retries**.

## Manual smoke and limits

1. At desktop width, open Inspector, then Agent options and its Compute submenu.
2. Shrink to 800 px, open Inspector's Add panel menu, and press Escape immediately. Only Add panel closes.
3. Press Escape again: Inspector closes while the composer menus remain. Further presses close Compute, then Agent options.
4. Repeat with the conversation outline. Enlarge back to desktop width and verify Escape closes the outline while Inspector remains open.

The repaired frontend is verified in the mocked browser build; a rebuilt native app has not been smoke-tested. This change addresses root-owned drawer/composer navigation, with no changes to scientific execution or stored data.
