### PR TITLE
修复 macOS 僵尸进程组导致的 MCP/runtime 关闭错误

### DIFF
--- a/crates/wisp-mcp/examples/smoke.rs
+++ b/crates/wisp-mcp/examples/smoke.rs
@@ -50,6 +50,7 @@ async fn main() -> anyhow::Result<()> {
     assert!(res.success);
     assert_eq!(res.content, "echo: hello mcp");
     let _ = ToolResult::ok(""); // touch ToolResult import
+    client.shutdown().await?;
     println!("wisp-mcp smoke OK");
     Ok(())
 }

--- a/crates/wisp-mcp/tests/mcp_transport.rs
+++ b/crates/wisp-mcp/tests/mcp_transport.rs
@@ -125,7 +125,16 @@ async fn concurrent_stdio_calls_keep_matching_ids() -> Result<(), String> {
     {
         return Err(format!("fast call received {:?}", fast.structured_content));
     }
-    client.shutdown().await.map_err(|error| error.to_string())?;
+    client
+        .shutdown()
+        .await
+        .map_err(|error| format!("shutdown after successful concurrent calls: {error}"))?;
+    // EOF-only servers exit before the tree's signal grace period. Repeated
+    // shutdown must also succeed once that unreaped zombie has been handled.
+    client
+        .shutdown()
+        .await
+        .map_err(|error| format!("repeated shutdown: {error}"))?;
     Ok(())
 }
 

--- a/crates/wisp-tools/src/process.rs
+++ b/crates/wisp-tools/src/process.rs
@@ -214,8 +214,10 @@ impl ProcessTree {
                 return Ok(true);
             }
             let error = io::Error::last_os_error();
+            if self.group_is_gone(&error) {
+                return Ok(false);
+            }
             return match error.raw_os_error() {
-                Some(libc::ESRCH) => Ok(false),
                 Some(libc::EPERM) => Ok(true),
                 _ => Err(error),
             };
@@ -262,19 +264,37 @@ impl ProcessTree {
     }
 
     #[cfg(unix)]
-    /// Returns whether the target process group existed when the signal was
-    /// issued. ESRCH permanently disarms this numeric PGID.
+    /// Returns whether the group may still contain live members. Missing
+    /// groups and confirmed macOS zombie-only groups disarm this numeric PGID.
     fn signal_group(&self, signal: libc::c_int) -> io::Result<bool> {
         let result = unsafe { libc::kill(-self.process_group, signal) };
         if result == 0 {
             return Ok(true);
         }
         let error = io::Error::last_os_error();
-        if error.raw_os_error() == Some(libc::ESRCH) {
+        if self.group_is_gone(&error) {
             Ok(false)
         } else {
             Err(error)
         }
+    }
+
+    #[cfg(unix)]
+    fn group_is_gone(&self, error: &io::Error) -> bool {
+        if error.raw_os_error() == Some(libc::ESRCH) {
+            return true;
+        }
+        // Darwin killpg skips zombies and returns EPERM when none of the
+        // remaining members can receive a signal. Do not confuse that with a
+        // real permission failure, or reap the leader before tree signalling.
+        #[cfg(target_os = "macos")]
+        if error.raw_os_error() == Some(libc::EPERM) {
+            return confirmed_zombie_group(
+                || macos_group_members(self.process_group),
+                |pid| macos_group_member_is_zombie(pid, self.process_group),
+            );
+        }
+        false
     }
 
     #[cfg(windows)]
@@ -323,6 +343,86 @@ impl ProcessTree {
             job,
         })
     }
