### PR TITLE
fix: retire deleted-session MCP connections and unblock local bridge tools

### DIFF
--- a/docs/mcp-connection-lifecycle.md
+++ b/docs/mcp-connection-lifecycle.md
@@ -20,7 +20,10 @@ queued, unsent cancelled requests are skipped. Late responses are discarded.
 Wisp owns connections separately from transient Agent instances and views.
 Scopes include project, conversation, state scope, execution context and
 connector configuration. Normal connections live until Wisp exits or the user
-disables, replaces or explicitly restarts them. Failed initialization, broken
+disables, replaces or explicitly restarts them, or deletes their conversation.
+Deleting a conversation closes its connections, interrupts initialization and
+rejects late background restore attempts; other conversations keep their own
+connections. Failed initialization, broken
 pipes and exited subprocesses are still cleaned up. HTTP session shutdown does
 not terminate the remote service.
 
@@ -52,6 +55,11 @@ persisted in SQLite or forwarded to plugin environments. Browser-origin
 requests are rejected. A streaming lease cancels that bridge's pending requests
 when the bridge disappears; the Host retains plugin processes. JSON-RPC stdout
 never carries diagnostics.
+
+Local bridge tools (including skills, memory, Run queries/cancellation and
+questions) do not initialize unrelated plugins or wait for remote discovery.
+Remote tool discovery and calls share a separately initialized catalog, so a
+slow plugin cannot block those local requests.
 
 Host tracing records `mcp.connection.*` and `mcp.request.*` events, with logical
 identity, connection generation, request ID, method, tool, elapsed time and

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5217,7 +5217,10 @@ async fn finish_custom_mcp_wiring(
             result.plugin_runtime_checks.entry(id.clone()).or_default();
         }
         set.spawn(async move {
-            let res = client.tools_list().await.map(|_| client);
+            let res = match client {
+                Ok(client) => client.tools_list().await.map(|_| client),
+                Err(error) => Err(anyhow::anyhow!(error)),
+            };
             let approval = plugin_id.is_some();
             (index, name, plugin_id, connector_id, approval, res)
         });

