### PR TITLE
Close research journey when returning to Projects

### DIFF
--- a/docs/research-journey.md
+++ b/docs/research-journey.md
@@ -12,6 +12,12 @@
 
 Escape 每次只关闭最上层：产物查看器、补充记录或运行详情、关系详情，最后返回原工作区。也可以通过右上角关闭按钮返回。
 
+通过侧栏「返回项目」或命令面板「打开项目列表」回到首页时，研究历程会随项目视图一起关闭。再次进入项目后，可从侧栏重新打开研究历程，默认查看本月；旧的日期筛选和局部面板不会带回。即使从首页研究日历进入项目的请求尚未完成，先返回首页后，延迟结果也不会重新打开研究历程。
+
+Returning to Projects from the sidebar or command palette closes the project’s
+research journey. Reopening it starts in the current month. A delayed calendar
+drill-down response cannot reopen the journey after you have returned home.
+
 Windows 下研究历程位于集成标题栏下方，菜单和窗口控制按钮保持可用；使用原生标题栏的平台不额外留白。按日时间线和右侧来源栏、以及关系图列表不预留常驻滚动槽，滚动条叠在内容上、悬停时才显现，避免两条系统滚动条把版面切开。运行记录使用宽版弹窗，分区显示状态、运行环境、本地起止时间、退出码、执行命令及标准输出/标准错误的日志尾部。长命令和日志自动换行，内容在弹窗内滚动，关闭按钮始终可见；未记录的字段和空日志显示明确提示。
 
 ## 首页研究日历 / Home research calendar

