### PR TITLE
Fix media Blob URL leaks during long WebView sessions

### DIFF
--- a/crates/wisp-dto/src/lib.rs
+++ b/crates/wisp-dto/src/lib.rs
@@ -28,6 +28,9 @@ pub struct UiHealthSnapshot {
     pub parked_apps: u32,
     pub app_messages: u32,
     pub drag_overlays: u32,
+    pub media_blob_urls: u32,
+    pub media_blob_bytes: u64,
+    pub media_owners: u32,
 }
 
 #[derive(Deserialize, Serialize, Clone, Copy, Debug, Default, Hash, PartialEq, Eq)]

--- a/docs/webview-recovery.md
+++ b/docs/webview-recovery.md
@@ -37,7 +37,10 @@ label and reload success/error. The heartbeat carries numeric diagnostics:
 - maximum visible-page timer delay and longest observed long task;
 - cumulative long-task, script-error and unhandled-rejection counts;
 - active and parked MCP App counts, cumulative incoming App messages;
-- current drag-overlay count.
+- current drag-overlay count;
+- live host media Blob URL count, encoded Blob bytes and mounted media-owner
+  count (`mediaBlobUrls`, `mediaBlobBytes`, `mediaOwners`). These exclude MCP
+  iframe images, decoded bitmaps, JS/WASM heaps and GPU allocations.
 
 Cumulative counters and maxima are bounded and reset with the document. No
 conversation text, plugin arguments, image data, URLs or error messages from
@@ -46,14 +49,39 @@ timer does **not** prove that clicks work: healthy heartbeats with a stuck UI
 call for checking overlays, pointer targeting and script failures. A native
 reload request being accepted also does not prove that navigation completed.
 
+## Long-running media sessions
+
+Host chat images, videos, attachment thumbnails and research-journal previews
+release their Blob URLs after both their mounted DOM owners and cache entries
+let go of them. Full-media cache retention is limited to 64 entries / 64 MiB;
+thumbnail retention is limited to 128 entries / 16 MiB. Mounted cards and
+in-flight decodes can exceed those cache budgets. Small thumbnails share their
+source URL safely, concurrent loads share work, and failed reads can be retried.
+These limits apply to encoded Blobs, not total renderer memory.
+
+This fixes a confirmed leak found during the #1179 follow-up: the previous
+caches deleted lookup entries without revoking Blob URLs, retaining media until
+the document was unloaded. It does **not** establish that this leak caused the
+reported Windows stall after approximately five hours. An idle window without
+media churn may have a different cause. The existing watchdog still handles
+heartbeat loss; there is no periodic forced reload of a healthy window.
+
 ## Validation
 
 Run the focused browser workload from `ui-tests`:
 
 ```powershell
 $env:UI_TEST_PORT="1432"
-npx playwright test tests/webview-health.spec.ts tests/long-session-stress.spec.ts tests/chat-responsive.spec.ts --workers=1
+npx playwright test tests/media-lifetime.spec.ts tests/webview-health.spec.ts tests/long-session-stress.spec.ts tests/chat-responsive.spec.ts --workers=1
 ```
+
+The media workload cycles through 600 thumbnail loads, checks live Blob counts
+after eviction, tests byte limits with large media, and covers shared URLs,
+concurrent reads and cards removed while loading. It is an accelerated
+lifecycle regression, not a five-hour WebView2 soak test. With 800×600 SVG
+fixtures, the original implementation retained 400 / 800 / 1200 Blob URLs
+after successive batches of 200 loads. The regression now checks that each
+batch returns to 192 (64 source URLs plus 128 downscaled thumbnail URLs).
 
 The mock workload combines a paginated long transcript, two simultaneous
 session streams, and two App instances with 96 local thumbnail cards each.
@@ -81,6 +109,14 @@ Manual Windows check: open two project windows, focus the second, then use the
 tray's stop and reload entries. Check the target label in the log, the first
 window's unchanged state, and existing Run records. For a stopped heartbeat,
 check that another window's healthy heartbeat cannot suppress target recovery.
+
+For the five-hour Windows report, record the installed Wisp and WebView2
+versions and compare `webview health` samples before and near the stall while
+repeating the actual workload for at least six hours. Track host Blob counts
+alongside the renderer's memory in Task Manager. Also compare an idle session.
+If it stalls, record whether tray **Reload last active window** restores input
+and whether the last heartbeats continued; this distinguishes page liveness
+from input/compositor failures. Check that existing backend Runs continue.
 
 ## Scope and follow-up
 

