### PR TITLE
Fix Windows terminal close and conversation find (#1210, #1212)

### DIFF
--- a/docs/conversation-find.md
+++ b/docs/conversation-find.md
@@ -1,0 +1,20 @@
+# Find in a conversation
+
+Press **Ctrl+F** on Windows/Linux or **Command+F** on macOS while viewing the
+conversation to search its displayed message bodies. The count and orange
+active highlight use the same ordered list of matches; yellow highlights show
+the other matches. Sidebar labels, session titles, composer text and hidden
+content are excluded. Matching is literal and case-insensitive, including text
+split by inline Markdown formatting.
+
+**Enter** / **Shift+Enter** and the next/previous arrows move through matches,
+wrapping at either end. Navigation pauses automatic following of new output,
+so a result reached from the bottom remains visible. **Back to latest** resumes
+following. **Escape** closes the find bar after any overlaid dialog or menu;
+closing find preserves the reading position. Changing sessions closes find.
+
+Search covers the currently displayed transcript window. Load older messages
+to search that window; the count refreshes when displayed content changes.
+Collapsed content is searchable after expanding it. Editors and terminals keep
+their own find shortcuts when focused.
+Older WebViews without the CSS Highlight API retain their native find UI.

--- a/docs/terminal-sessions.md
+++ b/docs/terminal-sessions.md
@@ -22,7 +22,10 @@ sessions in tabs; use **New terminal (+)** to choose any registered execution
 context. Switching tabs keeps every terminal attached so background output is
 not interrupted. The **−** button collapses the panel while keeping its views
 attached, so shells continue running in the background. The **×** inside each
-tab closes that tab and terminates its process. Terminal sessions and scrollback
+tab closes that tab and terminates its process with one click, including on
+Windows. An already exited shell can also be closed immediately; a genuine
+termination failure keeps the tab available and reports the error for retry.
+Terminal sessions and scrollback
 are ephemeral and are not written to SQLite or included in project sync.
 
 The xterm instances are mounted directly in the main application webview. PTY

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -82,6 +82,7 @@ windows = { version = "0.61", features = [
     "Win32_Foundation",
     "Win32_System_DataExchange",
     "Win32_System_Memory",
+    "Win32_System_Threading",
     "Win32_UI_Shell",
     "Win32_Graphics_Gdi",
     "Win32_System_LibraryLoader",

--- a/src-tauri/src/terminal_sessions.rs
+++ b/src-tauri/src/terminal_sessions.rs
@@ -9,7 +9,7 @@
 
 use crate::workspace_surface::WorkspaceSurface;
 use base64::Engine;
-use portable_pty::{native_pty_system, Child, ChildKiller, CommandBuilder, MasterPty, PtySize};
+use portable_pty::{native_pty_system, Child, CommandBuilder, MasterPty, PtySize};
 use serde::Serialize;
 use std::collections::HashMap;
 use std::io::{Read, Write};
@@ -21,6 +21,60 @@ use tauri::State;
 const DEFAULT_ROWS: u16 = 30;
 const DEFAULT_COLS: u16 = 100;
 const MAX_SCROLLBACK_BYTES: usize = 4 * 1024 * 1024;
+
+struct TerminalKiller {
+    #[cfg(windows)]
+    handle: std::os::windows::io::OwnedHandle,
+    #[cfg(not(windows))]
+    inner: Box<dyn portable_pty::ChildKiller + Send + Sync>,
+}
+
+impl TerminalKiller {
+    fn new(child: &dyn Child) -> std::io::Result<Self> {
+        #[cfg(windows)]
+        {
+            use std::os::windows::io::BorrowedHandle;
+            let raw = child.as_raw_handle().ok_or_else(|| {
+                std::io::Error::other("terminal child has no Windows process handle")
+            })?;
+            // Duplicate while the child still owns the handle. The waiter may
+            // exit concurrently later; never reopen by a potentially reused PID.
+            let handle = unsafe { BorrowedHandle::borrow_raw(raw) }.try_clone_to_owned()?;
+            Ok(Self { handle })
+        }
+        #[cfg(not(windows))]
+        {
+            Ok(Self {
+                inner: child.clone_killer(),
+            })
+        }
+    }
+
+    fn kill(&mut self) -> std::io::Result<()> {
+        #[cfg(windows)]
+        {
+            use std::os::windows::io::AsRawHandle;
+            use windows::Win32::Foundation::{HANDLE, WAIT_OBJECT_0};
+            use windows::Win32::System::Threading::{TerminateProcess, WaitForSingleObject};
+            let handle = HANDLE(self.handle.as_raw_handle());
+            // portable-pty 0.9's cloned Windows killer inverts the BOOL result.
+            // Use the typed API and only ignore failure if the process exited
+            // concurrently (TerminateProcess then reports access denied).
+            if unsafe { WaitForSingleObject(handle, 0) } == WAIT_OBJECT_0 {
+                return Ok(());
+            }
+            match unsafe { TerminateProcess(handle, 1) } {
+                Ok(()) => Ok(()),
+                Err(_) if unsafe { WaitForSingleObject(handle, 0) } == WAIT_OBJECT_0 => Ok(()),
+                Err(error) => Err(error.into()),
+            }
+        }
+        #[cfg(not(windows))]
+        {
+            self.inner.kill()
+        }
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TerminalLaunchSpec {
@@ -84,7 +138,7 @@ struct TerminalSession {
     process_id: Option<u32>,
     master: Mutex<Box<dyn MasterPty + Send>>,
     writer: Mutex<Box<dyn Write + Send>>,
-    killer: Mutex<Box<dyn ChildKiller + Send + Sync>>,
+    killer: Mutex<TerminalKiller>,
     output: Mutex<TerminalOutputState>,
     /// One-shot OpenSSH askpass files. Must stay on disk until the child
     /// exits — authentication happens after spawn, not at spawn.
@@ -376,7 +430,7 @@ fn spawn_session(
         command.cwd(cwd);
     }
 
-    let child = pair.slave.spawn_command(command).map_err(|error| {
+    let mut child = pair.slave.spawn_command(command).map_err(|error| {
         crate::ssh_hosts::cleanup_password_auth_env(&cleanup_envs);
         format!("failed to start {context_id} terminal: {error}")
     })?;
@@ -397,7 +451,11 @@ fn spawn_session(
         }
     };
     let process_id = child.process_id();
-    let killer = child.clone_killer();
+    let killer = TerminalKiller::new(child.as_ref()).map_err(|error| {
+        let _ = child.kill();
+        crate::ssh_hosts::cleanup_password_auth_env(&cleanup_envs);
+        format!("failed to duplicate terminal process handle: {error}")
+    })?;
     let session = Arc::new(TerminalSession {
         id: uuid::Uuid::new_v4().to_string(),
         project_id: project_id.into(),
@@ -601,6 +659,91 @@ pub fn close_terminal(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(windows)]
+    fn open_test_terminal(manager: &TerminalManager) -> Arc<TerminalSession> {
+        let summary = manager
+            .open_spec(
+                "test-project",
+                "main",
+                "local",
+                "Close regression".into(),
+                "local",
+                TerminalLaunchSpec {
+                    program: "powershell.exe".into(),
+                    args: vec![
+                        "-NoLogo".into(),
+                        "-NoProfile".into(),
+                        "-Command".into(),
+                        "[Console]::WriteLine('terminal-ready'); Start-Sleep -Seconds 30".into(),
+                    ],
+                    cwd: None,
+                    display_cwd: String::new(),
+                    envs: Vec::new(),
+                },
+            )
+            .unwrap();
+        let session = manager.get(&summary.id).unwrap();
+        // ConPTY asks xterm for the cursor position before launching the shell.
+        // This headless test supplies the same terminal response.
+        session.write("\u{1b}[1;1R").unwrap();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        while !String::from_utf8_lossy(&lock(&session.output).scrollback).contains("terminal-ready")
+        {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "terminal did not start: {:?}",
+                String::from_utf8_lossy(&lock(&session.output).scrollback)
+            );
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+        session
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn windows_terminal_closes_on_first_attempt_and_exited_kill_is_idempotent() {
+        let manager = TerminalManager::new();
+        let session = open_test_terminal(&manager);
+        assert!(session.running());
+
+        manager
+            .close(&session.id)
+            .expect("first close must succeed");
+        assert!(manager.get(&session.id).is_err());
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while session.running() {
+            assert!(std::time::Instant::now() < deadline, "child did not exit");
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+        // Exercise the handle directly, including the exit race that can
+        // precede the waiter's update of TerminalOutputState.
+        lock(&session.killer).kill().unwrap();
+        session.terminate().unwrap();
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn windows_terminal_retains_session_on_real_termination_failure() {
+        use std::os::windows::io::{FromRawHandle, OwnedHandle};
+        use windows::Win32::System::Threading::{OpenProcess, PROCESS_SYNCHRONIZE};
+
+        let manager = TerminalManager::new();
+        let session = open_test_terminal(&manager);
+        // A valid handle without PROCESS_TERMINATE must report access denied,
+        // not silently unregister a still-running shell.
+        let raw = unsafe { OpenProcess(PROCESS_SYNCHRONIZE, false, session.process_id.unwrap()) }
+            .unwrap();
+        let restricted = unsafe { OwnedHandle::from_raw_handle(raw.0) };
+        let original = std::mem::replace(&mut lock(&session.killer).handle, restricted);
+        let result = manager.close(&session.id);
+        let retained = manager.get(&session.id).is_ok();
+        lock(&session.killer).handle = original;
+        manager.close(&session.id).unwrap();
+
+        assert!(result.unwrap_err().contains("failed to terminate terminal"));
+        assert!(retained);
+    }
 
     #[test]
     fn builds_wsl_terminal_for_selected_distro_and_project() {

--- a/ui-tests/tests/conversation-find.spec.ts
+++ b/ui-tests/tests/conversation-find.spec.ts
@@ -1,0 +1,129 @@
+import { test, expect, type Page } from "@playwright/test";
+import { tauriMock } from "./mock-tauri";
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(tauriMock);
+  await page.goto("/?mockLongPages=8");
+  await page.locator(".proj-card-main").first().click();
+  await expect(page.getByText(/Window page 0 row 19/)).toBeVisible();
+  await page.evaluate(async () => { await document.fonts.ready; });
+});
+
+async function activeMatch(page: Page) {
+  return page.evaluate(() => {
+    const range = [...((CSS as any).highlights.get("wisp-find-active") ?? [])][0] as Range | undefined;
+    if (!range) return null;
+    const viewport = document.getElementById("chat-scroller")!.getBoundingClientRect();
+    const rect = range.getBoundingClientRect();
+    return {
+      text: range.toString(),
+      body: range.startContainer.parentElement?.closest(".body")?.textContent,
+      visible: rect.top >= viewport.top && rect.bottom <= viewport.bottom,
+    };
+  });
+}
+
+for (const modifier of ["Control", "Meta"]) {
+  test(`${modifier}+F counts only conversation bodies and stays on backward results (#1212)`, async ({ page }) => {
+    await page.locator("#composer-input").fill("Window page outside the transcript");
+    await page.keyboard.press(`${modifier}+f`);
+    const input = page.locator("#chat-find-input");
+    await expect(input).toBeFocused();
+    await input.fill("Window page");
+    const count = page.locator(".chat-find-count");
+    await expect(count).toHaveText("1 / 20");
+    await expect.poll(() => activeMatch(page)).toMatchObject({ body: expect.stringContaining("row 0 "), visible: true });
+    await input.press("Enter");
+    await expect(count).toHaveText("2 / 20");
+    await expect.poll(() => activeMatch(page)).toMatchObject({ body: expect.stringContaining("row 1 "), visible: true });
+    await input.press("Shift+Enter");
+    await input.press("Shift+Enter");
+    await expect(count).toHaveText("20 / 20");
+    await expect.poll(() => activeMatch(page)).toMatchObject({ body: expect.stringContaining("row 19 "), visible: true });
+    await page.locator(".msg.assistant .body").last().evaluate(body => {
+      body.appendChild(document.createTextNode(" streamed output".repeat(500)));
+    });
+    await page.waitForTimeout(250);
+    await expect(count).toHaveText("20 / 20");
+    await expect.poll(() => activeMatch(page)).toMatchObject({ body: expect.stringContaining("row 19 "), visible: true });
+    await page.getByRole("button", { name: "Previous match", exact: true }).click();
+    await expect(count).toHaveText("19 / 20");
+    // Outlive the scroll gesture guard and pending observer/follow callbacks.
+    await page.waitForTimeout(750);
+    await expect.poll(() => activeMatch(page)).toMatchObject({ body: expect.stringContaining("row 18 "), visible: true });
+    await page.locator(".msg.assistant .body").last().evaluate(body => {
+      body.appendChild(document.createTextNode(" streamed output".repeat(500)));
+    });
+    await page.waitForTimeout(250);
+    await expect(count).toHaveText("19 / 20");
+    await expect.poll(() => activeMatch(page)).toMatchObject({ body: expect.stringContaining("row 18 "), visible: true });
+    const scroller = page.locator("#chat-scroller");
+    const top = await scroller.evaluate(el => el.scrollTop);
+    await page.keyboard.press("Escape");
+    await expect(input).toHaveCount(0);
+    await expect.poll(() => scroller.evaluate(el => el.scrollTop)).toBeCloseTo(top, 0);
+    await expect.poll(() => page.evaluate(() => (CSS as any).highlights.has("wisp-find-active"))).toBe(false);
+    await page.locator("#chat-jump-pill").click();
+    await expect.poll(() => scroller.evaluate(el => el.scrollHeight - el.clientHeight - el.scrollTop)).toBeLessThan(8);
+  });
+}
+
+test("find uses literal Unicode ranges across inline formatting and refreshes changed content", async ({ page }) => {
+  // Bounded rendered-DOM fixture: exercise inline splits, hidden content and
+  // the same subtree replacement/append notifications used by streaming rows.
+  await page.locator(".msg.assistant .body").first().evaluate(body => {
+    body.innerHTML = '<p>你好 <strong>please</strong> [a.b] 你好</p><p hidden>你好</p><button>你好</button>';
+  });
+  await page.keyboard.press("Control+f");
+  const input = page.locator("#chat-find-input");
+  const count = page.locator(".chat-find-count");
+  await input.fill("你好 PLEASE");
+  await expect(count).toHaveText("1 / 1");
+  expect((await activeMatch(page))?.text).toBe("你好 please");
+  await input.fill("[a.b]");
+  await expect(count).toHaveText("1 / 1");
+  await input.fill("你好");
+  await expect(count).toHaveText("1 / 2");
+  await input.press("Enter");
+  await expect(count).toHaveText("2 / 2");
+  await page.locator(".msg.assistant .body").first().evaluate(body => {
+    body.innerHTML = '<p>你好 <strong>please</strong> [a.b] 你好 你好</p>';
+  });
+  await expect(count).toHaveText("2 / 3");
+  await page.getByRole("button", { name: "Next match", exact: true }).click();
+  await expect(count).toHaveText("3 / 3");
+  await input.fill("missing literal");
+  await expect(count).toHaveText("0 / 0");
+  await expect(page.getByRole("button", { name: "Next match", exact: true })).toBeDisabled();
+  await input.fill("");
+  await expect(count).toHaveText("0 / 0");
+});
+
+test("Escape closes only the top layer and session changes clear find", async ({ page }) => {
+  await page.keyboard.press("Control+f");
+  // No focus preparation before Escape.
+  await page.keyboard.press("Escape");
+  await expect(page.locator(".chat-find")).toHaveCount(0);
+  await page.keyboard.press("Control+f");
+  await page.locator("#chat-find-input").fill("Window page");
+  await page.keyboard.press("Control+f");
+  await expect(page.locator("#chat-find-input")).toHaveValue("Window page");
+  await page.keyboard.press("Control+p");
+  await expect(page.locator(".action-palette")).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(page.locator(".action-palette")).not.toBeVisible();
+  await expect(page.locator(".chat-find")).toBeVisible();
+  await page.getByRole("button", { name: "New session", exact: true }).click();
+  await expect(page.locator(".chat-find")).toHaveCount(0);
+  expect(await page.evaluate(() => (CSS as any).highlights.has("wisp-find"))).toBe(false);
+});
+
+test("find bar fits a narrow conversation viewport", async ({ page }) => {
+  await page.setViewportSize({ width: 760, height: 700 });
+  await page.keyboard.press("Control+f");
+  await page.locator("#chat-find-input").fill("Window page");
+  const bar = page.locator(".chat-find");
+  await expect(bar).toBeVisible();
+  expect(await bar.evaluate(el => el.scrollWidth <= el.clientWidth)).toBe(true);
+  await page.screenshot({ path: test.info().outputPath("conversation-find-narrow.png"), animations: "disabled" });
+});

--- a/ui/src/app_support/messages.rs
+++ b/ui/src/app_support/messages.rs
@@ -212,6 +212,7 @@ pub(crate) fn compose_icon(kind: &str) -> impl IntoView {
         "panel" => view! { <rect x="3" y="3" width="18" height="18" rx="2"/><path d="M15 3v18"/> }.into_view(),
         "dock" => view! { <rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 15h18"/> }.into_view(),
         "chevron-down" => view! { <path d="m6 9 6 6 6-6"/> }.into_view(),
+        "chevron-up" => view! { <path d="m6 15 6-6 6 6"/> }.into_view(),
         "chevron-left" => view! { <path d="m15 18-6-6 6-6"/> }.into_view(),
         "chevron-right" => view! { <path d="m9 18 6-6-6-6"/> }.into_view(),
         "expand" => view! { <path d="M15 3h6v6"/><path d="m21 3-7 7"/><path d="M9 21H3v-6"/><path d="m3 21 7-7"/> }.into_view(),

--- a/ui/src/chat_find.js
+++ b/ui/src/chat_find.js
@@ -1,0 +1,130 @@
+import { reveal_chat_range } from "./scroll.js";
+
+let state = null;
+const ALL = "wisp-find";
+const ACTIVE = "wisp-find-active";
+
+// Only intercept the conversation shortcut. Editors, terminals and modal
+// inputs retain their own find behavior, including in the split layout.
+export function can_find_chat() {
+  if (!CSS.highlights || typeof Highlight === "undefined") return false;
+  const scroller = document.getElementById("chat-scroller");
+  if (!scroller?.getClientRects().length) return false;
+  const active = document.activeElement;
+  if (active?.closest(".center-file, .terminal-dock, [role=dialog]")) return false;
+  if (active?.matches("input, textarea, [contenteditable=true]")
+      && !active.closest(".chat-stage, .composer")) return false;
+  const rect = scroller.getBoundingClientRect();
+  const top = document.elementFromPoint(rect.x + rect.width / 2, rect.y + rect.height / 2);
+  return !!top?.closest(".chat-stage");
+}
+
+export function focus_chat_find() {
+  const input = document.getElementById("chat-find-input");
+  input?.focus({ preventScroll: true });
+  input?.select();
+}
+
+function collect(query) {
+  if (!query || !state) return [];
+  const matches = [];
+  const pattern = new RegExp(query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "giu");
+  for (const body of state.root.querySelectorAll(".msg .body")) {
+    // Don't double-count nested message bodies or hidden/collapsed content.
+    if (body.parentElement.closest(".body")) continue;
+    const walker = document.createTreeWalker(body, NodeFilter.SHOW_TEXT);
+    let text = "";
+    const spans = [];
+    let lastBlock = null;
+    while (walker.nextNode()) {
+      const node = walker.currentNode;
+      const parent = node.parentElement;
+      if (!parent || parent.closest("button, script, style, textarea, [aria-hidden=true]")) continue;
+      const probe = new Range();
+      probe.selectNodeContents(node);
+      if (!Array.from(probe.getClientRects()).some(rect => rect.width && rect.height)
+          || getComputedStyle(parent).visibility !== "visible") continue;
+      const block = parent.closest("p, div, li, pre, td, th, h1, h2, h3, h4, h5, h6");
+      if (lastBlock && block !== lastBlock) text += "\n";
+      lastBlock = block;
+      spans.push({ node, start: text.length, end: text.length + node.length });
+      text += node.data;
+    }
+    pattern.lastIndex = 0;
+    let match;
+    let ordinal = 0;
+    while ((match = pattern.exec(text))) {
+      const start = spans.find(span => span.end > match.index);
+      const endOffset = match.index + match[0].length;
+      const end = spans.find(span => span.end >= endOffset);
+      if (!start || !end) continue;
+      const range = new Range();
+      range.setStart(start.node, match.index - start.start);
+      range.setEnd(end.node, endOffset - end.start);
+      const row = body.closest("[data-ui-index]");
+      matches.push({ range, key: `${row?.dataset.uiIndex ?? ""}:${ordinal++}` });
+    }
+  }
+  return matches;
+}
+
+function paint(reveal) {
+  if (!state) return;
+  const { matches, index, report } = state;
+  const current = matches[index];
+  if (CSS.highlights) {
+    CSS.highlights.set(ALL, new Highlight(...matches.map(match => match.range)));
+    CSS.highlights.set(ACTIVE, new Highlight(...(current ? [current.range] : [])));
+  }
+  report(current ? index + 1 : 0, matches.length);
+  if (reveal && current) reveal_chat_range(current.range);
+}
+
+function rebuild(reset = false, reveal = false) {
+  if (!state) return;
+  const previous = state.matches[state.index];
+  state.matches = collect(state.query);
+  const retained = reset || !previous ? -1 : state.matches.findIndex(match =>
+    (match.range.startContainer === previous.range.startContainer
+      && match.range.startOffset === previous.range.startOffset)
+    || match.key === previous.key);
+  state.index = reset ? 0 : retained >= 0 ? retained : Math.min(state.index, state.matches.length - 1);
+  if (state.index < 0) state.index = 0;
+  paint(reveal);
+}
+
+export function start_chat_find(report) {
+  stop_chat_find();
+  const root = document.getElementById("chat-thread");
+  if (!root) return;
+  const observer = new MutationObserver(() => {
+    cancelAnimationFrame(state?.pending);
+    if (state) state.pending = requestAnimationFrame(() => rebuild());
+  });
+  state = { root, report, observer, query: "", matches: [], index: 0, pending: 0 };
+  observer.observe(root, { childList: true, subtree: true, characterData: true, attributes: true,
+    attributeFilter: ["open", "hidden", "style", "class"] });
+}
+
+export function query_chat_find(query) {
+  if (!state) return;
+  state.query = query;
+  rebuild(true, true);
+}
+
+export function step_chat_find(direction) {
+  if (!state) return;
+  rebuild(); // Enter can race the pending DOM update notification.
+  if (state.matches.length) {
+    state.index = (state.index + direction + state.matches.length) % state.matches.length;
+  }
+  paint(true);
+}
+
+export function stop_chat_find() {
+  state?.observer.disconnect();
+  cancelAnimationFrame(state?.pending);
+  state = null;
+  CSS.highlights?.delete(ALL);
+  CSS.highlights?.delete(ACTIVE);
+}

--- a/ui/src/chat_find.rs
+++ b/ui/src/chat_find.rs
@@ -1,0 +1,63 @@
+use crate::{compose_icon, i18n::Locale};
+use leptos::*;
+use wasm_bindgen::{prelude::*, JsCast};
+
+#[wasm_bindgen(module = "/src/chat_find.js")]
+extern "C" {
+    pub(crate) fn can_find_chat() -> bool;
+    pub(crate) fn focus_chat_find();
+    fn start_chat_find(report: &js_sys::Function);
+    fn query_chat_find(query: &str);
+    fn step_chat_find(direction: i32);
+    fn stop_chat_find();
+}
+
+#[component]
+pub(crate) fn ChatFindBar(open: RwSignal<bool>, locale: RwSignal<Locale>) -> impl IntoView {
+    let count = create_rw_signal((0_u32, 0_u32));
+    let report =
+        Closure::<dyn Fn(u32, u32)>::new(move |current, total| count.set((current, total)));
+    start_chat_find(report.as_ref().unchecked_ref());
+    on_cleanup(move || {
+        stop_chat_find();
+        drop(report);
+    });
+    let input = create_node_ref::<html::Input>();
+    create_effect(move |_| {
+        if let Some(input) = input.get() {
+            let _ = input.focus();
+        }
+    });
+    let label = move |en: &'static str, zh: &'static str| {
+        if locale.get() == Locale::Zh {
+            zh
+        } else {
+            en
+        }
+    };
+    view! {
+        <div class="chat-find" role="search" aria-label=move || label("Find in displayed conversation", "查找当前显示的会话")>
+            <input id="chat-find-input" node_ref=input type="search"
+                aria-label=move || label("Find in displayed conversation", "查找当前显示的会话")
+                placeholder=move || label("Find in conversation", "在会话中查找")
+                on:input=move |ev| query_chat_find(&event_target_value(&ev))
+                on:keydown=move |ev| {
+                    if ev.key() == "Enter" && !crate::ime_composing(&ev) {
+                        ev.prevent_default();
+                        ev.stop_propagation();
+                        step_chat_find(if ev.shift_key() { -1 } else { 1 });
+                    }
+                } />
+            <span class="chat-find-count" role="status" aria-live="polite">{move || {
+                let (current, total) = count.get();
+                format!("{current} / {total}")
+            }}</span>
+            <button type="button" aria-label=move || label("Previous match", "上一个匹配")
+                disabled=move || count.get().1 == 0 on:click=move |_| step_chat_find(-1)>{compose_icon("chevron-up")}</button>
+            <button type="button" aria-label=move || label("Next match", "下一个匹配")
+                disabled=move || count.get().1 == 0 on:click=move |_| step_chat_find(1)>{compose_icon("chevron-down")}</button>
+            <button type="button" aria-label=move || label("Close find", "关闭查找")
+                on:click=move |_| open.set(false)>{compose_icon("close")}</button>
+        </div>
+    }
+}

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -3,6 +3,7 @@ mod agent_workflows;
 mod app_overlays;
 mod bindings;
 mod channels_view;
+mod chat_find;
 mod chat_render;
 mod context_menu;
 mod dto;
@@ -380,6 +381,7 @@ fn App() -> impl IntoView {
     let conversation_outlines =
         create_rw_signal::<HashMap<String, Vec<SessionOutlineItem>>>(HashMap::new());
     let conversation_outline_open = create_rw_signal(false);
+    let chat_find_open = create_rw_signal(false);
     let conversation_outline_mounted = create_rw_signal(false);
     let conversation_outline_selected = create_rw_signal::<Option<usize>>(None);
     create_effect(move |_| {
@@ -464,6 +466,10 @@ fn App() -> impl IntoView {
     // Configured model profiles + the composer's bottom-right picker state.
     let models = create_rw_signal::<Vec<ModelProfile>>(vec![]);
     let active_session = create_rw_signal::<Option<String>>(None);
+    create_effect(move |_| {
+        active_session.get();
+        chat_find_open.set(false);
+    });
     // The stopping banner belongs to the session where Stop was clicked, and
     // only while that session is still running. Switching conversations must
     // not carry it over; a missed or late Done must not leave it over Send.
@@ -8864,6 +8870,12 @@ fn App() -> impl IntoView {
             return;
         }
 
+        if chat_find_open.get() {
+            ev.prevent_default();
+            chat_find_open.set(false);
+            return;
+        }
+
         // --- drag cancel ---
         if dragging.get() {
             ev.prevent_default();
@@ -10093,11 +10105,16 @@ fn App() -> impl IntoView {
         let Some(ev) = ev.dyn_ref::<web_sys::KeyboardEvent>() else {
             return;
         };
-        if ime_composing(ev) || !(ev.ctrl_key() || ev.meta_key()) {
+        if ev.default_prevented() || ime_composing(ev) || !(ev.ctrl_key() || ev.meta_key()) {
             return;
         }
         let key = ev.key().to_lowercase();
         match key.as_str() {
+            "f" if !ev.alt_key() && !ev.shift_key() && chat_find::can_find_chat() => {
+                ev.prevent_default();
+                chat_find_open.set(true);
+                chat_find::focus_chat_find();
+            }
             "p" => {
                 ev.prevent_default();
                 command_palette_open.set(false);
@@ -11495,6 +11512,9 @@ fn App() -> impl IntoView {
                 aria-label=move || t(locale.get(), "center.resize_split")
                 on:mousedown=on_center_split_resize_start></div>
             <div class="chat-stage" class:center-hidden=move || center_file_open.get() && !center_split.get()>
+            <Show when=move || chat_find_open.get()>
+                <chat_find::ChatFindBar open=chat_find_open locale=locale />
+            </Show>
             <div class="chat" id=CHAT_SCROLLER_ID
                 on:mouseup=move |ev| {
                     // Primary button only: a right-click mouseup would re-raise

--- a/ui/src/scroll.js
+++ b/ui/src/scroll.js
@@ -5,9 +5,11 @@ const chatPositions = new Map();
 let panelSession = null;
 
 function scrollWithin(scroller, target) {
-  if (!scroller || !scroller.contains(target)) return;
+  const isRange = target instanceof Range;
+  if (!scroller || !scroller.contains(isRange ? target.commonAncestorContainer : target)) return;
   scroller.scrollTop += target.getBoundingClientRect().top
-    - scroller.getBoundingClientRect().top - scroller.clientTop;
+    - scroller.getBoundingClientRect().top - scroller.clientTop
+    - (isRange ? scroller.clientHeight / 2 : 0);
 }
 
 // ponytail: single chat scroller, so the jump pill id is a constant.
@@ -46,6 +48,7 @@ export function attach_chat_scroll(scrollerId, contentId) {
   let hidden = false;
   let pointerDown = false;
   let jumping = false;
+  let followGeneration = 0;
   const setFollow = (value) => {
     follow = value;
     scroller.style.overflowAnchor = value ? "none" : "auto";
@@ -229,6 +232,10 @@ export function attach_chat_scroll(scrollerId, contentId) {
     onGrowth,
     unfollow: parkHere,
     jumpTo: (el) => {
+      // Result navigation supersedes delayed follow snaps queued before it.
+      followGeneration++;
+      lastUserScroll = -Infinity;
+      pointerDown = false;
       jumping = true;
       setFollow(false);
       scrollWithin(scroller, el);
@@ -237,13 +244,14 @@ export function attach_chat_scroll(scrollerId, contentId) {
     },
     snap: () => {
       const requested = performance.now();
+      const generation = ++followGeneration;
       setFollow(true);
       snapFollow(true);
       lastHeight = content.scrollHeight;
       syncPill();
       requestAnimationFrame(() => {
         requestAnimationFrame(() => {
-          if (lastUserScroll < requested) {
+          if (generation === followGeneration && lastUserScroll < requested) {
             setFollow(true);
             snapFollow(true);
             lastHeight = content.scrollHeight;
@@ -288,6 +296,13 @@ export function attach_chat_scroll(scrollerId, contentId) {
 
   setFollow(true);
   snapFollow();
+}
+
+/** Navigate a find result through the same bookmark/follow contract as a turn jump. */
+export function reveal_chat_range(range) {
+  const hook = hooks.get("chat-scroller");
+  if (hook) hook.jumpTo(range);
+  else scrollWithin(document.getElementById("chat-scroller"), range);
 }
 
 /** Save the previous conversation and restore this conversation after render.

--- a/ui/src/styles/chat.css
+++ b/ui/src/styles/chat.css
@@ -402,6 +402,15 @@
    instantly while the follow snap-back would animate, so the view visibly
    bounces up and down on every thinking delta. Snaps must be instant. */
 .chat-stage { position: relative; display: flex; flex: 1 1 auto; min-width: 0; min-height: 0; }
+.chat-find { position: absolute; top: 8px; right: 20px; z-index: 5; display: flex; align-items: center; gap: 6px; box-sizing: border-box; max-width: calc(100% - 32px); padding: 6px 8px; border: 1px solid var(--border); border-radius: var(--radius-sm); background: var(--bg-elev); color: var(--text); box-shadow: var(--shadow-sm); }
+.chat-find input { min-width: 0; width: 210px; padding: 5px 7px; border: 1px solid var(--border); border-radius: var(--radius-xs); background: var(--bg-app); color: var(--text); font: inherit; font-size: 13px; }
+.chat-find-count { flex-shrink: 0; color: var(--text-muted); font-size: 12px; font-variant-numeric: tabular-nums; white-space: nowrap; }
+.chat-find button { display: grid; place-items: center; flex-shrink: 0; width: 28px; height: 28px; padding: 4px; border: 0; border-radius: var(--radius-xs); background: transparent; color: var(--text); cursor: pointer; }
+.chat-find button:hover { background: var(--surface-hover); }
+.chat-find button:disabled { opacity: .4; cursor: default; }
+.chat-find svg { width: 18px; height: 18px; }
+::highlight(wisp-find) { background-color: #ffe082; color: #241d00; }
+::highlight(wisp-find-active) { background-color: #ff963d; color: #201000; }
 .chat { flex: 1 1 auto; min-width: 0; overflow-x: hidden; overflow-y: auto; overflow-anchor: none; overscroll-behavior: contain; }
 .thread {
   max-width: var(--chat-col-max); width: 100%; margin: 0 auto;


### PR DESCRIPTION
Fixes #1210
Fixes #1212

Closing a Windows terminal now succeeds on the first click. `portable-pty 0.9` reverses the result of `TerminateProcess` in its cloned Windows killer; the terminal manager now owns a duplicated process handle and uses the correctly typed Windows API. Already exited processes are harmless, while real termination failures retain the session for retry. Unix keeps the existing PTY killer.

Ctrl/Cmd+F in the conversation now counts and highlights the same ordered set of displayed message-body matches, excluding sidebar/session titles and composer text. Enter, Shift+Enter and the arrows navigate literal, case-insensitive matches across inline Markdown. Result navigation pauses bottom-follow and cancels queued follow snaps, including when the last match is at the bottom and new output arrives. The bar participates in the root Escape stack and clears on session changes.

### Changes and validation
- `terminal_sessions.rs` and Windows API features: handle ownership, termination and two real local ConPTY regression tests. All 7 terminal tests pass on Windows.
- `chat_find.rs` / `chat_find.js`, shared icons, chat CSS and root integration: scoped find UI, CSS highlights and mutation-aware match counts. Five new Playwright regressions pass, including Control/Meta, reverse navigation, streaming growth, Unicode/inline formatting, Escape and narrow layout.
- `scroll.js`: explicit navigation invalidates pending follow snaps. Ten existing history/responsive checks pass (one page-load timeout during a rebuild passed on rerun).
- Updated terminal documentation and added `docs/conversation-find.md`.
- Workspace/UI formatting and WASM check pass. Full Playwright run: 677 passed, 2 skipped, and 1 page-load timeout in the unrelated Memory settings test. That test passed on an isolated rerun after the build settled (678 passing cases overall, 2 skipped). The final scroll change also passed the focused history/responsive/find checks.
- `cargo test --workspace` stops in unchanged `wisp-runs`: 165 pass, 2 fail (`ssh_launch_failure_stops_after_the_first_attempt`, `ssh_input_staging_ledgers_uploaded_files`), both with `artifact path is outside project root`. This matches the existing Windows failure; the terminal tests pass separately.

### Manual smoke / limits
- Windows desktop: open a local terminal, close once, and verify no error dialog and no remaining shell. Local real ConPTY behavior was exercised by the automated tests; native desktop clicking and macOS runtime were not manually exercised.
- In a long conversation at the bottom, use Ctrl/Cmd+F, navigate backward and forward, and verify the counter, orange active highlight and stable viewport. Stream more output, press Escape, then use Back to latest. Rendered Chromium UI and narrow-layout screenshot were checked locally.
- Find covers the currently displayed transcript window; load older messages or expand collapsed content to include them. Older WebViews without CSS Highlight API retain native find. No backend search index or persistent schema was added.
- CI for commit `892bfeb9`: Rust stable and Rust 1.88.0 pass; headless evaluations pass on Ubuntu, macOS and Windows. UI CI is still running at this update.
- Follow-up outside this PR: the existing Windows `wisp-runs` path-test failures.