--- a/src-tauri/src/mcp_bridge.rs
+++ b/src-tauri/src/mcp_bridge.rs
@@ -1341,6 +1341,7 @@ fn is_builtin_tool(name: &str) -> bool {
     matches!(
         name,
         "wisp_get_capabilities"
+            | "ask_user"
             | "wisp_list_skills"
             | "wisp_use_skill"
             | "wisp_search_tools"
@@ -1395,8 +1396,57 @@ fn sanitize_tool_part(raw: &str) -> String {
     }
 }
 
+/// Local requests never acquire the discovery lock. Only requests that expose
+/// or call remote tools share initialization; publish a complete snapshot so
+/// cancelling discovery cannot leave its loaded flags set on a partial catalog.
+struct BridgeDispatcher {
+    local: BridgeServer,
+    remote: tokio::sync::Mutex<Option<BridgeServer>>,
+}
+
+impl BridgeDispatcher {
+    fn new(local: BridgeServer) -> Self {
+        Self {
+            local,
+            remote: tokio::sync::Mutex::new(None),
+        }
+    }
+
+    async fn handle(&self, req: JsonRpcIn) -> Option<Value> {
+        let needs_remote = match req.method.as_str() {
+            "tools/list" => !self.local.allowed_connectors().is_empty(),
+            "tools/call" => req
+                .params
+                .as_ref()
+                .and_then(|params| params.get("name"))
+                .and_then(Value::as_str)
+                .is_some_and(|name| {
+                    matches!(name, "wisp_search_tools" | "wisp_use_tool") || !is_builtin_tool(name)
+                }),
+            _ => false,
+        };
+        let mut snapshot = if needs_remote {
+            let mut remote = self.remote.lock().await;
+            if remote.is_none() {
+                let mut candidate = self.local.clone();
+                if let Err(error) = candidate.ensure_remote_tools().await {
+                    return req.id.map(|id| {
+                        json!({"jsonrpc":"2.0", "id":id,
+                        "error":{"code":-32000,"message":error.to_string()}})
+                    });
+                }
+                *remote = Some(candidate);
+            }
+            remote.as_ref().unwrap().clone()
+        } else {
+            self.local.clone()
+        };
+        snapshot.handle(req).await
+    }
+}
+
 pub(crate) async fn run_stdio(cfg: BridgeConfig) -> Result<()> {
-    let server = Arc::new(tokio::sync::Mutex::new(BridgeServer::new(cfg).await?));
+    let server = Arc::new(BridgeDispatcher::new(BridgeServer::new(cfg).await?));
     // A streaming lease lets the Host cancel this bridge's calls on process loss.
     let lease = if let Some(config) = crate::mcp_broker::proxy_config() {
         let (base, token) = (&config.base, &config.token);
@@ -1468,14 +1518,7 @@ pub(crate) async fn run_stdio(cfg: BridgeConfig) -> Result<()> {
         let (start, ready) = tokio::sync::oneshot::channel();
         let task = tasks.spawn(async move {
             let _ = ready.await;
-            let mut snapshot = {
-                let mut server = server.lock().await;
-                if req.method == "tools/call" {
-                    let _ = server.ensure_remote_tools().await;
-                }
-                server.clone()
-            };
-            if let Some(response) = snapshot.handle(req).await {
+            if let Some(response) = server.handle(req).await {
                 let _ = responses.send(response).await;
             }
             pending_task.lock().unwrap().remove(&request_id);
@@ -1579,6 +1622,140 @@ pub fn run_mcp_bridge_cli() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn local_requests_bypass_blocked_discovery_and_do_not_initialize_plugins() {
+        let base =
+            std::env::temp_dir().join(format!("wisp-bridge-dispatch-{}", uuid::Uuid::new_v4()));
+        let server = BridgeServer::new(BridgeConfig {
+            app_data: base.join("app-data"),
+            project_root: base.join("project"),
+            resource_root: None,
+            project_id: "p".into(),
+            frame_id: None,
+            allowed_tools: None,
+        })
+        .await
+        .unwrap();
+        let dispatcher = BridgeDispatcher::new(server);
+        // Hold the same lock a slow remote initialization owns. Poll a real
+        // discovery request into it before issuing local/control requests.
+        let discovery = dispatcher.remote.lock().await;
+        let mut remote = Box::pin(dispatcher.handle(JsonRpcIn {
+            id: Some(json!(1)),
+            method: "tools/call".into(),
+            params: Some(json!({"name":"wisp_search_tools","arguments":{"query":"echo"}})),
+        }));
+        assert!(futures_util::poll!(remote.as_mut()).is_pending());
+        for (id, method, params) in [
+            (2, "initialize", None),
+            (3, "tools/list", None),
+            (
+                4,
+                "tools/call",
+                Some(json!({"name":"wisp_list_skills","arguments":{}})),
+            ),
+            (
+                5,
+                "tools/call",
+                Some(json!({"name":"wisp_get_run","arguments":{"run_id":"missing"}})),
+            ),
+            (
+                6,
+                "tools/call",
+                Some(json!({"name":"wisp_cancel_run","arguments":{"run_id":"missing"}})),
+            ),
+            (
+                7,
+                "tools/call",
+                Some(json!({"name":"ask_user","arguments":{"question":"test"}})),
+            ),
+        ] {
+            let response = tokio::time::timeout(
+                std::time::Duration::from_secs(2),
+                dispatcher.handle(JsonRpcIn {
+                    id: Some(json!(id)),
+                    method: method.into(),
+                    params,
+                }),
+            )
+            .await
+            .expect("local request waited on plugin discovery")
+            .unwrap();
+            assert_eq!(response["id"], id);
+            assert!(response.get("result").is_some() || response.get("error").is_some());
+        }
+        assert!(
+            discovery.is_none(),
+            "local calls must not initialize remote tools"
+        );
+        drop(remote);
+        drop(discovery);
+        drop(dispatcher);
+        let _ = std::fs::remove_dir_all(base);
+    }
+
+    #[tokio::test]
+    async fn remote_dispatch_keeps_grants_and_shares_the_discovered_catalog() {
+        let base =
+            std::env::temp_dir().join(format!("wisp-bridge-catalog-{}", uuid::Uuid::new_v4()));
+        let mut server = BridgeServer::new(BridgeConfig {
+            app_data: base.join("app-data"),
+            project_root: base.join("project"),
+            resource_root: None,
+            project_id: "p".into(),
+            frame_id: None,
+            allowed_tools: Some(HashSet::from([
+                crate::delegation_resources::connector_token("pubmed"),
+            ])),
+        })
+        .await
+        .unwrap();
+        // Preloaded local native tools exercise real listing/dispatch without
+        // a provider, Python environment, or external network.
+        server.bundled_bio_tools_loaded = true;
+        server.custom_mcp_tools_loaded = true;
+        server.register_native_bio_tools("mcp_bio", &mut HashSet::new());
+        let dispatcher = BridgeDispatcher::new(server);
+        let listed = dispatcher
+            .handle(JsonRpcIn {
+                id: Some(json!(1)),
+                method: "tools/list".into(),
+                params: None,
+            })
+            .await
+            .unwrap();
+        assert!(listed["result"]["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|t| t["name"] == "search_articles"));
+        assert!(dispatcher.remote.lock().await.is_some());
+        let called = dispatcher
+            .handle(JsonRpcIn {
+                id: Some(json!(2)),
+                method: "tools/call".into(),
+                params: Some(json!({"name":"search_articles","arguments":{"query":""}})),
+            })
+            .await
+            .unwrap();
+        assert_eq!(called["result"]["isError"], true);
+        assert!(called.to_string().contains("query must contain"));
+        let denied = dispatcher
+            .handle(JsonRpcIn {
+                id: Some(json!(3)),
+                method: "tools/call".into(),
+                params: Some(json!({"name":"wisp_get_run","arguments":{"run_id":"missing"}})),
+            })
+            .await
+            .unwrap();
+        assert!(denied["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("outside this Agent's capability grant"));
+        drop(dispatcher);
+        let _ = std::fs::remove_dir_all(base);
+    }
 
     #[tokio::test]
     async fn native_bio_registration_honors_filters_grants_and_errors_without_python() {

--- a/src-tauri/src/mcp_broker.rs
+++ b/src-tauri/src/mcp_broker.rs
@@ -293,7 +293,8 @@ async fn request(
                 scope.scope_key(),
                 spec,
             )
-            .await;
+            .await
+            .map_err(anyhow::Error::msg)?;
         match method {
             "initialize" | "tools/list" => {
                 let tools: Vec<_> = client
@@ -519,7 +520,8 @@ mod tests {
         let scope = store.frame_state_scope(&frame).await.unwrap().unwrap();
         let client = mcp_connections::host()
             .acquire(&store, "p", &frame, scope.scope_key(), &specs[0])
-            .await;
+            .await
+            .unwrap();
         assert!(client.is_connected());
         assert_eq!(
             client

--- a/src-tauri/src/mcp_connections.rs
+++ b/src-tauri/src/mcp_connections.rs
@@ -73,6 +73,9 @@ struct Entry {
 #[derive(Default)]
 pub(crate) struct Connections {
     entries: tokio::sync::Mutex<HashMap<Key, Entry>>,
+    // Access only while holding entries, so retirement and registration are atomic.
+    // Frame IDs are never reused; retain tombstones until the Host exits.
+    retired_frames: StdMutex<HashSet<String>>,
     closing: Arc<AtomicBool>,
 }
 pub(crate) fn host() -> &'static Connections {
@@ -155,6 +158,34 @@ impl Connections {
             let _ = entry.client.shutdown().await;
         }
     }
+    pub(crate) async fn retire_frame(&self, frame: &str) {
+        let mut entries = self.entries.lock().await;
+        self.retired_frames.lock().unwrap().insert(frame.into());
+        let keys: Vec<_> = entries
+            .keys()
+            .filter(|k| k.frame == frame)
+            .cloned()
+            .collect();
+        let old: Vec<_> = keys
+            .into_iter()
+            .filter_map(|k| entries.remove(&k))
+            .collect();
+        drop(entries);
+        tracing::info!(target: "wisp", frame, reason="conversation-deleted", "mcp.scope.close");
+        // Dropping a window's delete future must not abort cleanup after the
+        // entries have been removed. Dropped JoinHandles let shutdown finish.
+        let tasks: Vec<_> = old
+            .into_iter()
+            .map(|entry| {
+                tokio::spawn(async move {
+                    let _ = entry.client.shutdown().await;
+                })
+            })
+            .collect();
+        for task in tasks {
+            let _ = task.await;
+        }
+    }
     pub(crate) async fn acquire(
         &self,
         store: &Store,
@@ -162,7 +193,16 @@ impl Connections {
         frame: &str,
         scope: &str,
         spec: &Spec,
-    ) -> Arc<McpClient> {
+    ) -> Result<Arc<McpClient>, String> {
+        if store
+            .frame_project_id(frame)
+            .await
+            .map_err(|e| e.to_string())?
+            .as_deref()
+            != Some(project)
+        {
+            return Err("MCP conversation was deleted or moved".into());
+        }
         let context = format!(
             "{:?}",
             ssh_hosts::stored_session_default_execution_context(store, frame).await
@@ -177,21 +217,28 @@ impl Connections {
         let descriptor = spec.descriptor();
         let (client, old) = {
             let mut entries = self.entries.lock().await;
+            if self.closing.load(Ordering::SeqCst)
+                || self.retired_frames.lock().unwrap().contains(frame)
+            {
+                return Err("MCP conversation or Host was closed; request not sent".into());
+            }
             if let Some(entry) = entries.get(&key) {
                 if entry.descriptor == descriptor {
-                    return entry.client.clone();
+                    return Ok(entry.client.clone());
                 }
             }
             let factory = spec.factory();
             let store = store.clone();
             let project_owned = project.to_string();
+            let frame_owned = frame.to_string();
             let connector = spec.id().to_string();
             let expected = descriptor.clone();
             let closing = self.closing.clone();
             let checked: ClientFactory = Arc::new(move || {
-                let (store, project, connector, expected, factory) = (
+                let (store, project, frame, connector, expected, factory) = (
                     store.clone(),
                     project_owned.clone(),
+                    frame_owned.clone(),
                     connector.clone(),
                     expected.clone(),
                     factory.clone(),
@@ -200,6 +247,16 @@ impl Connections {
                 Box::pin(async move {
                     let valid = || async {
                         if closing.load(Ordering::SeqCst) {
+                            return false;
+                        }
+                        if store
+                            .frame_project_id(&frame)
+                            .await
+                            .ok()
+                            .flatten()
+                            .as_deref()
+                            != Some(&project)
+                        {
                             return false;
                         }
                         configured(&store, &project)
@@ -234,7 +291,7 @@ impl Connections {
         if let Some(old) = old {
             let _ = old.client.shutdown().await;
         }
-        client
+        Ok(client)
     }
 
     /// Config changes close only changed/disabled connections, never every idle agent.
@@ -249,6 +306,17 @@ impl Connections {
             .collect();
         let mut specs = HashMap::new();
         for key in keys {
+            let owner = match store.frame_project_id(&key.frame).await {
+                Ok(owner) => owner,
+                Err(error) => {
+                    tracing::warn!(target: "wisp", frame=%key.frame, %error, "MCP ownership check failed");
+                    continue;
+                }
+            };
+            if owner.as_deref() != Some(&key.project) {
+                self.retire_frame(&key.frame).await;
+                continue;
+            }
             if !specs.contains_key(&key.project) {
                 let (current, _) = configured(store, &key.project).await;
                 specs.insert(
@@ -365,7 +433,7 @@ pub(crate) async fn restore_app(
         .ok_or("MCP conversation scope missing")?;
     let client = host()
         .acquire(&state.store, &project, frame, scope.scope_key(), spec)
-        .await;
+        .await?;
     let catalog = Arc::new(client.tools_list().await.map_err(|e| e.to_string())?);
     let name = payload
         .pointer("/tool/name")
@@ -477,9 +545,12 @@ pub(crate) async fn restore(store: &Store, project: &str, frame: &str) {
         {
             continue;
         }
-        let client = host()
+        let Ok(client) = host()
             .acquire(store, project, frame, scope.scope_key(), &spec)
-            .await;
+            .await
+        else {
+            continue;
+        };
         tasks.spawn(async move {
             let _ = client.tools_list().await;
         });
@@ -490,6 +561,191 @@ pub(crate) async fn restore(store: &Store, project: &str, frame: &str) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::{
+        extract::State as FixtureState, http::StatusCode, response::IntoResponse, routing::post,
+        Json, Router,
+    };
+
+    #[derive(Default)]
+    struct LifecycleFixture {
+        starts: std::sync::atomic::AtomicUsize,
+        stops: std::sync::atomic::AtomicUsize,
+        hold_initialize: AtomicBool,
+        entered: tokio::sync::Notify,
+        release: tokio::sync::Notify,
+    }
+
+    async fn lifecycle_fixture() -> (
+        PathBuf,
+        Store,
+        Spec,
+        Arc<LifecycleFixture>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        let root = std::env::temp_dir().join(format!("wisp-mcp-lifecycle-{}", Uuid::new_v4()));
+        let store = Store::open(&root.join("wisp.sqlite")).await.unwrap();
+        store
+            .create_project("p", "test", &root.to_string_lossy())
+            .await
+            .unwrap();
+        for frame in ["a", "b"] {
+            store
+                .create_frame(frame, "p", "test", "model")
+                .await
+                .unwrap();
+        }
+        let fixture = Arc::new(LifecycleFixture::default());
+        let router = Router::new()
+            .route(
+                "/",
+                post(
+                    |FixtureState(f): FixtureState<Arc<LifecycleFixture>>,
+                     Json(rpc): Json<serde_json::Value>| async move {
+                        let result = match rpc["method"].as_str().unwrap_or("") {
+                            "initialize" => {
+                                f.starts.fetch_add(1, Ordering::SeqCst);
+                                f.entered.notify_one();
+                                if f.hold_initialize.load(Ordering::SeqCst) {
+                                    f.release.notified().await;
+                                }
+                                json!({"capabilities":{"tools":{}}})
+                            }
+                            "tools/list" => json!({"tools":[]}),
+                            "notifications/initialized" | "notifications/cancelled" => {
+                                return StatusCode::ACCEPTED.into_response()
+                            }
+                            _ => json!({"content":[{"type":"text","text":"ok"}]}),
+                        };
+                        (
+                            [("mcp-session-id", "fixture")],
+                            Json(json!({"jsonrpc":"2.0","id":rpc["id"],"result":result})),
+                        )
+                            .into_response()
+                    },
+                )
+                .delete(
+                    |FixtureState(f): FixtureState<Arc<LifecycleFixture>>| async move {
+                        f.stops.fetch_add(1, Ordering::SeqCst);
+                        StatusCode::OK
+                    },
+                ),
+            )
+            .with_state(fixture.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let conn = McpConnection {
+            id: "fixture".into(),
+            name: "test".into(),
+            enabled: true,
+            transport: McpTransport::Http {
+                url: format!("http://{}", listener.local_addr().unwrap()),
+                headers: vec![],
+                auth: McpHttpAuth::None,
+            },
+        };
+        save_mcp_connections(&store, &[conn.clone()]).await.unwrap();
+        let server = tokio::spawn(async move {
+            axum::serve(listener, router).await.unwrap();
+        });
+        (root, store, Spec::Custom(conn), fixture, server)
+    }
+
+    #[tokio::test]
+    async fn deleting_frame_closes_connections_and_fences_late_restore_without_affecting_peers() {
+        let (root, store, spec, fixture, server) = lifecycle_fixture().await;
+        let owner = Connections::default();
+        let a = owner
+            .acquire(&store, "p", "a", "main", &spec)
+            .await
+            .unwrap();
+        let b = owner
+            .acquire(&store, "p", "b", "main", &spec)
+            .await
+            .unwrap();
+        a.tools_list().await.unwrap();
+        b.tools_list().await.unwrap();
+        owner.retire_frame("a").await;
+        assert!(!a.is_connected());
+        assert_eq!(fixture.stops.load(Ordering::SeqCst), 1);
+        assert_eq!(b.tool_call("echo", &json!({})).await.unwrap(), "ok");
+        // Retirement precedes the SQLite delete: even an already-read restore
+        // snapshot must be refused while the frame still exists in the store.
+        assert!(owner
+            .acquire(&store, "p", "a", "main", &spec)
+            .await
+            .is_err());
+        assert!(a.tools_list().await.is_err());
+        store.delete_session("a", "p").await.unwrap();
+        assert!(owner
+            .acquire(&store, "p", "a", "main", &spec)
+            .await
+            .is_err());
+        assert_eq!(owner.entries.lock().await.len(), 1);
+        assert_eq!(fixture.starts.load(Ordering::SeqCst), 2);
+        owner.shutdown_all().await;
+        server.abort();
+        drop((a, b, owner, store));
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn deletion_interrupts_in_progress_initialization() {
+        let (root, store, spec, fixture, server) = lifecycle_fixture().await;
+        fixture.hold_initialize.store(true, Ordering::SeqCst);
+        let owner = Connections::default();
+        let client = owner
+            .acquire(&store, "p", "a", "main", &spec)
+            .await
+            .unwrap();
+        let connecting = tokio::spawn(async move { client.tools_list().await });
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            fixture.entered.notified(),
+        )
+        .await
+        .unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(2), owner.retire_frame("a"))
+            .await
+            .unwrap();
+        assert!(connecting.await.unwrap().is_err());
+        fixture.release.notify_one();
+        assert!(owner
+            .acquire(&store, "p", "a", "main", &spec)
+            .await
+            .is_err());
+        assert!(owner.entries.lock().await.is_empty());
+        assert_eq!(fixture.starts.load(Ordering::SeqCst), 1);
+        server.abort();
+        drop((owner, store));
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[tokio::test]
+    async fn reconcile_removes_deleted_frames_and_unstarted_handles_cannot_reconnect() {
+        let (root, store, spec, fixture, server) = lifecycle_fixture().await;
+        let owner = Connections::default();
+        let a = owner
+            .acquire(&store, "p", "a", "main", &spec)
+            .await
+            .unwrap();
+        let b = owner
+            .acquire(&store, "p", "b", "main", &spec)
+            .await
+            .unwrap();
+        a.tools_list().await.unwrap();
+        store.delete_session("a", "p").await.unwrap();
+        store.delete_session("b", "p").await.unwrap();
+        // A previously acquired handle must check durable ownership on launch.
+        assert!(b.tools_list().await.is_err());
+        owner.reconcile(&store, None).await;
+        assert!(!a.is_connected());
+        assert!(owner.entries.lock().await.is_empty());
+        assert_eq!(fixture.stops.load(Ordering::SeqCst), 1);
+        assert_eq!(fixture.starts.load(Ordering::SeqCst), 1);
+        server.abort();
+        drop((a, b, owner, store));
+        let _ = std::fs::remove_dir_all(root);
+    }
+
     #[tokio::test]
     async fn owner_reuses_only_same_scope_and_disable_revokes_old_handles() {
         let root = std::env::temp_dir().join(format!("wisp-mcp-owner-{}", Uuid::new_v4()));
@@ -519,16 +775,31 @@ mod tests {
         };
         save_mcp_connections(&store, &[conn.clone()]).await.unwrap();
         let owner = Connections::default();
-        let a = owner.acquire(&store, "p", "a", "main", &spec).await;
-        let b = owner.acquire(&store, "p", "b", "main", &spec).await;
+        let a = owner
+            .acquire(&store, "p", "a", "main", &spec)
+            .await
+            .unwrap();
+        let b = owner
+            .acquire(&store, "p", "b", "main", &spec)
+            .await
+            .unwrap();
         assert!(!Arc::ptr_eq(&a, &b));
         assert!(Arc::ptr_eq(
             &a,
-            &owner.acquire(&store, "p", "a", "main", &spec).await
+            &owner
+                .acquire(&store, "p", "a", "main", &spec)
+                .await
+                .unwrap()
         ));
         owner.reconcile(&store, None).await;
         assert!(
-            Arc::ptr_eq(&a, &owner.acquire(&store, "p", "a", "main", &spec).await),
+            Arc::ptr_eq(
+                &a,
+                &owner
+                    .acquire(&store, "p", "a", "main", &spec)
+                    .await
+                    .unwrap()
+            ),
             "agent rebuild must retain unchanged connections"
         );
         let mut disabled = conn.clone();
@@ -543,7 +814,10 @@ mod tests {
             .to_string()
             .contains("disabled"));
         // A racing stale wiring snapshot cannot relaunch an explicitly disabled plugin.
-        let stale = owner.acquire(&store, "p", "a", "main", &spec).await;
+        let stale = owner
+            .acquire(&store, "p", "a", "main", &spec)
+            .await
+            .unwrap();
         assert!(stale
             .tools_list()
             .await

--- a/src-tauri/src/project_commands.rs
+++ b/src-tauri/src/project_commands.rs
@@ -251,6 +251,7 @@ pub(super) async fn cancel_project_sessions(state: &AppState, project_id: &str) 
     }
     for fid in &frame_ids {
         acp::cancel_frame(state, fid).await;
+        mcp_connections::host().retire_frame(fid).await;
     }
     for (_, rt) in &runtimes {
         let _workflow = rt.workflow.lock().await;

--- a/src-tauri/src/session_commands.rs
+++ b/src-tauri/src/session_commands.rs
@@ -807,6 +807,9 @@ pub(super) async fn delete_session(
         rt.cancel.store(true, Ordering::Relaxed);
     }
     acp::cancel_frame(&state, &id).await;
+    // Revoke Host ownership before waiting for a turn that may be connecting.
+    // This also fences background restore/wiring snapshots for this frame.
+    mcp_connections::host().retire_frame(&id).await;
     // Match send/Plan lock order. The tombstone prevents work already queued
     // behind these guards from restarting after the DB cascade.
     let _workflow_guard = match runtime.as_ref() {


### PR DESCRIPTION
Deleting a conversation could leave its Host-owned MCP servers running, while the ACP bridge made even local Run queries and skill reads wait for unrelated plugin initialization. This follow-up to #1225 closes deleted conversations' connections and keeps local bridge tools responsive during remote discovery.

## Changes

- `mcp_connections.rs`: retire frame connections before waiting for active turns, fence late restore/wiring attempts with frame tombstones, and validate persisted ownership before acquiring or launching a connection. Reconciliation removes deleted frames. Shutdown continues if the caller stops waiting.
- `session_commands.rs` and `project_commands.rs`: retire connections for direct conversation deletion and project/scratch cleanup. Other conversations retain their connections.
- `mcp_bridge.rs`: add a dispatcher with independent local handling and a shared remote-discovery cache. Only discovery and remote-tool requests wait for initialization; `ask_user` is classified as a built-in tool. Publish the remote catalog after initialization, preserving existing capability grants.
- `lib.rs` and `mcp_broker.rs`: propagate rejected connection acquisitions. Update `docs/mcp-connection-lifecycle.md` with the resulting behavior.

## Validation

Five new regression tests cover connection shutdown with peer isolation, late restoration, deletion during initialization, durable ownership checks, local requests during blocked discovery, and remote listing/calls with capability grants.

- `cargo test -p wisp-tauri mcp_ --offline -- --test-threads=4`: 61 passed.
- `cargo test --workspace --offline --no-fail-fast -- --test-threads=8`: 2063 passed, 0 failed, 0 ignored; process-level MCP fixtures also passed.
- `cargo fmt --all -- --check` and `git diff --check`: passed.
- UI `cargo check --target wasm32-unknown-unknown --offline`: passed.
- `cargo run -p wisp-mcp --example smoke --offline`: passed against the local mock server with uv offline.
- `npm ci`, fresh Trunk build, and full Playwright suite (`--fully-parallel --workers=4`): 721 passed, 2 existing optional-fixture skips.

## Manual acceptance and limitations

Real-plugin desktop acceptance remains to be performed:

1. Open two conversations using the same safe MCP plugin. Delete one and verify only its server process/session closes; the other conversation remains usable. Repeat by deleting a project.
2. Delete a conversation while its plugin is initializing and verify the server does not return when initialization or background restoration completes.
3. With an intentionally slow MCP initialization in an ACP session, confirm a local skill read or Run query/cancellation still responds while remote discovery is waiting.

Playwright uses the mocked Tauri bridge; lifecycle tests use local fake HTTP services. Cancelling or disconnecting an MCP request does not establish that a remote write was rolled back. Eager plugin restoration when loading an existing conversation remains a separate follow-up from the review.