--- a/src-tauri/src/dto_contract_tests.rs
+++ b/src-tauri/src/dto_contract_tests.rs
@@ -593,7 +593,8 @@ fn research_calendar_contract_preserves_project_errors_and_truncation() {
 #[test]
 fn renderer_health_accepts_partial_numeric_snapshots() {
     let snapshot: wisp_dto::UiHealthSnapshot = serde_json::from_value(serde_json::json!({
-        "timerLagMs": 850, "activeApps": 1, "parkedApps": 2, "scriptErrors": 3
+        "timerLagMs": 850, "activeApps": 1, "parkedApps": 2, "scriptErrors": 3,
+        "mediaBlobUrls": 42, "mediaBlobBytes": 5_000_000_000_u64, "mediaOwners": 12
     }))
     .unwrap();
     assert_eq!(snapshot.timer_lag_ms, 850);
@@ -601,6 +602,15 @@ fn renderer_health_accepts_partial_numeric_snapshots() {
     assert_eq!(snapshot.parked_apps, 2);
     assert_eq!(snapshot.script_errors, 3);
     assert_eq!(snapshot.app_messages, 0);
+    assert_eq!(snapshot.media_blob_urls, 42);
+    assert_eq!(snapshot.media_blob_bytes, 5_000_000_000);
+    assert_eq!(snapshot.media_owners, 12);
+    assert_eq!(
+        serde_json::from_value::<wisp_dto::UiHealthSnapshot>(serde_json::json!({}))
+            .unwrap()
+            .media_blob_urls,
+        0
+    );
     let encoded = serde_json::to_value(snapshot).unwrap();
     assert_eq!(encoded["timerLagMs"], 850);
     assert!(

--- a/ui-tests/tests/media-lifetime.spec.ts
+++ b/ui-tests/tests/media-lifetime.spec.ts
@@ -1,0 +1,181 @@
+import { test, expect } from "@playwright/test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+// Exercise the production JS module with real browser Blobs, image decoding,
+// DOM removal and MutationObserver delivery. No model, filesystem IPC or GPU.
+test.beforeEach(async ({ page }) => {
+  await page.route("**/__media-test/**", async (route) => {
+    const file = new URL(route.request().url()).pathname.split("/").at(-1)!;
+    await route.fulfill(file === "index.html"
+      ? { contentType: "text/html", body: "<!doctype html><body></body>" }
+      : { contentType: "text/javascript", body: readFileSync(resolve(__dirname, "../../ui/src", file), "utf8") });
+  });
+  await page.goto("/__media-test/index.html");
+  await page.evaluate(async () => {
+    const w = window as any;
+    w.liveUrls = new Map<string, number>();
+    w.revokedUrls = new Set<string>();
+    w.duplicateRevokes = 0;
+    const create = URL.createObjectURL.bind(URL);
+    const revoke = URL.revokeObjectURL.bind(URL);
+    URL.createObjectURL = (blob: Blob) => {
+      const url = create(blob);
+      w.liveUrls.set(url, blob.size);
+      return url;
+    };
+    URL.revokeObjectURL = (url: string) => {
+      if (w.revokedUrls.has(url)) w.duplicateRevokes++;
+      w.revokedUrls.add(url);
+      w.liveUrls.delete(url);
+      revoke(url);
+    };
+    w.reads = 0;
+    w.readBytes = () => new TextEncoder().encode('<svg xmlns="http://www.w3.org/2000/svg" width="800" height="600"><rect width="800" height="600" fill="green"/></svg>');
+    w.__TAURI__ = { core: { invoke: async (cmd: string, args: any) => {
+      if (cmd === "ui_heartbeat") { w.health = args.snapshot; return; }
+      w.reads++;
+      return w.readBytes();
+    } } };
+    const moduleUrl = "/__media-test/api.js";
+    w.media = await import(moduleUrl);
+    w.media.start_ui_health();
+    w.owner = (id: string) => {
+      const node = document.createElement("div");
+      node.id = id;
+      document.body.append(node);
+      return node;
+    };
+    w.settle = () => new Promise((done) => setTimeout(done, 20));
+  });
+});
+
+test("repeated thumbnail eviction releases blobs and reaches a stable bound", async ({ page }) => {
+  const results = await page.evaluate(async () => {
+    const w = window as any;
+    const sizes: number[] = [];
+    for (let cycle = 0; cycle < 3; cycle++) {
+      for (let i = 0; i < 200; i++) {
+        const id = `thumb-${cycle}-${i}`;
+        const owner = w.owner(id);
+        const url = await w.media.media_thumbnail_url(id, id);
+        const img = new Image();
+        img.src = url;
+        await img.decode();
+        if (img.naturalWidth !== 384) throw new Error("thumbnail was not downscaled");
+        owner.remove();
+      }
+      await w.settle();
+      sizes.push(w.liveUrls.size);
+    }
+    w.media.report_ui_health();
+    await w.settle();
+    return { sizes, revoked: w.revokedUrls.size, duplicates: w.duplicateRevokes, health: w.health };
+  });
+  expect(results.sizes).toEqual([192, 192, 192]); // 64 full + 128 thumbnail cache slots
+  expect(results.revoked).toBeGreaterThan(900);
+  expect(results.duplicates).toBe(0);
+  expect(results.health).toMatchObject({ mediaBlobUrls: 192, mediaOwners: 0 });
+});
+
+test("concurrent reads share one URL and mounted owners survive cache eviction", async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    const w = window as any;
+    const a = w.owner("a");
+    const b = w.owner("b");
+    const urls = await Promise.all(Array.from({ length: 50 }, (_, i) => w.media.media_url("shared", i % 2 ? "a" : "b")));
+    const reads = w.reads;
+    for (let i = 0; i < 80; i++) {
+      const owner = w.owner(`other-${i}`);
+      await w.media.media_url(`other-${i}`, owner.id);
+      owner.remove();
+    }
+    // Reparenting a mounted owner must not release its reference.
+    b.append(a);
+    await w.settle();
+    const repeat = await w.media.media_url("shared", "a");
+    a.remove();
+    await w.settle();
+    const stillReadable = (await fetch(urls[0])).ok;
+    b.remove();
+    await w.settle();
+    return { unique: new Set(urls).size, reads, repeat: repeat === urls[0], stillReadable,
+      revoked: w.revokedUrls.has(urls[0]), live: w.liveUrls.size, duplicates: w.duplicateRevokes };
+  });
+  expect(result).toEqual({ unique: 1, reads: 1, repeat: true, stillReadable: true, revoked: true, live: 64, duplicates: 0 });
+});
+
+test("byte budget bounds large media while protecting the visible video slot", async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    const w = window as any;
+    w.readBytes = () => new Uint8Array(8 * 1024 * 1024);
+    const visible = w.owner("video");
+    const videoUrl = await w.media.media_url("video", visible.id);
+    for (let i = 0; i < 20; i++) {
+      const owner = w.owner(`large-${i}`);
+      await w.media.media_url(`large-${i}`, owner.id);
+      owner.remove();
+    }
+    await w.settle();
+    const sum = () => [...w.liveUrls.values()].reduce((a: number, b: any) => a + b, 0);
+    const pinnedBytes = sum();
+    const readable = (await fetch(videoUrl)).ok;
+    visible.remove();
+    await w.settle();
+    return { pinnedBytes, readable, cachedBytes: sum(), duplicates: w.duplicateRevokes };
+  });
+  expect(result).toEqual({ pinnedBytes: 72 * 1024 * 1024, readable: true, cachedBytes: 64 * 1024 * 1024, duplicates: 0 });
+});
+
+test("small thumbnails share source ownership across both cache evictions", async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    const w = window as any;
+    w.readBytes = () => new TextEncoder().encode('<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"/>');
+    const owner = w.owner("small");
+    const full = await w.media.media_url("small", owner.id);
+    const thumb = await w.media.media_thumbnail_url("small", owner.id);
+    for (let i = 0; i < 150; i++) {
+      const other = w.owner(`small-${i}`);
+      await w.media.media_thumbnail_url(other.id, other.id);
+      other.remove();
+    }
+    await w.settle();
+    const readable = (await fetch(thumb)).ok;
+    owner.remove();
+    await w.settle();
+    return { shared: full === thumb, readable, revoked: w.revokedUrls.has(thumb), live: w.liveUrls.size, duplicates: w.duplicateRevokes };
+  });
+  expect(result).toEqual({ shared: true, readable: true, revoked: true, live: 128, duplicates: 0 });
+});
+
+test("late loads cannot attach to a replacement owner and failed reads remain retryable", async ({ page }) => {
+  const result = await page.evaluate(async () => {
+    const w = window as any;
+    const bytes = w.readBytes();
+    let resolveRead: (bytes: Uint8Array) => void = () => {};
+    w.readBytes = () => new Promise<Uint8Array>((resolve) => { resolveRead = resolve; });
+    const removed = w.owner("pending");
+    const pending = w.media.media_url("pending", removed.id);
+    removed.remove();
+    w.owner("pending");
+    resolveRead(bytes);
+    const late = await pending;
+    const lateUrl = [...w.liveUrls.keys()][0];
+    w.readBytes = () => { throw new Error("missing"); };
+    const failures = await Promise.all(Array.from({ length: 150 }, (_, i) => w.media.media_thumbnail_url(`missing-${i}`, "pending")));
+    w.readBytes = () => bytes;
+    const recovered = await w.media.media_thumbnail_url("missing-0", "pending");
+    document.getElementById("pending")!.remove();
+    for (let i = 0; i < 70; i++) {
+      const owner = w.owner(`evict-${i}`);
+      await w.media.media_url(owner.id, owner.id);
+      owner.remove();
+    }
+    await w.settle();
+    w.media.report_ui_health();
+    await w.settle();
+    return { late, failed: failures.every((url) => url === null), recovered: recovered?.startsWith("blob:"),
+      lateReleased: w.revokedUrls.has(lateUrl), owners: w.health.mediaOwners, errors: w.health.unhandledRejections };
+  });
+  expect(result).toEqual({ late: null, failed: true, recovered: true, lateReleased: true, owners: 0, errors: 0 });
+});

