### PR TITLE
Fix stale history paging responses and preserve generated folder state

### DIFF
--- a/crates/wisp-dto/src/lib.rs
+++ b/crates/wisp-dto/src/lib.rs
@@ -2467,7 +2467,8 @@ pub struct LoadedPresentation {
 pub struct TranscriptPageState {
     pub next_before_seq: Option<i64>,
     pub user_offset: usize,
-    pub loading: bool,
+    /// Identity of the active UI paging request; replacement pages clear it.
+    pub loading_request: Option<u64>,
     pub window_user_start: usize,
 }
 

--- a/docs/conversation-history.md
+++ b/docs/conversation-history.md
@@ -12,6 +12,9 @@ remains available while the Agent is working. A pending request disables the
 button and shows **Loading earlier messages…**. If reading or decoding a page
 fails, an inline error appears beside the paging controls; click **Load earlier
 messages** again to retry. Failed requests do not advance the history cursor.
+Reopening a session replaces its paging request. A superseded request cannot
+insert older rows, show an error, or clear the newer request's loading state,
+even when both requests use the same history cursor.
 
 ## Manual smoke checks
 

--- a/docs/generated-artifacts.md
+++ b/docs/generated-artifacts.md
@@ -14,7 +14,9 @@ within a bounded height.
 
 Use Tab to focus a disclosure and Enter or Space to expand/collapse it. These
 are inline disclosures, not overlays. Closing and reopening the Generated
-section preserves folder expansion while the reply remains mounted.
+section preserves folder expansion while the reply remains mounted. Artifact
+updates also preserve those choices, including when a later reply regenerates
+one of the files and changes this reply's Generated count.
 
 Manual smoke: generate many outputs across nested directories, open Generated,
 check counts, expand individual folders, preview a file, and use Open in center.

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -11785,6 +11785,47 @@ test("a stale earlier page does not duplicate history after reloading a session 
   await expect(page.locator(".msg.user")).toHaveCount(10);
 });
 
