### PR TITLE
fix: preserve rich MCP results across agent host boundaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7324,6 +7324,7 @@ version = "1.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64 0.22.1",
  "libc",
  "regex",
  "reqwest 0.12.28",

--- a/crates/wisp-core/src/agent.rs
+++ b/crates/wisp-core/src/agent.rs
@@ -71,6 +71,36 @@ fn budget_tool_result_with_limit(
     content: Content,
     budget: usize,
 ) -> Content {
+    if let Content::Parts(parts) = &content {
+        // Mixed MCP output must obey the same text budget as text-only tools.
+        let text = parts
+            .iter()
+            .filter_map(|part| match part {
+                Part::Text { text, .. } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        if budget == 0 || text.len() <= budget {
+            return content;
+        }
+        let Content::Text(bounded) =
+            budget_tool_result_with_limit(root, tool_name, Content::text(text), budget)
+        else {
+            unreachable!()
+        };
+        let mut bounded_parts = vec![Part::Text {
+            kind: "text".into(),
+            text: bounded,
+        }];
+        bounded_parts.extend(
+            parts
+                .iter()
+                .filter(|part| !matches!(part, Part::Text { .. }))
+                .cloned(),
+        );
+        return Content::Parts(bounded_parts);
+    }
     let Content::Text(text) = &content else {
         return content;
     };
@@ -572,42 +602,9 @@ async fn agent_loop_inner(
                     });
                 }
             }