--- a/ui-tests/tests/research-calendar.spec.ts
+++ b/ui-tests/tests/research-calendar.spec.ts
@@ -173,6 +173,37 @@ test("failed project drill-down returns to a recoverable home screen", async ({ 
   await expect(page.getByTestId("research-journey")).toBeVisible();
 });
 
+test("returning home before a calendar project opens prevents a late journey page", async ({ page }) => {
+  await open(page);
+  await page.evaluate(() => {
+    const core = (window as any).__TAURI__.core;
+    const invoke = core.invoke;
+    core.invoke = (cmd: string, args: any) => {
+      const id = args instanceof Map ? args.get("id") : args?.id;
+      if (cmd === "open_project" && id === "other") {
+        return new Promise((resolve, reject) => {
+          (window as any).__releaseCalendarProjectOpen = () => {
+            core.invoke = invoke;
+            return invoke(cmd, args).then(resolve, reject);
+          };
+        });
+      }
+      return invoke(cmd, args);
+    };
+  });
+  await page.getByTestId("home-calendar-details").getByRole("button", { name: "Other project · Research journey", exact: true }).click();
+  await expect.poll(() => page.evaluate(() => typeof (window as any).__releaseCalendarProjectOpen)).toBe("function");
+  await page.getByRole("button", { name: "Back to projects", exact: true }).click();
+  await expect(page.locator(".projects-screen")).toBeVisible();
+  await page.evaluate(() => (window as any).__releaseCalendarProjectOpen());
+  // This read is issued after the delayed open completes and attempts to show
+  // its requested day. Wait for that boundary rather than using a fixed sleep.
+  await expect.poll(() => page.evaluate(() => ((window as any).__skillInvokeLog ?? [])
+    .filter((call: any) => call.cmd === "get_research_graph").length)).toBeGreaterThan(0);
+  await expect(page.getByTestId("research-journey")).toHaveCount(0);
+  await expect(page.locator(".projects-screen")).toBeVisible();
+});
+
 test("capture home calendar visual QA", async ({ page }, testInfo) => {
   await page.setViewportSize({width:1488,height:1058});
   await page.goto("/?mockLocale=zh&mockJourney=design");

--- a/ui-tests/tests/research-journey.spec.ts
+++ b/ui-tests/tests/research-journey.spec.ts
@@ -17,6 +17,40 @@ async function open(page: Page, query = "") {
   await expect(page.getByTestId("research-journey")).toBeVisible();
 }
 
+for (const route of ["sidebar", "command palette"]) {
+  test(`returning home through the ${route} closes the research journey`, async ({ page }) => {
+    await page.addInitScript(() => Object.defineProperty(navigator, "platform", { get: () => "Win32" }));
+    await open(page);
+    const journey = page.getByTestId("research-journey");
+    await journey.getByTestId("journey-calendar").getByRole("button", { name: "2026-09-08", exact: true }).click();
+    if (route === "sidebar") {
+      await page.getByRole("button", { name: "Back to projects", exact: true }).click();
+    } else {
+      await page.keyboard.press("Control+p");
+      const input = page.locator("#action-palette-input");
+      await input.fill("Open projects");
+      await expect(page.locator(".action-palette-row.active")).toContainText("Open projects");
+      await input.press("Enter");
+    }
+    await expect(page.locator(".projects-screen")).toBeVisible();
+    await expect(journey).toHaveCount(0);
+    // Demo entry bypasses the normal project-switch reset. A hidden but still
+    // true journey flag must not revive the old project's page here.
+    await page.locator(".proj-example").click();
+    await expect(page.locator(".projects-screen")).toHaveCount(0);
+    await expect(journey).toHaveCount(0);
+    await page.getByRole("button", { name: "Back to projects", exact: true }).click();
+    await page.locator(".proj-card-main").first().click();
+    await expect(journey).toHaveCount(0);
+    await page.locator(".sidebar").getByRole("button", { name: "Research journey", exact: true }).click();
+    await expect(journey).toBeVisible();
+    await expect(journey.locator(".journey-day")).toHaveCount(3);
+    await page.keyboard.press("Escape");
+    await expect(journey).toHaveCount(0);
+    await expect(page.locator("#composer-input")).toBeVisible();
+  });
+}
+
 for (const platform of ["Windows NT 10.0; Win64; x64", "Macintosh; Intel Mac OS X 10_15_7"]) {
   test(`research journey respects the title bar on ${platform}`, async ({ browser }) => {
     const context = await browser.newContext({ userAgent: `Mozilla/5.0 (${platform}) AppleWebKit/537.36 Chrome/136 Safari/537.36` });

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -1553,6 +1553,17 @@ fn App() -> impl IntoView {
     let home_dialog_open = create_rw_signal(false);
     let calendar_journey_request = create_rw_signal(None::<(String, i64)>);
     let journey_initial_day = create_rw_signal(None::<i64>);
+    // Every home navigation path must dispose the project journey. Also watch
+    // its open flag while at home: a delayed calendar drill-down can set it
+    // after the user has already left the project.
+    create_effect(move |_| {
+        if show_projects.get() {
+            if show_research_graph.get() {
+                show_research_graph.set(false);
+            }
+            journey_initial_day.set(None);
+        }
+    });
     let show_publication_workspace = create_rw_signal(false);
     let publication_binding_source = create_rw_signal::<Option<PublicationEvidenceSource>>(None);
     create_effect(move |previous: Option<Option<String>>| {
@@ -10412,7 +10423,7 @@ fn App() -> impl IntoView {
                 can_insert=Signal::derive(move || !show_projects.get())
             />
         })}
-        {move || show_research_graph.get().then(|| view! {
+        {move || (!show_projects.get() && show_research_graph.get()).then(|| view! {
             <ResearchJourneyView
                 locale=locale
                 project_name=project_info.get().map(|p|p.name.clone()).unwrap_or_default()


### PR DESCRIPTION
## Problem and change

Returning to the Projects screen left the project’s Research Journey visible over the homepage. A delayed project open from the home research calendar could also reopen it after the user had returned home.

- `ui/src/main.rs` resets the journey’s open flag and initial day at the shared home-navigation boundary, including late calendar completions. Rendering is also restricted to the project view.
- `ui-tests/tests/research-journey.spec.ts` covers sidebar and command-palette return, entering the demo without reviving the old journey, and reopening with the current month.
- `ui-tests/tests/research-calendar.spec.ts` holds a project-open response until after returning home, then verifies that its completion cannot reopen the journey.
- `docs/research-journey.md` documents the navigation behavior.

## Validation

- Reproduced all three navigation regressions before the fix; the new tests pass after it.
- `cargo fmt --all -- --check` passed.
- `cd ui && cargo check --target wasm32-unknown-unknown --offline` passed.
- Trunk built the fixed frontend successfully.
- `cargo test --workspace --offline -- --test-threads=2` passed.
- `npm ci` completed; full Playwright suite: **646 passed, 2 skipped** (4 workers, mocked Tauri bridge).
- The manually released calendar-response regression was also rerun separately and passed.

## Manual smoke steps

1. Open a project and its Research Journey, select another date, then use the sidebar’s Back to projects button. Confirm the homepage is unobstructed.
2. Repeat through Ctrl+P / Cmd+P → Open projects. Open the demo or another project and confirm the previous journey does not reappear.
3. Reopen Research Journey explicitly. Confirm the current month is shown and Escape closes only the journey, leaving the project workspace open.
4. From the home research calendar, open a project’s day and return home while it is loading. Confirm the late response does not reopen Research Journey.

## Limitations / follow-up

Validation uses the browser with a mocked Tauri bridge. Smoke-test packaged Windows/macOS builds before release; existing desktop installations receive the fix through a new build.
