### PR TITLE
Restore window-scoped recovery when the WebView stops responding

### DIFF
--- a/crates/wisp-dto/src/lib.rs
+++ b/crates/wisp-dto/src/lib.rs
@@ -15,6 +15,21 @@ use std::rc::Rc;
 /// The UI must not offer native HTTP transcript recovery for these errors.
 pub const ACP_TURN_ERROR_PREFIX: &str = "ACP turn failed: ";
 
+/// Bounded numeric renderer diagnostics. Never includes user or plugin content.
+#[derive(Deserialize, Serialize, Clone, Debug, Default, PartialEq, Eq)]
+#[serde(default, rename_all = "camelCase")]
+pub struct UiHealthSnapshot {
+    pub timer_lag_ms: u32,
+    pub long_tasks: u32,
+    pub longest_task_ms: u32,
+    pub script_errors: u32,
+    pub unhandled_rejections: u32,
+    pub active_apps: u32,
+    pub parked_apps: u32,
+    pub app_messages: u32,
+    pub drag_overlays: u32,
+}
+
 #[derive(Deserialize, Serialize, Clone, Copy, Debug, Default, Hash, PartialEq, Eq)]
 pub struct ContextUsage {
     #[serde(default)]

--- a/docs/webview-recovery.md
+++ b/docs/webview-recovery.md
@@ -1,0 +1,91 @@
+# Recovering an unresponsive window
+
+When a Wisp window no longer accepts clicks, native recovery actions remain
+available without asking the page's JavaScript to handle the click:
+
+- **Windows:** right-click the Wisp notification-area icon. Choose **Stop agent
+  in last active window** or **Reload last active window**. The target is the
+  most recently focused Wisp workspace window, excluding the desktop pet. If
+  that window was closed, the main window is used.
+- **macOS:** use the native **Window** menu's **Stop current agent** or **Reload
+  current window** action. Only the focused window handles the action.
+- Linux currently has automatic recovery; these native menu entries are not
+  exposed there.
+
+Stop targets only that window's active session and uses the existing native/ACP
+cancellation path. A window without an active session does nothing. Reload
+recreates only that window's page; it does not restart Wisp, cancel a Run, or
+terminate a remote SSH job. In-memory editor drafts and MCP App selections can
+be lost on reload. Persisted sessions can be reopened, and backend agents and
+the Run Manager remain alive. This does not guarantee survival of arbitrary
+unmanaged remote shell processes when the entire application exits.
+
+## Automatic recovery and evidence
+
+Each workspace window reports a heartbeat every five seconds. The backend
+tracks windows separately, checks every ten seconds, and reloads a focused
+window after sixty seconds without a heartbeat. Returning from an unfocused
+window grants a fresh sixty-second grace period. A window that never finishes
+initializing is also covered. Attempts have a per-window two-minute cooldown,
+including failed reload requests; failure to boot after a reload remains
+eligible for another attempt. Closing a window removes its health state.
+
+The log contains `webview health` once per minute per reporting window, plus
+`native stop requested` and `webview recovery requested` records with a window
+label and reload success/error. The heartbeat carries numeric diagnostics:
+
+- maximum visible-page timer delay and longest observed long task;
+- cumulative long-task, script-error and unhandled-rejection counts;
+- active and parked MCP App counts, cumulative incoming App messages;
+- current drag-overlay count.
+
+Cumulative counters and maxima are bounded and reset with the document. No
+conversation text, plugin arguments, image data, URLs or error messages from
+JavaScript are included. Long-task metrics depend on browser support. A living
+timer does **not** prove that clicks work: healthy heartbeats with a stuck UI
+call for checking overlays, pointer targeting and script failures. A native
+reload request being accepted also does not prove that navigation completed.
+
+## Validation
+
+Run the focused browser workload from `ui-tests`:
+
+```powershell
+$env:UI_TEST_PORT="1432"
+npx playwright test tests/webview-health.spec.ts tests/long-session-stress.spec.ts tests/chat-responsive.spec.ts --workers=1
+```
+
+The mock workload combines a paginated long transcript, two simultaneous
+session streams, and two App instances with 96 local thumbnail cards each.
+One App remains parked while the other is visible. The test clicks a candidate,
+Stop, tab close and New session, and checks numeric diagnostics. It also guards
+against a model picker overflowing over Stop in a narrow chat split.
+
+Run the optional native smoke from the repository root:
+
+```powershell
+$env:WISP_CATALOG_OFFLINE="1"
+cargo run -p wisp-tauri --example webview_recovery_smoke
+```
+
+This opens two hidden, disposable **real WebView2** windows on Windows (the
+platform WebView elsewhere), with temporary browser profiles and fake backend
+sessions. It blocks one page's JavaScript for fifteen seconds, exercises the
+same Rust stop/reload functions as the native menus, and checks that the scoped
+stop completes before the block ends and that only the target page reboots.
+It does not open the user's SQLite database, contact MCP/model services, or
+exercise a real SSH job. Native menu clicking, macOS execution, and the exact
+SFL 0.6.7 incident still require separate manual validation.
+
+Manual Windows check: open two project windows, focus the second, then use the
+tray's stop and reload entries. Check the target label in the log, the first
+window's unchanged state, and existing Run records. For a stopped heartbeat,
+check that another window's healthy heartbeat cannot suppress target recovery.
+
+## Scope and follow-up
+
+This addresses recovery gaps and the reproduced narrow-pane click obstruction
+reported while investigating #1179. It does not establish the original stall's
+root cause. Independent MCP App WebViews, suspending parked Apps, candidate-list
+virtualization and cross-session plugin-process sharing remain separate work,
+to be guided by the new diagnostics and profiling of the real SFL workload.

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -19,6 +19,18 @@ fn main() {
     purge_stale_seed_dirs();
     bake_model_catalog();
     tauri_build::build();
+    // tauri-build embeds the Windows manifest into binaries, not examples.
+    // The real-WebView smoke also needs Common Controls v6 (TaskDialogIndirect).
+    if std::env::var("CARGO_CFG_TARGET_ENV").as_deref() == Ok("msvc") {
+        let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("examples/webview_recovery_smoke.manifest");
+        println!("cargo:rerun-if-changed={}", manifest.display());
+        println!("cargo:rustc-link-arg-examples=/MANIFEST:EMBED");
+        println!(
+            "cargo:rustc-link-arg-examples=/MANIFESTINPUT:{}",
+            manifest.display()
+        );
+    }
 }
 
 /// Distill models.dev into `$OUT_DIR/model_catalog.json`, falling back to the

--- a/src-tauri/examples/webview_recovery_smoke.manifest
+++ b/src-tauri/examples/webview_recovery_smoke.manifest
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <dependency><dependentAssembly>
+    <assemblyIdentity type="win32" name="Microsoft.Windows.Common-Controls" version="6.0.0.0" processorArchitecture="*" publicKeyToken="6595b64144ccf1df" language="*" />
+  </dependentAssembly></dependency>
+</assembly>

--- a/src-tauri/examples/webview_recovery_smoke.rs
+++ b/src-tauri/examples/webview_recovery_smoke.rs
@@ -1,0 +1,146 @@
+//! Optional real-WebView smoke: cargo run -p wisp-tauri --example webview_recovery_smoke
+//! Uses disposable hidden windows and fake sessions, never the user's database.
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+use tauri::{Manager, WebviewWindow};
+
+#[path = "../src/ui_health.rs"]
+#[allow(dead_code)]
+mod ui_health;
+
+#[derive(Default)]
+struct AppState {
+    stopped: Mutex<Vec<String>>,
+    boots: Mutex<HashMap<String, usize>>,
+}
+impl AppState {
+    fn active_frame(&self, label: &str) -> Option<String> {
+        (label == "main").then(|| "session-a".to_string())
+    }
+}
+mod agent_turn {
+    pub async fn stop_agent(
+        state: tauri::State<'_, super::AppState>,
+        id: Option<String>,
+    ) -> Result<(), String> {
+        state
+            .stopped
+            .lock()
+            .unwrap()
+            .push(id.expect("native stop must be scoped"));
+        Ok(())
+    }
+}
+
+#[tauri::command]
+fn smoke_ready(window: WebviewWindow, state: tauri::State<'_, AppState>) {
+    *state
+        .boots
+        .lock()
+        .unwrap()
+        .entry(window.label().to_string())
+        .or_default() += 1;
+}
+
+const HTML: &str = r#"<!doctype html><body>Disposable renderer recovery smoke<script>
+window.__TAURI_INTERNALS__.invoke('smoke_ready');
+setInterval(()=>window.__TAURI_INTERNALS__.invoke('ui_heartbeat'),1000);
+</script></body>"#;
+struct SmokeAssets;
+impl tauri::Assets<tauri::Wry> for SmokeAssets {
+    fn get(&self, _: &tauri::utils::assets::AssetKey) -> Option<Cow<'_, [u8]>> {
+        Some(Cow::Borrowed(HTML.as_bytes()))
+    }
+    fn iter(&self) -> Box<tauri::utils::assets::AssetsIter<'_>> {
+        Box::new(std::iter::empty())
+    }
+    fn csp_hashes(
+        &self,
+        _: &tauri::utils::assets::AssetKey,
+    ) -> Box<dyn Iterator<Item = tauri::utils::assets::CspHash<'_>> + '_> {
+        Box::new(std::iter::empty())
+    }
+}
+
+fn main() {
+    let data = std::env::temp_dir().join(format!("wisp-webview-smoke-{}", std::process::id()));
+    let mut context = tauri::generate_context!();
+    context.config_mut().identifier = "science.wisp.webview-recovery-smoke".into();
+    context.config_mut().build.dev_url = None;
+    context.set_assets(Box::new(SmokeAssets));
+    tauri::Builder::default()
+        .manage(AppState::default())
+        .invoke_handler(tauri::generate_handler![ui_health::ui_heartbeat, smoke_ready])
+        .setup(move |app| {
+            for label in ["main", "proj-health"] {
+                tauri::WebviewWindowBuilder::new(app, label, tauri::WebviewUrl::App("index.html".into()))
+                    .title("Wisp disposable recovery smoke").visible(false)
+                    .data_directory(data.join(label)).build()?;
+            }
+            let app = app.handle().clone();
+            std::thread::spawn(move || {
+                let result = run_smoke(&app);
+                match result {
+                    Ok(()) => { println!("PASS: real WebView reload; native scoped stop during blocked renderer; sibling preserved"); app.exit(0); }
+                    Err(error) => { eprintln!("FAIL: {error}"); app.exit(1); }
+                }
+            });
+            Ok(())
+        })
+        .run(context).expect("run disposable WebView smoke");
+}
+
+fn wait_for(check: impl Fn() -> bool, description: &str) -> Result<(), String> {
+    let started = Instant::now();
+    while started.elapsed() < Duration::from_secs(30) {
+        if check() {
+            return Ok(());
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    Err(format!("timed out: {description}"))
+}
+
+fn run_smoke(app: &tauri::AppHandle) -> Result<(), String> {
+    let state = app.state::<AppState>();
+    wait_for(
+        || state.boots.lock().unwrap().len() == 2,
+        "both WebViews boot",
+    )?;
+    let main = app.get_webview_window("main").unwrap();
+    let sibling = app.get_webview_window("proj-health").unwrap();
+    // Bounded busy loop: verifies the escape path without leaving a wedged process.
+    main.eval("const end = performance.now() + 15000; while (performance.now() < end) {}")
+        .map_err(|e| e.to_string())?;
+    std::thread::sleep(Duration::from_secs(1));
+    let started = Instant::now();
+    ui_health::stop_window_agent(&main);
+    ui_health::stop_window_agent(&sibling); // No active session must not mean stop all.
+    wait_for(|| !state.stopped.lock().unwrap().is_empty(), "native stop")?;
+    if started.elapsed() > Duration::from_secs(3) {
+        return Err("native stop waited on renderer".into());
+    }
+    if *state.stopped.lock().unwrap() != ["session-a"] {
+        return Err("stop leaked to another session".into());
+    }
+    ui_health::reload_window(&main, "native smoke");
+    wait_for(
+        || {
+            state
+                .boots
+                .lock()
+                .unwrap()
+                .get("main")
+                .copied()
+                .unwrap_or_default()
+                >= 2
+        },
+        "target reload",
+    )?;
+    if state.boots.lock().unwrap().get("proj-health") != Some(&1) {
+        return Err("sibling was reloaded".into());
+    }
+    Ok(())
+}

--- a/src-tauri/src/desktop_lifecycle.rs
+++ b/src-tauri/src/desktop_lifecycle.rs
@@ -35,6 +35,8 @@ const TRAY_ID: &str = "wisp-tray";
 #[derive(Debug, PartialEq, Eq)]
 enum TrayAction {
     Show,
+    StopAgent,
+    ReloadWindow,
     Restart,
     Quit,
 }
@@ -43,6 +45,8 @@ enum TrayAction {
 fn tray_action(id: &str) -> Option<TrayAction> {
     match id {
         "tray-show" => Some(TrayAction::Show),
+        "tray-stop-agent" => Some(TrayAction::StopAgent),
+        "tray-reload-window" => Some(TrayAction::ReloadWindow),
         "tray-restart" => Some(TrayAction::Restart),
         "tray-quit" => Some(TrayAction::Quit),
         _ => None,
@@ -69,6 +73,8 @@ impl TrayLocale {
 #[cfg(any(target_os = "windows", test))]
 struct TrayLabels {
     show: &'static str,
+    stop_agent: &'static str,
+    reload_window: &'static str,
     restart: &'static str,
     quit: &'static str,
 }
@@ -78,11 +84,15 @@ fn tray_labels(locale: TrayLocale) -> TrayLabels {
     match locale {
         TrayLocale::Zh => TrayLabels {
             show: "打开 Wisp Science",
+            stop_agent: "停止最近窗口的当前 Agent",
+            reload_window: "重载最近使用的窗口",
             restart: "重启",
             quit: "退出",
         },
         TrayLocale::En => TrayLabels {
             show: "Open Wisp Science",
+            stop_agent: "Stop agent in last active window",
+            reload_window: "Reload last active window",
             restart: "Restart",
             quit: "Quit",
         },
@@ -96,9 +106,11 @@ fn build_tray_menu<M: Manager<tauri::Wry>>(
 ) -> tauri::Result<Menu<tauri::Wry>> {
     let labels = tray_labels(locale);
     let show = MenuItemBuilder::with_id("tray-show", labels.show).build(app)?;
+    let stop = MenuItemBuilder::with_id("tray-stop-agent", labels.stop_agent).build(app)?;
+    let reload = MenuItemBuilder::with_id("tray-reload-window", labels.reload_window).build(app)?;
     let restart = MenuItemBuilder::with_id("tray-restart", labels.restart).build(app)?;
     let quit = MenuItemBuilder::with_id("tray-quit", labels.quit).build(app)?;
-    Menu::with_items(app, &[&show, &restart, &quit])
+    Menu::with_items(app, &[&show, &stop, &reload, &restart, &quit])
 }
 
 pub(crate) fn activate_workspace(app: &AppHandle) {
@@ -250,6 +262,16 @@ pub(crate) fn install_windows_shell(app: &mut App, locale_tag: &str) -> tauri::R
         .show_menu_on_left_click(false)
         .on_menu_event(|app, event| match tray_action(event.id().as_ref()) {
             Some(TrayAction::Show) => activate_workspace(app),
+            Some(TrayAction::StopAgent) => {
+                if let Some(window) = crate::ui_health::last_workspace_window(app) {
+                    crate::ui_health::stop_window_agent(&window);
+                }
+            }
+            Some(TrayAction::ReloadWindow) => {
+                if let Some(window) = crate::ui_health::last_workspace_window(app) {
+                    crate::ui_health::reload_window(&window, "native tray");
+                }
+            }
             Some(TrayAction::Restart) => app.request_restart(),
             Some(TrayAction::Quit) => app.exit(0),
             _ => {}
@@ -299,6 +321,11 @@ mod tests {
     #[test]
     fn windows_tray_actions_include_restart() {
         assert_eq!(tray_action("tray-show"), Some(TrayAction::Show));
+        assert_eq!(tray_action("tray-stop-agent"), Some(TrayAction::StopAgent));
+        assert_eq!(
+            tray_action("tray-reload-window"),
+            Some(TrayAction::ReloadWindow)
+        );
         assert_eq!(tray_action("tray-restart"), Some(TrayAction::Restart));
         assert_eq!(tray_action("tray-quit"), Some(TrayAction::Quit));
         assert_eq!(tray_action("unknown"), None);
@@ -308,11 +335,15 @@ mod tests {
     fn windows_tray_labels_follow_saved_locale() {
         let zh = tray_labels(TrayLocale::from_tag("zh-CN"));
         assert_eq!(zh.show, "打开 Wisp Science");
+        assert_eq!(zh.stop_agent, "停止最近窗口的当前 Agent");
+        assert_eq!(zh.reload_window, "重载最近使用的窗口");
         assert_eq!(zh.restart, "重启");
         assert_eq!(zh.quit, "退出");
 
         let en = tray_labels(TrayLocale::from_tag("en"));
         assert_eq!(en.show, "Open Wisp Science");
+        assert_eq!(en.stop_agent, "Stop agent in last active window");
+        assert_eq!(en.reload_window, "Reload last active window");
         assert_eq!(en.restart, "Restart");
         assert_eq!(en.quit, "Quit");
 

--- a/src-tauri/src/dto_contract_tests.rs
+++ b/src-tauri/src/dto_contract_tests.rs
@@ -590,3 +590,23 @@ fn research_calendar_contract_preserves_project_errors_and_truncation() {
         backend
     );
 }
+#[test]
+fn renderer_health_accepts_partial_numeric_snapshots() {
+    let snapshot: wisp_dto::UiHealthSnapshot = serde_json::from_value(serde_json::json!({
+        "timerLagMs": 850, "activeApps": 1, "parkedApps": 2, "scriptErrors": 3
+    }))
+    .unwrap();
+    assert_eq!(snapshot.timer_lag_ms, 850);
+    assert_eq!(snapshot.active_apps, 1);
+    assert_eq!(snapshot.parked_apps, 2);
+    assert_eq!(snapshot.script_errors, 3);
+    assert_eq!(snapshot.app_messages, 0);
+    let encoded = serde_json::to_value(snapshot).unwrap();
+    assert_eq!(encoded["timerLagMs"], 850);
+    assert!(
+        serde_json::from_value::<wisp_dto::UiHealthSnapshot>(serde_json::json!({
+            "scriptErrors": "arbitrary content"
+        }))
+        .is_err()
+    );
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -110,6 +110,7 @@ mod trajectory;
 mod trajectory_export;
 mod turn_memory;
 mod turn_undo;
+mod ui_health;
 mod video_generation_tool;
 mod windows_snap;
 mod workspace_manifest;
@@ -3507,6 +3508,23 @@ fn mac_menu_action(id: &str, focused: bool) -> Option<&'static str> {
 fn wire_macos_menu_events(window: &tauri::WebviewWindow) {
     window.on_menu_event(|window, event| {
         // Tauri invokes every window's menu handler for each native action.
+        if window.is_focused().unwrap_or(false) {
+            match event.id().as_ref() {
+                "recovery.stop-agent" => {
+                    if let Some(target) = window.app_handle().get_webview_window(window.label()) {
+                        ui_health::stop_window_agent(&target);
+                    }
+                    return;
+                }
+                "recovery.reload-window" => {
+                    if let Some(target) = window.app_handle().get_webview_window(window.label()) {
+                        ui_health::reload_window(&target, "native menu");
+                    }
+                    return;
+                }
+                _ => {}
+            }
+        }
         if let Some(action) =
             mac_menu_action(event.id().as_ref(), window.is_focused().unwrap_or(false))
         {
@@ -3696,6 +3714,33 @@ fn install_macos_app_menu(app: &AppHandle, locale_tag: &str) -> Result<(), Strin
         .map_err(|error| error.to_string())?;
 
     let window_menu = SubmenuBuilder::new(app, labels.window)
+        .item(
+            &build_menu_item(
+                app,
+                "recovery.stop-agent",
+                if locale_tag.starts_with("zh") {
+                    "停止当前 Agent"
+                } else {
+                    "Stop current agent"
+                },
+                None,
+            )
+            .map_err(|error| error.to_string())?,
+        )
+        .item(
+            &build_menu_item(
+                app,
+                "recovery.reload-window",
+                if locale_tag.starts_with("zh") {
+                    "重载当前窗口"
+                } else {
+                    "Reload current window"
+                },
+                None,
+            )
+            .map_err(|error| error.to_string())?,
+        )
+        .separator()
         .item(&PredefinedMenuItem::minimize(app, None).map_err(|error| error.to_string())?)
         .item(&PredefinedMenuItem::maximize(app, None).map_err(|error| error.to_string())?)
         .item(&PredefinedMenuItem::fullscreen(app, None).map_err(|error| error.to_string())?)
@@ -6514,78 +6559,6 @@ pub(crate) fn startup_report_summary() -> String {
         .unwrap_or_default()
 }
 
-/// Frontend `ui_heartbeat` timer. Silence on a focused window means the
-/// renderer died; reload recovers because sessions live in SQLite.
-static UI_HEARTBEAT: StdMutex<Option<std::time::Instant>> = StdMutex::new(None);
-static UI_WATCHDOG_LAST_RELOAD: StdMutex<Option<std::time::Instant>> = StdMutex::new(None);
-const UI_HEARTBEAT_STALE: std::time::Duration = std::time::Duration::from_secs(60);
-const UI_WATCHDOG_COOLDOWN: std::time::Duration = std::time::Duration::from_secs(120);
-
-#[tauri::command]
-fn ui_heartbeat() {
-    if let Ok(mut last) = UI_HEARTBEAT.lock() {
-        *last = Some(std::time::Instant::now());
-    }
-}
-
-fn ui_watchdog_requires_reload(
-    secs_since_beat: Option<u64>,
-    secs_since_reload: Option<u64>,
-) -> bool {
-    match secs_since_beat {
-        Some(secs) if secs >= UI_HEARTBEAT_STALE.as_secs() => match secs_since_reload {
-            Some(secs) => secs >= UI_WATCHDOG_COOLDOWN.as_secs(),
-            None => true,
-        },
-        _ => false,
-    }
-}
-
-/// Backgrounded webviews throttle JS timers, so elapsed time is not a death
-/// signal. Refresh the clock while unfocused so a later focus does not look
-/// immediately stale. Leave `None` alone: that means "wait for a real beat".
-fn ui_watchdog_note_unfocused(last_beat: &mut Option<std::time::Instant>) {
-    if last_beat.is_some() {
-        *last_beat = Some(std::time::Instant::now());
-    }
-}
-
-async fn run_ui_watchdog(app: tauri::AppHandle) {
-    loop {
-        tokio::time::sleep(std::time::Duration::from_secs(10)).await;
-        let secs_since_beat = UI_HEARTBEAT
-            .lock()
-            .ok()
-            .and_then(|last| last.map(|instant| instant.elapsed().as_secs()));
-        let secs_since_reload = UI_WATCHDOG_LAST_RELOAD
-            .lock()
-            .ok()
-            .and_then(|last| last.map(|instant| instant.elapsed().as_secs()));
-        if !ui_watchdog_requires_reload(secs_since_beat, secs_since_reload) {
-            continue;
-        }
-        let Some(window) = app.get_webview_window("main") else {
-            continue;
-        };
-        if !window.is_focused().unwrap_or(false) {
-            if let Ok(mut last) = UI_HEARTBEAT.lock() {
-                ui_watchdog_note_unfocused(&mut last);
-            }
-            continue;
-        }
-        tracing::warn!(target: "wisp", secs_since_beat = secs_since_beat.unwrap_or_default(),
-            "main webview stopped heartbeating; reloading to recover the UI");
-        if window.reload().is_ok() {
-            if let Ok(mut last) = UI_WATCHDOG_LAST_RELOAD.lock() {
-                *last = Some(std::time::Instant::now());
-            }
-            if let Ok(mut last) = UI_HEARTBEAT.lock() {
-                *last = None;
-            }
-        }
-    }
-}
-
 /// Windows creates the main WebView2 before `setup` runs but cannot service it
 /// until the event loop pumps messages, so everything `setup` does on the way
 /// to the first paint is time the user spends looking at a blank window. Record
@@ -6822,11 +6795,15 @@ pub fn run() {
         .on_window_event(|window, event| match event {
             tauri::WindowEvent::Focused(focused) => {
                 record_window_focus(window.label(), *focused);
+                ui_health::note_focus(window.label(), *focused);
                 if *focused {
                     drain_pending_notify_target(window);
                 }
             }
-            tauri::WindowEvent::Destroyed => record_window_focus(window.label(), false),
+            tauri::WindowEvent::Destroyed => {
+                record_window_focus(window.label(), false);
+                ui_health::remove_window(window.label());
+            }
             _ => {}
         })
         // The blank window ends when the main webview finishes loading its
@@ -6867,7 +6844,7 @@ pub fn run() {
             #[cfg(target_os = "windows")]
             let main_builder = main_builder.decorations(false).shadow(true);
             main_builder.build().expect("create main window");
-            tauri::async_runtime::spawn(run_ui_watchdog(app.handle().clone()));
+            tauri::async_runtime::spawn(ui_health::run_watchdog(app.handle().clone()));
             let mut startup = StartupTimeline::default();
             if let Ok(res) = app.path().resource_dir() {
                 wisp_paths::set_resource_root(res);
@@ -7447,7 +7424,7 @@ pub fn run() {
             app_commands::browser_extension_status,
             app_commands::update_browser_extension,
             app_commands::extension_connected,
-            ui_heartbeat,
+            ui_health::ui_heartbeat,
             app_commands::reveal_in_file_manager,
             app_commands::open_workspace_path,
             connector_commands::list_mcp_connections,

--- a/src-tauri/src/lib_tests.rs
+++ b/src-tauri/src/lib_tests.rs
@@ -10,11 +10,10 @@ use super::{
     persist_ui_events, provenance_ui_file_changes, receive_confirm_decision,
     reclaim_unconsumed_cutin, resolve_acp_artifact_references, resolve_composer_references,
     resolve_reader_references, resolve_review_backend, resolve_workspace, session_runtime_status,
-    should_hide_app_on_macos_close, should_persist_ui_event, ui_watchdog_note_unfocused,
-    ui_watchdog_requires_reload, user_message_start, AgentEvent, ComposerReferenceArg,
-    McpConnection, McpHttpAuth, McpTransport, ProjectActivityLocks, QueuedItem, SessionRuntime,
-    SkillInfo, StartupReport, StartupTimeline, MAX_PENDING_UI_EVENT_BYTES,
-    UI_STREAM_OUTPUT_MAX_BYTES, UI_TOOL_RESULT_MAX_CHARS,
+    should_hide_app_on_macos_close, should_persist_ui_event, user_message_start, AgentEvent,
+    ComposerReferenceArg, McpConnection, McpHttpAuth, McpTransport, ProjectActivityLocks,
+    QueuedItem, SessionRuntime, SkillInfo, StartupReport, StartupTimeline,
+    MAX_PENDING_UI_EVENT_BYTES, UI_STREAM_OUTPUT_MAX_BYTES, UI_TOOL_RESULT_MAX_CHARS,
 };
 use std::collections::{HashMap, HashSet};
 use std::ffi::OsString;
@@ -2805,31 +2804,6 @@ fn desktop_app_icon_native_catalog_matches_its_sources_and_bundle_config() {
     assert_eq!(images[0]["value"], "wisp-light.svg");
     assert_eq!(images[1]["appearance"], "dark");
     assert_eq!(images[1]["value"], "wisp-dark.svg");
-}
-
-#[test]
-fn ui_watchdog_reload_decision() {
-    // Never fired a beat (fresh boot, or beat cleared after a reload): the
-    // watchdog must wait for fresh beats, not reload on startup silence.
-    assert!(!ui_watchdog_requires_reload(None, None));
-    // Healthy stream.
-    assert!(!ui_watchdog_requires_reload(Some(5), None));
-    // Freshly reloaded, still loading: inside the cooldown.
-    assert!(!ui_watchdog_requires_reload(Some(120), Some(30)));
-    // Dead renderer, first recovery.
-    assert!(ui_watchdog_requires_reload(Some(120), None));
-    // Dead again after the cooldown expired.
-    assert!(ui_watchdog_requires_reload(Some(120), Some(180)));
-}
-
-#[test]
-fn ui_watchdog_unfocused_silence_is_not_stale() {
-    let mut beat = Some(std::time::Instant::now() - std::time::Duration::from_secs(120));
-    ui_watchdog_note_unfocused(&mut beat);
-    assert!(beat.unwrap().elapsed() < std::time::Duration::from_secs(1));
-    let mut none = None;
-    ui_watchdog_note_unfocused(&mut none);
-    assert!(none.is_none());
 }
 
 async fn open_temp_store(prefix: &str) -> (wisp_store::Store, PathBuf) {

--- a/src-tauri/src/ui_health.rs
+++ b/src-tauri/src/ui_health.rs
@@ -1,0 +1,244 @@
+//! Window-scoped renderer liveness and native recovery. No Run cancellation.
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+use tauri::{AppHandle, Manager, WebviewWindow};
+use wisp_dto::UiHealthSnapshot;
+
+const STALE: Duration = Duration::from_secs(60);
+const COOLDOWN: Duration = Duration::from_secs(120);
+
+#[derive(Debug)]
+struct WindowHealth {
+    last_beat: Instant,
+    focused: bool,
+    last_attempt: Option<Instant>,
+    last_log: Option<Instant>,
+    snapshot: UiHealthSnapshot,
+}
+
+impl WindowHealth {
+    fn new(now: Instant) -> Self {
+        Self {
+            last_beat: now,
+            focused: false,
+            last_attempt: None,
+            last_log: None,
+            snapshot: UiHealthSnapshot::default(),
+        }
+    }
+
+    fn focus(&mut self, focused: bool, now: Instant) {
+        // Background timer throttling is not failure. Allow a full grace period
+        // on returning to this window, without borrowing any other window's beat.
+        if !focused || !self.focused {
+            self.last_beat = now;
+        }
+        self.focused = focused;
+    }
+
+    fn reserve_recovery(&mut self, now: Instant) -> bool {
+        if !self.focused || now.duration_since(self.last_beat) < STALE {
+            return false;
+        }
+        if self
+            .last_attempt
+            .is_some_and(|last| now.duration_since(last) < COOLDOWN)
+        {
+            return false;
+        }
+        // Rate limit attempts, including failed reloads. Do not disarm when a
+        // reload succeeds: a renderer that never boots must remain recoverable.
+        self.last_attempt = Some(now);
+        true
+    }
+}
+
+#[derive(Default)]
+struct HealthRegistry {
+    windows: HashMap<String, WindowHealth>,
+    last_focused: Option<String>,
+}
+
+fn registry() -> &'static Mutex<HealthRegistry> {
+    static REGISTRY: OnceLock<Mutex<HealthRegistry>> = OnceLock::new();
+    REGISTRY.get_or_init(Default::default)
+}
+
+pub(crate) fn note_focus(label: &str, focused: bool) {
+    if label == "pet" {
+        return;
+    }
+    let now = Instant::now();
+    let mut registry = registry().lock().unwrap();
+    registry
+        .windows
+        .entry(label.to_string())
+        .or_insert_with(|| WindowHealth::new(now))
+        .focus(focused, now);
+    if focused {
+        registry.last_focused = Some(label.to_string());
+    }
+}
+
+pub(crate) fn remove_window(label: &str) {
+    let mut registry = registry().lock().unwrap();
+    registry.windows.remove(label);
+    if registry.last_focused.as_deref() == Some(label) {
+        registry.last_focused = None;
+    }
+}
+
+#[tauri::command]
+pub(crate) fn ui_heartbeat(window: WebviewWindow, snapshot: Option<UiHealthSnapshot>) {
+    if window.label() == "pet" {
+        return;
+    }
+    let now = Instant::now();
+    let mut registry = registry().lock().unwrap();
+    let health = registry
+        .windows
+        .entry(window.label().to_string())
+        .or_insert_with(|| WindowHealth::new(now));
+    health.last_beat = now;
+    health.snapshot = snapshot.unwrap_or_default();
+    if health
+        .last_log
+        .is_none_or(|last| now.duration_since(last) >= Duration::from_secs(60))
+    {
+        health.last_log = Some(now);
+        // Numeric summaries only: no prompts, tool arguments, URLs or error text.
+        tracing::info!(target: "wisp", window = window.label(), focused = health.focused,
+            diagnostics = ?health.snapshot, "webview health");
+    }
+}
+
+pub(crate) async fn run_watchdog(app: AppHandle) {
+    loop {
+        tokio::time::sleep(Duration::from_secs(10)).await;
+        let windows = app.webview_windows();
+        registry()
+            .lock()
+            .unwrap()
+            .windows
+            .retain(|label, _| windows.contains_key(label));
+        for (label, window) in windows {
+            if label == "pet" {
+                continue;
+            }
+            let focused = window.is_focused().unwrap_or(false);
+            let now = Instant::now();
+            let recover = {
+                let mut registry = registry().lock().unwrap();
+                let health = registry
+                    .windows
+                    .entry(label.clone())
+                    .or_insert_with(|| WindowHealth::new(now));
+                health.focus(focused, now);
+                health.reserve_recovery(now)
+            };
+            if recover {
+                reload_window(&window, "heartbeat timeout");
+            }
+        }
+    }
+}
+
+pub(crate) fn reload_window(window: &WebviewWindow, reason: &str) {
+    // Reload only the WebView; AppState, agent runtimes and RunManager stay alive.
+    let now = Instant::now();
+    {
+        let mut registry = registry().lock().unwrap();
+        let health = registry
+            .windows
+            .entry(window.label().to_string())
+            .or_insert_with(|| WindowHealth::new(now));
+        health.last_attempt = Some(now);
+        health.last_beat = now;
+    }
+    let result = window.reload();
+    tracing::warn!(target: "wisp", window = window.label(), reason,
+        success = result.is_ok(), error = ?result.err(), "webview recovery requested");
+}
+
+pub(crate) fn stop_window_agent(window: &WebviewWindow) {
+    let app = window.app_handle().clone();
+    let Some(state) = app.try_state::<crate::AppState>() else {
+        return;
+    };
+    // Never pass None to stop_agent: its legacy meaning is all sessions.
+    let Some(session_id) = state
+        .active_frame(window.label())
+        .filter(|id| !id.is_empty())
+    else {
+        return;
+    };
+    tracing::info!(target: "wisp", window = window.label(), "native stop requested");
+    tauri::async_runtime::spawn(async move {
+        if let Err(error) = crate::agent_turn::stop_agent(app.state(), Some(session_id)).await {
+            tracing::warn!(target: "wisp", %error, "native stop failed");
+        }
+    });
+}
+
+#[cfg(target_os = "windows")]
+pub(crate) fn last_workspace_window(app: &AppHandle) -> Option<WebviewWindow> {
+    let label = registry().lock().unwrap().last_focused.clone();
+    label
+        .and_then(|label| app.get_webview_window(&label))
+        .or_else(|| app.get_webview_window("main"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn healthy_window_cannot_mask_another_window_and_cooldowns_are_independent() {
+        let start = Instant::now();
+        let mut windows = HashMap::from([
+            ("main", WindowHealth::new(start)),
+            ("project-a", WindowHealth::new(start)),
+        ]);
+        for health in windows.values_mut() {
+            health.focus(true, start);
+        }
+        windows.get_mut("main").unwrap().last_beat = start + Duration::from_secs(59);
+        let now = start + STALE;
+        assert!(!windows.get_mut("main").unwrap().reserve_recovery(now));
+        assert!(windows.get_mut("project-a").unwrap().reserve_recovery(now));
+        assert!(!windows
+            .get_mut("project-a")
+            .unwrap()
+            .reserve_recovery(now + Duration::from_secs(10)));
+        assert!(windows
+            .get_mut("main")
+            .unwrap()
+            .reserve_recovery(now + STALE));
+    }
+
+    #[test]
+    fn silent_startup_and_failed_reloads_remain_recoverable() {
+        let now = Instant::now();
+        let mut health = WindowHealth::new(now);
+        health.focus(true, now);
+        assert!(!health.reserve_recovery(now + STALE - Duration::from_secs(1)));
+        assert!(health.reserve_recovery(now + STALE));
+        assert!(health.reserve_recovery(now + STALE + COOLDOWN));
+        health.last_beat = now + STALE + COOLDOWN;
+        assert!(!health.reserve_recovery(health.last_beat + Duration::from_secs(5)));
+    }
+
+    #[test]
+    fn background_and_focus_transitions_get_a_grace_period() {
+        let now = Instant::now();
+        let later = now + Duration::from_secs(600);
+        let mut health = WindowHealth::new(now);
+        health.focus(false, now);
+        assert!(!health.reserve_recovery(later));
+        health.focus(true, later);
+        assert!(!health.reserve_recovery(later));
+        health.focus(true, later + STALE);
+        assert!(health.reserve_recovery(later + STALE));
+    }
+}

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -4967,6 +4967,7 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string;
           case "dismiss_onboarding":
             return null;
           case "stop_agent":
+            (window as any).__healthStressFinish?.();
             if ((window as any).__failStopAgent) {
               throw new Error("stop command unavailable");
             }
@@ -5280,6 +5281,29 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string;
             // Slow stream keeps send_message pending until Done. This mirrors the
             // native command lifecycle and leaves enough live time to assert that
             // Markdown/projection work is deferred between token batches.
+            if (String(arg("message") ?? "").includes("HEALTHSTRESS")) {
+              return await new Promise<string>((resolve) => {
+                const background = "health-background";
+                emit("agent", { kind: "User", frame_id: fid, text: msg });
+                emit("agent", { kind: "User", frame_id: background, text: "background stress" });
+                let n = 0;
+                const timer = setInterval(() => {
+                  for (const id of [fid, background]) {
+                    emit("agent", { kind: "Text", frame_id: id, delta: `**stress ${n}** ${"x".repeat(800)}\n` });
+                  }
+                  n += 1;
+                }, 50);
+                (window as any).__healthStressFinish = () => {
+                  clearInterval(timer);
+                  delete (window as any).__healthStressFinish;
+                  emit("agent", { kind: "Done", frame_id: fid });
+                  emit("agent", { kind: "Done", frame_id: background });
+                  resolve(fid);
+                };
+                // Bound a failed test's producer as well.
+                setTimeout(() => (window as any).__healthStressFinish?.(), 25_000);
+              });
+            }
             if (String(arg("message") ?? "").includes("MARKDOWNSTREAM")) {
               return await new Promise<string>((resolve) => {
                 let n = 0;

--- a/ui-tests/tests/webview-health.spec.ts
+++ b/ui-tests/tests/webview-health.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect, type Page } from "@playwright/test";
+import { tauriMock } from "./mock-tauri";
+
+async function lastArgs(page: Page, command: string) {
+  return page.evaluate((cmd) => {
+    const plain = (v: any): any => v instanceof Map ? Object.fromEntries([...v].map(([k, v]) => [k, plain(v)]))
+      : Array.isArray(v) ? v.map(plain) : v && typeof v === "object"
+        ? Object.fromEntries(Object.entries(v).map(([k, v]) => [k, plain(v)])) : v;
+    return plain((window as any).__skillInvokeLog?.filter((c: any) => c.cmd === cmd).at(-1)?.args);
+  }, command);
+}
+
+test.beforeEach(async ({ page }) => { await page.addInitScript(tauriMock); });
+
+test("two candidate apps and concurrent streams leave host controls responsive", async ({ page }) => {
+  await page.goto("/?mockLongPages=8&mockLongRows=40&mockLongRowBytes=2048");
+  await page.locator(".proj-card-main").first().click();
+  await expect(page.getByText(/Window page 0 row 39/)).toBeVisible();
+  await page.locator(".composer-inner textarea").first().fill("HEALTHSTRESS");
+  await page.getByRole("button", { name: "Send", exact: true }).click();
+  await expect.poll(() => lastArgs(page, "send_message")).toBeTruthy();
+  const frameId = String((await lastArgs(page, "send_message")).sessionId);
+  await page.evaluate(({ frameId }) => {
+    // Local SVG thumbnail images; no service, real MCP or network required.
+    const svg = encodeURIComponent('<svg xmlns="http://www.w3.org/2000/svg" width="320" height="180"><path d="M10 160L80 100L170 130L300 10" fill="none" stroke="green"/></svg>');
+    const html = `<!doctype html><body>${Array.from({ length: 96 }, (_, i) =>
+      `<article><img width="320" height="180" src="data:image/svg+xml,${svg}"><button onclick="this.textContent='Selected ${i}'">Select ${i}</button></article>`).join("")}
+      <script>setInterval(()=>parent.postMessage({jsonrpc:'2.0',method:'ping',id:Date.now()},'*'),100);</script></body>`;
+    for (const [suffix, title] of [["a", "Candidates A"], ["b", "Candidates B"]]) {
+      (window as any).__tauriEmit("agent", { kind: "ToolPresentation", frame_id: frameId,
+        presentation_kind: "mcp_app", payload: { tool: { name: "figure_library_search", title },
+          arguments: {}, result: { content: [] },
+          resource: { uri: `ui://figure-library/candidates-${suffix}.html`, text: html, _meta: {} } } });
+    }
+  }, { frameId });
+  const tabs = page.locator('.center-tab[data-center-path^="mcp-app:"]');
+  await expect(tabs).toHaveCount(2);
+  // Mount each instance, leaving A alive in the parking root while B is visible.
+  await tabs.filter({ hasText: "Candidates A" }).click();
+  await expect(page.frameLocator('iframe[title="Candidates A"]').locator("article")).toHaveCount(96);
+  await tabs.filter({ hasText: "Candidates B" }).click();
+  const candidates = page.frameLocator('iframe[title="Candidates B"]');
+  await candidates.getByRole("button", { name: "Select 0", exact: true }).click({ timeout: 2000 });
+  await expect(candidates.getByRole("button", { name: "Selected 0", exact: true })).toBeVisible();
+  await expect.poll(async () => (await lastArgs(page, "ui_heartbeat"))?.snapshot, { timeout: 10_000 })
+    .toMatchObject({ activeApps: 1, parkedApps: 1, dragOverlays: 0 });
+  expect((await lastArgs(page, "ui_heartbeat")).snapshot.appMessages).toBeGreaterThan(0);
+  await page.screenshot({ path: test.info().outputPath("combined-load.png") });
+  // Assert during the stream, not only a rAF after completion.
+  await page.getByRole("button", { name: "Stop", exact: true }).click({ timeout: 2000 });
+  await expect.poll(() => lastArgs(page, "stop_agent")).toMatchObject({ sessionId: frameId });
+  await tabs.filter({ hasText: "Candidates B" }).locator("..").locator(".center-tab-close").click({ timeout: 2000 });
+  await expect(tabs).toHaveCount(1);
+  await page.locator(".sidebar").getByRole("button", { name: "New session", exact: true }).click({ timeout: 2000 });
+  await page.locator(".composer-inner textarea").first().fill("host still accepts input");
+  await expect(page.locator(".composer-inner textarea").first()).toHaveValue("host still accepts input");
+});
+
+test("heartbeat diagnoses script failures and input blockers without exporting content", async ({ page }) => {
+  await page.goto("/");
+  await page.locator(".proj-card-main").first().click();
+  await page.evaluate(() => {
+    window.dispatchEvent(new ErrorEvent("error", { message: "private prompt must not be logged" }));
+    const overlay = document.createElement("div");
+    overlay.className = "drag-overlay";
+    document.body.appendChild(overlay);
+  });
+  await expect.poll(async () => (await lastArgs(page, "ui_heartbeat"))?.snapshot, { timeout: 10_000 })
+    .toMatchObject({ scriptErrors: 1, dragOverlays: 1 });
+  const snapshot = (await lastArgs(page, "ui_heartbeat")).snapshot;
+  expect(Object.values(snapshot).every((value) => typeof value === "number")).toBe(true);
+  expect(JSON.stringify(snapshot)).not.toContain("private prompt");
+});

--- a/ui/src/api.js
+++ b/ui/src/api.js
@@ -9,6 +9,57 @@ function tauriEvent() {
   return window.__TAURI__?.event;
 }
 
+let uiHealthStarted = false;
+let reportUiHealth = () => {};
+const uiHealth = { timerLagMs: 0, longTasks: 0, longestTaskMs: 0, scriptErrors: 0, unhandledRejections: 0, appMessages: 0 };
+const boundedHealthCount = (value) => Math.min(1_000_000, Math.max(0, Math.round(value) || 0));
+
+export function report_ui_health() { void reportUiHealth(); }
+
+/** Numeric diagnostics only. The heartbeat is driven by the WASM app timer,
+ * so a broken WASM callback cannot be masked by an independent healthy JS timer. */
+export function start_ui_health() {
+  if (uiHealthStarted) return;
+  uiHealthStarted = true;
+  window.addEventListener("error", () => { uiHealth.scriptErrors = boundedHealthCount(uiHealth.scriptErrors + 1); });
+  window.addEventListener("unhandledrejection", () => { uiHealth.unhandledRejections = boundedHealthCount(uiHealth.unhandledRejections + 1); });
+  if (typeof PerformanceObserver !== "undefined" && PerformanceObserver.supportedEntryTypes?.includes("longtask")) {
+    new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        uiHealth.longTasks = boundedHealthCount(uiHealth.longTasks + 1);
+        uiHealth.longestTaskMs = Math.max(uiHealth.longestTaskMs, boundedHealthCount(entry.duration));
+      }
+    }).observe({ type: "longtask" });
+  }
+  let lastTick = performance.now();
+  let inFlight = false;
+  const beat = async () => {
+    const now = performance.now();
+    const timerLagMs = document.visibilityState === "visible" ? boundedHealthCount(now - lastTick - 5000) : 0;
+    uiHealth.timerLagMs = Math.max(uiHealth.timerLagMs, timerLagMs);
+    lastTick = now;
+    if (inFlight || !tauriCore()) return;
+    inFlight = true;
+    let activeApps = 0;
+    let parkedApps = 0;
+    for (const instance of mcpAppInstances.values()) {
+      if (instance.target?.isConnected) activeApps += 1;
+      else parkedApps += 1;
+    }
+    const snapshot = { ...uiHealth, activeApps, parkedApps,
+      dragOverlays: document.querySelectorAll(".drag-overlay").length };
+    // Counters are cumulative and bounded: a once-per-minute backend log cannot
+    // miss a brief error or message burst between its sampled heartbeats.
+    try { await invoke_timeout("ui_heartbeat", { snapshot }, 4000); }
+    catch { /* A failed IPC must not create its own rejection storm. */ }
+    finally { inFlight = false; }
+  };
+  reportUiHealth = beat;
+  document.addEventListener("visibilitychange", () => { lastTick = performance.now(); });
+  window.addEventListener("focus", () => { lastTick = performance.now(); });
+  void beat();
+}
+
 export function is_windows() {
   return navigator.userAgent.includes("Windows");
 }
@@ -2743,6 +2794,7 @@ function createMcpAppInstance(instanceId, payloadJson) {
   };
   instance.onMessage = (event) => {
     if (event.source !== frame.contentWindow || !event.data || event.data.jsonrpc !== "2.0") return;
+    uiHealth.appMessages = boundedHealthCount(uiHealth.appMessages + 1);
     const message = event.data;
     if (message.method?.startsWith("wisp/notifications/motif-")) {
       if (message.method === "wisp/notifications/motif-bridge-ready") {

--- a/ui/src/bindings.rs
+++ b/ui/src/bindings.rs
@@ -28,6 +28,8 @@ extern "C" {
 #[wasm_bindgen(module = "/src/api.js")]
 extern "C" {
     pub(crate) async fn invoke(cmd: &str, args: JsValue) -> JsValue;
+    pub(crate) fn start_ui_health();
+    pub(crate) fn report_ui_health();
     #[wasm_bindgen(catch, js_name = invoke_strict)]
     pub(crate) async fn invoke_checked(cmd: &str, args: JsValue) -> Result<JsValue, JsValue>;
     #[wasm_bindgen(catch, js_name = invoke_timeout)]

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -7652,14 +7652,11 @@ fn App() -> impl IntoView {
     });
     refresh_runtimes(runtime_infos);
     refresh_runs(run_records, locale);
+    crate::bindings::start_ui_health();
     {
-        // UI liveness heartbeat for the backend watchdog: a webview whose
-        // renderer died (process crash / WASM panic) stops beating and gets
-        // reloaded; see `run_ui_watchdog` in src-tauri/src/lib.rs.
+        // Keep liveness tied to the WASM app, while JS collects bounded metrics.
         let beat = Closure::wrap(Box::new(move || {
-            spawn_local(async move {
-                let _ = invoke("ui_heartbeat", JsValue::UNDEFINED).await;
-            });
+            crate::bindings::report_ui_health();
         }) as Box<dyn FnMut()>);
         if let Some(window) = web_sys::window() {
             let _ = window.set_interval_with_callback_and_timeout_and_arguments_0(

--- a/ui/src/styles/chat.css
+++ b/ui/src/styles/chat.css
@@ -1397,7 +1397,7 @@ details.tool:not([open]) > summary.head .run-dot { animation: tool-pulse 1.1s ea
 .composer-fast.pending { opacity: .62; }
 .composer-fast:disabled { cursor: default; }
 .model-picker { position: relative; display: flex; flex: 0 1 auto; min-width: 0; }
-.model-picker-btn { display: inline-flex; align-items: center; gap: 5px; height: 32px; padding: 0 11px; border: 1px solid var(--border-strong); border-radius: 999px; background: var(--bg-elev); color: var(--text-muted); font: inherit; font-size: 12px; font-weight: 500; cursor: pointer; max-width: min(220px, 38vw); transition: color .12s ease, border-color .12s ease, background .12s ease; }
+.model-picker-btn { min-width: 0; display: inline-flex; align-items: center; gap: 5px; height: 32px; padding: 0 11px; border: 1px solid var(--border-strong); border-radius: 999px; background: var(--bg-elev); color: var(--text-muted); font: inherit; font-size: 12px; font-weight: 500; cursor: pointer; max-width: min(220px, 38vw); transition: color .12s ease, border-color .12s ease, background .12s ease; }
 .model-picker-btn:hover, .model-picker-btn.active { color: var(--text); background: var(--bg-sunken); border-color: color-mix(in srgb, var(--clay-strong) 30%, var(--border-strong)); }
 .model-picker-label { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-family: var(--font-mono); font-size: 11.5px; letter-spacing: -.01em; }
 .model-picker-chev { flex: 0 0 auto; font-size: 9px; color: var(--text-faint); margin-top: 1px; }


### PR DESCRIPTION
## Problem and behavior

An unresponsive WebView can leave Stop and navigation unusable while backend agents keep running (#1179). The old process-wide heartbeat lets another healthy window mask a stalled window and only reloads `main`. This change tracks each workspace window separately, includes silent startup and failed-reload retries, and exposes native recovery actions that do not require the page to handle a click.

Windows tray actions target the last active workspace window; macOS Window-menu actions target the focused window. Stop uses only that window's active session (never the legacy stop-all fallback). Reload recreates only that WebView, preserving backend state and the Run Manager. The combined workload also reproduced a model picker overlapping Stop in a narrow split; allowing the button to shrink fixes that obstruction.

## Changes

- `ui_health.rs`: window-scoped heartbeat, focus grace, per-window recovery cooldown, bounded numeric diagnostics and native stop/reload handlers. Shared DTO in `wisp-dto`; existing desktop menus wire the handlers directly.
- Frontend: retain the WASM-driven heartbeat while collecting numeric error, long-task, App-instance/message and drag-overlay diagnostics. No conversation or plugin content is logged.
- Tests/docs: multiwindow policy/DTO/tray regressions, two-stream/192-card browser workload, disposable real-WebView smoke, recovery instructions and explicit limitations in `docs/webview-recovery.md`.

## Validation

- Passed: formatting, WASM check, 14 focused Playwright tests (health, long-session stress and responsive chat), MCP smoke.
- Passed on this Windows 11 computer: `cargo run -p wisp-tauri --example webview_recovery_smoke`. A 15-second blocked WebView still permits the Rust scoped stop; only the target WebView reloads. Fake sessions and temporary browser profiles; no user database or SSH host.
- Tauri library suite: 828 passed, 8 failures in untouched method-search and resource-lease tests. All new policy/DTO/tray tests passed.
- Workspace suite stopped at wisp-runs: 162 passed, 2 SSH input-staging failures. Both passed individually on an unmodified origin/main checkout; branch reruns were mixed. Full local Rust validation is therefore not green and these failures are not being silently classified as confirmed baseline failures.
- Full 601-test Playwright run: 596 passed, 2 skipped, 3 timed out. On the final commit, all three timeout cases passed in an isolated rerun, together with both new health tests (5/5). The original full run is recorded as non-green; no failures are hidden.

## Manual smoke and limitations

On Windows, open two project windows, focus the second, and use the native tray's Stop and Reload entries. Check the logged target window and that the first window and existing Run records remain unchanged. On macOS, exercise the equivalent native Window-menu entries.

Native menu clicks and macOS execution have not been manually verified. Reload can lose unsaved editor drafts and App selections. The exact SFL 0.6.7 incident is not reproduced; independent App WebViews, suspending parked Apps, candidate virtualization and plugin-process sharing remain follow-ups guided by diagnostics. A successful reload request does not by itself prove navigation completed.

Refs #1179.

CI at handoff: headless agent eval passed on Windows, macOS and Ubuntu; Rust and UI CI are still running.

