### PR TITLE
Fix approval scope picker with isolated MCP Apps

### DIFF
--- a/docs/mcp-app-isolation.md
+++ b/docs/mcp-app-isolation.md
@@ -96,7 +96,10 @@ observation, scroll/resize events and ancestor-animation tracking coalesce
 updates by frame.
 Only bounds/context are resent, never the HTML. Host interactions hide the
 native view before opening host overlays; semantic overlays and hit-testing
-keep it hidden until the active view is unobscured. Native resize/minimize
+keep it hidden until the active view is unobscured. Clicking native selects
+(including the chat approval scope or its label) skips this temporary
+hide/show cycle so WebView2 does not dismiss the option picker. DOM menus and
+dialogs retain the same occlusion handling. Native resize/minimize
 hides stale geometry. Guest Escape explicitly returns focus to the primary
 document and dispatches to its existing window Escape stack.
 

--- a/ui-tests/tests/mcp-app-isolation.spec.ts
+++ b/ui-tests/tests/mcp-app-isolation.spec.ts
@@ -117,6 +117,33 @@ test("host modal hides child before interaction; Escape restores only active ins
   await expect.poll(() => latestBounds(page)).toMatchObject({viewportWidth:1000,viewportHeight:720});
 });
 
+test("approval scope click preserves native child visibility and submits the selected scope", async ({page}) => {
+  const frame = await start(page);
+  await present(page, frame);
+  await page.evaluate(frame => (window as any).__tauriEmit("confirm-request", {
+    frame_id: frame, tool: "figure_library_source_status", preview: "{}", message: "Approval required",
+  }), frame);
+  const scope = page.getByLabel("Approval scope");
+  await expect(scope).toBeVisible();
+  await expect.poll(() => latestBounds(page)).toMatchObject({visible:true});
+  await page.evaluate(() => { (window as any).__nativeCalls = []; });
+  // selectOption alone skips the pointerdown that used to hide/show WebView2.
+  await scope.click();
+  await page.keyboard.press("Escape");
+  await page.evaluate(() => new Promise<void>(resolve => requestAnimationFrame(() => requestAnimationFrame(() => resolve()))));
+  expect((await calls(page, "update_mcp_app_child_bounds")).filter((c: any) => !c.args.bounds.visible)).toEqual([]);
+  await expect(scope).toBeFocused();
+  await page.locator(".approval-scope > span").click();
+  await page.evaluate(() => new Promise<void>(resolve => requestAnimationFrame(() => requestAnimationFrame(() => resolve()))));
+  expect((await calls(page, "update_mcp_app_child_bounds")).filter((c: any) => !c.args.bounds.visible)).toEqual([]);
+  await scope.selectOption("project");
+  await page.getByRole("button", {name:"Allow for this project", exact:true}).click();
+  await expect.poll(() => page.evaluate(() => {
+    const call = (window as any).__skillInvokeLog.find((c: any) => c.cmd === "confirm_response");
+    return call?.args instanceof Map ? Object.fromEntries(call.args) : call?.args;
+  })).toMatchObject({approved:true, scope:"project"});
+});
+
 test("Motif selection crosses only the restricted host action bridge", async ({page}) => {
   const frame = await start(page); await present(page,frame,"Motif","motif_open_workbench","ui://motif/view");
   await expect.poll(() => latestBounds(page)).toMatchObject({visible:true});

--- a/ui/src/mcp_app_isolated.js
+++ b/ui/src/mcp_app_isolated.js
@@ -92,7 +92,16 @@ function installObservers() {
   window.addEventListener("wisp-mcp-native-resize", () => { if (active) active.boundsKey = null; schedule(); });
   // Hide on the initiating event, before a host click opens a modal/menu.
   // Mutation/resize observation later restores only the still-current view.
-  const beforeHostInteraction = () => {
+  const beforeHostInteraction = (event) => {
+    // A native select opens its picker during the pointer's default action.
+    // Hiding/showing a sibling WebView2 here can dismiss that picker. Labels
+    // can initiate the same action; DOM menus still use normal occlusion below.
+    const target = event.target instanceof Element ? event.target : null;
+    const control = target?.closest("select") || target?.closest("label")?.control;
+    if (control instanceof HTMLSelectElement) {
+      schedule();
+      return;
+    }
     inputOccluded = true;
     sync(true);
     requestAnimationFrame(() => { inputOccluded = false; schedule(); });


### PR DESCRIPTION
## Problem and change

On Windows, the approval scope picker can fail to stay open while an isolated MCP App occupies the center pane. The host's capture-phase pointer handler temporarily hides and restores the native child WebView on every click, including clicks that open a native select picker. Ordinary chat has no native child to cycle.

`ui/src/mcp_app_isolated.js` now skips that temporary visibility cycle for native selects and their associated labels. DOM menu/dialog occlusion continues to use the existing observers and hit testing. Approval options and submission semantics are unchanged; no new abstractions are introduced.

`ui-tests/tests/mcp-app-isolation.spec.ts` adds a real pointer-click regression covering the approval select, its label, focus preservation, and project-scope submission. `docs/mcp-app-isolation.md` documents the native-picker exception.

## Validation

- The new regression failed against the old handler because clicking the select emitted hidden child bounds; it passes with the fix.
- Full Playwright run: **711 passed, 2 skipped** (`--fully-parallel --workers=6 --max-failures=1`, dedicated local server). Native-backend mock, legacy App, approval, occlusion, and Escape coverage passed.
- Passed: `npm ci`, UI WASM check, Trunk build, `cargo fmt --all -- --check`, `git diff --check`, and `cargo run -p wisp-mcp --example smoke --offline`.
- `cargo test --workspace --offline` stopped at the unrelated `wisp-paths::tests::dev_tree_has_bundled_assets` failure (`skills_dir().is_some()`). The workspace suite is not fully green.

## Native smoke follow-up

The installed Windows session was inspected, but its approval had already completed. Browser mocks verify the visibility-command regression; the actual WebView2 popup has not yet been verified in a rebuilt desktop app.

1. In a disposable Windows session, open an MCP App in the center pane and trigger a harmless tool approval.
2. Click the approval scope picker and verify all four choices remain open; select a scope and verify the matching approval action.
3. Check label/keyboard focus and ordinary chat approval behavior.
4. Open a host menu/dialog over the App; verify child occlusion and that Escape closes only the top layer and restores the App.

Windows native mouse/popup acceptance remains the follow-up before claiming desktop verification. macOS/Linux retain their legacy iframe backend.
