### PR TITLE
Fix file context menus for bound message resources

### DIFF
--- a/docs/superpowers/specs/2026-07-15-message-resource-bindings.md
+++ b/docs/superpowers/specs/2026-07-15-message-resource-bindings.md
@@ -25,6 +25,21 @@ use the artifact preview policy.
 Unresolvable references are persisted as structured failures. Their raw paths
 are not sent back through the WebView navigation path.
 
+Right-clicking a bound resource opens its file menu using the persisted resource
+ID, including when the rendered link has `href="#"`. For source paths inside the
+active project, **Open with default app**, **Show in file manager**, and **Copy
+absolute/relative path** operate on the current workspace file. **Open in center**
+and **Download** use the immutable version saved with the message. If the source
+is outside the active project (for example after a project move), only the saved
+version actions are available. Unresolved bindings do not fall through to the
+whole-message copy menu.
+
+Manual desktop smoke check (Windows Explorer / macOS Finder): right-click an HTML
+report link in a completed answer, open it with the default app, reveal it in the
+file manager, and paste each copied path to verify the filename and directory.
+Press Escape immediately after opening the menu; the menu closes and the
+conversation stays visible.
+
 ## Scope boundary
 
 This design applies only when a new assistant message is persisted after the

--- a/ui-tests/tests/mock-tauri.ts
+++ b/ui-tests/tests/mock-tauri.ts
@@ -2264,7 +2264,7 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string;
               return {
                 items: [{
                   role: "assistant",
-                  text: "[Open bound report](D:/ZZM/03.%20figures/report.md')\n\n[Open bound manuscript](/abs/path/D:/ZZM/paper/manuscript.docx)\n\n[Open bound references](references.bib)\n\n[Open bound Python script](analysis/scripts/random_walk_demo.py)\n\n[Open bound R script](analysis/plot.R)",
+                  text: "[Open bound report](D:/ZZM/03.%20figures/report.md')\n\n[Open bound manuscript](/abs/path/D:/ZZM/paper/manuscript.docx)\n\n[Open bound references](references.bib)\n\n[Open bound Python script](analysis/scripts/random_walk_demo.py)\n\n[Open bound R script](analysis/plot.R)\n\n[quality_report.html](results/quality%20report.html)",
                   tool_name: null,
                   ok: null,
                   resources: [
@@ -2325,6 +2325,18 @@ export function tauriMock(fixtures?: { xlsxBase64?: string; pptxBase64?: string;
                       displayName: "plot.R",
                       kind: "code",
                       mimeType: "text/x-r",
+                      status: "ready",
+                      error: null,
+                    },
+                    {
+                      id: "resource-link-html",
+                      ordinal: 5,
+                      originalReference: "results/quality%20report.html",
+                      artifactId: "resource-artifact-html",
+                      artifactVersionId: "resource-version-html",
+                      displayName: "quality report.html",
+                      kind: "html",
+                      mimeType: "text/html",
                       status: "ready",
                       error: null,
                     },

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -12971,6 +12971,65 @@ test("reverse preview selections anchor the action popup above the first selecte
     .toBeLessThan(selection.top);
 });
 
+test("bound report links own file actions and copy file paths", async ({ page }) => {
+  await page.goto("/?mockResourceSession=1");
+  await page.getByRole("button", { name: "Search", exact: true }).click();
+  const search = commandPalette(page);
+  await search.fill("Enumerate");
+  await search.press("Enter");
+  await page.evaluate(() => {
+    Object.defineProperty(navigator.clipboard, "writeText", {
+      configurable: true,
+      value: async (text: string) => { (window as any).__copiedResourcePath = text; },
+    });
+  });
+  const link = page.getByRole("link", { name: "quality_report.html", exact: true });
+  await expect(link).toHaveAttribute("href", "#");
+  const menu = page.locator(".ctx-menu");
+  await link.click({ button: "right" });
+  await expect(menu.getByRole("button", { name: "Open with default app" })).toBeVisible();
+  await expect(menu.getByRole("button", { name: "Copy message" })).toHaveCount(0);
+  await page.keyboard.press("Escape");
+  await expect(menu).toHaveCount(0);
+  await expect(link).toBeVisible();
+
+  // A leftover text selection must not replace the file menu.
+  await link.evaluate(el => {
+    const range = document.createRange();
+    range.selectNodeContents(el);
+    window.getSelection()!.removeAllRanges();
+    window.getSelection()!.addRange(range);
+  });
+  for (const [label, expected] of [
+    ["Copy relative path", "results/quality report.html"],
+    ["Copy absolute path", "/mock/root/results/quality report.html"],
+  ]) {
+    await link.click({ button: "right" });
+    await menu.getByRole("button", { name: label, exact: true }).click();
+    await expect.poll(() => page.evaluate(() => (window as any).__copiedResourcePath)).toBe(expected);
+  }
+  for (const [label, command] of [
+    ["Open with default app", "open_workspace_path"],
+    ["Show in file manager", "reveal_in_file_manager"],
+  ]) {
+    await link.click({ button: "right" });
+    await menu.getByRole("button", { name: label }).click();
+    await expect.poll(() => lastInvokeArgs(page, command)).toMatchObject({ path: "results/quality report.html" });
+  }
+  await link.click({ button: "right" });
+  await menu.getByRole("button", { name: "Download", exact: true }).click();
+  await expect.poll(() => lastInvokeArgs(page, "download_artifact_version"))
+    .toMatchObject({ versionId: "resource-version-html" });
+
+  const references = page.getByRole("link", { name: "Open bound references" });
+  await references.click({ button: "right" });
+  await menu.getByRole("button", { name: "Open in center" }).click();
+  await expect(page.locator('.center-tab[data-center-path="artifact-version:resource-version-bib"]'))
+    .toContainText("references.bib");
+  await expect.poll(() => lastInvokeArgs(page, "read_artifact_version"))
+    .toMatchObject({ versionId: "resource-version-bib" });
+});
+
 test("bound Markdown resources use immutable versions and a scrollable center preview", async ({ page }) => {
   await page.goto("/?mockResourceSession=1");
   await page.getByRole("button", { name: "Search", exact: true }).click();

--- a/ui/src/context_menu.rs
+++ b/ui/src/context_menu.rs
@@ -2,7 +2,7 @@ use crate::app_support::{
     selection_targets_center_file, workspace_absolute_path, workspace_relative_path,
     SessionTransferMode,
 };
-use crate::dto::QuickAction;
+use crate::dto::{ChatItem, MessageResource, QuickAction};
 use crate::i18n::{self, Locale};
 use crate::text::{
     decode_href, file_kind, is_external_href, is_runtime_code_selection, normalize_path,
@@ -205,6 +205,47 @@ fn chat_workspace_path_menu(
         path,
     ));
     CtxMenu { x, y, items }
+}
+
+// Bound links deliberately have href="#". Resolve their menu from the same
+// persisted identity used by left-click previews, never from that placeholder.
+fn bound_resource_menu(
+    x: f64,
+    y: f64,
+    resource: &MessageResource,
+    project_root: Option<&str>,
+    locale: Locale,
+) -> CtxMenu {
+    let mut menu = CtxMenu {
+        x,
+        y,
+        items: Vec::new(),
+    };
+    let Some(version_id) = resource
+        .artifact_version_id
+        .as_ref()
+        .filter(|_| resource.status == "ready")
+    else {
+        return menu;
+    };
+    if let Some(path) = local_workspace_menu_path(project_root, &resource.original_reference) {
+        menu = chat_workspace_path_menu(x, y, path, project_root, locale);
+        menu.items
+            .retain(|item| item.action != "openWorkspaceFileCenter");
+    }
+    let preview_path = format!("artifact-version:{version_id}");
+    menu.items.push(item(
+        "openBoundResourceCenter",
+        i18n::t(locale, "center.open_file"),
+        serde_json::to_string(&(&preview_path, &resource.display_name, &resource.kind))
+            .unwrap_or_default(),
+    ));
+    menu.items.push(item(
+        "downloadFile",
+        i18n::t(locale, "artifact.download"),
+        preview_path,
+    ));
+    menu
 }
 
 pub fn remote_file_download_uri(context_id: &str, path: &str) -> Option<String> {
@@ -581,6 +622,7 @@ pub fn build(
     quick_actions: &[QuickAction],
     project_root: Option<&str>,
     selected_workspace_paths: &[String],
+    chat_items: &[ChatItem],
 ) -> Option<CtxMenu> {
     let target = event_target(ev)?;
     let x = ev.client_x() as f64;
@@ -607,6 +649,28 @@ pub fn build(
                 ],
             });
         }
+    }
+
+    if let Some(reference) = closest(&target, ".md [data-resource-id]") {
+        let resource_id = reference
+            .get_attribute("data-resource-id")
+            .unwrap_or_default();
+        let resource = chat_items.iter().find_map(|item| match item {
+            ChatItem::Assistant { resources, .. } => {
+                resources.iter().find(|resource| resource.id == resource_id)
+            }
+            _ => None,
+        });
+        // An unresolved binding must not fall through to copying the message.
+        return Some(
+            resource
+                .map(|resource| bound_resource_menu(x, y, resource, project_root, locale))
+                .unwrap_or(CtxMenu {
+                    x,
+                    y,
+                    items: Vec::new(),
+                }),
+        );
     }
 
     // All workspace-path controls inside assistant Markdown own one
@@ -995,6 +1059,90 @@ mod remote_file_tests {
 #[cfg(test)]
 mod chat_workspace_path_tests {
     use super::local_workspace_menu_path;
+
+    #[test]
+    fn bound_file_menu_keeps_workspace_actions_separate_from_snapshot_actions() {
+        let mut resource = crate::dto::MessageResource {
+            id: "link".into(),
+            ordinal: 0,
+            original_reference: "results/quality%20report.html".into(),
+            artifact_id: Some("artifact".into()),
+            artifact_version_id: Some("version".into()),
+            display_name: "quality report.html".into(),
+            kind: "html".into(),
+            mime_type: "text/html".into(),
+            status: "ready".into(),
+            error: None,
+        };
+        for (root, reference, absolute) in [
+            (
+                "/work/project",
+                "results/quality%20report.html",
+                "/work/project/results/quality report.html",
+            ),
+            (
+                r"C:\work\project",
+                "c:%5CWORK%5Cproject%5Cresults%5Cquality%20report.html",
+                r"C:\work\project\results\quality report.html",
+            ),
+        ] {
+            resource.original_reference = reference.into();
+            let menu = super::bound_resource_menu(
+                0.0,
+                0.0,
+                &resource,
+                Some(root),
+                crate::i18n::Locale::En,
+            );
+            let payload = |action| {
+                menu.items
+                    .iter()
+                    .find(|item| item.action == action)
+                    .unwrap()
+                    .payload
+                    .as_str()
+            };
+            for action in [
+                "openWorkspacePathInSystem",
+                "revealInFileManager",
+                "copyRelativePath",
+            ] {
+                assert_eq!(payload(action), "results/quality report.html");
+            }
+            assert_eq!(payload("copyAbsolutePath"), absolute);
+            assert_eq!(payload("downloadFile"), "artifact-version:version");
+            let preview: (String, String, String) =
+                serde_json::from_str(payload("openBoundResourceCenter")).unwrap();
+            assert_eq!(
+                preview,
+                (
+                    "artifact-version:version".into(),
+                    "quality report.html".into(),
+                    "html".into()
+                )
+            );
+            assert!(!menu.items.iter().any(|item| item.action == "copyMessage"));
+        }
+        // Imported snapshots may no longer have a local source in this project.
+        let menu = super::bound_resource_menu(
+            0.0,
+            0.0,
+            &resource,
+            Some("/other/project"),
+            crate::i18n::Locale::En,
+        );
+        assert_eq!(menu.items.len(), 2);
+        resource.status = "unresolved".into();
+        assert!(super::bound_resource_menu(
+            0.0,
+            0.0,
+            &resource,
+            Some("/other/project"),
+            crate::i18n::Locale::En
+        )
+        .items
+        .is_empty());
+    }
 
     #[test]
     fn normalizes_local_paths_and_rejects_non_workspace_resources() {

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -8085,6 +8085,18 @@ fn App() -> impl IntoView {
                 });
                 return;
             }
+            if action == "openBoundResourceCenter" {
+                if let Ok((path, name, kind)) = serde_json::from_str::<ModalArtifact>(&payload) {
+                    let tab = CenterFileTab::new(path.clone(), name, kind);
+                    center_files.update(|files| {
+                        if !files.iter().any(|file| file.path == path) {
+                            files.push(tab);
+                        }
+                    });
+                    center_file.set(Some(path));
+                }
+                return;
+            }
             if action == "openWorkspaceFileCenter" {
                 let tab = CenterFileTab::from_path(payload.clone());
                 center_files.update(|files| {
@@ -8437,15 +8449,18 @@ fn App() -> impl IntoView {
         } else {
             Vec::new()
         };
-        if let Some(menu) = context_menu::build(
-            &ev,
-            loc,
-            active_session.get().is_some(),
-            center.as_deref(),
-            &quick_actions.get_untracked(),
-            project_root.as_deref(),
-            &selected_paths,
-        ) {
+        if let Some(menu) = items.with_untracked(|rows| {
+            context_menu::build(
+                &ev,
+                loc,
+                active_session.get().is_some(),
+                center.as_deref(),
+                &quick_actions.get_untracked(),
+                project_root.as_deref(),
+                &selected_paths,
+                rows,
+            )
+        }) {
             if !menu.items.is_empty() {
                 ev.prevent_default();
                 // The context menu supersedes the selection popup — never


### PR DESCRIPTION
Right-clicking a file link in a completed assistant reply could show only **Copy message**, even after the earlier file-menu fixes. Persisted resource links render with `href="#"`; the context menu recognized ordinary paths and artifact chips but missed these resource identities.

This change resolves bound links by their persisted resource ID. For a source inside the active project, the menu offers opening with the default app, revealing in the file manager, and copying the correct absolute or relative path. **Open in center** and **Download** retain the immutable version attached to the message. Unresolved bindings no longer fall through to whole-message copying.

### Changes

- `ui/src/context_menu.rs`: resolve resource identities before path, selection, and message fallbacks; add Windows and POSIX path/payload tests.
- `ui/src/main.rs`: provide transcript bindings to the menu and open pinned versions with their original name and preview kind.
- `ui-tests/tests/mock-tauri.ts` and `ui.spec.ts`: add a bound HTML report fixture and verify clipboard text, backend command arguments, Escape dismissal, selection precedence, and immutable preview/download behavior.
- Message resource binding spec: document file-menu behavior and desktop smoke steps. No new persistence abstraction or schema changes.

### Validation

- `cargo fmt --all -- --check` and `git diff --check`: passed.
- `WISP_CATALOG_OFFLINE=1 cargo test --workspace --offline`: 2,060 passed.
- `cargo test --manifest-path ui/Cargo.toml --offline`: 328 passed.
- `cd ui && cargo check --target wasm32-unknown-unknown --offline`: passed.
- `cd ui-tests && npm ci --offline`: passed.
- Targeted Playwright regression tests: 3 passed, including the existing artifact-path and bound-preview tests.
- Full Playwright suite with 4 parallel workers: 712 passed, 2 skipped (optional real Motif/SnapGene fixtures).

### Desktop smoke steps

1. In a completed assistant reply, right-click a bound HTML report link, including a filename with spaces.
2. Select **Open with default app** and **Show in file manager**; verify the current project file opens or is selected in Explorer/Finder.
3. Paste each copied path and verify the absolute and project-relative values.
4. Open the menu and immediately press Escape; verify only the menu closes.
5. Verify **Open in center** and **Download** use the saved message version.

### Limitations and follow-up

Native Windows/macOS launch behavior is covered by mocked command assertions, not a manual desktop run in this environment; perform the smoke steps before release. Local actions retain the existing workspace-path eligibility rules. Saved resources whose source is outside the active project expose only saved-version actions. No additional implementation follow-up is required for this regression.