+for (const staleOutcome of ["success", "failure"]) {
+  test(`reloaded history rejects an old ${staleOutcome} while the same cursor is requested again`, async ({ page }) => {
+    await enterApp(page, "/?mockLongSession=1");
+    await page.evaluate((staleOutcome) => {
+      const core = (window as any).__TAURI__.core;
+      const original = core.invoke;
+      (window as any).__historyRequests = [];
+      core.invoke = async (cmd: string, args: any) => {
+        const before = args instanceof Map ? args.get("beforeSeq") : args?.beforeSeq;
+        if (cmd === "load_session" && before != null) {
+          const index = (window as any).__historyRequests.length;
+          await new Promise((resolve) => (window as any).__historyRequests.push(resolve));
+          if (index === 0 && staleOutcome === "failure") throw new Error("Obsolete history failure");
+          const result = await original(cmd, args);
+          if (index === 0) result.items[0].text = "Obsolete historical question";
+          return result;
+        }
+        return original(cmd, args);
+      };
+    }, staleOutcome);
+    const loadEarlier = page.getByRole("button", { name: "Load earlier messages", exact: true });
+    const loading = page.getByRole("button", { name: "Loading earlier messages…", exact: true });
+    await loadEarlier.click();
+    await expect(loading).toBeDisabled();
+    await newSessionButton(page).click();
+    await page.locator(".side-item.ses", { hasText: "Long transcript" }).click();
+    await loadEarlier.click();
+    await expect.poll(() => page.evaluate(() => (window as any).__historyRequests.length)).toBe(2);
+    await page.evaluate(() => (window as any).__historyRequests[0]());
+    // Flush the rejected promise / decoded response and the browser render.
+    await page.evaluate(() => new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve))));
+    await expect(page.getByRole("alert")).toHaveCount(0);
+    await expect(page.getByText("Obsolete historical question", { exact: true })).toHaveCount(0);
+    await expect(loading).toBeDisabled();
+    await page.evaluate(() => (window as any).__historyRequests[1]());
+    await expect(page.getByText("Oldest loaded question", { exact: true })).toBeAttached();
+    await expect(page.getByRole("alert")).toHaveCount(0);
+    await expect(loading).toHaveCount(0);
+  });
+}
+
 test("a 62-turn history with a large message reaches its first question (#1199)", async ({ page }) => {
   await page.goto("/?mockLongPages=4&mockLongRows=40");
   await page.evaluate(() => {
@@ -16123,4 +16164,40 @@ test("Generated outputs use a collapsed nested directory tree with working previ
   await results.locator(":scope > summary").click();
   await tree.locator('[data-artifact-name="new.png"]').click();
   await expect(page.locator(".artifact-modal")).toBeVisible();
+});
+
+test("Generated folders stay open when another reply updates an existing artifact", async ({ page }) => {
+  await enterApp(page);
+  await composer(page).fill("GENERATEDTREE");
+  await page.getByRole("button", { name: "Send", exact: true }).click();
+  const reply = page.locator(".msg.assistant", { hasText: "Generated tree fixture complete." });
+  await reply.locator(".message-artifacts-label").click();
+  const results = reply.locator(".generated-directory").filter({ has: page.locator(":scope > summary .generated-directory-name", { hasText: /^results$/ }) });
+  await results.locator(":scope > summary").click();
+  await results.locator(".generated-directory > summary").filter({ hasText: "batch" }).click();
+  const output = reply.locator('[data-artifact-name="output-1.csv"]');
+  await expect(output).toBeVisible();
+  const frameId = await page.locator(".side-item.ses.active").getAttribute("data-session-id");
+  expect(frameId).toBeTruthy();
+  await emitTauriEvent(page, "agent", { kind: "User", frame_id: frameId, text: "Update the first result" });
+  await emitTauriEvent(page, "agent", { kind: "ToolCall", frame_id: frameId, name: "write", preview: "Update output-0.csv" });
+  await emitTauriEvent(page, "agent", { kind: "FileChanged", frame_id: frameId, path: "/mock/root/results/batch/output-0.csv" });
+  await emitTauriEvent(page, "agent", { kind: "ToolResult", frame_id: frameId, name: "write", ok: true, content: "Updated." });
+  await emitTauriEvent(page, "agent", { kind: "Text", frame_id: frameId, delta: "Result updated." });
+  await emitTauriEvent(page, "agent", { kind: "Done", frame_id: frameId });
+  await expect(reply.locator(".message-artifacts-label")).toHaveText("Generated · 65");
+  await expect(reply.locator('[data-artifact-name="output-0.csv"]')).toHaveCount(0);
+  await expect(reply.locator(".message-artifacts")).toHaveJSProperty("open", true);
+  await expect(results).toHaveJSProperty("open", true);
+  await expect(output).toBeVisible();
+  // The old reply remains independently collapsible after the update.
+  await results.locator(":scope > summary").click();
+  await expect(output).not.toBeVisible();
+  await results.locator(":scope > summary").focus();
+  await page.keyboard.press("Space");
+  await expect(output).toBeVisible();
+  const newReply = page.locator(".msg.assistant", { hasText: "Result updated." });
+  await expect(newReply.locator(".generated-artifact-tree")).not.toBeVisible();
+  await page.locator("#chat-scroller").evaluate(el => el.dispatchEvent(new WheelEvent("wheel", { deltaY: -100 })));
+  await reply.locator(".message-artifacts").screenshot({ path: test.info().outputPath("generated-folders-after-update.png") });
 });

--- a/ui/src/app_support/messages.rs
+++ b/ui/src/app_support/messages.rs
@@ -919,23 +919,35 @@ impl GeneratedDirectory {
     }
 }
 
-fn generated_directory_view(node: GeneratedDirectory, on_artifact: Callback<usize>) -> View {
+fn generated_directory_view(
+    node: GeneratedDirectory,
+    on_artifact: Callback<usize>,
+    disclosures: RwSignal<std::collections::HashMap<String, bool>>,
+    parent: String,
+) -> View {
     let locale = use_locale();
     let folders = node
         .directories
         .into_iter()
         .map(|(name, child)| {
             let count = child.count();
+            let path = format!("{parent}/{name}");
+            let open_path = path.clone();
+            let toggle_path = path.clone();
             view! {
-                <details class="generated-directory">
-                    <summary>
+                <details class="generated-directory"
+                    open=move || crate::chat_render::disclosure_open(disclosures, &open_path, false)>
+                    <summary on:click=move |event| {
+                        event.prevent_default();
+                        crate::chat_render::toggle_disclosure(disclosures, &toggle_path, false);
+                    }>
                         {compose_icon("chevron-right")}
                         {compose_icon("folder")}
                         <span class="generated-directory-name">{name}</span>
                         <span class="generated-directory-count">{count}</span>
                     </summary>
                     <div class="generated-directory-children">
-                        {generated_directory_view(child, on_artifact)}
+                        {generated_directory_view(child, on_artifact, disclosures, path)}
                     </div>
                 </details>
             }
@@ -1043,6 +1055,9 @@ pub(crate) fn AssistantMessage(
     let on_artifact_for_cards = on_artifact.clone();
     let on_file = on_file.clone();
     let resources_for_click = resources.clone();
+    // Artifact updates rebuild the tree (including when an output moves to a
+    // later reply). Keep disclosure choices by folder path for this mounted row.
+    let generated_disclosures = create_rw_signal(std::collections::HashMap::new());
     let generated = create_memo(move |_| {
         let root = project
             .and_then(|project| project.get().map(|project| project.root))
@@ -1117,13 +1132,17 @@ pub(crate) fn AssistantMessage(
                     )
                 }></div>
             {move || (generated_count() > 0).then(|| view! {
-                <details class="message-artifacts">
-                    <summary class="message-artifacts-label">
+                <details class="message-artifacts"
+                    open=move || crate::chat_render::disclosure_open(generated_disclosures, "", false)>
+                    <summary class="message-artifacts-label" on:click=move |event| {
+                        event.prevent_default();
+                        crate::chat_render::toggle_disclosure(generated_disclosures, "", false);
+                    }>
                         {compose_icon("chevron-right")}
                         {move || tf(locale.get(), "artifact.generated_count", &[("n", &generated_count().to_string())])}
                     </summary>
                     <div class="generated-artifact-tree">
-                        {move || generated_directory_view(generated.get(), on_artifact_for_cards)}
+                        {move || generated_directory_view(generated.get(), on_artifact_for_cards, generated_disclosures, String::new())}
                     </div>
                 </details>
             })}

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -375,6 +375,7 @@ fn App() -> impl IntoView {
     let pending_turns = create_rw_signal::<HashMap<String, usize>>(HashMap::new());
     let transcripts = create_rw_signal::<HashMap<String, Vec<ChatItem>>>(HashMap::new());
     let transcript_pages = create_rw_signal::<HashMap<String, TranscriptPageState>>(HashMap::new());
+    let transcript_request_sequence = store_value(0_u64);
     let transcript_page_error = create_rw_signal::<Option<(String, String)>>(None);
     let conversation_outlines =
         create_rw_signal::<HashMap<String, Vec<SessionOutlineItem>>>(HashMap::new());
@@ -3099,7 +3100,7 @@ fn App() -> impl IntoView {
                     items.drain(..first_item);
                     page.next_before_seq = Some(before_seq);
                     page.user_offset = user_offset;
-                    page.loading = false;
+                    page.loading_request = None;
                     page.window_user_start = usize::MAX;
                     trimmed = true;
                 });
@@ -4602,7 +4603,7 @@ fn App() -> impl IntoView {
                                 Some(TranscriptPageState {
                                     next_before_seq: page.next_before_seq,
                                     user_offset: page.user_offset,
-                                    loading: false,
+                                    loading_request: None,
                                     window_user_start: usize::MAX,
                                 }),
                             )
@@ -4803,7 +4804,7 @@ fn App() -> impl IntoView {
                                         TranscriptPageState {
                                             next_before_seq: page.next_before_seq,
                                             user_offset: page.user_offset,
-                                            loading: false,
+                                            loading_request: None,
                                             window_user_start: usize::MAX,
                                         },
                                     );
@@ -5848,7 +5849,7 @@ fn App() -> impl IntoView {
                         TranscriptPageState {
                             next_before_seq: page.next_before_seq,
                             user_offset: page.user_offset,
-                            loading: false,
+                            loading_request: None,
                             window_user_start: usize::MAX,
                         },
                     );
@@ -6158,16 +6159,21 @@ fn App() -> impl IntoView {
             return;
         };
         let Some(cursor) = transcript_pages.with_untracked(|pages| {
-            pages
-                .get(&id)
-                .and_then(|page| (!page.loading).then_some(page.next_before_seq).flatten())
+            pages.get(&id).and_then(|page| {
+                page.loading_request
+                    .is_none()
+                    .then_some(page.next_before_seq)
+                    .flatten()
+            })
         }) else {
             return;
         };
         transcript_page_error.set(None);
+        transcript_request_sequence.update_value(|sequence| *sequence += 1);
+        let request_id = transcript_request_sequence.get_value();
         transcript_pages.update(|pages| {
             if let Some(page) = pages.get_mut(&id) {
-                page.loading = true;
+                page.loading_request = Some(request_id);
             }
         });
         spawn_local(async move {
@@ -6188,11 +6194,12 @@ fn App() -> impl IntoView {
                     .map_err(|error| error.to_string())
             });
             // A reload/outline jump may have replaced this page while the
-            // request was in flight. Never prepend into a different window.
+            // request was in flight and started another request with the same
+            // cursor. Only the owning request can change rows or loading/errors.
             if !transcript_pages.with_untracked(|pages| {
-                pages
-                    .get(&id)
-                    .is_some_and(|page| page.loading && page.next_before_seq == Some(cursor))
+                pages.get(&id).is_some_and(|page| {
+                    page.loading_request == Some(request_id) && page.next_before_seq == Some(cursor)
+                })
             }) {
                 return;
             }
@@ -6201,7 +6208,7 @@ fn App() -> impl IntoView {
                 Err(error) => {
                     transcript_pages.update(|pages| {
                         if let Some(page) = pages.get_mut(&id) {
-                            page.loading = false;
+                            page.loading_request = None;
                         }
                     });
                     transcript_page_error.set(Some((
@@ -6242,7 +6249,7 @@ fn App() -> impl IntoView {
                     TranscriptPageState {
                         next_before_seq: page.next_before_seq,
                         user_offset: page.user_offset,
-                        loading: false,
+                        loading_request: None,
                         window_user_start: 0,
                     },
                 );
@@ -6554,7 +6561,7 @@ fn App() -> impl IntoView {
                         TranscriptPageState {
                             next_before_seq: page.next_before_seq,
                             user_offset: page.user_offset,
-                            loading: false,
+                            loading_request: None,
                             window_user_start: target_local,
                         },
                     );
@@ -11610,7 +11617,7 @@ fn App() -> impl IntoView {
                                 })
                             } else {
                                 page.next_before_seq.map(|_| {
-                                let loading = page.loading;
+                                let loading = page.loading_request.is_some();
                                 view! {
                                     <div class="transcript-page-control">
                                         <button


### PR DESCRIPTION
## Problem and behavior

After reopening a conversation and requesting the same history cursor again, an older in-flight response could insert obsolete messages or clear the new request with an old error. Paging now associates loading state with a unique request ID, so only the active request may update rows, errors, and completion state.

Generated directories also collapsed whenever the reply-local artifact list changed. Each mounted reply now retains its Generated and nested-folder disclosure choices by folder path, including when a later reply regenerates an output. Keyboard interaction and independent reply state remain intact.

Follow-up to #1201 and #1205. The XLSX external-reference behavior from #1198 was reviewed and regression-tested; it needs no implementation change in this PR.

## Changes

- `crates/wisp-dto/src/lib.rs`, `ui/src/main.rs`: replace the UI paging boolean with an optional request identity and invalidate it when replacing the page. No serialized IPC or database schema changes.
- `ui/src/app_support/messages.rs`: retain reply-local folder disclosure state using the existing disclosure helpers.
- `ui-tests/tests/ui.spec.ts`: stale success/error responses while a replacement request uses the same cursor; artifact updates, nested disclosure preservation, keyboard toggling, and independent reply state.
- `docs/conversation-history.md`, `docs/generated-artifacts.md`: describe the resulting behavior.

## Validation

- Both paging races and the artifact-update collapse were reproduced on the merged implementation before the fixes.
- Final focused Playwright suite: 14 passed, including XLSX external references, history scrolling/paging, and Generated artifacts. An earlier dev-server run had two page-startup timeouts; the final run serves the completed build without a rebuilding development server.
- Native OOXML validation: 4 passed, including the external-reference allowlist and blocked media/unsafe-link cases.
- WASM `cargo check`, workspace/UI formatting, and `git diff --check`: passed.
- Captured and visually inspected the expanded directory tree after a later reply updated an output.
- Full final-revision Playwright (`--fully-parallel --workers=6`, served from the completed static build): **673 passed, 2 skipped, 0 failed**.
- Full Windows `cargo test --workspace --no-fail-fast` with `WISP_CATALOG_OFFLINE=1`: **2006 passed, 2 failed**, including all **861 Tauri tests passing**. The only failures are the unchanged `wisp-runs` tests `ssh_input_staging_ledgers_uploaded_files` and `ssh_launch_failure_stops_after_the_first_attempt`, both reporting `artifact path is outside project root`. No run-manager implementation is changed.
- GitHub CI: the release-notes helper and all three Headless agent eval jobs passed; Rust stable/MSRV and UI E2E are still running at the time of this update.

## Manual smoke and limitations

Open a long conversation, load earlier messages, reopen it, and load earlier history again while the old request is delayed. Only the current request should control loading/errors and the inserted rows. Generate files across nested directories, expand Generated/results/batch, then regenerate one file in a later reply. The old reply should keep its expanded folders; verify Enter/Space toggling, updated counts, and preview behavior.

The original private macOS conversation from #1199 remains unverified. Browser tests use mocked Tauri commands and do not establish native macOS/WebView behavior. Folder choices last only while the reply remains mounted, not across app restarts. No new dependencies or packaged resources are introduced.