+}
+
+// This fallback is used only after EPERM. Any incomplete or changing view is
+// inconclusive, so the original permission error remains visible. The second
+// membership snapshot catches children spawned between listing a live parent
+// and observing that parent as a zombie. No child is reaped by these queries.
+#[cfg(target_os = "macos")]
+fn confirmed_zombie_group(
+    mut members: impl FnMut() -> Option<Vec<libc::pid_t>>,
+    mut is_zombie: impl FnMut(libc::pid_t) -> bool,
+) -> bool {
+    let Some(before) = members().filter(|pids| !pids.is_empty()) else {
+        return false;
+    };
+    before.iter().all(|pid| is_zombie(*pid)) && members().as_ref() == Some(&before)
+}
+
+#[cfg(target_os = "macos")]
+fn macos_group_members(process_group: libc::pid_t) -> Option<Vec<libc::pid_t>> {
+    // sys/proc_info.h; this selector is not exported by our libc version.
+    const PROC_PGRP_ONLY: u32 = 2;
+    // Bound allocation if the OS returns an unexpected size. Inconclusive
+    // queries preserve EPERM rather than asserting that the group is dead.
+    const MAX_SNAPSHOT_BYTES: libc::c_int = 4 * 1024 * 1024;
+    let pid_size = std::mem::size_of::<libc::pid_t>();
+    // SAFETY: a null buffer and zero size request the required buffer size.
+    let needed = unsafe {
+        libc::proc_listpids(
+            PROC_PGRP_ONLY,
+            process_group as u32,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    if needed <= 0 || needed > MAX_SNAPSHOT_BYTES {
+        return None;
+    }
+    let mut pids = vec![0; (needed as usize).div_ceil(pid_size) + 32];
+    let capacity = (pids.len() * pid_size) as libc::c_int;
+    // SAFETY: pids is aligned, initialized storage of exactly capacity bytes.
+    let written = unsafe {
+        libc::proc_listpids(
+            PROC_PGRP_ONLY,
+            process_group as u32,
+            pids.as_mut_ptr().cast(),
+            capacity,
+        )
+    };
+    // A full buffer may be truncated if the group grew between queries.
+    if written <= 0 || written >= capacity || written as usize % pid_size != 0 {
+        return None;
+    }
+    pids.truncate(written as usize / pid_size);
+    if pids.iter().any(|pid| *pid <= 0) {
+        return None;
+    }
+    pids.sort_unstable();
+    Some(pids)
+}
+
+#[cfg(target_os = "macos")]
+fn macos_group_member_is_zombie(pid: libc::pid_t, process_group: libc::pid_t) -> bool {
+    // SAFETY: proc_bsdinfo is a C record whose fields all permit zero values.
+    let mut info: libc::proc_bsdinfo = unsafe { std::mem::zeroed() };
+    let size = std::mem::size_of_val(&info) as libc::c_int;
+    // SAFETY: info provides the buffer required by this flavor. arg=1 asks
+    // Darwin to include unreaped zombies. Query failures are inconclusive.
+    let written = unsafe {
+        libc::proc_pidinfo(
+            pid,
+            libc::PROC_PIDTBSDINFO,
+            1,
+            &mut info as *mut _ as *mut libc::c_void,
+            size,
+        )
+    };
+    written == size
+        && info.pbi_pid == pid as u32
+        && info.pbi_pgid == process_group as u32
+        && info.pbi_status == libc::SZOMB
 }
 
 impl Drop for ProcessTree {
@@ -422,5 +522,105 @@ mod tests {
 
         assert!(!tree.is_running().unwrap());
         assert_eq!(tree.state.load(Ordering::SeqCst), TREE_DISARMED);
+    }
+
+    #[cfg(target_os = "macos")]
+    async fn wait_for_zombie(pid: libc::pid_t) {
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                let mut info: libc::proc_bsdinfo = unsafe { std::mem::zeroed() };
+                let size = std::mem::size_of_val(&info) as libc::c_int;
+                // arg=1 includes unreaped zombies; do not call Child::try_wait
+                // here, since reaping would hide the macOS regression.
+                let read = unsafe {
+                    libc::proc_pidinfo(
+                        pid,
+                        libc::PROC_PIDTBSDINFO,
+                        1,
+                        &mut info as *mut _ as *mut libc::c_void,
+                        size,
+                    )
+                };
+                if read == size && info.pbi_status == libc::SZOMB {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("child must become an unreaped zombie");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[tokio::test]
+    async fn macos_zombie_group_disarms_without_losing_the_child_exit_status() {
+        use super::*;
+        // Exercise each entry point with a fresh, still-armed tree.
+        for operation in ["probe", "term", "kill"] {
+            let mut command = Command::new("sh");
+            command.args(["-c", "exit 23"]).kill_on_drop(true);
+            ProcessTree::configure(&mut command);
+            let mut child = command.spawn().unwrap();
+            let tree = ProcessTree::attach(&child).unwrap();
+            wait_for_zombie(tree.process_group).await;
+            assert_eq!(unsafe { libc::kill(-tree.process_group, 0) }, -1);
+            assert_eq!(io::Error::last_os_error().raw_os_error(), Some(libc::EPERM));
+            match operation {
+                "probe" => assert!(!tree.is_running().unwrap()),
+                "term" => tree.terminate_gracefully().unwrap(),
+                _ => tree.terminate_forcefully().unwrap(),
+            }
+            assert_eq!(tree.state.load(Ordering::SeqCst), TREE_DISARMED);
+            tree.terminate_gracefully().unwrap();
+            tree.terminate_forcefully().unwrap();
+            assert_eq!(child.wait().await.unwrap().code(), Some(23));
+            assert!(!tree.is_running().unwrap());
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_zombie_confirmation_rejects_unknown_live_or_changed_membership() {
+        use super::confirmed_zombie_group;
+        for snapshots in [
+            [None, None],
+            [Some(vec![]), Some(vec![])],
+            [Some(vec![1]), None],
+            [Some(vec![1]), Some(vec![1, 2])],
+            [Some(vec![1, 2]), Some(vec![1])],
+        ] {
+            let mut snapshots = snapshots.into_iter();
+            assert!(!confirmed_zombie_group(
+                || snapshots.next().flatten(),
+                |_| true
+            ));
+        }
+        assert!(!confirmed_zombie_group(|| Some(vec![1, 2]), |pid| pid == 1));
+        assert!(confirmed_zombie_group(|| Some(vec![1, 2]), |_| true));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[tokio::test]
+    async fn macos_live_group_does_not_turn_permission_errors_into_success() {
+        use super::*;
+        let mut command = Command::new("sh");
+        command
+            .args(["-c", "read line"])
+            .stdin(std::process::Stdio::piped())
+            .kill_on_drop(true);
+        ProcessTree::configure(&mut command);
+        let mut child = command.spawn().unwrap();
+        let tree = ProcessTree::attach(&child).unwrap();
+        // Inject EPERM without requiring a privileged/foreign process in tests.
+        assert!(!tree.group_is_gone(&io::Error::from_raw_os_error(libc::EPERM)));
+        assert!(!tree.group_is_gone(&io::Error::from_raw_os_error(libc::EACCES)));
+        assert_eq!(tree.state.load(Ordering::SeqCst), TREE_ACTIVE);
+        assert!(tree.is_running().unwrap());
+        tree.terminate_forcefully().unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(5), child.wait())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(!tree.is_running().unwrap());
     }
 }

--- a/docs/superpowers/specs/2026-07-14-wisp-runtime-design.md
+++ b/docs/superpowers/specs/2026-07-14-wisp-runtime-design.md
@@ -757,6 +757,13 @@ artifacts, not hidden runtime checkpoints.
   budget for one stop request is shared across the runtimes it covers: a worker that
   refuses to exit must never block an Agent turn, a project switch, or app exit.
   Stopping therefore also reclaims a background process a cell left running.
+- On macOS, a process group containing only unreaped zombies can make `killpg`
+  return `EPERM`. The shared process-tree boundary used by runtimes and MCP
+  checks complete group membership and zombie status before treating this case
+  as stopped. Permission errors, failed queries, and changing membership remain
+  errors; live descendants still receive TERM/KILL before the leader is reaped.
+  This lets an EOF-only MCP server close normally and preserves a crashed
+  runtime worker's original exit status in its startup diagnostic.
 - Arbitrary Python/R execution continues to use the existing approval system.
 - Code travels over inherited local/WSL/SSH stdio, not an unauthenticated listening
   port.


### PR DESCRIPTION
## 问题与修复

macOS 上，一个正常退出但尚未回收的 MCP server 会使 shutdown 返回 `Operation not permitted`；崩溃的 runtime worker 也可能丢失退出码，显示 `exit status unavailable`。

根因是 Darwin 对仅含僵尸进程的进程组发送信号时返回 EPERM，而共享 `ProcessTree` 把它当作真实终止失败。MCP/runtime 为避免 PGID 重用，需要保留组长直到完成组信号，不能通过无条件提前 wait 来解决。

本 PR 在共享边界增加 macOS 专用检查：只有在 EPERM 后获得完整、稳定的成员列表，并确认每个成员仍属于该组且状态为僵尸，才将进程树标记为已结束。随后原有 wait 路径回收子进程并取得真实退出码。存活成员、查询失败、截断结果或变化中的成员列表均保留原有错误处理。

## 变更范围

- `crates/wisp-tools/src/process.rs`：统一状态探测和信号错误的判断；通过现有 libc 的原生进程查询实现 macOS 检查，无新增依赖。
- `crates/wisp-mcp/tests/mcp_transport.rs`：覆盖 EOF 正常关闭后的重复 shutdown，并为关闭失败补充阶段信息。
- `crates/wisp-mcp/examples/smoke.rs`：明确验证 shutdown 成功。
- runtime 设计文档：说明 macOS 关闭语义和错误处理边界。

## 测试

- 新增 macOS 原生回归：僵尸组的 probe、TERM、KILL 三个入口均正确结束，且退出码 23 保留。该测试先在修复前失败，修复后通过。
- 新增保守判断测试：拒绝未知、存活或成员变化的情况；存活进程组不会因模拟 EPERM 被当作已结束。
- MCP 单元与 transport/process-tree 集成测试通过。
- 原先失败的 runtime 退出码诊断测试及 worker process-tree 集成测试通过。
- `UV_OFFLINE=1 cargo run -p wisp-mcp --example smoke` 通过。
- `cargo fmt --all -- --check` 通过。
- `WISP_CATALOG_OFFLINE=1 cargo test --workspace --no-fail-fast` 全部通过（退出码 0），包含 Run Manager 170 项、runtime 77 项、Store 166 项、Tauri 845 项、tools 71 项及 MCP/runtime 进程树集成测试；原先两项失败均已消除。

## 手动冒烟步骤

1. 在 macOS 启动一个收到 stdin EOF 后正常退出的 MCP server，执行请求后关闭，确认不再报 EPERM，重复关闭也成功。
2. 启动一个打印 stderr 后以 23 退出的 runtime worker，确认诊断保留 stderr 和退出码 23。
3. 使用仓库的 MCP/runtime process-tree fixture，确认组长已退出、后代仍存活或忽略 TERM 时，后代仍被 KILL 清理。

## 限制

无法完整确认进程组状态时继续保留原错误，不把所有 EPERM 都视为成功。修复仅在 macOS 条件编译路径启用，Linux/Windows 沿用原平台策略；本机未执行 Linux/Windows 原生测试。

Closes #1186