-            let (content, tool_text, ok) = if let Some(img) = &result.image {
-                if ctx.supports_vision {
-                    // Fast path: the active model reads images natively, so
-                    // attach the picture directly to the tool result. The old
-                    // path round-tripped every view_image through a vision
-                    // describer first — one extra LLM call per image that, on
-                    // a reasoning vision model, averaged ~18s (p90 154s) per
-                    // look. The label text keeps the transcript readable and
-                    // `age_images` keeps old images bounded in context.
-                    (
-                        image_content(&img.label, &img.data_url),
-                        img.label.clone(),
-                        true,
-                    )
-                } else {
-                    match vision_provider {
-                        Some(vision) => match describe_image(vision, img, &name, &args).await {
-                            Ok(text) => (Content::text(text.clone()), text, true),
-                            Err(e) => {
-                                let text = format!("{name} error: vision model failed: {e}");
-                                (Content::text(text.clone()), text, false)
-                            }
-                        },
-                        None => {
-                            let text = format!("{name} error: no vision model is configured. Mark an API model as vision-capable in Settings -> Models and set it for image analysis.");
-                            (Content::text(text.clone()), text, false)
-                        }
-                    }
-                }
-            } else {
-                (
-                    Content::text(result.content.clone()),
-                    result.content.clone(),
-                    result.success,
-                )
-            };
+            let (content, tool_text, ok) =
+                model_tool_result(&result, ctx.supports_vision, vision_provider, &name, &args)
+                    .await;
             output.tool_result(&tools.event_name(&name, &args), ok, &tool_text, duration_ms);
             ctx.append_tool(
                 &tc.id,
@@ -842,6 +839,53 @@ async fn summarize_at_iteration_limit(
     result
 }
 
+/// Images supplement the result's text/structured facts, never replace them.
+/// A failed MCP result remains failed even when its attached images render.
+async fn model_tool_result(
+    result: &ToolResult,
+    supports_vision: bool,
+    vision_provider: Option<&dyn Provider>,
+    name: &str,
+    args: &serde_json::Value,
+) -> (Content, String, bool) {
+    if result.images.is_empty() {
+        return (
+            Content::text(result.content.clone()),
+            result.content.clone(),
+            result.success,
+        );
+    }
+    if supports_vision {
+        return (
+            native_image_content(&result.content, &result.images),
+            result.content.clone(),
+            result.success,
+        );
+    }
+    let mut text = result.content.clone();
+    let mut ok = result.success;
+    for image in &result.images {
+        match vision_provider {
+            Some(vision) => match describe_image(vision, image, name, args).await {
+                Ok(observation) => text.push_str(&format!(
+                    "\n\nVision-model observation for {} (not a tool assertion):\n{observation}",
+                    image.label,
+                )),
+                Err(error) => {
+                    ok = false;
+                    text.push_str(&format!("\n{name} error: vision model failed: {error}"));
+                }
+            },
+            None => {
+                ok = false;
+                text.push_str("\nImage content was not inspected: no vision model is configured. Mark an API model as vision-capable in Settings -> Models and set it for image analysis.");
+                break;
+            }
+        }
+    }
+    (Content::text(text.clone()), text, ok)
+}
+
 async fn describe_image(
     provider: &dyn Provider,
     img: &ImageData,
@@ -991,14 +1035,11 @@ fn hash_observation_part(hasher: &mut Sha256, part: &[u8]) {
 fn hash_tool_result(hasher: &mut Sha256, result: &ToolResult) {
     hasher.update([u8::from(result.success)]);
     hash_observation_part(hasher, result.content.as_bytes());
-    match &result.image {
-        Some(image) => {
-            hasher.update([1]);
-            hash_observation_part(hasher, image.mime.as_bytes());
-            hash_observation_part(hasher, image.label.as_bytes());
-            hash_observation_part(hasher, image.data_url.as_bytes());
-        }
-        None => hasher.update([0]),
+    hasher.update((result.images.len() as u64).to_le_bytes());
+    for image in &result.images {
+        hash_observation_part(hasher, image.mime.as_bytes());
+        hash_observation_part(hasher, image.label.as_bytes());
+        hash_observation_part(hasher, image.data_url.as_bytes());
     }
     hasher.update([match result.control {
         ToolControl::Continue => 0,
@@ -2178,6 +2219,81 @@ mod tests {
             data_url: "data:image/png;base64,aW1hZ2U=".into(),
             label: "Attached image: uploads/plot.png".into(),
         }
+    }
+
+    #[tokio::test]
+    async fn rich_tool_result_preserves_text_all_images_and_failure() {
+        let mut result = ToolResult::fail("TERMINAL: true; planDigest: exact");
+        result.images = vec![test_image(), test_image()];
+        let fallback = RecordingProvider::new("fallback", "observation");
+        let (content, text, ok) = model_tool_result(
+            &result,
+            true,
+            Some(&fallback),
+            "preview",
+            &serde_json::json!({}),
+        )
+        .await;
+        assert!(!ok);
+        assert_eq!(text, result.content);
+        let Content::Parts(parts) = content else {
+            panic!("expected multimodal content")
+        };
+        assert_eq!(parts.len(), 3);
+        assert!(matches!(&parts[0], Part::Text { text, .. } if text.contains("exact")));
+        assert_eq!(
+            parts
+                .iter()
+                .filter(|part| matches!(part, Part::Image { .. }))
+                .count(),
+            2
+        );
+        assert!(fallback.complete_messages.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn rich_tool_result_no_vision_keeps_structured_facts_and_reports_omission() {
+        let mut result = ToolResult::ok("planDigest: exact");
+        result.images = vec![test_image()];
+        let (_, text, ok) =
+            model_tool_result(&result, false, None, "preview", &serde_json::json!({})).await;
+        assert!(!ok);
+        assert!(text.contains("planDigest: exact"));
+        assert!(text.contains("not inspected"));
+    }
+
+    #[test]
+    fn mixed_tool_text_is_budgeted_without_dropping_images() {
+        let root = std::env::temp_dir().join(format!("wisp-rich-budget-{}", uuid::Uuid::new_v4()));
+        let content = native_image_content(&"fact ".repeat(10_000), &[test_image(), test_image()]);
+        let bounded = budget_tool_result_with_limit(&root, "preview", content, 1024);
+        let Content::Parts(parts) = bounded else {
+            panic!("expected parts")
+        };
+        assert_eq!(parts.len(), 3);
+        assert!(
+            matches!(&parts[0], Part::Text { text, .. } if text.len() < 2000 && text.contains("full output at"))
+        );
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[tokio::test]
+    async fn rich_tool_result_fallback_supplements_text_and_does_not_clear_error() {
+        let mut result = ToolResult::fail("NEXT_ACTION: ask_user; planDigest: exact");
+        result.images = vec![test_image(), test_image()];
+        let fallback = RecordingProvider::new("fallback", "visible evidence");
+        let (_, text, ok) = model_tool_result(
+            &result,
+            false,
+            Some(&fallback),
+            "preview",
+            &serde_json::json!({}),
+        )
+        .await;
+        assert!(!ok);
+        assert!(text.contains("planDigest: exact"));
+        assert_eq!(text.matches("visible evidence").count(), 2);
+        assert_eq!(fallback.complete_messages.lock().unwrap().len(), 2);
     }
 
     #[tokio::test]

--- a/crates/wisp-mcp/Cargo.toml
+++ b/crates/wisp-mcp/Cargo.toml
@@ -11,6 +11,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 async-trait = "0.1"
 anyhow = { workspace = true }
+base64 = { workspace = true }
 regex = { workspace = true }
 tracing = { workspace = true }
 wisp-llm = { workspace = true }

--- a/crates/wisp-mcp/src/lib.rs
+++ b/crates/wisp-mcp/src/lib.rs
@@ -6,6 +6,7 @@
 //! search/dispatch pair instead of sending the full catalog on every turn.
 
 pub mod client;
+pub mod result;
 pub mod tool;
 
 pub use client::{McpCallResult, McpClient, RemoteTool};

--- a/crates/wisp-mcp/src/result.rs
+++ b/crates/wisp-mcp/src/result.rs
@@ -1,0 +1,238 @@
+//! Deliberate MCP -> model projection. The raw result remains available to
+//! Apps; model context must never inherit App-only `_meta` or binary blobs.
+
+use base64::Engine;
+use serde_json::{json, Value};
+use wisp_tools::{ImageData, ToolResult};
+
+use crate::McpCallResult;
+
+const MAX_IMAGES: usize = 8;
+const MAX_TOTAL_IMAGE_BYTES: usize = 20 * 1024 * 1024;
+
+fn model_visible(block: &Value) -> bool {
+    block
+        .pointer("/annotations/audience")
+        .and_then(Value::as_array)
+        .is_none_or(|audience| {
+            audience
+                .iter()
+                .any(|role| role.as_str() == Some("assistant"))
+        })
+}
+
+/// Preserve text, structured facts, images and resource references without
+/// fetching a URI, executing an artifact, or turning tool errors into success.
+pub fn model_result(result: &McpCallResult) -> ToolResult {
+    let mut text = Vec::new();
+    let mut images = Vec::new();
+    let mut total_image_bytes = 0;
+    for (index, block) in result.content.iter().enumerate() {
+        if !model_visible(block) {
+            continue;
+        }
+        match block.get("type").and_then(Value::as_str) {
+            Some("text") => {
+                if let Some(value) = block.get("text").and_then(Value::as_str) {
+                    text.push(value.to_string());
+                }
+            }
+            Some("image") => {
+                match model_image(block, index, images.len(), &mut total_image_bytes) {
+                    Ok(image) => {
+                        text.push(image.label.clone());
+                        images.push(image);
+                    }
+                    Err(reason) => text.push(format!(
+                        "[MCP image at content[{index}] not delivered to the model: {reason}; no visual inspection was performed for this image.]"
+                    )),
+                }
+            }
+            Some("resource_link") => {
+                // A link is a reference, not permission to fetch it.
+                text.push(format!("MCP resource link: {}", json!({
+                    "uri": block.get("uri"),
+                    "name": block.get("name"),
+                    "description": block.get("description"),
+                    "mimeType": block.get("mimeType"),
+                })));
+            }
+            Some("resource") => {
+                if let Some(resource) = block.get("resource") {
+                    text.push(format!("MCP embedded resource: {}", json!({
+                        "uri": resource.get("uri"),
+                        "mimeType": resource.get("mimeType"),
+                        "text": resource.get("text"),
+                    })));
+                    if resource.get("blob").is_some() {
+                        text.push("[Embedded binary resource not delivered to the model.]".into());
+                    }
+                }
+            }
+            _ => text.push(format!(
+                "[Unsupported MCP content at index {index} not delivered to the model.]"
+            )),
+        }
+    }
+    if let Some(structured) = &result.structured_content {
+        // Some servers already serialize the same object in a text block.
+        if !text
+            .iter()
+            .any(|value| serde_json::from_str::<Value>(value).ok().as_ref() == Some(structured))
+        {
+            text.push(format!("MCP structuredContent: {structured}"));
+        }
+    }
+    let content = if text.is_empty() {
+        "(no model-visible output)".to_string()
+    } else {
+        text.join("\n")
+    };
+    let mut output = if result.is_error {
+        ToolResult::fail(content)
+    } else {
+        ToolResult::ok(content)
+    };
+    output.images = images;
+    output
+}
+
+fn model_image(
+    block: &Value,
+    index: usize,
+    image_count: usize,
+    total_bytes: &mut usize,
+) -> Result<ImageData, &'static str> {
+    if image_count >= MAX_IMAGES {
+        return Err("image-count limit exceeded");
+    }
+    let mime = block.get("mimeType").and_then(Value::as_str).unwrap_or("");
+    if !matches!(
+        mime,
+        "image/png" | "image/jpeg" | "image/gif" | "image/webp"
+    ) {
+        return Err("unsupported MIME type");
+    }
+    let data = block
+        .get("data")
+        .and_then(Value::as_str)
+        .ok_or("missing base64 data")?;
+    if data.len() > wisp_tools::image::MAX_BYTES.div_ceil(3) * 4 {
+        return Err("image-size limit exceeded");
+    }
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(data)
+        .map_err(|_| "invalid base64 data")?;
+    if bytes.is_empty() {
+        return Err("empty image");
+    }
+    if bytes.len() > wisp_tools::image::MAX_BYTES
+        || total_bytes.saturating_add(bytes.len()) > MAX_TOTAL_IMAGE_BYTES
+    {
+        return Err("image-size limit exceeded");
+    }
+    *total_bytes += bytes.len();
+    Ok(ImageData {
+        mime: mime.into(),
+        data_url: format!("data:{mime};base64,{data}"),
+        label: format!("MCP image at content[{index}] ({mime})"),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn result(content: Vec<Value>) -> McpCallResult {
+        McpCallResult {
+            content,
+            structured_content: Some(json!({"planDigest": "exact-digest", "terminal": true})),
+            meta: Some(json!({"privateAppState": "must-not-reach-model"})),
+            is_error: false,
+        }
+    }
+
+    #[test]
+    fn mixed_result_keeps_text_images_structure_and_error_but_not_private_meta() {
+        let mut input = result(vec![
+            json!({"type": "text", "text": "TERMINAL: true\nNEXT_ACTION: ask_user"}),
+            json!({"type": "image", "mimeType": "image/png", "data": "aGVsbG8="}),
+            json!({"type": "image", "mimeType": "image/jpeg", "data": "d29ybGQ="}),
+        ]);
+        input.is_error = true;
+        let output = model_result(&input);
+        assert!(!output.success);
+        assert_eq!(output.images.len(), 2);
+        assert!(output.content.contains("NEXT_ACTION: ask_user"));
+        assert!(output.content.contains("exact-digest"));
+        assert!(!output.content.contains("must-not-reach-model"));
+        assert!(!output.content.contains("aGVsbG8="));
+    }
+
+    #[test]
+    fn structured_only_result_is_not_no_output_or_duplicated_json() {
+        let input = result(vec![]);
+        assert!(model_result(&input).content.contains("exact-digest"));
+        let mut repeated = input.clone();
+        repeated.content = vec![json!({
+            "type": "text", "text": input.structured_content.unwrap().to_string()
+        })];
+        assert_eq!(
+            model_result(&repeated)
+                .content
+                .matches("exact-digest")
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn audience_and_resource_boundaries_are_preserved() {
+        let output = model_result(&result(vec![
+            json!({"type": "text", "text": "user-only", "annotations": {"audience": ["user"]}}),
+            json!({"type": "image", "mimeType": "image/png", "data": "YQ==",
+                   "annotations": {"audience": ["user"]}}),
+            json!({"type": "resource_link", "uri": "https://example.org/a", "_meta": {"secret": "hidden"}}),
+            json!({"type": "resource", "resource": {"uri": "test://code", "text": "x = 1", "_meta": {"secret": "hidden"}}}),
+            json!({"type": "audio", "data": "do-not-dump-base64"}),
+        ]));
+        assert!(output.images.is_empty());
+        assert!(!output.content.contains("user-only"));
+        assert!(!output.content.contains("hidden"));
+        assert!(!output.content.contains("do-not-dump-base64"));
+        assert!(output.content.contains("https://example.org/a"));
+        assert!(output.content.contains("x = 1"));
+        assert!(output.content.contains("Unsupported MCP content"));
+    }
+
+    #[test]
+    fn invalid_unsupported_and_oversized_images_have_explicit_omission_notices() {
+        for block in [
+            json!({"type": "image", "mimeType": "image/png", "data": "bad!"}),
+            json!({"type": "image", "mimeType": "image/svg+xml", "data": "YQ=="}),
+            json!({"type": "image", "mimeType": "image/png", "data": ""}),
+            json!({"type": "image", "mimeType": "image/png", "data": "A".repeat(8 * 1024 * 1024)}),
+        ] {
+            let output = model_result(&result(vec![block]));
+            assert!(output.images.is_empty());
+            assert!(output
+                .content
+                .contains("no visual inspection was performed"));
+        }
+        let output = model_result(&result(vec![
+            json!({"type": "image", "mimeType": "image/png", "data": "YQ=="});
+            9
+        ]));
+        assert_eq!(output.images.len(), MAX_IMAGES);
+        assert!(output.content.contains("image-count limit exceeded"));
+        let mut total = MAX_TOTAL_IMAGE_BYTES;
+        assert!(model_image(
+            &json!({"type": "image", "mimeType": "image/png", "data": "YQ=="}),
+            0,
+            0,
+            &mut total,
+        )
+        .is_err());
+        assert_eq!(total, MAX_TOTAL_IMAGE_BYTES);
+    }
+}

--- a/crates/wisp-mcp/src/tool.rs
+++ b/crates/wisp-mcp/src/tool.rs
@@ -465,11 +465,11 @@ impl Tool for McpTool {
     async fn run(&self, args: &Value, env: &dyn ToolEnv) -> ToolResult {
         match self.client.tool_call_rich(&self.name, args).await {
             Ok(result) => {
-                let mut content = result.text_content();
+                let mut output = crate::result::model_result(&result);
                 let artifacts = materialize_html_resources(&result, env.project_root(), env).await;
                 if !artifacts.is_empty() {
-                    content.push_str("\n\nGenerated artifacts: ");
-                    content.push_str(
+                    output.content.push_str("\n\nGenerated artifacts: ");
+                    output.content.push_str(
                         &artifacts
                             .iter()
                             .map(|path| path.to_string_lossy())
@@ -480,14 +480,7 @@ impl Tool for McpTool {
                 if let Some(uri) = self.remote.ui_resource_uri() {
                     self.emit_mcp_app(uri, args, &result, env).await;
                 }
-                if content.trim().is_empty() {
-                    content = "(no output)".into();
-                }
-                if result.is_error {
-                    ToolResult::fail(content)
-                } else {
-                    ToolResult::ok(content)
-                }
+                output
             }
             Err(e) => ToolResult::fail(format!("mcp {name} error: {e}", name = self.name)),
         }

--- a/crates/wisp-mcp/tests/mcp_transport.rs
+++ b/crates/wisp-mcp/tests/mcp_transport.rs
@@ -6,6 +6,20 @@ use std::io::{BufRead, Write};
 use std::process::ExitCode;
 use std::time::Duration;
 use wisp_mcp::McpClient;
+use wisp_tools::{Registry, ToolEnv, ToolEvent};
+
+struct TestEnv;
+
+#[async_trait::async_trait]
+impl ToolEnv for TestEnv {
+    fn project_root(&self) -> &std::path::Path {
+        std::path::Path::new(".")
+    }
+    async fn confirm(&self, _: &str) -> bool {
+        true
+    }
+    async fn emit(&self, _: ToolEvent) {}
+}
 
 const ECHO_ARG: &str = "--fake-echo-mcp";
 
@@ -73,13 +87,26 @@ fn fake_echo_server() -> ExitCode {
                 if delay > 0 {
                     std::thread::sleep(Duration::from_millis(delay));
                 }
-                json!({
-                    "content": [{ "type": "text", "text": "ok" }],
-                    "structuredContent": {
-                        "token": arguments.get("token").cloned().unwrap_or(Value::Null)
-                    },
-                    "isError": false
-                })
+                if arguments.get("rich") == Some(&json!(true)) {
+                    json!({
+                        "content": [
+                            {"type": "text", "text": "TERMINAL: true\nNEXT_ACTION: ask_user"},
+                            {"type": "image", "mimeType": "image/png", "data": "aW1hZ2U="},
+                            {"type": "image", "mimeType": "image/png", "data": "aW1hZ2U="}
+                        ],
+                        "structuredContent": {"planDigest": "exact-token"},
+                        "_meta": {"appOnly": "private-selection"},
+                        "isError": true
+                    })
+                } else {
+                    json!({
+                        "content": [{ "type": "text", "text": "ok" }],
+                        "structuredContent": {
+                            "token": arguments.get("token").cloned().unwrap_or(Value::Null)
+                        },
+                        "isError": false
+                    })
+                }
             }
             _ => json!({}),
         };
@@ -92,8 +119,41 @@ fn fake_echo_server() -> ExitCode {
 }
 
 async fn run_stdio_transport_regressions() -> Result<(), String> {
+    deferred_tool_retains_rich_result().await?;
     concurrent_stdio_calls_keep_matching_ids().await?;
     cancelled_isolated_call_leaves_connection_usable().await
+}
+
+async fn deferred_tool_retains_rich_result() -> Result<(), String> {
+    let executable = std::env::current_exe().map_err(|e| e.to_string())?;
+    let client = std::sync::Arc::new(
+        McpClient::launch(&executable.to_string_lossy(), &[ECHO_ARG.into()])
+            .await
+            .map_err(|e| e.to_string())?,
+    );
+    let remote = client
+        .tools_list()
+        .await
+        .map_err(|e| e.to_string())?
+        .remove(0);
+    let mut registry = Registry::builtins();
+    registry.add(Box::new(wisp_mcp::McpTool::new(remote, client.clone())));
+    let result = registry
+        .run(
+            "use_mcp_tool",
+            &json!({
+                "tool_name": "echo", "tool_input": {"token": "rich", "rich": true}
+            }),
+            &TestEnv,
+        )
+        .await;
+    assert!(!result.success);
+    assert_eq!(result.images.len(), 2);
+    assert!(result.content.contains("exact-token"));
+    assert!(result.content.contains("NEXT_ACTION: ask_user"));
+    assert!(!result.content.contains("private-selection"));
+    drop(registry);
+    client.shutdown().await.map_err(|e| e.to_string())
 }
 
 async fn concurrent_stdio_calls_keep_matching_ids() -> Result<(), String> {

--- a/crates/wisp-runs/src/run_context/remote.rs
+++ b/crates/wisp-runs/src/run_context/remote.rs
@@ -10,7 +10,9 @@ pub(super) fn resolve_input_paths(root: &Path, refs: &[String]) -> Result<Vec<Pa
     if refs.is_empty() {
         return Ok(Vec::new());
     }
-    let canonical_root = std::fs::canonicalize(root)
+    // Match snapshot_store and native tool paths: Windows verbatim paths
+    // cannot be lexically compared to their ordinary drive-letter roots.
+    let canonical_root = dunce::canonicalize(root)
         .map_err(|e| format!("cannot resolve project root {}: {e}", root.display()))?;
     let mut names = HashSet::new();
     refs.iter()
@@ -28,7 +30,7 @@ pub(super) fn resolve_input_paths(root: &Path, refs: &[String]) -> Result<Vec<Pa
                 return Err(format!("SSH input must be project-relative: {value}"));
             }
             let candidate = canonical_root.join(relative);
-            let path = std::fs::canonicalize(&candidate)
+            let path = dunce::canonicalize(&candidate)
                 .map_err(|e| format!("cannot resolve SSH input {value}: {e}"))?;
             if !path.starts_with(&canonical_root) || !path.is_file() {
                 return Err(format!("SSH input is not a project file: {value}"));

--- a/crates/wisp-runs/src/run_context/tests.rs
+++ b/crates/wisp-runs/src/run_context/tests.rs
@@ -3738,6 +3738,27 @@ async fn cleanup_refuses_while_an_external_reference_points_into_the_workdir() {
 
 // --- remote staging ledger ---------------------------------------------------
 
+#[test]
+fn ssh_input_paths_remain_compatible_with_artifact_snapshots() {
+    let root = std::env::temp_dir().join(format!("wisp_staging_snapshot_{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&root).unwrap();
+    std::fs::write(root.join("input.fasta"), b">seq\nACGT\n").unwrap();
+    let paths = resolve_input_paths(&root, &["input.fasta".into()]).unwrap();
+    assert_eq!(paths.len(), 1);
+    assert_eq!(
+        paths[0],
+        dunce::canonicalize(root.join("input.fasta")).unwrap()
+    );
+    let snapshot = crate::snapshot_store::capture_file(
+        &root,
+        &paths[0],
+        crate::snapshot_store::SnapshotPolicy::Reference,
+    )
+    .unwrap();
+    assert_eq!(snapshot.size_bytes, 10);
+    std::fs::remove_dir_all(root).unwrap();
+}
+
 #[tokio::test]
 async fn ssh_input_staging_ledgers_uploaded_files() {
     let tmp = std::env::temp_dir().join(format!("wisp_staging_ledger_{}", uuid::Uuid::new_v4()));

--- a/crates/wisp-runtime/src/tool.rs
+++ b/crates/wisp-runtime/src/tool.rs
@@ -503,7 +503,7 @@ async fn run_runtime(
                             source.script.as_ref(),
                             &runtime,
                         ),
-                        image: None,
+                        images: Vec::new(),
                         control: wisp_tools::ToolControl::Continue,
                     };
                 }

--- a/crates/wisp-tools/src/env.rs
+++ b/crates/wisp-tools/src/env.rs
@@ -337,7 +337,8 @@ pub trait ToolEnv: Send + Sync {
 pub struct ToolResult {
     pub success: bool,
     pub content: String,
-    pub image: Option<ImageData>,
+    /// Model-visible images accompanying (not replacing) the text result.
+    pub images: Vec<ImageData>,
     /// Code-level control flow for the agent loop. This keeps user-decision
     /// boundaries out of prompt wording: stale sibling calls can be skipped,
     /// and tools such as `ask_user` can end the turn outright.
@@ -365,7 +366,7 @@ impl ToolResult {
         Self {
             success: true,
             content: content.into(),
-            image: None,
+            images: Vec::new(),
             control: ToolControl::Continue,
         }
     }
@@ -373,7 +374,7 @@ impl ToolResult {
         Self {
             success: false,
             content: content.into(),
-            image: None,
+            images: Vec::new(),
             control: ToolControl::Continue,
         }
     }
@@ -382,7 +383,7 @@ impl ToolResult {
         Self {
             success: true,
             content: label,
-            image: Some(img),
+            images: vec![img],
             control: ToolControl::Continue,
         }
     }

--- a/docs/feature-plugins.md
+++ b/docs/feature-plugins.md
@@ -76,6 +76,40 @@ rather than its entire workspace.
 
 ## Safety boundary
 
+### Tool-result fidelity
+
+Plugin results are not text-only. The native agent receives MCP text and
+`structuredContent`, plus all supported model-visible image blocks. Images
+supplement text rather than replacing selectors, plan digests, terminal
+outcomes, or error flags. App-only `_meta` is not model context. Explicit
+content `annotations.audience` that omit `assistant` stay out of the native
+agent's projection. An image does not make a failed result successful.
+
+The native image projection accepts base64 PNG/JPEG/GIF/WebP, at most eight
+images, 5 MiB decoded per image, and 20 MiB decoded per result. This validates
+MIME/base64/size, not pixel-level file integrity. Unsupported or omitted content
+produces an explicit notice; it is never silently represented as inspected.
+Resource links are reported without automatically fetching them; embedded
+resource text is retained and binary blobs are not dumped into model text.
+Text in mixed image results uses the same context budget and spill-to-file
+path as text-only output. A configured vision model may describe images for a
+text-only primary model; those observations supplement the original result
+and are identified as model observations, not server facts.
+
+The external-agent MCP bridge preserves the remote CallToolResult envelope
+for both direct calls and `wisp_use_tool`, including `isError`,
+`structuredContent`, media and `_meta`. The receiving host must apply its
+own model-visibility rules. This does not add Apps rendering to a headless
+external agent or equate model-visible images with user-visible App previews.
+
+Regression gates: `cargo test -p wisp-mcp -p wisp-core --offline`, the
+`custom_bridge_preserves_rich_results_for_direct_and_dispatch_calls` Tauri
+test, and the full workspace suite. MCP stdio fixtures use a local test
+executable; the bridge test uses an ephemeral loopback HTTP fixture, not a
+real plugin, user Library, external API, or credential.
+
+### Isolation and execution policy
+
 - ZIP extraction rejects traversal, symbolic links, duplicate paths, oversized
   files, excessive file counts, and expansion beyond the configured limit.
 - Install does not run `npm install`, `postinstall`, shell scripts, or any other

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4884,7 +4884,7 @@ async fn load_image_attachments(
             } else {
                 wisp_tools::image::view_image(&path.to_string_lossy())
             };
-            let mut image = result.image.ok_or(result.content)?;
+            let mut image = result.images.into_iter().next().ok_or(result.content)?;
             image.label = format!("Attached image: {attachment}. {}", image.label);
             Ok(image)
         })

--- a/src-tauri/src/lib_tests.rs
+++ b/src-tauri/src/lib_tests.rs
@@ -525,7 +525,7 @@ fn image_helper_loads_supported_extension_for_model_input() {
     // Small images do not need the UI confirmation path; exercise the shared
     // loader directly through its image helper here.
     let result = wisp_tools::image::view_image(&uploads.join("plot.PNG").to_string_lossy());
-    let images = vec![result.image.unwrap()];
+    let images = result.images;
 
     assert_eq!(images.len(), 1);
     assert!(images[0].data_url.starts_with("data:image/png;base64,"));

--- a/src-tauri/src/mcp_bridge.rs
+++ b/src-tauri/src/mcp_bridge.rs
@@ -317,10 +317,10 @@ impl BridgeServer {
                 else {
                     return Ok(tool_call_result("'tool_input' must be a JSON object", true));
                 };
-                match self.call_remote_tool(tool_name, tool_input).await {
-                    Ok(result) => result,
-                    Err(error) => (error.to_string(), true),
-                }
+                return match self.call_remote_tool(tool_name, tool_input).await {
+                    Ok(result) => Ok(result),
+                    Err(error) => Ok(tool_call_result(error.to_string(), true)),
+                };
             }
             "wisp_search_memory" => match self.search_memory_text(&args) {
                 Ok(s) => (s, false),
@@ -407,7 +407,7 @@ impl BridgeServer {
                     .await;
                 (result.content, !result.success)
             }
-            other => self.call_remote_tool(other, &args).await?,
+            other => return self.call_remote_tool(other, &args).await,
         };
         Ok(tool_call_result(text, is_error))
     }
@@ -655,7 +655,7 @@ impl BridgeServer {
         search_tool_catalog(self.route_tools(), args)
     }
 
-    async fn call_remote_tool(&mut self, name: &str, args: &Value) -> Result<(String, bool)> {
+    async fn call_remote_tool(&mut self, name: &str, args: &Value) -> Result<Value> {
         self.ensure_remote_tools().await?;
         let route = self
             .routes
@@ -669,8 +669,8 @@ impl BridgeServer {
                 ..
             } => {
                 return Ok(match client.call(&remote_name, args).await {
-                    Ok(value) => (value.to_string(), false),
-                    Err(error) => (error.to_string(), true),
+                    Ok(value) => tool_call_result(value.to_string(), false),
+                    Err(error) => tool_call_result(error.to_string(), true),
                 });
             }
             Route::Custom {
@@ -679,9 +679,12 @@ impl BridgeServer {
                 ..
             } => (client, remote_name),
         };
-        Ok(match client.tool_call(&remote_name, args).await {
-            Ok(text) => (text, false),
-            Err(error) => (error.to_string(), true),
+        Ok(match client.tool_call_rich(&remote_name, args).await {
+            // Host-to-host transport: preserve the MCP envelope, including
+            // isError, images, structuredContent and App-only metadata. The
+            // receiving host is responsible for its own model projection.
+            Ok(result) => serde_json::to_value(result)?,
+            Err(error) => tool_call_result(error.to_string(), true),
         })
     }
 
@@ -1712,6 +1715,78 @@ mod tests {
             result["results"][0]["input_schema"]["properties"]["query"]["type"],
             "string"
         );
+    }
+
+    #[tokio::test]
+    async fn custom_bridge_preserves_rich_results_for_direct_and_dispatch_calls() {
+        let expected = json!({
+            "content": [
+                {"type": "text", "text": "NEXT_ACTION: ask_user"},
+                {"type": "image", "mimeType": "image/png", "data": "aW1hZ2U="}
+            ],
+            "structuredContent": {"planDigest": "exact"},
+            "_meta": {"appOnly": "not-model-context"},
+            "isError": true
+        });
+        let response = expected.clone();
+        let router = axum::Router::new().route(
+            "/",
+            axum::routing::post(move |axum::Json(request): axum::Json<Value>| {
+                let response = response.clone();
+                async move {
+                    let result = if request["method"] == "tools/call" {
+                        response
+                    } else {
+                        json!({"protocolVersion": "2024-11-05", "capabilities": {},
+                               "serverInfo": {"name": "fixture", "version": "1"}})
+                    };
+                    axum::Json(json!({"jsonrpc": "2.0", "id": request["id"], "result": result}))
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}/", listener.local_addr().unwrap());
+        let service = tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
+        let client = Arc::new(
+            wisp_mcp::McpClient::connect_http_with_proxy(&url, &[], "none")
+                .await
+                .unwrap(),
+        );
+        let base = std::env::temp_dir().join(format!("wisp_bridge_rich_{}", uuid::Uuid::new_v4()));
+        let project_root = base.join("project");
+        std::fs::create_dir_all(&project_root).unwrap();
+        let mut server = BridgeServer::new(BridgeConfig {
+            app_data: base.join("app-data"),
+            project_root,
+            resource_root: None,
+            project_id: "rich-test".into(),
+            frame_id: None,
+            allowed_tools: None,
+        })
+        .await
+        .unwrap();
+        server.bundled_bio_tools_loaded = true;
+        server.custom_mcp_tools_loaded = true;
+        server.routes.insert(
+            "fixture_preview".into(),
+            Route::Custom {
+                connector_id: "fixture".into(),
+                client,
+                remote_name: "preview".into(),
+                description: String::new(),
+                input_schema: json!({"type": "object"}),
+            },
+        );
+        for params in [
+            json!({"name": "fixture_preview", "arguments": {}}),
+            json!({"name": "wisp_use_tool", "arguments": {"tool_name": "fixture_preview", "tool_input": {}}}),
+        ] {
+            assert_eq!(server.tools_call(params).await.unwrap(), expected);
+        }
+        drop(server);
+        service.abort();
+        let _ = service.await;
+        let _ = std::fs::remove_dir_all(base);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## 问题

SFL 等科学工作台插件会返回 text、image、structuredContent 和 isError。MCP client 已保留这些字段，但原生 McpTool adapter 调用 text_content() 后只把文字交给 Agent：视觉模型也收不到实际图片，未镜像到文字的 selector/digest 等结构化信息会丢失。

外部 Agent MCP bridge 还存在独立的错误状态问题：远端 JSON-RPC 成功、工具业务结果 isError=true 时，原来的 String 适配路径会将其重新包装成 isError=false。

仅补上一张图片不够：内部 ToolResult 原来只支持一个 image，Agent 图片分支又会用 label 替换正文并标记成功。

## 修改

- 在 wisp-mcp 增加集中式 model_result 投影，保留正文、structuredContent、支持的图片和资源引用；原始结果继续用于 App/Host 传输。
- 原生模型不接收 App-only _meta；尊重 content annotations.audience；资源链接不会被自动下载。
- 将内部单图结果改为 images 列表，图片补充而非替换正文；保留失败状态，视觉模型观察与插件事实分开标注。
- 图文混合结果使用现有文字预算和 spill-to-file 机制，不通过 Content::Parts 绕过预算。
- 外部 bridge 的 direct call 和 wisp_use_tool 均保留标准 CallToolResult 字段，包括媒体、structuredContent、isError 和 Host-to-Host _meta。
- 增加单元测试、stdio -> deferred dispatcher 集成测试、loopback HTTP -> bridge 双入口回归测试。
- 更新插件文档，说明结果保真、限制及可见性边界。

这不是 SFL 工具名特判；其他返回多模态/结构化结果的插件同样受益。没有放宽审批、自动透传 secrets、解除 Library 写锁或重放 Apply。

## 独立 Windows 修复

完整回归暴露两个 SSH staging 用例失败：输入解析返回 std::fs::canonicalize 的 Windows verbatim 路径，而下游 snapshot_store 使用 dunce-normalized 路径，导致合法文件被误判为项目外文件。

第二个提交统一 resolve_input_paths 的 root/input 规范化为 dunce::canonicalize，并新增 staging -> artifact snapshot 回归；不放宽 containment 检查。

## 提交

- c0edc0d8 — Preserve rich MCP results across native and external agent paths
- 7631b035 — Normalize Windows staged input paths for artifact snapshots

## 验证

- [x] cargo fmt --all -- --check
- [x] cargo test --workspace --offline --no-fail-fast：2044 passed / 0 failed / 0 ignored；无标准 harness 的 transport/process-tree fixtures 也成功
- [x] wisp-core：194 passed；wisp-mcp：16 passed；wisp-runs：168 passed；wisp-tauri：869 passed
- [x] MCP stdio smoke：wisp-mcp smoke OK
- [x] UI cargo check --target wasm32-unknown-unknown --offline
- [x] Windows release-wasm 前端构建 + optimized native Release 构建 + x64 NSIS 打包
- [x] 新 Release EXE 在独立临时 app-data/project 中通过 headless MCP initialize、tools/list、capability call，退出码 0；未启动 GUI 或访问真实 Library
- [ ] Playwright：原配置 webServer 启动超过 180 秒，尚未进入实际浏览器用例；不声称 UI E2E 通过
- [ ] 真实 Wisp GUI + SFL 交互验收：测试包已交由用户测试

首轮沙箱内的 Python cache / local Run 目录访问限制已区分为环境问题；授权的沙箱外完整离线测试最终通过。没有忽略失败测试或排除失败包。Release 构建复用本机已有工具，未升级依赖。

## 人工 smoke 建议

1. 退出旧 Wisp（含托盘），启动测试构建并新建会话。
2. 启用 SFL，先做只读搜索和精确预览；确认视觉模型收到图片，而非仅复述文件名或摘要。
3. 检查结构化 selector/digest 和下一步动作仍可用。
4. 使用外部 Agent bridge 时确认业务失败仍为 isError=true。
5. 单独验收 App 用户可见预览与 Agent 视觉输入；不要将两者混为一谈。写入测试只使用明确选择的测试数据，并保留 plan/approval/apply 边界。

## 已知限制与后续

- 原生图片投影支持 base64 PNG/JPEG/GIF/WebP：最多 8 张、每张 decoded 5 MiB、合计 decoded 20 MiB；验证 MIME/base64/大小，不承诺像素级完整性校验。
- 不支持/超限内容有明确遗漏提示；audio 和 embedded binary 尚未实现完整原生投影。
- 原生 structuredContent 会序列化为可读 JSON，超长结果受现有预算/存档规则限制；外部接收 Host 必须实施自己的 model/UI 可见性规则。
- 连接生命周期、计划失效提示、工具名称空间及完整 App conformance 不在本 PR 内。
- 本 PR 不提交安装包、用户数据、凭据或构建缓存，也不发布新版本。