--- a/ui/src/api.js
+++ b/ui/src/api.js
@@ -47,6 +47,7 @@ export function start_ui_health() {
       else parkedApps += 1;
     }
     const snapshot = { ...uiHealth, activeApps, parkedApps,
+      mediaBlobUrls, mediaBlobBytes, mediaOwners: mediaOwners.size,
       dragOverlays: document.querySelectorAll(".drag-overlay").length };
     // Counters are cumulative and bounded: a once-per-minute backend log cannot
     // miss a brief error or message burst between its sampled heartbeats.
@@ -1388,16 +1389,138 @@ function normalizeRawBytes(value) {
   throw new Error("Binary preview command returned an unsupported payload");
 }
 
-// Chat media (generated images/videos, attachment thumbnails, inline resource
-// images) used to inline as base64 data URLs — a 64 MB video became ~85 MB of
-// string per card, and repeated loads under row remounts pushed the WebView
-// renderer toward OOM (#dead-window). Instead, bytes are fetched through the
-// same preview command family and handed to the browser as a blob object URL:
-// decoded once by the media stack, shareable across cards with one entry per
-// path, and revocable when evicted.
-const MEDIA_URL_CACHE_LIMIT = 64;
-const mediaUrlCache = new Map(); // path -> { url, mime }
-const thumbnailJobs = new Map(); // path -> Promise<string | null>
+// Cache slots, in-flight conversions and mounted DOM owners each hold a
+// reference. Eviction releases its reference; only the last release revokes
+// the URL, so a visible video or a small thumbnail sharing its source survives.
+const mediaUrlCache = { entries: new Map(), bytes: 0, limit: 64, maxBytes: 64 * 1024 * 1024 };
+const thumbnailCache = { entries: new Map(), bytes: 0, limit: 128, maxBytes: 16 * 1024 * 1024 };
+const mediaJobs = new Map();
+const thumbnailJobs = new Map();
+const mediaOwners = new Map(); // Element -> Map<slot, entry>; actual DOM lifetime, not reactive owner lifetime
+let mediaOwnerObserver;
+let mediaSweepTimer;
+let mediaBlobUrls = 0;
+let mediaBlobBytes = 0;
+
+function createMediaEntry(blob) {
+  const entry = { url: URL.createObjectURL(blob), bytes: blob.size, refs: 1 };
+  mediaBlobUrls += 1;
+  mediaBlobBytes += entry.bytes;
+  return entry;
+}
+
+function retainMedia(entry) {
+  entry.refs += 1;
+  return entry;
+}
+
+function releaseMedia(entry) {
+  if (--entry.refs !== 0) return;
+  URL.revokeObjectURL(entry.url);
+  mediaBlobUrls -= 1;
+  mediaBlobBytes -= entry.bytes;
+}
+
+function cacheMedia(cache, key, entry) {
+  if (cache.entries.has(key)) cache.entries.delete(key);
+  else {
+    retainMedia(entry);
+    cache.bytes += entry.bytes;
+  }
+  cache.entries.set(key, entry);
+  while (cache.entries.size > cache.limit || cache.bytes > cache.maxBytes) {
+    const oldest = cache.entries.keys().next().value;
+    const removed = cache.entries.get(oldest);
+    cache.entries.delete(oldest);
+    cache.bytes -= removed.bytes;
+    releaseMedia(removed);
+  }
+}
+
+// Each caller receives one reference, including concurrent callers. The job
+// keeps its own reference until every waiter has acquired its result, even if
+// other loads evict that result from the cache in the meantime.
+async function acquireMedia(cache, jobs, key, produce) {
+  const cached = cache.entries.get(key);
+  if (cached) {
+    retainMedia(cached);
+    cacheMedia(cache, key, cached);
+    return cached;
+  }
+  let job = jobs.get(key);
+  if (!job) {
+    job = { promise: produce(), waiters: 0 };
+    jobs.set(key, job);
+  }
+  job.waiters += 1;
+  let entry;
+  try {
+    entry = await job.promise;
+    if (!entry) return null; // failures are retryable and occupy no cache slot
+    retainMedia(entry);
+    cacheMedia(cache, key, entry);
+    return entry;
+  } finally {
+    if (--job.waiters === 0) {
+      jobs.delete(key);
+      if (entry) releaseMedia(entry);
+    }
+  }
+}
+
+function sweepMediaOwners() {
+  mediaSweepTimer = undefined;
+  for (const [owner, entries] of mediaOwners) {
+    if (owner.isConnected) continue;
+    mediaOwners.delete(owner);
+    for (const entry of entries.values()) releaseMedia(entry);
+  }
+  if (!mediaOwners.size) {
+    mediaOwnerObserver?.disconnect();
+    mediaOwnerObserver = undefined;
+  }
+}
+
+async function ownedMediaUrl(path, ownerId, kind, acquire) {
+  // A CSR resource may start just before its view is inserted. Yield once;
+  // never keep loading for a card which has already left the document.
+  let owner = document.getElementById(ownerId);
+  if (!owner) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    owner = document.getElementById(ownerId);
+  }
+  if (!owner) return null;
+  const slot = `${kind}:${path}`;
+  const existing = mediaOwners.get(owner)?.get(slot);
+  if (existing) return existing.url;
+  let entry;
+  try { entry = await acquire(String(path || "")); }
+  catch { return null; }
+  if (!entry) return null;
+  if (!owner.isConnected) {
+    releaseMedia(entry);
+    return null;
+  }
+  let entries = mediaOwners.get(owner);
+  if (!entries) mediaOwners.set(owner, entries = new Map());
+  const previous = entries.get(slot);
+  if (previous) {
+    releaseMedia(entry);
+    return previous.url;
+  }
+  entries.set(slot, entry); // transfer the caller's reference to the DOM owner
+  if (!mediaOwnerObserver) {
+    mediaOwnerObserver = new MutationObserver((records) => {
+      if (mediaSweepTimer === undefined && records.some((record) => record.removedNodes.length)) {
+        // Coalesce streaming mutations; a node moved within the document keeps
+        // its lease. No full-document media scan or permanent polling timer.
+        mediaSweepTimer = setTimeout(sweepMediaOwners, 0);
+      }
+    });
+    mediaOwnerObserver.observe(document.documentElement, { childList: true, subtree: true });
+  }
+  return entry.url;
+}
 
 function mediaBytesCommand(path) {
   // Mirrors `previewBytes`'s command selection for the four path spellings.
@@ -1424,108 +1547,61 @@ function mediaBytesCommand(path) {
   return { command: "read_file_bytes", args: { path } };
 }
 
-export async function media_url(path) {
-  const key = String(path || "");
-  if (!key) return null;
-  const hit = mediaUrlCache.get(key);
-  if (hit) {
-    // Refresh insertion order so eviction is LRU.
-    mediaUrlCache.delete(key);
-    mediaUrlCache.set(key, hit);
-    return hit.url;
-  }
-  const { command, args } = mediaBytesCommand(key);
-  // One shot rather than invoke: a missing file must surface as null (the
-  // callers paint their fallback), not a console error.
-  const core = tauriCore();
-  if (!core) return null;
-  let bytes;
-  try {
-    bytes = normalizeRawBytes(await core.invoke(command, args));
-  } catch (_) {
-    return null;
-  }
-  const mime = blobMime(bytes);
-  const entry = { url: URL.createObjectURL(new Blob([bytes], { type: mime })), mime };
-  mediaUrlCache.set(key, entry);
-  if (mediaUrlCache.size > MEDIA_URL_CACHE_LIMIT) {
-    // Drop the lookup only. The URL may still be an <img>/<video> src
-    // (and media_thumbnail_url reuses it when the image is already small).
-    const oldest = mediaUrlCache.keys().next().value;
-    mediaUrlCache.delete(oldest);
-  }
-  return entry.url;
+function acquireFullMedia(key) {
+  return acquireMedia(mediaUrlCache, mediaJobs, key, async () => {
+    if (!key || !tauriCore()) return null;
+    const { command, args } = mediaBytesCommand(key);
+    const bytes = normalizeRawBytes(await tauriCore().invoke(command, args));
+    return createMediaEntry(new Blob([bytes], { type: blobMime(bytes) }));
+  });
 }
 
-// Thumbnails for attachment/artifact cards: a small canvas re-encode instead
-// of the full-resolution object URL, so a 20-message history of pasted photos
-// does not keep 20 decoded full-size bitmaps alive.
+/** The unique owner element must remain mounted for the returned URL's use. */
+export function media_url(path, ownerId) {
+  return ownedMediaUrl(path, ownerId, "full", acquireFullMedia);
+}
+
 const THUMB_MAX_EDGE = 384;
-// path -> downscaled blob URL. Kept (never revoked alongside the media cache)
-// because a thumbnail URL handed to the DOM must stay valid for the DOM's
-// lifetime; the thumbs are ≤384px re-encodes, so a bounded count of them is
-// the cheap side of the trade.
-const THUMB_CACHE_LIMIT = 128;
-const thumbnailCache = new Map();
 
-export async function media_thumbnail_url(path) {
-  const key = String(path || "");
-  if (!key) return null;
-  const cached = thumbnailCache.get(key);
-  if (cached !== undefined) return cached;
-  const pending = thumbnailJobs.get(key);
-  if (pending) return pending;
-  const job = (async () => {
-    const url = await media_url(key);
-    if (!url) {
-      thumbnailCache.set(key, null);
-      return null;
-    }
-    let thumb;
+export function media_thumbnail_url(path, ownerId) {
+  return ownedMediaUrl(path, ownerId, "thumb", (key) => acquireMedia(thumbnailCache, thumbnailJobs, key, async () => {
+    const source = await acquireFullMedia(key);
+    if (!source) return null;
     try {
-      thumb = await downscaleToPngBlobUrl(url, THUMB_MAX_EDGE);
-    } catch (_) {
-      thumb = url; // non-decodable or huge image: show it as-is
+      const blob = await downscaleToPngBlob(source.url, THUMB_MAX_EDGE);
+      if (blob) return createMediaEntry(blob);
+      return retainMedia(source); // small images and decode failures share the source
+    } finally {
+      releaseMedia(source);
     }
-    thumbnailCache.set(key, thumb);
-    if (thumbnailCache.size > THUMB_CACHE_LIMIT) {
-      // Drop the oldest entry's cache slot only; its URL may still be in the
-      // DOM, so revoking here would blank a live thumbnail.
-      const oldest = thumbnailCache.keys().next().value;
-      thumbnailCache.delete(oldest);
-    }
-    return thumb;
-  })();
-  thumbnailJobs.set(key, job.finally(() => thumbnailJobs.delete(key)));
-  return job;
+  }));
 }
 
-function downscaleToPngBlobUrl(url, maxEdge) {
-  return new Promise((resolve, reject) => {
+function downscaleToPngBlob(url, maxEdge) {
+  return new Promise((resolve) => {
     const img = new Image();
+    const finish = (blob) => {
+      img.onload = null;
+      img.onerror = null;
+      img.removeAttribute("src");
+      resolve(blob);
+    };
     img.onload = () => {
       try {
         const scale = Math.min(1, maxEdge / Math.max(img.naturalWidth, img.naturalHeight));
-        if (scale >= 1) {
-          resolve(url); // already small enough; reuse the media URL
-          return;
-        }
+        if (scale >= 1) { finish(null); return; }
         const canvas = document.createElement("canvas");
         canvas.width = Math.max(1, Math.round(img.naturalWidth * scale));
         canvas.height = Math.max(1, Math.round(img.naturalHeight * scale));
         canvas.getContext("2d").drawImage(img, 0, 0, canvas.width, canvas.height);
         canvas.toBlob((blob) => {
-          if (!blob) {
-            resolve(url);
-            return;
-          }
-          resolve(URL.createObjectURL(blob));
+          canvas.width = 0;
+          canvas.height = 0;
+          finish(blob);
         }, "image/png");
-      } catch (err) {
-        reject(err);
-      }
+      } catch { finish(null); }
     };
-    img.onerror = () => reject(new Error("image decode failed"));
+    img.onerror = () => finish(null);
     img.src = url;
   });
 }

--- a/ui/src/app_support/messages.rs
+++ b/ui/src/app_support/messages.rs
@@ -301,14 +301,19 @@ pub(crate) fn ImageGenerationCard(
     on_file: Callback<ModalArtifact>,
 ) -> impl IntoView {
     let locale = use_locale();
+    let dom_id = unique_dom_id("generated-media");
     let source = create_rw_signal(None::<String>);
     let preview_failed = create_rw_signal(false);
     if ok == Some(true) {
         let load_path = path.clone();
+        let owner_id = dom_id.clone();
         spawn_local(async move {
             // Full-resolution blob object URL from the shared cache — a data
             // URL here meant ~1.33x the file size as a string in the DOM.
-            match crate::bindings::media_url(&load_path).await.as_string() {
+            match crate::bindings::media_url(&load_path, &owner_id)
+                .await
+                .as_string()
+            {
                 Some(url) => {
                     let _ = source.try_set(Some(url));
                 }
@@ -338,6 +343,7 @@ pub(crate) fn ImageGenerationCard(
     view! {
         <article
             class="image-generation-card"
+            id=dom_id
             data-testid="image-generation-card"
             data-status=status
             data-path=path
@@ -415,15 +421,20 @@ pub(crate) fn ImageGenerationCard(
 #[component]
 pub(crate) fn VideoGenerationCard(path: String, ok: Option<bool>, output: String) -> impl IntoView {
     let locale = use_locale();
+    let dom_id = unique_dom_id("generated-media");
     let source = create_rw_signal(None::<String>);
     let preview_failed = create_rw_signal(false);
     if ok == Some(true) {
         let load_path = path.clone();
+        let owner_id = dom_id.clone();
         spawn_local(async move {
             // Blob object URL streamed by the browser's media stack. A 64 MB
             // MP4 inlined as base64 was ~85 MB of string in the DOM — the
             // worst offender of the renderer OOM reports.
-            match crate::bindings::media_url(&load_path).await.as_string() {
+            match crate::bindings::media_url(&load_path, &owner_id)
+                .await
+                .as_string()
+            {
                 Some(url) => {
                     let _ = source.try_set(Some(url));
                 }
@@ -451,6 +462,7 @@ pub(crate) fn VideoGenerationCard(path: String, ok: Option<bool>, output: String
     view! {
         <article
             class="video-generation-card"
+            id=dom_id
             data-testid="video-generation-card"
             data-status=status
             data-path=path
@@ -516,18 +528,21 @@ pub(crate) fn VideoGenerationCard(path: String, ok: Option<bool>, output: String
 #[component]
 pub(crate) fn AttachmentThumbnail(path: String, alt: String) -> impl IntoView {
     let source = create_rw_signal(None::<String>);
+    let dom_id = unique_dom_id("attachment-thumb");
+    let owner_id = dom_id.clone();
     let path_for_effect = path;
     create_effect(move |_| {
         let path = path_for_effect.clone();
+        let owner_id = owner_id.clone();
         spawn_local(async move {
-            let url = crate::bindings::media_thumbnail_url(&path)
+            let url = crate::bindings::media_thumbnail_url(&path, &owner_id)
                 .await
                 .as_string();
             let _ = source.try_set(url);
         });
     });
     view! {
-        <span class="attachment-thumbnail">
+        <span class="attachment-thumbnail" id=dom_id>
             {move || source.get().map_or_else(
                 || view! { <span class="attachment-thumbnail-placeholder">{compose_icon("image")}</span> }.into_view(),
                 |src| view! { <img src=src alt=alt.clone() /> }.into_view(),
@@ -554,7 +569,7 @@ fn ArtifactThumb(path: Option<String>, kind: &'static str) -> impl IntoView {
         // the artifact:/version:/ssh:// spellings `load_file_content` does.
         let dom_id_for_load = dom_id.clone();
         spawn_local(async move {
-            let url = crate::bindings::media_thumbnail_url(&path)
+            let url = crate::bindings::media_thumbnail_url(&path, &dom_id_for_load)
                 .await
                 .as_string();
             let Some(url) = url else { return };
@@ -961,7 +976,7 @@ pub(crate) fn AssistantMessage(
                 // repeated mounts of the same image reuse one blob instead of
                 // re-fetching and re-inlining its base64.
                 let path = format!("artifact-version:{version_id}");
-                let Some(url) = crate::bindings::media_url(&path).await.as_string() else {
+                let Some(url) = crate::bindings::media_url(&path, &dom_id).await.as_string() else {
                     continue;
                 };
                 let selector = format!(r#"#{dom_id} [data-resource-id="{}"]"#, resource.id);

--- a/ui/src/bindings.rs
+++ b/ui/src/bindings.rs
@@ -67,12 +67,13 @@ extern "C" {
     pub(crate) fn pasted_image_count(event: JsValue) -> usize;
     /// Chat media as a cached blob object URL (never a base64 data URL) —
     /// `null` when the file cannot be read, so callers paint their fallback.
+    /// `owner_id` is a unique mounted element that owns the URL until removal.
     #[wasm_bindgen(js_name = media_url)]
-    pub(crate) async fn media_url(path: &str) -> JsValue;
+    pub(crate) async fn media_url(path: &str, owner_id: &str) -> JsValue;
     /// Small canvas-downscaled variant of [`media_url`] for thumbnail-sized
     /// cards, so long histories do not keep full-size decoded bitmaps alive.
     #[wasm_bindgen(js_name = media_thumbnail_url)]
-    pub(crate) async fn media_thumbnail_url(path: &str) -> JsValue;
+    pub(crate) async fn media_thumbnail_url(path: &str, owner_id: &str) -> JsValue;
     #[wasm_bindgen(js_name = drag_has_files)]
     pub(crate) fn drag_has_files(event: JsValue) -> bool;
     #[wasm_bindgen(js_name = set_drag_copy)]

--- a/ui/src/research_journey.rs
+++ b/ui/src/research_journey.rs
@@ -7,7 +7,7 @@ use crate::dto::{
     ResearchJourneySource, RunRecord,
 };
 use crate::i18n::{t, Locale};
-use crate::text::{file_kind, parse_csv_line};
+use crate::text::{file_kind, parse_csv_line, unique_dom_id};
 use crate::window_capture_escape;
 use leptos::*;
 use std::collections::{BTreeMap, HashSet};
@@ -447,16 +447,19 @@ fn JourneyOutput(
     let kind = file_kind(&entry.title).unwrap_or("text");
     let path = format!("artifact-version:{}", entry.source_id);
     let discarded = entry.source_discarded;
+    let dom_id = unique_dom_id("journey-output");
+    let owner_id = dom_id.clone();
     let preview = create_local_resource(
         || (),
         move |_| {
             let path = path.clone();
+            let owner_id = owner_id.clone();
             async move {
                 if discarded {
                     return None;
                 }
                 if kind == "image" {
-                    media_thumbnail_url(&path)
+                    media_thumbnail_url(&path, &owner_id)
                         .await
                         .as_string()
                         .map(|s| (true, s))
@@ -472,7 +475,7 @@ fn JourneyOutput(
             }
         },
     );
-    view! {<button type="button" class="journey-output" class:selected=move || selected.get().is_some_and(|e|e.id==id) on:click=move |_|on_select.call(output.clone()) aria-label=entry.title.clone()>
+    view! {<button type="button" class="journey-output" id=dom_id class:selected=move || selected.get().is_some_and(|e|e.id==id) on:click=move |_|on_select.call(output.clone()) aria-label=entry.title.clone()>
         <div class="journey-output-preview">{move ||match preview.get().flatten(){
             Some((true,url))=>view!{<img src=url alt="" loading="lazy"/>}.into_view(),
             Some((false,text)) if kind=="csv" => {


### PR DESCRIPTION
Repeated image, video and thumbnail loads could retain media until the WebView document was unloaded: cache eviction deleted lookup entries without revoking Blob URLs, and concurrent full-media loads could allocate duplicate URLs. This change gives cached media explicit ownership and releases a URL after both its cache slots and mounted DOM owners let go.

Related to #1179. This fixes a reproduced accumulation leak found during the follow-up investigation; it does not establish the cause of the reported Windows stall after approximately five hours.

## Changes

- `ui/src/api.js`: share in-flight loads, reference-count cache/conversion/DOM ownership, and coalesce cleanup after DOM removal. Full-media retention is limited to 64 entries / 64 MiB; thumbnail retention to 128 entries / 16 MiB. Mounted media remains usable after cache eviction, including small thumbnails that share their source URL. Failed reads remain retryable.
- `ui/src/bindings.rs`, `app_support/messages.rs`, and `research_journey.rs`: give generated images/videos, attachments, inline resource images and journal previews unique DOM owners. Late results cannot attach to a replacement owner.
- `wisp-dto` and the desktop DTO contract test: add backward-compatible numeric `mediaBlobUrls`, `mediaBlobBytes`, and `mediaOwners` heartbeat diagnostics.
- `ui-tests/tests/media-lifetime.spec.ts` and `docs/webview-recovery.md`: add lifecycle regressions, cache limits, diagnostic scope and Windows soak-test instructions.

## Validation

A browser workload of three batches of 200 thumbnail loads retained **400 / 800 / 1200** Blob URLs with the original implementation. The fixed implementation returns to **192 / 192 / 192** (64 source URLs plus 128 downscaled thumbnails).

- Five browser regressions cover repeated eviction, concurrent readers, byte budgets, shared small-image URLs, DOM reparenting/removal, late results and retryable failures. All pass.
- `WISP_CATALOG_OFFLINE=1 cargo test --workspace -- --test-threads=1`: **2001 passed**. The initial default-parallel run hit a SQLite lock in the existing SSH harvest lease test; the complete single-thread run, including that test, passed.
- `cargo check --target wasm32-unknown-unknown` in `ui`: passed.
- Workspace and standalone UI format checks, plus `git diff --check`: passed.
- `npm ci`, then the full Playwright suite against a fixed Trunk build: **611 passed, 2 skipped**. Command: `PLAYWRIGHT_REUSE_SERVER=1 UI_TEST_PORT=1433 npx playwright test --workers=4 --fully-parallel`. The fixed build avoided an empty WASM asset encountered during a watched rebuild.

## Windows manual smoke and follow-up

Not yet performed on a real Windows WebView2 instance:

1. Open media-heavy chat history and journal previews; switch sessions repeatedly. Check that visible images and video controls still work while older cache entries are evicted.
2. Repeat the reported workload for at least six hours, recording Wisp/WebView2 versions, renderer memory and `webview health` samples. Compare an idle window as well.
3. If input stalls, record whether heartbeats continue and whether the tray's **Reload last active window** restores input. Verify existing backend Runs continue.

The budgets cover encoded cached Blobs. Mounted DOM owners and in-flight work can exceed them; these diagnostics exclude MCP iframe images, decoded bitmaps, JS/WASM heaps and GPU allocations. The remaining #1179 investigation needs the real Windows workload and logs.
