### PR TITLE
Fix file-sort UI test across midnight

### DIFF
--- a/ui-tests/tests/file-sort.spec.ts
+++ b/ui-tests/tests/file-sort.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from "@playwright/test";
+import { tauriMock } from "./mock-tauri";
+
+test.describe("Files modification timestamps", () => {
+  test.use({ timezoneId: "UTC" });
+
+  for (const { scenario, now, expectedModified } of [
+    { scenario: "same day", now: "2026-09-12T12:00:30Z", expectedModified: "11:59" },
+    { scenario: "across midnight", now: "2026-09-12T00:00:30Z", expectedModified: "09-11 23:59" },
+  ]) {
+    test(`Files sorts by size and modified time and Escape closes only the sort menu (${scenario})`, async ({ page }) => {
+      // The mock file is 90 seconds old. Freeze Date before navigation so both
+      // the fixture and UI use the same clock, including at the UTC day boundary.
+      // Register the clock before the mock init script captures FILE_NOW.
+      await page.clock.setFixedTime(new Date(now));
+      await page.addInitScript(tauriMock);
+      await page.goto("/");
+      expect(await page.evaluate(() => Date.now())).toBe(Date.parse(now));
+      await page.locator(".proj-card-main").first().click();
+      await expect(page.locator(".sidebar").getByRole("button", { name: "New session" })).toBeVisible();
+      await page.getByRole("button", { name: "Files" }).click();
+      const files = page.locator(".rp-files");
+      const fileRows = files.locator(".fb-row:not(.dir)");
+
+      await expect(files.locator('.fb-row[data-workspace-path="report.csv"] .fb-size')).toHaveText("4.0 KB");
+
+      await files.getByTestId("files-sort").click();
+      const sortMenu = files.locator(".fb-sort-menu");
+      await expect(sortMenu).toBeVisible();
+      await page.keyboard.press("Escape");
+      await expect(sortMenu).toHaveCount(0);
+      await expect(files).toBeVisible();
+
+      await files.getByTestId("files-sort").click();
+      await sortMenu.getByRole("menuitem", { name: "Size" }).click();
+      await expect(fileRows.first()).toHaveAttribute("data-workspace-path", "manuscript.docx");
+      await expect(fileRows.first().locator(".fb-size")).toHaveText("11.1 KB");
+
+      await files.getByTestId("files-sort").click();
+      await sortMenu.getByRole("menuitem", { name: "Modified" }).click();
+      await expect(fileRows.first()).toHaveAttribute("data-workspace-path", "report.csv");
+      await expect(fileRows.first().locator(".fb-size")).toHaveText(expectedModified);
+      await expect(files.locator('.fb-row.dir[data-workspace-path="DEG"] .fb-size')).toHaveText(/\d/);
+    });
+  }
+});

--- a/ui-tests/tests/ui.spec.ts
+++ b/ui-tests/tests/ui.spec.ts
@@ -5371,33 +5371,6 @@ test("Files creates, renames, deletes, and refreshes local entries", async ({ pa
   await expect.poll(() => lastInvokeArgs(page, "list_dir")).toMatchObject({ path: "." });
 });
 
-test("Files sorts by size and modified time and Escape closes only the sort menu", async ({ page }) => {
-  await enterApp(page);
-  await page.getByRole("button", { name: "Files" }).click();
-  const files = page.locator(".rp-files");
-  const fileRows = files.locator(".fb-row:not(.dir)");
-
-  await expect(files.locator('.fb-row[data-workspace-path="report.csv"] .fb-size')).toHaveText("4.0 KB");
-
-  await files.getByTestId("files-sort").click();
-  const sortMenu = files.locator(".fb-sort-menu");
-  await expect(sortMenu).toBeVisible();
-  await page.keyboard.press("Escape");
-  await expect(sortMenu).toHaveCount(0);
-  await expect(files).toBeVisible();
-
-  await files.getByTestId("files-sort").click();
-  await sortMenu.getByRole("menuitem", { name: "Size" }).click();
-  await expect(fileRows.first()).toHaveAttribute("data-workspace-path", "manuscript.docx");
-  await expect(fileRows.first().locator(".fb-size")).toHaveText("11.1 KB");
-
-  await files.getByTestId("files-sort").click();
-  await sortMenu.getByRole("menuitem", { name: "Modified" }).click();
-  await expect(fileRows.first()).toHaveAttribute("data-workspace-path", "report.csv");
-  await expect(fileRows.first().locator(".fb-size")).toHaveText(/^\d{2}:\d{2}$/);
-  await expect(files.locator('.fb-row.dir[data-workspace-path="DEG"] .fb-size')).toHaveText(/\d/);
-});
-
 test("text entries keep the native context menu", async ({ page }) => {
   await enterApp(page);
   await page.locator(".proj-switch").click();


### PR DESCRIPTION
The UI checks for #1226 and #1227 failed on the same existing file-sort assertion near UTC midnight. The fixture makes `report.csv` 90 seconds old, but the test always expected `HH:mm`. At `00:00:30`, the correct display is the previous day's `09-11 23:59`.

Move the file-sort scenario from `ui.spec.ts` to `file-sort.spec.ts`, where the clock can be installed before the Tauri mock captures its fixture timestamps. Pin the browser timezone to UTC and test both midday and midnight with exact expected text. The existing size ordering, modified ordering, and immediate Escape dismissal checks remain covered. Product code and the shared fixture remain unchanged.

Validation:

- Reproduced the original CI failure deterministically at UTC midnight: expected `HH:mm`, received `09-11 23:59`.
- Both fixed-time scenarios repeated three times: 6 passed.
- Full browser suite on the merged main plus this fix: 722 passed, 2 skipped (optional real Motif/SnapGene fixtures), using 6 parallel workers.
- `cargo fmt --all -- --check` and `git diff --check`: passed.

No desktop smoke steps or product documentation changes are needed for this test-only correction. No known implementation follow-up remains; CI still needs to run on the new PR head.
