### PR TITLE
Isolate Windows MCP Apps into a native child WebView

### DIFF
--- a/crates/wisp-dto/src/lib.rs
+++ b/crates/wisp-dto/src/lib.rs
@@ -11,6 +11,9 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::rc::Rc;
 
+mod mcp_app_child;
+pub use mcp_app_child::*;
+
 /// Identifies a stopped ACP turn in persisted errors and invoke rejections.
 /// The UI must not offer native HTTP transcript recovery for these errors.
 pub const ACP_TURN_ERROR_PREFIX: &str = "ACP turn failed: ";

--- a/crates/wisp-dto/src/mcp_app_child.rs
+++ b/crates/wisp-dto/src/mcp_app_child.rs
@@ -1,0 +1,71 @@
+//! Internal desktop App-host contract. Not an extension to the MCP wire protocol.
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct McpAppHostInfo {
+    pub backend: String,
+    pub owner_epoch: String,
+}
+
+/// CSS client coordinates plus the primary document's viewport. Native bounds
+/// are calculated from the actual WebView size, not a guessed system DPI.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct McpAppChildBounds {
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+    pub viewport_width: f64,
+    pub viewport_height: f64,
+    pub visible: bool,
+    pub revision: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct McpAppChildHandle {
+    pub owner_epoch: String,
+    pub mount_serial: u64,
+    pub child_label: String,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum McpAppChildCloseReason {
+    Suspend,
+    UserClose,
+    Replace,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpAppChildBootstrap {
+    pub handle: McpAppChildHandle,
+    pub instance_id: String,
+    pub payload: Value,
+    pub host_context: Value,
+    pub version: String,
+    pub server_tools_available: bool,
+}
+
+/// Both endpoints validate the method allowlist; plugin strings are never
+/// concatenated into executable JavaScript when delivering this envelope.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpAppChildDelivery {
+    pub kind: String,
+    pub request_id: Option<String>,
+    pub method: Option<String>,
+    pub params: Value,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpAppChildRequest {
+    pub id: Option<Value>,
+    pub method: String,
+    pub params: Value,
+}

--- a/crates/wisp-mcp/src/client.rs
+++ b/crates/wisp-mcp/src/client.rs
@@ -277,6 +277,27 @@ impl Drop for CancellationCleanup<'_> {
 }
 
 impl McpClient {
+    /// Local transport liveness only; never issue a network probe or a tool
+    /// call just to advertise the App capability. HTTP remains best-effort.
+    pub fn is_connected(&self) -> bool {
+        match &self.transport {
+            Transport::Stdio {
+                closing,
+                terminated,
+                child,
+                ..
+            } => {
+                !closing.load(Ordering::SeqCst)
+                    && !terminated.load(Ordering::SeqCst)
+                    && child.try_lock().map_or(true, |mut child| {
+                        child
+                            .as_mut()
+                            .is_some_and(|child| matches!(child.try_wait(), Ok(None)))
+                    })
+            }
+            Transport::Http(_) => true,
+        }
+    }
     /// Spawn `command args...` and perform the MCP initialize handshake.
     pub async fn launch(command: &str, args: &[String]) -> Result<Self> {
         let mut cmd = tokio::process::Command::new(command);

--- a/crates/wisp-mcp/src/tool.rs
+++ b/crates/wisp-mcp/src/tool.rs
@@ -158,6 +158,11 @@ impl McpAppServerHandle {
 
 #[async_trait]
 impl McpAppServer for McpAppServerHandle {
+    fn is_connected(&self) -> bool {
+        self.client
+            .upgrade()
+            .is_some_and(|client| client.is_connected())
+    }
     fn connector_id(&self) -> &str {
         &self.connector_id
     }

--- a/crates/wisp-runs/src/snapshot_store.rs
+++ b/crates/wisp-runs/src/snapshot_store.rs
@@ -38,6 +38,9 @@ pub fn capture_file(
     };
     reject_project_symlinks(project_root, source)?;
     let metadata = std::fs::symlink_metadata(&source_path).map_err(|error| error.to_string())?;
+    if metadata.file_type().is_symlink() {
+        return Err("artifact snapshots do not follow symlinks".into());
+    }
     if !metadata.is_file() {
         return Err(format!("'{}' is not a regular file", source.display()));
     }
@@ -200,16 +203,23 @@ fn verify_blob(path: &Path, expected_checksum: &str, expected_size: u64) -> Resu
 fn reject_project_symlinks(project_root: &Path, source: &Path) -> Result<(), String> {
     // macOS exposes the temporary directory through `/var` while canonical
     // input paths use `/private/var`. Compare against the physical root so a
-    // path that is genuinely inside the project is not rejected.
+    // path that is genuinely inside the project is not rejected. dunce avoids
+    // Windows `\\?\` prefixes that would fail strip_prefix.
+    let logical_root = project_root;
     let project_root =
-        dunce::canonicalize(project_root).unwrap_or_else(|_| project_root.to_path_buf());
-    let source_path = if source.is_absolute() {
-        source.to_path_buf()
+        dunce::canonicalize(logical_root).unwrap_or_else(|_| logical_root.to_path_buf());
+    // Walk the requested path. Canonicalizing the leaf first would follow a
+    // source symlink and treat its target as a regular in-project file.
+    let source = if source.is_absolute() {
+        source
+            .strip_prefix(logical_root)
+            .or_else(|_| source.strip_prefix(&project_root))
+            .map(|relative| project_root.join(relative))
+            .unwrap_or_else(|_| source.to_path_buf())
     } else {
         project_root.join(source)
     };
-    let canonical_source = dunce::canonicalize(&source_path).map_err(|error| error.to_string())?;
-    let relative = canonical_source
+    let relative = source
         .strip_prefix(&project_root)
         .map_err(|_| "artifact path is outside project root".to_string())?;
     let mut current = project_root;
@@ -303,7 +313,7 @@ mod tests {
 
         let error =
             capture_file(&root, &root.join("link.txt"), SnapshotPolicy::Always).unwrap_err();
-        assert!(error.contains("symlink"));
+        assert!(error.contains("symlink"), "{error}");
 
         let _ = std::fs::remove_dir_all(root);
     }

--- a/crates/wisp-runs/src/snapshot_store.rs
+++ b/crates/wisp-runs/src/snapshot_store.rs
@@ -31,14 +31,19 @@ pub fn capture_file(
     source: &Path,
     policy: SnapshotPolicy,
 ) -> Result<CapturedFile, String> {
+    let source_path = if source.is_absolute() {
+        source.to_path_buf()
+    } else {
+        project_root.join(source)
+    };
     reject_project_symlinks(project_root, source)?;
-    let metadata = std::fs::symlink_metadata(source).map_err(|error| error.to_string())?;
+    let metadata = std::fs::symlink_metadata(&source_path).map_err(|error| error.to_string())?;
     if !metadata.is_file() {
         return Err(format!("'{}' is not a regular file", source.display()));
     }
 
     let root = dunce::canonicalize(project_root).map_err(|error| error.to_string())?;
-    let source = dunce::canonicalize(source).map_err(|error| error.to_string())?;
+    let source = dunce::canonicalize(&source_path).map_err(|error| error.to_string())?;
     if !source.starts_with(&root) {
         return Err(format!(
             "artifact path '{}' is outside project root",
@@ -196,19 +201,15 @@ fn reject_project_symlinks(project_root: &Path, source: &Path) -> Result<(), Str
     // macOS exposes the temporary directory through `/var` while canonical
     // input paths use `/private/var`. Compare against the physical root so a
     // path that is genuinely inside the project is not rejected.
-    let logical_root = project_root;
-    let project_root = logical_root
-        .canonicalize()
-        .unwrap_or_else(|_| logical_root.to_path_buf());
-    let source = if source.is_absolute() {
-        source
-            .strip_prefix(logical_root)
-            .map(|relative| project_root.join(relative))
-            .unwrap_or_else(|_| source.to_path_buf())
+    let project_root =
+        dunce::canonicalize(project_root).unwrap_or_else(|_| project_root.to_path_buf());
+    let source_path = if source.is_absolute() {
+        source.to_path_buf()
     } else {
         project_root.join(source)
     };
-    let relative = source
+    let canonical_source = dunce::canonicalize(&source_path).map_err(|error| error.to_string())?;
+    let relative = canonical_source
         .strip_prefix(&project_root)
         .map_err(|_| "artifact path is outside project root".to_string())?;
     let mut current = project_root;
@@ -304,6 +305,28 @@ mod tests {
             capture_file(&root, &root.join("link.txt"), SnapshotPolicy::Always).unwrap_err();
         assert!(error.contains("symlink"));
 
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn canonical_source_with_logical_root_is_contained() {
+        let root =
+            std::env::temp_dir().join(format!("wisp_snapshot_canonical_{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&root).unwrap();
+        let source = root.join("input.txt");
+        std::fs::write(&source, "bounded input").unwrap();
+        let canonical = dunce::canonicalize(&source).unwrap();
+        reject_project_symlinks(&root, &canonical).unwrap();
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn relative_source_is_resolved_against_project_root() {
+        let root = std::env::temp_dir().join(format!("wisp_snapshot_rel_{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(root.join("input.txt"), "hello").unwrap();
+        let captured = capture_file(&root, Path::new("input.txt"), SnapshotPolicy::Always).unwrap();
+        assert_eq!(captured.size_bytes, 5);
         let _ = std::fs::remove_dir_all(root);
     }
 

--- a/crates/wisp-tools/src/env.rs
+++ b/crates/wisp-tools/src/env.rs
@@ -15,6 +15,11 @@ use std::sync::Arc;
 /// connection secrets stay on the host and are reused via the existing client.
 #[async_trait]
 pub trait McpAppServer: Send + Sync {
+    /// Cheap liveness probe, without sending a tool request or exposing the
+    /// connection to the guest. Implementations with weak clients override it.
+    fn is_connected(&self) -> bool {
+        true
+    }
     /// Host-readable connector identity for audit and approval UI.
     fn connector_id(&self) -> &str;
     /// Human app name for audit and approval UI.

--- a/crates/wisp-tools/src/network.rs
+++ b/crates/wisp-tools/src/network.rs
@@ -57,13 +57,21 @@ mod tests {
                 )
             })
             .collect::<std::collections::HashMap<_, _>>();
-        assert_eq!(envs["HTTPS_PROXY"], "http://localhost:7890");
-        assert_eq!(envs["https_proxy"], "http://localhost:7890");
-        assert_eq!(envs["no_proxy"], "");
+        // Windows Command env keys are case-insensitive, so both spellings
+        // collapse to one entry. Look up ignore-case instead of requiring
+        // both HashMap keys to exist.
+        let get = |name: &str| {
+            envs.iter()
+                .find(|(key, _)| key.eq_ignore_ascii_case(name))
+                .map(|(_, value)| value.as_str())
+        };
+        assert_eq!(get("HTTPS_PROXY"), Some("http://localhost:7890"));
+        assert_eq!(get("https_proxy"), Some("http://localhost:7890"));
+        assert_eq!(get("no_proxy"), Some(""));
         command.envs(proxy_env("none"));
-        assert!(command
-            .get_envs()
-            .any(|(k, v)| k == "NO_PROXY" && v == Some(std::ffi::OsStr::new("*"))));
+        assert!(command.get_envs().any(|(k, v)| {
+            k.eq_ignore_ascii_case("NO_PROXY") && v == Some(std::ffi::OsStr::new("*"))
+        }));
     }
 
     #[test]

--- a/docs/mcp-app-isolation.md
+++ b/docs/mcp-app-isolation.md
@@ -1,0 +1,168 @@
+# Windows MCP App renderer isolation
+
+## Scope and user-visible behavior
+
+On Windows, an MCP App still occupies the center split pane, but its document
+no longer lives inside the primary chat document. A native child WebView hosts
+a small trusted shell and an opaque-origin `sandbox="allow-scripts"` iframe.
+The child uses a new WebView2 data directory for each mount; it never receives
+the primary window's profile. macOS/Linux retain the legacy iframe backend.
+
+The host toolbar, Reload App button, tab close controls, sidebar, composer and
+Stop stay in the primary document. Creation errors are visible and retryable;
+there is **no Windows production fallback to a primary-document iframe**.
+
+This work sits on current `main` (including #1188). Host chat images, videos
+and thumbnails keep the media owner / `revokeObjectURL` stack; isolation does
+not replace it. #1188 still excludes MCP iframe images from host Blob
+diagnostics. On Windows those App images now live in the child WebView
+instead of the primary document.
+
+Leaving a tab or session invalidates the child's identity immediately, then
+destroys its native view. Reopening creates a new generation and sends the
+saved inputs/results, without automatically replaying a tool call. This is not
+full UI-state restoration: unsubmitted selections, page positions and edits
+may be lost. The UI displays this warning. Already dispatched server-side
+effects cannot be undone by closing the view, and the MCP connection or remote
+Run is not terminated. A disconnected original server is not advertised as
+`serverTools`; the restored viewer displays an unavailable-connection notice.
+
+## Native compatibility and authority
+
+Adding a child makes Tauri's single-view `WebviewWindow` lookup/extractor stop
+matching the owner window. `WorkspaceSurface` therefore holds a `Window` and
+its primary `Webview` explicitly. Workspace command injection accepts only a
+real primary document (its label equals its native window label), never a
+`mcp-app-child-*` caller. Reload/eval operate on that primary document; native
+size/menu/tray operations operate on the native window. `WorkspaceManager`
+enumerates primary surfaces rather than assuming one WebView per window.
+
+Tauri remains locked to the existing dependency versions; only its `unstable`
+feature is enabled for `Window::add_child()`. The migrated references across
+command modules are deliberate, not a rename of the native window object.
+
+All capabilities now target **webview labels**, not native-window labels.
+The child capability grants **no core/plugin permissions** (`permissions: []`).
+Application commands are registered globally, so the invoke handler is the
+fail-closed second layer: it denies every child command except bootstrap,
+ready, protocol request and action reply. A child cannot use workspace
+settings, filesystem, dialog, event subscriptions, window controls or
+another session's bridge.
+
+The Rust registry binds owner label, owner document epoch, mount serial,
+child label, instance/session identity and bridge generation. Serial
+tombstones fence close-before-create races. Old creation replies never choose
+the active tab; old close operations cannot revoke a newer bridge generation.
+Logical references survive suspension and are counted across windows. Final
+user close releases only the corresponding logical binding/context/bridge.
+
+No registry lock is held while constructing or destroying native WebViews.
+`add_child` and native hide/close share `native_ops` so a retired label cannot
+be created after close. Construction uses `spawn_blocking` and does not hold
+`native_ops` while waiting for the shell to become ready. Close invalidates
+first, hides the view, sends optional resource teardown, and closes natively
+after at most a 500 ms grace period without waiting for guest JavaScript.
+Generated profile cleanup retries independently when WebView2 still holds
+files; it only targets generated leaf profiles under this feature's per-boot
+directory. A process exit during cleanup can leave a disposable profile
+directory; do not erase user profiles to fix it.
+
+## Protocol and layout
+
+```
+guest iframe -> child shell -> restricted Rust request -> original MCP server
+```
+
+Tool traffic does not pass through primary-page JavaScript. The shared Rust
+tool service retains same-server visibility, schema checking, approval and
+Plan Mode gates, 3 MiB arguments, 4 MiB results, 30 s execution timeout, four
+concurrent calls and twenty calls per ten seconds. Identity is rechecked
+after asynchronous approval and after tool completion. Motif host actions
+carry the current handle and a bounded request/response id; a stale reply
+cannot reach a replacement view. Large payloads are targeted, not broadcast.
+
+The child shell and legacy host share CSP/Motif document helpers. Guest
+messages require the iframe's exact `event.source` and opaque `null` origin.
+The shell permits only its own local navigation; new windows/downloads are
+denied. It does not grant `allow-same-origin`, filesystem or connection secrets.
+
+The primary page measures a dedicated content rectangle beneath host controls.
+CSS client coordinates plus the actual primary-WebView physical size determine
+bounds (including DPI/page zoom). Child `set_bounds` is relative to the parent
+window client area; the primary document fills that area, so the origin is
+(0, 0). The primary webview's `position()` is not added, because a
+webview-window reports a desktop-relative inner position. Resize and mutation
+observation, scroll/resize events and ancestor-animation tracking coalesce
+updates by frame.
+Only bounds/context are resent, never the HTML. Host interactions hide the
+native view before opening host overlays; semantic overlays and hit-testing
+keep it hidden until the active view is unobscured. Native resize/minimize
+hides stale geometry. Guest Escape explicitly returns focus to the primary
+document and dispatches to its existing window Escape stack.
+
+## Validation and release gates
+
+Automated entry points (PowerShell, from the worktree):
+
+```powershell
+$env:WISP_CATALOG_OFFLINE = '1'
+cargo fmt --all -- --check
+cargo check -p wisp-tauri --offline
+cargo test --workspace --offline
+cargo run -p wisp-mcp --example smoke --offline
+cargo run -p wisp-tauri --example webview_recovery_smoke --offline
+$env:WISP_ISOLATION_CYCLES = '100'
+cargo run -p wisp-tauri --example mcp_app_isolation_smoke --offline
+Push-Location ui
+cargo check --target wasm32-unknown-unknown --offline
+Pop-Location
+Push-Location ui-tests
+npx --no-install playwright test
+Pop-Location
+```
+
+The native isolation probe uses hidden disposable windows, fake sessions,
+the production native registry/create/close implementation and production
+child shell. Its profiles are under `target/mcp-isolation-smoke/`. It records
+browser/renderer process trees, runs a bounded 20-second guest block, exercises
+primary DOM control handlers during the block, rejects a child workspace IPC,
+tests scoped native Stop, closes a blocked child and cycles mount/destruction.
+It waits for profile cleanup and asserts no orphan controllers. It does not
+instantiate the normal database, normal Wisp plugins or real remote tasks.
+
+Browser tests explicitly distinguish a native-backend mock (no primary
+iframe) from legacy iframe regression. They cover mount/suspend/rebuild,
+close-before-create, fail-closed creation/retry, geometry, host occlusion,
+Escape, Motif host selection and direct shell protocol. Existing MCP/Motif
+business tests remain important; native mock success is not real WebView2
+acceptance. `WISP_MOTIF_APP_HTML` and `WISP_SNAPGENE_FIXTURE` are optional local
+fixture inputs for the pre-existing real-Motif tests; absence is a skip, not
+a pass.
+
+Before release, **also** verify visibly in disposable Windows environments:
+
+- Real SFL paging/details/selection/tools, Motif local/project imports and
+  selection-to-composer, real approval and Plan Mode transitions.
+- Actual primary mouse/keyboard interactions and heartbeat within 1 s during
+  guest blockage, with no primary reload. The hidden smoke's programmatic DOM
+  events alone do not cover all physical focus/hit-test behavior.
+- 100%, 150%, 200% DPI; maximization, cross-monitor movement, zoom, split-pane
+  dragging, host menus/modals over the guest, Escape and focus return.
+- Long-session / large-result / dual-stream replay without Apps, then with SFL
+  paging. Capture performance traces if primary rendering still stalls.
+- macOS/Linux build and legacy behavior (Windows checks cannot substitute).
+
+Do not close the original freeze issue solely because isolation code compiles
+or a blocked view can be reloaded. This change removes one propagation path;
+it does not establish the initial JavaScript/layout call stack that froze the
+user's original chat. No claim is made that every long-chat bottleneck is fixed.
+
+## Separate Windows baseline regression fixes
+
+The full-workspace run also exposed existing Windows path/env mismatches:
+`snapshot_store` relative/canonical containment, a case-sensitive `.R`
+expectation in a resource-lease test, and `Command` env lookups that assumed
+distinct `https_proxy` / `HTTPS_PROXY` keys. These small Windows
+compatibility fixes are separate from renderer isolation.
+The capability regression assertion was updated from native-window matching
+to primary-WebView matching as part of the isolation change.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,7 +18,7 @@ serde_json = "1"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls-native-roots"] }
 
 [dependencies]
-tauri = { version = "2", features = ["devtools", "tray-icon"] }
+tauri = { version = "2", features = ["devtools", "tray-icon", "unstable"] }
 tauri-plugin-dialog = "2"
 tauri-plugin-notification = "2"
 tauri-plugin-opener = "2"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -2,7 +2,7 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "Main window IPC: core APIs and agent event stream",
-  "windows": ["main", "proj-*", "home-*"],
+  "webviews": ["main", "proj-*", "home-*"],
   "remote": {
     "urls": ["http://localhost:1421", "http://127.0.0.1:1421"]
   },

--- a/src-tauri/capabilities/mcp-app-child.json
+++ b/src-tauri/capabilities/mcp-app-child.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "mcp-app-child",
+  "description": "Trusted local MCP shell: no plugin, event, window or filesystem permissions. App IPC is additionally restricted by caller label and the native registry.",
+  "webviews": ["mcp-app-child-*"],
+  "permissions": []
+}

--- a/src-tauri/capabilities/pet.json
+++ b/src-tauri/capabilities/pet.json
@@ -2,7 +2,7 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "pet",
   "description": "Pet window IPC and native dragging",
-  "windows": ["pet"],
+  "webviews": ["pet"],
   "remote": {
     "urls": ["http://localhost:1421", "http://127.0.0.1:1421"]
   },

--- a/src-tauri/capabilities/terminal.json
+++ b/src-tauri/capabilities/terminal.json
@@ -2,7 +2,7 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "terminal",
   "description": "Terminal window IPC: PTY stream and window controls",
-  "windows": ["terminal-*"],
+  "webviews": ["terminal-*"],
   "remote": {
     "urls": ["http://localhost:1421", "http://127.0.0.1:1421"]
   },

--- a/src-tauri/examples/mcp_app_isolation_smoke.rs
+++ b/src-tauri/examples/mcp_app_isolation_smoke.rs
@@ -1,0 +1,431 @@
+//! Disposable native renderer isolation probe. No Store, MCP connection,
+//! single-instance plugin, normal Wisp profile, or remote run is constructed.
+//! Run: cargo run -p wisp-tauri --example mcp_app_isolation_smoke --offline
+//! Optional: WISP_ISOLATION_CYCLES=100. Results remain in target/.
+use serde_json::{json, Value};
+use std::{
+    borrow::Cow,
+    collections::HashMap,
+    sync::Mutex,
+    time::{Duration, Instant},
+};
+use tauri::{Manager, Webview};
+use wisp_dto::{McpAppChildBootstrap, McpAppChildBounds, McpAppChildRequest};
+#[path = "../src/mcp_app_children.rs"]
+#[allow(dead_code)]
+mod mcp_app_children;
+#[path = "../src/ui_health.rs"]
+#[allow(dead_code)]
+mod ui_health;
+#[path = "../src/workspace_surface.rs"]
+#[allow(dead_code)]
+mod workspace_surface;
+use mcp_app_children::{Child, McpAppChildren};
+use workspace_surface::{WorkspaceManager, WorkspaceSurface};
+
+#[derive(Default)]
+struct AppState {
+    beats: Mutex<HashMap<String, u64>>,
+    actions: Mutex<Vec<String>>,
+    child_events: Mutex<Vec<String>>,
+    stopped: Mutex<Vec<String>>,
+}
+impl AppState {
+    fn active_frame(&self, label: &str) -> Option<String> {
+        (label == "main").then(|| "fake-session".into())
+    }
+}
+mod agent_turn {
+    pub async fn stop_agent(
+        state: tauri::State<'_, super::AppState>,
+        id: Option<String>,
+    ) -> Result<(), String> {
+        state
+            .stopped
+            .lock()
+            .unwrap()
+            .push(id.expect("stop must be scoped"));
+        Ok(())
+    }
+}
+#[tauri::command]
+fn smoke_tick(window: WorkspaceSurface, state: tauri::State<'_, AppState>) {
+    *state
+        .beats
+        .lock()
+        .unwrap()
+        .entry(window.label().into())
+        .or_default() += 1;
+}
+#[tauri::command]
+fn smoke_control(window: WorkspaceSurface, state: tauri::State<'_, AppState>, action: String) {
+    state
+        .actions
+        .lock()
+        .unwrap()
+        .push(format!("{}:{action}", window.label()));
+}
+#[tauri::command]
+fn mcp_app_child_bootstrap(
+    webview: Webview,
+    app: tauri::AppHandle,
+) -> Result<McpAppChildBootstrap, String> {
+    let child = mcp_app_children::caller_child(&app, &webview)?;
+    Ok(McpAppChildBootstrap {
+        handle: child.handle,
+        instance_id: child.instance_id,
+        payload: (*child.payload).clone(),
+        host_context: json!({}),
+        version: "smoke".into(),
+        server_tools_available: false,
+    })
+}
+#[tauri::command]
+fn mcp_app_child_ready(webview: Webview, app: tauri::AppHandle) -> Result<(), String> {
+    let child = mcp_app_children::caller_child(&app, &webview)?;
+    mcp_app_children::set_ready(&app, &child.handle.child_label)?;
+    Ok(())
+}
+#[tauri::command]
+fn mcp_app_child_request(
+    webview: Webview,
+    app: tauri::AppHandle,
+    request: McpAppChildRequest,
+) -> Result<Value, String> {
+    let _ = mcp_app_children::caller_child(&app, &webview)?;
+    app.state::<AppState>()
+        .child_events
+        .lock()
+        .unwrap()
+        .push(request.method.clone());
+    let result = if request.method == "ui/initialize" {
+        json!({"hostInfo":{"name":"wisp-science"},"hostCapabilities":{},"protocolVersion":"2026-01-26"})
+    } else {
+        json!({})
+    };
+    Ok(json!({"jsonrpc":"2.0", "id":request.id, "result":result}))
+}
+const MAIN: &str = r#"<!doctype html><body>
+<button id="sidebar">Sidebar</button><button id="new-session">New session</button><button id="stop">Stop</button><input id="input">
+<script>
+for(const el of document.querySelectorAll('button,input')) el.addEventListener(el.tagName==='INPUT'?'input':'click',()=>window.__TAURI_INTERNALS__.invoke('smoke_control',{action:el.id}));
+setInterval(()=>{window.__TAURI_INTERNALS__.invoke('smoke_tick');window.__TAURI_INTERNALS__.invoke('ui_heartbeat');},100);
+</script></body>"#;
+const GUEST: &str = r#"<!doctype html><body>Disposable blocked guest<script>
+addEventListener('message',e=>{if(e.data?.method==='smoke/block'){parent.postMessage({jsonrpc:'2.0',method:'block-start',params:{}},'*');setTimeout(()=>{const end=performance.now()+20000;while(performance.now()<end){};parent.postMessage({jsonrpc:'2.0',method:'block-end',params:{}},'*')},100)}});
+parent.postMessage({jsonrpc:'2.0',method:'ui/initialize',id:1,params:{}},'*');
+</script></body>"#;
+struct Assets;
+impl tauri::Assets<tauri::Wry> for Assets {
+    fn get(&self, key: &tauri::utils::assets::AssetKey) -> Option<Cow<'_, [u8]>> {
+        let asset = match key.as_ref() {
+            "mcp-app/shell.html" | "/mcp-app/shell.html" => {
+                include_str!("../../ui/mcp-app/shell.html")
+            }
+            "mcp-app/shell.js" | "/mcp-app/shell.js" => include_str!("../../ui/mcp-app/shell.js"),
+            "mcp_app_protocol.js" | "/mcp_app_protocol.js" => {
+                include_str!("../../ui/src/mcp_app_protocol.js")
+            }
+            _ => MAIN,
+        };
+        Some(Cow::Borrowed(asset.as_bytes()))
+    }
+    fn iter(&self) -> Box<tauri::utils::assets::AssetsIter<'_>> {
+        Box::new(std::iter::empty())
+    }
+    fn csp_hashes(
+        &self,
+        _: &tauri::utils::assets::AssetKey,
+    ) -> Box<dyn Iterator<Item = tauri::utils::assets::CspHash<'_>> + '_> {
+        Box::new(std::iter::empty())
+    }
+}
+fn wait(check: impl Fn() -> bool, what: &str, timeout: Duration) -> Result<(), String> {
+    let started = Instant::now();
+    while started.elapsed() < timeout {
+        if check() {
+            return Ok(());
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    Err(format!("timeout: {what}"))
+}
+fn create(app: &tauri::AppHandle, serial: u64) -> Result<Child, String> {
+    let main = app.workspace_surface("main").ok_or("primary missing")?;
+    let child = {
+        let state = app.state::<McpAppChildren>();
+        let mut r = state.registry.lock().unwrap();
+        let e = r.epoch("main");
+        let (child, retired) = r.reserve(
+            "main",
+            &e,
+            serial,
+            "mcp-app:fake-session:ui://smoke",
+            json!({"tool":{"name":"smoke"},"resource":{"uri":"ui://smoke","text":GUEST}}),
+            json!({}),
+            McpAppChildBounds {
+                x: 350.,
+                y: 100.,
+                width: 400.,
+                height: 400.,
+                viewport_width: 900.,
+                viewport_height: 650.,
+                visible: true,
+                revision: 1,
+            },
+            None,
+        )?;
+        assert!(retired.children.is_empty());
+        child
+    };
+    tauri::async_runtime::block_on(mcp_app_children::create_native(app, &main, &child))?;
+    wait(
+        || {
+            app.state::<McpAppChildren>()
+                .registry
+                .lock()
+                .unwrap()
+                .get(&child.handle.child_label)
+                .is_ok_and(|c| c.ready)
+        },
+        "child ready",
+        Duration::from_secs(30),
+    )?;
+    Ok(child)
+}
+fn close(app: &tauri::AppHandle, child: &Child) -> Result<(), String> {
+    let state = app.state::<McpAppChildren>();
+    let retired = state.registry.lock().unwrap().close(
+        "main",
+        &child.handle.owner_epoch,
+        child.handle.mount_serial,
+        &child.instance_id,
+        wisp_dto::McpAppChildCloseReason::Suspend,
+    );
+    mcp_app_children::retire_native(app, retired.children);
+    wait(
+        || app.get_webview(&child.handle.child_label).is_none(),
+        "native child close",
+        Duration::from_secs(3),
+    )?;
+    if child.ensure_live().is_ok() {
+        return Err("retired identity remains live".into());
+    }
+    Ok(())
+}
+#[cfg(windows)]
+fn browser_pid(view: &Webview) -> Result<u32, String> {
+    let (tx, rx) = std::sync::mpsc::channel();
+    view.with_webview(move |platform| unsafe {
+        let mut pid = 0;
+        let r = platform
+            .controller()
+            .CoreWebView2()
+            .and_then(|v| v.BrowserProcessId(&mut pid));
+        let _ = tx.send(r.map(|_| pid).map_err(|e| e.to_string()));
+    })
+    .map_err(|e| e.to_string())?;
+    rx.recv_timeout(Duration::from_secs(5))
+        .map_err(|e| e.to_string())?
+}
+fn run(app: &tauri::AppHandle) -> Result<(), String> {
+    let state = app.state::<AppState>();
+    wait(
+        || state.beats.lock().unwrap().len() == 2,
+        "primary and sibling heartbeat",
+        Duration::from_secs(30),
+    )?;
+    let main = app.workspace_surface("main").unwrap();
+    let child = create(app, 1)?;
+    // This is the regression Tauri's WebviewWindow extractor used to miss.
+    if app.workspace_surfaces().len() != 2 {
+        return Err("workspace lookup includes children or loses parents".into());
+    }
+    let view = app.get_webview(&child.handle.child_label).unwrap();
+    #[cfg(windows)]
+    {
+        let primary_pid = browser_pid(main.webview())?;
+        let child_pid = browser_pid(&view)?;
+        println!("browser PID primary={primary_pid}, child={child_pid}");
+        if primary_pid == child_pid {
+            return Err("child and primary share the browser environment".into());
+        }
+        use std::os::windows::process::CommandExt;
+        let script = format!("Get-CimInstance Win32_Process | Where-Object {{ $_.ParentProcessId -eq {primary_pid} -or $_.ParentProcessId -eq {child_pid} }} | Select-Object ProcessId,ParentProcessId,CommandLine | ConvertTo-Json -Compress");
+        let output = std::process::Command::new("powershell.exe")
+            .args(["-NoProfile", "-Command", &script])
+            .creation_flags(0x08000000)
+            .output()
+            .map_err(|e| e.to_string())?;
+        println!(
+            "dedicated process tree: {}",
+            String::from_utf8_lossy(&output.stdout)
+        );
+    }
+    view.eval("window.__TAURI_INTERNALS__.invoke('smoke_control',{action:'forged'}).then(()=>window.__TAURI_INTERNALS__.invoke('mcp_app_child_request',{request:{id:null,method:'security-failed',params:{}}}),()=>window.__TAURI_INTERNALS__.invoke('mcp_app_child_request',{request:{id:null,method:'security-denied',params:{}}}));").map_err(|e| e.to_string())?;
+    wait(
+        || {
+            state
+                .child_events
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|m| m == "security-denied")
+        },
+        "child workspace command denied",
+        Duration::from_secs(5),
+    )?;
+    view.eval(
+        "document.querySelector('iframe').contentWindow.postMessage({method:'smoke/block'},'*');",
+    )
+    .map_err(|e| e.to_string())?;
+    wait(
+        || {
+            state
+                .child_events
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|m| m == "block-start")
+        },
+        "guest block start",
+        Duration::from_secs(5),
+    )?;
+    std::thread::sleep(Duration::from_millis(250));
+    for _ in 0..10 {
+        let count = state.actions.lock().unwrap().len();
+        let started = Instant::now();
+        main.eval("(()=>{for(const id of ['sidebar','new-session','stop'])document.getElementById(id).click();const input=document.getElementById('input');input.value='responsive';input.dispatchEvent(new Event('input'));})();").map_err(|e| e.to_string())?;
+        wait(
+            || state.actions.lock().unwrap().len() == count + 4,
+            "primary DOM control responses",
+            Duration::from_secs(1),
+        )?;
+        println!(
+            "four primary DOM controls responded in {}ms during guest block",
+            started.elapsed().as_millis()
+        );
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    if state
+        .child_events
+        .lock()
+        .unwrap()
+        .iter()
+        .any(|m| m == "block-end")
+    {
+        return Err("guest was not blocked during interaction checks".into());
+    }
+    ui_health::stop_window_agent(&main);
+    ui_health::stop_window_agent(&app.workspace_surface("proj-smoke").unwrap());
+    wait(
+        || state.stopped.lock().unwrap().len() == 1,
+        "scoped native stop",
+        Duration::from_secs(1),
+    )?;
+    if state.stopped.lock().unwrap()[0] != "fake-session" {
+        return Err("stop leaked to sibling".into());
+    }
+    let started = Instant::now();
+    close(app, &child)?;
+    println!(
+        "blocked child closed in {}ms",
+        started.elapsed().as_millis()
+    );
+    let cycles = std::env::var("WISP_ISOLATION_CYCLES")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(5);
+    for serial in 2..=cycles + 1 {
+        let c = create(app, serial)?;
+        close(app, &c)?;
+        if serial % 10 == 0 {
+            println!("cycles completed: {serial}");
+        }
+    }
+    let children_root = app.state::<McpAppChildren>().profile_root.clone().unwrap();
+    wait(
+        || {
+            std::fs::read_dir(&children_root)
+                .map(|boots| {
+                    boots.flatten().all(|boot| {
+                        std::fs::read_dir(boot.path())
+                            .map(|dirs| dirs.count() == 0)
+                            .unwrap_or(false)
+                    })
+                })
+                .unwrap_or(false)
+        },
+        "profile cleanup drained",
+        Duration::from_secs(35),
+    )?;
+    println!("profile cleanup drained: zero child profiles; registry and controllers bounded");
+    if app.webviews().len() != 2 {
+        return Err("orphan native controller".into());
+    }
+    println!("PASS: isolated guest block, primary JS/DOM controls, scoped Stop, stale IPC denial; {} create/destroy cycles. Manual DPI/focus and real SFL acceptance still required.", cycles);
+    Ok(())
+}
+fn main() {
+    if !cfg!(windows) {
+        eprintln!("Windows-only native probe");
+        return;
+    }
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../target/mcp-isolation-smoke")
+        .join(uuid::Uuid::new_v4().to_string());
+    std::fs::create_dir_all(&root).unwrap();
+    println!("disposable profiles: {}", root.display());
+    let mut children = McpAppChildren::default();
+    children.profile_root = Some(root.join("children"));
+    let mut context = tauri::generate_context!();
+    context.config_mut().identifier = "science.wisp.isolation-smoke".into();
+    context.config_mut().build.dev_url = None;
+    context.set_assets(Box::new(Assets));
+    tauri::Builder::default()
+        .manage(AppState::default())
+        .manage(children)
+        .invoke_handler(|invoke| {
+            if !mcp_app_children::child_command_allowed(
+                invoke.message.webview().label(),
+                invoke.message.command(),
+            ) {
+                invoke.resolver.reject("denied child command");
+                return true;
+            }
+            let handler: fn(tauri::ipc::Invoke<tauri::Wry>) -> bool = tauri::generate_handler![
+                smoke_tick,
+                smoke_control,
+                ui_health::ui_heartbeat,
+                mcp_app_child_bootstrap,
+                mcp_app_child_ready,
+                mcp_app_child_request
+            ];
+            handler(invoke)
+        })
+        .setup(move |app| {
+            for label in ["main", "proj-smoke"] {
+                tauri::WebviewWindowBuilder::new(
+                    app,
+                    label,
+                    tauri::WebviewUrl::App("index.html".into()),
+                )
+                .title("Disposable Wisp isolation test")
+                .visible(false)
+                .inner_size(900., 650.)
+                .data_directory(root.join(label))
+                .build()?;
+            }
+            let app = app.handle().clone();
+            std::thread::spawn(move || {
+                let result = run(&app);
+                if let Err(error) = &result {
+                    eprintln!("FAIL: {error}");
+                }
+                app.exit(if result.is_ok() { 0 } else { 1 });
+            });
+            Ok(())
+        })
+        .run(context)
+        .expect("run native isolation probe");
+}

--- a/src-tauri/examples/webview_recovery_smoke.rs
+++ b/src-tauri/examples/webview_recovery_smoke.rs
@@ -4,7 +4,14 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
-use tauri::{Manager, WebviewWindow};
+use tauri::Manager;
+#[path = "../src/mcp_app_children.rs"]
+#[allow(dead_code)]
+mod mcp_app_children;
+#[path = "../src/workspace_surface.rs"]
+#[allow(dead_code)]
+mod workspace_surface;
+use workspace_surface::{WorkspaceManager, WorkspaceSurface};
 
 #[path = "../src/ui_health.rs"]
 #[allow(dead_code)]
@@ -35,7 +42,7 @@ mod agent_turn {
 }
 
 #[tauri::command]
-fn smoke_ready(window: WebviewWindow, state: tauri::State<'_, AppState>) {
+fn smoke_ready(window: WorkspaceSurface, state: tauri::State<'_, AppState>) {
     *state
         .boots
         .lock()
@@ -109,8 +116,8 @@ fn run_smoke(app: &tauri::AppHandle) -> Result<(), String> {
         || state.boots.lock().unwrap().len() == 2,
         "both WebViews boot",
     )?;
-    let main = app.get_webview_window("main").unwrap();
-    let sibling = app.get_webview_window("proj-health").unwrap();
+    let main = app.workspace_surface("main").unwrap();
+    let sibling = app.workspace_surface("proj-health").unwrap();
     // Bounded busy loop: verifies the escape path without leaving a wedged process.
     main.eval("const end = performance.now() + 15000; while (performance.now() < end) {}")
         .map_err(|e| e.to_string())?;

--- a/src-tauri/src/acp.rs
+++ b/src-tauri/src/acp.rs
@@ -218,7 +218,7 @@ pub(crate) async fn list_acp_agents(
 #[tauri::command]
 pub(crate) async fn get_acp_session_agent(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     frame_id: String,
 ) -> Result<Option<String>, String> {
     let project = state.require_active(window.label())?;
@@ -249,7 +249,7 @@ pub(crate) async fn get_acp_session_agent(
 #[tauri::command]
 pub(crate) async fn get_acp_session_state(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     frame_id: String,
 ) -> Result<Option<wisp_dto::AcpSessionState>, String> {
     let project = state.require_active(window.label())?;
@@ -339,7 +339,7 @@ pub(crate) async fn test_acp_agent(
 pub(crate) async fn authenticate_acp_agent(
     state: State<'_, AppState>,
     terminals: State<'_, crate::terminal_sessions::TerminalManager>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     id: String,
     method_id: String,
 ) -> Result<Option<crate::terminal_sessions::TerminalSessionSummary>, String> {
@@ -1642,7 +1642,7 @@ pub(crate) async fn respond_remote_permission(
 pub(crate) async fn respond_ask_user(
     state: State<'_, AppState>,
     app: AppHandle,
-    _window: tauri::WebviewWindow,
+    _window: crate::workspace_surface::WorkspaceSurface,
     request_id: String,
     answer: String,
 ) -> Result<(), String> {
@@ -1704,7 +1704,7 @@ pub(crate) async fn respond_ask_user(
 pub(crate) async fn set_acp_session_config(
     state: State<'_, AppState>,
     app: AppHandle,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     frame_id: String,
     config_id: String,
     value: serde_json::Value,
@@ -1752,7 +1752,7 @@ pub(crate) async fn set_acp_session_config(
 #[tauri::command]
 pub(crate) async fn set_acp_session_mode(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     frame_id: String,
     mode_id: String,
 ) -> Result<String, String> {

--- a/src-tauri/src/agent_turn.rs
+++ b/src-tauri/src/agent_turn.rs
@@ -28,7 +28,7 @@ impl TurnOrigin {
 pub(crate) async fn send_message(
     state: State<'_, AppState>,
     app: AppHandle,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     session_id: Option<String>,
     message: String,
     attachments: Option<Vec<String>>,
@@ -1367,7 +1367,7 @@ pub(crate) fn spawn_queue_driver(
 pub(crate) async fn enqueue_turn(
     state: State<'_, AppState>,
     app: AppHandle,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     session_id: String,
     id: u64,
     message: String,
@@ -1470,7 +1470,7 @@ pub(crate) fn reclaim_unconsumed_cutin(
 pub(crate) async fn queued_turn_action(
     state: State<'_, AppState>,
     app: AppHandle,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     session_id: String,
     id: u64,
     action: String,

--- a/src-tauri/src/app_commands.rs
+++ b/src-tauri/src/app_commands.rs
@@ -185,7 +185,7 @@ pub(super) async fn pick_executable_file(app: AppHandle) -> Result<Option<String
 pub(super) async fn upload_to_context(
     app: AppHandle,
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     context_id: String,
     destination_dir: String,
     source_paths: Option<Vec<String>>,
@@ -241,7 +241,7 @@ pub(super) fn parse_ssh_artifact_uri(uri: &str) -> Option<(String, String)> {
 pub(super) async fn download_file(
     app: AppHandle,
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     path: String,
 ) -> Result<Option<String>, String> {
     use tauri_plugin_dialog::DialogExt;
@@ -422,7 +422,7 @@ pub(super) async fn save_share_html(
 #[tauri::command]
 pub(super) async fn get_capabilities(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
 ) -> Result<Capabilities, String> {
     let ap = state.require_active(window.label())?;
     let tags = load_skill_tags(&state.store).await;
@@ -716,7 +716,7 @@ pub(super) async fn extension_connected(state: State<'_, AppState>) -> Result<bo
 pub(super) fn reveal_in_file_manager(
     app: AppHandle,
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     path: String,
 ) -> Result<(), String> {
     use tauri_plugin_opener::OpenerExt;
@@ -734,7 +734,7 @@ pub(super) fn reveal_in_file_manager(
 pub(super) fn open_workspace_path(
     app: AppHandle,
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     path: String,
 ) -> Result<(), String> {
     use tauri_plugin_opener::OpenerExt;

--- a/src-tauri/src/app_state.rs
+++ b/src-tauri/src/app_state.rs
@@ -279,6 +279,7 @@ pub(crate) struct ActiveProject {
 /// instance stale instead of pinning the server process.
 #[derive(Clone)]
 pub(crate) struct McpAppToolBridge {
+    pub(crate) generation: u64,
     pub(crate) frame_id: String,
     pub(crate) server: Arc<dyn wisp_tools::McpAppServer>,
     pub(crate) limiter: Arc<McpAppCallLimiter>,
@@ -294,11 +295,25 @@ pub(crate) const MCP_APP_CALL_WINDOW: std::time::Duration = std::time::Duration:
 #[derive(Default)]
 pub(crate) struct McpAppBridges {
     bridges: StdMutex<HashMap<String, McpAppToolBridge>>,
+    next_generation: std::sync::atomic::AtomicU64,
 }
 
 impl McpAppBridges {
-    pub(crate) fn register(&self, instance_id: String, bridge: McpAppToolBridge) {
+    pub(crate) fn register(&self, instance_id: String, mut bridge: McpAppToolBridge) {
+        bridge.generation = self.next_generation.fetch_add(1, Ordering::SeqCst) + 1;
         self.bridges.lock().unwrap().insert(instance_id, bridge);
+    }
+
+    pub(crate) fn close_generation(&self, instance_id: &str, generation: Option<u64>) -> bool {
+        let mut bridges = self.bridges.lock().unwrap();
+        if bridges
+            .get(instance_id)
+            .is_some_and(|b| Some(b.generation) == generation)
+        {
+            bridges.remove(instance_id);
+            return true;
+        }
+        false
     }
 
     pub(crate) fn get(&self, instance_id: &str) -> Option<McpAppToolBridge> {
@@ -422,6 +437,7 @@ impl ProjectActivityLocks {
 }
 
 pub(crate) struct AppState {
+    pub(crate) desktop: tauri::AppHandle,
     pub(crate) app_data: PathBuf,
     pub(crate) store: Store,
     pub(crate) library: LibraryStore,
@@ -546,6 +562,7 @@ impl AppState {
         self.active_frame.read().unwrap().get(label).cloned()
     }
     pub(crate) fn set_active_frame(&self, label: &str, frame: Option<String>) {
+        let changed = self.active_frame(label) != frame;
         match frame {
             Some(f) => {
                 self.active_frame
@@ -556,6 +573,12 @@ impl AppState {
             None => {
                 self.active_frame.write().unwrap().remove(label);
             }
+        }
+        // Drop active_frame before touching the child registry. Native
+        // suspend is a no-op when the isolation manager is not installed
+        // (unit tests without a full desktop runtime).
+        if changed {
+            crate::mcp_app_child_commands::suspend_owner(&self.desktop, label);
         }
     }
     pub(crate) fn set_notification_window(&self, frame_id: &str, label: &str) {
@@ -579,6 +602,7 @@ impl AppState {
     /// Revoke every app bridge owned by a conversation (session delete).
     pub(crate) fn remove_mcp_app_bridges_for_frame(&self, frame_id: &str) {
         self.mcp_app_tool_bridges.remove_for_frame(frame_id);
+        crate::mcp_app_child_commands::remove_frame(&self.desktop, frame_id);
     }
     pub(crate) fn preferred_notification_window(
         &self,

--- a/src-tauri/src/approval_commands.rs
+++ b/src-tauri/src/approval_commands.rs
@@ -160,7 +160,7 @@ pub(crate) async fn respond_remote_confirmation(
 #[tauri::command]
 pub(super) async fn get_session_full_permission(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     session_id: String,
 ) -> Result<bool, String> {
     let project = state.require_active(window.label())?;
@@ -171,7 +171,7 @@ pub(super) async fn get_session_full_permission(
 #[tauri::command]
 pub(super) async fn set_session_full_permission(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     session_id: String,
     enabled: bool,
 ) -> Result<bool, String> {

--- a/src-tauri/src/artifact_commands.rs
+++ b/src-tauri/src/artifact_commands.rs
@@ -207,7 +207,7 @@ async fn register_artifact_at(
 #[tauri::command]
 pub(super) async fn upload_file(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     filename: String,
     data_base64: String,
 ) -> Result<ArtifactInfo, String> {
@@ -236,7 +236,7 @@ pub(super) async fn upload_file(
 #[tauri::command]
 pub(super) async fn register_artifact(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     path: String,
     content_type: Option<String>,
 ) -> Result<ArtifactInfo, String> {
@@ -327,7 +327,7 @@ mod tests {
 #[tauri::command]
 pub(super) async fn list_artifacts(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     session_id: Option<String>,
 ) -> Result<Vec<ArtifactInfo>, String> {
     let frame_id = match session_id.as_deref().filter(|s| !s.is_empty()) {
@@ -374,7 +374,7 @@ pub(super) async fn list_artifacts(
 #[tauri::command]
 pub(super) async fn search_artifacts(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     query: Option<String>,
     limit: Option<i64>,
     project_id: Option<String>,
@@ -453,7 +453,7 @@ pub(super) async fn search_artifacts(
 #[tauri::command]
 pub(super) fn missing_files(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     paths: Vec<String>,
 ) -> Result<Vec<String>, String> {
     let ap = state.require_active(window.label())?;
@@ -470,7 +470,7 @@ pub(super) fn missing_files(
 #[tauri::command]
 pub(super) async fn read_artifact(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     id: String,
 ) -> Result<FileContent, String> {
     let (working_project, scope) =
@@ -509,7 +509,7 @@ pub(super) async fn read_artifact(
 #[tauri::command]
 pub(super) async fn read_artifact_bytes(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     id: String,
     max_bytes: Option<u64>,
 ) -> Result<Response, String> {
@@ -554,7 +554,7 @@ pub(super) async fn read_artifact_bytes(
 pub(super) async fn download_artifact(
     app: AppHandle,
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     id: String,
 ) -> Result<Option<String>, String> {
     use tauri_plugin_dialog::DialogExt;
@@ -621,7 +621,7 @@ pub(super) async fn download_artifact(
 #[tauri::command]
 pub(super) async fn read_artifact_version(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     version_id: String,
 ) -> Result<FileContent, String> {
     let version = state
@@ -662,7 +662,7 @@ pub(super) async fn read_artifact_version(
 #[tauri::command]
 pub(super) async fn read_artifact_version_bytes(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     version_id: String,
     max_bytes: Option<u64>,
 ) -> Result<Response, String> {
@@ -712,7 +712,7 @@ pub(super) async fn read_artifact_version_bytes(
 pub(super) async fn download_artifact_version(
     app: AppHandle,
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     version_id: String,
 ) -> Result<Option<String>, String> {
     use tauri_plugin_dialog::DialogExt;

--- a/src-tauri/src/browser_bridge/mod.rs
+++ b/src-tauri/src/browser_bridge/mod.rs
@@ -10,6 +10,7 @@
 //! This module is Wisp's independent Rust implementation; see
 //! `browser-extension/NOTICE.md` for provenance details.
 
+use crate::workspace_surface::WorkspaceManager;
 use async_trait::async_trait;
 use futures_util::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
@@ -3576,7 +3577,7 @@ impl Tool for WebAgentReadTool {
 #[tauri::command]
 pub async fn list_pending_browser_tab_cleanups(
     state: tauri::State<'_, crate::AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
 ) -> Result<Vec<BrowserTabCleanupPrompt>, String> {
     let project_id = crate::window_bound_project_id(&state, window.label());
     state
@@ -3621,7 +3622,7 @@ pub(crate) async fn emit_browser_needs_human(
 ) {
     use tauri::{Emitter, Manager};
     let state = app.state::<crate::AppState>();
-    for (label, window) in app.webview_windows() {
+    for (label, window) in app.workspace_surfaces() {
         let project_id = crate::window_bound_project_id(&state, &label);
         if let Ok(prompt) =
             project_browser_needs_human(&state.store, tabs, project_id.as_deref()).await
@@ -3660,7 +3661,7 @@ pub async fn dismiss_browser_tab_cleanup(
 #[tauri::command]
 pub async fn list_pending_browser_needs_human(
     state: tauri::State<'_, crate::AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
 ) -> Result<BrowserNeedsHumanPrompt, String> {
     let project_id = crate::window_bound_project_id(&state, window.label());
     let prompt = state.browser_bridge.list_needs_human().await;

--- a/src-tauri/src/channels/mod.rs
+++ b/src-tauri/src/channels/mod.rs
@@ -15,6 +15,7 @@
 //! lives in SQLite settings; the Feishu app secret and WeChat bot token live
 //! in the keyring.
 
+use crate::workspace_surface::WorkspaceManager;
 pub mod feishu;
 pub mod feishu_card;
 pub mod feishu_registration;
@@ -1112,7 +1113,7 @@ pub(crate) async fn handle_inbound_observed(
         return format!("未知命令“{command}”。发送 /help 查看可用命令。");
     }
 
-    let Some(window) = app.get_webview_window("main") else {
+    let Some(window) = app.workspace_surface("main") else {
         return "桌面端主窗口不可用,无法处理消息。".to_string();
     };
     // Resolve and, when needed, create the shared target atomically.

--- a/src-tauri/src/codex_import.rs
+++ b/src-tauri/src/codex_import.rs
@@ -1482,7 +1482,7 @@ pub(super) async fn preview_claude_session(
 
 async fn import_sessions(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     paths: Vec<String>,
     context_id: Option<String>,
     provider: ImportProvider,
@@ -1568,7 +1568,7 @@ async fn import_sessions(
 #[tauri::command]
 pub(super) async fn import_codex_sessions(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     paths: Vec<String>,
     context_id: Option<String>,
 ) -> Result<ExternalImportSummary, String> {
@@ -1578,7 +1578,7 @@ pub(super) async fn import_codex_sessions(
 #[tauri::command]
 pub(super) async fn import_claude_sessions(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     paths: Vec<String>,
     context_id: Option<String>,
 ) -> Result<ExternalImportSummary, String> {

--- a/src-tauri/src/connector_commands.rs
+++ b/src-tauri/src/connector_commands.rs
@@ -6,9 +6,10 @@ use super::{
     save_json_setting, save_mcp_connections, window_bound_project_id, AppState, McpConnection,
     McpHttpAuth, McpTransport,
 };
+use crate::workspace_surface::WorkspaceSurface;
 use serde::Serialize;
 use std::collections::{BTreeMap, HashMap, HashSet};
-use tauri::{State, WebviewWindow};
+use tauri::State;
 
 #[derive(Serialize, Clone)]
 pub(super) struct McpConnectionsView {
@@ -174,7 +175,7 @@ fn bundled_connector_infos(
 #[tauri::command]
 pub(super) async fn list_connectors(
     state: State<'_, AppState>,
-    window: WebviewWindow,
+    window: WorkspaceSurface,
 ) -> Result<ConnectorsView, String> {
     let store = &state.store;
     // Unbound windows show the inherited global defaults without writing them.
@@ -238,7 +239,7 @@ pub(super) async fn set_connector_enabled(
 #[tauri::command]
 pub(super) async fn set_tool_approval(
     state: State<'_, AppState>,
-    window: WebviewWindow,
+    window: WorkspaceSurface,
     tool: String,
     mode: String,
 ) -> Result<(), String> {
@@ -257,7 +258,7 @@ pub(super) async fn set_tool_approval(
 #[tauri::command]
 pub(super) async fn set_approval_scope(
     state: State<'_, AppState>,
-    window: WebviewWindow,
+    window: WorkspaceSurface,
     scope: String,
 ) -> Result<(), String> {
     let project_id = persist_approval_scope_overlay(
@@ -274,7 +275,7 @@ pub(super) async fn set_approval_scope(
 #[tauri::command]
 pub(super) async fn set_connector_skip_approvals(
     state: State<'_, AppState>,
-    window: WebviewWindow,
+    window: WorkspaceSurface,
     key: String,
     enabled: bool,
 ) -> Result<(), String> {

--- a/src-tauri/src/delegation_completion.rs
+++ b/src-tauri/src/delegation_completion.rs
@@ -98,7 +98,7 @@ pub(crate) async fn save_session_completion_settings(
 #[tauri::command]
 pub(crate) async fn get_session_agent_completion(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     session_id: String,
 ) -> Result<AgentCompletionSettings, String> {
     let project = state.require_active(window.label())?;
@@ -120,7 +120,7 @@ pub(crate) async fn get_session_agent_completion(
 #[tauri::command]
 pub(crate) async fn set_session_agent_completion(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     session_id: String,
     policy: AgentCompletionPolicy,
     auto_resume: bool,

--- a/src-tauri/src/delegation_runtime.rs
+++ b/src-tauri/src/delegation_runtime.rs
@@ -149,7 +149,7 @@ pub(crate) fn sync_delegation_prompt(prompt: &mut String, enabled: bool) {
 #[tauri::command]
 pub(crate) async fn get_session_delegation_enabled(
     state: State<'_, crate::AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     session_id: String,
 ) -> Result<bool, String> {
     let project = state.require_active(window.label())?;
@@ -160,7 +160,7 @@ pub(crate) async fn get_session_delegation_enabled(
 #[tauri::command]
 pub(crate) async fn set_session_delegation_enabled(
     state: State<'_, crate::AppState>,
-    _window: tauri::WebviewWindow,
+    _window: crate::workspace_surface::WorkspaceSurface,
     session_id: String,
     enabled: bool,
 ) -> Result<bool, String> {
@@ -181,7 +181,7 @@ pub(crate) async fn set_session_delegation_enabled(
 #[tauri::command]
 pub(crate) async fn list_agent_workflows(
     state: State<'_, crate::AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     session_id: Option<String>,
 ) -> Result<Vec<AgentWorkflowSnapshot>, String> {
     let project = state.require_active(window.label())?;
@@ -419,7 +419,7 @@ pub(crate) async fn create_dynamic_agent_workflow_draft(
 #[tauri::command]
 pub(crate) async fn get_dynamic_agent_options(
     state: State<'_, crate::AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
 ) -> Result<dynamic_workflow::DynamicAgentEditorOptions, String> {
     let project = state.require_active(window.label())?;
     let frame_id = state.active_frame(window.label());
@@ -583,7 +583,7 @@ pub(crate) async fn load_agent_workflow_result(
 #[tauri::command]
 pub(crate) async fn get_agent_workflow_result(
     state: State<'_, crate::AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     workflow_id: String,
     step_id: String,
 ) -> Result<AgentWorkflowResultDetail, String> {
@@ -642,7 +642,7 @@ pub(crate) async fn approve_created_automatic_workflow(
 #[tauri::command]
 pub(crate) async fn approve_agent_workflow(
     state: State<'_, crate::AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     workflow_id: String,
     expected_version: i64,
 ) -> Result<AgentWorkflowSnapshot, String> {
@@ -669,7 +669,7 @@ pub(crate) async fn approve_agent_workflow(
 #[tauri::command]
 pub(crate) async fn cancel_agent_workflow(
     state: State<'_, crate::AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     workflow_id: String,
 ) -> Result<(), String> {
     let project = state.require_active(window.label())?;
@@ -692,7 +692,7 @@ pub(crate) async fn cancel_agent_workflow(
 #[tauri::command]
 pub(crate) async fn discard_agent_workflow(
     state: State<'_, crate::AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     workflow_id: String,
 ) -> Result<(), String> {
     let project = state.require_active(window.label())?;
@@ -713,7 +713,7 @@ pub(crate) async fn discard_agent_workflow(
 #[tauri::command]
 pub(crate) async fn retry_agent_workflow(
     state: State<'_, crate::AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     workflow_id: String,
     budget_overrides: Option<HashMap<String, dynamic_workflow::AgentBudgetProposal>>,
 ) -> Result<AgentWorkflowSnapshot, String> {
@@ -942,7 +942,7 @@ pub(crate) async fn prepare_agent_workflow_retry(
 #[tauri::command]
 pub(crate) async fn run_agent_workflow(
     state: State<'_, crate::AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     workflow_id: String,
 ) -> Result<DelegationExecutionResult, String> {
     let project = state.require_active(window.label())?;

--- a/src-tauri/src/desktop_lifecycle.rs
+++ b/src-tauri/src/desktop_lifecycle.rs
@@ -1,3 +1,4 @@
+use crate::workspace_surface::WorkspaceManager;
 #[cfg(target_os = "windows")]
 use tauri::{
     menu::{Menu, MenuItemBuilder},
@@ -117,13 +118,13 @@ pub(crate) fn activate_workspace(app: &AppHandle) {
     #[cfg(target_os = "macos")]
     let _ = app.show();
 
-    for (label, window) in app.webview_windows() {
+    for (label, window) in app.workspace_surfaces() {
         if should_activate_workspace_window(&label) {
             let _ = window.show();
             let _ = window.unminimize();
         }
     }
-    if let Some(main) = app.get_webview_window("main") {
+    if let Some(main) = app.workspace_surface("main") {
         let _ = main.set_focus();
     }
 }
@@ -142,8 +143,8 @@ pub(crate) fn activate_workspace_window(
     let _ = app.show();
 
     let window = app
-        .get_webview_window(preferred_label)
-        .or_else(|| app.get_webview_window("main"));
+        .workspace_surface(preferred_label)
+        .or_else(|| app.workspace_surface("main"));
     let Some(window) = window else {
         return;
     };
@@ -179,7 +180,7 @@ fn default_pet_position(app: &AppHandle) -> Option<(f64, f64)> {
 
 #[cfg(target_os = "windows")]
 fn ensure_pet_window(app: &AppHandle) -> Result<(), String> {
-    if app.get_webview_window(PET_WINDOW_LABEL).is_some() {
+    if app.workspace_surface(PET_WINDOW_LABEL).is_some() {
         return Ok(());
     }
     let url = WebviewUrl::App("index.html?pet=desktop".into());
@@ -208,7 +209,7 @@ fn ensure_pet_window(app: &AppHandle) -> Result<(), String> {
 #[cfg(target_os = "windows")]
 pub(crate) fn sync_pet_window(app: &AppHandle, enabled: bool) -> Result<(), String> {
     if !enabled {
-        if let Some(window) = app.get_webview_window(PET_WINDOW_LABEL) {
+        if let Some(window) = app.workspace_surface(PET_WINDOW_LABEL) {
             let _ = window.hide();
         }
         return Ok(());
@@ -230,7 +231,7 @@ pub(crate) fn set_pet_window_visible(app: tauri::AppHandle, visible: bool) -> Re
         if visible {
             ensure_pet_window(&app)?;
         }
-        if let Some(window) = app.get_webview_window(PET_WINDOW_LABEL) {
+        if let Some(window) = app.workspace_surface(PET_WINDOW_LABEL) {
             if visible {
                 window.show().map_err(|error| error.to_string())?;
             } else {
@@ -296,7 +297,7 @@ pub(crate) fn install_windows_shell(app: &mut App, locale_tag: &str) -> tauri::R
     }
     tray.build(app)?;
 
-    if let Some(main) = app.get_webview_window("main") {
+    if let Some(main) = app.workspace_surface("main") {
         let app_handle = app.handle().clone();
         main.on_window_event(move |event| {
             if let tauri::WindowEvent::CloseRequested { api, .. } = event {
@@ -304,7 +305,7 @@ pub(crate) fn install_windows_shell(app: &mut App, locale_tag: &str) -> tauri::R
                     // Hide only the main window (it lives on in the tray).
                     // Per-project windows close independently (#420).
                     api.prevent_close();
-                    if let Some(main) = app_handle.get_webview_window("main") {
+                    if let Some(main) = app_handle.workspace_surface("main") {
                         let _ = main.hide();
                     }
                 }

--- a/src-tauri/src/device_bridge.rs
+++ b/src-tauri/src/device_bridge.rs
@@ -5,6 +5,7 @@
 //! pre-shared token. The action surface is a closed list and never enters the
 //! Agent/tool execution path.
 
+use crate::workspace_surface::WorkspaceManager;
 use crate::{
     desktop_lifecycle,
     device_hub::DeviceHub,
@@ -360,7 +361,7 @@ impl SessionFocus for TauriSessionFocus {
             .state::<crate::AppState>()
             .session_surface_labels(session_id, Some(&project_id))
             .into_iter()
-            .filter(|label| self.app.get_webview_window(label).is_some())
+            .filter(|label| self.app.workspace_surface(label).is_some())
             .min_by_key(|label| (label == "main", label.clone()))
             .unwrap_or_else(|| "main".into());
         desktop_lifecycle::activate_workspace_window(

--- a/src-tauri/src/dto_contract_tests.rs
+++ b/src-tauri/src/dto_contract_tests.rs
@@ -9,6 +9,42 @@
 use serde_json::json;
 
 #[test]
+fn mcp_app_isolation_dtos_keep_js_camel_case_and_page_generation() {
+    let handle = wisp_dto::McpAppChildHandle {
+        owner_epoch: "page-1".into(),
+        mount_serial: 4,
+        child_label: "mcp-app-child-test".into(),
+    };
+    let value = serde_json::to_value(&handle).unwrap();
+    assert_eq!(
+        value,
+        json!({"ownerEpoch":"page-1","mountSerial":4,"childLabel":"mcp-app-child-test"})
+    );
+    let bounds: wisp_dto::McpAppChildBounds = serde_json::from_value(json!({"x":10,"y":20,"width":300,"height":200,"viewportWidth":1000,"viewportHeight":700,"visible":false,"revision":3})).unwrap();
+    assert_eq!(bounds.revision, 3);
+    let bootstrap = wisp_dto::McpAppChildBootstrap {
+        handle,
+        instance_id: "mcp-app:session:ui://test".into(),
+        payload: json!({"resource":{"text":"<body>"}}),
+        host_context: json!({"theme":"light"}),
+        version: "test".into(),
+        server_tools_available: false,
+    };
+    let decoded: wisp_dto::McpAppChildBootstrap = roundtrip(&bootstrap);
+    assert_eq!(decoded.handle.mount_serial, 4);
+    assert_eq!(decoded.host_context["theme"], "light");
+    let request: wisp_dto::McpAppChildRequest = serde_json::from_value(
+        json!({"id":null,"method":"ui/notifications/initialized","params":{}}),
+    )
+    .unwrap();
+    assert!(request.id.is_none());
+    assert_eq!(
+        serde_json::to_value(wisp_dto::McpAppChildCloseReason::UserClose).unwrap(),
+        "user_close"
+    );
+}
+
+#[test]
 fn network_settings_support_partial_persisted_configuration() {
     let settings: wisp_dto::NetworkSettings = serde_json::from_value(json!({
         "model_proxy_url": "none",

--- a/src-tauri/src/exploration_commands.rs
+++ b/src-tauri/src/exploration_commands.rs
@@ -5,12 +5,13 @@
 use crate::exploration_workspace::{
     ExplorationWorkspaceBackend, PersistentExplorationWorkspace, WorkspaceSnapshot,
 };
+use crate::workspace_surface::WorkspaceSurface;
 use crate::{load_skill_index, ActiveProject, AppState, MemoryManager};
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use tauri::{State, WebviewWindow};
+use tauri::State;
 use wisp_store::{
     ArtifactHead, ContextArchiveRecord, Exploration, ExplorationBaselineArtifactHead,
     ExplorationBaselineEntity, ExplorationCheckpoint, ExplorationFamily, ExplorationStatus,
@@ -882,7 +883,7 @@ pub(crate) async fn reject_private_exploration_project_mutation(
 pub(crate) async fn start_exploration(
     state: State<'_, AppState>,
     terminals: State<'_, crate::terminal_sessions::TerminalManager>,
-    window: WebviewWindow,
+    window: WorkspaceSurface,
     source_frame_id: String,
     turn_index: Option<i64>,
     name: String,
@@ -962,7 +963,7 @@ pub(crate) async fn start_exploration(
 #[tauri::command]
 pub(crate) async fn list_project_explorations(
     state: State<'_, AppState>,
-    window: WebviewWindow,
+    window: WorkspaceSurface,
 ) -> Result<Vec<ExplorationSummary>, String> {
     let project = state.require_active(window.label())?;
     state
@@ -975,7 +976,7 @@ pub(crate) async fn list_project_explorations(
 #[tauri::command]
 pub(crate) async fn open_exploration(
     state: State<'_, AppState>,
-    window: WebviewWindow,
+    window: WorkspaceSurface,
     exploration_id: String,
 ) -> Result<Exploration, String> {
     let exploration = state
@@ -997,7 +998,7 @@ pub(crate) async fn open_exploration(
 pub(crate) async fn abandon_exploration_round(
     state: State<'_, AppState>,
     terminals: State<'_, crate::terminal_sessions::TerminalManager>,
-    window: WebviewWindow,
+    window: WorkspaceSurface,
     source_frame_id: String,
 ) -> Result<(), String> {
     let owner = state

--- a/src-tauri/src/exploration_promotion.rs
+++ b/src-tauri/src/exploration_promotion.rs
@@ -892,7 +892,7 @@ pub(crate) async fn open_exploration_manual_resolution(
 pub(crate) async fn promote_exploration(
     state: State<'_, AppState>,
     terminals: State<'_, crate::terminal_sessions::TerminalManager>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     exploration_id: String,
     expected_guard_hash: String,
 ) -> Result<ExplorationPromotionResult, String> {
@@ -1029,7 +1029,7 @@ pub(crate) async fn promote_exploration(
 pub(crate) async fn discard_exploration(
     state: State<'_, AppState>,
     terminals: State<'_, crate::terminal_sessions::TerminalManager>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     exploration_id: String,
 ) -> Result<(), String> {
     let exploration = state

--- a/src-tauri/src/file_browser.rs
+++ b/src-tauri/src/file_browser.rs
@@ -1,9 +1,10 @@
 use super::AppState;
+use crate::workspace_surface::WorkspaceSurface;
 use base64::Engine;
 use serde::Serialize;
 use std::io::{Cursor, Read};
 use std::path::{Path, PathBuf};
-use tauri::{ipc::Response, State, WebviewWindow};
+use tauri::{ipc::Response, State};
 
 const REMOTE_DIR_PROTOCOL: &[u8] = b"WISP_REMOTE_DIR_V1\0";
 const REMOTE_FILE_PROTOCOL: &[u8] = b"WISP_REMOTE_FILE_V1\0";
@@ -484,7 +485,7 @@ fn collect_file_search_hits(
 #[tauri::command]
 pub(super) fn search_files(
     state: State<'_, AppState>,
-    window: WebviewWindow,
+    window: WorkspaceSurface,
     query: String,
     limit: Option<usize>,
 ) -> Result<Vec<FileSearchHit>, String> {
@@ -508,7 +509,7 @@ pub(super) fn search_files(
 #[tauri::command]
 pub(super) fn list_dir(
     state: State<'_, AppState>,
-    window: WebviewWindow,
+    window: WorkspaceSurface,
     path: Option<String>,
 ) -> Result<Vec<DirEntry>, String> {
     let ap = state.require_active(window.label())?;
@@ -617,7 +618,7 @@ async fn writable_active_project(
 #[tauri::command]
 pub(super) async fn create_file(
     state: State<'_, AppState>,
-    window: WebviewWindow,
+    window: WorkspaceSurface,
     path: String,
 ) -> Result<(), String> {
     let (project, scope, _activity) = writable_active_project(&state, window.label()).await?;
@@ -652,7 +653,7 @@ pub(super) fn save_file_at(root: &Path, path: &str, content: &str) -> Result<(),
 #[tauri::command]
 pub(super) async fn save_file(
     state: State<'_, AppState>,
-    window: WebviewWindow,
+    window: WorkspaceSurface,
     path: String,
     content: String,
 ) -> Result<(), String> {
@@ -675,7 +676,7 @@ pub(super) fn create_directory_at(root: &Path, path: &str) -> Result<(), String>
 #[tauri::command]
 pub(super) async fn create_directory(
     state: State<'_, AppState>,
-    window: WebviewWindow,
+    window: WorkspaceSurface,
     path: String,
 ) -> Result<(), String> {
     let (project, scope, _activity) = writable_active_project(&state, window.label()).await?;
@@ -715,7 +716,7 @@ pub(super) fn rename_entry_at(root: &Path, path: &str, new_path: &str) -> Result
 #[tauri::command]
 pub(super) async fn rename_entry(
     state: State<'_, AppState>,
-    window: WebviewWindow,
+    window: WorkspaceSurface,
     path: String,
     new_path: String,
 ) -> Result<(), String> {
@@ -744,7 +745,7 @@ pub(super) fn delete_entry_at(root: &Path, path: &str) -> Result<(), String> {
 #[tauri::command]
 pub(super) async fn delete_entry(
     state: State<'_, AppState>,
-    window: WebviewWindow,
+    window: WorkspaceSurface,
     path: String,
 ) -> Result<(), String> {
     let (project, scope, _activity) = writable_active_project(&state, window.label()).await?;
@@ -1315,7 +1316,7 @@ fn file_content_from_bytes(
 #[tauri::command]
 pub(super) fn read_file(
     state: State<'_, AppState>,
-    window: WebviewWindow,
+    window: WorkspaceSurface,
     path: String,
     max_bytes: Option<u64>,
 ) -> Result<FileContent, String> {
@@ -1325,7 +1326,7 @@ pub(super) fn read_file(
 #[tauri::command]
 pub(super) fn read_file_bytes(
     state: State<'_, AppState>,
-    window: WebviewWindow,
+    window: WorkspaceSurface,
     path: String,
     max_bytes: Option<u64>,
 ) -> Result<Response, String> {
@@ -1399,7 +1400,7 @@ pub(super) fn append_review_note_at(
 #[tauri::command]
 pub(super) async fn append_review_note(
     state: State<'_, AppState>,
-    window: WebviewWindow,
+    window: WorkspaceSurface,
     source_path: String,
     quote: String,
     note: Option<String>,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 //! Tauri v2 desktop shell: commands that drive the Wisp agent and stream
 //! events to the webview, plus a settings/confirm surface.
 
+use crate::workspace_surface::WorkspaceManager;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::ffi::OsString;
@@ -105,6 +106,8 @@ pub(crate) use wisp_runs::ssh_guard;
 mod ssh_hosts;
 pub(crate) use wisp_runs::ssh_master;
 mod clipboard_files;
+mod mcp_app_child_commands;
+mod mcp_app_children;
 mod storage_prefs;
 mod terminal_sessions;
 mod trajectory;
@@ -117,6 +120,7 @@ mod windows_snap;
 mod workspace_manifest;
 mod workspace_scan;
 mod workspace_session_recovery;
+mod workspace_surface;
 mod wsl_contexts;
 
 pub(crate) use agent_turn::*;
@@ -2483,6 +2487,17 @@ async fn call_mcp_app_tool(
     name: String,
     arguments: serde_json::Value,
 ) -> Result<serde_json::Value, String> {
+    call_mcp_app_tool_inner(app, &state, instance_id, name, arguments, None).await
+}
+
+async fn call_mcp_app_tool_inner(
+    app: AppHandle,
+    state: &AppState,
+    instance_id: String,
+    name: String,
+    arguments: serde_json::Value,
+    child: Option<&mcp_app_children::Child>,
+) -> Result<serde_json::Value, String> {
     let frame_id = mcp_app_frame_id(&instance_id)?.to_string();
     if name.is_empty() || name.len() > MAX_MCP_APP_TOOL_NAME_BYTES {
         return Err("MCP App tool name is empty or too long.".into());
@@ -2513,6 +2528,12 @@ async fn call_mcp_app_tool(
     };
     if bridge.frame_id != frame_id {
         return Err(MCP_APP_STALE_INSTANCE_ERROR.into());
+    }
+    if let Some(child) = child {
+        mcp_app_child_commands::ensure_current(state, child)?;
+        if child.bridge_generation != Some(bridge.generation) {
+            return Err(MCP_APP_STALE_INSTANCE_ERROR.into());
+        }
     }
     if !bridge.server.visible_to_app(&name) {
         return Err(format!(
@@ -2621,6 +2642,11 @@ async fn call_mcp_app_tool(
             }
         }
     }
+    // Approval may outlive the page that asked for it. Never dispatch a stale
+    // request after an asynchronous policy/user decision.
+    if let Some(child) = child {
+        mcp_app_child_commands::ensure_current(state, child)?;
+    }
     audit_mcp_app_tool(
         "mcp_app.tool_call_approved",
         &instance_id,
@@ -2639,6 +2665,9 @@ async fn call_mcp_app_tool(
     .await
     {
         Ok(result) => {
+            if let Some(child) = child {
+                mcp_app_child_commands::ensure_current(state, child)?;
+            }
             let result_bytes = serde_json::to_vec(&result)
                 .map_err(|error| format!("Invalid MCP App tool result: {error}"))?
                 .len();
@@ -2726,7 +2755,7 @@ async fn mcp_app_has_server_tools(
     let frame_id = mcp_app_frame_id(&instance_id)?;
     Ok(state
         .mcp_app_bridge(&instance_id)
-        .is_some_and(|bridge| bridge.frame_id == frame_id))
+        .is_some_and(|bridge| bridge.frame_id == frame_id && bridge.server.is_connected()))
 }
 
 /// Revoke an MCP App instance's host-side bridge when the iframe tears down
@@ -3025,6 +3054,7 @@ impl Output for TauriOutput {
                 self.app.state::<AppState>().register_mcp_app_bridge(
                     instance_id,
                     McpAppToolBridge {
+                        generation: 0,
                         frame_id: self.frame_id.clone(),
                         server,
                         limiter: McpAppCallLimiter::new(),
@@ -3506,19 +3536,19 @@ fn mac_menu_action(id: &str, focused: bool) -> Option<&'static str> {
 }
 
 #[cfg(target_os = "macos")]
-fn wire_macos_menu_events(window: &tauri::WebviewWindow) {
+fn wire_macos_menu_events(window: &crate::workspace_surface::WorkspaceSurface) {
     window.on_menu_event(|window, event| {
         // Tauri invokes every window's menu handler for each native action.
         if window.is_focused().unwrap_or(false) {
             match event.id().as_ref() {
                 "recovery.stop-agent" => {
-                    if let Some(target) = window.app_handle().get_webview_window(window.label()) {
+                    if let Some(target) = window.app_handle().workspace_surface(window.label()) {
                         ui_health::stop_window_agent(&target);
                     }
                     return;
                 }
                 "recovery.reload-window" => {
-                    if let Some(target) = window.app_handle().get_webview_window(window.label()) {
+                    if let Some(target) = window.app_handle().workspace_surface(window.label()) {
                         ui_health::reload_window(&target, "native menu");
                     }
                     return;
@@ -5989,7 +6019,7 @@ struct ReviewerBackendTestResult {
 #[tauri::command]
 async fn test_reviewer_backend(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     mut reviewer: specialists::Specialist,
 ) -> Result<ReviewerBackendTestResult, String> {
     if reviewer.id != "reviewer" {
@@ -6042,7 +6072,7 @@ async fn test_reviewer_backend(
 async fn review_session(
     state: State<'_, AppState>,
     app: AppHandle,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     session_id: Option<String>,
 ) -> Result<(), String> {
     let frame_id = match session_id.as_deref().filter(|s| !s.is_empty()) {
@@ -6204,7 +6234,7 @@ fn branch_title(raw: Option<&str>) -> Option<String> {
 #[tauri::command]
 async fn side_chat(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     session_id: Option<String>,
     question: String,
     acp_agent_id: Option<String>,
@@ -6399,7 +6429,7 @@ async fn build_project_info(state: &AppState, label: &str) -> Result<ProjectInfo
 /// Tell the webview whether we're in dev (keep native context menu / DevTools).
 fn set_dev_flag(app: &tauri::AppHandle) {
     let dev = cfg!(debug_assertions);
-    let Some(window) = app.get_webview_window("main") else {
+    let Some(window) = app.workspace_surface("main") else {
         return;
     };
     let _ = window.eval(&format!("window.__WISP_DEV__ = {};", dev));
@@ -6784,6 +6814,7 @@ pub fn run() {
     let macos_exit_for_setup = Arc::clone(&macos_exit_in_progress);
 
     tauri::Builder::default()
+        .manage(mcp_app_children::McpAppChildren::default())
         // Keep this first so a repeated launch is intercepted before other plugins
         // and application state are initialized in a second process.
         .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
@@ -6802,8 +6833,12 @@ pub fn run() {
                 }
             }
             tauri::WindowEvent::Destroyed => {
+                mcp_app_child_commands::reset_owner(window.app_handle(), window.label(), true);
                 record_window_focus(window.label(), false);
                 ui_health::remove_window(window.label());
+            }
+            tauri::WindowEvent::Resized(_) | tauri::WindowEvent::ScaleFactorChanged { .. } => {
+                mcp_app_children::hide_owner(window.app_handle(), window.label());
             }
             _ => {}
         })
@@ -6812,6 +6847,11 @@ pub fn run() {
         // `setup` total next to a huge `window_ready` moves the search from the
         // backend to WebView2 and asset loading.
         .on_page_load(|webview, payload| {
+            if workspace_surface::is_primary_document(webview.window().label(), webview.label())
+                && matches!(payload.event(), tauri::webview::PageLoadEvent::Started)
+            {
+                mcp_app_child_commands::reset_owner(webview.app_handle(), webview.label(), false);
+            }
             if webview.label() != "main"
                 || !matches!(payload.event(), tauri::webview::PageLoadEvent::Finished)
             {
@@ -6976,6 +7016,7 @@ pub fn run() {
                 store.clone(),
             ));
             let state = AppState {
+                desktop: app.handle().clone(),
                 app_data,
                 store,
                 library,
@@ -7047,14 +7088,14 @@ pub fn run() {
                 startup.record("windows_shell", || {
                     desktop_lifecycle::install_windows_shell(app, &locale)
                 })?;
-                if let Some(window) = app.get_webview_window("main") {
+                if let Some(window) = app.workspace_surface("main") {
                     let _ = window.set_decorations(false);
                     let _ = window.set_shadow(true);
                     windows_snap::install_for_window(&window);
                 }
             }
             #[cfg(target_os = "macos")]
-            if let Some(window) = app.get_webview_window("main") {
+            if let Some(window) = app.workspace_surface("main") {
                 wire_macos_menu_events(&window);
                 let app_handle = app.handle().clone();
                 let label = window.label().to_string();
@@ -7075,13 +7116,27 @@ pub fn run() {
             // Dev runs the bare debug binary, which does not grab focus on macOS.
             // release launches from the .app bundle and activates normally.
             #[cfg(debug_assertions)]
-            if let Some(w) = app.get_webview_window("main") {
+            if let Some(w) = app.workspace_surface("main") {
                 let _ = w.set_focus();
             }
             startup.finish();
             Ok(())
         })
-        .invoke_handler(tauri::generate_handler![
+        .invoke_handler(|invoke| {
+            if !mcp_app_children::child_command_allowed(invoke.message.webview().label(), invoke.message.command()) {
+                invoke.resolver.reject("MCP App child command is not permitted");
+                return true;
+            }
+            let handler: fn(tauri::ipc::Invoke<tauri::Wry>) -> bool = tauri::generate_handler![
+            mcp_app_child_commands::mcp_app_host_info,
+            mcp_app_child_commands::open_mcp_app_child,
+            mcp_app_child_commands::update_mcp_app_child_bounds,
+            mcp_app_child_commands::mcp_app_child_bootstrap,
+            mcp_app_child_commands::mcp_app_child_ready,
+            mcp_app_child_commands::mcp_app_child_request,
+            mcp_app_child_commands::request_mcp_app_child_action,
+            mcp_app_child_commands::mcp_app_child_action_reply,
+            mcp_app_child_commands::close_mcp_app_child,
             clipboard_files::read_clipboard_file_paths,
             agent_turn::send_message,
             update_mcp_app_context,
@@ -7449,7 +7504,9 @@ pub fn run() {
             specialists::remove_specialist,
             specialists::set_session_specialist,
             specialists::get_session_specialist,
-        ])
+        ];
+            handler(invoke)
+        })
         .build(tauri::generate_context!())
         .expect("error while building Wisp")
         .run(move |_app, _event| {

--- a/src-tauri/src/lib_tests.rs
+++ b/src-tauri/src/lib_tests.rs
@@ -200,6 +200,7 @@ impl wisp_tools::McpAppServer for FakeAppServer {
 
 fn fake_app_bridge(frame_id: &str, connector_id: &str, tool: &str) -> super::McpAppToolBridge {
     super::McpAppToolBridge {
+        generation: 0,
         frame_id: frame_id.into(),
         server: Arc::new(FakeAppServer {
             connector_id: connector_id.into(),
@@ -259,6 +260,25 @@ async fn parallel_mcp_app_instances_keep_separate_bridges() {
     assert!(bridges.get(motif).is_some());
     bridges.remove_for_frame("session-b");
     assert!(bridges.get(motif).is_none());
+}
+
+#[test]
+fn mcp_app_stale_cleanup_cannot_remove_replacement_generation() {
+    let bridges = super::McpAppBridges::default();
+    let id = "mcp-app:session-a:figures";
+    bridges.register(
+        id.into(),
+        fake_app_bridge("session-a", "figure-library", "preview"),
+    );
+    let old = bridges.get(id).unwrap().generation;
+    bridges.register(
+        id.into(),
+        fake_app_bridge("session-a", "figure-library", "preview"),
+    );
+    let new = bridges.get(id).unwrap().generation;
+    assert_ne!(old, new);
+    assert!(!bridges.close_generation(id, Some(old)));
+    assert!(bridges.close_generation(id, Some(new)));
 }
 
 #[tokio::test]
@@ -2205,9 +2225,13 @@ fn project_window_url_carries_the_target_session() {
 fn default_capability_grants_ipc_to_blank_windows() {
     let spec: serde_json::Value =
         serde_json::from_str(include_str!("../capabilities/default.json")).unwrap();
-    let windows: Vec<&str> = spec["windows"]
+    assert!(
+        spec.get("windows").is_none(),
+        "window-scoped grants would leak to MCP child WebViews"
+    );
+    let windows: Vec<&str> = spec["webviews"]
         .as_array()
-        .expect("default capability lists windows")
+        .expect("default capability lists primary WebViews")
         .iter()
         .filter_map(|value| value.as_str())
         .collect();

--- a/src-tauri/src/mcp_app_child_commands.rs
+++ b/src-tauri/src/mcp_app_child_commands.rs
@@ -1,0 +1,554 @@
+//! Commands for the isolated MCP App shell.
+//!
+//! The primary document owns layout and user-facing lifecycle.  The child
+//! document owns only the JSON-RPC-shaped guest protocol.  Keeping these
+//! commands separate is intentional: a child WebView must not become a second
+//! general-purpose workspace client just because it shares a native window.
+
+use std::time::Duration;
+
+use serde_json::{json, Value};
+use tauri::{AppHandle, Manager, State, Webview};
+
+use wisp_dto::{
+    McpAppChildBootstrap, McpAppChildBounds, McpAppChildCloseReason, McpAppChildDelivery,
+    McpAppChildHandle, McpAppChildRequest, McpAppHostInfo,
+};
+
+use crate::{
+    app_state::{mcp_app_frame_id, AppState},
+    mcp_app_children::{self, Child, McpAppChildren, Retirement, STALE},
+    workspace_surface::WorkspaceSurface,
+};
+
+fn jsonrpc_error(id: Option<Value>, message: impl Into<String>) -> Value {
+    json!({ "jsonrpc": "2.0", "id": id, "error": { "code": -32603, "message": message.into() } })
+}
+
+fn jsonrpc_result(id: Option<Value>, result: Value) -> Value {
+    json!({ "jsonrpc": "2.0", "id": id, "result": result })
+}
+
+fn verify_owner(
+    state: &AppState,
+    owner: &WorkspaceSurface,
+    instance_id: &str,
+) -> Result<(), String> {
+    let frame = mcp_app_frame_id(instance_id)?;
+    if state.active_frame(owner.label()).as_deref() != Some(frame) {
+        return Err(STALE.into());
+    }
+    Ok(())
+}
+
+fn finish_retirement(app: &AppHandle, retired: Retirement) {
+    // Releases are generation-fenced. A replacement with the same instance id
+    // must never have its newly registered bridge revoked by this cleanup.
+    for (instance, generation) in retired.releases {
+        // During the initial page load AppState may not exist yet.
+        let Some(state) = app.try_state::<AppState>() else {
+            continue;
+        };
+        // A reopen can race the native retirement queue. Check the logical
+        // reference count again while closing only the observed generation.
+        {
+            let Some(children) = app.try_state::<McpAppChildren>() else {
+                continue;
+            };
+            let registry = children.registry.lock().unwrap();
+            if !registry.has_binding(&instance) {
+                state
+                    .mcp_app_tool_bridges
+                    .close_generation(&instance, generation);
+            }
+        }
+        let app = app.clone();
+        tauri::async_runtime::spawn(async move {
+            let Some(state) = app.try_state::<AppState>() else {
+                return;
+            };
+            let sessions = state.sessions.lock().await;
+            let Some(children) = app.try_state::<McpAppChildren>() else {
+                return;
+            };
+            let registry = children.registry.lock().unwrap();
+            if !registry.has_binding(&instance) && state.mcp_app_bridge(&instance).is_none() {
+                if let Ok(frame) = mcp_app_frame_id(&instance) {
+                    if let Some(runtime) = sessions.get(frame) {
+                        runtime.set_mcp_app_context(instance.clone(), None);
+                    }
+                }
+            }
+        });
+    }
+    mcp_app_children::retire_native(app, retired.children);
+}
+
+pub(crate) fn ensure_current(state: &AppState, child: &Child) -> Result<(), String> {
+    child.ensure_live()?;
+    if state.active_frame(&child.owner).as_deref() != Some(mcp_app_frame_id(&child.instance_id)?) {
+        return Err(STALE.into());
+    }
+    let current = state.mcp_app_bridge(&child.instance_id);
+    if child.bridge_generation.is_some()
+        && current.as_ref().map(|b| b.generation) != child.bridge_generation
+    {
+        return Err(STALE.into());
+    }
+    Ok(())
+}
+
+pub(crate) fn suspend_owner(app: &AppHandle, owner: &str) {
+    let Some(state) = app.try_state::<McpAppChildren>() else {
+        return;
+    };
+    let retired = {
+        let mut registry = state.registry.lock().unwrap();
+        registry.suspend_owner(owner)
+    };
+    finish_retirement(app, retired);
+}
+
+pub(crate) fn reset_owner(app: &AppHandle, owner: &str, destroy: bool) {
+    let Some(state) = app.try_state::<McpAppChildren>() else {
+        return;
+    };
+    let retirement = {
+        let mut registry = state.registry.lock().unwrap();
+        registry.reset_owner(owner, destroy)
+    };
+    finish_retirement(app, retirement);
+}
+
+pub(crate) fn remove_frame(app: &AppHandle, frame: &str) {
+    let Some(state) = app.try_state::<McpAppChildren>() else {
+        return;
+    };
+    let retirement = {
+        let mut registry = state.registry.lock().unwrap();
+        registry.remove_frame(&format!("mcp-app:{frame}:"))
+    };
+    finish_retirement(app, retirement);
+}
+
+#[tauri::command]
+pub(crate) fn mcp_app_host_info(window: WorkspaceSurface) -> Result<McpAppHostInfo, String> {
+    let app = window.app_handle();
+    let state = app.state::<McpAppChildren>();
+    let owner_epoch = state.registry.lock().unwrap().epoch(window.label());
+    Ok(McpAppHostInfo {
+        backend: if cfg!(windows) {
+            "native-child"
+        } else {
+            "legacy-iframe"
+        }
+        .into(),
+        owner_epoch,
+    })
+}
+
+#[tauri::command]
+pub(crate) async fn open_mcp_app_child(
+    app: AppHandle,
+    window: WorkspaceSurface,
+    state: State<'_, AppState>,
+    instance_id: String,
+    payload: Value,
+    host_context: Value,
+    bounds: McpAppChildBounds,
+    owner_epoch: String,
+    mount_serial: u64,
+) -> Result<McpAppChildHandle, String> {
+    verify_owner(&state, &window, &instance_id)?;
+    let frame = mcp_app_frame_id(&instance_id)?;
+    if crate::mcp_app_instance_id(frame, &payload) != instance_id {
+        return Err("MCP App presentation identity does not match the Tab".into());
+    }
+    if payload
+        .pointer("/resource/text")
+        .and_then(Value::as_str)
+        .is_none_or(str::is_empty)
+        || serde_json::to_vec(&payload)
+            .map_err(|e| e.to_string())?
+            .len()
+            > 32 * 1024 * 1024
+        || serde_json::to_vec(&host_context)
+            .map_err(|e| e.to_string())?
+            .len()
+            > 64 * 1024
+    {
+        return Err("Invalid or oversized MCP App presentation/context".into());
+    }
+    let (child, retired) = {
+        let children = app.state::<McpAppChildren>();
+        let mut registry = children.registry.lock().unwrap();
+        // Do not read active_frame while holding the registry: session switches
+        // update the frame first, then suspend. Recheck after native create.
+        let generation = state.mcp_app_bridge(&instance_id).map(|b| b.generation);
+        if owner_epoch != registry.epoch(window.label()) {
+            return Err(STALE.into());
+        }
+        registry.reserve(
+            window.label(),
+            &owner_epoch,
+            mount_serial,
+            &instance_id,
+            payload,
+            host_context,
+            bounds,
+            generation,
+        )?
+    };
+    finish_retirement(&app, retired);
+    let created = async {
+        mcp_app_children::create_native(&app, &window, &child).await?;
+        tokio::time::timeout(Duration::from_secs(15), async {
+            loop {
+                ensure_current(&state, &child)?;
+                if app
+                    .state::<McpAppChildren>()
+                    .registry
+                    .lock()
+                    .unwrap()
+                    .get(&child.handle.child_label)?
+                    .ready
+                {
+                    return Ok::<_, String>(());
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .map_err(|_| "MCP App shell did not become ready; close or retry this view".to_string())?
+    }
+    .await;
+    if let Err(error) = created {
+        let retired = {
+            let children = app.state::<McpAppChildren>();
+            let mut registry = children.registry.lock().unwrap();
+            registry.close(
+                window.label(),
+                &child.handle.owner_epoch,
+                child.handle.mount_serial,
+                &child.instance_id,
+                McpAppChildCloseReason::Replace,
+            )
+        };
+        finish_retirement(&app, retired);
+        return Err(error);
+    }
+    if verify_owner(&state, &window, &instance_id).is_err() {
+        suspend_owner(&app, window.label());
+        return Err(STALE.into());
+    }
+    child.ensure_live()?;
+    Ok(child.handle)
+}
+
+#[tauri::command]
+pub(crate) async fn update_mcp_app_child_bounds(
+    window: WorkspaceSurface,
+    app: AppHandle,
+    state: State<'_, AppState>,
+    handle: McpAppChildHandle,
+    bounds: McpAppChildBounds,
+    host_context: Value,
+) -> Result<bool, String> {
+    let children = app.state::<McpAppChildren>();
+    let _native = children.native_ops.lock().await;
+    let child = app
+        .state::<McpAppChildren>()
+        .registry
+        .lock()
+        .unwrap()
+        .get(&handle.child_label)?;
+    verify_owner(&state, &window, &child.instance_id)?;
+    if serde_json::to_vec(&host_context)
+        .map_err(|e| e.to_string())?
+        .len()
+        > 64 * 1024
+    {
+        return Err("Oversized host context".into());
+    }
+    if !bounds.visible {
+        window.focus_document().map_err(|e| e.to_string())?;
+    }
+    mcp_app_children::update_geometry(&app, window.label(), &handle, bounds, host_context)
+}
+
+#[tauri::command]
+pub(crate) fn mcp_app_child_bootstrap(
+    webview: Webview,
+    app: AppHandle,
+) -> Result<McpAppChildBootstrap, String> {
+    let child = mcp_app_children::caller_child(&app, &webview)?;
+    ensure_current(&app.state::<AppState>(), &child)?;
+    Ok(McpAppChildBootstrap {
+        server_tools_available: app
+            .state::<AppState>()
+            .mcp_app_bridge(&child.instance_id)
+            .is_some_and(|b| {
+                Some(b.generation) == child.bridge_generation && b.server.is_connected()
+            }),
+        handle: child.handle,
+        instance_id: child.instance_id,
+        payload: (*child.payload).clone(),
+        host_context: child.host_context,
+        version: env!("CARGO_PKG_VERSION").into(),
+    })
+}
+
+#[tauri::command]
+pub(crate) async fn mcp_app_child_ready(webview: Webview, app: AppHandle) -> Result<(), String> {
+    let children = app.state::<McpAppChildren>();
+    let _native = children.native_ops.lock().await;
+    let child = mcp_app_children::caller_child(&app, &webview)?;
+    mcp_app_children::set_ready(&app, &child.handle.child_label)?;
+    Ok(())
+}
+
+#[tauri::command]
+pub(crate) async fn mcp_app_child_request(
+    webview: Webview,
+    app: AppHandle,
+    state: State<'_, AppState>,
+    request: McpAppChildRequest,
+) -> Result<Value, String> {
+    let child = mcp_app_children::caller_child(&app, &webview)?;
+    ensure_current(&state, &child)?;
+    if request.method.len() > 128
+        || request.id.as_ref().is_some_and(|id| {
+            !id.is_null() && !id.is_number() && !id.as_str().is_some_and(|s| s.len() <= 256)
+        })
+        || serde_json::to_vec(&request.params)
+            .map_err(|e| e.to_string())?
+            .len()
+            > crate::MAX_MCP_APP_ARGUMENT_BYTES
+    {
+        return Err("Invalid or oversized MCP App request".into());
+    }
+    let id = request.id.clone();
+    let result = match request.method.as_str() {
+        "ping" => json!({}),
+        "ui/initialize" => {
+            let csp = child
+                .payload
+                .pointer("/resource/_meta/ui/csp")
+                .or_else(|| child.payload.pointer("/resource/_meta/csp"))
+                .cloned()
+                .unwrap_or_else(|| json!({}));
+            let mut capabilities =
+                json!({ "sandbox": { "csp": csp }, "updateModelContext": { "text": {} } });
+            if state.mcp_app_bridge(&child.instance_id).is_some_and(|b| {
+                Some(b.generation) == child.bridge_generation && b.server.is_connected()
+            }) {
+                capabilities["serverTools"] = json!({});
+            }
+            json!({ "protocolVersion": request.params.get("protocolVersion").and_then(Value::as_str).unwrap_or("2026-01-26"), "hostCapabilities": capabilities, "hostContext": child.host_context, "hostInfo": { "name": "wisp-science", "version": env!("CARGO_PKG_VERSION") } })
+        }
+        "tools/list" => {
+            let bridge = state.mcp_app_bridge(&child.instance_id).ok_or(STALE)?;
+            if Some(bridge.generation) != child.bridge_generation || !bridge.server.is_connected() {
+                return Err(crate::MCP_APP_STALE_INSTANCE_ERROR.into());
+            }
+            json!({ "tools": bridge.server.tools().into_iter().filter(|tool| tool.get("name").and_then(Value::as_str).is_some_and(|name| bridge.server.visible_to_app(name))).collect::<Vec<_>>() })
+        }
+        "tools/call" => {
+            let params = request
+                .params
+                .as_object()
+                .ok_or("tools/call params must be an object")?;
+            let name = params
+                .get("name")
+                .and_then(Value::as_str)
+                .ok_or("tools/call requires a name")?
+                .to_string();
+            let arguments = params
+                .get("arguments")
+                .cloned()
+                .unwrap_or_else(|| json!({}));
+            crate::call_mcp_app_tool_inner(
+                app.clone(),
+                &state,
+                child.instance_id.clone(),
+                name,
+                arguments,
+                Some(&child),
+            )
+            .await?
+        }
+        "ui/update-model-context" => {
+            let title = child
+                .payload
+                .pointer("/tool/title")
+                .or_else(|| child.payload.pointer("/tool/name"))
+                .and_then(Value::as_str)
+                .unwrap_or("MCP App");
+            let context = crate::normalize_mcp_app_context(title, request.params)?;
+            let frame = mcp_app_frame_id(&child.instance_id)?.to_string();
+            if state
+                .store
+                .frame_project_id(&frame)
+                .await
+                .map_err(|e| e.to_string())?
+                .is_none()
+            {
+                return Err(STALE.into());
+            }
+            let mut sessions = state.sessions.lock().await;
+            ensure_current(&state, &child)?;
+            let runtime = sessions
+                .entry(frame)
+                .or_insert_with(|| std::sync::Arc::new(crate::SessionRuntime::new()));
+            if runtime.deleted.load(std::sync::atomic::Ordering::SeqCst) {
+                return Err(STALE.into());
+            }
+            runtime.set_mcp_app_context(child.instance_id.clone(), context);
+            json!({})
+        }
+        "ui/notifications/initialized" => json!({}),
+        "wisp/escape" => {
+            if let Some(owner) = app.get_webview(&child.owner) {
+                owner.set_focus().map_err(|e| e.to_string())?;
+                owner.eval("window.dispatchEvent(new KeyboardEvent('keydown', {key:'Escape', bubbles:true, cancelable:true}));").map_err(|e| e.to_string())?;
+            }
+            json!({})
+        }
+        _ => return Ok(jsonrpc_error(id, "Capability is not granted by Wisp")),
+    };
+    ensure_current(&state, &child)?;
+    Ok(jsonrpc_result(id, result))
+}
+
+#[tauri::command]
+pub(crate) async fn request_mcp_app_child_action(
+    app: AppHandle,
+    window: WorkspaceSurface,
+    state: State<'_, AppState>,
+    instance_id: String,
+    handle: McpAppChildHandle,
+    method: String,
+    params: Value,
+) -> Result<Value, String> {
+    verify_owner(&state, &window, &instance_id)?;
+    let child = app
+        .state::<McpAppChildren>()
+        .registry
+        .lock()
+        .unwrap()
+        .get_by_instance(window.label(), &instance_id)?;
+    ensure_current(&state, &child)?;
+    if handle != child.handle {
+        return Err(STALE.into());
+    }
+    if child.payload.pointer("/tool/name").and_then(Value::as_str) != Some("motif_open_workbench")
+        || !matches!(
+            method.as_str(),
+            "wisp/motif-get-selection" | "wisp/motif-add-records" | "ui/notifications/tool-result"
+        )
+        || serde_json::to_vec(&params)
+            .map_err(|e| e.to_string())?
+            .len()
+            > crate::MAX_MCP_APP_RESULT_BYTES
+    {
+        return Err("MCP App host action is not permitted or is oversized".into());
+    }
+    let request_id = uuid::Uuid::new_v4().to_string();
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    app.state::<McpAppChildren>()
+        .actions
+        .lock()
+        .unwrap()
+        .insert(request_id.clone(), (child.handle.child_label.clone(), tx));
+    let message = McpAppChildDelivery {
+        kind: "request".into(),
+        request_id: Some(request_id.clone()),
+        method: Some(method),
+        params,
+    };
+    if let Err(error) = mcp_app_children::deliver(&app, &child, &message) {
+        app.state::<McpAppChildren>()
+            .actions
+            .lock()
+            .unwrap()
+            .remove(&request_id);
+        return Err(error);
+    }
+    let result = match tokio::time::timeout(Duration::from_secs(5), rx).await {
+        Ok(Ok(result)) => result,
+        Ok(Err(_)) => Err("MCP App action channel closed.".into()),
+        Err(_) => {
+            app.state::<McpAppChildren>()
+                .actions
+                .lock()
+                .unwrap()
+                .remove(&request_id);
+            Err("MCP App did not respond in time.".into())
+        }
+    };
+    ensure_current(&state, &child)?;
+    result
+}
+
+#[tauri::command]
+pub(crate) fn mcp_app_child_action_reply(
+    webview: Webview,
+    app: AppHandle,
+    request_id: String,
+    result: Option<Value>,
+    error: Option<String>,
+) -> Result<(), String> {
+    let child = mcp_app_children::caller_child(&app, &webview)?;
+    let children = app.state::<McpAppChildren>();
+    let mut actions = children.actions.lock().unwrap();
+    if actions
+        .get(&request_id)
+        .is_none_or(|(label, _)| label != &child.handle.child_label)
+    {
+        return Err(STALE.into());
+    }
+    if result.as_ref().is_some_and(|v| {
+        serde_json::to_vec(v).map_or(true, |v| v.len() > crate::MAX_MCP_APP_RESULT_BYTES)
+    }) {
+        return Err("MCP App action result is oversized".into());
+    }
+    let entry = actions.remove(&request_id);
+    let Some((label, tx)) = entry else {
+        return Err(STALE.into());
+    };
+    if label != child.handle.child_label {
+        return Err(STALE.into());
+    }
+    let _ = tx.send(match error {
+        Some(error) => Err(error.chars().take(512).collect()),
+        None => Ok(result.unwrap_or(Value::Null)),
+    });
+    Ok(())
+}
+
+#[tauri::command]
+pub(crate) fn close_mcp_app_child(
+    app: AppHandle,
+    window: WorkspaceSurface,
+    instance_id: String,
+    owner_epoch: String,
+    mount_serial: u64,
+    reason: McpAppChildCloseReason,
+) -> Result<bool, String> {
+    mcp_app_frame_id(&instance_id)?;
+    let retirement = app
+        .state::<McpAppChildren>()
+        .registry
+        .lock()
+        .unwrap()
+        .close(
+            window.label(),
+            &owner_epoch,
+            mount_serial,
+            &instance_id,
+            reason,
+        );
+    let had_child = !retirement.children.is_empty();
+    finish_retirement(&app, retirement);
+    Ok(had_child)
+}

--- a/src-tauri/src/mcp_app_children.rs
+++ b/src-tauri/src/mcp_app_children.rs
@@ -1,0 +1,827 @@
+//! Native child-view ownership. No database, tool execution or plugin credentials.
+//! The registry is also used by the disposable native smoke, so lifecycle tests
+//! exercise the production implementation rather than a second window manager.
+use crate::workspace_surface::{WorkspaceManager, WorkspaceSurface};
+use serde_json::Value;
+use std::{
+    collections::HashMap,
+    path::PathBuf,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    },
+    time::Duration,
+};
+use tauri::{AppHandle, Manager, Webview};
+use wisp_dto::{McpAppChildBounds, McpAppChildCloseReason, McpAppChildDelivery, McpAppChildHandle};
+
+pub(crate) const CHILD_PREFIX: &str = "mcp-app-child-";
+pub(crate) const STALE: &str = "stale-instance: this MCP App view has been closed or replaced";
+
+#[derive(Clone)]
+pub(crate) struct Child {
+    pub owner: String,
+    pub instance_id: String,
+    pub handle: McpAppChildHandle,
+    pub payload: Arc<Value>,
+    pub host_context: Value,
+    pub bounds: McpAppChildBounds,
+    pub alive: Arc<AtomicBool>,
+    pub ready: bool,
+    pub profile: Option<PathBuf>,
+    pub bridge_generation: Option<u64>,
+}
+
+impl Child {
+    pub(crate) fn ensure_live(&self) -> Result<(), String> {
+        if self.alive.load(Ordering::SeqCst) {
+            Ok(())
+        } else {
+            Err(STALE.into())
+        }
+    }
+}
+
+struct Owner {
+    epoch: String,
+    serial: u64,
+    closed: bool,
+}
+impl Default for Owner {
+    fn default() -> Self {
+        Self {
+            epoch: uuid::Uuid::new_v4().to_string(),
+            serial: 0,
+            closed: false,
+        }
+    }
+}
+
+#[derive(Clone)]
+struct Binding {
+    serial: u64,
+    bridge_generation: Option<u64>,
+}
+
+#[derive(Default)]
+pub(crate) struct Registry {
+    owners: HashMap<String, Owner>,
+    children: HashMap<String, Child>,
+    // Logical ownership survives a Tab switch. Closing one view must not revoke
+    // the same session's bridge while another window still has that App open.
+    bindings: HashMap<(String, String), Binding>,
+}
+
+#[derive(Default)]
+pub(crate) struct Retirement {
+    pub children: Vec<Child>,
+    pub releases: Vec<(String, Option<u64>)>,
+}
+
+impl Registry {
+    pub(crate) fn epoch(&mut self, owner: &str) -> String {
+        self.owners.entry(owner.into()).or_default().epoch.clone()
+    }
+
+    fn retire_matching(&mut self, predicate: impl Fn(&Child) -> bool) -> Vec<Child> {
+        let labels: Vec<_> = self
+            .children
+            .values()
+            .filter(|c| predicate(c))
+            .map(|c| c.handle.child_label.clone())
+            .collect();
+        labels
+            .into_iter()
+            .filter_map(|label| self.children.remove(&label))
+            .inspect(|c| {
+                c.alive.store(false, Ordering::SeqCst);
+            })
+            .collect()
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn reserve(
+        &mut self,
+        owner: &str,
+        epoch: &str,
+        serial: u64,
+        instance_id: &str,
+        payload: Value,
+        context: Value,
+        bounds: McpAppChildBounds,
+        bridge_generation: Option<u64>,
+    ) -> Result<(Child, Retirement), String> {
+        let o = self.owners.get_mut(owner).ok_or(STALE)?;
+        if o.epoch != epoch || serial == 0 || serial <= o.serial {
+            return Err(STALE.into());
+        }
+        o.serial = serial;
+        o.closed = false;
+        let retired = self.retire_matching(|c| c.owner == owner);
+        let child = Child {
+            owner: owner.into(),
+            instance_id: instance_id.into(),
+            handle: McpAppChildHandle {
+                owner_epoch: epoch.into(),
+                mount_serial: serial,
+                child_label: format!("{CHILD_PREFIX}{}", uuid::Uuid::new_v4()),
+            },
+            payload: Arc::new(payload),
+            host_context: context,
+            bounds,
+            alive: Arc::new(AtomicBool::new(true)),
+            ready: false,
+            profile: None,
+            bridge_generation,
+        };
+        self.bindings.insert(
+            (owner.into(), instance_id.into()),
+            Binding {
+                serial,
+                bridge_generation,
+            },
+        );
+        self.children
+            .insert(child.handle.child_label.clone(), child.clone());
+        Ok((
+            child,
+            Retirement {
+                children: retired,
+                releases: vec![],
+            },
+        ))
+    }
+
+    pub(crate) fn get(&self, label: &str) -> Result<Child, String> {
+        let c = self.children.get(label).ok_or(STALE)?;
+        c.ensure_live()?;
+        Ok(c.clone())
+    }
+
+    pub(crate) fn get_by_instance(&self, owner: &str, instance: &str) -> Result<Child, String> {
+        self.children
+            .values()
+            .find(|c| c.owner == owner && c.instance_id == instance)
+            .cloned()
+            .ok_or_else(|| STALE.into())
+    }
+
+    pub(crate) fn has_binding(&self, instance: &str) -> bool {
+        self.bindings.keys().any(|(_, id)| id == instance)
+    }
+
+    pub(crate) fn suspend_owner(&mut self, owner: &str) -> Retirement {
+        Retirement {
+            children: self.retire_matching(|c| c.owner == owner),
+            releases: vec![],
+        }
+    }
+
+    pub(crate) fn close(
+        &mut self,
+        owner: &str,
+        epoch: &str,
+        serial: u64,
+        instance: &str,
+        reason: McpAppChildCloseReason,
+    ) -> Retirement {
+        let Some(o) = self.owners.get_mut(owner).filter(|o| o.epoch == epoch) else {
+            return Retirement::default();
+        };
+        // A close can arrive before a slow open reaches reserve(). Fence it out.
+        if serial >= o.serial {
+            o.serial = serial;
+            o.closed = true;
+        }
+        let children = self.retire_matching(|c| {
+            c.owner == owner && c.handle.mount_serial == serial && c.instance_id == instance
+        });
+        let mut releases = vec![];
+        if reason == McpAppChildCloseReason::UserClose {
+            let key = (owner.into(), instance.into());
+            if self.bindings.get(&key).is_some_and(|b| b.serial == serial) {
+                let old = self.bindings.remove(&key).unwrap();
+                if !self.bindings.keys().any(|(_, i)| i == instance) {
+                    releases.push((instance.into(), old.bridge_generation));
+                }
+            }
+        }
+        Retirement { children, releases }
+    }
+
+    pub(crate) fn reset_owner(&mut self, owner: &str, destroy: bool) -> Retirement {
+        let children = self.retire_matching(|c| c.owner == owner);
+        let mut releases = vec![];
+        if destroy {
+            self.owners.remove(owner);
+            let keys: Vec<_> = self
+                .bindings
+                .keys()
+                .filter(|(o, _)| o == owner)
+                .cloned()
+                .collect();
+            for key in keys {
+                let old = self.bindings.remove(&key).unwrap();
+                if !self.bindings.keys().any(|(_, i)| i == &key.1) {
+                    releases.push((key.1, old.bridge_generation));
+                }
+            }
+        } else {
+            self.owners.insert(owner.into(), Owner::default());
+        }
+        Retirement { children, releases }
+    }
+
+    pub(crate) fn remove_frame(&mut self, frame_prefix: &str) -> Retirement {
+        self.bindings
+            .retain(|(_, id), _| !id.starts_with(frame_prefix));
+        Retirement {
+            children: self.retire_matching(|c| c.instance_id.starts_with(frame_prefix)),
+            releases: vec![],
+        }
+    }
+}
+
+pub(crate) struct McpAppChildren {
+    pub registry: Mutex<Registry>,
+    pub actions:
+        Mutex<HashMap<String, (String, tokio::sync::oneshot::Sender<Result<Value, String>>)>>,
+    pub native_ops: tokio::sync::Mutex<()>,
+    boot_id: String,
+    pub profile_root: Option<PathBuf>,
+}
+impl Default for McpAppChildren {
+    fn default() -> Self {
+        Self {
+            registry: Mutex::new(Registry::default()),
+            actions: Mutex::new(HashMap::new()),
+            native_ops: tokio::sync::Mutex::new(()),
+            boot_id: uuid::Uuid::new_v4().to_string(),
+            profile_root: None,
+        }
+    }
+}
+
+/// Explicit allowlist for application commands. Core/plugin commands are gated
+/// separately by capabilities scoped to webview labels (no window inheritance).
+pub(crate) fn child_command_allowed(label: &str, command: &str) -> bool {
+    !label.starts_with(CHILD_PREFIX)
+        || matches!(
+            command,
+            "mcp_app_child_bootstrap"
+                | "mcp_app_child_ready"
+                | "mcp_app_child_request"
+                | "mcp_app_child_action_reply"
+        )
+}
+
+pub(crate) fn child_navigation_allowed(url: &url::Url) -> bool {
+    // Do not let a plugin turn its trusted shell into arbitrary app assets or a
+    // remote document with access to the shell's IPC endpoints.
+    url.path() == "/mcp-app/shell.html"
+        && ((url.scheme() == "tauri" && url.host_str() == Some("localhost"))
+            || (matches!(url.scheme(), "http" | "https")
+                && url.host_str() == Some("tauri.localhost"))
+            || (cfg!(debug_assertions)
+                && url.scheme() == "http"
+                && matches!(url.host_str(), Some("localhost" | "127.0.0.1"))
+                && url.port() == Some(1421)))
+}
+
+pub(crate) fn deliver(
+    app: &AppHandle,
+    child: &Child,
+    message: &McpAppChildDelivery,
+) -> Result<(), String> {
+    let view = app.get_webview(&child.handle.child_label).ok_or(STALE)?;
+    // JSON serialization is the only interpolation; there is no plugin-supplied
+    // JavaScript callback name. This never broadcasts via the event bus.
+    let json = serde_json::to_string(message).map_err(|e| e.to_string())?;
+    view.eval(format!("window.__wispMcpReceive?.({json});"))
+        .map_err(|e| e.to_string())
+}
+
+pub(crate) fn retire_native(app: &AppHandle, children: Vec<Child>) {
+    if children.is_empty() {
+        return;
+    }
+    let Some(state) = app.try_state::<McpAppChildren>() else {
+        return;
+    };
+    for child in children {
+        let app = app.clone();
+        // Invalidate immediately, hide immediately, and finish native close even
+        // if the guest's event loop never handles resource-teardown.
+        state
+            .actions
+            .lock()
+            .unwrap()
+            .retain(|_, (label, _)| label != &child.handle.child_label);
+        tauri::async_runtime::spawn(async move {
+            let Some(state) = app.try_state::<McpAppChildren>() else {
+                return;
+            };
+            {
+                let _native = state.native_ops.lock().await;
+                if let Some(view) = app.get_webview(&child.handle.child_label) {
+                    let _ = view.hide();
+                }
+                let _ = deliver(
+                    &app,
+                    &child,
+                    &McpAppChildDelivery {
+                        kind: "teardown".into(),
+                        request_id: None,
+                        method: None,
+                        params: Value::Null,
+                    },
+                );
+            }
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            {
+                let Some(state) = app.try_state::<McpAppChildren>() else {
+                    return;
+                };
+                let _native = state.native_ops.lock().await;
+                if let Some(view) = app.get_webview(&child.handle.child_label) {
+                    let _ = view.close();
+                }
+            }
+            if let Some(profile) = child.profile {
+                cleanup_profile(profile).await;
+            }
+        });
+    }
+}
+
+async fn cleanup_profile(profile: PathBuf) {
+    // Only a generated leaf in this feature's per-boot directory is eligible.
+    if !profile
+        .file_name()
+        .and_then(|p| p.to_str())
+        .is_some_and(|p| p.starts_with(CHILD_PREFIX))
+        || profile
+            .parent()
+            .and_then(|p| p.file_name())
+            .and_then(|p| p.to_str())
+            .and_then(|p| uuid::Uuid::parse_str(p).ok())
+            .is_none()
+    {
+        return;
+    }
+    for _ in 0..30 {
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        let p = profile.clone();
+        let done =
+            tauri::async_runtime::spawn_blocking(move || match std::fs::remove_dir_all(&p) {
+                Ok(()) => true,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => true,
+                Err(_) => false,
+            })
+            .await
+            .unwrap_or(false);
+        if done {
+            return;
+        }
+    }
+    tracing::warn!(target: "wisp", "MCP App profile is still locked; deferred cleanup (no user data removed)");
+}
+
+/// Validate/clamp in CSS space before converting using the primary WebView's
+/// real physical client size. This handles monitor DPI and page zoom together.
+/// `origin` is parent-window-client-relative; Wisp passes (0, 0) because the
+/// primary document fills the client area.
+pub(crate) fn physical_bounds(
+    b: &McpAppChildBounds,
+    size: tauri::PhysicalSize<u32>,
+    origin: tauri::PhysicalPosition<i32>,
+) -> Option<tauri::Rect> {
+    if !b.visible
+        || [
+            b.x,
+            b.y,
+            b.width,
+            b.height,
+            b.viewport_width,
+            b.viewport_height,
+        ]
+        .iter()
+        .any(|n| !n.is_finite())
+        || b.viewport_width <= 0.0
+        || b.viewport_height <= 0.0
+        || b.width <= 0.0
+        || b.height <= 0.0
+        || size.width == 0
+        || size.height == 0
+    {
+        return None;
+    }
+    let left = b.x.max(0.0).min(b.viewport_width);
+    let top = b.y.max(0.0).min(b.viewport_height);
+    let right = (b.x + b.width).max(left).min(b.viewport_width);
+    let bottom = (b.y + b.height).max(top).min(b.viewport_height);
+    let sx = size.width as f64 / b.viewport_width;
+    let sy = size.height as f64 / b.viewport_height;
+    let (x, y, r, d) = (
+        (left * sx).ceil() as i32,
+        (top * sy).ceil() as i32,
+        (right * sx).floor() as i32,
+        (bottom * sy).floor() as i32,
+    );
+    if r <= x || d <= y {
+        return None;
+    }
+    Some(tauri::Rect {
+        position: tauri::PhysicalPosition::new(origin.x + x, origin.y + y).into(),
+        size: tauri::PhysicalSize::new((r - x) as u32, (d - y) as u32).into(),
+    })
+}
+
+pub(crate) fn apply_bounds(app: &AppHandle, child: &Child) -> Result<(), String> {
+    child.ensure_live()?;
+    let view = app.get_webview(&child.handle.child_label).ok_or(STALE)?;
+    let owner = app.workspace_surface(&child.owner).ok_or(STALE)?;
+    // Child set_bounds is parent-window-client-relative (Tauri 2.11.3 / wry
+    // WebView2). The primary document fills that client area. Do not add
+    // Webview::position() of the primary webview: for a webview-window it
+    // returns the window inner position, which is desktop-relative.
+    let bounds = physical_bounds(
+        &child.bounds,
+        owner.webview().size().map_err(|e| e.to_string())?,
+        tauri::PhysicalPosition::new(0, 0),
+    );
+    if !child.ready
+        || !owner.is_visible().unwrap_or(false)
+        || owner.is_minimized().unwrap_or(true)
+        || bounds.is_none()
+    {
+        view.hide().map_err(|e| e.to_string())?;
+    } else if let Some(bounds) = bounds {
+        view.set_bounds(bounds).map_err(|e| e.to_string())?;
+        // Recheck after native setters so a concurrent close cannot reshow it.
+        child.ensure_live()?;
+        view.show().map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+pub(crate) async fn create_native(
+    app: &AppHandle,
+    owner: &WorkspaceSurface,
+    child: &Child,
+) -> Result<(), String> {
+    let state = app.state::<McpAppChildren>();
+    child.ensure_live()?;
+    let root = match &state.profile_root {
+        Some(root) => root.clone(),
+        None => app
+            .path()
+            .app_cache_dir()
+            .map_err(|e| e.to_string())?
+            .join("mcp-app-webviews"),
+    }
+    .join(&state.boot_id);
+    let profile = root.join(&child.handle.child_label);
+    {
+        let state = app.state::<McpAppChildren>();
+        let mut r = state.registry.lock().unwrap();
+        r.children
+            .get_mut(&child.handle.child_label)
+            .ok_or(STALE)?
+            .profile = Some(profile.clone());
+    }
+    std::fs::create_dir_all(&profile).map_err(|e| e.to_string())?;
+    let label = child.handle.child_label.clone();
+    let window = owner.webview().window();
+    let alive = child.alive.clone();
+    // Serialize with hide/close. Do not hold this lock while waiting for the
+    // shell to become ready, and do not hold the registry lock here.
+    let state = app.state::<McpAppChildren>();
+    let _native = state.native_ops.lock().await;
+    child.ensure_live()?;
+    let created_label = label.clone();
+    let result = tauri::async_runtime::spawn_blocking(move || {
+        if !alive.load(Ordering::SeqCst) {
+            return Err(STALE.into());
+        }
+        let builder = tauri::webview::WebviewBuilder::new(
+            label,
+            tauri::WebviewUrl::App("mcp-app/shell.html".into()),
+        )
+        .data_directory(profile)
+        .focused(false)
+        .disable_drag_drop_handler()
+        .on_navigation(child_navigation_allowed)
+        .on_new_window(|_, _| tauri::webview::NewWindowResponse::Deny)
+        .on_download(|_, _| false);
+        let view = window
+            .add_child(
+                builder,
+                tauri::LogicalPosition::new(-10000.0, -10000.0),
+                tauri::LogicalSize::new(1.0, 1.0),
+            )
+            .map_err(|e| e.to_string())?;
+        view.hide().map_err(|e| e.to_string())?;
+        if !alive.load(Ordering::SeqCst) {
+            let _ = view.close();
+            return Err(STALE.into());
+        }
+        Ok::<_, String>(())
+    })
+    .await
+    .map_err(|e| e.to_string())?;
+    if let Err(error) = result {
+        return Err(error);
+    }
+    if child.ensure_live().is_err() {
+        if let Some(view) = app.get_webview(&created_label) {
+            let _ = view.hide();
+            let _ = view.close();
+        }
+        return Err(STALE.into());
+    }
+    Ok(())
+}
+
+#[cfg(not(windows))]
+pub(crate) async fn create_native(
+    _: &AppHandle,
+    _: &WorkspaceSurface,
+    _: &Child,
+) -> Result<(), String> {
+    Err("Native MCP App children are enabled on Windows only.".into())
+}
+
+pub(crate) fn caller_child(app: &AppHandle, webview: &Webview) -> Result<Child, String> {
+    let child = app
+        .state::<McpAppChildren>()
+        .registry
+        .lock()
+        .unwrap()
+        .get(webview.label())?;
+    if webview.window().label() != child.owner {
+        return Err(STALE.into());
+    }
+    Ok(child)
+}
+
+pub(crate) fn update_geometry(
+    app: &AppHandle,
+    owner: &str,
+    handle: &McpAppChildHandle,
+    bounds: McpAppChildBounds,
+    context: Value,
+) -> Result<bool, String> {
+    let child = {
+        let state = app.state::<McpAppChildren>();
+        let mut r = state.registry.lock().unwrap();
+        let c = r.children.get_mut(&handle.child_label).ok_or(STALE)?;
+        if c.owner != owner || c.handle != *handle {
+            return Err(STALE.into());
+        }
+        if bounds.revision <= c.bounds.revision {
+            return Ok(false);
+        }
+        c.bounds = bounds;
+        c.host_context = context;
+        c.clone()
+    };
+    apply_bounds(app, &child)?;
+    let _ = deliver(
+        app,
+        &child,
+        &McpAppChildDelivery {
+            kind: "host-context".into(),
+            request_id: None,
+            method: None,
+            params: child.host_context.clone(),
+        },
+    );
+    Ok(true)
+}
+
+pub(crate) fn set_ready(app: &AppHandle, label: &str) -> Result<Child, String> {
+    let child = {
+        let state = app.state::<McpAppChildren>();
+        let mut r = state.registry.lock().unwrap();
+        let c = r.children.get_mut(label).ok_or(STALE)?;
+        c.ready = true;
+        c.clone()
+    };
+    apply_bounds(app, &child)?;
+    Ok(child)
+}
+
+pub(crate) fn hide_owner(app: &AppHandle, owner: &str) {
+    let children: Vec<_> = app
+        .state::<McpAppChildren>()
+        .registry
+        .lock()
+        .unwrap()
+        .children
+        .values()
+        .filter(|c| c.owner == owner)
+        .cloned()
+        .collect();
+    for c in children {
+        if let Some(w) = app.get_webview(&c.handle.child_label) {
+            let _ = w.hide();
+        }
+    }
+    // Bounds are stale until the primary document has measured the new client
+    // area/DPI. Do not restore using the pre-resize coordinates.
+    if let Some(view) = app.get_webview(owner) {
+        let _ = view.eval("window.dispatchEvent(new Event('wisp-mcp-native-resize')); ");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn open(
+        r: &mut Registry,
+        owner: &str,
+        epoch: &str,
+        serial: u64,
+        instance: &str,
+    ) -> Result<(Child, Retirement), String> {
+        r.reserve(
+            owner,
+            epoch,
+            serial,
+            instance,
+            Value::Null,
+            Value::Null,
+            McpAppChildBounds::default(),
+            Some(serial),
+        )
+    }
+    #[test]
+    fn close_before_open_and_old_page_cannot_resurrect_a_child() {
+        let mut r = Registry::default();
+        let epoch = r.epoch("main");
+        r.close("main", &epoch, 1, "app", McpAppChildCloseReason::Suspend);
+        assert!(open(&mut r, "main", &epoch, 1, "app").is_err());
+        let (a, _) = open(&mut r, "main", &epoch, 2, "app").unwrap();
+        r.reset_owner("main", false);
+        assert!(a.ensure_live().is_err());
+        assert!(open(&mut r, "main", &epoch, 3, "app").is_err());
+    }
+    #[test]
+    fn replacement_is_bounded_and_stale_close_cannot_revoke_new_binding() {
+        let mut r = Registry::default();
+        let e = r.epoch("main");
+        let (a, _) = open(&mut r, "main", &e, 1, "app").unwrap();
+        let (b, retired) = open(&mut r, "main", &e, 2, "app").unwrap();
+        assert_eq!(retired.children.len(), 1);
+        assert!(a.ensure_live().is_err());
+        let retirement = r.close("main", &e, 1, "app", McpAppChildCloseReason::UserClose);
+        assert!(retirement.releases.is_empty());
+        assert!(r.get(&b.handle.child_label).is_ok());
+        assert_eq!(r.children.len(), 1);
+    }
+    #[test]
+    fn suspension_keeps_binding_and_two_owners_release_only_the_last_reference() {
+        let mut r = Registry::default();
+        let a = r.epoch("main");
+        let b = r.epoch("proj-b");
+        open(&mut r, "main", &a, 1, "app").unwrap();
+        open(&mut r, "proj-b", &b, 1, "app").unwrap();
+        assert!(r
+            .close("main", &a, 1, "app", McpAppChildCloseReason::Suspend)
+            .releases
+            .is_empty());
+        assert!(r
+            .close("main", &a, 1, "app", McpAppChildCloseReason::UserClose)
+            .releases
+            .is_empty());
+        assert_eq!(
+            r.close("proj-b", &b, 1, "app", McpAppChildCloseReason::UserClose)
+                .releases,
+            vec![("app".into(), Some(1))]
+        );
+    }
+    #[test]
+    fn ipc_and_navigation_are_fail_closed() {
+        assert!(child_command_allowed(
+            "mcp-app-child-x",
+            "mcp_app_child_request"
+        ));
+        for cmd in [
+            "stop_agent",
+            "read_file",
+            "update_mcp_app_context",
+            "call_mcp_app_tool",
+            "close_mcp_app",
+            "open_mcp_app_child",
+        ] {
+            assert!(!child_command_allowed("mcp-app-child-x", cmd));
+        }
+        assert!(child_navigation_allowed(
+            &"http://tauri.localhost/mcp-app/shell.html".parse().unwrap()
+        ));
+        for url in [
+            "http://tauri.localhost/index.html",
+            "https://example.com/mcp-app/shell.html",
+            "file:///mcp-app/shell.html",
+        ] {
+            assert!(!child_navigation_allowed(&url.parse().unwrap()));
+        }
+    }
+    #[test]
+    fn dpi_zoom_clipping_and_invalid_rects() {
+        let b = McpAppChildBounds {
+            x: 100.0,
+            y: 60.0,
+            width: 300.0,
+            height: 200.0,
+            viewport_width: 800.0,
+            viewport_height: 600.0,
+            visible: true,
+            revision: 1,
+        };
+        for scale in [1.0, 1.5, 2.0] {
+            let rect = physical_bounds(
+                &b,
+                tauri::PhysicalSize::new((800.0 * scale) as u32, (600.0 * scale) as u32),
+                tauri::PhysicalPosition::new(0, 0),
+            )
+            .unwrap();
+            assert_eq!(
+                rect.position.to_physical::<i32>(1.0).x,
+                (100.0 * scale) as i32
+            );
+            assert_eq!(
+                rect.size.to_physical::<u32>(1.0).width,
+                (300.0 * scale) as u32
+            );
+        }
+        // Parent-relative origin is 0 when the primary document fills the
+        // window client area. A desktop-relative inner position (e.g. 1920,1080)
+        // must not be mixed in by apply_bounds.
+        let origin_zero = physical_bounds(
+            &b,
+            tauri::PhysicalSize::new(800, 600),
+            tauri::PhysicalPosition::new(0, 0),
+        )
+        .unwrap();
+        assert_eq!(origin_zero.position.to_physical::<i32>(1.0).x, 100);
+        assert_eq!(origin_zero.position.to_physical::<i32>(1.0).y, 60);
+        assert!(physical_bounds(
+            &McpAppChildBounds {
+                width: f64::NAN,
+                ..b
+            },
+            tauri::PhysicalSize::new(800, 600),
+            tauri::PhysicalPosition::new(0, 0)
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn repeated_switches_leave_one_child_and_session_delete_invalidates_calls() {
+        let mut registry = Registry::default();
+        let epoch = registry.epoch("main");
+        for n in 1..=100 {
+            let (child, retired) =
+                open(&mut registry, "main", &epoch, n, "mcp-app:session-a:ui://a").unwrap();
+            assert!(retired.children.len() <= 1);
+            assert_eq!(registry.children.len(), 1);
+            let retired = registry.suspend_owner("main");
+            assert_eq!(retired.children.len(), 1);
+            assert!(child.ensure_live().is_err());
+            assert!(retired.releases.is_empty());
+        }
+        assert_eq!(registry.bindings.len(), 1);
+        let (child, _) = open(
+            &mut registry,
+            "main",
+            &epoch,
+            101,
+            "mcp-app:session-a:ui://a",
+        )
+        .unwrap();
+        registry.remove_frame("mcp-app:session-a:");
+        assert!(child.ensure_live().is_err());
+        assert!(registry.bindings.is_empty());
+        assert!(registry.children.is_empty());
+    }
+
+    #[test]
+    fn capabilities_never_inherit_permissions_from_native_window() {
+        for json in [
+            include_str!("../capabilities/default.json"),
+            include_str!("../capabilities/pet.json"),
+            include_str!("../capabilities/terminal.json"),
+            include_str!("../capabilities/mcp-app-child.json"),
+        ] {
+            let capability: Value = serde_json::from_str(json).unwrap();
+            assert!(capability.get("windows").is_none());
+            assert!(capability["webviews"].is_array());
+        }
+        let child: Value =
+            serde_json::from_str(include_str!("../capabilities/mcp-app-child.json")).unwrap();
+        assert_eq!(child["permissions"], serde_json::json!([]));
+    }
+}

--- a/src-tauri/src/memory_commands.rs
+++ b/src-tauri/src/memory_commands.rs
@@ -348,7 +348,7 @@ async fn require_writable_memory_target(
 #[tauri::command]
 pub(super) async fn get_memory_view(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     project_id: Option<String>,
 ) -> Result<MemoryView, String> {
     let enabled = load_memory_enabled(&state.store).await;
@@ -358,7 +358,7 @@ pub(super) async fn get_memory_view(
 #[tauri::command]
 pub(super) async fn set_memory_enabled(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     enabled: bool,
     project_id: Option<String>,
 ) -> Result<MemoryView, String> {
@@ -370,7 +370,7 @@ pub(super) async fn set_memory_enabled(
 #[tauri::command]
 pub(super) async fn read_memory_file(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     name: String,
     project_id: Option<String>,
 ) -> Result<String, String> {
@@ -385,7 +385,7 @@ pub(super) async fn read_memory_file(
 #[tauri::command]
 pub(super) async fn write_memory_file(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     name: String,
     content: String,
     project_id: Option<String>,
@@ -417,7 +417,7 @@ pub(super) async fn write_memory_file(
 #[tauri::command]
 pub(super) async fn delete_memory_file(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     name: String,
     project_id: Option<String>,
 ) -> Result<Vec<MemoryFile>, String> {
@@ -447,7 +447,7 @@ pub(super) async fn delete_memory_file(
 #[tauri::command]
 pub(super) async fn clear_memory(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     project_id: Option<String>,
 ) -> Result<Vec<MemoryFile>, String> {
     let target_project_id = match project_id

--- a/src-tauri/src/method_search.rs
+++ b/src-tauri/src/method_search.rs
@@ -901,7 +901,7 @@ async fn method_search_details(
 #[tauri::command]
 pub(crate) async fn get_method_search_run(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     run_id: String,
 ) -> Result<MethodSearchRunDetails, String> {
     let project = state.require_active(window.label())?;
@@ -911,7 +911,7 @@ pub(crate) async fn get_method_search_run(
 #[tauri::command]
 pub(crate) async fn pause_method_search(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     run_id: String,
 ) -> Result<MethodSearchRunDetails, String> {
     let project = state.require_active(window.label())?;
@@ -966,7 +966,7 @@ async fn continue_recovered_workflow(
 #[tauri::command]
 pub(crate) async fn start_method_search(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     run_id: String,
 ) -> Result<MethodSearchRunDetails, String> {
     let (project, scope) =
@@ -1064,7 +1064,7 @@ pub(crate) async fn start_method_search(
 #[tauri::command]
 pub(crate) async fn resume_method_search(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     run_id: String,
 ) -> Result<MethodSearchRunDetails, String> {
     let (project, scope) =
@@ -1160,7 +1160,7 @@ pub(crate) async fn resume_method_search(
 #[tauri::command]
 pub(crate) async fn cancel_method_search(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     run_id: String,
 ) -> Result<MethodSearchRunDetails, String> {
     let project = state.require_active(window.label())?;

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -1353,7 +1353,7 @@ pub async fn list_models(state: State<'_, crate::AppState>) -> Result<Vec<ModelP
 #[tauri::command]
 pub async fn get_session_model(
     state: State<'_, crate::AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     session_id: String,
 ) -> Result<String, String> {
     let project = state.require_active(window.label())?;
@@ -1382,7 +1382,7 @@ pub async fn get_session_model(
 #[tauri::command]
 pub async fn get_session_reasoning_effort(
     state: State<'_, crate::AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     session_id: String,
 ) -> Result<Option<String>, String> {
     let project = state.require_active(window.label())?;
@@ -1406,7 +1406,7 @@ pub async fn get_session_reasoning_effort(
 #[tauri::command]
 pub async fn get_session_service_tier(
     state: State<'_, crate::AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     session_id: String,
 ) -> Result<Option<String>, String> {
     let project = state.require_active(window.label())?;
@@ -1634,7 +1634,7 @@ pub async fn reorder_models(
 #[tauri::command]
 pub async fn set_active_model(
     state: State<'_, crate::AppState>,
-    _window: tauri::WebviewWindow,
+    _window: crate::workspace_surface::WorkspaceSurface,
     id: String,
     session_id: Option<String>,
 ) -> Result<Vec<ModelProfile>, String> {

--- a/src-tauri/src/plan_mode.rs
+++ b/src-tauri/src/plan_mode.rs
@@ -69,7 +69,7 @@ async fn ensure_project_frame(
 #[tauri::command]
 pub(crate) async fn get_session_plan_mode(
     state: State<'_, crate::AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     session_id: String,
 ) -> Result<Option<bool>, String> {
     let project = state.require_active(window.label())?;
@@ -83,7 +83,7 @@ pub(crate) async fn get_session_plan_mode(
 #[tauri::command]
 pub(crate) async fn set_session_plan_mode(
     state: State<'_, crate::AppState>,
-    _window: tauri::WebviewWindow,
+    _window: crate::workspace_surface::WorkspaceSurface,
     session_id: String,
     enabled: bool,
 ) -> Result<bool, String> {

--- a/src-tauri/src/plugins.rs
+++ b/src-tauri/src/plugins.rs
@@ -929,7 +929,7 @@ pub(crate) async fn enabled_plugin_mcp_launches(
 #[tauri::command]
 pub(super) async fn list_plugins(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
 ) -> Result<Vec<PluginView>, String> {
     let project = state.require_active(window.label())?;
     let bindings = state
@@ -1138,7 +1138,7 @@ pub(super) async fn install_plugin_url(
 #[tauri::command]
 pub(super) async fn set_plugin_enabled(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     plugin_id: String,
     version: String,
     enabled: bool,

--- a/src-tauri/src/project_commands.rs
+++ b/src-tauri/src/project_commands.rs
@@ -1,6 +1,7 @@
 //! Project Commands split out of lib.rs; shared state/helpers stay in the crate root.
 
 use super::*;
+use crate::workspace_surface::WorkspaceManager;
 use std::collections::HashMap;
 use tauri::Manager;
 
@@ -27,7 +28,7 @@ pub(crate) fn same_workspace_path(left: &Path, right: &Path) -> bool {
 #[tauri::command]
 pub(super) async fn get_research_graph(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
 ) -> Result<wisp_store::ResearchGraph, String> {
     let (_, scope) =
         exploration_commands::working_project_for_active_frame(&state, window.label()).await?;
@@ -55,7 +56,7 @@ pub(super) async fn get_research_calendar(
 #[tauri::command]
 pub(super) async fn get_research_journey(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     from: i64,
     until: i64,
 ) -> Result<wisp_dto::ResearchJourney, String> {
@@ -71,7 +72,7 @@ pub(super) async fn get_research_journey(
 #[tauri::command]
 pub(super) async fn add_research_journal_entry(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     input: wisp_dto::ResearchJournalInput,
 ) -> Result<String, String> {
     let (_, scope) =
@@ -86,7 +87,7 @@ pub(super) async fn add_research_journal_entry(
 #[tauri::command]
 pub(super) async fn get_research_journey_source(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     version_id: String,
 ) -> Result<wisp_dto::ResearchJourneySource, String> {
     let (_, scope) =
@@ -386,14 +387,17 @@ pub(super) fn app_window_title(project_name: Option<&str>) -> String {
     }
 }
 
-fn apply_app_window_title(window: &tauri::WebviewWindow, project_name: Option<&str>) {
+fn apply_app_window_title(
+    window: &crate::workspace_surface::WorkspaceSurface,
+    project_name: Option<&str>,
+) {
     let _ = window.set_title(&app_window_title(project_name));
 }
 
 #[tauri::command]
 pub(super) async fn open_project(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     id: String,
 ) -> Result<ProjectSummary, String> {
     let _project_activity = state.begin_project_activity(&id)?;
@@ -520,10 +524,10 @@ pub(super) async fn spawn_project_window(
     let existing = state
         .session_surface_labels("", Some(id))
         .into_iter()
-        .find(|label| label.starts_with("proj-") && app.get_webview_window(label).is_some());
+        .find(|label| label.starts_with("proj-") && app.workspace_surface(label).is_some());
     if let Some(w) = existing
         .as_deref()
-        .and_then(|label| app.get_webview_window(label))
+        .and_then(|label| app.workspace_surface(label))
     {
         let label = w.label().to_string();
         let _ = w.set_focus();
@@ -537,7 +541,7 @@ pub(super) async fn spawn_project_window(
         return Ok(label);
     }
     let mut label = project_window_label(id);
-    if app.get_webview_window(&label).is_some() {
+    if app.workspace_surface(&label).is_some() {
         label = project_window_label(&Uuid::new_v4().to_string());
     }
     spawn_project_window_with_label(app, state, &label, id, session, anchor_label).await
@@ -566,8 +570,8 @@ pub(super) async fn spawn_project_window_with_label(
     // spot. Sizes/positions are physical, so convert through the anchor's
     // scale factor for the builder's logical `position`.
     let anchor = anchor_label
-        .and_then(|label| app.get_webview_window(label))
-        .or_else(|| app.get_webview_window("main"));
+        .and_then(|label| app.workspace_surface(label))
+        .or_else(|| app.workspace_surface("main"));
     if let Some(anchor) = anchor {
         if let (Ok(pos), Ok(size)) = (anchor.outer_position(), anchor.outer_size()) {
             let scale = anchor.scale_factor().unwrap_or(1.0);
@@ -580,6 +584,7 @@ pub(super) async fn spawn_project_window_with_label(
     #[cfg(target_os = "windows")]
     let builder = builder.decorations(false).shadow(true);
     let win = builder.build().map_err(|e| e.to_string())?;
+    let win = crate::workspace_surface::WorkspaceSurface::from_webview(win.as_ref().clone())?;
     crate::windows_snap::install_for_window(&win);
     #[cfg(target_os = "macos")]
     wire_macos_menu_events(&win);
@@ -612,7 +617,7 @@ pub(super) async fn spawn_project_window_with_label(
 pub(super) async fn open_project_window(
     app: AppHandle,
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     id: String,
     session: Option<String>,
 ) -> Result<String, String> {
@@ -641,8 +646,8 @@ pub(super) async fn spawn_blank_window(
         .resizable(true)
         .on_navigation(crate::guard_webview_navigation);
     let anchor = anchor_label
-        .and_then(|label| app.get_webview_window(label))
-        .or_else(|| app.get_webview_window("main"));
+        .and_then(|label| app.workspace_surface(label))
+        .or_else(|| app.workspace_surface("main"));
     if let Some(anchor) = anchor {
         if let Ok(pos) = anchor.outer_position() {
             let scale = anchor.scale_factor().unwrap_or(1.0);
@@ -654,6 +659,7 @@ pub(super) async fn spawn_blank_window(
     #[cfg(target_os = "windows")]
     let builder = builder.decorations(false).shadow(true);
     let win = builder.build().map_err(|e| e.to_string())?;
+    let win = crate::workspace_surface::WorkspaceSurface::from_webview(win.as_ref().clone())?;
     crate::windows_snap::install_for_window(&win);
     #[cfg(target_os = "macos")]
     wire_macos_menu_events(&win);
@@ -672,7 +678,7 @@ pub(super) async fn spawn_blank_window(
 #[tauri::command]
 pub(super) async fn open_new_window(
     app: AppHandle,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
 ) -> Result<String, String> {
     spawn_blank_window(&app, Some(window.label())).await
 }
@@ -680,7 +686,7 @@ pub(super) async fn open_new_window(
 #[tauri::command]
 pub(super) async fn delete_project(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     id: String,
     delete_data: Option<bool>,
 ) -> Result<(), String> {
@@ -866,7 +872,7 @@ async fn settings_project(
 #[tauri::command]
 pub(super) async fn get_project_settings(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     id: Option<String>,
 ) -> Result<ProjectSettings, String> {
     let (project_id, root, name, description) =
@@ -892,7 +898,7 @@ pub(super) struct ProjectRunRetention {
 #[tauri::command]
 pub(super) async fn get_project_run_retention(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
 ) -> Result<ProjectRunRetention, String> {
     let ap = state.require_active(window.label())?;
     let (run_retention_days, failed_run_retention_days, orphan_file_retention_days) = state
@@ -910,7 +916,7 @@ pub(super) async fn get_project_run_retention(
 #[tauri::command]
 pub(super) async fn set_project_run_retention(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     run_retention_days: Option<i64>,
     failed_run_retention_days: Option<i64>,
     orphan_file_retention_days: Option<i64>,
@@ -942,7 +948,7 @@ pub(super) async fn set_project_run_retention(
 #[tauri::command]
 pub(super) async fn update_project(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     id: Option<String>,
     name: String,
     description: String,
@@ -976,7 +982,7 @@ pub(super) async fn update_project(
     }
     for label in state.session_surface_labels("", Some(&project_id)) {
         if label.starts_with("proj-") {
-            if let Some(proj_win) = window.app_handle().get_webview_window(&label) {
+            if let Some(proj_win) = window.app_handle().workspace_surface(&label) {
                 apply_app_window_title(&proj_win, Some(name));
             }
         }
@@ -987,7 +993,7 @@ pub(super) async fn update_project(
 #[tauri::command]
 pub(super) async fn get_project_info(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
 ) -> Result<ProjectInfo, String> {
     build_project_info(&state, window.label()).await
 }

--- a/src-tauri/src/project_transfer.rs
+++ b/src-tauri/src/project_transfer.rs
@@ -2,13 +2,14 @@ use super::{
     build_project_summary, exploration_commands, workspace_manifest, workspace_scan, AppState,
     ProjectSummary,
 };
+use crate::workspace_surface::WorkspaceSurface;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::io::{Read, Write};
 use std::path::{Component, Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
-use tauri::{AppHandle, Emitter, State, WebviewWindow};
+use tauri::{AppHandle, Emitter, State};
 
 const ARCHIVE_KIND: &str = "wisp-project";
 const ARCHIVE_VERSION: u32 = 1;
@@ -66,7 +67,7 @@ impl TransferReporterState {
 impl TransferReporter {
     fn new(
         app: AppHandle,
-        window: &WebviewWindow,
+        window: &WorkspaceSurface,
         direction: &'static str,
         project_id: Option<String>,
     ) -> Self {
@@ -834,7 +835,7 @@ pub(super) async fn pick_import_parent(app: &AppHandle) -> Result<Option<PathBuf
 pub(super) async fn export_project(
     app: AppHandle,
     state: State<'_, AppState>,
-    window: WebviewWindow,
+    window: WorkspaceSurface,
     id: String,
 ) -> Result<Option<String>, String> {
     use tauri_plugin_dialog::DialogExt;
@@ -945,7 +946,7 @@ pub(super) async fn export_project(
 pub(super) async fn import_project(
     app: AppHandle,
     state: State<'_, AppState>,
-    window: WebviewWindow,
+    window: WorkspaceSurface,
 ) -> Result<Option<ProjectSummary>, String> {
     let (_, scope) =
         exploration_commands::working_project_for_active_frame(&state, window.label()).await?;

--- a/src-tauri/src/publication_commands.rs
+++ b/src-tauri/src/publication_commands.rs
@@ -596,7 +596,7 @@ async fn bind_evidence(
 #[tauri::command]
 pub(super) async fn list_publication_sources(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     kind: String,
     query: String,
     offset: u32,
@@ -612,7 +612,7 @@ pub(super) async fn list_publication_sources(
 #[tauri::command]
 pub(super) async fn get_publication_workspace(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     publication_id: Option<String>,
     revision_id: Option<String>,
 ) -> Result<PublicationWorkspace, String> {
@@ -630,7 +630,7 @@ pub(super) async fn get_publication_workspace(
 #[tauri::command]
 pub(super) async fn create_publication_workspace(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     input: CreatePublicationInput,
 ) -> Result<PublicationWorkspace, String> {
     let (project, _activity) =
@@ -646,7 +646,7 @@ pub(super) async fn create_publication_workspace(
 #[tauri::command]
 pub(super) async fn save_publication_item(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     input: SavePublicationItemInput,
 ) -> Result<PublicationWorkspace, String> {
     let (project, _activity) =
@@ -685,7 +685,7 @@ pub(super) async fn save_publication_item(
 #[tauri::command]
 pub(super) async fn bind_publication_evidence(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     input: BindPublicationEvidenceInput,
 ) -> Result<PublicationWorkspace, String> {
     let (project, _activity) =
@@ -701,7 +701,7 @@ pub(super) async fn bind_publication_evidence(
 #[tauri::command]
 pub(super) async fn update_publication_evidence_binding(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     input: UpdateEvidenceBindingInput,
 ) -> Result<PublicationWorkspace, String> {
     let (project, _activity) =
@@ -736,7 +736,7 @@ pub(super) async fn update_publication_evidence_binding(
 #[tauri::command]
 pub(super) async fn clone_publication_revision(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     revision_id: String,
     label: String,
 ) -> Result<PublicationWorkspace, String> {
@@ -762,7 +762,7 @@ pub(super) async fn clone_publication_revision(
 #[tauri::command]
 pub(super) async fn save_publication_waiver(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     input: SavePublicationWaiverInput,
 ) -> Result<PublicationWorkspace, String> {
     let (project, _activity) =
@@ -794,7 +794,7 @@ pub(super) async fn save_publication_waiver(
 #[tauri::command]
 pub(super) async fn verify_publication_revision(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     input: VerifyPublicationRevisionInput,
 ) -> Result<PublicationWorkspace, String> {
     let (project, _activity) =

--- a/src-tauri/src/publication_freeze.rs
+++ b/src-tauri/src/publication_freeze.rs
@@ -578,7 +578,7 @@ struct DirectArtifactGroup {
 #[tauri::command]
 pub(crate) async fn freeze_publication_revision(
     state: tauri::State<'_, crate::AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     revision_id: String,
     policy: PublicationFreezePolicy,
 ) -> Result<PublicationFreezeOutcome, String> {
@@ -594,7 +594,7 @@ pub(crate) async fn freeze_publication_revision(
 #[tauri::command]
 pub(crate) async fn check_publication_revision(
     state: tauri::State<'_, crate::AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     revision_id: String,
     policy: PublicationFreezePolicy,
 ) -> Result<PublicationFreezeOutcome, String> {

--- a/src-tauri/src/quick_actions.rs
+++ b/src-tauri/src/quick_actions.rs
@@ -1617,7 +1617,7 @@ async fn create_action_session(
 #[tauri::command]
 pub(crate) async fn run_quick_action(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     action_id: String,
     mut input: QuickActionInput,
 ) -> Result<QuickActionRun, String> {

--- a/src-tauri/src/resource_leases.rs
+++ b/src-tauri/src/resource_leases.rs
@@ -303,7 +303,13 @@ mod tests {
         std::fs::write(root.join("plot.R"), "plot(1)\n").unwrap();
         let request =
             request_for_call(&root, "edit", &serde_json::json!({"path": "plot.R"})).unwrap();
-        assert_eq!(request, path(ResourceAccess::Write, "plot.R"));
+        assert_eq!(
+            request,
+            path(
+                ResourceAccess::Write,
+                if cfg!(windows) { "plot.r" } else { "plot.R" }
+            )
+        );
         std::fs::remove_dir_all(root).ok();
     }
 }

--- a/src-tauri/src/runtime_commands.rs
+++ b/src-tauri/src/runtime_commands.rs
@@ -85,7 +85,7 @@ fn resolve_runtime_key(
 #[tauri::command]
 pub(super) async fn list_runtimes(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
 ) -> Result<Vec<wisp_runtime::RuntimeInfo>, String> {
     let (_, scope) =
         exploration_commands::working_project_for_active_frame(&state, window.label()).await?;
@@ -101,7 +101,7 @@ pub(super) async fn list_runtimes(
 #[tauri::command]
 pub(super) async fn inspect_runtime(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     project_id: String,
     context_id: String,
     language: wisp_runtime::RuntimeLanguage,
@@ -157,7 +157,7 @@ pub(crate) struct RuntimeExecutionSummary {
 #[tauri::command]
 pub(super) async fn execute_runtime(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     context_id: String,
     language: wisp_runtime::RuntimeLanguage,
     code: String,
@@ -206,7 +206,7 @@ pub(super) async fn execute_runtime(
 #[tauri::command]
 pub(super) async fn execute_runtime_script(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     context_id: String,
     language: wisp_runtime::RuntimeLanguage,
     script_path: String,
@@ -290,7 +290,7 @@ async fn finish_runtime_execution(
 #[tauri::command]
 pub(super) async fn start_runtime(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     context_id: String,
     language: wisp_runtime::RuntimeLanguage,
 ) -> Result<wisp_runtime::RuntimeInfo, String> {
@@ -316,7 +316,7 @@ pub(super) async fn start_runtime(
 #[tauri::command]
 pub(super) async fn dismiss_runtime(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     runtime_id: String,
 ) -> Result<(), String> {
     let (_, scope) =
@@ -344,7 +344,7 @@ pub(super) async fn dismiss_runtime(
 #[tauri::command]
 pub(super) async fn stop_runtime(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     project_id: String,
     context_id: String,
     language: wisp_runtime::RuntimeLanguage,
@@ -393,7 +393,7 @@ pub(super) async fn stop_runtime(
 #[tauri::command]
 pub(super) async fn restart_runtime(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     project_id: String,
     context_id: String,
     language: wisp_runtime::RuntimeLanguage,
@@ -447,7 +447,7 @@ pub(super) async fn restart_runtime(
 #[tauri::command]
 pub(super) async fn list_runs(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
 ) -> Result<Vec<wisp_store::RunSummary>, String> {
     let (_, scope) =
         exploration_commands::working_project_for_active_frame(&state, window.label()).await?;
@@ -461,7 +461,7 @@ pub(super) async fn list_runs(
 #[tauri::command]
 pub(super) async fn get_run_detail(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     run_id: String,
 ) -> Result<wisp_store::RunRecord, String> {
     let (_, scope) =
@@ -485,7 +485,7 @@ pub(super) async fn get_run_detail(
 #[tauri::command]
 pub(super) async fn cancel_run(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     run_id: String,
 ) -> Result<wisp_store::RunRecord, String> {
     let (ap, scope) =
@@ -524,7 +524,7 @@ pub(super) async fn cancel_run(
 #[tauri::command]
 pub(super) async fn harvest_run(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     run_id: String,
 ) -> Result<wisp_store::RunRecord, String> {
     let (ap, scope) =
@@ -560,7 +560,7 @@ pub(super) async fn harvest_run(
 
 async fn scoped_run(
     state: &State<'_, AppState>,
-    window: &tauri::WebviewWindow,
+    window: &crate::workspace_surface::WorkspaceSurface,
     run_id: &str,
 ) -> Result<(), String> {
     let (ap, scope) =
@@ -592,7 +592,7 @@ async fn scoped_run(
 #[tauri::command]
 pub(super) async fn list_run_workspace_files(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     run_id: String,
     path: Option<String>,
     name_filter: Option<String>,
@@ -618,7 +618,7 @@ pub(super) async fn list_run_workspace_files(
 #[tauri::command]
 pub(super) async fn download_run_files(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     run_id: String,
     files: Option<Vec<String>>,
     dirs: Option<Vec<String>>,
@@ -645,7 +645,7 @@ pub(super) async fn download_run_files(
 #[tauri::command]
 pub(super) async fn should_prompt_run_review(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     run_id: String,
 ) -> Result<bool, String> {
     scoped_run(&state, &window, &run_id).await?;
@@ -660,7 +660,7 @@ pub(super) async fn should_prompt_run_review(
 #[tauri::command]
 pub(super) async fn dismiss_run_review(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     run_id: String,
 ) -> Result<(), String> {
     scoped_run(&state, &window, &run_id).await?;
@@ -676,7 +676,7 @@ pub(super) async fn dismiss_run_review(
 #[tauri::command]
 pub(super) async fn delete_run_files(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     run_id: String,
     paths: Vec<String>,
 ) -> Result<(), String> {
@@ -694,7 +694,7 @@ pub(super) async fn delete_run_files(
 #[tauri::command]
 pub(super) async fn list_remote_files(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     context_id: String,
 ) -> Result<Vec<crate::run_context::remote_files::RemoteFileView>, String> {
     let (ap, _) =
@@ -707,7 +707,7 @@ pub(super) async fn list_remote_files(
 #[tauri::command]
 pub(super) async fn remove_remote_files(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     context_id: String,
     ids: Vec<String>,
     force: Option<bool>,
@@ -741,7 +741,7 @@ pub(super) async fn remove_remote_files(
 #[tauri::command]
 pub(super) async fn context_disposal_report(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     context_id: String,
 ) -> Result<crate::run_context::remote_files::ContextDisposalReport, String> {
     let (ap, _) =
@@ -760,7 +760,7 @@ pub(super) async fn context_disposal_report(
 #[tauri::command]
 pub(super) async fn cleanup_run_workspace(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     run_id: String,
     force: Option<bool>,
 ) -> Result<wisp_store::RunRecord, String> {

--- a/src-tauri/src/scheduler.rs
+++ b/src-tauri/src/scheduler.rs
@@ -202,7 +202,7 @@ async fn load_schedule(state: &AppState, id: &str) -> Result<ScheduleRecord, Str
 #[tauri::command]
 pub(crate) async fn create_schedule(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     name: String,
     prompt: String,
     interval_secs: i64,
@@ -257,7 +257,7 @@ pub(crate) async fn create_schedule(
 #[tauri::command]
 pub(crate) async fn list_schedules(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
 ) -> Result<Vec<ScheduleRecord>, String> {
     let project_id = state.require_active(window.label())?.id;
     state

--- a/src-tauri/src/scratch_commands.rs
+++ b/src-tauri/src/scratch_commands.rs
@@ -117,7 +117,7 @@ pub(super) struct ScratchChatInfo {
 #[tauri::command]
 pub(super) async fn start_scratch_chat(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
 ) -> Result<ScratchChatInfo, String> {
     let label = window.label().to_string();
     close_scratch_for_window(state.inner(), &label).await;
@@ -164,7 +164,7 @@ pub(super) async fn start_scratch_chat(
 #[tauri::command]
 pub(super) async fn close_scratch_chat(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
 ) -> Result<(), String> {
     close_scratch_for_window(state.inner(), window.label()).await;
     Ok(())

--- a/src-tauri/src/seed.rs
+++ b/src-tauri/src/seed.rs
@@ -79,7 +79,7 @@ pub(super) fn list_demos_cmd() -> Vec<DemoInfo> {
 #[tauri::command(rename = "load_demo")]
 pub(super) fn load_demo_cmd(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     id: String,
 ) -> Result<Demo, String> {
     let ap = state.require_active(window.label())?;

--- a/src-tauri/src/session_commands.rs
+++ b/src-tauri/src/session_commands.rs
@@ -5,7 +5,7 @@ use super::*;
 #[tauri::command]
 pub(super) async fn new_session(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
 ) -> Result<String, String> {
     // Create a fresh frame and hand its id to the UI up front, so the UI can
     // route streamed events to the right transcript *before* the first delta
@@ -30,7 +30,7 @@ pub(super) async fn new_session(
 #[tauri::command]
 pub(super) async fn branch_session(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     session_id: Option<String>,
     title: Option<String>,
     user_index: Option<usize>,
@@ -142,7 +142,7 @@ pub(super) async fn branch_session(
 #[tauri::command]
 pub(super) async fn preview_session_branch_merge(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     id: String,
 ) -> Result<wisp_store::SessionBranchMergePreview, String> {
     let project = state.require_active(window.label())?;
@@ -200,7 +200,7 @@ fn branch_summary_payload(
 #[tauri::command]
 pub(super) async fn summarize_session_branch_merge(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     id: String,
     expected_guard_hash: String,
     current_version: Option<String>,
@@ -258,7 +258,7 @@ pub(super) async fn summarize_session_branch_merge(
 #[tauri::command]
 pub(super) async fn merge_session_branch_summary(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     id: String,
     expected_guard_hash: String,
     summary: String,
@@ -364,7 +364,7 @@ async fn session_branch_is_busy(state: &AppState, ids: &[String]) -> bool {
 #[tauri::command]
 pub(super) async fn list_sessions_page(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     cursor: Option<SessionCursor>,
 ) -> Result<SessionPage, String> {
     let ap = state.require_active(window.label())?;
@@ -490,7 +490,7 @@ async fn stale_prompt_frames(
 #[tauri::command]
 pub(super) async fn reload_project_rules(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     frame_id: String,
 ) -> Result<bool, String> {
     let ap = state.require_active(window.label())?;
@@ -547,7 +547,7 @@ pub(super) async fn reload_project_rules(
 #[tauri::command]
 pub(super) async fn list_folders(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
 ) -> Result<Vec<FolderInfo>, String> {
     let ap = state.require_active(window.label())?;
     let rows = state
@@ -564,7 +564,7 @@ pub(super) async fn list_folders(
 #[tauri::command]
 pub(super) async fn create_folder(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     name: String,
 ) -> Result<FolderInfo, String> {
     let ap = state.require_active(window.label())?;
@@ -584,7 +584,7 @@ pub(super) async fn create_folder(
 #[tauri::command]
 pub(super) async fn rename_folder(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     id: String,
     name: String,
 ) -> Result<(), String> {
@@ -601,7 +601,7 @@ pub(super) async fn rename_folder(
 #[tauri::command]
 pub(super) async fn delete_folder(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     id: String,
 ) -> Result<(), String> {
     let ap = state.require_active(window.label())?;
@@ -617,7 +617,7 @@ pub(super) async fn delete_folder(
 #[tauri::command]
 pub(super) async fn move_session(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     id: String,
     folder_id: Option<String>,
 ) -> Result<(), String> {
@@ -634,7 +634,7 @@ pub(super) async fn move_session(
 #[tauri::command]
 pub(super) async fn transfer_session_to_project(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     id: String,
     target_project_id: String,
     mode: String,
@@ -743,7 +743,7 @@ pub(super) async fn transfer_session_to_project(
 #[tauri::command]
 pub(super) async fn delete_session(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     id: String,
 ) -> Result<(), String> {
     let ap = state.require_active(window.label())?;
@@ -822,7 +822,7 @@ pub(super) async fn delete_session(
 #[tauri::command]
 pub(super) async fn rename_session(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     id: String,
     title: String,
 ) -> Result<(), String> {
@@ -839,7 +839,7 @@ pub(super) async fn rename_session(
 #[tauri::command]
 pub(super) async fn set_session_pinned(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     id: String,
     pinned: bool,
 ) -> Result<(), String> {
@@ -863,7 +863,7 @@ pub(super) const RECENT_SESSIONS_LIMIT: i64 = 5;
 #[tauri::command]
 pub(super) async fn latest_used_session(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
 ) -> Result<Option<String>, String> {
     let ap = state.require_active(window.label())?;
     let Some(id) = state
@@ -925,7 +925,7 @@ pub(super) async fn list_recent_sessions(
 #[tauri::command]
 pub(super) async fn rewind_session(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     session_id: Option<String>,
     user_index: usize,
 ) -> Result<(), String> {
@@ -1227,7 +1227,7 @@ pub(super) fn transcript_page_items(
 #[tauri::command]
 pub(super) async fn load_session(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     id: String,
     before_seq: Option<i64>,
 ) -> Result<SessionTranscriptPage, String> {
@@ -1375,7 +1375,7 @@ pub(super) async fn load_session_trajectory(
 #[tauri::command]
 pub(super) async fn set_viewed_session(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     id: String,
 ) -> Result<(), String> {
     let (project, _) = exploration_commands::working_project_for_frame(&state, &id).await?;

--- a/src-tauri/src/session_export.rs
+++ b/src-tauri/src/session_export.rs
@@ -382,7 +382,7 @@ pub(super) async fn capture_env(
 #[tauri::command]
 pub(super) async fn get_artifact_provenance(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     session_id: Option<String>,
     path: String,
 ) -> Result<Option<ArtifactProvenance>, String> {
@@ -447,7 +447,7 @@ pub(super) async fn artifact_provenance_for_path(
 pub(super) async fn export_session(
     app: AppHandle,
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     session_id: String,
     artifact_paths: Vec<String>,
 ) -> Result<Option<String>, String> {

--- a/src-tauri/src/session_import.rs
+++ b/src-tauri/src/session_import.rs
@@ -312,7 +312,7 @@ async fn import_parsed(
 pub(super) async fn import_session_archive(
     app: AppHandle,
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
 ) -> Result<Option<ImportSessionSummary>, String> {
     use tauri_plugin_dialog::DialogExt;
 

--- a/src-tauri/src/share_social.rs
+++ b/src-tauri/src/share_social.rs
@@ -333,7 +333,7 @@ fn clamp_chars(text: &str, max: usize) -> String {
 #[tauri::command]
 pub(super) async fn generate_share_social_copy(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     session_id: Option<String>,
     platform: String,
     locale: String,

--- a/src-tauri/src/skill_commands.rs
+++ b/src-tauri/src/skill_commands.rs
@@ -46,7 +46,7 @@ async fn list_skill_infos_for_project(
 #[tauri::command]
 pub(super) async fn list_skills(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
 ) -> Result<Vec<SkillInfo>, String> {
     list_skill_infos_for_project(&state, window.label()).await
 }
@@ -54,7 +54,7 @@ pub(super) async fn list_skills(
 #[tauri::command]
 pub(super) async fn list_skill_files(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     name: String,
 ) -> Result<Vec<String>, String> {
     let ap = state.require_active(window.label())?;
@@ -72,7 +72,7 @@ pub(super) async fn list_skill_files(
 #[tauri::command]
 pub(super) async fn read_skill_file(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     name: String,
     path: String,
 ) -> Result<wisp_dto::SkillFileContent, String> {
@@ -94,7 +94,7 @@ pub(super) async fn read_skill_file(
 #[tauri::command]
 pub(super) async fn reload_skills(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
 ) -> Result<Vec<SkillInfo>, String> {
     let label = window.label();
     let mut project = state.require_active(label)?;
@@ -191,7 +191,7 @@ async fn update_skills_enabled(
 #[tauri::command]
 pub(super) async fn set_skill_enabled(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     name: String,
     enabled: bool,
 ) -> Result<(), String> {
@@ -201,7 +201,7 @@ pub(super) async fn set_skill_enabled(
 #[tauri::command]
 pub(super) async fn set_skills_enabled(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     names: Vec<String>,
     enabled: bool,
 ) -> Result<(), String> {
@@ -253,7 +253,7 @@ pub(super) fn validate_skill_name(name: &str) -> Result<(), String> {
 #[tauri::command]
 pub(super) async fn install_skill(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     src_path: String,
 ) -> Result<String, String> {
     let src = PathBuf::from(&src_path);
@@ -359,7 +359,7 @@ fn find_archived_skill_dir(root: &Path) -> Result<PathBuf, String> {
 #[tauri::command]
 pub(super) async fn remove_skill(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     name: String,
 ) -> Result<(), String> {
     validate_skill_name(&name)?;

--- a/src-tauri/src/skill_portfolio.rs
+++ b/src-tauri/src/skill_portfolio.rs
@@ -105,7 +105,7 @@ struct AgentPortfolioTask {
 #[tauri::command]
 pub(crate) async fn plan_skill_portfolio(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     request: SkillPortfolioRequest,
 ) -> Result<SkillPortfolioDraft, String> {
     let research_request = request.request.trim();

--- a/src-tauri/src/storage_prefs.rs
+++ b/src-tauri/src/storage_prefs.rs
@@ -23,7 +23,7 @@ pub(crate) struct ContextStoragePrefsView {
 #[tauri::command]
 pub(crate) async fn get_context_storage_prefs(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     context_id: String,
 ) -> Result<ContextStoragePrefsView, String> {
     let (ap, _) =
@@ -41,7 +41,7 @@ pub(crate) async fn get_context_storage_prefs(
 #[tauri::command]
 pub(crate) async fn set_context_storage_prefs(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     context_id: String,
     remote_data_root: String,
     remote_workdir_root: String,

--- a/src-tauri/src/terminal_sessions.rs
+++ b/src-tauri/src/terminal_sessions.rs
@@ -7,6 +7,7 @@
 //! `open_terminal` call creates an independent PTY so multiple terminals can
 //! run concurrently, including multiple shells in the same context.
 
+use crate::workspace_surface::WorkspaceSurface;
 use base64::Engine;
 use portable_pty::{native_pty_system, Child, ChildKiller, CommandBuilder, MasterPty, PtySize};
 use serde::Serialize;
@@ -15,7 +16,7 @@ use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use tauri::ipc::Channel;
-use tauri::{State, WebviewWindow};
+use tauri::State;
 
 const DEFAULT_ROWS: u16 = 30;
 const DEFAULT_COLS: u16 = 100;
@@ -537,7 +538,7 @@ fn lock<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
 pub async fn open_terminal(
     app_state: State<'_, crate::AppState>,
     terminals: State<'_, TerminalManager>,
-    window: WebviewWindow,
+    window: WorkspaceSurface,
     context_id: String,
 ) -> Result<TerminalSessionSummary, String> {
     let (project, scope) =

--- a/src-tauri/src/turn_undo.rs
+++ b/src-tauri/src/turn_undo.rs
@@ -389,7 +389,7 @@ async fn validate_undo_session(state: &AppState, frame_id: &str) -> Result<(), S
 #[tauri::command]
 pub(super) async fn preview_turn_undo(
     state: State<'_, AppState>,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     session_id: Option<String>,
     user_index: usize,
 ) -> Result<TurnUndoPreview, String> {
@@ -405,7 +405,7 @@ pub(super) async fn preview_turn_undo(
 pub(super) async fn undo_turn(
     state: State<'_, AppState>,
     app: AppHandle,
-    window: tauri::WebviewWindow,
+    window: crate::workspace_surface::WorkspaceSurface,
     session_id: Option<String>,
     user_index: usize,
 ) -> Result<TurnUndoPreview, String> {

--- a/src-tauri/src/ui_health.rs
+++ b/src-tauri/src/ui_health.rs
@@ -1,8 +1,10 @@
 //! Window-scoped renderer liveness and native recovery. No Run cancellation.
+use crate::workspace_surface::WorkspaceManager;
+use crate::workspace_surface::WorkspaceSurface;
 use std::collections::HashMap;
 use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant};
-use tauri::{AppHandle, Manager, WebviewWindow};
+use tauri::{AppHandle, Manager};
 use wisp_dto::UiHealthSnapshot;
 
 const STALE: Duration = Duration::from_secs(60);
@@ -90,7 +92,7 @@ pub(crate) fn remove_window(label: &str) {
 }
 
 #[tauri::command]
-pub(crate) fn ui_heartbeat(window: WebviewWindow, snapshot: Option<UiHealthSnapshot>) {
+pub(crate) fn ui_heartbeat(window: WorkspaceSurface, snapshot: Option<UiHealthSnapshot>) {
     if window.label() == "pet" {
         return;
     }
@@ -116,7 +118,7 @@ pub(crate) fn ui_heartbeat(window: WebviewWindow, snapshot: Option<UiHealthSnaps
 pub(crate) async fn run_watchdog(app: AppHandle) {
     loop {
         tokio::time::sleep(Duration::from_secs(10)).await;
-        let windows = app.webview_windows();
+        let windows = app.workspace_surfaces();
         registry()
             .lock()
             .unwrap()
@@ -144,7 +146,7 @@ pub(crate) async fn run_watchdog(app: AppHandle) {
     }
 }
 
-pub(crate) fn reload_window(window: &WebviewWindow, reason: &str) {
+pub(crate) fn reload_window(window: &WorkspaceSurface, reason: &str) {
     // Reload only the WebView; AppState, agent runtimes and RunManager stay alive.
     let now = Instant::now();
     {
@@ -161,7 +163,7 @@ pub(crate) fn reload_window(window: &WebviewWindow, reason: &str) {
         success = result.is_ok(), error = ?result.err(), "webview recovery requested");
 }
 
-pub(crate) fn stop_window_agent(window: &WebviewWindow) {
+pub(crate) fn stop_window_agent(window: &WorkspaceSurface) {
     let app = window.app_handle().clone();
     let Some(state) = app.try_state::<crate::AppState>() else {
         return;
@@ -182,11 +184,11 @@ pub(crate) fn stop_window_agent(window: &WebviewWindow) {
 }
 
 #[cfg(target_os = "windows")]
-pub(crate) fn last_workspace_window(app: &AppHandle) -> Option<WebviewWindow> {
+pub(crate) fn last_workspace_window(app: &AppHandle) -> Option<WorkspaceSurface> {
     let label = registry().lock().unwrap().last_focused.clone();
     label
-        .and_then(|label| app.get_webview_window(&label))
-        .or_else(|| app.get_webview_window("main"))
+        .and_then(|label| app.workspace_surface(&label))
+        .or_else(|| app.workspace_surface("main"))
 }
 
 #[cfg(test)]

--- a/src-tauri/src/windows_snap.rs
+++ b/src-tauri/src/windows_snap.rs
@@ -13,7 +13,8 @@
 //!
 //! Geometry is platform-agnostic so tests do not need a real HWND.
 
-use tauri::WebviewWindow;
+use crate::workspace_surface::WorkspaceManager;
+use crate::workspace_surface::WorkspaceSurface;
 
 /// Must match `.window-titlebar { height }` in `ui/src/styles/base.css`.
 pub const TITLEBAR_HEIGHT: u32 = 38;
@@ -41,7 +42,7 @@ pub fn should_install_snap(window_label: &str) -> bool {
 }
 
 #[tauri::command]
-pub fn start_window_move(window: WebviewWindow) -> Result<(), String> {
+pub fn start_window_move(window: WorkspaceSurface) -> Result<(), String> {
     #[cfg(windows)]
     {
         return start_caption_move(&window);
@@ -53,7 +54,7 @@ pub fn start_window_move(window: WebviewWindow) -> Result<(), String> {
     }
 }
 
-pub fn install_for_window(window: &WebviewWindow) {
+pub fn install_for_window(window: &WorkspaceSurface) {
     if !should_install_snap(window.label()) {
         return;
     }
@@ -66,7 +67,7 @@ pub fn install_for_window(window: &WebviewWindow) {
 }
 
 #[cfg(windows)]
-fn start_caption_move(window: &WebviewWindow) -> Result<(), String> {
+fn start_caption_move(window: &WorkspaceSurface) -> Result<(), String> {
     use windows::Win32::Foundation::{HWND, LPARAM, WPARAM};
     use windows::Win32::UI::Input::KeyboardAndMouse::ReleaseCapture;
     use windows::Win32::UI::WindowsAndMessaging::{SendMessageW, WM_SYSCOMMAND};
@@ -97,7 +98,7 @@ fn start_caption_move(window: &WebviewWindow) -> Result<(), String> {
 }
 
 #[cfg(windows)]
-fn attach_maximize_overlay(window: &WebviewWindow) -> Result<(), String> {
+fn attach_maximize_overlay(window: &WorkspaceSurface) -> Result<(), String> {
     use std::collections::HashMap;
     use std::sync::{Mutex, OnceLock};
 
@@ -165,7 +166,7 @@ fn attach_maximize_overlay(window: &WebviewWindow) -> Result<(), String> {
         let Some(state) = state(hwnd) else {
             return;
         };
-        let Some(window) = state.app.get_webview_window(&state.label) else {
+        let Some(window) = state.app.workspace_surface(&state.label) else {
             return;
         };
         if window.is_maximized().unwrap_or(false) {
@@ -175,7 +176,7 @@ fn attach_maximize_overlay(window: &WebviewWindow) -> Result<(), String> {
         }
     }
 
-    fn logical_inner_size(window: &WebviewWindow) -> Option<(u32, u32, f64)> {
+    fn logical_inner_size(window: &WorkspaceSurface) -> Option<(u32, u32, f64)> {
         let scale = window.scale_factor().ok()?;
         let size = window.inner_size().ok()?;
         let width = (f64::from(size.width) / scale).round() as u32;
@@ -183,7 +184,7 @@ fn attach_maximize_overlay(window: &WebviewWindow) -> Result<(), String> {
         Some((width, height, scale))
     }
 
-    fn place(overlay: HWND, window: &WebviewWindow) {
+    fn place(overlay: HWND, window: &WorkspaceSurface) {
         let Some((width, height, scale)) = logical_inner_size(window) else {
             return;
         };

--- a/src-tauri/src/workspace_surface.rs
+++ b/src-tauri/src/workspace_surface.rs
@@ -1,0 +1,107 @@
+//! A primary document and its native window are different objects. In particular,
+//! adding an MCP App child makes Tauri's `WebviewWindow` command extractor fail.
+//! Keep native window operations and document operations explicitly separated.
+use std::{collections::HashMap, ops::Deref};
+use tauri::{
+    ipc::{CommandArg, CommandItem, InvokeError},
+    Manager, Webview, Window,
+};
+
+#[derive(Clone, Debug)]
+pub(crate) struct WorkspaceSurface {
+    window: Window,
+    webview: Webview,
+}
+
+pub(crate) fn is_primary_document(window_label: &str, webview_label: &str) -> bool {
+    window_label == webview_label && !webview_label.starts_with("mcp-app-child-")
+}
+
+impl WorkspaceSurface {
+    pub(crate) fn from_webview(webview: Webview) -> Result<Self, String> {
+        let window = webview.window();
+        if !is_primary_document(window.label(), webview.label()) {
+            return Err("This command requires the primary workspace WebView.".into());
+        }
+        Ok(Self { window, webview })
+    }
+
+    pub(crate) fn webview(&self) -> &Webview {
+        &self.webview
+    }
+    pub(crate) fn reload(&self) -> tauri::Result<()> {
+        // Native recovery cannot depend on the unresponsive primary JS page.
+        if let Some(children) = self
+            .app_handle()
+            .try_state::<crate::mcp_app_children::McpAppChildren>()
+        {
+            let retired = children
+                .registry
+                .lock()
+                .unwrap()
+                .reset_owner(self.label(), false);
+            crate::mcp_app_children::retire_native(self.app_handle(), retired.children);
+        }
+        self.webview.reload()
+    }
+    pub(crate) fn eval(&self, script: impl Into<String>) -> tauri::Result<()> {
+        self.webview.eval(script)
+    }
+    pub(crate) fn focus_document(&self) -> tauri::Result<()> {
+        self.webview.set_focus()
+    }
+    pub(crate) fn set_focus(&self) -> tauri::Result<()> {
+        self.window.set_focus()?;
+        self.focus_document()
+    }
+}
+
+// Native APIs (size, HWND, menu, focus, window close) never select an arbitrary
+// child. Explicit methods above are the only operations on the primary page.
+impl Deref for WorkspaceSurface {
+    type Target = Window;
+    fn deref(&self) -> &Self::Target {
+        &self.window
+    }
+}
+
+impl<'de> CommandArg<'de, tauri::Wry> for WorkspaceSurface {
+    fn from_command(command: CommandItem<'de, tauri::Wry>) -> Result<Self, InvokeError> {
+        Self::from_webview(command.message.webview()).map_err(InvokeError::from)
+    }
+}
+
+pub(crate) trait WorkspaceManager: Manager<tauri::Wry> {
+    fn workspace_surface(&self, label: &str) -> Option<WorkspaceSurface> {
+        self.get_webview(label)
+            .and_then(|w| WorkspaceSurface::from_webview(w).ok())
+    }
+    fn workspace_surfaces(&self) -> HashMap<String, WorkspaceSurface> {
+        self.webviews()
+            .into_iter()
+            .filter_map(|(label, w)| {
+                WorkspaceSurface::from_webview(w)
+                    .ok()
+                    .map(|surface| (label, surface))
+            })
+            .collect()
+    }
+}
+impl<T: Manager<tauri::Wry>> WorkspaceManager for T {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn a_child_cannot_impersonate_its_owner_even_in_a_multiwebview_window() {
+        for label in ["main", "proj-a", "home-b", "terminal-c", "pet"] {
+            assert!(is_primary_document(label, label));
+            assert!(!is_primary_document(label, "mcp-app-child-123"));
+        }
+        assert!(!is_primary_document("main", "proj-a"));
+        assert!(!is_primary_document(
+            "mcp-app-child-123",
+            "mcp-app-child-123"
+        ));
+    }
+}

--- a/ui-tests/tests/mcp-app-isolation.spec.ts
+++ b/ui-tests/tests/mcp-app-isolation.spec.ts
@@ -1,0 +1,150 @@
+import { test, expect, type Page } from "@playwright/test";
+import { tauriMock } from "./mock-tauri";
+
+// Models the native backend, NEVER implements an iframe fallback. Guest
+// protocol tests below exercise the separate shell document independently.
+function nativeMock() {
+  const w = window as any;
+  w.__WISP_MCP_APP_BACKEND__ = "native-child";
+  const original = w.__TAURI__.core.invoke;
+  w.__nativeCalls = [];
+  w.__nativeActive = null;
+  let fence = 0;
+  w.__TAURI__.core.invoke = async (command: string, args: any = {}) => {
+    if (!command.includes("mcp_app_child") && command !== "mcp_app_host_info") return original(command, args);
+    w.__nativeCalls.push({ command, args });
+    if (command === "mcp_app_host_info") return { backend:"native-child", ownerEpoch:"test-owner" };
+    if (command === "open_mcp_app_child") {
+      if (args.mountSerial <= fence) throw new Error("stale-instance");
+      fence = args.mountSerial;
+      if (w.__nativeFail) throw new Error("simulated native controller failure");
+      const handle = { ownerEpoch:"test-owner", mountSerial:args.mountSerial, childLabel:`mcp-app-child-${args.mountSerial}` };
+      w.__nativeActive = handle;
+      if (w.__nativeDelay) await new Promise((resolve) => setTimeout(resolve, w.__nativeDelay));
+      return handle;
+    }
+    if (command === "close_mcp_app_child") {
+      fence = Math.max(fence, args.mountSerial);
+      if (w.__nativeActive?.mountSerial === args.mountSerial) w.__nativeActive = null;
+      return true;
+    }
+    if (command === "update_mcp_app_child_bounds") return true;
+    if (command === "request_mcp_app_child_action") {
+      if (args.method === "wisp/motif-get-selection") return { recordName:"test DNA", recordId:"dna1", molecule:"dna", start:1, end:4, strand:"forward", sequence:"ACGT" };
+      return {};
+    }
+    throw new Error(`Unexpected isolated command ${command}`);
+  };
+}
+async function start(page: Page) {
+  await page.addInitScript(tauriMock);
+  await page.addInitScript(nativeMock);
+  await page.goto("/");
+  await page.locator(".proj-card-main").first().click();
+  await page.locator(".composer-inner textarea").first().fill("open isolated app");
+  await page.getByRole("button", { name:"Send", exact:true }).click();
+  await expect.poll(() => page.evaluate(() => (window as any).__skillInvokeLog?.some((c: any) => c.cmd === "send_message"))).toBe(true);
+  return page.evaluate(() => {
+    const args = (window as any).__skillInvokeLog.filter((c: any) => c.cmd === "send_message").at(-1).args;
+    return String(args instanceof Map ? args.get("sessionId") : args.sessionId);
+  });
+}
+async function present(page: Page, frame: string, title = "Isolated figures", tool = "figures_open", uri = "ui://figures/view") {
+  await page.evaluate(({frame,title,tool,uri}) => (window as any).__tauriEmit("agent", {kind:"ToolPresentation", frame_id:frame, presentation_kind:"mcp_app", payload:{tool:{name:tool,title}, resource:{uri,text:"<!doctype html><body>Guest in native renderer</body>",_meta:{}}, arguments:{}, result:{content:[]}}}), {frame,title,tool,uri});
+}
+async function calls(page: Page, command: string) { return page.evaluate(command => (window as any).__nativeCalls.filter((c: any) => c.command === command), command); }
+async function latestBounds(page: Page) { return (await calls(page, "update_mcp_app_child_bounds")).at(-1)?.args.bounds; }
+
+test("isolated backend mounts no primary iframe; Tab switch destroys and rebuilds", async ({page}) => {
+  const frame = await start(page);
+  await present(page, frame);
+  await expect(page.locator('[data-mcp-backend="native-child"]')).toBeVisible();
+  await expect.poll(() => calls(page,"open_mcp_app_child")).toHaveLength(1);
+  await expect(page.locator(".center-mcp-app iframe")).toHaveCount(0);
+  await expect(page.locator("#wisp-mcp-app-parking")).toHaveCount(0);
+  await present(page, frame, "Second App", "other_open", "ui://other/view");
+  await expect.poll(() => calls(page,"open_mcp_app_child")).toHaveLength(2);
+  expect((await calls(page,"close_mcp_app_child")).some((c:any)=>c.args.reason==="suspend")).toBe(true);
+  await page.locator(".center-tab").filter({hasText:"Isolated figures"}).click();
+  await expect.poll(() => calls(page,"open_mcp_app_child")).toHaveLength(3);
+  await page.locator(".center-tab").filter({hasText:"Isolated figures"}).locator("..").locator(".center-tab-close").click();
+  await expect.poll(async () => (await calls(page,"close_mcp_app_child")).some((c:any)=>c.args.reason==="user_close")).toBe(true);
+});
+
+test("native creation fails closed and can retry, never falls back", async ({page}) => {
+  const frame = await start(page);
+  await page.evaluate(() => (window as any).__nativeFail = true);
+  await present(page, frame);
+  await expect(page.getByRole("alert").filter({hasText:"simulated native controller failure"})).toBeVisible();
+  await expect(page.locator(".center-mcp-app iframe")).toHaveCount(0);
+  await page.evaluate(() => (window as any).__nativeFail = false);
+  await page.getByRole("button",{name:"Reload App",exact:true}).click();
+  await expect.poll(() => latestBounds(page)).toMatchObject({visible:true});
+});
+
+test("late create cannot resurrect a closed Tab; native rectangles exclude host controls", async ({page}) => {
+  const frame = await start(page);
+  await page.evaluate(() => (window as any).__nativeDelay = 500);
+  await present(page, frame);
+  await expect.poll(() => calls(page,"open_mcp_app_child")).toHaveLength(1);
+  await page.locator(".center-tab").filter({hasText:"Isolated figures"}).locator("..").locator(".center-tab-close").click();
+  await expect.poll(() => page.evaluate(() => (window as any).__nativeActive)).toBeNull();
+  await page.waitForTimeout(650); // controlled mock late-create boundary
+  expect(await page.evaluate(() => (window as any).__nativeActive)).toBeNull();
+  await page.evaluate(() => (window as any).__nativeDelay = 0);
+  await present(page, frame);
+  await expect.poll(() => latestBounds(page)).toMatchObject({visible:true});
+  await expect.poll(async () => {
+    const b = await latestBounds(page); const rect = await page.locator(".mcp-app-native-content").boundingBox();
+    return Math.abs(b.y - rect!.y) + Math.abs(b.x - rect!.x);
+  }).toBeLessThan(.5);
+  const b = await latestBounds(page);
+  const reload = await page.getByRole("button",{name:"Reload App",exact:true}).boundingBox();
+  expect(reload!.y + reload!.height).toBeLessThanOrEqual(b.y);
+});
+
+test("host modal hides child before interaction; Escape restores only active instance", async ({page}) => {
+  const frame = await start(page); await present(page,frame);
+  await expect.poll(() => latestBounds(page)).toMatchObject({visible:true});
+  await page.evaluate(() => {
+    const el = document.createElement("div");el.id="test-host-overlay";el.setAttribute("role","dialog");el.setAttribute("aria-modal","true");el.style.cssText="position:fixed;inset:0;z-index:999999;background:white";document.body.append(el);
+    window.addEventListener("keydown", (e) => {if(e.key==="Escape") {e.preventDefault();el.remove();}}, {once:true,capture:true});
+  });
+  await expect.poll(() => latestBounds(page)).toMatchObject({visible:false});
+  await page.keyboard.press("Escape");
+  await expect.poll(() => latestBounds(page)).toMatchObject({visible:true});
+  await page.setViewportSize({width:1000,height:720});
+  await expect.poll(() => latestBounds(page)).toMatchObject({viewportWidth:1000,viewportHeight:720});
+});
+
+test("Motif selection crosses only the restricted host action bridge", async ({page}) => {
+  const frame = await start(page); await present(page,frame,"Motif","motif_open_workbench","ui://motif/view");
+  await expect.poll(() => latestBounds(page)).toMatchObject({visible:true});
+  await page.locator(".center-mcp-app-toolbar button").nth(1).click();
+  await expect.poll(async () => (await calls(page,"request_mcp_app_child_action")).at(-1)?.args.method).toBe("wisp/motif-get-selection");
+  await expect(page.locator(".composer-inner textarea").first()).toHaveValue(/ACGT/);
+  await expect(page.locator(".center-mcp-app iframe")).toHaveCount(0);
+});
+
+test("child shell preserves sandbox/CSP and directly forwards guest protocol", async ({page}) => {
+  await page.addInitScript(() => {
+    const w = window as any; w.__shellCalls=[];
+    w.__TAURI_INTERNALS__ = { invoke:async (command:string,args:any={}) => {
+      w.__shellCalls.push({command,args});
+      if(command==="mcp_app_child_bootstrap") return {handle:{},instanceId:"mcp-app:fake:ui://test",version:"test",hostContext:{theme:"light"},payload:{tool:{name:"test"},resource:{text:`<!doctype html><body><div id="result">waiting</div><script>
+      addEventListener('message',e=>{if(e.data.id===1)parent.postMessage({jsonrpc:'2.0',method:'tools/call',id:2,params:{name:'paginate',arguments:{page:2}}},'*');if(e.data.id===2)document.querySelector('#result').textContent=e.data.result.structuredContent.page;});
+      parent.postMessage({jsonrpc:'2.0',method:'ui/initialize',id:1,params:{}},'*');<\/script>`},result:{content:[]}}};
+      if(command==="mcp_app_child_request") return {jsonrpc:"2.0",id:args.request.id,result:args.request.method==="tools/call"?{structuredContent:{page:2}}:{hostInfo:{name:"wisp-science"}}};
+      return {};
+    }};
+  });
+  await page.goto("/mcp-app/shell.html");
+  await expect(page.locator("iframe")).toHaveAttribute("sandbox","allow-scripts");
+  await expect(page.locator("iframe")).toHaveAttribute("referrerpolicy","no-referrer");
+  await expect(page.frameLocator("iframe").locator("#result")).toHaveText("2");
+  const requests = await page.evaluate(() => (window as any).__shellCalls.filter((c:any)=>c.command==="mcp_app_child_request"));
+  expect(requests.map((c:any)=>c.args.request.method)).toEqual(["ui/initialize","tools/call"]);
+  await page.evaluate(() => window.postMessage({jsonrpc:"2.0",method:"tools/call",id:99,params:{name:"forged"}},"*"));
+  await page.waitForTimeout(50);
+  expect(await page.evaluate(() => (window as any).__shellCalls.filter((c:any)=>c.command==="mcp_app_child_request").length)).toBe(2);
+});

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -27,6 +27,7 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string;
     }
   };
   (window as any).__tauriEmit = emit;
+  (window as any).__WISP_MCP_APP_BACKEND__ = "legacy-iframe";
   // Tauri app listeners also receive events addressed to a different window.
   (window as any).__tauriEmitToOtherWindow = (event: string, payload: unknown) => {
     listeners[event]?.({ payload });

--- a/ui/Trunk.toml
+++ b/ui/Trunk.toml
@@ -11,6 +11,7 @@ dist = "dist"
 [watch]
 watch = [
   "src",
+  "mcp-app",
   "index.html",
   "fonts.css",
   "fonts",

--- a/ui/index.html
+++ b/ui/index.html
@@ -29,6 +29,9 @@
     <link data-trunk rel="css" href="src/styles/terminal-dock.css" />
     <link rel="stylesheet" href="/vendor-runtime/xterm.css" />
     <link data-trunk rel="copy-file" href="mock-bridge.js" />
+    <link data-trunk rel="copy-dir" href="mcp-app" />
+    <link data-trunk rel="copy-file" href="src/mcp_app_protocol.js" />
+    <link data-trunk rel="copy-file" href="src/mcp_app_isolated.js" />
     <link data-trunk rel="copy-file" href="logo.svg" />
     <link data-trunk rel="copy-file" href="logo-mark.svg" />
     <link data-trunk rel="copy-file" href="../docs/assets/wordmark-light.svg" />

--- a/ui/mcp-app/shell.html
+++ b/ui/mcp-app/shell.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Wisp MCP App</title>
+<style>html,body{margin:0;width:100%;height:100%;overflow:hidden;background:transparent}body{display:flex;flex-direction:column}iframe{display:block;width:100%;flex:1;min-height:0;border:0;background:white}#error,#connection-status{padding:8px 12px;font:13px system-ui;color:#b3261e;background:#fff4e5}</style>
+</head><body><div id="error" role="alert"></div><script type="module" src="shell.js"></script></body></html>

--- a/ui/mcp-app/shell.js
+++ b/ui/mcp-app/shell.js
@@ -1,0 +1,109 @@
+// This trusted shell is a separate native WebView. It has no workspace event
+// subscription, no filesystem APIs and no reference to the main document.
+import { injectMcpAppCsp, injectMotifWispBridge } from "../mcp_app_protocol.js";
+
+const invoke = (command, args = {}) => window.__TAURI_INTERNALS__.invoke(command, args);
+let frame, bootstrap, initialized = false, closed = false;
+const pendingActions = new Map();
+const post = (message) => frame?.contentWindow?.postMessage(message, "*");
+const errorText = (error) => String(error?.message || error).slice(0, 512);
+const reply = (message, result, error) => post({jsonrpc:"2.0", id:message.id,
+  ...(error ? {error:{code:-32603, message:errorText(error)}} : {result})});
+
+function sendData() {
+  post({jsonrpc:"2.0", method:"ui/notifications/tool-input", params:{arguments:bootstrap.payload.arguments || {}}});
+  post({jsonrpc:"2.0", method:"ui/notifications/tool-result", params:bootstrap.payload.result || {content:[]}});
+  post({jsonrpc:"2.0", method:"ui/notifications/host-context-changed", params:bootstrap.hostContext});
+}
+async function ready() {
+  if (initialized || closed) return;
+  initialized = true;
+  sendData();
+}
+
+window.__wispMcpReceive = (message) => {
+  if (message.kind === "teardown") {
+    closed = true;
+    pendingActions.clear();
+    post({jsonrpc:"2.0", id:"wisp-native-teardown", method:"ui/resource-teardown", params:{reason:"view closed; unsubmitted state is not retained"}});
+    return;
+  }
+  if (closed) return;
+  if (message.kind === "host-context") {
+    bootstrap.hostContext = message.params;
+    if (initialized) post({jsonrpc:"2.0", method:"ui/notifications/host-context-changed", params:message.params});
+  }
+  if (message.kind === "request" && initialized) {
+    const {requestId, method, params} = message;
+    if (!["wisp/motif-add-records", "wisp/motif-get-selection", "ui/notifications/tool-result"].includes(method)) return;
+    if (method === "ui/notifications/tool-result") {
+      bootstrap.payload.result = params;
+      post({jsonrpc:"2.0", method, params});
+      void invoke("mcp_app_child_action_reply", {requestId, result:{}, error:null}).catch(()=>{});
+    } else {
+      pendingActions.set(requestId, method);
+      post({jsonrpc:"2.0", method, params:{...params, requestId}});
+      setTimeout(()=>pendingActions.delete(requestId), 5000);
+    }
+  }
+};
+
+window.addEventListener("message", async (event) => {
+  if (closed || event.source !== frame?.contentWindow || event.origin !== "null") return;
+  const message = event.data;
+  if (!message || message.jsonrpc !== "2.0" || typeof message.method !== "string") return;
+  if (message.method === "wisp/notifications/motif-bridge-ready") {
+    if (bootstrap.payload?.tool?.name === "motif_open_workbench") await ready();
+    return;
+  }
+  if (message.method.startsWith("wisp/notifications/motif-")) {
+    const requestId = message.params?.requestId;
+    const expected = pendingActions.get(requestId);
+    const method = message.method;
+    if (!expected || !["wisp/notifications/motif-bridge-error",
+      expected === "wisp/motif-get-selection" ? "wisp/notifications/motif-selection" : "wisp/notifications/motif-records-added"].includes(method)) return;
+    pendingActions.delete(requestId);
+    await invoke("mcp_app_child_action_reply", {requestId,
+      result:message.params || {}, error:method.endsWith("bridge-error") ? errorText(message.params?.message) : null}).catch(()=>{});
+    return;
+  }
+  try {
+    const response = await invoke("mcp_app_child_request", {request:{id:message.id ?? null, method:message.method, params:message.params ?? {}}});
+    if (closed) return;
+    if (message.id != null) post(response);
+    if (message.method === "ui/notifications/initialized") await ready();
+  } catch (error) {
+    if (!closed && message.id != null) reply(message, null, error);
+  }
+});
+
+try {
+  bootstrap = await invoke("mcp_app_child_bootstrap");
+  frame = document.createElement("iframe");
+  frame.title = bootstrap.payload?.tool?.title || bootstrap.payload?.tool?.name || "MCP App";
+  frame.setAttribute("sandbox", "allow-scripts");
+  frame.setAttribute("referrerpolicy", "no-referrer");
+  let html = bootstrap.payload.resource.text;
+  if (bootstrap.payload?.tool?.name === "motif_open_workbench") html = injectMotifWispBridge(html);
+  // Respect a guest's own Escape handler first, then forward to the owner's
+  // existing window-level Escape stack. Events cannot bubble across WebViews.
+  html += `<script>addEventListener('keydown',e=>{if(e.key==='Escape'&&!e.isComposing)queueMicrotask(()=>{if(!e.defaultPrevented)parent.postMessage({jsonrpc:'2.0',method:'wisp/escape',params:{}},'*')})});<\/script>`;
+  frame.srcdoc = injectMcpAppCsp(html, bootstrap.payload?.resource?._meta);
+  document.body.replaceChildren(frame);
+  if (bootstrap.serverToolsAvailable === false) {
+    const status = document.createElement("div");
+    status.id = "connection-status"; status.setAttribute("role", "status");
+    status.textContent = String(bootstrap.hostContext?.locale || "").startsWith("zh")
+      ? "原 MCP 连接不可用：仅显示保存的结果；不会自动重执行工具。"
+      : "Original MCP connection unavailable: saved results only. Tools are not automatically replayed.";
+    document.body.prepend(status);
+  }
+  // Show the host after the shell is ready, not after guest JS runs: a guest
+  // that blocks on startup must still be visible/closable via the parent.
+  await invoke("mcp_app_child_ready");
+} catch (error) {
+  const alert = document.createElement("div");
+  alert.id = "error";
+  alert.textContent = `MCP App unavailable: ${errorText(error)}. Close or retry from Wisp.`;
+  document.body.replaceChildren(alert);
+}

--- a/ui/mock-bridge.js
+++ b/ui/mock-bridge.js
@@ -1,3 +1,4 @@
+window.__WISP_MCP_APP_BACKEND__ = "legacy-iframe";
 // Dev-only Tauri bridge mock. Load with http://localhost:1421/?mock=1
 (function () {
   const listeners = {};

--- a/ui/src/api.js
+++ b/ui/src/api.js
@@ -1,5 +1,7 @@
 // Tauri v2 shim + scientific preview mounts (single file so Trunk ships one snippet).
 import { highlight_root } from "./highlight.js";
+import { injectMcpAppCsp, injectMotifWispBridge } from "/mcp_app_protocol.js";
+import { isolatedApps, mountIsolatedApp, suspendIsolatedApp, closeIsolatedApp, isolatedAction, useIsolatedHost } from "/mcp_app_isolated.js";
 
 function tauriCore() {
   return window.__TAURI__?.core;
@@ -42,7 +44,7 @@ export function start_ui_health() {
     inFlight = true;
     let activeApps = 0;
     let parkedApps = 0;
-    for (const instance of mcpAppInstances.values()) {
+    for (const instance of [...mcpAppInstances.values(), ...isolatedApps.values()]) {
       if (instance.target?.isConnected) activeApps += 1;
       else parkedApps += 1;
     }
@@ -2553,249 +2555,6 @@ let mcpAppParkingRoot = null;
 let wispAppVersion = "0.0.0";
 window.__TAURI__?.app?.getVersion?.().then((version) => { wispAppVersion = version; });
 
-function injectMcpAppCsp(html, resourceMeta) {
-  const csp = resourceMeta?.ui?.csp || resourceMeta?.csp || {};
-  const safeOrigins = (values, websocket = false) => (Array.isArray(values) ? values : [])
-    .filter((value) => typeof value === "string"
-      && new RegExp(`^(?:https${websocket ? "|wss" : ""}):\\/\\/(?:\\*\\.)?[a-z0-9.-]+(?::\\d+)?$`, "i").test(value));
-  const connect = safeOrigins(csp.connectDomains, true);
-  const resources = safeOrigins(csp.resourceDomains);
-  const frames = safeOrigins(csp.frameDomains);
-  const bases = safeOrigins(csp.baseUriDomains);
-  const policy = [
-    "default-src 'none'",
-    `script-src 'unsafe-inline' 'unsafe-eval' blob: ${resources.join(" ")}`.trim(),
-    `style-src 'unsafe-inline' ${resources.join(" ")}`.trim(),
-    `img-src data: blob: ${resources.join(" ")}`.trim(),
-    `font-src data: ${resources.join(" ")}`.trim(),
-    `media-src blob: ${resources.length ? resources.join(" ") : "'none'"}`,
-    `connect-src ${connect.length ? connect.join(" ") : "'none'"}`,
-    `frame-src ${frames.length ? frames.join(" ") : "'none'"}`,
-    `base-uri ${bases.length ? bases.join(" ") : "'self'"}`,
-    "object-src 'none'",
-    "form-action 'none'",
-  ].join("; ");
-  const tag = `<meta http-equiv="Content-Security-Policy" content="${escAttr(policy)}">`;
-  if (/<head(\s[^>]*)?>/i.test(html)) {
-    return html.replace(/<head(\s[^>]*)?>/i, (head) => `${head}${tag}`);
-  }
-  return `<!doctype html><html><head>${tag}</head><body>${html}</body></html>`;
-}
-
-function injectMotifWispBridge(html) {
-  const script = `<script>
-(() => {
-  const reply = (method, params) => parent.postMessage({ jsonrpc: "2.0", method, params }, "*");
-  const activeRecord = () => {
-    try { return typeof window.motifGetActiveRecord === "function" ? window.motifGetActiveRecord() : null; }
-    catch { return null; }
-  };
-  const recordSequence = (record) => typeof record?.seq === "string"
-    ? record.seq.toUpperCase()
-    : typeof record?.sequence === "string"
-      ? record.sequence.toUpperCase()
-      : "";
-  const coordinateNumber = (value) => Number(String(value || "").replace(/[^0-9]/g, ""));
-  const sequenceRange = (record, start, end, wrap = false) => {
-    const source = recordSequence(record);
-    if (!start || !end || start > source.length || end > source.length) return "";
-    return wrap || start > end
-      ? source.slice(start - 1) + source.slice(0, end)
-      : source.slice(start - 1, end);
-  };
-  const renderedSelection = (record) => {
-    const label = document.querySelector(
-      ".motif-cs-selection-bar:not([data-empty='true']) .motif-cs-selection-name",
-    )?.textContent?.trim() || "";
-    const match = label.match(/^([0-9][0-9,. ]*)-([0-9][0-9,. ]*)( wrap)? \\(([0-9][0-9,. ]*)\\)$/);
-    if (!match) return null;
-    const start = coordinateNumber(match[1]);
-    const end = coordinateNumber(match[2]);
-    const length = coordinateNumber(match[4]);
-    const sequence = sequenceRange(record, start, end, Boolean(match[3]));
-    return sequence.length === length ? { start, end, strand: "forward", sequence } : null;
-  };
-  const featureSelection = (record) => {
-    const label = document.querySelector(
-      ".motif-cs-selection-bar:not([data-empty='true']) .motif-cs-selection-name",
-    )?.textContent?.trim() || "";
-    const labelMatch = label.match(/^(.*?)\s+([0-9][0-9,. ]*)-([0-9][0-9,. ]*)(?:\s+wrap)?$/);
-    const annotations = Array.isArray(record?.annotations)
-      ? record.annotations
-      : Array.isArray(record?.features) ? record.features : [];
-    const selectedNode = document.querySelector(
-      ".motif-pm-feature[aria-pressed='true'][data-feature-id], .motif-cs-feature-block[aria-pressed='true']",
-    );
-    const selectedId = selectedNode?.getAttribute("data-feature-id") || "";
-    let feature = selectedId
-      ? annotations.find((annotation) => String(annotation?.id || "") === selectedId)
-      : null;
-    if (!feature && labelMatch) {
-      const start = coordinateNumber(labelMatch[2]);
-      const end = coordinateNumber(labelMatch[3]);
-      const name = labelMatch[1].trim();
-      feature = annotations.find((annotation) => (
-        Number(annotation?.start) + 1 === start
-        && Number(annotation?.end) === end
-        && String(annotation?.name || "").trim() === name
-      ));
-    }
-    if (!feature) return null;
-    const start = Number(feature.start) + 1;
-    const end = Number(feature.end);
-    const sequence = sequenceRange(record, start, end);
-    if (!sequence) return null;
-    return {
-      start,
-      end,
-      strand: Number(feature.strand) === -1 ? "reverse" : "forward",
-      sequence,
-      featureName: String(feature.name || "").trim() || undefined,
-    };
-  };
-  const nativeSelection = (record) => {
-    const source = recordSequence(record);
-    const raw = String(getSelection()?.toString() || "");
-    const sequence = raw.replace(/[^A-Za-z*.-]/g, "").toUpperCase();
-    if (!source || !sequence) return null;
-    const offset = source.indexOf(sequence);
-    return offset < 0 ? null : { start: offset + 1, end: offset + sequence.length, strand: "forward", sequence };
-  };
-  let lastNativeSelection = null;
-  let selectionLengthFrame = 0;
-  const updateSelectionLength = () => {
-    selectionLengthFrame = 0;
-    const bar = document.querySelector(".motif-cs-selection-bar");
-    if (!bar) return;
-    const record = activeRecord();
-    const recordId = String(record?.id || "");
-    const selection = renderedSelection(record)
-      || featureSelection(record)
-      || (bar.matches(":not([data-empty='true'])")
-        ? null
-        : nativeSelection(record)
-          || (lastNativeSelection?.recordId === recordId ? lastNativeSelection : null));
-    let badge = bar.querySelector("[data-wisp-motif-selection-length]");
-    if (!selection?.sequence) {
-      badge?.remove();
-      return;
-    }
-    const length = Array.from(selection.sequence).length;
-    const label = length.toLocaleString() + " bp";
-    if (!badge) {
-      badge = document.createElement("span");
-      badge.setAttribute("data-wisp-motif-selection-length", "");
-      badge.style.cssText = "margin-left:auto;padding-left:10px;white-space:nowrap;font-weight:700;font-variant-numeric:tabular-nums;color:currentColor;pointer-events:none";
-      bar.appendChild(badge);
-    }
-    if (badge.textContent !== label) badge.textContent = label;
-    badge.setAttribute("aria-label", "Selected sequence length: " + label);
-  };
-  const scheduleSelectionLengthUpdate = () => {
-    if (selectionLengthFrame) return;
-    selectionLengthFrame = requestAnimationFrame(updateSelectionLength);
-  };
-  const rememberNativeSelection = () => {
-    const record = activeRecord();
-    const selection = nativeSelection(record);
-    if (selection) lastNativeSelection = { recordId: String(record?.id || ""), ...selection };
-    scheduleSelectionLengthUpdate();
-  };
-  document.addEventListener("selectionchange", rememberNativeSelection);
-  document.addEventListener("pointerup", rememberNativeSelection, true);
-  document.addEventListener("keyup", rememberNativeSelection, true);
-  const scrollSelectedFeatureIntoView = () => {
-    requestAnimationFrame(() => requestAnimationFrame(() => {
-      const block = document.querySelector(".motif-cs-feature-block[aria-pressed='true']");
-      const pane = block?.closest(".motif-cs-sequence-column");
-      if (!block || !pane) return;
-      const blockRect = block.getBoundingClientRect();
-      const paneRect = pane.getBoundingClientRect();
-      pane.scrollTop = Math.max(0, pane.scrollTop + blockRect.top - paneRect.top
-        - Math.max(0, (pane.clientHeight - blockRect.height) / 2));
-    }));
-  };
-  const scheduleFeatureFocus = (target) => {
-    if (!(target instanceof Element) || !target.closest(".motif-pm-feature[data-feature-id]")) return;
-    lastNativeSelection = null;
-    scrollSelectedFeatureIntoView();
-  };
-  document.addEventListener("click", (event) => scheduleFeatureFocus(event.target), true);
-  document.addEventListener("keydown", (event) => {
-    if (event.key === "Enter" || event.key === " ") scheduleFeatureFocus(event.target);
-  }, true);
-  const featureFocusObserver = new MutationObserver(() => {
-    if (document.querySelector(".motif-cs-feature-block[aria-pressed='true']")) {
-      scrollSelectedFeatureIntoView();
-    }
-    scheduleSelectionLengthUpdate();
-  });
-  featureFocusObserver.observe(document.body, {
-    subtree: true,
-    childList: true,
-    attributes: true,
-    attributeFilter: ["aria-pressed"],
-  });
-  scheduleSelectionLengthUpdate();
-  addEventListener("message", (event) => {
-    const message = event.data || {};
-    if (message.jsonrpc !== "2.0") return;
-    if (message.method === "wisp/motif-add-records") {
-      try {
-        if (typeof window.motifAddRecords !== "function") throw new Error("Motif record API is not ready.");
-        const records = Array.isArray(message.params?.records) ? message.params.records : [];
-        window.motifAddRecords(records);
-        reply("wisp/notifications/motif-records-added", { requestId: message.params?.requestId, count: records.length });
-      } catch (error) {
-        reply("wisp/notifications/motif-bridge-error", { requestId: message.params?.requestId, message: error instanceof Error ? error.message : String(error) });
-      }
-    }
-    if (message.method === "wisp/motif-get-selection") {
-      try {
-        const record = activeRecord();
-        const recordId = String(record?.id || "");
-        const selection = renderedSelection(record)
-          || featureSelection(record)
-          || (document.querySelector(".motif-cs-selection-bar:not([data-empty='true'])")
-            ? null
-            : nativeSelection(record)
-              || (lastNativeSelection?.recordId === recordId ? lastNativeSelection : null));
-        if (!record || !selection) throw new Error("Select a sequence range in Motif first.");
-        reply("wisp/notifications/motif-selection", {
-          requestId: message.params?.requestId,
-          recordName: String(record.name || record.id || "Motif record"),
-          recordId,
-          molecule: String(record.type || record.molecule || "dna"),
-          start: selection.start,
-          end: selection.end,
-          strand: selection.strand || "forward",
-          sequence: selection.sequence,
-          featureName: selection.featureName,
-        });
-      } catch (error) {
-        reply("wisp/notifications/motif-bridge-error", { requestId: message.params?.requestId, message: error instanceof Error ? error.message : String(error) });
-      }
-    }
-  });
-  let readyAttempts = 0;
-  const announceReady = () => {
-    if (typeof window.motifGetActiveRecord === "function") {
-      reply("wisp/notifications/motif-bridge-ready", {});
-      return;
-    }
-    readyAttempts += 1;
-    if (readyAttempts < 200) setTimeout(announceReady, 50);
-  };
-  announceReady();
-})();
-</script>`;
-  // Motif bundles may contain literal `</body>` text inside minified scripts.
-  // Never splice the document with a regex: HTML parsers accept a trailing
-  // script after </html> and place it in the document body without corrupting
-  // any of Motif's original script boundaries.
-  return `${html}${script}`;
-}
-
 function ensureMcpAppParkingRoot() {
   if (mcpAppParkingRoot?.isConnected) return mcpAppParkingRoot;
   const root = document.createElement("div");
@@ -3073,6 +2832,7 @@ function mcpAppDocumentKey(payload) {
  * origin and scripts only; filesystem, forms, popups, top navigation,
  * downloads, and same-origin access remain unavailable. */
 export function mount_mcp_app(instanceId, elId, payloadJson) {
+  if (useIsolatedHost()) return mountIsolatedApp(instanceId, elId, payloadJson);
   const target = document.getElementById(elId);
   if (!target) return false;
   let instance = mcpAppInstances.get(instanceId);
@@ -3114,7 +2874,8 @@ export function mount_mcp_app(instanceId, elId, payloadJson) {
 
 /** Keep a live iframe attached off-screen while another center tab is active. */
 export function park_mcp_app(instanceId) {
-  const instance = mcpAppInstances.get(instanceId);
+  if (useIsolatedHost()) return suspendIsolatedApp(instanceId);
+  const instance = isolatedApps.get(instanceId) || mcpAppInstances.get(instanceId);
   if (!instance) return;
   instance.resizeObserver?.disconnect();
   instance.target = null;
@@ -3327,6 +3088,7 @@ async function callMotifOpen(instance, motifArgs) {
 }
 
 function motifBridgeRequest(instance, method, params = {}) {
+  if (instance.isolated) return isolatedAction(instance, method, params);
   return new Promise((resolve, reject) => {
     const requestId = ++instance.motifRequestId;
     instance.motifRequests.set(requestId, { resolve, reject });
@@ -3342,8 +3104,8 @@ function motifBridgeRequest(instance, method, params = {}) {
 }
 
 export async function import_motif_dna_file(instanceId) {
-  const instance = mcpAppInstances.get(instanceId);
-  if (!instance?.initialized || !instance.frame.contentWindow) {
+  const instance = isolatedApps.get(instanceId) || mcpAppInstances.get(instanceId);
+  if (!instance?.initialized || (!instance.isolated && !instance.frame.contentWindow)) {
     throw new Error("The Motif workbench is not ready.");
   }
   if (instance.payload?.tool?.name !== "motif_open_workbench") {
@@ -3373,11 +3135,12 @@ export async function import_motif_dna_file(instanceId) {
   );
 
   const result = await callMotifOpen(instance, motifArgs);
-  instance.frame.contentWindow.postMessage({
-    jsonrpc: "2.0",
-    method: "ui/notifications/tool-result",
-    params: result || { content: [] },
-  }, "*");
+  if (instance.isolated) {
+    await isolatedAction(instance, "ui/notifications/tool-result", result || { content: [] });
+    instance.payload.result = result;
+  } else {
+    instance.frame.contentWindow.postMessage({jsonrpc:"2.0", method:"ui/notifications/tool-result", params:result || {content:[]}}, "*");
+  }
   return {
     imported: true,
     filename: file.name,
@@ -3388,7 +3151,7 @@ export async function import_motif_dna_file(instanceId) {
 /** Parse a project file with Motif's MCP tool, then append its records to the
  * already-open workbench without replacing the current inventory. */
 export async function add_workspace_file_to_motif(instanceId, path) {
-  const instance = mcpAppInstances.get(instanceId);
+  const instance = isolatedApps.get(instanceId) || mcpAppInstances.get(instanceId);
   if (!instance?.initialized || instance.payload?.tool?.name !== "motif_open_workbench") {
     throw new Error("Open Motif in the current conversation before adding a project file.");
   }
@@ -3402,7 +3165,7 @@ export async function add_workspace_file_to_motif(instanceId, path) {
 }
 
 export async function request_motif_selection(instanceId) {
-  const instance = mcpAppInstances.get(instanceId);
+  const instance = isolatedApps.get(instanceId) || mcpAppInstances.get(instanceId);
   if (!instance?.initialized || instance.payload?.tool?.name !== "motif_open_workbench") {
     throw new Error("The Motif workbench is not ready.");
   }
@@ -3411,6 +3174,7 @@ export async function request_motif_selection(instanceId) {
 
 /** Close a center-tab MCP App and give it a bounded graceful teardown window. */
 export function close_mcp_app(instanceId) {
+  if (useIsolatedHost()) return closeIsolatedApp(instanceId);
   mcpAppInstances.get(instanceId)?.requestTeardown("user closed the app");
 }
 

--- a/ui/src/mcp_app_isolated.js
+++ b/ui/src/mcp_app_isolated.js
@@ -1,0 +1,200 @@
+// Windows native MCP App controller. Never create an iframe in this document.
+// The explicit mock override is used by browser tests to separate the two
+// backends; native creation errors deliberately do NOT fall back to an iframe.
+export const isolatedApps = new Map();
+export const useIsolatedHost = () => window.__WISP_MCP_APP_BACKEND__
+  ? window.__WISP_MCP_APP_BACKEND__ === "native-child"
+  : navigator.userAgent.includes("Windows");
+const invoke = (command, args = {}) => {
+  const core = window.__TAURI__?.core || window.__TAURI_INTERNALS__;
+  if (!core) return Promise.reject(new Error("The native MCP App host is unavailable."));
+  return core.invoke(command, args);
+};
+let hostPromise, serial = 0, revision = 0, active = null;
+let frame = 0, observer, inputOccluded = false;
+const host = () => hostPromise ||= invoke("mcp_app_host_info").then((info) => {
+  if (info?.backend !== "native-child" || !info.ownerEpoch) throw new Error("Native MCP App isolation is unavailable; refusing unsafe iframe fallback.");
+  return info;
+});
+const current = (instance) => active === instance && !instance.closed && instance.target?.isConnected;
+const text = () => document.documentElement.lang.startsWith("zh") ? {
+  hint:"此 App 在独立视图中运行；切走将销毁，切回重建。未提交的勾选、分页和编辑可能丢失。",
+  retry:"重新加载 App", loading:"正在创建隔离视图…", error:"App 隔离视图不可用：",
+} : {
+  hint:"Isolated App: leaving destroys this view. Reopening restores saved results, not unsubmitted selections, pages or edits.",
+  retry:"Reload App", loading:"Creating isolated view…", error:"Isolated App unavailable: ",
+};
+
+const visibleElement = (el) => {
+  const style = getComputedStyle(el);
+  return style.display !== "none" && style.visibility !== "hidden" && el.getClientRects().length > 0;
+};
+const intersects = (a, b) => a.left < b.right && a.right > b.left && a.top < b.bottom && a.bottom > b.top;
+function occluded(target, rect) {
+  if (inputOccluded || document.visibilityState !== "visible") return true;
+  // Native children do not participate in DOM stacking. Covers root dialogs,
+  // component-local menus/popovers, and explicit future occlusion surfaces.
+  for (const el of document.querySelectorAll('[aria-modal="true"], [role="dialog"], [role="menu"], .overlay, .project-search-overlay, .compose-menu, .mention-menu, .context-menu, .drag-overlay, [data-mcp-app-occludes]')) {
+    if (!target.contains(el) && visibleElement(el) && intersects(rect, el.getBoundingClientRect())) return true;
+  }
+  // Also catch positioned host UI that does not yet use the semantic markers.
+  for (const fx of [0.02, 0.5, 0.98]) for (const fy of [0.02, 0.5, 0.98]) {
+    const el = document.elementFromPoint(rect.left + rect.width * fx, rect.top + rect.height * fy);
+    if (el && el !== target && !target.contains(el)) return true;
+  }
+  return false;
+}
+function bounds(instance, forceHidden = false) {
+  const rect = instance.target?.getBoundingClientRect();
+  return {x:rect?.x || 0, y:rect?.y || 0, width:rect?.width || 0, height:rect?.height || 0,
+    viewportWidth:window.innerWidth, viewportHeight:window.innerHeight,
+    visible:!!rect && current(instance) && visibleElement(instance.target) && !forceHidden && !occluded(instance.target, rect),
+    revision:++revision};
+}
+function context(instance, b) {
+  return {theme:document.documentElement.dataset.theme === "dark" ? "dark" : "light", displayMode:"inline",
+    availableDisplayModes:["inline"], containerDimensions:{width:b.width, height:b.height},
+    locale:document.documentElement.lang || navigator.language, timeZone:Intl.DateTimeFormat().resolvedOptions().timeZone,
+    platform:"desktop", toolInfo:{tool:instance.payload.tool || {}}};
+}
+function schedule() {
+  if (frame || !active) return;
+  frame = requestAnimationFrame(() => {
+    frame = 0; sync();
+    // ResizeObserver does not fire for an animated translate/position. Follow
+    // only the content's ancestors, not arbitrary spinning guest/host icons.
+    for (let el = active?.target; el; el = el.parentElement) {
+      if (el.getAnimations().some((animation) => animation.playState === "running")) { schedule(); break; }
+    }
+  });
+}
+function sync(forceHidden = false) {
+  const instance = active;
+  if (!instance?.handle || !current(instance)) return;
+  const b = bounds(instance, forceHidden), hostContext = context(instance, b);
+  const key = JSON.stringify({...b, revision:0, hostContext});
+  if (key === instance.boundsKey) return;
+  instance.boundsKey = key;
+  void invoke("update_mcp_app_child_bounds", {handle:instance.handle, bounds:b, hostContext})
+    .catch((error) => { if (current(instance) && !String(error).includes("stale-instance")) showError(instance, error); });
+}
+function installObservers() {
+  if (observer) return;
+  observer = new MutationObserver(schedule);
+  observer.observe(document.documentElement, {subtree:true, childList:true, attributes:true,
+    attributeFilter:["class", "style", "hidden", "open", "data-theme"]});
+  window.addEventListener("resize", schedule);
+  window.addEventListener("scroll", schedule, true);
+  window.addEventListener("transitionrun", schedule, true);
+  window.addEventListener("animationstart", schedule, true);
+  document.addEventListener("visibilitychange", schedule);
+  window.addEventListener("focus", schedule);
+  window.addEventListener("wisp-mcp-native-resize", () => { if (active) active.boundsKey = null; schedule(); });
+  // Hide on the initiating event, before a host click opens a modal/menu.
+  // Mutation/resize observation later restores only the still-current view.
+  const beforeHostInteraction = () => {
+    inputOccluded = true;
+    sync(true);
+    requestAnimationFrame(() => { inputOccluded = false; schedule(); });
+  };
+  window.addEventListener("pointerdown", beforeHostInteraction, true);
+  // Do not force-hide on every keydown: that would flash the child while
+  // typing in the composer. Dialogs/menus are still caught by occlusion
+  // observers after they appear.
+  window.addEventListener("keydown", schedule, true);
+}
+function disposeObservers() {
+  // The one window-level observer is bounded and shared. Per-view observers
+  // and animation state are disconnected on every retirement below.
+  if (!active && frame) { cancelAnimationFrame(frame); frame = 0; }
+}
+function showError(instance, error) {
+  if (!current(instance)) return;
+  instance.initialized = false;
+  instance.status.textContent = text().error + String(error?.message || error).slice(0, 512);
+  instance.status.setAttribute("role", "alert");
+  instance.status.hidden = false;
+}
+function retire(instance, reason) {
+  instance.closed = true;
+  instance.initialized = false;
+  instance.resizeObserver?.disconnect();
+  if (active === instance) active = null;
+  disposeObservers();
+  // Use the mount serial, not a returned child label: a close may beat a slow
+  // creation reply. Rust records the tombstone before it starts native work.
+  return host().then((info) => invoke("close_mcp_app_child", {instanceId:instance.id,
+    ownerEpoch:info.ownerEpoch, mountSerial:instance.serial, reason})).catch(()=>{});
+}
+
+export function mountIsolatedApp(id, elId, payloadJson) {
+  const root = document.getElementById(elId);
+  if (!root) return false;
+  const old = isolatedApps.get(id);
+  // A remount retains the latest imported result, but never automatically
+  // replays a tools/call. A new presentation always replaces this snapshot.
+  const source = typeof payloadJson === "string" ? payloadJson : JSON.stringify(payloadJson);
+  let payload;
+  try { payload = old?.source === source ? old.payload : JSON.parse(source); }
+  catch { return false; }
+  if (typeof payload?.resource?.text !== "string") return false;
+  if (active) void retire(active, "suspend");
+  const instance = {id, payload, source, serial:++serial, isolated:true, closed:false, initialized:false,
+    target:null, handle:null, boundsKey:null, status:null, resizeObserver:null};
+  isolatedApps.set(id, instance);
+  active = instance;
+  root.dataset.mcpBackend = "native-child";
+  // Reload and the warning live OUTSIDE the native content rectangle.
+  const controls = document.createElement("div");
+  controls.className = "mcp-app-isolation-controls";
+  const hint = document.createElement("span"); hint.textContent = text().hint;
+  const reload = document.createElement("button"); reload.type = "button"; reload.textContent = text().retry;
+  reload.addEventListener("click", () => mountIsolatedApp(id, elId, instance.source));
+  controls.append(hint, reload);
+  const target = document.createElement("div"); target.className = "mcp-app-native-content";
+  const status = document.createElement("div"); status.className = "mcp-app-native-status"; status.textContent = text().loading;
+  target.append(status);
+  root.replaceChildren(controls, target);
+  instance.target = target;
+  instance.status = status;
+  installObservers();
+  instance.resizeObserver = new ResizeObserver(schedule);
+  instance.resizeObserver.observe(target);
+  void (async () => {
+    try {
+      const info = await host();
+      if (!current(instance)) return;
+      const b = bounds(instance);
+      const handle = await invoke("open_mcp_app_child", {instanceId:id, payload:instance.payload,
+        ownerEpoch:info.ownerEpoch, mountSerial:instance.serial, bounds:b, hostContext:context(instance, b)});
+      if (!current(instance)) { await retire(instance, "suspend"); return; }
+      instance.handle = handle;
+      instance.initialized = true;
+      status.hidden = true;
+      schedule();
+    } catch (error) { showError(instance, error); }
+  })();
+  return true;
+}
+
+export function suspendIsolatedApp(id) {
+  const instance = isolatedApps.get(id);
+  if (instance && !instance.closed) void retire(instance, "suspend");
+}
+export function closeIsolatedApp(id) {
+  const instance = isolatedApps.get(id);
+  if (!instance) return;
+  isolatedApps.delete(id);
+  void retire(instance, "user_close");
+}
+export async function isolatedAction(instance, method, params = {}) {
+  if (!current(instance) || !instance.initialized) throw new Error("The App view is not ready or was closed.");
+  const result = await invoke("request_mcp_app_child_action", {instanceId:instance.id, handle:instance.handle, method, params});
+  if (!current(instance)) throw new Error("The App view was replaced while the request was running.");
+  if (method === "wisp/motif-add-records" && Array.isArray(params.records)) {
+    const previous = instance.payload.result?.structuredContent?.payload?.records || [];
+    instance.payload.result = {...instance.payload.result, structuredContent:{...instance.payload.result?.structuredContent,
+      payload:{...instance.payload.result?.structuredContent?.payload, records:[...previous, ...params.records]}}};
+  }
+  return result;
+}

--- a/ui/src/mcp_app_protocol.js
+++ b/ui/src/mcp_app_protocol.js
@@ -1,0 +1,247 @@
+// Guest document policy shared by the legacy host and the isolated shell.
+const escAttr = (s) => String(s).replaceAll("&", "&amp;").replaceAll("\"", "&quot;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+
+export function injectMcpAppCsp(html, resourceMeta) {
+  const csp = resourceMeta?.ui?.csp || resourceMeta?.csp || {};
+  const safeOrigins = (values, websocket = false) => (Array.isArray(values) ? values : [])
+    .filter((value) => typeof value === "string"
+      && new RegExp(`^(?:https${websocket ? "|wss" : ""}):\\/\\/(?:\\*\\.)?[a-z0-9.-]+(?::\\d+)?$`, "i").test(value));
+  const connect = safeOrigins(csp.connectDomains, true);
+  const resources = safeOrigins(csp.resourceDomains);
+  const frames = safeOrigins(csp.frameDomains);
+  const bases = safeOrigins(csp.baseUriDomains);
+  const policy = [
+    "default-src 'none'",
+    `script-src 'unsafe-inline' 'unsafe-eval' blob: ${resources.join(" ")}`.trim(),
+    `style-src 'unsafe-inline' ${resources.join(" ")}`.trim(),
+    `img-src data: blob: ${resources.join(" ")}`.trim(),
+    `font-src data: ${resources.join(" ")}`.trim(),
+    `media-src blob: ${resources.length ? resources.join(" ") : "'none'"}`,
+    `connect-src ${connect.length ? connect.join(" ") : "'none'"}`,
+    `frame-src ${frames.length ? frames.join(" ") : "'none'"}`,
+    `base-uri ${bases.length ? bases.join(" ") : "'self'"}`,
+    "object-src 'none'",
+    "form-action 'none'",
+  ].join("; ");
+  const tag = `<meta http-equiv="Content-Security-Policy" content="${escAttr(policy)}">`;
+  if (/<head(\s[^>]*)?>/i.test(html)) {
+    return html.replace(/<head(\s[^>]*)?>/i, (head) => `${head}${tag}`);
+  }
+  return `<!doctype html><html><head>${tag}</head><body>${html}</body></html>`;
+}
+
+export function injectMotifWispBridge(html) {
+  const script = `<script>
+(() => {
+  const reply = (method, params) => parent.postMessage({ jsonrpc: "2.0", method, params }, "*");
+  const activeRecord = () => {
+    try { return typeof window.motifGetActiveRecord === "function" ? window.motifGetActiveRecord() : null; }
+    catch { return null; }
+  };
+  const recordSequence = (record) => typeof record?.seq === "string"
+    ? record.seq.toUpperCase()
+    : typeof record?.sequence === "string"
+      ? record.sequence.toUpperCase()
+      : "";
+  const coordinateNumber = (value) => Number(String(value || "").replace(/[^0-9]/g, ""));
+  const sequenceRange = (record, start, end, wrap = false) => {
+    const source = recordSequence(record);
+    if (!start || !end || start > source.length || end > source.length) return "";
+    return wrap || start > end
+      ? source.slice(start - 1) + source.slice(0, end)
+      : source.slice(start - 1, end);
+  };
+  const renderedSelection = (record) => {
+    const label = document.querySelector(
+      ".motif-cs-selection-bar:not([data-empty='true']) .motif-cs-selection-name",
+    )?.textContent?.trim() || "";
+    const match = label.match(/^([0-9][0-9,. ]*)-([0-9][0-9,. ]*)( wrap)? \\(([0-9][0-9,. ]*)\\)$/);
+    if (!match) return null;
+    const start = coordinateNumber(match[1]);
+    const end = coordinateNumber(match[2]);
+    const length = coordinateNumber(match[4]);
+    const sequence = sequenceRange(record, start, end, Boolean(match[3]));
+    return sequence.length === length ? { start, end, strand: "forward", sequence } : null;
+  };
+  const featureSelection = (record) => {
+    const label = document.querySelector(
+      ".motif-cs-selection-bar:not([data-empty='true']) .motif-cs-selection-name",
+    )?.textContent?.trim() || "";
+    const labelMatch = label.match(/^(.*?)\s+([0-9][0-9,. ]*)-([0-9][0-9,. ]*)(?:\s+wrap)?$/);
+    const annotations = Array.isArray(record?.annotations)
+      ? record.annotations
+      : Array.isArray(record?.features) ? record.features : [];
+    const selectedNode = document.querySelector(
+      ".motif-pm-feature[aria-pressed='true'][data-feature-id], .motif-cs-feature-block[aria-pressed='true']",
+    );
+    const selectedId = selectedNode?.getAttribute("data-feature-id") || "";
+    let feature = selectedId
+      ? annotations.find((annotation) => String(annotation?.id || "") === selectedId)
+      : null;
+    if (!feature && labelMatch) {
+      const start = coordinateNumber(labelMatch[2]);
+      const end = coordinateNumber(labelMatch[3]);
+      const name = labelMatch[1].trim();
+      feature = annotations.find((annotation) => (
+        Number(annotation?.start) + 1 === start
+        && Number(annotation?.end) === end
+        && String(annotation?.name || "").trim() === name
+      ));
+    }
+    if (!feature) return null;
+    const start = Number(feature.start) + 1;
+    const end = Number(feature.end);
+    const sequence = sequenceRange(record, start, end);
+    if (!sequence) return null;
+    return {
+      start,
+      end,
+      strand: Number(feature.strand) === -1 ? "reverse" : "forward",
+      sequence,
+      featureName: String(feature.name || "").trim() || undefined,
+    };
+  };
+  const nativeSelection = (record) => {
+    const source = recordSequence(record);
+    const raw = String(getSelection()?.toString() || "");
+    const sequence = raw.replace(/[^A-Za-z*.-]/g, "").toUpperCase();
+    if (!source || !sequence) return null;
+    const offset = source.indexOf(sequence);
+    return offset < 0 ? null : { start: offset + 1, end: offset + sequence.length, strand: "forward", sequence };
+  };
+  let lastNativeSelection = null;
+  let selectionLengthFrame = 0;
+  const updateSelectionLength = () => {
+    selectionLengthFrame = 0;
+    const bar = document.querySelector(".motif-cs-selection-bar");
+    if (!bar) return;
+    const record = activeRecord();
+    const recordId = String(record?.id || "");
+    const selection = renderedSelection(record)
+      || featureSelection(record)
+      || (bar.matches(":not([data-empty='true'])")
+        ? null
+        : nativeSelection(record)
+          || (lastNativeSelection?.recordId === recordId ? lastNativeSelection : null));
+    let badge = bar.querySelector("[data-wisp-motif-selection-length]");
+    if (!selection?.sequence) {
+      badge?.remove();
+      return;
+    }
+    const length = Array.from(selection.sequence).length;
+    const label = length.toLocaleString() + " bp";
+    if (!badge) {
+      badge = document.createElement("span");
+      badge.setAttribute("data-wisp-motif-selection-length", "");
+      badge.style.cssText = "margin-left:auto;padding-left:10px;white-space:nowrap;font-weight:700;font-variant-numeric:tabular-nums;color:currentColor;pointer-events:none";
+      bar.appendChild(badge);
+    }
+    if (badge.textContent !== label) badge.textContent = label;
+    badge.setAttribute("aria-label", "Selected sequence length: " + label);
+  };
+  const scheduleSelectionLengthUpdate = () => {
+    if (selectionLengthFrame) return;
+    selectionLengthFrame = requestAnimationFrame(updateSelectionLength);
+  };
+  const rememberNativeSelection = () => {
+    const record = activeRecord();
+    const selection = nativeSelection(record);
+    if (selection) lastNativeSelection = { recordId: String(record?.id || ""), ...selection };
+    scheduleSelectionLengthUpdate();
+  };
+  document.addEventListener("selectionchange", rememberNativeSelection);
+  document.addEventListener("pointerup", rememberNativeSelection, true);
+  document.addEventListener("keyup", rememberNativeSelection, true);
+  const scrollSelectedFeatureIntoView = () => {
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+      const block = document.querySelector(".motif-cs-feature-block[aria-pressed='true']");
+      const pane = block?.closest(".motif-cs-sequence-column");
+      if (!block || !pane) return;
+      const blockRect = block.getBoundingClientRect();
+      const paneRect = pane.getBoundingClientRect();
+      pane.scrollTop = Math.max(0, pane.scrollTop + blockRect.top - paneRect.top
+        - Math.max(0, (pane.clientHeight - blockRect.height) / 2));
+    }));
+  };
+  const scheduleFeatureFocus = (target) => {
+    if (!(target instanceof Element) || !target.closest(".motif-pm-feature[data-feature-id]")) return;
+    lastNativeSelection = null;
+    scrollSelectedFeatureIntoView();
+  };
+  document.addEventListener("click", (event) => scheduleFeatureFocus(event.target), true);
+  document.addEventListener("keydown", (event) => {
+    if (event.key === "Enter" || event.key === " ") scheduleFeatureFocus(event.target);
+  }, true);
+  const featureFocusObserver = new MutationObserver(() => {
+    if (document.querySelector(".motif-cs-feature-block[aria-pressed='true']")) {
+      scrollSelectedFeatureIntoView();
+    }
+    scheduleSelectionLengthUpdate();
+  });
+  featureFocusObserver.observe(document.body, {
+    subtree: true,
+    childList: true,
+    attributes: true,
+    attributeFilter: ["aria-pressed"],
+  });
+  scheduleSelectionLengthUpdate();
+  addEventListener("message", (event) => {
+    if (event.source !== parent) return;
+    const message = event.data || {};
+    if (message.jsonrpc !== "2.0") return;
+    if (message.method === "wisp/motif-add-records") {
+      try {
+        if (typeof window.motifAddRecords !== "function") throw new Error("Motif record API is not ready.");
+        const records = Array.isArray(message.params?.records) ? message.params.records : [];
+        window.motifAddRecords(records);
+        reply("wisp/notifications/motif-records-added", { requestId: message.params?.requestId, count: records.length });
+      } catch (error) {
+        reply("wisp/notifications/motif-bridge-error", { requestId: message.params?.requestId, message: error instanceof Error ? error.message : String(error) });
+      }
+    }
+    if (message.method === "wisp/motif-get-selection") {
+      try {
+        const record = activeRecord();
+        const recordId = String(record?.id || "");
+        const selection = renderedSelection(record)
+          || featureSelection(record)
+          || (document.querySelector(".motif-cs-selection-bar:not([data-empty='true'])")
+            ? null
+            : nativeSelection(record)
+              || (lastNativeSelection?.recordId === recordId ? lastNativeSelection : null));
+        if (!record || !selection) throw new Error("Select a sequence range in Motif first.");
+        reply("wisp/notifications/motif-selection", {
+          requestId: message.params?.requestId,
+          recordName: String(record.name || record.id || "Motif record"),
+          recordId,
+          molecule: String(record.type || record.molecule || "dna"),
+          start: selection.start,
+          end: selection.end,
+          strand: selection.strand || "forward",
+          sequence: selection.sequence,
+          featureName: selection.featureName,
+        });
+      } catch (error) {
+        reply("wisp/notifications/motif-bridge-error", { requestId: message.params?.requestId, message: error instanceof Error ? error.message : String(error) });
+      }
+    }
+  });
+  let readyAttempts = 0;
+  const announceReady = () => {
+    if (typeof window.motifGetActiveRecord === "function") {
+      reply("wisp/notifications/motif-bridge-ready", {});
+      return;
+    }
+    readyAttempts += 1;
+    if (readyAttempts < 200) setTimeout(announceReady, 50);
+  };
+  announceReady();
+})();
+</script>`;
+  // Motif bundles may contain literal `</body>` text inside minified scripts.
+  // Never splice the document with a regex: HTML parsers accept a trailing
+  // script after </html> and place it in the document body without corrupting
+  // any of Motif's original script boundaries.
+  return `${html}${script}`;
+}
+

--- a/ui/src/styles/right-pane.css
+++ b/ui/src/styles/right-pane.css
@@ -836,3 +836,9 @@ button.run-status:hover { filter:brightness(0.96); }
 .highlight-text { flex: 1; min-width: 0; text-align: left; background: none; border: none; margin: 0; padding: 2px 0 2px 10px; border-left: 3px solid var(--clay); color: var(--text); font: inherit; font-size: 13px; line-height: 1.55; cursor: pointer; white-space: pre-wrap; word-break: break-word; }
 .highlight-text:hover { color: var(--clay-strong); }
 .highlight-actions { display: flex; flex-direction: column; gap: 2px; }
+.center-mcp-app[data-mcp-backend="native-child"] { display: flex; flex-direction: column; min-height: 0; }
+.mcp-app-isolation-controls { display: flex; gap: 8px; align-items: center; padding: 6px 10px; flex: 0 0 auto; font-size: 12px; }
+.mcp-app-isolation-controls span { flex: 1; opacity: .75; }
+.mcp-app-isolation-controls button { flex: 0 0 auto; }
+.mcp-app-native-content { position: relative; flex: 1 1 0; min-height: 0; overflow: hidden; }
+.mcp-app-native-status { padding: 16px; }


### PR DESCRIPTION
Isolate Windows MCP Apps from the primary chat WebView.

This is a follow-up to the author's existing #1179 work, not a replacement.
It is rebased on current `main`, including:

- #1182 WebView recovery / native Stop and heartbeat
- #1188 media Blob URL lifetime (`media_url(ownerId)`, `revokeObjectURL`, cache/DOM owners)
- #1190 research-journey home navigation
- #1191 native clipboard file paths

The isolation path keeps those host-side fixes. It does not revert the media-lifetime stack, and it does not claim that #1179 is fully root-caused or fully solved. Long-session chat rendering can still stall the primary page; this PR only prevents a stuck MCP App from taking the sidebar, composer, and Stop with it.

Related to #1179.

## Why this is on top of the author's changes

#1188 correctly fixed a reproduced Blob-URL leak in the **host** chat/journal media path. That leak is real, but it does not isolate MCP App documents: Apps still load as `srcdoc` iframes in the primary chat page, and hiding a tab does not destroy that renderer work.

This PR keeps #1188's owner/revoke diagnostics for host media, then moves **Windows** MCP Apps into a native child WebView so App HTML, images, and JS no longer share the primary WebView2 renderer.

## User-visible behavior

On Windows:

- The App still occupies the existing split pane.
- The primary document keeps the tab chrome, Reload App, close controls, sidebar, composer, and Stop.
- The App document runs in a child WebView with its own WebView2 data directory.
- Leaving the tab/session invalidates the child immediately and destroys the native view.
- Returning creates a new generation and restores saved inputs/results. It does **not** replay tool calls, and it is **not** a full UI-state restore (unsubmitted selections, page positions, and edits may be lost). The isolated chrome shows that warning.
- Creation failure is a visible, retryable error. Windows does **not** silently fall back to a primary-document iframe.

macOS/Linux keep the current iframe host. This PR does not claim the same isolation there.

## Architecture

```
Wisp native window
├── primary chat WebView (sidebar, chat, Stop, App chrome)
└── MCP App child WebView covering only the App content box
    └── trusted shell
        └── sandbox="allow-scripts" iframe (opaque origin)
            └── SFL / Motif / other MCP App
```

Protocol:

```
guest iframe → child shell → restricted Rust bridge → original MCP server
```

Tool traffic no longer loops through primary-page JavaScript. Existing approval, Plan Mode, schema, stale-instance, size, timeout, and rate limits remain in the shared Rust tool service.

Because a second WebView makes Tauri's single-view `WebviewWindow` lookup fail, workspace commands now go through `WorkspaceSurface` (`Window` + primary `Webview`). Child labels cannot impersonate the primary document.

Capabilities are bound to **webview labels**. The child capability grants no core/plugin permissions; the invoke handler additionally allowlists only bootstrap/ready/request/action-reply for `mcp-app-child-*`.

## Validation

After rebasing onto current `main` (#1190 + #1191 merge in `src-tauri/src/lib.rs`):

- `WISP_CATALOG_OFFLINE=1 cargo check -p wisp-tauri --offline`
- `WISP_CATALOG_OFFLINE=1 cargo check --target wasm32-unknown-unknown --offline` in `ui`

Before that rebase, on the isolation commit:

- Native Windows smoke, 100 open/switch/close cycles: PASS. Guest 20s busy-loop left primary DOM click handling at ~10ms; child close ~518ms; separate WebView2 renderer PIDs.
- Playwright: `mcp-app-isolation.spec.ts` and `media-lifetime.spec.ts` (11 passed). Isolated mode asserts **zero** primary MCP App iframes.

Not claimed:

- Full Playwright suite was not re-run after the #1190/#1191 rebase.
- This does not prove that a media-heavy chat with no App open cannot still freeze the primary page.
- macOS/Linux isolation is unchanged.

## Follow-up

If a no-App long session still stalls, keep a performance trace on the primary chat renderer rather than treating isolation as the complete #1179 fix.
